### PR TITLE
in_windows_exporter_metrics: Add service metrics support

### DIFF
--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -14,6 +14,7 @@ set(src
   we_wmi_cpu_info.c
   we_wmi_logon.c
   we_wmi_system.c
+  we_wmi_service.c
   )
 
 set(libs

--- a/plugins/in_windows_exporter_metrics/we.c
+++ b/plugins/in_windows_exporter_metrics/we.c
@@ -916,6 +916,16 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_we, raw_where_clause),
      "Specify the where clause for retrieving service metrics."
     },
+    {
+     FLB_CONFIG_MAP_STR, "we.service.include", NULL,
+     0, FLB_TRUE, offsetof(struct flb_we, raw_service_include),
+     "Specify the key value condition pairs for includeing condition to construct where clause of service metrics."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "we.service.exclude", NULL,
+     0, FLB_TRUE, offsetof(struct flb_we, raw_service_exclude),
+     "Specify the key value condition pairs for excludeing condition to construct where clause of service metrics."
+    },
     /* EOF */
     {0}
 };

--- a/plugins/in_windows_exporter_metrics/we.c
+++ b/plugins/in_windows_exporter_metrics/we.c
@@ -35,6 +35,13 @@
 #include "we_logical_disk.h"
 #include "we_cs.h"
 
+/* wmi collectors */
+#include "we_wmi_cpu_info.h"
+#include "we_wmi_logon.h"
+#include "we_wmi_system.h"
+#include "we_wmi_thermalzone.h"
+#include "we_wmi_service.h"
+
 static int we_timer_cpu_metrics_cb(struct flb_input_instance *ins,
                                    struct flb_config *config, void *in_context)
 {
@@ -121,6 +128,16 @@ static int we_timer_wmi_system_metrics_cb(struct flb_input_instance *ins,
     struct flb_ne *ctx = in_context;
 
     we_wmi_system_update(ctx);
+
+    return 0;
+}
+
+static int we_timer_wmi_service_metrics_cb(struct flb_input_instance *ins,
+                                           struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    we_wmi_service_update(ctx);
 
     return 0;
 }
@@ -240,6 +257,13 @@ static void we_wmi_system_update_cb(char *name, void *p1, void *p2)
     we_wmi_system_update(ctx);
 }
 
+static void we_wmi_service_update_cb(char *name, void *p1, void *p2)
+{
+    struct flb_we *ctx = p1;
+
+    we_wmi_service_update(ctx);
+}
+
 static int we_update_cb(struct flb_we *ctx, char *name)
 {
     int ret;
@@ -262,6 +286,7 @@ struct flb_we_callback ne_callbacks[] = {
     { "thermalzone", we_wmi_thermalzone_update_cb },
     { "logon", we_wmi_logon_update_cb },
     { "system", we_wmi_system_update_cb },
+    { "service", we_wmi_service_update_cb },
     { 0 }
 };
 
@@ -295,6 +320,7 @@ static int in_we_init(struct flb_input_instance *in,
     ctx->coll_wmi_cpu_info_fd = -1;
     ctx->coll_wmi_logon_fd = -1;
     ctx->coll_wmi_system_fd = -1;
+    ctx->coll_wmi_service_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -574,6 +600,31 @@ static int in_we_init(struct flb_input_instance *in,
                         return -1;
                     }
                 }
+                else if (strncmp(entry->str, "service", 7) == 0) {
+                    if (ctx->wmi_service_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 9;
+                    }
+                    else {
+                        /* Create the service collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           we_timer_wmi_service_metrics_cb,
+                                                           ctx->wmi_service_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set service collector for Windows Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_wmi_service_fd = ret;
+                    }
+
+                    /* Initialize service metric collectors */
+                    ret = we_wmi_service_init(ctx);
+                    if (ret) {
+                        return -1;
+                    }
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                     metric_idx = -1;
@@ -644,6 +695,9 @@ static int in_we_exit(void *data, struct flb_config *config)
                 else if (strncmp(entry->str, "system", 6) == 0) {
                     we_wmi_system_exit(ctx);
                 }
+                else if (strncmp(entry->str, "service", 7) == 0) {
+                    we_wmi_service_exit(ctx);
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                 }
@@ -680,6 +734,9 @@ static int in_we_exit(void *data, struct flb_config *config)
     }
     if (ctx->coll_wmi_system_fd != -1) {
         we_wmi_system_exit(ctx);
+    }
+    if (ctx->coll_wmi_service_fd != -1) {
+        we_wmi_service_exit(ctx);
     }
 
     flb_we_config_destroy(ctx);
@@ -721,6 +778,9 @@ static void in_we_pause(void *data, struct flb_config *config)
     if (ctx->coll_wmi_system_fd != -1) {
         flb_input_collector_pause(ctx->coll_wmi_system_fd, ctx->ins);
     }
+    if (ctx->coll_wmi_service_fd != -1) {
+        flb_input_collector_pause(ctx->coll_wmi_service_fd, ctx->ins);
+    }
 }
 
 static void in_we_resume(void *data, struct flb_config *config)
@@ -756,6 +816,9 @@ static void in_we_resume(void *data, struct flb_config *config)
     }
     if (ctx->coll_wmi_system_fd != -1) {
         flb_input_collector_resume(ctx->coll_wmi_system_fd, ctx->ins);
+    }
+    if (ctx->coll_wmi_service_fd != -1) {
+        flb_input_collector_resume(ctx->coll_wmi_service_fd, ctx->ins);
     }
 }
 
@@ -823,8 +886,13 @@ static struct flb_config_map config_map[] = {
      "scrape interval to collect system metrics from the node."
     },
     {
+     FLB_CONFIG_MAP_TIME, "collector.service.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_we, wmi_service_scrape_interval),
+     "scrape interval to collect service metrics from the node."
+    },
+    {
      FLB_CONFIG_MAP_CLIST, "metrics",
-     "cpu,cpu_info,os,net,logical_disk,cs,thermalzone,logon,system",
+     "cpu,cpu_info,os,net,logical_disk,cs,thermalzone,logon,system,service",
      0, FLB_TRUE, offsetof(struct flb_we, metrics),
      "Comma separated list of keys to enable metrics."
     },
@@ -842,6 +910,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "we.net.allow_nic_regex", "/.+/",
      0, FLB_TRUE, offsetof(struct flb_we, raw_allowing_nic),
      "Specify to be scribable regex for net metrics by name of NIC."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "we.service.where", NULL,
+     0, FLB_TRUE, offsetof(struct flb_we, raw_where_clause),
+     "Specify the where clause for retrieving service metrics."
     },
     /* EOF */
     {0}

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -145,6 +145,15 @@ struct we_wmi_system_counters {
     int                    operational;
 };
 
+struct we_wmi_service_counters {
+    struct wmi_query_spec *info;
+    struct cmt_gauge *information;
+    struct cmt_gauge *state;
+    struct cmt_gauge *start_mode;
+    struct cmt_gauge *status;
+    int operational;
+};
+
 struct we_os_counters {
     struct cmt_gauge *info;
     struct cmt_gauge *users;
@@ -178,6 +187,7 @@ struct flb_we {
     char *raw_allowing_disk;
     char *raw_denying_disk;
     char *raw_allowing_nic;
+    char *raw_where_clause;
 
     struct flb_regex *allowing_disk_regex;
     struct flb_regex *denying_disk_regex;
@@ -203,6 +213,7 @@ struct flb_we {
     int wmi_cpu_info_scrape_interval;
     int wmi_logon_scrape_interval;
     int wmi_system_scrape_interval;
+    int wmi_service_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_net_fd;                                    /* collector fd (net)  */
@@ -213,6 +224,7 @@ struct flb_we {
     int coll_wmi_cpu_info_fd;                           /* collector fd (wmi_cpu_info) */
     int coll_wmi_logon_fd;                              /* collector fd (wmi_logon)    */
     int coll_wmi_system_fd;                             /* collector fd (wmi_system)    */
+    int coll_wmi_service_fd;                            /* collector fd (wmi_service) */
 
     /*
      * Metrics Contexts
@@ -228,7 +240,7 @@ struct flb_we {
     struct we_wmi_cpu_info_counters *wmi_cpu_info;
     struct we_wmi_logon_counters *wmi_logon;
     struct we_wmi_system_counters *wmi_system;
-
+    struct we_wmi_service_counters *wmi_service;
 };
 
 typedef int (*collector_cb)(struct flb_we *);

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -188,6 +188,12 @@ struct flb_we {
     char *raw_denying_disk;
     char *raw_allowing_nic;
     char *raw_where_clause;
+    char *raw_service_include;
+    char *raw_service_exclude;
+    char *service_include_buffer;
+    int   service_include_buffer_size;
+    char *service_exclude_buffer;
+    int   service_exclude_buffer_size;
 
     struct flb_regex *allowing_disk_regex;
     struct flb_regex *denying_disk_regex;

--- a/plugins/in_windows_exporter_metrics/we_config.c
+++ b/plugins/in_windows_exporter_metrics/we_config.c
@@ -19,6 +19,7 @@
  */
 
 #include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_pack.h>
 #include "we.h"
 
 struct flb_we *flb_we_config_create(struct flb_input_instance *ins,
@@ -26,6 +27,7 @@ struct flb_we *flb_we_config_create(struct flb_input_instance *ins,
 {
     int ret;
     struct flb_we *ctx;
+    int root_type;
 
     ctx = flb_calloc(1, sizeof(struct flb_we));
     if (!ctx) {
@@ -36,6 +38,10 @@ struct flb_we *flb_we_config_create(struct flb_input_instance *ins,
     ctx->allowing_disk_regex = NULL;
     ctx->denying_disk_regex = NULL;
     ctx->allowing_nic_regex = NULL;
+    ctx->service_include_buffer = NULL;
+    ctx->service_include_buffer_size = 0;
+    ctx->service_exclude_buffer = NULL;
+    ctx->service_exclude_buffer_size = 0;
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *) ctx);
@@ -55,6 +61,34 @@ struct flb_we *flb_we_config_create(struct flb_input_instance *ins,
 
     if (ctx->raw_allowing_nic != NULL) {
         ctx->allowing_nic_regex = flb_regex_create(ctx->raw_allowing_nic);
+    }
+
+    if (ctx->raw_service_include != NULL) {
+        ret = flb_pack_json(ctx->raw_service_include,
+                            strlen(ctx->raw_service_include),
+                            &ctx->service_include_buffer,
+                            &ctx->service_include_buffer_size,
+                            &root_type,
+                            NULL);
+        if (ret != 0) {
+            flb_plg_warn(ctx->ins, "we.service.include is incomplete. Ignored.");
+            ctx->service_include_buffer = NULL;
+            ctx->service_include_buffer_size = 0;
+        }
+    }
+
+    if (ctx->raw_service_exclude != NULL) {
+        ret = flb_pack_json(ctx->raw_service_exclude,
+                            strlen(ctx->raw_service_exclude),
+                            &ctx->service_exclude_buffer,
+                            &ctx->service_exclude_buffer_size,
+                            &root_type,
+                            NULL);
+        if (ret != 0) {
+            flb_plg_warn(ctx->ins, "we.service.exclude is incomplete. Ignored.");
+            ctx->service_exclude_buffer = NULL;
+            ctx->service_exclude_buffer_size = 0;
+        }
     }
 
     ctx->cmt = cmt_create();
@@ -83,6 +117,14 @@ void flb_we_config_destroy(struct flb_we *ctx)
 
     if (ctx->allowing_nic_regex != NULL) {
         flb_regex_destroy(ctx->allowing_nic_regex);
+    }
+
+    if (ctx->service_include_buffer != NULL) {
+        flb_free(ctx->service_include_buffer);
+    }
+
+    if (ctx->service_exclude_buffer != NULL) {
+        flb_free(ctx->service_exclude_buffer);
     }
 
     if (ctx->cmt) {

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -231,6 +231,28 @@ static double wmi_get_property_value(struct flb_we *ctx, char *raw_property_key,
     return val;
 }
 
+static char *wmi_get_property_str_value(struct flb_we *ctx, char *raw_property_key,
+                                        IWbemClassObject *class_obj)
+{
+    VARIANT prop;
+    char *strprop;
+    char *str_val = NULL;
+    HRESULT hr;
+    wchar_t *wproperty;
+
+
+    VariantInit(&prop);
+    wproperty = we_convert_str(raw_property_key);
+    hr = class_obj->lpVtbl->Get(class_obj, wproperty, 0, &prop, 0, 0);
+    if (FAILED(hr)) {
+        flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+    }
+    str_val = convert_prop_to_str(&prop, FLB_TRUE);
+    VariantClear(&prop);
+    flb_free(wproperty);
+
+    return str_val;
+}
 
 static inline int wmi_update_metrics(struct flb_we *ctx, struct wmi_query_spec *spec,
                                      double val, IWbemClassObject *class_obj, uint64_t timestamp)
@@ -279,12 +301,21 @@ static inline int wmi_execute_query(struct flb_we *ctx, struct wmi_query_spec *s
     size_t size;
 
     size = 14 + strlen(spec->wmi_counter);
+    if (spec->where_clause != NULL) {
+        size += 7 + strlen(spec->where_clause);
+    }
     query = flb_calloc(size, sizeof(char *));
     if (!query) {
         flb_errno();
         return -1;
     }
-    snprintf(query, size, "SELECT * FROM %s", spec->wmi_counter);
+    if (spec->where_clause != NULL) {
+        snprintf(query, size, "SELECT * FROM %s WHERE %s", spec->wmi_counter, spec->where_clause);
+    }
+    else {
+        snprintf(query, size, "SELECT * FROM %s", spec->wmi_counter);
+    }
+    flb_trace("[wmi] query = %s", query);
     wquery = we_convert_str(query);
     flb_free(query);
 
@@ -517,6 +548,12 @@ double we_wmi_get_value(struct flb_we *ctx, struct wmi_query_spec *spec, IWbemCl
 double we_wmi_get_property_value(struct flb_we *ctx, char *raw_property_key, IWbemClassObject *class_obj)
 {
     return wmi_get_property_value(ctx, raw_property_key, class_obj);
+}
+
+char *we_wmi_get_property_str_value(struct flb_we *ctx, char *raw_property_key,
+                                    IWbemClassObject *class_obj)
+{
+    return wmi_get_property_str_value(ctx, raw_property_key, class_obj);
 }
 
 int we_wmi_update_counters(struct flb_we *ctx, struct wmi_query_spec *spec, uint64_t timestamp, double val, int metric_label_count, char **metric_label_set)

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -191,7 +191,7 @@ static double wmi_get_value(struct flb_we *ctx, struct wmi_query_spec *spec, IWb
     wproperty = we_convert_str(spec->wmi_property);
     hr = class_obj->lpVtbl->Get(class_obj, wproperty, 0, &prop, 0, 0);
     if (FAILED(hr)) {
-        flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+        flb_plg_warn(ctx->ins, "Retrive prop '%s' failed. Error code = %x", spec->wmi_property, hr);
     }
     strprop = convert_prop_to_str(&prop, FLB_FALSE);
     if (strprop == NULL) {
@@ -217,7 +217,7 @@ static double wmi_get_property_value(struct flb_we *ctx, char *raw_property_key,
     wproperty = we_convert_str(raw_property_key);
     hr = class_obj->lpVtbl->Get(class_obj, wproperty, 0, &prop, 0, 0);
     if (FAILED(hr)) {
-        flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+        flb_plg_warn(ctx->ins, "Retrive prop '%s' failed. Error code = %x", raw_property_key, hr);
     }
     strprop = convert_prop_to_str(&prop, FLB_FALSE);
     if (strprop == NULL) {
@@ -245,7 +245,7 @@ static char *wmi_get_property_str_value(struct flb_we *ctx, char *raw_property_k
     wproperty = we_convert_str(raw_property_key);
     hr = class_obj->lpVtbl->Get(class_obj, wproperty, 0, &prop, 0, 0);
     if (FAILED(hr)) {
-        flb_plg_warn(ctx->ins, "Retrive prop failed. Error code = %x", hr);
+        flb_plg_warn(ctx->ins, "Retrive prop '%s' failed. Error code = %x", raw_property_key, hr);
     }
     str_val = convert_prop_to_str(&prop, FLB_TRUE);
     VariantClear(&prop);

--- a/plugins/in_windows_exporter_metrics/we_wmi.h
+++ b/plugins/in_windows_exporter_metrics/we_wmi.h
@@ -34,6 +34,7 @@ struct wmi_query_spec {
     char *wmi_property;
     int label_property_count;
     char **label_property_keys;
+    char *where_clause;
 };
 
 int we_wmi_init(struct flb_we *ctx);
@@ -50,6 +51,8 @@ int we_wmi_coinitialize(struct flb_we *ctx);
 int we_wmi_execute_query(struct flb_we *ctx, struct wmi_query_spec *spec, IEnumWbemClassObject **out_enumerator);
 double we_wmi_get_value(struct flb_we *ctx, struct wmi_query_spec *spec, IWbemClassObject *class_obj);
 double we_wmi_get_property_value(struct flb_we *ctx, char *raw_property_key, IWbemClassObject *class_obj);
+char *we_wmi_get_property_str_value(struct flb_we *ctx, char *raw_property_key,
+                                    IWbemClassObject *class_obj);
 int we_wmi_update_counters(struct flb_we *ctx, struct wmi_query_spec *spec,
                            uint64_t timestamp, double val, int metric_label_count, char **metric_label_set);
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_cpu_info.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_cpu_info.c
@@ -84,6 +84,7 @@ int we_wmi_cpu_info_init(struct flb_we *ctx)
     ctx->wmi_cpu_info->info->label_property_keys[4] = "l2cachesize" ;
     ctx->wmi_cpu_info->info->label_property_keys[5] = "l3cachesize" ;
     ctx->wmi_cpu_info->info->label_property_keys[6] = "name" ;
+    ctx->wmi_cpu_info->info->where_clause = NULL;
 
     ctx->wmi_cpu_info->operational = FLB_TRUE;
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_logon.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_logon.c
@@ -70,6 +70,7 @@ int we_wmi_logon_init(struct flb_we *ctx)
     ctx->wmi_logon->info->wmi_property = "LogonType";
     ctx->wmi_logon->info->label_property_count = 1;
     ctx->wmi_logon->info->label_property_keys[0] = "status" ;
+    ctx->wmi_logon->info->where_clause = NULL;
 
     ctx->wmi_logon->operational = FLB_TRUE;
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_service.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_service.c
@@ -100,6 +100,8 @@ int we_wmi_service_init(struct flb_we *ctx)
 
 int we_wmi_service_exit(struct flb_we *ctx)
 {
+    ctx->wmi_service->operational = FLB_FALSE;
+
     flb_free(ctx->wmi_service->info);
     flb_free(ctx->wmi_service);
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_service.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_service.c
@@ -1,0 +1,224 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "we.h"
+#include "we_wmi.h"
+#include "we_wmi_service.h"
+#include "we_util.h"
+#include "we_metric.h"
+
+static double nop_adjust(double value)
+{
+    return value;
+}
+
+int we_wmi_service_init(struct flb_we *ctx)
+{
+    struct cmt_gauge *g;
+
+    ctx->wmi_service = flb_calloc(1, sizeof(struct we_wmi_service_counters));
+    if (!ctx->wmi_service) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_service->operational = FLB_FALSE;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "service", "info",
+                         "A metric for Windows Service information",
+                         4, (char *[]) {"name", "display_name", "process_id", "run_as"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_service->information = g;
+
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "service", "state",
+                         "A state of the service",
+                         2, (char *[]){"name", "state"});
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_service->state = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "service", "start_mode",
+                         "A start mode of the service",
+                         2, (char *[]){"name", "start_mode"});
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_service->start_mode = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "service", "status",
+                         "A status of the service",
+                         2, (char *[]){"name", "status"});
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_service->status = g;
+
+    ctx->wmi_service->info = flb_calloc(1, sizeof(struct wmi_query_spec));
+    if (!ctx->wmi_service->info) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_service->info->metric_instance = (void *)g;
+    ctx->wmi_service->info->type = CMT_GAUGE;
+    ctx->wmi_service->info->value_adjuster = nop_adjust;
+    ctx->wmi_service->info->wmi_counter = "Win32_Service";
+    ctx->wmi_service->info->wmi_property = "";
+    ctx->wmi_service->info->label_property_count = 0;
+    ctx->wmi_service->info->label_property_keys = NULL;
+    ctx->wmi_service->info->where_clause = ctx->raw_where_clause;
+
+    ctx->wmi_service->operational = FLB_TRUE;
+
+    return 0;
+}
+
+int we_wmi_service_exit(struct flb_we *ctx)
+{
+    flb_free(ctx->wmi_service->info);
+    flb_free(ctx->wmi_service);
+
+    return 0;
+}
+
+int we_wmi_service_update(struct flb_we *ctx)
+{
+    IEnumWbemClassObject* enumerator = NULL;
+    HRESULT hr;
+
+    IWbemClassObject *class_obj = NULL;
+    ULONG ret = 0;
+    int i = 0;
+    uint64_t timestamp = 0;
+    char *service_name = NULL;
+    char *display_name = NULL;
+    char *pid = NULL;
+    char *run_as = NULL;
+    char *str_prop = NULL;
+    char *state = NULL;
+    char *start_mode = NULL;
+    char *status = NULL;
+    char **states = (char *[]){
+        "stopped", "start pending", "stop pending", "running",
+        "continue pending", "pause pending", "paused", "unknown", NULL
+    };
+    char **statuses = (char *[]){
+        "ok", "error", "degraded", "unknown",
+        "pred fail", "starting", "stopping", "service",
+        "stressed", "nonrecover", "no contact", "lost comm", NULL
+    };
+    char **start_modes = (char *[]) {
+        "boot", "system", "auto", "manual", "disabled", NULL
+    };
+
+    if (!ctx->wmi_service->operational) {
+        flb_plg_error(ctx->ins, "windows_service collector not yet in operational state");
+
+        return -1;
+    }
+
+    if (FAILED(we_wmi_coinitialize(ctx))) {
+        return -1;
+    }
+
+    timestamp = cfl_time_now();
+
+    if (FAILED(we_wmi_execute_query(ctx, ctx->wmi_service->info, &enumerator))) {
+        return -1;
+    }
+
+    while (enumerator) {
+        hr = enumerator->lpVtbl->Next(enumerator, WBEM_INFINITE, 1,
+                                      &class_obj, &ret);
+
+        if (0 == ret) {
+            break;
+        }
+
+        service_name = we_wmi_get_property_str_value(ctx, "Name",        class_obj);
+        display_name = we_wmi_get_property_str_value(ctx, "DisplayName", class_obj);
+        pid          = we_wmi_get_property_str_value(ctx, "ProcessID",   class_obj);
+        run_as       = we_wmi_get_property_str_value(ctx, "StartName",   class_obj);
+        state        = we_wmi_get_property_str_value(ctx, "State",       class_obj);
+        start_mode   = we_wmi_get_property_str_value(ctx, "StartMode",   class_obj);
+        status       = we_wmi_get_property_str_value(ctx, "Status",      class_obj);
+
+        /* Information */
+        cmt_gauge_set(ctx->wmi_service->information, timestamp, 1.0,
+                      4, (char *[]){ service_name, display_name, pid, run_as});
+
+        /* State */
+        for (i = 0; states[i] != NULL; i++) {
+            if (strcasecmp(state, states[i]) == 0) {
+                cmt_gauge_set(ctx->wmi_service->state, timestamp, 1.0,
+                              2, (char *[]){ service_name, states[i]});
+            }
+            else {
+                cmt_gauge_set(ctx->wmi_service->state, timestamp, 0.0,
+                              2, (char *[]){ service_name, states[i]});
+            }
+        }
+        /* Start Mode */
+        for (i = 0; start_modes[i] != NULL; i++) {
+            if (strcasecmp(start_mode, start_modes[i]) == 0) {
+                cmt_gauge_set(ctx->wmi_service->start_mode, timestamp, 1.0,
+                              2, (char *[]){ service_name, start_modes[i]});
+            }
+            else {
+                cmt_gauge_set(ctx->wmi_service->start_mode, timestamp, 0.0,
+                              2, (char *[]){ service_name, start_modes[i]});
+            }
+        }
+
+        /* Status */
+        for (i = 0; statuses[i] != NULL; i++) {
+            if (strcasecmp(status, statuses[i]) == 0) {
+                cmt_gauge_set(ctx->wmi_service->status, timestamp, 1.0,
+                              2, (char *[]){ service_name, statuses[i]});
+            } else {
+                cmt_gauge_set(ctx->wmi_service->status, timestamp, 0.0,
+                              2, (char *[]){ service_name, statuses[i]});
+            }
+        }
+
+        class_obj->lpVtbl->Release(class_obj);
+
+        flb_free(service_name);
+        flb_free(display_name);
+        flb_free(pid);
+        flb_free(run_as);
+        flb_free(state);
+        flb_free(start_mode);
+        flb_free(status);
+    }
+
+    enumerator->lpVtbl->Release(enumerator);
+    we_wmi_cleanup(ctx);
+
+    return 0;
+}

--- a/plugins/in_windows_exporter_metrics/we_wmi_service.h
+++ b/plugins/in_windows_exporter_metrics/we_wmi_service.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_WE_WMI_SERVICE_H
+#define FLB_WE_WMI_SERVICE_H
+
+#include "we.h"
+
+int we_wmi_service_init(struct flb_we *ctx);
+int we_wmi_service_exit(struct flb_we *ctx);
+int we_wmi_service_update(struct flb_we *ctx);
+
+#endif

--- a/plugins/in_windows_exporter_metrics/we_wmi_system.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_system.c
@@ -111,6 +111,7 @@ int we_wmi_system_init(struct flb_we *ctx)
     ctx->wmi_system->info->wmi_property = "";
     ctx->wmi_system->info->label_property_count = 0;
     ctx->wmi_system->info->label_property_keys = NULL;
+    ctx->wmi_system->info->where_clause = NULL;
 
     ctx->wmi_system->operational = FLB_TRUE;
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_thermalzone.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_thermalzone.c
@@ -73,6 +73,7 @@ int we_wmi_thermalzone_init(struct flb_we *ctx)
     ctx->wmi_thermals->temperature_celsius->wmi_property = "HighPrecisionTemperature";
     ctx->wmi_thermals->temperature_celsius->label_property_count = 1;
     ctx->wmi_thermals->temperature_celsius->label_property_keys[0] = "name" ;
+    ctx->wmi_thermals->temperature_celsius->where_clause = NULL;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "thermalzone", "percent_passive_limit",
                          "The limit of passive limit (percent).",
@@ -100,6 +101,7 @@ int we_wmi_thermalzone_init(struct flb_we *ctx)
     ctx->wmi_thermals->percent_passive_limit->wmi_property = "PercentPassiveLimit";
     ctx->wmi_thermals->percent_passive_limit->label_property_count = 1;
     ctx->wmi_thermals->percent_passive_limit->label_property_keys[0] = "name";
+    ctx->wmi_thermals->percent_passive_limit->where_clause = NULL;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "thermalzone", "throttle_reasons",
                          "The reason of throttle.",
@@ -125,6 +127,7 @@ int we_wmi_thermalzone_init(struct flb_we *ctx)
     ctx->wmi_thermals->throttle_reasons->wmi_property = "ThrottleReasons";
     ctx->wmi_thermals->throttle_reasons->label_property_count = 1;
     ctx->wmi_thermals->throttle_reasons->label_property_keys[0] = "name";
+    ctx->wmi_thermals->throttle_reasons->where_clause = NULL;
 
     ctx->wmi_thermals->operational = FLB_TRUE;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes https://github.com/fluent/fluent-bit/issues/6669

windows exporter should support service collector.
Our service collector should be WMI based collector for now.
Also, it has where clause support.

Not specifying where clause, service collector just retrieves entire service information on the local box.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[SERVICE]
   flush_interval 10s

[INPUT]
   Name windows_exporter_metrics
   scrape_interval 10s
   metrics service
   # we.service.where Status!='OK'
   # we.service.where Name='docker' OR Name='WinRM' OR Name LIKE 'PenService%'
   # we.service.where (Name='docker' OR Name='WinRM')
   # we.service.where (Name='docker' OR Name LIKE '%Svc%' OR Name LIKE '%Service') AND (NOT Name LIKE 'UdkUserSvc%' AND NOT Name LIKE 'webthreatdefusersvc%' AND Name!='Steam Client Service')
   we.service.include {"Name":"docker","Name":"%Svc%", "Name":"%Service"}
   # we.service.exclude {"Name":"UdkUserSvc%","Name":"webthreatdefusersvc%","Name":"XboxNetApiSvc"}
   we.service.where NOT Name LIKE 'UdkUserSvc%' AND NOT Name LIKE 'webthreatdefusersvc%' AND Name!='XboxNetApiSvc'

[OUTPUT]
   Name stdout
```
- [x] Debug log output from testing the change

```
Fluent Bit v2.1.5
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/06/22 16:54:41] [ info] Configuration:
[2023/06/22 16:54:41] [ info]  flush time     | 1.000000 seconds
[2023/06/22 16:54:41] [ info]  grace          | 5 seconds
[2023/06/22 16:54:41] [ info]  daemon         | 0
[2023/06/22 16:54:41] [ info] ___________
[2023/06/22 16:54:41] [ info]  inputs:
[2023/06/22 16:54:41] [ info]      windows_exporter_metrics
[2023/06/22 16:54:41] [ info] ___________
[2023/06/22 16:54:41] [ info]  filters:
[2023/06/22 16:54:41] [ info] ___________
[2023/06/22 16:54:41] [ info]  outputs:
[2023/06/22 16:54:41] [ info]      stdout.0
[2023/06/22 16:54:41] [ info] ___________
[2023/06/22 16:54:41] [ info]  collectors:
[2023/06/22 16:54:41] [ info] [fluent bit] version=2.1.5, commit=41d3e17a43, pid=23324
[2023/06/22 16:54:41] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2023/06/22 16:54:41] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/06/22 16:54:41] [ info] [cmetrics] version=0.6.1
[2023/06/22 16:54:41] [ info] [ctraces ] version=0.3.1
[2023/06/22 16:54:41] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2023/06/22 16:54:41] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/06/22 16:54:41] [debug] [windows_exporter_metrics:windows_exporter_metrics.0] created event channels: read=876 write=880
[2023/06/22 16:54:41] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics service
[2023/06/22 16:54:41] [debug] [stdout:stdout.0] created event channels: read=904 write=1268
[2023/06/22 16:54:41] [ info] [sp] stream processor started
[2023/06/22 16:54:41] [ info] [output:stdout:stdout.0] worker #0 started
[2023/06/22 16:54:51] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....)
[2023/06/22 16:54:51] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2023/06/22 16:54:51] [debug] [input chunk] update output instances with new chunk size diff=294845, records=0, input=windows_exporter_metrics.0
[2023/06/22 16:54:52] [debug] [task] created task=0000012CC58DD420 id=0 OK
[2023/06/22 16:54:52] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2023-06-22T07:54:51.121886700Z windows_service_info{name="AppIDSvc",display_name="Application Identity",process_id="0",run_as="NT Authority\LocalService"} = 1
2023-06-22T07:54:51.121886700Z windows_service_info{name="Apple Mobile Device Service",display_name="Apple Mobile Device Service",process_id="5972",run_as="LocalSystem"} = 1
2023-06-22T07:54:51.121886700Z windows_service_info{name="AppXSvc",display_name="AppX Deployment Service (AppXSVC)",process_id="2268",run_as="LocalSystem"} = 1
<snip>
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="stopped"} = 1
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="start pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="stop pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="running"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="continue pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="pause pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="paused"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppIDSvc",state="unknown"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="stopped"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="start pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="stop pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="running"} = 1
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="continue pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="pause pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="paused"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="Apple Mobile Device Service",state="unknown"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="stopped"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="start pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="stop pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="running"} = 1
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="continue pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="pause pending"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="paused"} = 0
2023-06-22T07:54:51.121886700Z windows_service_state{name="AppXSvc",state="unknown"} = 0
<snip>
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="ok"} = 1
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="error"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="degraded"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="unknown"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="pred fail"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="starting"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="stopping"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="service"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="stressed"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="nonrecover"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="no contact"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="PrintWorkflowUserSvc_25bc49",status="lost comm"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="ok"} = 1
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="error"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="degraded"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="unknown"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="pred fail"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="starting"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="stopping"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="service"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="stressed"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="nonrecover"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="no contact"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UnistoreSvc_25bc49",status="lost comm"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="ok"} = 1
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="error"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="degraded"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="unknown"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="pred fail"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="starting"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="stopping"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="service"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="stressed"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="nonrecover"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="no contact"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="UserDataSvc_25bc49",status="lost comm"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="ok"} = 1
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="error"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="degraded"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="unknown"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="pred fail"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="starting"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="stopping"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="service"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="stressed"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="nonrecover"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="no contact"} = 0
2023-06-22T07:54:51.121886700Z windows_service_status{name="docker",status="lost comm"} = 0
<snip>
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1140

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
