### PR TITLE
in_node_exporter_metrics: handle not as error when missing cpu_throttle_metrics

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_cpu_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpu_linux.c
@@ -148,10 +148,9 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
                                         "thermal_throttle", "core_throttle_count",
                                         &core_throttle_count);
         if (ret != 0) {
-            flb_plg_error(ctx->ins,
+            flb_plg_debug(ctx->ins,
                           "CPU is missing core_throttle_count: %s",
                           entry->str);
-            continue;
         }
 
         snprintf(tmp1, sizeof(tmp1) -1, "%" PRIu64, core_id);
@@ -175,10 +174,9 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
                                         "thermal_throttle", "package_throttle_count",
                                         &package_throttle_count);
         if (ret != 0) {
-            flb_plg_error(ctx->ins,
+            flb_plg_debug(ctx->ins,
                           "CPU is missing package_throttle_count: %s",
                           entry->str);
-            continue;
         }
 
         /* Set new value */

--- a/plugins/in_node_exporter_metrics/ne_cpu_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpu_linux.c
@@ -152,15 +152,15 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
                           "CPU is missing core_throttle_count: %s",
                           entry->str);
         }
+        else {
+            snprintf(tmp1, sizeof(tmp1) -1, "%" PRIu64, core_id);
+            snprintf(tmp2, sizeof(tmp2) -1, "%" PRIu64, physical_package_id);
 
-        snprintf(tmp1, sizeof(tmp1) -1, "%" PRIu64, core_id);
-        snprintf(tmp2, sizeof(tmp2) -1, "%" PRIu64, physical_package_id);
-
-        /* Set new value */
-        cmt_counter_set(ctx->cpu_core_throttles, ts,
-                        (double) core_throttle_count,
-                        2, (char *[]) {tmp1, tmp2});
-
+            /* Set new value */
+            cmt_counter_set(ctx->cpu_core_throttles, ts,
+                            (double) core_throttle_count,
+                            2, (char *[]) {tmp1, tmp2});
+        }
 
         /* Only update this entry once */
         if (package_throttles_set[physical_package_id] != 0) {
@@ -178,11 +178,12 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
                           "CPU is missing package_throttle_count: %s",
                           entry->str);
         }
-
-        /* Set new value */
-        cmt_counter_set(ctx->cpu_package_throttles, ts,
-                        (double) package_throttle_count,
-                        1, (char *[]) {tmp2});
+        else {
+            /* Set new value */
+            cmt_counter_set(ctx->cpu_package_throttles, ts,
+                            (double) package_throttle_count,
+                            1, (char *[]) {tmp2});
+        }
     }
     flb_slist_destroy(&list);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
`node_cpu_core_throttles_total` and `node_cpu_package_throttles_total` metrics are not existing in the Virtual Machine (VM) environment,
In VM environment, they are just missing.
So, when they are absent, we should handle to output this issue with debug messages and not to handle as error.
The official node_exporter uses the same approach:
https://github.com/prometheus/node_exporter/blob/master/collector/cpu_linux.go#L267-L287

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes https://github.com/fluent/fluent-bit/issues/7589.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```console
$ bin/fluent-bit -i node_exporter_metrics -pmetrics=cpu -o stdout
```
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==564825== 
==564825== HEAP SUMMARY:
==564825==     in use at exit: 95,170 bytes in 702 blocks
==564825==   total heap usage: 6,896 allocs, 6,194 frees, 11,082,193 bytes allocated
==564825== 
==564825== LEAK SUMMARY:
==564825==    definitely lost: 0 bytes in 0 blocks
==564825==    indirectly lost: 0 bytes in 0 blocks
==564825==      possibly lost: 0 bytes in 0 blocks
==564825==    still reachable: 95,170 bytes in 702 blocks
==564825==         suppressed: 0 bytes in 0 blocks
==564825== Reachable blocks (those to which a pointer was found) are not shown.
==564825== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==564825== 
==564825== For lists of detected and suppressed errors, rerun with: -s
==564825== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
