### PR TITLE
es_out: support Upstream Servers with configuration overriding

### DIFF
--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -71,17 +71,14 @@ FLB_EXPORT int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                                    void (*out_callback) (void *, int, int,
                                                          void *, size_t, void *),
                                    void *out_callback_data,
-                                   void *test_ctx);
-FLB_EXPORT int flb_output_set_test_with_ctx_callback(
-                                   flb_ctx_t *ctx, int ffd, char *test_name,
-                                   void (*out_callback) (void *, int, int,
-                                                         void *, size_t, void *),
-                                   void *out_callback_data,
-                                   void *test_ctx,
-                                   void *(*test_ctx_callback) (
-                                           struct flb_config *,
-                                           struct flb_input_instance *,
-                                           void *, void *));
+                                   void *flush_ctx);
+FLB_EXPORT int flb_output_set_test_flush_ctx_callback(flb_ctx_t *ctx, int ffd,
+                                                      char *test_name,
+                                                      void *(*flush_ctx_callback)(
+                                                              struct flb_config *,
+                                                              struct flb_input_instance *,
+                                                              void *, void *),
+                                                      void *flush_ctx);
 FLB_EXPORT int flb_output_set_callback(flb_ctx_t *ctx, int ffd, char *name,
                                        void (*cb)(char *, void *, void *));
 FLB_EXPORT int flb_output_set_http_test(flb_ctx_t *ctx, int ffd, char *test_name,

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -23,6 +23,8 @@
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_config.h>
 
+struct flb_input_instance;
+
 /* Lib engine status */
 #define FLB_LIB_ERROR     -1
 #define FLB_LIB_NONE       0
@@ -70,6 +72,16 @@ FLB_EXPORT int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                                                          void *, size_t, void *),
                                    void *out_callback_data,
                                    void *test_ctx);
+FLB_EXPORT int flb_output_set_test_with_ctx_callback(
+                                   flb_ctx_t *ctx, int ffd, char *test_name,
+                                   void (*out_callback) (void *, int, int,
+                                                         void *, size_t, void *),
+                                   void *out_callback_data,
+                                   void *test_ctx,
+                                   void *(*test_ctx_callback) (
+                                           struct flb_config *,
+                                           struct flb_input_instance *,
+                                           void *, void *));
 FLB_EXPORT int flb_output_set_callback(flb_ctx_t *ctx, int ffd, char *name,
                                        void (*cb)(char *, void *, void *));
 FLB_EXPORT int flb_output_set_http_test(flb_ctx_t *ctx, int ffd, char *test_name,

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -154,8 +154,23 @@ struct flb_test_out_formatter {
      */
     void *rt_data;
 
-    /* optional context for flush callback */
+    /* optional context for "flush context callback" */
     void *flush_ctx;
+
+    /*
+     * Callback
+     * =========
+     * Optional "flush context callback": it references the function that extracts
+     * optional flush context for "formatter callback".
+     */
+    void *(*flush_ctx_callback) (/* Fluent Bit context */
+                                 struct flb_config *,
+                                 /* plugin that ingested the records */
+                                 struct flb_input_instance *,
+                                 /* plugin instance context */
+                                 void *plugin_context,
+                                 /* context for "flush context callback" */
+                                 void *flush_ctx);
 
     /*
      * Callback

--- a/plugins/out_es/CMakeLists.txt
+++ b/plugins/out_es/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(src
   es_bulk.c
+  es_type.c
   es_conf_parse.c
   es_conf.c
   es.c

--- a/plugins/out_es/CMakeLists.txt
+++ b/plugins/out_es/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(src
   es_bulk.c
+  es_conf_parse.c
   es_conf.c
   es.c
   murmur3.c)

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -906,15 +906,15 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 {
     int ret;
     size_t pack_size;
-    char *pack;
-    void *out_buf;
+    char *pack = NULL;
+    void *out_buf = NULL;
     size_t out_size;
     size_t b_sent;
     struct flb_elasticsearch *ctx = out_context;
     struct flb_elasticsearch_config *ec;
     struct flb_connection *u_conn;
     struct flb_upstream_node *node;
-    struct flb_http_client *c;
+    struct flb_http_client *c = NULL;
     flb_sds_t signature = NULL;
     int compressed = FLB_FALSE;
     flb_sds_t header_line = NULL;
@@ -988,6 +988,11 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, ec->uri,
                         pack, pack_size, NULL, 0, NULL, 0);
+    if (!c) {
+        flb_plg_error(ctx->ins, "failed to create HTTP client");
+        ret = FLB_ERROR;
+        goto cleanup_and_return;
+    }
 
     flb_http_buffer_size(c, ec->buffer_size);
 
@@ -1105,29 +1110,24 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
         }
     }
 
+    ret = FLB_OK;
+
+ cleanup_and_return:
     /* Cleanup */
-    flb_http_client_destroy(c);
+    if (c) {
+        flb_http_client_destroy(c);
+    }
     flb_free(pack);
     flb_upstream_conn_release(u_conn);
     if (signature) {
         flb_sds_destroy(signature);
     }
-    FLB_OUTPUT_RETURN(FLB_OK);
+    FLB_OUTPUT_RETURN(ret);
 
     /* Issue a retry */
  retry:
-    flb_http_client_destroy(c);
-    flb_free(pack);
-
-    if (out_buf != pack) {
-        flb_free(out_buf);
-    }
-
-    flb_upstream_conn_release(u_conn);
-    if (signature) {
-        flb_sds_destroy(signature);
-    }
-    FLB_OUTPUT_RETURN(FLB_RETRY);
+    ret = FLB_RETRY;
+    goto cleanup_and_return;
 }
 
 static int elasticsearch_response_test(struct flb_config *config,
@@ -1156,6 +1156,10 @@ static int elasticsearch_response_test(struct flb_config *config,
     /* Compose HTTP Client request (dummy client) */
     c = flb_http_dummy_client(u_conn, FLB_HTTP_POST, ec->uri,
                               NULL, 0, NULL, 0, NULL, 0);
+    if (!c) {
+        flb_plg_error(ctx->ins, "failed to create dummy HTTP client");
+        return -2;
+    }
 
     flb_http_buffer_size(c, ec->buffer_size);
 

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -24,7 +24,6 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_signv4.h>
-#include <fluent-bit/flb_aws_credentials.h>
 #include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_ra_key.h>
@@ -44,11 +43,12 @@ struct flb_output_plugin out_es_plugin;
 
 static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
-                                 struct flb_elasticsearch *ctx);
+                                 struct flb_elasticsearch_config *ec);
 
 #ifdef FLB_HAVE_AWS
 static flb_sds_t add_aws_auth(struct flb_http_client *c,
-                              struct flb_elasticsearch *ctx)
+                              struct flb_elasticsearch *ctx,
+                              struct flb_elasticsearch_config *ec)
 {
     flb_sds_t signature = NULL;
     int ret;
@@ -66,9 +66,9 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
     flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
-                              ctx->aws_region, ctx->aws_service_name,
-                              S3_MODE_SIGNED_PAYLOAD, ctx->aws_unsigned_headers,
-                              ctx->aws_provider);
+                              ec->aws_region, ec->aws_service_name,
+                              S3_MODE_SIGNED_PAYLOAD, ec->aws_unsigned_headers,
+                              ec->aws_provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");
         return NULL;
@@ -79,7 +79,7 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
 
 static int es_pack_map_content(msgpack_packer *tmp_pck,
                                msgpack_object map,
-                               struct flb_elasticsearch *ctx)
+                               struct flb_elasticsearch_config *ec)
 {
     int i;
     char *ptr_key = NULL;
@@ -128,7 +128,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          *
          *   https://goo.gl/R5NMTr
          */
-        if (ctx->replace_dots == FLB_TRUE) {
+        if (ec->replace_dots == FLB_TRUE) {
             char *p   = ptr_key;
             char *end = ptr_key + key_size;
             while (p != end) {
@@ -153,7 +153,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          */
         if (v->type == MSGPACK_OBJECT_MAP) {
             msgpack_pack_map(tmp_pck, v->via.map.size);
-            es_pack_map_content(tmp_pck, *v, ctx);
+            es_pack_map_content(tmp_pck, *v, ec);
         }
         /*
          * The value can be any data type, if it's an array we need to
@@ -161,7 +161,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          */
         else if (v->type == MSGPACK_OBJECT_ARRAY) {
           msgpack_pack_array(tmp_pck, v->via.array.size);
-          es_pack_array_content(tmp_pck, *v, ctx);
+          es_pack_array_content(tmp_pck, *v, ec);
         }
         else {
             msgpack_pack_object(tmp_pck, *v);
@@ -176,7 +176,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
   */
 static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
-                                 struct flb_elasticsearch *ctx)
+                                 struct flb_elasticsearch_config *ec)
 {
     int i;
     msgpack_object *e;
@@ -186,12 +186,12 @@ static int es_pack_array_content(msgpack_packer *tmp_pck,
         if (e->type == MSGPACK_OBJECT_MAP)
         {
             msgpack_pack_map(tmp_pck, e->via.map.size);
-            es_pack_map_content(tmp_pck, *e, ctx);
+            es_pack_map_content(tmp_pck, *e, ec);
         }
         else if (e->type == MSGPACK_OBJECT_ARRAY)
         {
             msgpack_pack_array(tmp_pck, e->via.array.size);
-            es_pack_array_content(tmp_pck, *e, ctx);
+            es_pack_array_content(tmp_pck, *e, ec);
         }
         else
         {
@@ -207,19 +207,20 @@ static int es_pack_array_content(msgpack_packer *tmp_pck,
  * If it failed, return NULL.
 */
 static flb_sds_t es_get_id_value(struct flb_elasticsearch *ctx,
-                                msgpack_object *map)
+                                 struct flb_elasticsearch_config *ec,
+                                 msgpack_object *map)
 {
     struct flb_ra_value *rval = NULL;
     flb_sds_t tmp_str;
-    rval = flb_ra_get_value_object(ctx->ra_id_key, *map);
+    rval = flb_ra_get_value_object(ec->ra_id_key, *map);
     if (rval == NULL) {
         flb_plg_warn(ctx->ins, "the value of %s is missing",
-                     ctx->id_key);
+                     ec->id_key);
         return NULL;
     }
     else if(rval->o.type != MSGPACK_OBJECT_STR) {
         flb_plg_warn(ctx->ins, "the value of %s is not string",
-                     ctx->id_key);
+                     ec->id_key);
         flb_ra_key_value_destroy(rval);
         return NULL;
     }
@@ -250,7 +251,7 @@ static int es_action_line_value_is_safe(const char *value, size_t len)
     return FLB_TRUE;
 }
 
-static int compose_index_header(struct flb_elasticsearch *ctx,
+static int compose_index_header(struct flb_elasticsearch_config *ec,
                                 int es_index_custom_len,
                                 char *logstash_index, size_t logstash_index_size,
                                 char *separator_str,
@@ -265,7 +266,7 @@ static int compose_index_header(struct flb_elasticsearch *ctx,
     if (es_index_custom_len > 0) {
         p = logstash_index + es_index_custom_len;
     } else {
-        p = logstash_index + flb_sds_len(ctx->logstash_prefix);
+        p = logstash_index + flb_sds_len(ec->logstash_prefix);
     }
     len = p - logstash_index;
     ret = snprintf(p, logstash_index_size - len, "%s",
@@ -278,7 +279,7 @@ static int compose_index_header(struct flb_elasticsearch *ctx,
     len += strlen(separator_str);
 
     s = strftime(p, logstash_index_size - len,
-                 ctx->logstash_dateformat, tm);
+                 ec->logstash_dateformat, tm);
     if (s==0) {
         /* exceed limit */
         return -1;
@@ -337,6 +338,7 @@ static int elasticsearch_format(struct flb_config *config,
     uint16_t hash[8];
     int es_index_custom_len;
     struct flb_elasticsearch *ctx = plugin_context;
+    struct flb_elasticsearch_config *ec = flush_ctx;
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
 
@@ -364,14 +366,14 @@ static int elasticsearch_format(struct flb_config *config,
         return -1;
     }
 
-    if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0) {
+    if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0) {
         write_op_update = FLB_TRUE;
     }
-    else if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
+    else if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
         write_op_upsert = FLB_TRUE;
     }
 
-    if (ctx->ra_id_key && ctx->generate_id == FLB_FALSE &&
+    if (ec->ra_id_key && ec->generate_id == FLB_FALSE &&
         (write_op_update == FLB_TRUE || write_op_upsert == FLB_TRUE)) {
         id_key_required = FLB_TRUE;
     }
@@ -383,25 +385,25 @@ static int elasticsearch_format(struct flb_config *config,
      * The header stored in 'j_index' will be used for the all records on
      * this payload.
      */
-    if (ctx->logstash_format == FLB_FALSE && ctx->generate_id == FLB_FALSE) {
+    if (ec->logstash_format == FLB_FALSE && ec->generate_id == FLB_FALSE) {
         flb_time_get(&tms);
         gmtime_r(&tms.tm.tv_sec, &tm);
         strftime(index_formatted, sizeof(index_formatted) - 1,
-                 ctx->index, &tm);
+                 ec->index, &tm);
         es_index = index_formatted;
-        if (ctx->suppress_type_name) {
+        if (ec->suppress_type_name) {
             index_len = flb_sds_snprintf(&j_index,
                                          flb_sds_alloc(j_index),
                                          ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                         ctx->es_action,
+                                         ec->es_action,
                                          es_index);
         }
         else {
             index_len = flb_sds_snprintf(&j_index,
                                          flb_sds_alloc(j_index),
                                          ES_BULK_INDEX_FMT,
-                                         ctx->es_action,
-                                         es_index, ctx->type);
+                                         ec->es_action,
+                                         es_index, ec->type);
         }
     }
 
@@ -411,7 +413,7 @@ static int elasticsearch_format(struct flb_config *config,
      * in order to prevent generating millions of indexes
      * we can set to always use current time for index generation
      */
-    if (ctx->current_time_index == FLB_TRUE) {
+    if (ec->current_time_index == FLB_TRUE) {
         flb_time_get(&tms);
     }
 
@@ -421,7 +423,7 @@ static int elasticsearch_format(struct flb_config *config,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
 
         /* Only pop time from record if current_time_index is disabled */
-        if (ctx->current_time_index == FLB_FALSE) {
+        if (ec->current_time_index == FLB_FALSE) {
             flb_time_copy(&tms, &log_event.timestamp);
         }
 
@@ -429,14 +431,14 @@ static int elasticsearch_format(struct flb_config *config,
         map_size = map.via.map.size;
 
         /* Copy logstash prefix for the per-record fallback path. */
-        if (ctx->logstash_format == FLB_TRUE) {
-            strncpy(logstash_index, ctx->logstash_prefix, sizeof(logstash_index));
+        if (ec->logstash_format == FLB_TRUE) {
+            strncpy(logstash_index, ec->logstash_prefix, sizeof(logstash_index));
             logstash_index[sizeof(logstash_index) - 1] = '\0';
         }
 
         es_index_custom_len = 0;
-        if (ctx->logstash_prefix_key) {
-            flb_sds_t v = flb_ra_translate(ctx->ra_prefix_key,
+        if (ec->logstash_prefix_key) {
+            flb_sds_t v = flb_ra_translate(ec->ra_prefix_key,
                                            (char *) tag, tag_len,
                                            map, NULL);
             if (v) {
@@ -459,7 +461,7 @@ static int elasticsearch_format(struct flb_config *config,
         msgpack_sbuffer_init(&tmp_sbuf);
         msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
 
-        if (ctx->include_tag_key == FLB_TRUE) {
+        if (ec->include_tag_key == FLB_TRUE) {
             map_size++;
         }
 
@@ -467,14 +469,14 @@ static int elasticsearch_format(struct flb_config *config,
         msgpack_pack_map(&tmp_pck, map_size + 1);
 
         /* Append the time key */
-        msgpack_pack_str(&tmp_pck, flb_sds_len(ctx->time_key));
-        msgpack_pack_str_body(&tmp_pck, ctx->time_key, flb_sds_len(ctx->time_key));
+        msgpack_pack_str(&tmp_pck, flb_sds_len(ec->time_key));
+        msgpack_pack_str_body(&tmp_pck, ec->time_key, flb_sds_len(ec->time_key));
 
         /* Format the time */
         gmtime_r(&tms.tm.tv_sec, &tm);
         s = strftime(time_formatted, sizeof(time_formatted) - 1,
-                     ctx->time_key_format, &tm);
-        if (ctx->time_key_nanos) {
+                     ec->time_key_format, &tm);
+        if (ec->time_key_nanos) {
             len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
                            ".%09" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec);
         } else {
@@ -487,47 +489,47 @@ static int elasticsearch_format(struct flb_config *config,
         msgpack_pack_str(&tmp_pck, s);
         msgpack_pack_str_body(&tmp_pck, time_formatted, s);
 
-        es_index = ctx->index;
-        if (ctx->logstash_format == FLB_TRUE) {
-            ret = compose_index_header(ctx, es_index_custom_len,
+        es_index = ec->index;
+        if (ec->logstash_format == FLB_TRUE) {
+            ret = compose_index_header(ec, es_index_custom_len,
                                        &logstash_index[0], sizeof(logstash_index),
-                                       ctx->logstash_prefix_separator, &tm);
+                                       ec->logstash_prefix_separator, &tm);
             if (ret < 0) {
                 /* retry with default separator */
-                compose_index_header(ctx, es_index_custom_len,
+                compose_index_header(ec, es_index_custom_len,
                                      &logstash_index[0], sizeof(logstash_index),
                                      "-", &tm);
             }
 
             es_index = logstash_index;
-            if (ctx->generate_id == FLB_FALSE) {
-                if (ctx->suppress_type_name) {
+            if (ec->generate_id == FLB_FALSE) {
+                if (ec->suppress_type_name) {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                                 ctx->es_action,
+                                                 ec->es_action,
                                                  es_index);
                 }
                 else {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT,
-                                                 ctx->es_action,
-                                                 es_index, ctx->type);
+                                                 ec->es_action,
+                                                 es_index, ec->type);
                 }
             }
         }
-        else if (ctx->current_time_index == FLB_TRUE) {
+        else if (ec->current_time_index == FLB_TRUE) {
             /* Make sure we handle index time format for index */
             strftime(index_formatted, sizeof(index_formatted) - 1,
-                     ctx->index, &tm);
+                     ec->index, &tm);
             es_index = index_formatted;
         }
 
         /* Tag Key */
-        if (ctx->include_tag_key == FLB_TRUE) {
-            msgpack_pack_str(&tmp_pck, flb_sds_len(ctx->tag_key));
-            msgpack_pack_str_body(&tmp_pck, ctx->tag_key, flb_sds_len(ctx->tag_key));
+        if (ec->include_tag_key == FLB_TRUE) {
+            msgpack_pack_str(&tmp_pck, flb_sds_len(ec->tag_key));
+            msgpack_pack_str_body(&tmp_pck, ec->tag_key, flb_sds_len(ec->tag_key));
             msgpack_pack_str(&tmp_pck, tag_len);
             msgpack_pack_str_body(&tmp_pck, tag, tag_len);
         }
@@ -539,7 +541,7 @@ static int elasticsearch_format(struct flb_config *config,
          * Elasticsearch have a restriction that key names cannot contain
          * a dot; if some dot is found, it's replaced with an underscore.
          */
-        ret = es_pack_map_content(&tmp_pck, map, ctx);
+        ret = es_pack_map_content(&tmp_pck, map, ec);
         if (ret == -1) {
             flb_log_event_decoder_destroy(&log_decoder);
             msgpack_sbuffer_destroy(&tmp_sbuf);
@@ -548,29 +550,29 @@ static int elasticsearch_format(struct flb_config *config,
             return -1;
         }
 
-        if (ctx->generate_id == FLB_TRUE) {
+        if (ec->generate_id == FLB_TRUE) {
             MurmurHash3_x64_128(tmp_sbuf.data, tmp_sbuf.size, 42, hash);
             snprintf(es_uuid, sizeof(es_uuid),
                      "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
                      hash[0], hash[1], hash[2], hash[3],
                      hash[4], hash[5], hash[6], hash[7]);
-            if (ctx->suppress_type_name) {
+            if (ec->suppress_type_name) {
                 index_len = flb_sds_snprintf(&j_index,
                                              flb_sds_alloc(j_index),
                                              ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                             ctx->es_action,
+                                             ec->es_action,
                                              es_index,  es_uuid);
             }
             else {
                 index_len = flb_sds_snprintf(&j_index,
                                              flb_sds_alloc(j_index),
                                              ES_BULK_INDEX_FMT_ID,
-                                             ctx->es_action,
-                                             es_index, ctx->type, es_uuid);
+                                             ec->es_action,
+                                             es_index, ec->type, es_uuid);
             }
         }
-        if (ctx->ra_id_key) {
-            id_key_str = es_get_id_value(ctx ,&map);
+        if (ec->ra_id_key) {
+            id_key_str = es_get_id_value(ctx, ec, &map);
             id_key_safe = FLB_FALSE;
 
             if (id_key_str &&
@@ -580,19 +582,19 @@ static int elasticsearch_format(struct flb_config *config,
             }
 
             if (id_key_safe == FLB_TRUE) {
-                if (ctx->suppress_type_name) {
+                if (ec->suppress_type_name) {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                                 ctx->es_action,
+                                                 ec->es_action,
                                                  es_index,  id_key_str);
                 }
                 else {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_ID,
-                                                 ctx->es_action,
-                                                 es_index, ctx->type, id_key_str);
+                                                 ec->es_action,
+                                                 es_index, ec->type, id_key_str);
                 }
             }
             else if (id_key_required == FLB_TRUE) {
@@ -605,20 +607,20 @@ static int elasticsearch_format(struct flb_config *config,
                 msgpack_sbuffer_destroy(&tmp_sbuf);
                 continue;
             }
-            else if (ctx->generate_id == FLB_FALSE && id_key_str) {
-                if (ctx->suppress_type_name) {
+            else if (ec->generate_id == FLB_FALSE && id_key_str) {
+                if (ec->suppress_type_name) {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                                 ctx->es_action,
+                                                 ec->es_action,
                                                  es_index);
                 }
                 else {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT,
-                                                 ctx->es_action,
-                                                 es_index, ctx->type);
+                                                 ec->es_action,
+                                                 es_index, ec->type);
                 }
             }
 
@@ -680,7 +682,7 @@ static int elasticsearch_format(struct flb_config *config,
      * return the bulk->ptr buffer
      */
     flb_free(bulk);
-    if (ctx->trace_output) {
+    if (ec->trace_output) {
         fwrite(*out_data, 1, *out_size, stdout);
         fflush(stdout);
     }
@@ -693,21 +695,13 @@ static int cb_es_init(struct flb_output_instance *ins,
                       void *data)
 {
     struct flb_elasticsearch *ctx;
+    (void) data;
 
     ctx = flb_es_conf_create(ins, config);
     if (!ctx) {
         flb_plg_error(ins, "cannot initialize plugin");
         return -1;
     }
-
-    if (ctx->index == NULL && ctx->logstash_format == FLB_FALSE && ctx->generate_id == FLB_FALSE) {
-        flb_plg_error(ins, "cannot initialize plugin, index is not set and logstash_format and generate_id are both off");
-        return -1;
-    }
-
-    flb_plg_debug(ctx->ins, "host=%s port=%i uri=%s index=%s type=%s",
-                  ins->host.name, ins->host.port, ctx->uri,
-                  ctx->index, ctx->type);
 
     flb_output_set_context(ins, ctx);
 
@@ -718,6 +712,31 @@ static int cb_es_init(struct flb_output_instance *ins,
     flb_output_set_http_debug_callbacks(ins);
 
     return 0;
+}
+
+static struct flb_elasticsearch_config *flb_elasticsearch_target(
+        struct flb_elasticsearch *ctx, struct flb_upstream_node **node)
+{
+    struct flb_elasticsearch_config *ec;
+    struct flb_upstream_node *target_node;
+
+    if (ctx->ha_mode == FLB_FALSE) {
+        ec = mk_list_entry_first(&ctx->configs, struct flb_elasticsearch_config, _head);
+        *node = NULL;
+        return ec;
+    }
+
+    target_node = flb_upstream_ha_node_get(ctx->ha);
+    if (!target_node) {
+        *node = NULL;
+        return NULL;
+    }
+
+    /* Get elasticsearch_config stored in node opaque data */
+    ec = flb_upstream_node_get_data(target_node);
+    *node = target_node;
+
+    return ec;
 }
 
 static int elasticsearch_error_check(struct flb_elasticsearch *ctx,
@@ -891,21 +910,39 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     size_t out_size;
     size_t b_sent;
     struct flb_elasticsearch *ctx = out_context;
+    struct flb_elasticsearch_config *ec;
     struct flb_connection *u_conn;
+    struct flb_upstream_node *node;
     struct flb_http_client *c;
     flb_sds_t signature = NULL;
     int compressed = FLB_FALSE;
     flb_sds_t header_line = NULL;
 
-    /* Get upstream connection */
-    u_conn = flb_upstream_conn_get(ctx->u);
-    if (!u_conn) {
+    ec = flb_elasticsearch_target(ctx, &node);
+    if (!ec) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    /* Get upstream connection */
+    if (ctx->ha_mode == FLB_TRUE) {
+        u_conn = flb_upstream_conn_get(node->u);
+        if (!u_conn) {
+            flb_plg_error(ctx->ins, "no upstream connections available for %s node",
+                          node->name);
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+    }
+    else {
+        u_conn = flb_upstream_conn_get(ctx->u);
+        if (!u_conn) {
+            flb_plg_error(ctx->ins, "no upstream connections available");
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
     }
 
     /* Convert format */
     ret = elasticsearch_format(config, ins,
-                               ctx, NULL,
+                               ctx, ec,
                                event_chunk->type,
                                event_chunk->tag, flb_sds_len(event_chunk->tag),
                                event_chunk->data, event_chunk->size,
@@ -925,7 +962,7 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     pack_size = out_size;
 
     /* Should we compress the payload ? */
-    if (ctx->compress_gzip == FLB_TRUE) {
+    if (ec->compress_gzip == FLB_TRUE) {
         ret = flb_gzip_compress((void *) pack, pack_size,
                                 &out_buf, &out_size);
         if (ret == -1) {
@@ -948,10 +985,10 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Compose HTTP Client request */
-    c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
+    c = flb_http_client(u_conn, FLB_HTTP_POST, ec->uri,
                         pack, pack_size, NULL, 0, NULL, 0);
 
-    flb_http_buffer_size(c, ctx->buffer_size);
+    flb_http_buffer_size(c, ec->buffer_size);
 
 #ifndef FLB_HAVE_AWS
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
@@ -959,20 +996,20 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
     flb_http_add_header(c, "Content-Type", 12, "application/x-ndjson", 20);
 
-    if (ctx->http_user && ctx->http_passwd) {
-        flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
+    if (ec->http_user && ec->http_passwd) {
+        flb_http_basic_auth(c, ec->http_user, ec->http_passwd);
     }
-    else if (ctx->cloud_user && ctx->cloud_passwd) {
-        flb_http_basic_auth(c, ctx->cloud_user, ctx->cloud_passwd);
+    else if (ec->cloud_user && ec->cloud_passwd) {
+        flb_http_basic_auth(c, ec->cloud_user, ec->cloud_passwd);
     }
-    else if (ctx->http_api_key) {
+    else if (ec->http_api_key) {
         /* 7 for ApiKey + space */
-        header_line = flb_sds_create_size(strlen(ctx->http_api_key)+7);
+        header_line = flb_sds_create_size(strlen(ec->http_api_key)+7);
         if (header_line == NULL) {
             flb_plg_error(ctx->ins, "failed to format API key auth header");
             goto retry;
         }
-        header_line = flb_sds_printf(&header_line, "ApiKey %s", ctx->http_api_key);
+        header_line = flb_sds_printf(&header_line, "ApiKey %s", ec->http_api_key);
 
         if (flb_http_add_header(c,
                                 FLB_HTTP_HEADER_AUTH, strlen(FLB_HTTP_HEADER_AUTH),
@@ -986,8 +1023,8 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     }
 
 #ifdef FLB_HAVE_AWS
-    if (ctx->has_aws_auth == FLB_TRUE) {
-        signature = add_aws_auth(c, ctx);
+    if (ec->has_aws_auth == FLB_TRUE) {
+        signature = add_aws_auth(c, ctx, ec);
         if (!signature) {
             goto retry;
         }
@@ -1007,20 +1044,20 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {
-        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ctx->uri);
+        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ec->uri);
         goto retry;
     }
     else {
         /* The request was issued successfully, validate the 'error' field */
-        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ctx->uri);
+        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ec->uri);
         if (c->resp.status != 200 && c->resp.status != 201) {
             if (c->resp.payload_size > 0) {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s, response:\n%s\n",
-                              c->resp.status, ctx->uri, c->resp.payload);
+                              c->resp.status, ec->uri, c->resp.payload);
             }
             else {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s",
-                              c->resp.status, ctx->uri);
+                              c->resp.status, ec->uri);
             }
             goto retry;
         }
@@ -1037,7 +1074,7 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
             }
             else {
                 /* we got an error */
-                if (ctx->trace_error) {
+                if (ec->trace_error) {
                     /*
                      * If trace_error is set, trace the actual
                      * response from Elasticsearch explaining the problem.
@@ -1097,42 +1134,46 @@ static int elasticsearch_response_test(struct flb_config *config,
 {
     int ret = 0;
     struct flb_elasticsearch *ctx = plugin_context;
+    struct flb_elasticsearch_config *ec;
+    struct flb_upstream_node *node;
     struct flb_connection *u_conn;
     struct flb_http_client *c;
     size_t b_sent;
+
+    ec = flb_elasticsearch_target(ctx, &node);
+    if (!ec) {
+      flb_plg_warn(ctx->ins, "failed to get target configuration");
+      return -2;
+    }
 
     /* Not retrieve upstream connection */
     u_conn = NULL;
 
     /* Compose HTTP Client request (dummy client) */
-    c = flb_http_dummy_client(u_conn, FLB_HTTP_POST, ctx->uri,
+    c = flb_http_dummy_client(u_conn, FLB_HTTP_POST, ec->uri,
                               NULL, 0, NULL, 0, NULL, 0);
 
-    flb_http_buffer_size(c, ctx->buffer_size);
+    flb_http_buffer_size(c, ec->buffer_size);
 
     /* Just stubbing the HTTP responses */
     flb_http_set_response_test(c, "response", data, bytes, status, NULL, NULL);
 
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {
-        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ctx->uri);
-        goto error;
-    }
-    if (ret != 0) {
-        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ctx->uri);
+        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ec->uri);
         goto error;
     }
     else {
         /* The request was issued successfully, validate the 'error' field */
-        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ctx->uri);
+        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ec->uri);
         if (c->resp.status != 200 && c->resp.status != 201) {
             if (c->resp.payload_size > 0) {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s, response:\n%s\n",
-                              c->resp.status, ctx->uri, c->resp.payload);
+                              c->resp.status, ec->uri, c->resp.payload);
             }
             else {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s",
-                              c->resp.status, ctx->uri);
+                              c->resp.status, ec->uri);
             }
             goto error;
         }
@@ -1173,29 +1214,29 @@ static int cb_es_exit(void *data, struct flb_config *config)
 static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "index", FLB_ES_DEFAULT_INDEX,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, index),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, index),
      "Set an index name"
     },
     {
      FLB_CONFIG_MAP_STR, "type", FLB_ES_DEFAULT_TYPE,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, type),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, type),
      "Set the document type property"
     },
     {
      FLB_CONFIG_MAP_BOOL, "suppress_type_name", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, suppress_type_name),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, suppress_type_name),
      "If true, mapping types is removed. (for v7.0.0 or later)"
     },
 
     /* HTTP Authentication */
     {
      FLB_CONFIG_MAP_STR, "http_user", NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, http_user),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, http_user),
      "Optional username credential for Elastic X-Pack access"
     },
     {
      FLB_CONFIG_MAP_STR, "http_passwd", "",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, http_passwd),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, http_passwd),
      "Password for user defined in HTTP_User"
     },
     {
@@ -1227,17 +1268,17 @@ static struct flb_config_map config_map[] = {
 #ifdef FLB_HAVE_AWS
     {
      FLB_CONFIG_MAP_BOOL, "aws_auth", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, has_aws_auth),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, has_aws_auth),
      "Enable AWS Sigv4 Authentication"
     },
     {
      FLB_CONFIG_MAP_STR, "aws_region", NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_region),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_region),
      "AWS Region of your Amazon OpenSearch Service cluster"
     },
     {
      FLB_CONFIG_MAP_STR, "aws_sts_endpoint", NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_sts_endpoint),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_sts_endpoint),
      "Custom endpoint for the AWS STS API, used with the AWS_Role_ARN option"
     },
     {
@@ -1252,12 +1293,12 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, "aws_service_name", "es",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_service_name),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_service_name),
      "AWS Service Name"
     },
     {
      FLB_CONFIG_MAP_STR, "aws_profile", NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, aws_profile),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_profile),
      "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
      "$HOME/.aws/ directory."
     },
@@ -1266,12 +1307,12 @@ static struct flb_config_map config_map[] = {
     /* Logstash compatibility */
     {
      FLB_CONFIG_MAP_BOOL, "logstash_format", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, logstash_format),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_format),
      "Enable Logstash format compatibility"
     },
     {
      FLB_CONFIG_MAP_STR, "logstash_prefix", FLB_ES_DEFAULT_PREFIX,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, logstash_prefix),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix),
      "When Logstash_Format is enabled, the Index name is composed using a prefix "
      "and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will "
      "become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date "
@@ -1279,12 +1320,12 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, "logstash_prefix_separator", "-",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, logstash_prefix_separator),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix_separator),
      "Set a separator between logstash_prefix and date."
     },
     {
      FLB_CONFIG_MAP_STR, "logstash_prefix_key", NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, logstash_prefix_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix_key),
      "When included: the value in the record that belongs to the key will be looked "
      "up and over-write the Logstash_Prefix for index generation. If the key/value "
      "is not found in the record then the Logstash_Prefix option will act as a "
@@ -1292,42 +1333,42 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, "logstash_dateformat", FLB_ES_DEFAULT_TIME_FMT,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, logstash_dateformat),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_dateformat),
      "Time format (based on strftime) to generate the second part of the Index name"
     },
 
     /* Custom Time and Tag keys */
     {
      FLB_CONFIG_MAP_STR, "time_key", FLB_ES_DEFAULT_TIME_KEY,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, time_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key),
      "When Logstash_Format is enabled, each record will get a new timestamp field. "
      "The Time_Key property defines the name of that field"
     },
     {
      FLB_CONFIG_MAP_STR, "time_key_format", FLB_ES_DEFAULT_TIME_KEYF,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, time_key_format),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key_format),
      "When Logstash_Format is enabled, this property defines the format of the "
      "timestamp"
     },
     {
      FLB_CONFIG_MAP_BOOL, "time_key_nanos", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, time_key_nanos),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key_nanos),
      "When Logstash_Format is enabled, enabling this property sends nanosecond "
      "precision timestamps"
     },
     {
      FLB_CONFIG_MAP_BOOL, "include_tag_key", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, include_tag_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, include_tag_key),
      "When enabled, it append the Tag name to the record"
     },
     {
      FLB_CONFIG_MAP_STR, "tag_key", FLB_ES_DEFAULT_TAG_KEY,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, tag_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, tag_key),
      "When Include_Tag_Key is enabled, this property defines the key name for the tag"
     },
     {
      FLB_CONFIG_MAP_SIZE, "buffer_size", FLB_ES_DEFAULT_HTTP_MAX,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, buffer_size),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, buffer_size),
      "Specify the buffer size used to read the response from the Elasticsearch HTTP "
      "service. This option is useful for debugging purposes where is required to read "
      "full responses, note that response size grows depending of the number of records "
@@ -1354,44 +1395,51 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_BOOL, "generate_id", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, generate_id),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, generate_id),
      "When enabled, generate _id for outgoing records. This prevents duplicate "
      "records when retrying ES"
     },
     {
      FLB_CONFIG_MAP_STR, "write_operation", "create",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, write_operation),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, write_operation),
      "Operation to use to write in bulk requests"
     },
     {
      FLB_CONFIG_MAP_STR, "id_key", NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, id_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, id_key),
      "If set, _id will be the value of the key from incoming record."
     },
     {
      FLB_CONFIG_MAP_BOOL, "replace_dots", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, replace_dots),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, replace_dots),
      "When enabled, replace field name dots with underscore, required by Elasticsearch "
      "2.0-2.3."
     },
 
     {
      FLB_CONFIG_MAP_BOOL, "current_time_index", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, current_time_index),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, current_time_index),
      "Use current time for index generation instead of message record"
     },
 
     /* Trace */
     {
      FLB_CONFIG_MAP_BOOL, "trace_output", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, trace_output),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, trace_output),
      "When enabled print the Elasticsearch API calls to stdout (for diag only)"
     },
     {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch, trace_error),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, trace_error),
      "When enabled print the Elasticsearch exception to stderr (for diag only)"
     },
+
+    {
+     FLB_CONFIG_MAP_STR, "upstream", NULL,
+     0, FLB_FALSE, 0,
+     "Path to 'upstream' configuration file (define multiple nodes)"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -30,6 +30,7 @@
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_upstream_node.h>
 #include <msgpack.h>
 
 #include <time.h>
@@ -721,7 +722,7 @@ static struct flb_elasticsearch_config *flb_elasticsearch_target(
     struct flb_upstream_node *target_node;
 
     if (ctx->ha_mode == FLB_FALSE) {
-        ec = mk_list_entry_first(&ctx->configs, struct flb_elasticsearch_config, _head);
+        ec = flb_es_upstream_conf(ctx, NULL);
         *node = NULL;
         return ec;
     }
@@ -732,8 +733,7 @@ static struct flb_elasticsearch_config *flb_elasticsearch_target(
         return NULL;
     }
 
-    /* Get elasticsearch_config stored in node opaque data */
-    ec = flb_upstream_node_get_data(target_node);
+    ec = flb_es_upstream_conf(ctx, target_node);
     *node = target_node;
 
     return ec;
@@ -1241,7 +1241,7 @@ static struct flb_config_map config_map[] = {
     },
     {
     FLB_CONFIG_MAP_STR, "http_api_key", NULL,
-    0, FLB_TRUE, offsetof(struct flb_elasticsearch, http_api_key),
+    0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, http_api_key),
     "Base-64 encoded API key credential for Elasticsearch"
     },
 

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -1124,6 +1124,9 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     }
 
     flb_upstream_conn_release(u_conn);
+    if (signature) {
+        flb_sds_destroy(signature);
+    }
     FLB_OUTPUT_RETURN(FLB_RETRY);
 }
 

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -37,6 +37,7 @@
 
 #include "es.h"
 #include "es_conf.h"
+#include "es_conf_prop.h"
 #include "es_bulk.h"
 #include "murmur3.h"
 
@@ -1213,53 +1214,53 @@ static int cb_es_exit(void *data, struct flb_config *config)
 /* Configuration properties map */
 static struct flb_config_map config_map[] = {
     {
-     FLB_CONFIG_MAP_STR, "index", FLB_ES_DEFAULT_INDEX,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_INDEX, FLB_ES_DEFAULT_INDEX,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, index),
      "Set an index name"
     },
     {
-     FLB_CONFIG_MAP_STR, "type", FLB_ES_DEFAULT_TYPE,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TYPE, FLB_ES_DEFAULT_TYPE,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, type),
      "Set the document type property"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "suppress_type_name", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_SUPPRESS_TYPE_NAME, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, suppress_type_name),
      "If true, mapping types is removed. (for v7.0.0 or later)"
     },
 
     /* HTTP Authentication */
     {
-     FLB_CONFIG_MAP_STR, "http_user", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_HTTP_USER, NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, http_user),
      "Optional username credential for Elastic X-Pack access"
     },
     {
-     FLB_CONFIG_MAP_STR, "http_passwd", "",
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_HTTP_PASSWD, "",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, http_passwd),
      "Password for user defined in HTTP_User"
     },
     {
-    FLB_CONFIG_MAP_STR, "http_api_key", NULL,
+    FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_HTTP_API_KEY, NULL,
     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, http_api_key),
     "Base-64 encoded API key credential for Elasticsearch"
     },
 
     /* HTTP Compression */
     {
-     FLB_CONFIG_MAP_STR, "compress", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_COMPRESS, NULL,
      0, FLB_FALSE, 0,
      "Set payload compression mechanism. Option available is 'gzip'"
     },
 
     /* Cloud Authentication */
     {
-     FLB_CONFIG_MAP_STR, "cloud_id", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_CLOUD_ID, NULL,
      0, FLB_FALSE, 0,
      "Elastic cloud ID of the cluster to connect to"
     },
     {
-     FLB_CONFIG_MAP_STR, "cloud_auth", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_CLOUD_AUTH, NULL,
      0, FLB_FALSE, 0,
      "Elastic cloud authentication credentials"
     },
@@ -1267,37 +1268,37 @@ static struct flb_config_map config_map[] = {
     /* AWS Authentication */
 #ifdef FLB_HAVE_AWS
     {
-     FLB_CONFIG_MAP_BOOL, "aws_auth", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_AWS_AUTH, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, has_aws_auth),
      "Enable AWS Sigv4 Authentication"
     },
     {
-     FLB_CONFIG_MAP_STR, "aws_region", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_AWS_REGION, NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_region),
      "AWS Region of your Amazon OpenSearch Service cluster"
     },
     {
-     FLB_CONFIG_MAP_STR, "aws_sts_endpoint", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_AWS_STS_ENDPOINT, NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_sts_endpoint),
      "Custom endpoint for the AWS STS API, used with the AWS_Role_ARN option"
     },
     {
-     FLB_CONFIG_MAP_STR, "aws_role_arn", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_AWS_ROLE_ARN, NULL,
      0, FLB_FALSE, 0,
      "AWS IAM Role to assume to put records to your Amazon OpenSearch cluster"
     },
     {
-     FLB_CONFIG_MAP_STR, "aws_external_id", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_AWS_EXTERNAL_ID, NULL,
      0, FLB_FALSE, 0,
      "External ID for the AWS IAM Role specified with `aws_role_arn`"
     },
     {
-     FLB_CONFIG_MAP_STR, "aws_service_name", "es",
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_AWS_SERVICE_NAME, "es",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_service_name),
      "AWS Service Name"
     },
     {
-     FLB_CONFIG_MAP_STR, "aws_profile", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_AWS_PROFILE, NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, aws_profile),
      "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
      "$HOME/.aws/ directory."
@@ -1306,12 +1307,12 @@ static struct flb_config_map config_map[] = {
 
     /* Logstash compatibility */
     {
-     FLB_CONFIG_MAP_BOOL, "logstash_format", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_LOGSTASH_FORMAT, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_format),
      "Enable Logstash format compatibility"
     },
     {
-     FLB_CONFIG_MAP_STR, "logstash_prefix", FLB_ES_DEFAULT_PREFIX,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX, FLB_ES_DEFAULT_PREFIX,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix),
      "When Logstash_Format is enabled, the Index name is composed using a prefix "
      "and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will "
@@ -1319,12 +1320,12 @@ static struct flb_config_map config_map[] = {
      "when the data is being generated"
     },
     {
-     FLB_CONFIG_MAP_STR, "logstash_prefix_separator", "-",
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_SEPARATOR, "-",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix_separator),
      "Set a separator between logstash_prefix and date."
     },
     {
-     FLB_CONFIG_MAP_STR, "logstash_prefix_key", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_KEY, NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix_key),
      "When included: the value in the record that belongs to the key will be looked "
      "up and over-write the Logstash_Prefix for index generation. If the key/value "
@@ -1332,42 +1333,42 @@ static struct flb_config_map config_map[] = {
      "fallback. Nested keys are supported through record accessor pattern"
     },
     {
-     FLB_CONFIG_MAP_STR, "logstash_dateformat", FLB_ES_DEFAULT_TIME_FMT,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_DATEFORMAT, FLB_ES_DEFAULT_TIME_FMT,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_dateformat),
      "Time format (based on strftime) to generate the second part of the Index name"
     },
 
     /* Custom Time and Tag keys */
     {
-     FLB_CONFIG_MAP_STR, "time_key", FLB_ES_DEFAULT_TIME_KEY,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TIME_KEY, FLB_ES_DEFAULT_TIME_KEY,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key),
      "When Logstash_Format is enabled, each record will get a new timestamp field. "
      "The Time_Key property defines the name of that field"
     },
     {
-     FLB_CONFIG_MAP_STR, "time_key_format", FLB_ES_DEFAULT_TIME_KEYF,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TIME_KEY_FORMAT, FLB_ES_DEFAULT_TIME_KEYF,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key_format),
      "When Logstash_Format is enabled, this property defines the format of the "
      "timestamp"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "time_key_nanos", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_TIME_KEY_NANOS, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key_nanos),
      "When Logstash_Format is enabled, enabling this property sends nanosecond "
      "precision timestamps"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "include_tag_key", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_INCLUDE_TAG_KEY, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, include_tag_key),
      "When enabled, it append the Tag name to the record"
     },
     {
-     FLB_CONFIG_MAP_STR, "tag_key", FLB_ES_DEFAULT_TAG_KEY,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TAG_KEY, FLB_ES_DEFAULT_TAG_KEY,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, tag_key),
      "When Include_Tag_Key is enabled, this property defines the key name for the tag"
     },
     {
-     FLB_CONFIG_MAP_SIZE, "buffer_size", FLB_ES_DEFAULT_HTTP_MAX,
+     FLB_CONFIG_MAP_SIZE, FLB_ES_CONFIG_PROPERTY_BUFFER_SIZE, FLB_ES_DEFAULT_HTTP_MAX,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, buffer_size),
      "Specify the buffer size used to read the response from the Elasticsearch HTTP "
      "service. This option is useful for debugging purposes where is required to read "
@@ -1378,7 +1379,7 @@ static struct flb_config_map config_map[] = {
 
     /* Elasticsearch specifics */
     {
-     FLB_CONFIG_MAP_STR, "path", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_PATH, NULL,
      0, FLB_FALSE, 0,
      "Elasticsearch accepts new data on HTTP query path '/_bulk'. But it is also "
      "possible to serve Elasticsearch behind a reverse proxy on a subpath. This "
@@ -1386,7 +1387,7 @@ static struct flb_config_map config_map[] = {
      "prefix in the indexing HTTP POST URI"
     },
     {
-     FLB_CONFIG_MAP_STR, "pipeline", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_PIPELINE, NULL,
      0, FLB_FALSE, 0,
      "Newer versions of Elasticsearch allows to setup filters called pipelines. "
      "This option allows to define which pipeline the database should use. For "
@@ -1394,48 +1395,48 @@ static struct flb_config_map config_map[] = {
      "Fluent Bit side, avoid pipelines"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "generate_id", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_GENERATE_ID, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, generate_id),
      "When enabled, generate _id for outgoing records. This prevents duplicate "
      "records when retrying ES"
     },
     {
-     FLB_CONFIG_MAP_STR, "write_operation", "create",
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_WRITE_OPERATION, "create",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, write_operation),
      "Operation to use to write in bulk requests"
     },
     {
-     FLB_CONFIG_MAP_STR, "id_key", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_ID_KEY, NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, id_key),
      "If set, _id will be the value of the key from incoming record."
     },
     {
-     FLB_CONFIG_MAP_BOOL, "replace_dots", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_REPLACE_DOTS, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, replace_dots),
      "When enabled, replace field name dots with underscore, required by Elasticsearch "
      "2.0-2.3."
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "current_time_index", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_CURRENT_TIME_INDEX, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, current_time_index),
      "Use current time for index generation instead of message record"
     },
 
     /* Trace */
     {
-     FLB_CONFIG_MAP_BOOL, "trace_output", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_TRACE_OUTPUT, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, trace_output),
      "When enabled print the Elasticsearch API calls to stdout (for diag only)"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "trace_error", "false",
+     FLB_CONFIG_MAP_BOOL, FLB_ES_CONFIG_PROPERTY_TRACE_ERROR, "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, trace_error),
      "When enabled print the Elasticsearch exception to stderr (for diag only)"
     },
 
     {
-     FLB_CONFIG_MAP_STR, "upstream", NULL,
+     FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_UPSTREAM, NULL,
      0, FLB_FALSE, 0,
      "Path to 'upstream' configuration file (define multiple nodes)"
     },

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -716,7 +716,7 @@ static int cb_es_init(struct flb_output_instance *ins,
     return 0;
 }
 
-static struct flb_elasticsearch_config *flb_elasticsearch_target(
+struct flb_elasticsearch_config *flb_elasticsearch_target(
         struct flb_elasticsearch *ctx, struct flb_upstream_node **node)
 {
     struct flb_elasticsearch_config *ec;

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -69,8 +69,9 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
                               ec->aws_region, ec->aws_service_name,
-                              S3_MODE_SIGNED_PAYLOAD, ec->aws_unsigned_headers,
-                              ec->aws_provider);
+                              S3_MODE_SIGNED_PAYLOAD,
+                              ec->aws_unsigned_headers.value,
+                              ec->aws_provider.value);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");
         return NULL;
@@ -214,15 +215,15 @@ static flb_sds_t es_get_id_value(struct flb_elasticsearch *ctx,
 {
     struct flb_ra_value *rval = NULL;
     flb_sds_t tmp_str;
-    rval = flb_ra_get_value_object(ec->ra_id_key, *map);
+    rval = flb_ra_get_value_object(ec->ra_id_key.value, *map);
     if (rval == NULL) {
         flb_plg_warn(ctx->ins, "the value of %s is missing",
-                     ec->id_key);
+                     ec->id_key.value);
         return NULL;
     }
     else if(rval->o.type != MSGPACK_OBJECT_STR) {
         flb_plg_warn(ctx->ins, "the value of %s is not string",
-                     ec->id_key);
+                     ec->id_key.value);
         flb_ra_key_value_destroy(rval);
         return NULL;
     }
@@ -268,7 +269,7 @@ static int compose_index_header(struct flb_elasticsearch_config *ec,
     if (es_index_custom_len > 0) {
         p = logstash_index + es_index_custom_len;
     } else {
-        p = logstash_index + flb_sds_len(ec->logstash_prefix);
+        p = logstash_index + flb_sds_len(ec->logstash_prefix.value);
     }
     len = p - logstash_index;
     ret = snprintf(p, logstash_index_size - len, "%s",
@@ -281,7 +282,7 @@ static int compose_index_header(struct flb_elasticsearch_config *ec,
     len += strlen(separator_str);
 
     s = strftime(p, logstash_index_size - len,
-                 ec->logstash_dateformat, tm);
+                 ec->logstash_dateformat.value, tm);
     if (s==0) {
         /* exceed limit */
         return -1;
@@ -368,14 +369,14 @@ static int elasticsearch_format(struct flb_config *config,
         return -1;
     }
 
-    if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0) {
+    if (strcasecmp(ec->write_operation.value, FLB_ES_WRITE_OP_UPDATE) == 0) {
         write_op_update = FLB_TRUE;
     }
-    else if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
+    else if (strcasecmp(ec->write_operation.value, FLB_ES_WRITE_OP_UPSERT) == 0) {
         write_op_upsert = FLB_TRUE;
     }
 
-    if (ec->ra_id_key && ec->generate_id == FLB_FALSE &&
+    if (ec->ra_id_key.value && ec->generate_id == FLB_FALSE &&
         (write_op_update == FLB_TRUE || write_op_upsert == FLB_TRUE)) {
         id_key_required = FLB_TRUE;
     }
@@ -391,7 +392,7 @@ static int elasticsearch_format(struct flb_config *config,
         flb_time_get(&tms);
         gmtime_r(&tms.tm.tv_sec, &tm);
         strftime(index_formatted, sizeof(index_formatted) - 1,
-                 ec->index, &tm);
+                 ec->index.value, &tm);
         es_index = index_formatted;
         if (ec->suppress_type_name) {
             index_len = flb_sds_snprintf(&j_index,
@@ -405,7 +406,7 @@ static int elasticsearch_format(struct flb_config *config,
                                          flb_sds_alloc(j_index),
                                          ES_BULK_INDEX_FMT,
                                          ec->es_action,
-                                         es_index, ec->type);
+                                         es_index, ec->type.value);
         }
     }
 
@@ -434,13 +435,13 @@ static int elasticsearch_format(struct flb_config *config,
 
         /* Copy logstash prefix for the per-record fallback path. */
         if (ec->logstash_format == FLB_TRUE) {
-            strncpy(logstash_index, ec->logstash_prefix, sizeof(logstash_index));
+            strncpy(logstash_index, ec->logstash_prefix.value, sizeof(logstash_index));
             logstash_index[sizeof(logstash_index) - 1] = '\0';
         }
 
         es_index_custom_len = 0;
-        if (ec->logstash_prefix_key) {
-            flb_sds_t v = flb_ra_translate(ec->ra_prefix_key,
+        if (ec->logstash_prefix_key.value) {
+            flb_sds_t v = flb_ra_translate(ec->ra_prefix_key.value,
                                            (char *) tag, tag_len,
                                            map, NULL);
             if (v) {
@@ -471,13 +472,14 @@ static int elasticsearch_format(struct flb_config *config,
         msgpack_pack_map(&tmp_pck, map_size + 1);
 
         /* Append the time key */
-        msgpack_pack_str(&tmp_pck, flb_sds_len(ec->time_key));
-        msgpack_pack_str_body(&tmp_pck, ec->time_key, flb_sds_len(ec->time_key));
+        msgpack_pack_str(&tmp_pck, flb_sds_len(ec->time_key.value));
+        msgpack_pack_str_body(&tmp_pck, ec->time_key.value,
+                              flb_sds_len(ec->time_key.value));
 
         /* Format the time */
         gmtime_r(&tms.tm.tv_sec, &tm);
         s = strftime(time_formatted, sizeof(time_formatted) - 1,
-                     ec->time_key_format, &tm);
+                     ec->time_key_format.value, &tm);
         if (ec->time_key_nanos) {
             len = snprintf(time_formatted + s, sizeof(time_formatted) - 1 - s,
                            ".%09" PRIu64 "Z", (uint64_t) tms.tm.tv_nsec);
@@ -491,11 +493,11 @@ static int elasticsearch_format(struct flb_config *config,
         msgpack_pack_str(&tmp_pck, s);
         msgpack_pack_str_body(&tmp_pck, time_formatted, s);
 
-        es_index = ec->index;
+        es_index = ec->index.value;
         if (ec->logstash_format == FLB_TRUE) {
             ret = compose_index_header(ec, es_index_custom_len,
                                        &logstash_index[0], sizeof(logstash_index),
-                                       ec->logstash_prefix_separator, &tm);
+                                       ec->logstash_prefix_separator.value, &tm);
             if (ret < 0) {
                 /* retry with default separator */
                 compose_index_header(ec, es_index_custom_len,
@@ -517,21 +519,22 @@ static int elasticsearch_format(struct flb_config *config,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT,
                                                  ec->es_action,
-                                                 es_index, ec->type);
+                                                 es_index, ec->type.value);
                 }
             }
         }
         else if (ec->current_time_index == FLB_TRUE) {
             /* Make sure we handle index time format for index */
             strftime(index_formatted, sizeof(index_formatted) - 1,
-                     ec->index, &tm);
+                     ec->index.value, &tm);
             es_index = index_formatted;
         }
 
         /* Tag Key */
         if (ec->include_tag_key == FLB_TRUE) {
-            msgpack_pack_str(&tmp_pck, flb_sds_len(ec->tag_key));
-            msgpack_pack_str_body(&tmp_pck, ec->tag_key, flb_sds_len(ec->tag_key));
+            msgpack_pack_str(&tmp_pck, flb_sds_len(ec->tag_key.value));
+            msgpack_pack_str_body(&tmp_pck, ec->tag_key.value,
+                                  flb_sds_len(ec->tag_key.value));
             msgpack_pack_str(&tmp_pck, tag_len);
             msgpack_pack_str_body(&tmp_pck, tag, tag_len);
         }
@@ -570,10 +573,10 @@ static int elasticsearch_format(struct flb_config *config,
                                              flb_sds_alloc(j_index),
                                              ES_BULK_INDEX_FMT_ID,
                                              ec->es_action,
-                                             es_index, ec->type, es_uuid);
+                                             es_index, ec->type.value, es_uuid);
             }
         }
-        if (ec->ra_id_key) {
+        if (ec->ra_id_key.value) {
             id_key_str = es_get_id_value(ctx, ec, &map);
             id_key_safe = FLB_FALSE;
 
@@ -596,7 +599,8 @@ static int elasticsearch_format(struct flb_config *config,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_ID,
                                                  ec->es_action,
-                                                 es_index, ec->type, id_key_str);
+                                                 es_index, ec->type.value,
+                                                 id_key_str);
                 }
             }
             else if (id_key_required == FLB_TRUE) {
@@ -622,7 +626,7 @@ static int elasticsearch_format(struct flb_config *config,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT,
                                                  ec->es_action,
-                                                 es_index, ec->type);
+                                                 es_index, ec->type.value);
                 }
             }
 
@@ -1005,8 +1009,8 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     if (ec->http_user && ec->http_passwd) {
         flb_http_basic_auth(c, ec->http_user, ec->http_passwd);
     }
-    else if (ec->cloud_user && ec->cloud_passwd) {
-        flb_http_basic_auth(c, ec->cloud_user, ec->cloud_passwd);
+    else if (ec->cloud_user.value && ec->cloud_passwd.value) {
+        flb_http_basic_auth(c, ec->cloud_user.value, ec->cloud_passwd.value);
     }
     else if (ec->http_api_key) {
         /* 7 for ApiKey + space */
@@ -1222,12 +1226,14 @@ static int cb_es_exit(void *data, struct flb_config *config)
 static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_INDEX, FLB_ES_DEFAULT_INDEX,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, index),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, index) +
+         offsetof(struct flb_es_str, value),
      "Set an index name"
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TYPE, FLB_ES_DEFAULT_TYPE,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, type),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, type) +
+         offsetof(struct flb_es_str, value),
      "Set the document type property"
     },
     {
@@ -1320,7 +1326,9 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX, FLB_ES_DEFAULT_PREFIX,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix),
+     0, FLB_TRUE,
+     offsetof(struct flb_elasticsearch_config, logstash_prefix) +
+         offsetof(struct flb_es_sds_t, value),
      "When Logstash_Format is enabled, the Index name is composed using a prefix "
      "and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will "
      "become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date "
@@ -1328,12 +1336,16 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_SEPARATOR, "-",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix_separator),
+     0, FLB_TRUE,
+     offsetof(struct flb_elasticsearch_config, logstash_prefix_separator) +
+         offsetof(struct flb_es_sds_t, value),
      "Set a separator between logstash_prefix and date."
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_KEY, NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_prefix_key),
+     0, FLB_TRUE,
+     offsetof(struct flb_elasticsearch_config, logstash_prefix_key) +
+         offsetof(struct flb_es_sds_t, value),
      "When included: the value in the record that belongs to the key will be looked "
      "up and over-write the Logstash_Prefix for index generation. If the key/value "
      "is not found in the record then the Logstash_Prefix option will act as a "
@@ -1341,20 +1353,23 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_LOGSTASH_DATEFORMAT, FLB_ES_DEFAULT_TIME_FMT,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_dateformat),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, logstash_dateformat) +
+         offsetof(struct flb_es_sds_t, value),
      "Time format (based on strftime) to generate the second part of the Index name"
     },
 
     /* Custom Time and Tag keys */
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TIME_KEY, FLB_ES_DEFAULT_TIME_KEY,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key) +
+         offsetof(struct flb_es_sds_t, value),
      "When Logstash_Format is enabled, each record will get a new timestamp field. "
      "The Time_Key property defines the name of that field"
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TIME_KEY_FORMAT, FLB_ES_DEFAULT_TIME_KEYF,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key_format),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, time_key_format) +
+         offsetof(struct flb_es_sds_t, value),
      "When Logstash_Format is enabled, this property defines the format of the "
      "timestamp"
     },
@@ -1371,7 +1386,8 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_TAG_KEY, FLB_ES_DEFAULT_TAG_KEY,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, tag_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, tag_key) +
+         offsetof(struct flb_es_sds_t, value),
      "When Include_Tag_Key is enabled, this property defines the key name for the tag"
     },
     {
@@ -1409,12 +1425,14 @@ static struct flb_config_map config_map[] = {
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_WRITE_OPERATION, "create",
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, write_operation),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, write_operation) +
+         offsetof(struct flb_es_sds_t, value),
      "Operation to use to write in bulk requests"
     },
     {
      FLB_CONFIG_MAP_STR, FLB_ES_CONFIG_PROPERTY_ID_KEY, NULL,
-     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, id_key),
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch_config, id_key) +
+         offsetof(struct flb_es_sds_t, value),
      "If set, _id will be the value of the key from incoming record."
     },
     {

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -21,7 +21,8 @@
 #define FLB_OUT_ES_H
 
 #include <monkey/mk_core/mk_list.h>
-#include <fluent-bit/flb_sds.h>
+
+#include "es_type.h"
 
 #define FLB_ES_DEFAULT_HOST       "127.0.0.1"
 #define FLB_ES_DEFAULT_PORT       9200
@@ -48,19 +49,11 @@ struct flb_upstream;
 struct flb_upstream_ha;
 struct flb_upstream_node;
 struct flb_output_instance;
-struct flb_record_accessor;
-
-#ifdef FLB_HAVE_AWS
-struct flb_aws_provider;
-struct flb_tls;
-#endif
 
 struct flb_elasticsearch_config {
     /* Elasticsearch index (database) and type (table) */
-    char *index;
-    int own_index;
-    char *type;
-    int own_type;
+    struct flb_es_str index;
+    struct flb_es_str type;
     int suppress_type_name;
 
     /* HTTP Auth */
@@ -69,10 +62,8 @@ struct flb_elasticsearch_config {
     char *http_api_key;
 
     /* Elastic Cloud Auth */
-    char *cloud_user;
-    int own_cloud_user;
-    char *cloud_passwd;
-    int own_cloud_passwd;
+    struct flb_es_str cloud_user;
+    struct flb_es_str cloud_passwd;
 
     /* AWS Auth */
 #ifdef FLB_HAVE_AWS
@@ -80,18 +71,13 @@ struct flb_elasticsearch_config {
     char *aws_region;
     char *aws_sts_endpoint;
     char *aws_profile;
-    struct flb_aws_provider *aws_provider;
-    int own_aws_provider;
-    struct flb_aws_provider *base_aws_provider;
-    int own_base_aws_provider;
+    struct flb_es_aws_provider aws_provider;
+    struct flb_es_aws_provider base_aws_provider;
     /* tls instances can't be re-used; aws provider requires a separate one */
-    struct flb_tls *aws_tls;
-    int own_aws_tls;
-    struct flb_tls *aws_sts_tls;
-    int own_aws_sts_tls;
+    struct flb_es_tls aws_tls;
+    struct flb_es_tls aws_sts_tls;
     char *aws_service_name;
-    struct mk_list *aws_unsigned_headers;
-    int own_aws_unsigned_headers;
+    struct flb_es_slist aws_unsigned_headers;
 #endif
 
     /* HTTP Client Setup */
@@ -117,52 +103,41 @@ struct flb_elasticsearch_config {
     int current_time_index;
 
     /* prefix */
-    flb_sds_t logstash_prefix;
-    int own_logstash_prefix;
-    flb_sds_t logstash_prefix_separator;
-    int own_logstash_prefix_separator;
+    struct flb_es_sds_t logstash_prefix;
+    struct flb_es_sds_t logstash_prefix_separator;
 
     /* prefix key */
-    flb_sds_t logstash_prefix_key;
-    int own_logstash_prefix_key;
+    struct flb_es_sds_t logstash_prefix_key;
 
     /* date format */
-    flb_sds_t logstash_dateformat;
-    int own_logstash_dateformat;
+    struct flb_es_sds_t logstash_dateformat;
 
     /* time key */
-    flb_sds_t time_key;
-    int own_time_key;
+    struct flb_es_sds_t time_key;
 
     /* time key format */
-    flb_sds_t time_key_format;
-    int own_time_key_format;
+    struct flb_es_sds_t time_key_format;
 
     /* time key nanoseconds */
     int time_key_nanos;
 
     /* write operation */
-    flb_sds_t write_operation;
-    int own_write_operation;
+    struct flb_es_sds_t write_operation;
     /* write operation elasticsearch operation */
     const char *es_action;
 
     /* id_key */
-    flb_sds_t id_key;
-    int own_id_key;
-    struct flb_record_accessor *ra_id_key;
-    int own_ra_id_key;
+    struct flb_es_sds_t id_key;
+    struct flb_es_record_accessor ra_id_key;
 
     /* include_tag_key */
     int include_tag_key;
-    flb_sds_t tag_key;
-    int own_tag_key;
+    struct flb_es_sds_t tag_key;
 
     /* Elasticsearch HTTP API */
     char uri[256];
 
-    struct flb_record_accessor *ra_prefix_key;
-    int own_ra_prefix_key;
+    struct flb_es_record_accessor ra_prefix_key;
 
     /* Compression mode (gzip) */
     int compress_gzip;

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -184,4 +184,20 @@ struct flb_elasticsearch {
     struct flb_output_instance *ins;
 };
 
+/**
+ *  Get plugin configuration.
+ *  In HA mode, the selected upstream node is also output.
+ *  In HA mode, the returned plugin configuration matches the output upstream node.
+ *
+ *  @param ctx  Non-NULL plugin context.
+ *  @param node Non-NULL output parameter for selected upstream node.
+ *              `*node` is set to NULL if not in HA mode or
+ *              there is no upstream node.
+ *
+ *  @return Configuration of plugin or NULL if error happened or
+ *          there is no upstream node (in HA mode).
+ */
+struct flb_elasticsearch_config *flb_elasticsearch_target(
+        struct flb_elasticsearch *ctx, struct flb_upstream_node **node);
+
 #endif

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -34,10 +34,6 @@
 #define FLB_ES_DEFAULT_TAG_KEY    "flb-key"
 #define FLB_ES_DEFAULT_HTTP_MAX   "512k"
 #define FLB_ES_DEFAULT_HTTPS_PORT 443
-#define FLB_ES_WRITE_OP_INDEX     "index"
-#define FLB_ES_WRITE_OP_CREATE    "create"
-#define FLB_ES_WRITE_OP_UPDATE    "update"
-#define FLB_ES_WRITE_OP_UPSERT    "upsert"
 
 #define FLB_ES_STATUS_SUCCESS          (1 << 0)
 #define FLB_ES_STATUS_IMCOMPLETE       (1 << 1)
@@ -74,7 +70,9 @@ struct flb_elasticsearch_config {
 
     /* Elastic Cloud Auth */
     char *cloud_user;
+    int own_cloud_user;
     char *cloud_passwd;
+    int own_cloud_passwd;
 
     /* AWS Auth */
 #ifdef FLB_HAVE_AWS
@@ -83,12 +81,17 @@ struct flb_elasticsearch_config {
     char *aws_sts_endpoint;
     char *aws_profile;
     struct flb_aws_provider *aws_provider;
+    int own_aws_provider;
     struct flb_aws_provider *base_aws_provider;
+    int own_base_aws_provider;
     /* tls instances can't be re-used; aws provider requires a separate one */
     struct flb_tls *aws_tls;
+    int own_aws_tls;
     struct flb_tls *aws_sts_tls;
+    int own_aws_sts_tls;
     char *aws_service_name;
     struct mk_list *aws_unsigned_headers;
+    int own_aws_unsigned_headers;
 #endif
 
     /* HTTP Client Setup */
@@ -115,40 +118,51 @@ struct flb_elasticsearch_config {
 
     /* prefix */
     flb_sds_t logstash_prefix;
+    int own_logstash_prefix;
     flb_sds_t logstash_prefix_separator;
+    int own_logstash_prefix_separator;
 
     /* prefix key */
     flb_sds_t logstash_prefix_key;
+    int own_logstash_prefix_key;
 
     /* date format */
     flb_sds_t logstash_dateformat;
+    int own_logstash_dateformat;
 
     /* time key */
     flb_sds_t time_key;
+    int own_time_key;
 
     /* time key format */
     flb_sds_t time_key_format;
+    int own_time_key_format;
 
     /* time key nanoseconds */
     int time_key_nanos;
 
     /* write operation */
     flb_sds_t write_operation;
+    int own_write_operation;
     /* write operation elasticsearch operation */
-    flb_sds_t es_action;
+    const char *es_action;
 
     /* id_key */
     flb_sds_t id_key;
+    int own_id_key;
     struct flb_record_accessor *ra_id_key;
+    int own_ra_id_key;
 
     /* include_tag_key */
     int include_tag_key;
     flb_sds_t tag_key;
+    int own_tag_key;
 
     /* Elasticsearch HTTP API */
     char uri[256];
 
     struct flb_record_accessor *ra_prefix_key;
+    int own_ra_prefix_key;
 
     /* Compression mode (gzip) */
     int compress_gzip;

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -20,8 +20,11 @@
 #ifndef FLB_OUT_ES_H
 #define FLB_OUT_ES_H
 
+#include <monkey/mk_core/mk_list.h>
+#include <fluent-bit/flb_sds.h>
+
 #define FLB_ES_DEFAULT_HOST       "127.0.0.1"
-#define FLB_ES_DEFAULT_PORT       92000
+#define FLB_ES_DEFAULT_PORT       9200
 #define FLB_ES_DEFAULT_INDEX      "fluent-bit"
 #define FLB_ES_DEFAULT_TYPE       "_doc"
 #define FLB_ES_DEFAULT_PREFIX     "logstash"
@@ -45,10 +48,23 @@
 #define FLB_ES_STATUS_DUPLICATES       (1 << 6)
 #define FLB_ES_STATUS_ERROR            (1 << 7)
 
-struct flb_elasticsearch {
+struct flb_upstream;
+struct flb_upstream_ha;
+struct flb_upstream_node;
+struct flb_output_instance;
+struct flb_record_accessor;
+
+#ifdef FLB_HAVE_AWS
+struct flb_aws_provider;
+struct flb_tls;
+#endif
+
+struct flb_elasticsearch_config {
     /* Elasticsearch index (database) and type (table) */
     char *index;
+    int own_index;
     char *type;
+    int own_type;
     int suppress_type_name;
 
     /* HTTP Auth */
@@ -70,9 +86,7 @@ struct flb_elasticsearch {
     struct flb_aws_provider *base_aws_provider;
     /* tls instances can't be re-used; aws provider requires a separate one */
     struct flb_tls *aws_tls;
-    /* one for the standard chain provider, one for sts assume role */
     struct flb_tls *aws_sts_tls;
-    char *aws_session_name;
     char *aws_service_name;
     struct mk_list *aws_unsigned_headers;
 #endif
@@ -118,7 +132,6 @@ struct flb_elasticsearch {
     /* time key nanoseconds */
     int time_key_nanos;
 
-
     /* write operation */
     flb_sds_t write_operation;
     /* write operation elasticsearch operation */
@@ -140,8 +153,18 @@ struct flb_elasticsearch {
     /* Compression mode (gzip) */
     int compress_gzip;
 
-    /* Upstream connection to the backend server */
+    /* List entry data for flb_elasticsearch->configs list */
+    struct mk_list _head;
+};
+
+struct flb_elasticsearch {
+    /* if HA mode is enabled */
+    int ha_mode;
+    struct flb_upstream_ha *ha;
+
+    /* Upstream handler and config context for single mode (no HA) */
     struct flb_upstream *u;
+    struct mk_list configs;
 
     /* Plugin output instance reference */
     struct flb_output_instance *ins;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -21,23 +21,167 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_signv4.h>
 
-#include "es_conf.h"
-#include "es_conf_parse.h"
 #include "es.h"
+#include "es_conf_parse.h"
+#include "es_conf_prop.h"
+#include "es_conf.h"
+
+static const char * const es_default_path    = "";
+static const char * const es_write_op_index  = FLB_ES_WRITE_OP_INDEX;
+static const char * const es_write_op_create = FLB_ES_WRITE_OP_CREATE;
+static const char * const es_write_op_update = FLB_ES_WRITE_OP_UPDATE;
+static const char * const es_write_op_upsert = FLB_ES_WRITE_OP_UPSERT;
+
+static int config_set_ra_id_key(flb_sds_t id_key, struct flb_elasticsearch_config *ec,
+                                struct flb_elasticsearch *ctx)
+{
+    if (!id_key) {
+        return 0;
+    }
+
+    ec->ra_id_key = flb_ra_create(id_key, FLB_FALSE);
+    if (ec->ra_id_key == NULL) {
+        flb_plg_error(ctx->ins, "could not create record accessor for Id Key");
+        return -1;
+    }
+    ec->own_ra_id_key = FLB_TRUE;
+
+    if (ec->generate_id == FLB_TRUE) {
+        flb_plg_warn(ctx->ins, "Generate_ID is ignored when ID_key is set");
+        ec->generate_id = FLB_FALSE;
+    }
+
+    return 0;
+}
+
+static int config_set_es_action(const char *write_operation,
+                                const struct flb_record_accessor *ra_id_key,
+                                int generate_id,
+                                struct flb_elasticsearch_config *ec,
+                                struct flb_elasticsearch *ctx)
+{
+    if (!write_operation) {
+        return 0;
+    }
+
+    if (strcasecmp(write_operation, es_write_op_index) == 0) {
+        ec->es_action = es_write_op_index;
+    }
+    else if (strcasecmp(write_operation, es_write_op_create) == 0) {
+        ec->es_action = es_write_op_create;
+    }
+    else if (strcasecmp(write_operation, es_write_op_update) == 0
+             || strcasecmp(write_operation, es_write_op_upsert) == 0) {
+        ec->es_action = es_write_op_update;
+    }
+    else {
+        flb_plg_error(ctx->ins,
+                      "wrong Write_Operation (should be one of index, create, update, upsert)");
+        return -1;
+    }
+
+    if (strcasecmp(ec->es_action, es_write_op_update) == 0
+        && !ra_id_key
+        && generate_id == FLB_FALSE) {
+        flb_plg_error(ctx->ins,
+                      "Id_Key or Generate_Id must be set when Write_Operation update or upsert");
+        return -1;
+    }
+
+    return 0;
+}
+
+static size_t config_adjust_buffer_size(size_t buffer_size)
+{
+    /* HTTP Payload (response) maximum buffer size (0 == unlimited) */
+    if (buffer_size == -1) {
+        return 0;
+    }
+    return buffer_size;
+}
+
+static int config_is_compressed_gzip(const char *compress)
+{
+    if (strcasecmp(compress, "gzip") == 0) {
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
+static int config_set_pipeline(const char *path, const char *pipeline,
+                               struct flb_elasticsearch_config *ec)
+{
+    int ret;
+
+    if (!path) {
+        path = es_default_path;
+    }
+
+    if (pipeline && flb_str_emptyval(pipeline) != FLB_TRUE) {
+        ret = snprintf(ec->uri, sizeof(ec->uri) - 1, "%s/_bulk/?pipeline=%s", path,
+                       pipeline);
+    }
+    else {
+        ret = snprintf(ec->uri, sizeof(ec->uri) - 1, "%s/_bulk", path);
+    }
+
+    if (ret < 0 || ret >= sizeof(ec->uri)) {
+        return -1;
+    }
+    return 0;
+}
+
+static int config_set_ra_prefix_key(flb_sds_t logstash_prefix_key,
+                                    struct flb_elasticsearch_config *ec,
+                                    struct flb_elasticsearch *ctx)
+{
+    size_t len;
+    char *buf;
+
+    if (!logstash_prefix_key) {
+        return 0;
+    }
+
+    if (logstash_prefix_key[0] != '$') {
+        len = flb_sds_len(logstash_prefix_key);
+        buf = flb_malloc(len + 2);
+        if (!buf) {
+            flb_errno();
+            return -1;
+        }
+        buf[0] = '$';
+        memcpy(buf + 1, logstash_prefix_key, len);
+        buf[len + 1] = '\0';
+
+        ec->ra_prefix_key = flb_ra_create(buf, FLB_TRUE);
+        ec->own_ra_prefix_key = FLB_TRUE;
+        flb_free(buf);
+    }
+    else {
+        ec->ra_prefix_key = flb_ra_create(logstash_prefix_key, FLB_TRUE);
+        ec->own_ra_prefix_key = FLB_TRUE;
+    }
+
+    if (!ec->ra_prefix_key) {
+        flb_plg_error(ctx->ins, "invalid logstash_prefix_key pattern '%s'",
+                      logstash_prefix_key);
+        return -1;
+    }
+
+    return 0;
+}
 
 static int config_set_properties(struct flb_elasticsearch_config *ec,
                                  struct flb_elasticsearch *ctx,
                                  struct flb_config *config)
 {
-    size_t len;
-    ssize_t ret;
-    char *buf;
+    int ret;
     const char *tmp;
-    const char *path;
     struct flb_uri *uri = ctx->ins->host.uri;
     struct flb_uri_field *f_index = NULL;
     struct flb_uri_field *f_type = NULL;
@@ -45,14 +189,13 @@ static int config_set_properties(struct flb_elasticsearch_config *ec,
     if (uri) {
         if (uri->count >= 2) {
             f_index = flb_uri_get(uri, 0);
-            f_type  = flb_uri_get(uri, 1);
+            f_type = flb_uri_get(uri, 1);
         }
     }
 
     /* handle cloud_id */
-    ret = flb_es_conf_set_cloud_auth(flb_output_get_property("cloud_id",
-                                                             ctx->ins),
-                                     ctx);
+    ret = flb_es_conf_set_cloud_auth(
+            flb_output_get_property(FLB_ES_CONFIG_PROPERTY_CLOUD_ID, ctx->ins), ctx);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "cannot configure cloud_id");
         return -1;
@@ -65,21 +208,21 @@ static int config_set_properties(struct flb_elasticsearch_config *ec,
         return -1;
     }
 
+    ec->buffer_size = config_adjust_buffer_size(ec->buffer_size);
+
     /* handle cloud_auth */
     ret = flb_es_conf_set_cloud_credentials(
-            flb_output_get_property("cloud_auth", ctx->ins), ec);
+            flb_output_get_property(FLB_ES_CONFIG_PROPERTY_CLOUD_AUTH, ctx->ins), ec);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "cannot configure cloud_auth");
         return -1;
     }
 
     /* Compress (gzip) */
-    tmp = flb_output_get_property("compress", ctx->ins);
+    tmp = flb_output_get_property(FLB_ES_CONFIG_PROPERTY_COMPRESS, ctx->ins);
     ec->compress_gzip = FLB_FALSE;
     if (tmp) {
-        if (strcasecmp(tmp, "gzip") == 0) {
-            ec->compress_gzip = FLB_TRUE;
-        }
+        ec->compress_gzip = config_is_compressed_gzip(tmp);
     }
 
     /* Set manual Index and Type */
@@ -93,82 +236,30 @@ static int config_set_properties(struct flb_elasticsearch_config *ec,
         ec->own_type = FLB_TRUE;
     }
 
-    /* HTTP Payload (response) maximum buffer size (0 == unlimited) */
-    if (ec->buffer_size == -1) {
-        ec->buffer_size = 0;
+    /* Elasticsearch: path and pipeline */
+    ret = config_set_pipeline(
+            flb_output_get_property(FLB_ES_CONFIG_PROPERTY_PATH, ctx->ins),
+            flb_output_get_property(FLB_ES_CONFIG_PROPERTY_PIPELINE, ctx->ins),
+            ec);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "cannot configure path and/or pipeline");
+        return -1;
     }
 
-    /* Elasticsearch: Path */
-    path = flb_output_get_property("path", ctx->ins);
-    if (!path) {
-        path = "";
+    ret = config_set_ra_id_key(ec->id_key, ec, ctx);
+    if (ret != 0) {
+        return -1;
     }
 
-    /* Elasticsearch: Pipeline */
-    tmp = flb_output_get_property("pipeline", ctx->ins);
-    if (tmp) {
-        snprintf(ec->uri, sizeof(ec->uri) - 1, "%s/_bulk/?pipeline=%s", path, tmp);
-    }
-    else {
-        snprintf(ec->uri, sizeof(ec->uri) - 1, "%s/_bulk", path);
+    ret = config_set_es_action(ec->write_operation, ec->ra_id_key, ec->generate_id, ec,
+                               ctx);
+    if (ret != 0) {
+        return -1;
     }
 
-    if (ec->id_key) {
-        ec->ra_id_key = flb_ra_create(ec->id_key, FLB_FALSE);
-        if (ec->ra_id_key == NULL) {
-            flb_plg_error(ctx->ins, "could not create record accessor for Id Key");
-        }
-        if (ec->generate_id == FLB_TRUE) {
-            flb_plg_warn(ctx->ins, "Generate_ID is ignored when ID_key is set");
-            ec->generate_id = FLB_FALSE;
-        }
-    }
-
-    if (ec->write_operation) {
-        if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_INDEX) == 0) {
-            ec->es_action = flb_strdup(FLB_ES_WRITE_OP_INDEX);
-        }
-        else if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_CREATE) == 0) {
-            ec->es_action = flb_strdup(FLB_ES_WRITE_OP_CREATE);
-        }
-        else if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0
-            || strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
-            ec->es_action = flb_strdup(FLB_ES_WRITE_OP_UPDATE);
-        }
-        else {
-            flb_plg_error(ctx->ins, "wrong Write_Operation (should be one of index, create, update, upsert)");
-            return -1;
-        }
-        if (strcasecmp(ec->es_action, FLB_ES_WRITE_OP_UPDATE) == 0
-            && !ec->ra_id_key && ec->generate_id == FLB_FALSE) {
-            flb_plg_error(ctx->ins, "Id_Key or Generate_Id must be set when Write_Operation update or upsert");
-            return -1;
-        }
-    }
-
-    if (ec->logstash_prefix_key) {
-        if (ec->logstash_prefix_key[0] != '$') {
-            len = flb_sds_len(ec->logstash_prefix_key);
-            buf = flb_malloc(len + 2);
-            if (!buf) {
-                flb_errno();
-                return -1;
-            }
-            buf[0] = '$';
-            memcpy(buf + 1, ec->logstash_prefix_key, len);
-            buf[len + 1] = '\0';
-
-            ec->ra_prefix_key = flb_ra_create(buf, FLB_TRUE);
-            flb_free(buf);
-        }
-        else {
-            ec->ra_prefix_key = flb_ra_create(ec->logstash_prefix_key, FLB_TRUE);
-        }
-
-        if (!ec->ra_prefix_key) {
-            flb_plg_error(ctx->ins, "invalid logstash_prefix_key pattern '%s'", tmp);
-            return -1;
-        }
+    ret = config_set_ra_prefix_key(ec->logstash_prefix_key, ec, ctx);
+    if (ret != 0) {
+        return -1;
     }
 
 #ifdef FLB_HAVE_AWS
@@ -179,12 +270,334 @@ static int config_set_properties(struct flb_elasticsearch_config *ec,
     }
 
     ret = flb_es_conf_set_aws_provider(
-            flb_output_get_property("aws_external_id", ctx->ins),
-            flb_output_get_property("aws_role_arn", ctx->ins),
+            flb_output_get_property(FLB_ES_CONFIG_PROPERTY_AWS_EXTERNAL_ID, ctx->ins),
+            flb_output_get_property(FLB_ES_CONFIG_PROPERTY_AWS_ROLE_ARN, ctx->ins),
             ec, ctx, config);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "cannot configure AWS authentication");
         return -1;
+    }
+#endif
+
+    return 0;
+}
+
+static int parse_bool_property(struct flb_elasticsearch *ctx,
+                               const char *property, const char *value,
+                               int *out)
+{
+    int ret;
+    ret = flb_utils_bool(value);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "invalid value for boolean property '%s=%s'",
+                      property, value);
+        return -1;
+    }
+    *out = ret;
+    return 0;
+}
+
+static int config_set_node_properties(struct flb_upstream_node *node,
+                                      struct flb_elasticsearch_config *ec,
+                                      struct flb_elasticsearch_config *base,
+                                      struct flb_elasticsearch *ctx,
+                                      struct flb_config *config)
+{
+    const char *tmp;
+    int ret;
+    const char *path;
+
+#ifdef FLB_HAVE_AWS
+    const char *aws_external_id = NULL;
+    const char *aws_role_arn = NULL;
+    int aws_provider_node = FLB_FALSE;
+#endif
+
+    /* Copy base configuration */
+    *ec = *base;
+    ec->own_index = FLB_FALSE;
+    ec->own_type = FLB_FALSE;
+    ec->own_cloud_user = FLB_FALSE;
+    ec->own_cloud_passwd = FLB_FALSE;
+
+#ifdef FLB_HAVE_AWS
+    ec->own_base_aws_provider = FLB_FALSE;
+    ec->own_aws_provider = FLB_FALSE;
+    ec->own_aws_tls = FLB_FALSE;
+    ec->own_aws_sts_tls = FLB_FALSE;
+    ec->own_aws_unsigned_headers = FLB_FALSE;
+#endif
+
+    ec->own_logstash_prefix = FLB_FALSE;
+    ec->own_logstash_prefix_separator = FLB_FALSE;
+    ec->own_logstash_prefix_key = FLB_FALSE;
+    ec->own_logstash_dateformat = FLB_FALSE;
+    ec->own_time_key = FLB_FALSE;
+    ec->own_time_key_format = FLB_FALSE;
+    ec->own_write_operation = FLB_FALSE;
+    ec->own_id_key = FLB_FALSE;
+    ec->own_ra_id_key = FLB_FALSE;
+    ec->own_ra_prefix_key = FLB_FALSE;
+    ec->own_tag_key = FLB_FALSE;
+    mk_list_entry_init(&ec->_head);
+
+    /* Overwrite configuration from upstream node properties */
+
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_INDEX, node);
+    if (tmp) {
+        ec->index = (char *)tmp;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TYPE, node);
+    if (tmp) {
+        ec->type = (char *)tmp;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_SUPPRESS_TYPE_NAME, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_SUPPRESS_TYPE_NAME,
+                                   tmp, &ec->suppress_type_name)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_HTTP_USER, node);
+    if (tmp) {
+        ec->http_user = (char *)tmp;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_HTTP_PASSWD, node);
+    if (tmp) {
+        ec->http_passwd = (char *)tmp;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_HTTP_API_KEY, node);
+    if (tmp) {
+        ec->http_api_key = (char *)tmp;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_GENERATE_ID, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_GENERATE_ID,
+                                   tmp, &ec->generate_id)) {
+        return -1;
+    }
+
+#ifdef FLB_HAVE_AWS
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_AUTH, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_AWS_AUTH,
+                                   tmp, &ec->has_aws_auth)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_REGION, node);
+    if (tmp) {
+        ec->aws_region = (char *)tmp;
+        aws_provider_node = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_STS_ENDPOINT, node);
+    if (tmp) {
+        ec->aws_sts_endpoint = (char *)tmp;
+        aws_provider_node = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_SERVICE_NAME, node);
+    if (tmp) {
+        ec->aws_service_name = (char *)tmp;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_PROFILE, node);
+    if (tmp) {
+        ec->aws_profile = (char *)tmp;
+        aws_provider_node = FLB_TRUE;
+    }
+    if (ec->has_aws_auth) {
+        tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_EXTERNAL_ID,
+                                             node);
+        if (tmp) {
+            aws_external_id = tmp;
+            aws_provider_node = FLB_TRUE;
+        }
+        else {
+            aws_external_id = flb_output_get_property(
+                    FLB_ES_CONFIG_PROPERTY_AWS_EXTERNAL_ID, ctx->ins);
+        }
+        tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_AWS_ROLE_ARN, node);
+        if (tmp) {
+            aws_role_arn = tmp;
+            aws_provider_node = FLB_TRUE;
+        }
+        else {
+            aws_role_arn = flb_output_get_property(FLB_ES_CONFIG_PROPERTY_AWS_ROLE_ARN,
+                                                   ctx->ins);
+        }
+    }
+#endif
+
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_LOGSTASH_FORMAT, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_LOGSTASH_FORMAT,
+                                   tmp, &ec->logstash_format)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX, node);
+    if (tmp) {
+        ec->logstash_prefix = flb_sds_create(tmp);
+        if (ec->logstash_prefix == NULL) {
+            return -1;
+        }
+        ec->own_logstash_prefix = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_SEPARATOR,
+                                         node);
+    if (tmp) {
+        ec->logstash_prefix_separator = flb_sds_create(tmp);
+        if (ec->logstash_prefix_separator == NULL) {
+            return -1;
+        }
+        ec->own_logstash_prefix_separator = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_LOGSTASH_DATEFORMAT,
+                                         node);
+    if (tmp) {
+        ec->logstash_dateformat = flb_sds_create(tmp);
+        if (ec->logstash_dateformat == NULL) {
+            return -1;
+        }
+        ec->own_logstash_dateformat = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TIME_KEY, node);
+    if (tmp) {
+        ec->time_key = flb_sds_create(tmp);
+        if (ec->time_key == NULL) {
+            return -1;
+        }
+        ec->own_time_key = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TIME_KEY_FORMAT, node);
+    if (tmp) {
+        ec->time_key_format = flb_sds_create(tmp);
+        if (ec->time_key_format == NULL) {
+            return -1;
+        }
+        ec->own_time_key_format = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TIME_KEY_NANOS, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_TIME_KEY_NANOS,
+                                   tmp, &ec->time_key_nanos)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_INCLUDE_TAG_KEY, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_INCLUDE_TAG_KEY,
+                                   tmp, &ec->include_tag_key)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TAG_KEY, node);
+    if (tmp) {
+        ec->tag_key = flb_sds_create(tmp);
+        if (ec->tag_key == NULL) {
+            return -1;
+        }
+        ec->own_tag_key = FLB_TRUE;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_BUFFER_SIZE, node);
+    if (tmp) {
+        ec->buffer_size = config_adjust_buffer_size(flb_utils_size_to_bytes(tmp));
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_REPLACE_DOTS, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_REPLACE_DOTS,
+                                   tmp, &ec->replace_dots)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_CURRENT_TIME_INDEX, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_CURRENT_TIME_INDEX,
+                                   tmp, &ec->current_time_index)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TRACE_OUTPUT, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_TRACE_OUTPUT,
+                                   tmp, &ec->trace_output)) {
+        return -1;
+    }
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_TRACE_ERROR, node);
+    if (tmp && parse_bool_property(ctx, FLB_ES_CONFIG_PROPERTY_TRACE_ERROR,
+                                   tmp, &ec->trace_error)) {
+        return -1;
+    }
+
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_KEY,
+                                         node);
+    if (tmp) {
+        ec->logstash_prefix_key = flb_sds_create(tmp);
+        if (ec->logstash_prefix_key == NULL) {
+            return -1;
+        }
+        ec->own_logstash_prefix_key = FLB_TRUE;
+        ret = config_set_ra_prefix_key(ec->logstash_prefix_key, ec, ctx);
+        if (ret != 0) {
+            return -1;
+        }
+    }
+
+    /* handle cloud_auth */
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_CLOUD_AUTH, node);
+    if (tmp) {
+        ret = flb_es_conf_set_cloud_credentials(tmp, ec);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "cannot configure cloud_auth");
+            return -1;
+        }
+    }
+
+    /* Compress (gzip) */
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_COMPRESS, node);
+    if (tmp) {
+        ec->compress_gzip = config_is_compressed_gzip(tmp);
+    }
+
+    /* Elasticsearch: path and pipeline */
+    path = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_PATH, node);
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_PIPELINE, node);
+    if (path || tmp) {
+        if (!path) {
+            path = flb_output_get_property(FLB_ES_CONFIG_PROPERTY_PATH, ctx->ins);
+        }
+        if (!tmp) {
+            tmp = flb_output_get_property(FLB_ES_CONFIG_PROPERTY_PIPELINE, ctx->ins);
+        }
+        ret = config_set_pipeline(path, tmp, ec);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "cannot configure path and/or pipeline");
+            return -1;
+        }
+    }
+
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_ID_KEY, node);
+    if (tmp) {
+        ec->id_key = flb_sds_create(tmp);
+        if (ec->id_key == NULL) {
+            return -1;
+        }
+        ec->own_id_key = FLB_TRUE;
+        ret = config_set_ra_id_key(ec->id_key, ec, ctx);
+        if (ret != 0) {
+            return -1;
+        }
+    }
+
+    tmp = flb_upstream_node_get_property(FLB_ES_CONFIG_PROPERTY_WRITE_OPERATION, node);
+    if (tmp) {
+        ec->write_operation = flb_sds_create(tmp);
+        if (ec->write_operation == NULL) {
+            return -1;
+        }
+        ec->own_write_operation = FLB_TRUE;
+    }
+
+    ret = config_set_es_action(ec->write_operation, ec->ra_id_key,
+                               ec->generate_id, ec, ctx);
+    if (ret != 0) {
+        return -1;
+    }
+
+#ifdef FLB_HAVE_AWS
+    if ((base->has_aws_auth != ec->has_aws_auth)
+        || (base->has_aws_auth == FLB_TRUE
+            && ec->has_aws_auth == FLB_TRUE
+            && aws_provider_node == FLB_TRUE)) {
+        ret = flb_es_conf_set_aws_provider(aws_external_id, aws_role_arn, ec, ctx,
+                                           config);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "cannot configure AWS authentication");
+            return -1;
+        }
     }
 #endif
 
@@ -204,43 +617,80 @@ static int config_validate(struct flb_elasticsearch_config* ec,
 
 static void elasticsearch_config_destroy(struct flb_elasticsearch_config *ec)
 {
-    if (ec->ra_id_key) {
+    if (ec->own_tag_key == FLB_TRUE) {
+        flb_sds_destroy(ec->tag_key);
+    }
+
+    if (ec->ra_id_key && ec->own_ra_id_key == FLB_TRUE) {
         flb_ra_destroy(ec->ra_id_key);
         ec->ra_id_key = NULL;
     }
-    if (ec->es_action) {
-        flb_free(ec->es_action);
+
+    if (ec->own_write_operation == FLB_TRUE) {
+        flb_sds_destroy(ec->write_operation);
+    }
+
+    if (ec->own_id_key == FLB_TRUE) {
+        flb_sds_destroy(ec->id_key);
+    }
+
+    if (ec->own_time_key_format == FLB_TRUE) {
+        flb_sds_destroy(ec->time_key_format);
+    }
+
+    if (ec->own_time_key == FLB_TRUE) {
+        flb_sds_destroy(ec->time_key);
+    }
+
+    if (ec->own_logstash_dateformat == FLB_TRUE) {
+        flb_sds_destroy(ec->logstash_dateformat);
+    }
+
+    if (ec->own_logstash_prefix_key == FLB_TRUE) {
+        flb_sds_destroy(ec->logstash_prefix_key);
+    }
+
+    if (ec->own_logstash_prefix_separator == FLB_TRUE) {
+        flb_sds_destroy(ec->logstash_prefix_separator);
+    }
+
+    if (ec->own_logstash_prefix == FLB_TRUE) {
+        flb_sds_destroy(ec->logstash_prefix);
     }
 
 #ifdef FLB_HAVE_AWS
-    if (ec->base_aws_provider) {
+    if (ec->base_aws_provider && ec->own_base_aws_provider == FLB_TRUE) {
         flb_aws_provider_destroy(ec->base_aws_provider);
     }
 
-    if (ec->aws_provider) {
+    if (ec->aws_provider && ec->own_aws_provider == FLB_TRUE) {
         flb_aws_provider_destroy(ec->aws_provider);
     }
 
-    if (ec->aws_tls) {
+    if (ec->aws_tls && ec->own_aws_tls == FLB_TRUE) {
         flb_tls_destroy(ec->aws_tls);
     }
 
-    if (ec->aws_sts_tls) {
+    if (ec->aws_sts_tls && ec->own_aws_sts_tls == FLB_TRUE) {
         flb_tls_destroy(ec->aws_sts_tls);
     }
 
-    if (ec->aws_unsigned_headers) {
+    if (ec->aws_unsigned_headers && ec->own_aws_unsigned_headers == FLB_TRUE) {
         flb_slist_destroy(ec->aws_unsigned_headers);
         flb_free(ec->aws_unsigned_headers);
     }
 #endif
 
-    if (ec->ra_prefix_key) {
+    if (ec->ra_prefix_key && ec->own_ra_prefix_key == FLB_TRUE) {
         flb_ra_destroy(ec->ra_prefix_key);
     }
 
-    flb_free(ec->cloud_passwd);
-    flb_free(ec->cloud_user);
+    if (ec->own_cloud_passwd == FLB_TRUE) {
+        flb_free(ec->cloud_passwd);
+    }
+    if (ec->own_cloud_user == FLB_TRUE) {
+        flb_free(ec->cloud_user);
+    }
 
     if (ec->own_type == FLB_TRUE) {
         flb_free(ec->type);
@@ -258,10 +708,12 @@ int es_config_ha(const char *upstream_file, struct flb_elasticsearch *ctx,
 {
     int ret;
     struct mk_list *head;
+    struct mk_list *tmp;
     struct flb_upstream_node *node;
     struct flb_elasticsearch_config *ec;
+    struct flb_elasticsearch_config *node_ec;
 
-    /* Create elasticsearch_config context */
+    /* Create main elasticsearch_config context */
     ec = flb_calloc(1, sizeof(struct flb_elasticsearch_config));
     if (!ec) {
         flb_errno();
@@ -269,7 +721,7 @@ int es_config_ha(const char *upstream_file, struct flb_elasticsearch *ctx,
         return -1;
     }
 
-    /* Read properties into elasticsearch_config context */
+    /* Read properties into main elasticsearch_config context */
     ret = config_set_properties(ec, ctx, config);
     if (ret != 0) {
         elasticsearch_config_destroy(ec);
@@ -293,15 +745,70 @@ int es_config_ha(const char *upstream_file, struct flb_elasticsearch *ctx,
     }
 
     /*
-     * Iterate over upstreams nodes and link shared elasticsearch_config context
-     * with each node
+     * Iterate over upstreams nodes and create elasticsearch_config context
+     * for each node
      */
     mk_list_foreach(head, &ctx->ha->nodes) {
         node = mk_list_entry(head, struct flb_upstream_node, _head);
+        /* Create elasticsearch_config context for the upstream node */
+        node_ec = flb_calloc(1, sizeof(struct flb_elasticsearch_config));
+        if (!node_ec) {
+            flb_errno();
+            flb_plg_error(ctx->ins, "failed upstream node config allocation for %s node",
+                          node->name);
+            ret = -1;
+            break;
+        }
+
+        /*
+         * Fill elasticsearch_config context of the upstream node from:
+         * 1. main elasticsearch_config context
+         * 2. upstream node configuration section
+         */
+        ret = config_set_node_properties(node, node_ec, ec, ctx, config);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed upstream node configuration for %s node",
+                          node->name);
+            elasticsearch_config_destroy(node_ec);
+            break;
+        }
+
+        /* Validate configuration of the upstream node */
+        ret = config_validate(node_ec, ctx);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed upstream node configuration validation for %s node",
+                          node->name);
+            elasticsearch_config_destroy(node_ec);
+            break;
+        }
+
+        /* Register allocated elasticsearch_config context for later cleanup */
+        mk_list_add(&node_ec->_head, &ctx->configs);
+
         /* Set elasticsearch_config context into the node opaque data */
-        flb_upstream_node_set_data(ec, node);
+        flb_upstream_node_set_data(node_ec, node);
     }
 
+    if (ret != 0) {
+        /* Nullify each upstream node elasticsearch_config context */
+        mk_list_foreach(head, &ctx->ha->nodes) {
+            node = mk_list_entry(head, struct flb_upstream_node, _head);
+            flb_upstream_node_set_data(NULL, node);
+        }
+
+        /* Cleanup elasticsearch_config contexts which were created */
+        mk_list_foreach_safe(head, tmp, &ctx->configs) {
+            node_ec = mk_list_entry(head, struct flb_elasticsearch_config, _head);
+            mk_list_del(&node_ec->_head);
+            elasticsearch_config_destroy(node_ec);
+        }
+
+        flb_upstream_ha_destroy(ctx->ha);
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    /* Register allocated elasticsearch_config context for later cleanup */
     mk_list_add(&ec->_head, &ctx->configs);
 
     return 0;
@@ -397,7 +904,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     mk_list_init(&ctx->configs);
 
     /* Configure HA or simple mode ? */
-    upstream_file = flb_output_get_property("upstream", ins);
+    upstream_file = flb_output_get_property(FLB_ES_CONFIG_PROPERTY_UPSTREAM, ins);
     if (upstream_file) {
         ret = es_config_ha(upstream_file, ctx, config);
     }

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_signv4.h>
+#include <fluent-bit/flb_upstream_node.h>
 
 #include "es.h"
 #include "es_conf_parse.h"

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -456,3 +456,19 @@ void flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 
     flb_free(ctx);
 }
+
+struct flb_elasticsearch_config *flb_es_upstream_conf(struct flb_elasticsearch *ctx,
+                                                      struct flb_upstream_node *node)
+{
+    if (!ctx) {
+        return NULL;
+    }
+    if (node) {
+        /* Get elasticsearch_config stored in node opaque data */
+        return flb_upstream_node_get_data(node);
+    }
+    if (mk_list_is_empty(&ctx->configs) == 0) {
+        return NULL;
+    }
+    return mk_list_entry_last(&ctx->configs, struct flb_elasticsearch_config, _head);
+}

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -17,147 +17,30 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_mem.h>
-#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_signv4.h>
-#include <fluent-bit/flb_aws_credentials.h>
-#include <fluent-bit/flb_base64.h>
 
-#include "es.h"
 #include "es_conf.h"
+#include "es_conf_parse.h"
+#include "es.h"
 
-/*
- * extract_cloud_host extracts the public hostname
- * of a deployment from a Cloud ID string.
- *
- * The Cloud ID string has the format "<deployment_name>:<base64_info>".
- * Once decoded, the "base64_info" string has the format "<deployment_region>$<elasticsearch_hostname>$<kibana_hostname>"
- * and the function returns "<elasticsearch_hostname>.<deployment_region>" token.
- */
-static flb_sds_t extract_cloud_host(struct flb_elasticsearch *ctx,
-                                    const char *cloud_id)
+static int config_set_properties(struct flb_elasticsearch_config *ec,
+                                 struct flb_elasticsearch *ctx,
+                                 struct flb_config *config)
 {
-
-    char *colon;
-    char *region;
-    char *host;
-    char *port = NULL;
-    char buf[256] = {0};
-    char cloud_host_buf[256] = {0};
-    const char dollar[2] = "$";
     size_t len;
-    int ret;
-
-    /* keep only part after first ":" */
-    colon = strchr(cloud_id, ':');
-    if (colon == NULL) {
-        return NULL;
-    }
-    colon++;
-
-    /* decode base64 */
-    ret = flb_base64_decode((unsigned char *)buf, sizeof(buf), &len, (unsigned char *)colon, strlen(colon));
-    if (ret) {
-        flb_plg_error(ctx->ins, "cannot decode cloud_id");
-        return NULL;
-    }
-    region = strtok(buf, dollar);
-    if (region == NULL) {
-        return NULL;
-    }
-    host = strtok(NULL, dollar);
-    if (host == NULL) {
-        return NULL;
-    }
-
-    /*
-     * Some cloud id format is "<deployment_region>$<elasticsearch_hostname>:<port>$<kibana_hostname>" .
-     *   e.g. https://github.com/elastic/beats/blob/v8.4.1/libbeat/cloudid/cloudid_test.go#L60
-     *
-     * It means the variable "host" can contains ':' and port number.
-     */
-    colon = strchr(host, ':');
-    if (colon != NULL) {
-        /* host contains host number */
-        *colon = '\0'; /* remove port number from host */
-        port = colon+1;
-    }
-
-    strcpy(cloud_host_buf, host);
-    strcat(cloud_host_buf, ".");
-    strcat(cloud_host_buf, region);
-    if (port != NULL) {
-        strcat(cloud_host_buf, ":");
-        strcat(cloud_host_buf, port);
-    }
-    return flb_sds_create(cloud_host_buf);
-}
-
-/*
- * set_cloud_credentials gets a cloud_auth
- * and sets the context's cloud_user and cloud_passwd.
- * Example:
- *   cloud_auth = elastic:ZXVyb3BxxxxxxZTA1Ng
- *   ---->
- *   cloud_user = elastic
- *   cloud_passwd = ZXVyb3BxxxxxxZTA1Ng
- */
-static void set_cloud_credentials(struct flb_elasticsearch *ctx,
-                                  const char *cloud_auth)
-{
-    /* extract strings */
-    int items = 0;
-    struct mk_list *toks;
-    struct mk_list *head;
-    struct flb_split_entry *entry;
-    toks = flb_utils_split((const char *)cloud_auth, ':', -1);
-    mk_list_foreach(head, toks) {
-        items++;
-        entry = mk_list_entry(head, struct flb_split_entry, _head);
-        if (items == 1) {
-          ctx->cloud_user = flb_strdup(entry->value);
-        }
-        if (items == 2) {
-          ctx->cloud_passwd = flb_strdup(entry->value);
-        }
-    }
-    flb_utils_split_free(toks);
-}
-
-struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
-                                             struct flb_config *config)
-{
-    int len;
-    int io_flags = 0;
     ssize_t ret;
     char *buf;
     const char *tmp;
     const char *path;
-#ifdef FLB_HAVE_AWS
-    char *aws_role_arn = NULL;
-    char *aws_external_id = NULL;
-    char *aws_session_name = NULL;
-#endif
-    char *cloud_port_char;
-    char *cloud_host = NULL;
-    int cloud_host_port = 0;
-    int cloud_port = FLB_ES_DEFAULT_HTTPS_PORT;
-    struct flb_uri *uri = ins->host.uri;
+    struct flb_uri *uri = ctx->ins->host.uri;
     struct flb_uri_field *f_index = NULL;
     struct flb_uri_field *f_type = NULL;
-    struct flb_upstream *upstream;
-    struct flb_elasticsearch *ctx;
-
-    /* Allocate context */
-    ctx = flb_calloc(1, sizeof(struct flb_elasticsearch));
-    if (!ctx) {
-        flb_errno();
-        return NULL;
-    }
-    ctx->ins = ins;
 
     if (uri) {
         if (uri->count >= 2) {
@@ -167,371 +50,409 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     }
 
     /* handle cloud_id */
-    tmp = flb_output_get_property("cloud_id", ins);
-    if (tmp) {
-        cloud_host = extract_cloud_host(ctx, tmp);
-        if (cloud_host == NULL) {
-            flb_plg_error(ctx->ins, "cannot extract cloud_host");
-            flb_es_conf_destroy(ctx);
-            return NULL;
-        }
-        flb_plg_debug(ctx->ins, "extracted cloud_host: '%s'", cloud_host);
-
-        cloud_port_char = strchr(cloud_host, ':');
-
-	if (cloud_port_char == NULL) {
-            flb_plg_debug(ctx->ins, "cloud_host: '%s' does not contain a port: '%s'", cloud_host, cloud_host);
-        }
-        else {
-            cloud_port_char[0] = '\0';
-            cloud_port_char = &cloud_port_char[1];
-            flb_plg_debug(ctx->ins, "extracted cloud_port_char: '%s'", cloud_port_char);
-            cloud_host_port = (int) strtol(cloud_port_char, (char **) NULL, 10);
-            flb_plg_debug(ctx->ins, "converted cloud_port_char to port int: '%i'", cloud_host_port);
-	}
-
-        if (cloud_host_port == 0) {
-            cloud_host_port = cloud_port;
-        }
-
-        flb_plg_debug(ctx->ins,
-                      "checked whether extracted port was null and set it to "
-                      "default https port or not. Outcome: '%i' and cloud_host: '%s'.",
-                      cloud_host_port, cloud_host);
-
-        if (ins->host.name != NULL) {
-            flb_sds_destroy(ins->host.name);
-        }
-
-        ins->host.name = cloud_host;
-        ins->host.port = cloud_host_port;
+    ret = flb_es_conf_set_cloud_auth(flb_output_get_property("cloud_id",
+                                                             ctx->ins),
+                                     ctx);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "cannot configure cloud_id");
+        return -1;
     }
 
-    /* Set default network configuration */
-    flb_output_net_default("127.0.0.1", 9200, ins);
-
     /* Populate context with config map defaults and incoming properties */
-    ret = flb_output_config_map_set(ins, (void *) ctx);
-    if (ret == -1) {
+    ret = flb_output_config_map_set(ctx->ins, ec);
+    if (ret != 0) {
         flb_plg_error(ctx->ins, "configuration error");
-        flb_es_conf_destroy(ctx);
-        return NULL;
+        return -1;
     }
 
     /* handle cloud_auth */
-    tmp = flb_output_get_property("cloud_auth", ins);
-    if (tmp) {
-        set_cloud_credentials(ctx, tmp);
-    }
-
-    /* use TLS ? */
-    if (ins->use_tls == FLB_TRUE) {
-        io_flags = FLB_IO_TLS;
-    }
-    else {
-        io_flags = FLB_IO_TCP;
-    }
-
-    if (ins->host.ipv6 == FLB_TRUE) {
-        io_flags |= FLB_IO_IPV6;
+    ret = flb_es_conf_set_cloud_credentials(
+            flb_output_get_property("cloud_auth", ctx->ins), ec);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "cannot configure cloud_auth");
+        return -1;
     }
 
     /* Compress (gzip) */
-    tmp = flb_output_get_property("compress", ins);
-    ctx->compress_gzip = FLB_FALSE;
+    tmp = flb_output_get_property("compress", ctx->ins);
+    ec->compress_gzip = FLB_FALSE;
     if (tmp) {
         if (strcasecmp(tmp, "gzip") == 0) {
-            ctx->compress_gzip = FLB_TRUE;
+            ec->compress_gzip = FLB_TRUE;
         }
     }
 
-    /* Prepare an upstream handler */
-    upstream = flb_upstream_create(config,
-                                   ins->host.name,
-                                   ins->host.port,
-                                   io_flags,
-                                   ins->tls);
-    if (!upstream) {
-        flb_plg_error(ctx->ins, "cannot create Upstream context");
-        flb_es_conf_destroy(ctx);
-        return NULL;
-    }
-    ctx->u = upstream;
-
-    /* Set instance flags into upstream */
-    flb_output_upstream_set(ctx->u, ins);
-
     /* Set manual Index and Type */
     if (f_index) {
-        ctx->index = flb_strdup(f_index->value); /* FIXME */
+        ec->index = flb_strdup(f_index->value);
+        ec->own_index = FLB_TRUE;
     }
 
     if (f_type) {
-        ctx->type = flb_strdup(f_type->value); /* FIXME */
+        ec->type = flb_strdup(f_type->value);
+        ec->own_type = FLB_TRUE;
     }
 
     /* HTTP Payload (response) maximum buffer size (0 == unlimited) */
-    if (ctx->buffer_size == -1) {
-        ctx->buffer_size = 0;
+    if (ec->buffer_size == -1) {
+        ec->buffer_size = 0;
     }
 
     /* Elasticsearch: Path */
-    path = flb_output_get_property("path", ins);
+    path = flb_output_get_property("path", ctx->ins);
     if (!path) {
         path = "";
     }
 
     /* Elasticsearch: Pipeline */
-    tmp = flb_output_get_property("pipeline", ins);
+    tmp = flb_output_get_property("pipeline", ctx->ins);
     if (tmp) {
-        snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/_bulk/?pipeline=%s", path, tmp);
+        snprintf(ec->uri, sizeof(ec->uri) - 1, "%s/_bulk/?pipeline=%s", path, tmp);
     }
     else {
-        snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/_bulk", path);
+        snprintf(ec->uri, sizeof(ec->uri) - 1, "%s/_bulk", path);
     }
 
-    if (ctx->id_key) {
-        ctx->ra_id_key = flb_ra_create(ctx->id_key, FLB_FALSE);
-        if (ctx->ra_id_key == NULL) {
-            flb_plg_error(ins, "could not create record accessor for Id Key");
+    if (ec->id_key) {
+        ec->ra_id_key = flb_ra_create(ec->id_key, FLB_FALSE);
+        if (ec->ra_id_key == NULL) {
+            flb_plg_error(ctx->ins, "could not create record accessor for Id Key");
         }
-        if (ctx->generate_id == FLB_TRUE) {
-            flb_plg_warn(ins, "Generate_ID is ignored when ID_key is set");
-            ctx->generate_id = FLB_FALSE;
+        if (ec->generate_id == FLB_TRUE) {
+            flb_plg_warn(ctx->ins, "Generate_ID is ignored when ID_key is set");
+            ec->generate_id = FLB_FALSE;
         }
     }
 
-    if (ctx->write_operation) {
-        if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_INDEX) == 0) {
-            ctx->es_action = flb_strdup(FLB_ES_WRITE_OP_INDEX);
+    if (ec->write_operation) {
+        if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_INDEX) == 0) {
+            ec->es_action = flb_strdup(FLB_ES_WRITE_OP_INDEX);
         }
-        else if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_CREATE) == 0) {
-            ctx->es_action = flb_strdup(FLB_ES_WRITE_OP_CREATE);
+        else if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_CREATE) == 0) {
+            ec->es_action = flb_strdup(FLB_ES_WRITE_OP_CREATE);
         }
-        else if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0
-            || strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
-            ctx->es_action = flb_strdup(FLB_ES_WRITE_OP_UPDATE);
+        else if (strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0
+            || strcasecmp(ec->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
+            ec->es_action = flb_strdup(FLB_ES_WRITE_OP_UPDATE);
         }
         else {
-            flb_plg_error(ins, "wrong Write_Operation (should be one of index, create, update, upsert)");
-            flb_es_conf_destroy(ctx);
-            return NULL;
+            flb_plg_error(ctx->ins, "wrong Write_Operation (should be one of index, create, update, upsert)");
+            return -1;
         }
-        if (strcasecmp(ctx->es_action, FLB_ES_WRITE_OP_UPDATE) == 0
-            && !ctx->ra_id_key && ctx->generate_id == FLB_FALSE) {
-            flb_plg_error(ins, "Id_Key or Generate_Id must be set when Write_Operation update or upsert");
-            flb_es_conf_destroy(ctx);
-            return NULL;
+        if (strcasecmp(ec->es_action, FLB_ES_WRITE_OP_UPDATE) == 0
+            && !ec->ra_id_key && ec->generate_id == FLB_FALSE) {
+            flb_plg_error(ctx->ins, "Id_Key or Generate_Id must be set when Write_Operation update or upsert");
+            return -1;
         }
     }
 
-    if (ctx->logstash_prefix_key) {
-        if (ctx->logstash_prefix_key[0] != '$') {
-            len = flb_sds_len(ctx->logstash_prefix_key);
+    if (ec->logstash_prefix_key) {
+        if (ec->logstash_prefix_key[0] != '$') {
+            len = flb_sds_len(ec->logstash_prefix_key);
             buf = flb_malloc(len + 2);
             if (!buf) {
                 flb_errno();
-                flb_es_conf_destroy(ctx);
-                return NULL;
+                return -1;
             }
             buf[0] = '$';
-            memcpy(buf + 1, ctx->logstash_prefix_key, len);
+            memcpy(buf + 1, ec->logstash_prefix_key, len);
             buf[len + 1] = '\0';
 
-            ctx->ra_prefix_key = flb_ra_create(buf, FLB_TRUE);
+            ec->ra_prefix_key = flb_ra_create(buf, FLB_TRUE);
             flb_free(buf);
         }
         else {
-            ctx->ra_prefix_key = flb_ra_create(ctx->logstash_prefix_key, FLB_TRUE);
+            ec->ra_prefix_key = flb_ra_create(ec->logstash_prefix_key, FLB_TRUE);
         }
 
-        if (!ctx->ra_prefix_key) {
-            flb_plg_error(ins, "invalid logstash_prefix_key pattern '%s'", tmp);
-            flb_es_conf_destroy(ctx);
-            return NULL;
+        if (!ec->ra_prefix_key) {
+            flb_plg_error(ctx->ins, "invalid logstash_prefix_key pattern '%s'", tmp);
+            return -1;
         }
     }
 
 #ifdef FLB_HAVE_AWS
-    /* AWS Auth Unsigned Headers */
-    ctx->aws_unsigned_headers = flb_malloc(sizeof(struct mk_list));
+    ret = flb_es_set_aws_unsigned_headers(ec);
     if (ret != 0) {
-        flb_es_conf_destroy(ctx);
+        flb_plg_error(ctx->ins, "cannot configure AWS unsigned headers");
+        return -1;
     }
-    flb_slist_create(ctx->aws_unsigned_headers);
-    ret = flb_slist_add(ctx->aws_unsigned_headers, "Content-Length");
+
+    ret = flb_es_conf_set_aws_provider(
+            flb_output_get_property("aws_external_id", ctx->ins),
+            flb_output_get_property("aws_role_arn", ctx->ins),
+            ec, ctx, config);
     if (ret != 0) {
-        flb_es_conf_destroy(ctx);
+        flb_plg_error(ctx->ins, "cannot configure AWS authentication");
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+static int config_validate(struct flb_elasticsearch_config* ec,
+                           struct flb_elasticsearch* ctx)
+{
+    if (ec->index == NULL && ec->logstash_format == FLB_FALSE && ec->generate_id == FLB_FALSE) {
+        flb_plg_error(ctx->ins, "index is not set and logstash_format and generate_id are both off");
+        return -1;
+    }
+
+    return 0;
+}
+
+static void elasticsearch_config_destroy(struct flb_elasticsearch_config *ec)
+{
+    if (ec->ra_id_key) {
+        flb_ra_destroy(ec->ra_id_key);
+        ec->ra_id_key = NULL;
+    }
+    if (ec->es_action) {
+        flb_free(ec->es_action);
+    }
+
+#ifdef FLB_HAVE_AWS
+    if (ec->base_aws_provider) {
+        flb_aws_provider_destroy(ec->base_aws_provider);
+    }
+
+    if (ec->aws_provider) {
+        flb_aws_provider_destroy(ec->aws_provider);
+    }
+
+    if (ec->aws_tls) {
+        flb_tls_destroy(ec->aws_tls);
+    }
+
+    if (ec->aws_sts_tls) {
+        flb_tls_destroy(ec->aws_sts_tls);
+    }
+
+    if (ec->aws_unsigned_headers) {
+        flb_slist_destroy(ec->aws_unsigned_headers);
+        flb_free(ec->aws_unsigned_headers);
+    }
+#endif
+
+    if (ec->ra_prefix_key) {
+        flb_ra_destroy(ec->ra_prefix_key);
+    }
+
+    flb_free(ec->cloud_passwd);
+    flb_free(ec->cloud_user);
+
+    if (ec->own_type == FLB_TRUE) {
+        flb_free(ec->type);
+    }
+
+    if (ec->own_index == FLB_TRUE) {
+        flb_free(ec->index);
+    }
+
+    flb_free(ec);
+}
+
+int es_config_ha(const char *upstream_file, struct flb_elasticsearch *ctx,
+                 struct flb_config *config)
+{
+    int ret;
+    struct mk_list *head;
+    struct flb_upstream_node *node;
+    struct flb_elasticsearch_config *ec;
+
+    /* Create elasticsearch_config context */
+    ec = flb_calloc(1, sizeof(struct flb_elasticsearch_config));
+    if (!ec) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "failed config allocation");
+        return -1;
+    }
+
+    /* Read properties into elasticsearch_config context */
+    ret = config_set_properties(ec, ctx, config);
+    if (ret != 0) {
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    /* Create upstream nodes */
+    ctx->ha_mode = FLB_TRUE;
+    ctx->ha = flb_upstream_ha_from_file(upstream_file, config);
+    if (!ctx->ha) {
+        flb_plg_error(ctx->ins, "cannot load Upstream file");
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    ret = flb_output_upstream_ha_set(ctx->ha, ctx->ins);
+    if (ret != 0) {
+        flb_upstream_ha_destroy(ctx->ha);
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    /*
+     * Iterate over upstreams nodes and link shared elasticsearch_config context
+     * with each node
+     */
+    mk_list_foreach(head, &ctx->ha->nodes) {
+        node = mk_list_entry(head, struct flb_upstream_node, _head);
+        /* Set elasticsearch_config context into the node opaque data */
+        flb_upstream_node_set_data(ec, node);
+    }
+
+    mk_list_add(&ec->_head, &ctx->configs);
+
+    return 0;
+}
+
+int es_config_simple(struct flb_elasticsearch *ctx, struct flb_config *config)
+{
+    int ret;
+    struct flb_elasticsearch_config *ec;
+    int io_flags = 0;
+
+    /* Set default network configuration */
+    flb_output_net_default(FLB_ES_DEFAULT_HOST, FLB_ES_DEFAULT_PORT, ctx->ins);
+
+    /* Create elasticsearch_config context */
+    ec = flb_calloc(1, sizeof(struct flb_elasticsearch_config));
+    if (!ec) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "failed config allocation");
+        return -1;
+    }
+
+    /* Read properties into elasticsearch_config context */
+    ret = config_set_properties(ec, ctx, config);
+    if (ret != 0) {
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    /* Validate configuration */
+    ret = config_validate(ec, ctx);
+    if (ret != 0) {
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+#ifdef FLB_HAVE_TLS
+    /* use TLS ? */
+    if (ctx->ins->use_tls == FLB_TRUE) {
+        io_flags = FLB_IO_TLS;
+    }
+    else {
+        io_flags = FLB_IO_TCP;
+    }
+#else
+    io_flags = FLB_IO_TCP;
+#endif
+
+    if (ctx->ins->host.ipv6 == FLB_TRUE) {
+        io_flags |= FLB_IO_IPV6;
+    }
+
+    /* Create upstream */
+    ctx->ha_mode = FLB_FALSE;
+    ctx->u = flb_upstream_create(config,
+                                 ctx->ins->host.name,
+                                 ctx->ins->host.port,
+                                 io_flags,
+                                 ctx->ins->tls);
+    if (!ctx->u) {
+        flb_plg_error(ctx->ins, "cannot create Upstream context");
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    ret = flb_output_upstream_set(ctx->u, ctx->ins);
+    if (ret != 0) {
+        flb_upstream_destroy(ctx->u);
+        elasticsearch_config_destroy(ec);
+        return -1;
+    }
+
+    mk_list_add(&ec->_head, &ctx->configs);
+
+    return 0;
+}
+
+struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
+                                             struct flb_config *config)
+{
+    int ret;
+    const char *upstream_file;
+    struct flb_elasticsearch *ctx;
+
+    /* Allocate context */
+    ctx = flb_calloc(1, sizeof(struct flb_elasticsearch));
+    if (!ctx) {
+        flb_errno();
         return NULL;
     }
 
-    /* AWS Auth */
-    ctx->has_aws_auth = FLB_FALSE;
-    tmp = flb_output_get_property("aws_auth", ins);
-    if (tmp) {
-        if (strncasecmp(tmp, "On", 2) == 0) {
-            ctx->has_aws_auth = FLB_TRUE;
-            flb_debug("[out_es] Enabled AWS Auth");
+    ctx->ins = ins;
+    mk_list_init(&ctx->configs);
 
-            /* AWS provider needs a separate TLS instance */
-            ctx->aws_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
-                                          FLB_TRUE,
-                                          ins->tls_debug,
-                                          ins->tls_vhost,
-                                          ins->tls_ca_path,
-                                          ins->tls_ca_file,
-                                          ins->tls_crt_file,
-                                          ins->tls_key_file,
-                                          ins->tls_key_passwd);
-            if (!ctx->aws_tls) {
-                flb_errno();
-                flb_es_conf_destroy(ctx);
-                return NULL;
-            }
-
-            tmp = flb_output_get_property("aws_region", ins);
-            if (!tmp) {
-                flb_error("[out_es] aws_auth enabled but aws_region not set");
-                flb_es_conf_destroy(ctx);
-                return NULL;
-            }
-            ctx->aws_region = (char *) tmp;
-
-            tmp = flb_output_get_property("aws_sts_endpoint", ins);
-            if (tmp) {
-                ctx->aws_sts_endpoint = (char *) tmp;
-            }
-
-            ctx->aws_provider = flb_standard_chain_provider_create(config,
-                                                                   ctx->aws_tls,
-                                                                   ctx->aws_region,
-                                                                   ctx->aws_sts_endpoint,
-                                                                   NULL,
-                                                                   flb_aws_client_generator(),
-                                                                   ctx->aws_profile);
-            if (!ctx->aws_provider) {
-                flb_error("[out_es] Failed to create AWS Credential Provider");
-                flb_es_conf_destroy(ctx);
-                return NULL;
-            }
-
-            tmp = flb_output_get_property("aws_role_arn", ins);
-            if (tmp) {
-                /* Use the STS Provider */
-                ctx->base_aws_provider = ctx->aws_provider;
-                aws_role_arn = (char *) tmp;
-                aws_external_id = NULL;
-                tmp = flb_output_get_property("aws_external_id", ins);
-                if (tmp) {
-                    aws_external_id = (char *) tmp;
-                }
-
-                aws_session_name = flb_sts_session_name();
-                if (!aws_session_name) {
-                    flb_error("[out_es] Failed to create aws iam role "
-                              "session name");
-                    flb_es_conf_destroy(ctx);
-                    return NULL;
-                }
-
-                /* STS provider needs yet another separate TLS instance */
-                ctx->aws_sts_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
-                                                  FLB_TRUE,
-                                                  ins->tls_debug,
-                                                  ins->tls_vhost,
-                                                  ins->tls_ca_path,
-                                                  ins->tls_ca_file,
-                                                  ins->tls_crt_file,
-                                                  ins->tls_key_file,
-                                                  ins->tls_key_passwd);
-                if (!ctx->aws_sts_tls) {
-                    flb_errno();
-                    flb_es_conf_destroy(ctx);
-                    return NULL;
-                }
-
-                ctx->aws_provider = flb_sts_provider_create(config,
-                                                            ctx->aws_sts_tls,
-                                                            ctx->
-                                                            base_aws_provider,
-                                                            aws_external_id,
-                                                            aws_role_arn,
-                                                            aws_session_name,
-                                                            ctx->aws_region,
-                                                            ctx->aws_sts_endpoint,
-                                                            NULL,
-                                                            flb_aws_client_generator());
-                /* Session name can be freed once provider is created */
-                flb_free(aws_session_name);
-                if (!ctx->aws_provider) {
-                    flb_error("[out_es] Failed to create AWS STS Credential "
-                              "Provider");
-                    flb_es_conf_destroy(ctx);
-                    return NULL;
-                }
-
-            }
-
-            /* initialize credentials in sync mode */
-            ctx->aws_provider->provider_vtable->sync(ctx->aws_provider);
-            ctx->aws_provider->provider_vtable->init(ctx->aws_provider);
-            /* set back to async */
-            ctx->aws_provider->provider_vtable->async(ctx->aws_provider);
-            ctx->aws_provider->provider_vtable->upstream_set(ctx->aws_provider, ctx->ins);
-        }
+    /* Configure HA or simple mode ? */
+    upstream_file = flb_output_get_property("upstream", ins);
+    if (upstream_file) {
+        ret = es_config_ha(upstream_file, ctx, config);
     }
-#endif
+    else {
+        ret = es_config_simple(ctx, config);
+    }
+
+    if (ret != 0) {
+        flb_free(ctx);
+        return NULL;
+    }
 
     return ctx;
 }
 
-int flb_es_conf_destroy(struct flb_elasticsearch *ctx)
+void flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 {
+    struct flb_elasticsearch_config *ec;
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct flb_upstream_node *node;
+
     if (!ctx) {
-        return 0;
+        return;
     }
 
-    if (ctx->u) {
-        flb_upstream_destroy(ctx->u);
-    }
-    if (ctx->ra_id_key) {
-        flb_ra_destroy(ctx->ra_id_key);
-        ctx->ra_id_key = NULL;
-    }
-    if (ctx->es_action) {
-        flb_free(ctx->es_action);
-    }
-
-#ifdef FLB_HAVE_AWS
-    if (ctx->base_aws_provider) {
-        flb_aws_provider_destroy(ctx->base_aws_provider);
+    if (ctx->ha_mode == FLB_TRUE) {
+        /* Nullify each upstream node elasticsearch_config context */
+        if (ctx->ha) {
+            mk_list_foreach(head, &ctx->ha->nodes) {
+                node = mk_list_entry(head, struct flb_upstream_node, _head);
+                flb_upstream_node_set_data(NULL, node);
+            }
+        }
     }
 
-    if (ctx->aws_provider) {
-        flb_aws_provider_destroy(ctx->aws_provider);
+    /* Destroy elasticsearch_config contexts */
+    mk_list_foreach_safe(head, tmp, &ctx->configs) {
+        ec = mk_list_entry(head, struct flb_elasticsearch_config, _head);
+
+        mk_list_del(&ec->_head);
+        elasticsearch_config_destroy(ec);
     }
 
-    if (ctx->aws_tls) {
-        flb_tls_destroy(ctx->aws_tls);
+    /* Destroy upstreams */
+    if (ctx->ha_mode == FLB_TRUE) {
+        if (ctx->ha) {
+            flb_upstream_ha_destroy(ctx->ha);
+        }
+    }
+    else {
+        if (ctx->u) {
+            flb_upstream_destroy(ctx->u);
+        }
     }
 
-    if (ctx->aws_sts_tls) {
-        flb_tls_destroy(ctx->aws_sts_tls);
-    }
-
-    if (ctx->aws_unsigned_headers) {
-        flb_slist_destroy(ctx->aws_unsigned_headers);
-        flb_free(ctx->aws_unsigned_headers);
-    }
-#endif
-
-    if (ctx->ra_prefix_key) {
-        flb_ra_destroy(ctx->ra_prefix_key);
-    }
-
-    flb_free(ctx->cloud_passwd);
-    flb_free(ctx->cloud_user);
     flb_free(ctx);
-
-    return 0;
 }

--- a/plugins/out_es/es_conf.h
+++ b/plugins/out_es/es_conf.h
@@ -20,11 +20,18 @@
 #ifndef FLB_OUT_ES_CONF_H
 #define FLB_OUT_ES_CONF_H
 
-#include "es.h"
+struct flb_config;
+struct flb_output_instance;
+struct flb_upstream_node;
+struct flb_elasticsearch;
+struct flb_elasticsearch_config;
 
 struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                              struct flb_config *config);
 
 void flb_es_conf_destroy(struct flb_elasticsearch *ctx);
+
+struct flb_elasticsearch_config *flb_es_upstream_conf(struct flb_elasticsearch *ctx,
+                                                      struct flb_upstream_node *node);
 
 #endif

--- a/plugins/out_es/es_conf.h
+++ b/plugins/out_es/es_conf.h
@@ -20,14 +20,11 @@
 #ifndef FLB_OUT_ES_CONF_H
 #define FLB_OUT_ES_CONF_H
 
-#include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_output.h>
-#include <fluent-bit/flb_config.h>
-
 #include "es.h"
 
 struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                              struct flb_config *config);
-int flb_es_conf_destroy(struct flb_elasticsearch *ctx);
+
+void flb_es_conf_destroy(struct flb_elasticsearch *ctx);
 
 #endif

--- a/plugins/out_es/es_conf.h
+++ b/plugins/out_es/es_conf.h
@@ -26,6 +26,11 @@ struct flb_upstream_node;
 struct flb_elasticsearch;
 struct flb_elasticsearch_config;
 
+#define FLB_ES_WRITE_OP_INDEX  "index"
+#define FLB_ES_WRITE_OP_CREATE "create"
+#define FLB_ES_WRITE_OP_UPDATE "update"
+#define FLB_ES_WRITE_OP_UPSERT "upsert"
+
 struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
                                              struct flb_config *config);
 

--- a/plugins/out_es/es_conf_parse.c
+++ b/plugins/out_es/es_conf_parse.c
@@ -53,10 +53,18 @@ int flb_es_conf_set_cloud_credentials(const char *cloud_auth,
         entry = mk_list_entry(head, struct flb_split_entry, _head);
         if (items == 1) {
             ec->cloud_user = flb_strdup(entry->value);
+            if (ec->cloud_user == NULL) {
+                flb_utils_split_free(toks);
+                return -1;
+            }
             ec->own_cloud_user = FLB_TRUE;
         }
         if (items == 2) {
             ec->cloud_passwd = flb_strdup(entry->value);
+            if (ec->cloud_passwd == NULL) {
+                flb_utils_split_free(toks);
+                return -1;
+            }
             ec->own_cloud_passwd = FLB_TRUE;
         }
     }

--- a/plugins/out_es/es_conf_parse.c
+++ b/plugins/out_es/es_conf_parse.c
@@ -48,7 +48,10 @@ int flb_es_conf_set_cloud_credentials(const char *cloud_auth,
         return 0;
     }
 
-    toks = flb_utils_split((const char *)cloud_auth, ':', -1);
+    toks = flb_utils_split(cloud_auth, ':', -1);
+    if (!toks) {
+        return -1;
+    }
     mk_list_foreach(head, toks) {
         entry = mk_list_entry(head, struct flb_split_entry, _head);
         if (!items) {

--- a/plugins/out_es/es_conf_parse.c
+++ b/plugins/out_es/es_conf_parse.c
@@ -1,0 +1,327 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+
+#include <monkey/mk_core/mk_list.h>
+#include <fluent-bit/tls/flb_tls.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_slist.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_base64.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_aws_credentials.h>
+
+#include "es.h"
+#include "es_conf_parse.h"
+
+int flb_es_conf_set_cloud_credentials(const char *cloud_auth,
+                                      struct flb_elasticsearch_config *ec)
+{
+    /* extract strings */
+    int items = 0;
+    struct mk_list *toks;
+    struct mk_list *head;
+    struct flb_split_entry *entry;
+
+    if (!cloud_auth) {
+        return 0;
+    }
+
+    toks = flb_utils_split((const char *)cloud_auth, ':', -1);
+    mk_list_foreach(head, toks) {
+        items++;
+        entry = mk_list_entry(head, struct flb_split_entry, _head);
+        if (items == 1) {
+            ec->cloud_user = flb_strdup(entry->value);
+        }
+        if (items == 2) {
+            ec->cloud_passwd = flb_strdup(entry->value);
+        }
+    }
+    flb_utils_split_free(toks);
+
+    return 0;
+}
+
+/*
+ * extract_cloud_host extracts the public hostname
+ * of a deployment from a Cloud ID string.
+ *
+ * The Cloud ID string has the format "<deployment_name>:<base64_info>".
+ * Once decoded, the "base64_info" string has the format "<deployment_region>$<elasticsearch_hostname>$<kibana_hostname>"
+ * and the function returns "<elasticsearch_hostname>.<deployment_region>" token.
+ */
+static flb_sds_t extract_cloud_host(const char *cloud_id, struct flb_elasticsearch *ctx)
+{
+
+    char *colon;
+    char *region;
+    char *host;
+    char *port = NULL;
+    char buf[256] = {0};
+    char cloud_host_buf[256] = {0};
+    const char dollar[2] = "$";
+    size_t len;
+    int ret;
+
+    /* keep only part after first ":" */
+    colon = strchr(cloud_id, ':');
+    if (colon == NULL) {
+        return NULL;
+    }
+    colon++;
+
+    /* decode base64 */
+    ret = flb_base64_decode((unsigned char *)buf, sizeof(buf), &len,
+                            (unsigned char *)colon, strlen(colon));
+    if (ret) {
+        flb_plg_error(ctx->ins, "cannot decode cloud_id");
+        return NULL;
+    }
+    region = strtok(buf, dollar);
+    if (region == NULL) {
+        return NULL;
+    }
+    host = strtok(NULL, dollar);
+    if (host == NULL) {
+        return NULL;
+    }
+
+    /*
+     * Some cloud id format is "<deployment_region>$<elasticsearch_hostname>:<port>$<kibana_hostname>" .
+     *   e.g. https://github.com/elastic/beats/blob/v8.4.1/libbeat/cloudid/cloudid_test.go#L60
+     *
+     * It means the variable "host" can contains ':' and port number.
+     */
+    colon = strchr(host, ':');
+    if (colon != NULL) {
+        /* host contains host number */
+        *colon = '\0'; /* remove port number from host */
+        port = colon+1;
+    }
+
+    strcpy(cloud_host_buf, host);
+    strcat(cloud_host_buf, ".");
+    strcat(cloud_host_buf, region);
+    if (port != NULL) {
+        strcat(cloud_host_buf, ":");
+        strcat(cloud_host_buf, port);
+    }
+    return flb_sds_create(cloud_host_buf);
+}
+
+int flb_es_conf_set_cloud_auth(const char *cloud_auth, struct flb_elasticsearch *ctx)
+{
+    char *cloud_host;
+    int cloud_host_port = 0;
+    char *cloud_port_char;
+    int cloud_port = FLB_ES_DEFAULT_HTTPS_PORT;
+
+    if (!cloud_auth) {
+        return 0;
+    }
+
+    cloud_host = extract_cloud_host(cloud_auth, ctx);
+    if (cloud_host == NULL) {
+        flb_plg_error(ctx->ins, "cannot extract cloud_host");
+        return -1;
+    }
+    flb_plg_debug(ctx->ins, "extracted cloud_host: '%s'", cloud_host);
+
+    cloud_port_char = strchr(cloud_host, ':');
+
+    if (cloud_port_char == NULL) {
+        flb_plg_debug(ctx->ins, "cloud_host: '%s' does not contain a port: '%s'",
+                      cloud_host, cloud_host);
+    }
+    else {
+        cloud_port_char[0] = '\0';
+        cloud_port_char = &cloud_port_char[1];
+        flb_plg_debug(ctx->ins, "extracted cloud_port_char: '%s'", cloud_port_char);
+        cloud_host_port = (int)strtol(cloud_port_char, (char **)NULL, 10);
+        flb_plg_debug(ctx->ins, "converted cloud_port_char to port int: '%i'",
+                      cloud_host_port);
+    }
+
+    if (cloud_host_port == 0) {
+        cloud_host_port = cloud_port;
+    }
+
+    flb_plg_debug(ctx->ins,
+                  "checked whether extracted port was null and set it to "
+                  "default https port or not. Outcome: '%i' and cloud_host: '%s'.",
+                  cloud_host_port, cloud_host);
+
+    if (ctx->ins->host.name != NULL) {
+        flb_sds_destroy(ctx->ins->host.name);
+    }
+
+    ctx->ins->host.name = cloud_host;
+    ctx->ins->host.port = cloud_host_port;
+
+    return 0;
+}
+
+#ifdef FLB_HAVE_AWS
+
+int flb_es_set_aws_unsigned_headers(struct flb_elasticsearch_config *ec)
+{
+    int ret;
+
+    /* AWS Auth Unsigned Headers */
+    ec->aws_unsigned_headers = flb_malloc(sizeof(struct mk_list));
+    if (!ec->aws_unsigned_headers) {
+        flb_errno();
+        return -1;
+    }
+
+    flb_slist_create(ec->aws_unsigned_headers);
+    ret = flb_slist_add(ec->aws_unsigned_headers, "Content-Length");
+    if (ret != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_aws_sts_provider(const char *aws_external_id,
+                                const char *aws_role_arn,
+                                struct flb_elasticsearch_config *ec,
+                                struct flb_elasticsearch *ctx,
+                                struct flb_config *config)
+{
+    char *aws_session_name = NULL;
+
+    if (!aws_role_arn) {
+        return 0;
+    }
+
+    /* Use the STS Provider */
+    ec->base_aws_provider = ec->aws_provider;
+
+    aws_session_name = flb_sts_session_name();
+    if (!aws_session_name) {
+        flb_error("[out_es] Failed to create aws iam role session name");
+        return -1;
+    }
+
+    /* STS provider needs yet another separate TLS instance */
+    ec->aws_sts_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
+                                     FLB_TRUE,
+                                     ctx->ins->tls_debug,
+                                     ctx->ins->tls_vhost,
+                                     ctx->ins->tls_ca_path,
+                                     ctx->ins->tls_ca_file,
+                                     ctx->ins->tls_crt_file,
+                                     ctx->ins->tls_key_file,
+                                     ctx->ins->tls_key_passwd);
+    if (!ec->aws_sts_tls) {
+        flb_errno();
+        flb_free(aws_session_name);
+        return -1;
+    }
+
+    ec->aws_provider = flb_sts_provider_create(config,
+                                               ec->aws_sts_tls,
+                                               ec->base_aws_provider,
+                                               (char *)aws_external_id,
+                                               (char *)aws_role_arn,
+                                               aws_session_name,
+                                               ec->aws_region,
+                                               ec->aws_sts_endpoint,
+                                               NULL,
+                                               flb_aws_client_generator());
+    /* Session name can be freed once provider is created */
+    flb_free(aws_session_name);
+
+    if (!ec->aws_provider) {
+        flb_error("[out_es] Failed to create AWS STS Credential Provider");
+        return -1;
+    }
+
+    return 0;
+}
+
+int flb_es_conf_set_aws_provider(const char *aws_external_id,
+                                 const char *aws_role_arn,
+                                 struct flb_elasticsearch_config *ec,
+                                 struct flb_elasticsearch *ctx,
+                                 struct flb_config *config)
+{
+    int ret;
+
+    if (ec->has_aws_auth == FLB_FALSE) {
+        return 0;
+    }
+
+    flb_debug("[out_es] Enabled AWS Auth");
+
+    if (!ec->aws_region) {
+        flb_error("[out_es] aws_auth enabled but aws_region not set");
+        return -1;
+    }
+
+    /* AWS provider needs a separate TLS instance */
+    ec->aws_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
+                                 FLB_TRUE,
+                                 ctx->ins->tls_debug,
+                                 ctx->ins->tls_vhost,
+                                 ctx->ins->tls_ca_path,
+                                 ctx->ins->tls_ca_file,
+                                 ctx->ins->tls_crt_file,
+                                 ctx->ins->tls_key_file,
+                                 ctx->ins->tls_key_passwd);
+    if (!ec->aws_tls) {
+        flb_errno();
+        return -1;
+    }
+
+    ec->aws_provider = flb_standard_chain_provider_create(config,
+                                                          ec->aws_tls,
+                                                          ec->aws_region,
+                                                          ec->aws_sts_endpoint,
+                                                          NULL,
+                                                          flb_aws_client_generator(),
+                                                          ec->aws_profile);
+    if (!ec->aws_provider) {
+        flb_error("[out_es] Failed to create AWS Credential Provider");
+        return -1;
+    }
+
+    ret = set_aws_sts_provider(aws_external_id, aws_role_arn, ec, ctx, config);
+    if (ret != 0) {
+        flb_error("[out_es] Failed to configure AWS role");
+        return -1;
+    }
+
+    /* initialize credentials in sync mode */
+    ec->aws_provider->provider_vtable->sync(ec->aws_provider);
+    ec->aws_provider->provider_vtable->init(ec->aws_provider);
+    /* set back to async */
+    ec->aws_provider->provider_vtable->async(ec->aws_provider);
+    ec->aws_provider->provider_vtable->upstream_set(ec->aws_provider, ctx->ins);
+
+    return 0;
+}
+
+#endif

--- a/plugins/out_es/es_conf_parse.h
+++ b/plugins/out_es/es_conf_parse.h
@@ -1,0 +1,53 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_OUT_ES_CONF_PARSE_H
+#define FLB_OUT_ES_CONF_PARSE_H
+
+struct flb_config;
+struct flb_elasticsearch;
+struct flb_elasticsearch_config;
+
+/*
+ * flb_es_conf_set_cloud_credentials gets a cloud_auth
+ * and sets the context's cloud_user and cloud_passwd.
+ * Example:
+ *   cloud_auth = elastic:ZXVyb3BxxxxxxZTA1Ng
+ *   ---->
+ *   cloud_user = elastic
+ *   cloud_passwd = ZXVyb3BxxxxxxZTA1Ng
+ */
+int flb_es_conf_set_cloud_credentials(const char *cloud_auth,
+                                      struct flb_elasticsearch_config *ec);
+
+int flb_es_conf_set_cloud_auth(const char *cloud_auth, struct flb_elasticsearch *ctx);
+
+#ifdef FLB_HAVE_AWS
+
+int flb_es_set_aws_unsigned_headers(struct flb_elasticsearch_config *ec);
+
+int flb_es_conf_set_aws_provider(const char *aws_external_id,
+                                 const char *aws_role_arn,
+                                 struct flb_elasticsearch_config *ec,
+                                 struct flb_elasticsearch *ctx,
+                                 struct flb_config *config);
+
+#endif
+
+#endif

--- a/plugins/out_es/es_conf_parse.h
+++ b/plugins/out_es/es_conf_parse.h
@@ -2,7 +2,7 @@
 
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/plugins/out_es/es_conf_prop.h
+++ b/plugins/out_es/es_conf_prop.h
@@ -1,0 +1,65 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_OUT_ES_CONF_PROP_H
+#define FLB_OUT_ES_CONF_PROP_H
+
+#define FLB_ES_CONFIG_PROPERTY_INDEX                     "index"
+#define FLB_ES_CONFIG_PROPERTY_TYPE                      "type"
+#define FLB_ES_CONFIG_PROPERTY_SUPPRESS_TYPE_NAME        "suppress_type_name"
+#define FLB_ES_CONFIG_PROPERTY_HTTP_USER                 "http_user"
+#define FLB_ES_CONFIG_PROPERTY_HTTP_PASSWD               "http_passwd"
+#define FLB_ES_CONFIG_PROPERTY_HTTP_API_KEY              "http_api_key"
+#define FLB_ES_CONFIG_PROPERTY_COMPRESS                  "compress"
+#define FLB_ES_CONFIG_PROPERTY_CLOUD_ID                  "cloud_id"
+#define FLB_ES_CONFIG_PROPERTY_CLOUD_AUTH                "cloud_auth"
+
+#ifdef FLB_HAVE_AWS
+#define FLB_ES_CONFIG_PROPERTY_AWS_AUTH                  "aws_auth"
+#define FLB_ES_CONFIG_PROPERTY_AWS_REGION                "aws_region"
+#define FLB_ES_CONFIG_PROPERTY_AWS_STS_ENDPOINT          "aws_sts_endpoint"
+#define FLB_ES_CONFIG_PROPERTY_AWS_ROLE_ARN              "aws_role_arn"
+#define FLB_ES_CONFIG_PROPERTY_AWS_EXTERNAL_ID           "aws_external_id"
+#define FLB_ES_CONFIG_PROPERTY_AWS_SERVICE_NAME          "aws_service_name"
+#define FLB_ES_CONFIG_PROPERTY_AWS_PROFILE               "aws_profile"
+#endif
+
+#define FLB_ES_CONFIG_PROPERTY_LOGSTASH_FORMAT           "logstash_format"
+#define FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX           "logstash_prefix"
+#define FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_SEPARATOR "logstash_prefix_separator"
+#define FLB_ES_CONFIG_PROPERTY_LOGSTASH_PREFIX_KEY       "logstash_prefix_key"
+#define FLB_ES_CONFIG_PROPERTY_LOGSTASH_DATEFORMAT       "logstash_dateformat"
+#define FLB_ES_CONFIG_PROPERTY_TIME_KEY                  "time_key"
+#define FLB_ES_CONFIG_PROPERTY_TIME_KEY_FORMAT           "time_key_format"
+#define FLB_ES_CONFIG_PROPERTY_TIME_KEY_NANOS            "time_key_nanos"
+#define FLB_ES_CONFIG_PROPERTY_INCLUDE_TAG_KEY           "include_tag_key"
+#define FLB_ES_CONFIG_PROPERTY_TAG_KEY                   "tag_key"
+#define FLB_ES_CONFIG_PROPERTY_BUFFER_SIZE               "buffer_size"
+#define FLB_ES_CONFIG_PROPERTY_PATH                      "path"
+#define FLB_ES_CONFIG_PROPERTY_PIPELINE                  "pipeline"
+#define FLB_ES_CONFIG_PROPERTY_GENERATE_ID               "generate_id"
+#define FLB_ES_CONFIG_PROPERTY_WRITE_OPERATION           "write_operation"
+#define FLB_ES_CONFIG_PROPERTY_ID_KEY                    "id_key"
+#define FLB_ES_CONFIG_PROPERTY_REPLACE_DOTS              "replace_dots"
+#define FLB_ES_CONFIG_PROPERTY_CURRENT_TIME_INDEX        "current_time_index"
+#define FLB_ES_CONFIG_PROPERTY_TRACE_OUTPUT              "trace_output"
+#define FLB_ES_CONFIG_PROPERTY_TRACE_ERROR               "trace_error"
+#define FLB_ES_CONFIG_PROPERTY_UPSTREAM                  "upstream"
+
+#endif

--- a/plugins/out_es/es_conf_prop.h
+++ b/plugins/out_es/es_conf_prop.h
@@ -2,7 +2,7 @@
 
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/plugins/out_es/es_type.c
+++ b/plugins/out_es/es_type.c
@@ -1,0 +1,228 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_slist.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/tls/flb_tls.h>
+
+#include "es_type.h"
+
+void flb_es_str_destroy(struct flb_es_str *ins)
+{
+    if (ins->value && ins->owned != FLB_FALSE) {
+        flb_free(ins->value);
+    }
+    ins->value = NULL;
+    ins->owned = FLB_FALSE;
+}
+
+void flb_es_str_set_str(struct flb_es_str *dest, char *src)
+{
+    flb_es_str_destroy(dest);
+    dest->value = src;
+    dest->owned = FLB_FALSE;
+}
+
+int flb_es_str_copy_str(struct flb_es_str *dest, const char *src)
+{
+    char *dup;
+    if (!src) {
+        flb_es_str_destroy(dest);
+        return 0;
+    }
+    dup = flb_strdup(src);
+    if (!dup) {
+        return -1;
+    }
+    flb_es_str_destroy(dest);
+    dest->value = dup;
+    dest->owned = FLB_TRUE;
+    return 0;
+}
+
+void flb_es_sds_destroy(struct flb_es_sds_t *ins)
+{
+    if (ins->value && ins->owned != FLB_FALSE) {
+        flb_sds_destroy(ins->value);
+    }
+    ins->value = NULL;
+    ins->owned = FLB_FALSE;
+}
+
+void flb_es_sds_set_sds(struct flb_es_sds_t *dest, flb_sds_t src)
+{
+    flb_es_sds_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_FALSE;
+    }
+}
+
+int flb_es_sds_copy_str(struct flb_es_sds_t *dest, const char *src)
+{
+    flb_sds_t dup;
+    if (!src) {
+        flb_es_sds_destroy(dest);
+        return 0;
+    }
+    dup = flb_sds_create(src);
+    if (!dup) {
+        return -1;
+    }
+    flb_es_sds_destroy(dest);
+    dest->value = dup;
+    dest->owned = FLB_TRUE;
+    return 0;
+}
+
+void flb_es_slist_destroy(struct flb_es_slist *ins)
+{
+    if (ins->value && ins->owned != FLB_FALSE) {
+        flb_slist_destroy(ins->value);
+        flb_free(ins->value);
+    }
+    ins->value = NULL;
+    ins->owned = FLB_FALSE;
+}
+
+void flb_es_slist_set_slist(struct flb_es_slist *dest, struct mk_list *src)
+{
+    flb_es_slist_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_FALSE;
+    }
+}
+
+void flb_es_slist_move_slist(struct flb_es_slist *dest, struct mk_list *src)
+{
+    flb_es_slist_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_TRUE;
+    }
+}
+
+void flb_es_tls_destroy(struct flb_es_tls *ins)
+{
+    if (ins->value && ins->owned != FLB_FALSE) {
+        flb_tls_destroy(ins->value);
+    }
+    ins->value = NULL;
+    ins->owned = FLB_FALSE;
+}
+
+void flb_es_tls_set_tls(struct flb_es_tls *dest, struct flb_tls *src)
+{
+    flb_es_tls_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_FALSE;
+    }
+}
+
+void flb_es_tls_move_tls(struct flb_es_tls *dest, struct flb_tls *src)
+{
+    flb_es_tls_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_TRUE;
+    }
+}
+
+void flb_es_ra_destroy(struct flb_es_record_accessor *ins)
+{
+    if (ins->value && ins->owned != FLB_FALSE) {
+        flb_ra_destroy(ins->value);
+    }
+    ins->value = NULL;
+    ins->owned = FLB_FALSE;
+}
+
+void flb_es_ra_set_ra(struct flb_es_record_accessor *dest,
+                      struct flb_record_accessor *src)
+{
+    flb_es_ra_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_FALSE;
+    }
+}
+
+void flb_es_ra_move_ra(struct flb_es_record_accessor *dest,
+                       struct flb_record_accessor *src)
+{
+    flb_es_ra_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_TRUE;
+    }
+}
+
+#ifdef FLB_HAVE_AWS
+void flb_es_aws_provider_destroy(struct flb_es_aws_provider *ins)
+{
+    if (ins->value && ins->owned != FLB_FALSE) {
+        flb_aws_provider_destroy(ins->value);
+    }
+    ins->value = NULL;
+    ins->owned = FLB_FALSE;
+}
+
+void flb_es_aws_provider_set(struct flb_es_aws_provider *dest,
+                             const struct flb_es_aws_provider *src)
+{
+    if (dest == src) {
+        return;
+    }
+    flb_es_aws_provider_destroy(dest);
+    if (src) {
+        dest->value = src->value;
+        dest->owned = FLB_FALSE;
+    }
+}
+
+void flb_es_aws_provider_move(struct flb_es_aws_provider *dest,
+                              struct flb_es_aws_provider *src)
+{
+    if (dest == src) {
+        return;
+    }
+    flb_es_aws_provider_destroy(dest);
+    if (src) {
+        *dest = *src;
+        src->value = NULL;
+        src->owned = FLB_FALSE;
+    }
+}
+
+void flb_es_aws_provider_move_provider(struct flb_es_aws_provider *dest,
+                                       struct flb_aws_provider *src)
+{
+    flb_es_aws_provider_destroy(dest);
+    if (src) {
+        dest->value = src;
+        dest->owned = FLB_TRUE;
+    }
+}
+#endif

--- a/plugins/out_es/es_type.h
+++ b/plugins/out_es/es_type.h
@@ -1,0 +1,413 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_ES_TYPE_H
+#define FLB_ES_TYPE_H
+
+#include <fluent-bit/flb_sds.h>
+
+struct mk_list;
+struct flb_tls;
+struct flb_record_accessor;
+
+#ifdef FLB_HAVE_AWS
+struct flb_aws_provider;
+#endif
+
+/**
+ * Null-terminated string with ownership flag.
+ *
+ * It is not allowed to write members directly, functions like flb_es_str_*
+ * should be used instead. The only exceptions are:
+ * - initialization of struct,
+ * - modification of @c value when @c owned is FLB_FALSE.
+ */
+struct flb_es_str {
+    /* The actual null-terminated string. */
+    char *value;
+    /**
+     * A flag indicating if this struct owns the null-terminated string.
+     * FLB_FALSE implies no ownership.
+     */
+    int owned;
+};
+
+/**
+ * Simple Dynamic String with ownership flag.
+ *
+ * It is not allowed to write members directly, functions like flb_es_sds_*
+ * should be used instead. The only exceptions are:
+ * - initialization of struct,
+ * - modification of @c value when @c owned is FLB_FALSE.
+ */
+struct flb_es_sds_t {
+    /* The actual Simple Dynamic String. */
+    flb_sds_t value;
+    /**
+     * A flag indicating if this struct owns the string.
+     * FLB_FALSE implies no ownership.
+     */
+    int owned;
+};
+
+/**
+ * List of Simple Dynamic Strings with ownership flag.
+ *
+ * It is not allowed to write members directly, functions like flb_es_slist_*
+ * should be used instead. The only exceptions are:
+ * - initialization of struct,
+ * - modification of @c value when @c owned is FLB_FALSE.
+ */
+struct flb_es_slist {
+    /* The actual list. */
+    struct mk_list *value;
+    /**
+     * A flag indicating if this struct owns the list.
+     * FLB_FALSE implies no ownership.
+     */
+    int owned;
+};
+
+/**
+ * TLS context with ownership flag.
+ *
+ * It is not allowed to write members directly, functions like flb_es_tls_*
+ * should be used instead. The only exceptions are:
+ * - initialization of struct,
+ * - modification of @c value when @c owned is FLB_FALSE.
+ */
+struct flb_es_tls {
+    /* The actual TLS context. */
+    struct flb_tls *value;
+    /**
+     * A flag indicating if this struct owns the TLS context.
+     * FLB_FALSE implies no ownership.
+     */
+    int owned;
+};
+
+/**
+ * Record accessor with ownership flag.
+ *
+ * It is not allowed to write members directly, functions like flb_es_ra_*
+ * should be used instead. The only exceptions are:
+ * - initialization of struct,
+ * - modification of @c value when @c owned is FLB_FALSE.
+ */
+struct flb_es_record_accessor {
+    /* The actual record accessor. */
+    struct flb_record_accessor *value;
+    /**
+     * A flag indicating if this struct owns the record accessor.
+     * FLB_FALSE implies no ownership.
+     */
+    int owned;
+};
+
+#ifdef FLB_HAVE_AWS
+/**
+ * AWS provider with ownership flag.
+ *
+ * It is not allowed to write members directly, functions like
+ * flb_es_aws_provider_* should be used instead. The only exceptions are:
+ * - initialization of struct,
+ * - modification of @c value when @c owned is FLB_FALSE.
+ */
+struct flb_es_aws_provider {
+    /* The actual AWS provider. */
+    struct flb_aws_provider *value;
+    /**
+     * A flag indicating if this struct owns the AWS provider.
+     * FLB_FALSE implies no ownership.
+     */
+    int owned;
+};
+#endif
+
+/**
+ * If null-terminated string represented by @c value of ins is owned by ins,
+ * then frees @c value of ins using flb_free.
+ *
+ * Sets @c value of ins to NULL and @c owned of ins to FLB_FALSE.
+ *
+ * @param ins The destroyed instance of flb_es_str, NULL is not allowed.
+ */
+void flb_es_str_destroy(struct flb_es_str *ins);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given null-terminated string src
+ * with no ownership implied.
+ *
+ * @param dest The target instance of flb_es_str, NULL is not allowed.
+ * @param src  The source null-terminated string, NULL is allowed.
+ *             It is not allowed for null-terminated string represented by src
+ *             to intersect with null-terminated string represented
+ *             by @c value of dest if @c owned of dest is not FLB_FALSE,
+ *             e.g. it is not allowed for non-NULL src to be equal to
+ *             @c value of dest if @c owned of dest is not FLB_FALSE.
+ */
+void flb_es_str_set_str(struct flb_es_str *dest, char *src);
+
+/**
+ * Duplicates null-terminated string src using flb_strdup, then if succeeds
+ * destroys existing @c value of dest (if it is owned by dest) and assigns
+ * @c value of dest result of flb_strdup implying this null-terminated string
+ * is owned by dest.
+ *
+ * @param dest The target instance of flb_es_str, NULL is not allowed.
+ * @param src  The source null-terminated string, NULL is allowed.
+ *             If src is NULL, then flb_strdup is not called, @c value of dest
+ *             is assigned NULL and zero is returned.
+ *
+ * @return Zero if succeeds (flb_strdup succeeds or is not called, because src
+ *         is NULL), not zero otherwise.
+ */
+int flb_es_str_copy_str(struct flb_es_str *dest, const char *src);
+
+/**
+ * If Simple Dynamic String represented by @c value of ins is owned by ins,
+ * then destroys @c value of ins using flb_sds_destroy.
+ *
+ * Sets @c value of ins to NULL and @c owned of ins to FLB_FALSE.
+ *
+ * @param ins The destroyed instance of flb_es_sds_t, NULL is not allowed.
+ */
+void flb_es_sds_destroy(struct flb_es_sds_t *ins);
+
+/**
+ * Destroys @c value of dest if @c value is owned,
+ * then assigns @c value of dest given Simple Dynamic String src
+ * with no ownership implied.
+ *
+ * @param dest The target instance of flb_es_sds_t, NULL is not allowed.
+ * @param src  The source Simple Dynamic String, NULL is allowed.
+ *             It is not allowed for string represented by src to intersect
+ *             with string represented by @c value of dest if @c owned of dest
+ *             is not FLB_FALSE, e.g. it is not allowed for non-NULL src to be
+ *             equal to @c value of dest if @c owned of dest is not FLB_FALSE.
+ */
+void flb_es_sds_set_sds(struct flb_es_sds_t *dest, flb_sds_t src);
+
+/**
+ * Duplicates null-terminated string src using flb_sds_create,
+ * then if flb_sds_create succeeds destroys @c value of dest (if it is owned
+ * by dest) and assigns @c value of dest result of flb_sds_create implying
+ * this Simple Dynamic String is owned by dest.
+ *
+ * @param dest The target instance of flb_es_sds_t, NULL is not allowed.
+ * @param src  The source null-terminated string, NULL is allowed.
+ *             If src is NULL, then flb_sds_create is not called,
+ *             @c value of dest is assigned NULL and zero is returned.
+ *
+ * @return Zero if succeeds (flb_sds_create succeeds or is not called,
+ *         because src is NULL), not zero otherwise.
+ */
+int flb_es_sds_copy_str(struct flb_es_sds_t *dest, const char *src);
+
+/**
+ * If list represented by @c value of ins is owned by ins,
+ * then destroys list using flb_slist_destroy and frees memory using flb_free.
+ *
+ * Sets @c value of ins to NULL and @c owned of ins to FLB_FALSE.
+ *
+ * @param ins The destroyed instance of flb_es_slist, NULL is not allowed.
+ */
+void flb_es_slist_destroy(struct flb_es_slist *ins);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given src with no ownership implied.
+ *
+ * @param dest The target instance of flb_es_slist, NULL is not allowed.
+ * @param src  The source list of Simple Dynamic Strings, NULL is allowed.
+ *             It is not allowed for list represented by src to intersect with
+ *             list represented by @c value of dest if @c owned of dest
+ *             is not FLB_FALSE, e.g. it is not allowed for non-NULL src to be
+ *             equal to @c value of dest if @c owned of dest is not FLB_FALSE.
+ */
+void flb_es_slist_set_slist(struct flb_es_slist *dest, struct mk_list *src);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given src implying this list is owned by dest.
+ *
+ * @param dest The target instance of flb_es_slist, NULL is not allowed.
+ * @param src  The source list of Simple Dynamic Strings, NULL is allowed.
+ *             It is not allowed for list represented by src to intersect with
+ *             list represented by @c value of dest if @c owned of dest
+ *             is not FLB_FALSE, e.g. it is not allowed for non-NULL src to be
+ *             equal to @c value of dest if @c owned of dest is not FLB_FALSE.
+ */
+void flb_es_slist_move_slist(struct flb_es_slist *dest, struct mk_list *src);
+
+/**
+ * If TLS context represented by @c value of ins is owned by ins,
+ * then destroys TLS context using flb_tls_destroy.
+ *
+ * Sets @c value of ins to NULL and @c owned of ins to FLB_FALSE.
+ *
+ * @param ins The destroyed instance of flb_es_tls, NULL is not allowed.
+ */
+void flb_es_tls_destroy(struct flb_es_tls *ins);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given TLS context src
+ * with no ownership implied.
+ *
+ * @param dest The target instance of flb_es_tls, NULL is not allowed.
+ * @param src  The source TLS context, NULL is allowed.
+ *             It is not allowed for TLS context represented by src to intersect
+ *             with TLS context represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL src to be equal to @c value of dest if @c owned of dest
+ *             is not FLB_FALSE.
+ */
+void flb_es_tls_set_tls(struct flb_es_tls *dest, struct flb_tls *src);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given TLS context src implying this TLS context
+ * is owned by dest.
+ *
+ * @param dest The target instance of flb_es_tls, NULL is not allowed.
+ * @param src  The source TLS context, NULL is allowed.
+ *             It is not allowed for TLS context represented by src to intersect
+ *             with TLS context represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL src to be equal to @c value of dest if @c owned of dest
+ *             is not FLB_FALSE.
+ */
+void flb_es_tls_move_tls(struct flb_es_tls *dest, struct flb_tls *src);
+
+/**
+ * If record accessor represented by @c value of ins is owned by ins,
+ * then destroys record accessor using flb_ra_destroy.
+ *
+ * Sets @c value of ins to NULL and @c owned of ins to FLB_FALSE.
+ *
+ * @param ins The destroyed instance of flb_es_record_accessor,
+ *            NULL is not allowed.
+ */
+void flb_es_ra_destroy(struct flb_es_record_accessor *ins);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given record accessor src
+ * with no ownership implied.
+ *
+ * @param dest The target instance of flb_es_record_accessor,
+ *             NULL is not allowed.
+ * @param src  The source record accessor, NULL is allowed.
+ *             It is not allowed for record accessor represented by src to
+ *             intersect with record accessor represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL src to be equal to @c value of dest if @c owned of dest
+ *             is not FLB_FALSE.
+ */
+void flb_es_ra_set_ra(struct flb_es_record_accessor *dest,
+                      struct flb_record_accessor *src);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given record accessor src
+ * implying this record accessor is owned by dest.
+ *
+ * @param dest The target instance of flb_es_record_accessor,
+ *             NULL is not allowed.
+ * @param src  The source record accessor, NULL is allowed.
+ *             It is not allowed for record accessor represented by src to
+ *             intersect with record accessor represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL src to be equal to @c value of dest if @c owned of dest
+ *             is not FLB_FALSE.
+ */
+void flb_es_ra_move_ra(struct flb_es_record_accessor *dest,
+                       struct flb_record_accessor *src);
+
+#ifdef FLB_HAVE_AWS
+/**
+ * If AWS provider represented by @c value of ins is owned by ins,
+ * then destroys AWS provider using flb_aws_provider_destroy.
+ *
+ * Sets @c value of ins to NULL and @c owned of ins to FLB_FALSE.
+ *
+ * @param ins The destroyed instance of flb_es_aws_provider,
+ *            NULL is not allowed.
+ */
+void flb_es_aws_provider_destroy(struct flb_es_aws_provider *ins);
+
+/**
+ * If dest != src, then destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given AWS provider represented
+ * by @c value of src with no ownership implied.
+ *
+ * If dest == src then does nothing.
+ *
+ * @param dest The target instance of flb_es_aws_provider, NULL is not allowed.
+ * @param src  The source instance of flb_es_aws_provider, NULL is allowed.
+ *             It is not allowed for AWS provider represented by @c value of src
+ *             to intersect with AWS provider represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL @c value of src to be equal to @c value of dest if
+ *             @c owned of dest is not FLB_FALSE.
+ */
+void flb_es_aws_provider_set(struct flb_es_aws_provider *dest,
+                             const struct flb_es_aws_provider *src);
+
+/**
+ * If dest != src, then destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest @c value of src,
+ * then @c value of src is assigned NULL and @c owned of src is assigned
+ * FLB_FALSE. If assigned value was owned by src, then it is implied to be owned
+ * by dest, otherwise dest implies no ownership of its new value, i.e. both
+ * value and ownership are transferred from src to dest.
+ *
+ * If dest == src then does nothing.
+ *
+ * @param dest The target instance of flb_es_aws_provider, NULL is not allowed.
+ * @param src  The source instance of flb_es_aws_provider, NULL is allowed.
+ *             It is not allowed for AWS provider represented by @c value of src
+ *             to intersect with AWS provider represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL @c value of src to be equal to @c value of dest if
+ *             @c owned of dest is not FLB_FALSE.
+ */
+void flb_es_aws_provider_move(struct flb_es_aws_provider *dest,
+                              struct flb_es_aws_provider *src);
+
+/**
+ * Destroys @c value of dest if @c value is owned by dest,
+ * then assigns @c value of dest given AWS provider src implying this provider
+ * is owned by dest.
+ *
+ * @param dest The target instance of flb_es_aws_provider, NULL is not allowed.
+ * @param src  The source instance of flb_aws_provider, NULL is allowed.
+ *             It is not allowed for AWS provider represented by src to
+ *             intersect with AWS provider represented by @c value of dest
+ *             if @c owned of dest is not FLB_FALSE, e.g. it is not allowed for
+ *             non-NULL src to be equal to @c value of dest if @c owned of dest
+ *             is not FLB_FALSE.
+ */
+void flb_es_aws_provider_move_provider(struct flb_es_aws_provider *dest,
+                                       struct flb_aws_provider *src);
+#endif
+
+#endif

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -591,6 +591,18 @@ int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                         void *out_callback_data,
                         void *test_ctx)
 {
+    return flb_output_set_test_with_ctx_callback(ctx, ffd, test_name, out_callback,
+                                                 out_callback_data, test_ctx, NULL);
+}
+
+int flb_output_set_test_with_ctx_callback(flb_ctx_t *ctx, int ffd, char *test_name,
+                        void (*out_callback) (void *, int, int, void *, size_t, void *),
+                        void *out_callback_data,
+                        void *test_ctx,
+                        void *(*test_ctx_callback) (struct flb_config *,
+                                                    struct flb_input_instance *,
+                                                    void *, void *))
+{
     struct flb_output_instance *o_ins;
 
     o_ins = out_instance_get(ctx, ffd);
@@ -611,6 +623,7 @@ int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
         o_ins->test_formatter.rt_out_callback = out_callback;
         o_ins->test_formatter.rt_data = out_callback_data;
         o_ins->test_formatter.flush_ctx = test_ctx;
+        o_ins->test_formatter.flush_ctx_callback = test_ctx_callback;
     }
     else {
         return -1;

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -589,19 +589,7 @@ int flb_output_set_callback(flb_ctx_t *ctx, int ffd, char *name,
 int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                         void (*out_callback) (void *, int, int, void *, size_t, void *),
                         void *out_callback_data,
-                        void *test_ctx)
-{
-    return flb_output_set_test_with_ctx_callback(ctx, ffd, test_name, out_callback,
-                                                 out_callback_data, test_ctx, NULL);
-}
-
-int flb_output_set_test_with_ctx_callback(flb_ctx_t *ctx, int ffd, char *test_name,
-                        void (*out_callback) (void *, int, int, void *, size_t, void *),
-                        void *out_callback_data,
-                        void *test_ctx,
-                        void *(*test_ctx_callback) (struct flb_config *,
-                                                    struct flb_input_instance *,
-                                                    void *, void *))
+                        void *flush_ctx)
 {
     struct flb_output_instance *o_ins;
 
@@ -622,8 +610,41 @@ int flb_output_set_test_with_ctx_callback(flb_ctx_t *ctx, int ffd, char *test_na
         o_ins->test_formatter.rt_ffd = ffd;
         o_ins->test_formatter.rt_out_callback = out_callback;
         o_ins->test_formatter.rt_data = out_callback_data;
-        o_ins->test_formatter.flush_ctx = test_ctx;
-        o_ins->test_formatter.flush_ctx_callback = test_ctx_callback;
+        o_ins->test_formatter.flush_ctx = flush_ctx;
+    }
+    else {
+        return -1;
+    }
+
+    return 0;
+}
+
+int flb_output_set_test_flush_ctx_callback(flb_ctx_t *ctx, int ffd,
+                                           char *test_name,
+                                           void *(*flush_ctx_callback) (struct flb_config *,
+                                                                        struct flb_input_instance *,
+                                                                        void *, void *),
+                                           void *flush_ctx)
+{
+    struct flb_output_instance *o_ins;
+
+    o_ins = out_instance_get(ctx, ffd);
+    if (!o_ins) {
+        return -1;
+    }
+
+    /*
+     * Enabling a test, set the output instance in 'test' mode, so no real
+     * flush callback is invoked, only the desired implemented test.
+     */
+
+    /* Formatter test */
+    if (strcmp(test_name, "formatter") == 0) {
+        o_ins->test_mode = FLB_TRUE;
+        o_ins->test_formatter.rt_ctx = ctx;
+        o_ins->test_formatter.rt_ffd = ffd;
+        o_ins->test_formatter.flush_ctx = flush_ctx;
+        o_ins->test_formatter.flush_ctx_callback = flush_ctx_callback;
     }
     else {
         return -1;

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -1,11 +1,31 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
 #include <fluent-bit.h>
 #include "flb_tests_runtime.h"
 
 /* Test data */
 #include "data/es/json_es.h" /* JSON_ES */
 
+/*
+ * Include plugin headers to get the definition of structure used as flush context
+ * and to know how to extract that structure from plugin context.
+ */
+#include "../../plugins/out_es/es.h"
+#include "../../plugins/out_es/es_conf.h"
+
+static void *cb_flush_context(struct flb_config *config, struct flb_input_instance *ins,
+                              void *plugin_context, void *flush_ctx)
+{
+    struct flb_elasticsearch *ctx = plugin_context;
+    (void) config;
+    (void) ins;
+    (void) flush_ctx;
+    return flb_es_upstream_conf(ctx, NULL);
+}
 
 static void cb_check_http_api_key(void *ctx, int ffd,
                                 int res_ret, void *res_data,
@@ -210,9 +230,10 @@ void flb_test_write_operation_index()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_write_op_index,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_write_op_index,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -254,9 +275,10 @@ void flb_test_write_operation_create()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_write_op_create,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_write_op_create,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -300,9 +322,10 @@ void flb_test_write_operation_update()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_write_op_update,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_write_op_update,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -346,9 +369,10 @@ void flb_test_write_operation_upsert()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_write_op_upsert,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_write_op_upsert,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -390,9 +414,10 @@ void flb_test_null_index()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_index_type,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_index_type,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -432,9 +457,10 @@ void flb_test_index_type()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_index_type,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_index_type,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -478,9 +504,10 @@ void flb_test_logstash_format()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_logstash_format,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_logstash_format,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -525,9 +552,10 @@ void flb_test_logstash_format_nanos()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_logstash_format_nanos,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_logstash_format_nanos,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -570,9 +598,10 @@ void flb_test_tag_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_tag_key,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_tag_key,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -614,9 +643,10 @@ void flb_test_replace_dots()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_replace_dots,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_replace_dots,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -658,9 +688,10 @@ void flb_test_id_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_id_key,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_id_key,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -712,9 +743,10 @@ void flb_test_div0()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_nothing,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_nothing,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -766,9 +798,10 @@ void flb_test_http_api_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_http_api_key,
-                              api_key, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_http_api_key,
+                                                api_key, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -837,9 +870,10 @@ void flb_test_long_index()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_long_index,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_long_index,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);
@@ -884,9 +918,10 @@ void flb_test_logstash_prefix_separator()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_logstash_prefix_separator,
-                              NULL, NULL);
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_logstash_prefix_separator,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
 
     /* Start */
     ret = flb_start(ctx);

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -1066,6 +1066,7 @@ TEST_LIST = {
     {"write_operation_create", flb_test_write_operation_create },
     {"write_operation_update", flb_test_write_operation_update },
     {"write_operation_upsert", flb_test_write_operation_upsert },
+    {"null_index"            , flb_test_null_index },
     {"index_type"            , flb_test_index_type },
     {"logstash_format"       , flb_test_logstash_format },
     {"logstash_format_nanos" , flb_test_logstash_format_nanos },

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -15,16 +15,111 @@
  * and to know how to extract that structure from plugin context.
  */
 #include "../../plugins/out_es/es.h"
-#include "../../plugins/out_es/es_conf.h"
+
+static const char * const es_upstream_section_property_prefix = "    ";
+static const char * const es_upstream_section_value_prefix    = " ";
+
+static char *create_upstream_conf_file(const char *first_property, ...)
+{
+    char *upstream_conf_filename;
+    FILE *upstream_conf_file;
+    int ret;
+    const char *arg;
+    int arg_idx;
+    va_list args;
+
+    upstream_conf_filename = (char *) flb_malloc(L_tmpnam);
+    if (!upstream_conf_filename) {
+        return NULL;
+    }
+
+    if (!tmpnam(upstream_conf_filename)) {
+        flb_free(upstream_conf_filename);
+        return NULL;
+    }
+
+    upstream_conf_file = fopen(upstream_conf_filename, "w");
+    if (upstream_conf_file == NULL) {
+        flb_free(upstream_conf_filename);
+        return NULL;
+    }
+
+    ret = fprintf(upstream_conf_file, "%s\n%s%s%s%s\n%s\n%s%s%s%s\n%s%s%s%s\n%s%s%s%s\n",
+                  "[UPSTREAM]",
+                  es_upstream_section_property_prefix,
+                  "name", es_upstream_section_value_prefix, "es-balancing",
+                  "[NODE]",
+                  es_upstream_section_property_prefix,
+                  "name", es_upstream_section_value_prefix, "node1",
+                  es_upstream_section_property_prefix,
+                  "host", es_upstream_section_value_prefix, FLB_ES_DEFAULT_HOST,
+                  es_upstream_section_property_prefix,
+                  "port", es_upstream_section_value_prefix, "9200");
+    if (ret < 0) {
+        fclose(upstream_conf_file);
+        remove(upstream_conf_filename);
+        flb_free(upstream_conf_filename);
+        return NULL;
+    }
+
+    arg = first_property;
+    arg_idx = 0;
+    va_start(args, first_property);
+    while (arg != NULL) {
+        if (arg_idx == 0) {
+            ret = fprintf(upstream_conf_file, "%s%s",
+                          es_upstream_section_property_prefix, arg);
+        }
+        else {
+            if (strlen(arg) > 0) {
+                ret = fprintf(upstream_conf_file, "%s%s\n",
+                              es_upstream_section_value_prefix, arg);
+            }
+            else {
+                ret = fprintf(upstream_conf_file, "\n");
+            }
+        }
+        if (ret < 0) {
+            va_end(args);
+            fclose(upstream_conf_file);
+            remove(upstream_conf_filename);
+            flb_free(upstream_conf_filename);
+            return NULL;
+        }
+        arg = va_arg(args, const char *);
+        arg_idx ^= 1;
+    }
+    va_end(args);
+
+    if (arg_idx != 0) {
+        ret = fprintf(upstream_conf_file, "\n");
+        if (ret < 0) {
+            fclose(upstream_conf_file);
+            remove(upstream_conf_filename);
+            flb_free(upstream_conf_filename);
+            return NULL;
+        }
+    }
+
+    ret = fclose(upstream_conf_file);
+    if (ret != 0) {
+        remove(upstream_conf_filename);
+        flb_free(upstream_conf_filename);
+        return NULL;
+    }
+
+    return upstream_conf_filename;
+}
 
 static void *cb_flush_context(struct flb_config *config, struct flb_input_instance *ins,
                               void *plugin_context, void *flush_ctx)
 {
+    struct flb_upstream_node *node;
     struct flb_elasticsearch *ctx = plugin_context;
     (void) config;
     (void) ins;
     (void) flush_ctx;
-    return flb_es_upstream_conf(ctx, NULL);
+    return flb_elasticsearch_target(ctx, &node);
 }
 
 static void cb_check_http_api_key(void *ctx, int ffd,
@@ -389,7 +484,6 @@ void flb_test_write_operation_upsert()
 void flb_test_null_index()
 {
     int ret;
-    int size = sizeof(JSON_ES) - 1;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -935,6 +1029,360 @@ void flb_test_logstash_prefix_separator()
     flb_destroy(ctx);
 }
 
+void flb_test_upstream_write_operation()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *upstream_conf_filename;
+
+    /* Override write_operation to index at upstream node level */
+    upstream_conf_filename = create_upstream_conf_file("write_operation", "index", NULL);
+    TEST_ASSERT(upstream_conf_filename != NULL);
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Override defaults of index and type */
+    flb_output_set(ctx, out_ffd,
+                   "Write_Operation", "Upsert",
+                   "Generate_Id", "True",
+                   NULL);
+
+    /* Use upstream servers */
+    flb_output_set(ctx, out_ffd,
+                   "Upstream", upstream_conf_filename,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_write_op_index,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    /* Cleanup temporary configuration file */
+    TEST_CHECK(remove(upstream_conf_filename) == 0);
+    flb_free(upstream_conf_filename);
+}
+
+void flb_test_upstream_null_index()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *upstream_conf_filename;
+
+    /* Override index at upstream node level */
+    upstream_conf_filename = create_upstream_conf_file("generate_id", "off", NULL);
+    TEST_ASSERT(upstream_conf_filename != NULL);
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "index", "",
+                   "generate_id", "on",
+                   "match", "test",
+                   NULL);
+
+    /* Use upstream servers */
+    flb_output_set(ctx, out_ffd,
+                   "Upstream", upstream_conf_filename,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_write_op_index,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == -1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    /* Cleanup temporary configuration file */
+    TEST_CHECK(remove(upstream_conf_filename) == 0);
+    flb_free(upstream_conf_filename);
+}
+
+void flb_test_upstream_index_type()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *upstream_conf_filename;
+
+    /* Override default index and type at upstream node level */
+    upstream_conf_filename = create_upstream_conf_file("index", "index_test",
+                                                       "type", "type_test",
+                                                       NULL);
+    TEST_ASSERT(upstream_conf_filename != NULL);
+
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "another_index_test",
+                   "type", "another_type_test",
+                   NULL);
+
+    /* Use upstream servers */
+    flb_output_set(ctx, out_ffd,
+                   "Upstream", upstream_conf_filename,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_index_type,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    /* Cleanup temporary configuration file */
+    TEST_CHECK(remove(upstream_conf_filename) == 0);
+    flb_free(upstream_conf_filename);
+}
+
+void flb_test_upstream_logstash_format()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *upstream_conf_filename;
+
+    /* Specify Logstash format at upstream node level */
+    upstream_conf_filename = create_upstream_conf_file("logstash_format", "on",
+                                                       "logstash_prefix", "prefix",
+                                                       "logstash_prefix_separator", "SEP",
+                                                       "logstash_dateformat", "%Y-%m-%d",
+                                                       NULL);
+    TEST_ASSERT(upstream_conf_filename != NULL);
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Use configuration different from upstream node configuration */
+    flb_output_set(ctx, out_ffd,
+                   "logstash_format", "off",
+                   "logstash_prefix", "logstash",
+                   "logstash_prefix_separator", "-",
+                   "logstash_dateformat", "%Y.%m.%d",
+                   NULL);
+
+    /* Use upstream servers */
+    flb_output_set(ctx, out_ffd,
+                   "Upstream", upstream_conf_filename,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_logstash_prefix_separator,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    /* Cleanup temporary configuration file */
+    TEST_CHECK(remove(upstream_conf_filename) == 0);
+    flb_free(upstream_conf_filename);
+}
+
+void flb_test_upstream_replace_dots()
+{
+    int ret;
+    int size = sizeof(JSON_DOTS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *upstream_conf_filename;
+
+    /* Specify Logstash format at upstream node level */
+    upstream_conf_filename = create_upstream_conf_file("replace_dots", "on",
+                                                       NULL);
+    TEST_ASSERT(upstream_conf_filename != NULL);
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Use configuration different from upstream node configuration */
+    flb_output_set(ctx, out_ffd,
+                   "replace_dots", "off",
+                   NULL);
+
+    /* Use upstream servers */
+    flb_output_set(ctx, out_ffd,
+                   "Upstream", upstream_conf_filename,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_replace_dots,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_DOTS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    /* Cleanup temporary configuration file */
+    TEST_CHECK(remove(upstream_conf_filename) == 0);
+    flb_free(upstream_conf_filename);
+}
+
+void flb_test_upstream_id_key()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *upstream_conf_filename;
+
+    /* Specify Logstash format at upstream node level */
+    upstream_conf_filename = create_upstream_conf_file("id_key", "key_2", NULL);
+    TEST_ASSERT(upstream_conf_filename != NULL);
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Use upstream servers */
+    flb_output_set(ctx, out_ffd,
+                   "Upstream", upstream_conf_filename,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_id_key,
+                                                NULL, NULL, cb_flush_context);
+    TEST_CHECK(ret == 0);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    /* Cleanup temporary configuration file */
+    TEST_CHECK(remove(upstream_conf_filename) == 0);
+    flb_free(upstream_conf_filename);
+}
+
 static void cb_check_response_success(void *ctx, int ffd,
                                      int res_ret, void *res_data,
                                      size_t res_size, void *data)
@@ -1113,5 +1561,11 @@ TEST_LIST = {
     {"response_success"      , flb_test_response_success },
     {"response_successes", flb_test_response_successes },
     {"response_partially_success" , flb_test_response_partially_success },
+    {"upstream_write_operation"  , flb_test_upstream_write_operation },
+    {"upstream_null_index"       , flb_test_upstream_null_index },
+    {"upstream_index_type"       , flb_test_upstream_index_type },
+    {"upstream_logstash_format"  , flb_test_upstream_logstash_format },
+    {"upstream_replace_dots"     , flb_test_upstream_replace_dots },
+    {"upstream_id_key"           , flb_test_upstream_id_key },
     {NULL, NULL}
 };

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -325,9 +325,12 @@ void flb_test_write_operation_index()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_write_op_index,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_write_op_index,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -370,9 +373,12 @@ void flb_test_write_operation_create()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_write_op_create,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_write_op_create,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -417,9 +423,12 @@ void flb_test_write_operation_update()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_write_op_update,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_write_op_update,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -464,9 +473,12 @@ void flb_test_write_operation_upsert()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_write_op_upsert,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_write_op_upsert,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -508,9 +520,12 @@ void flb_test_null_index()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_index_type,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_type,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -551,9 +566,12 @@ void flb_test_index_type()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_index_type,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_type,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -598,9 +616,12 @@ void flb_test_logstash_format()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_logstash_format,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_logstash_format,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -646,9 +667,12 @@ void flb_test_logstash_format_nanos()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_logstash_format_nanos,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_logstash_format_nanos,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -692,9 +716,12 @@ void flb_test_tag_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_tag_key,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_tag_key,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -737,9 +764,12 @@ void flb_test_replace_dots()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_replace_dots,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_replace_dots,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -782,9 +812,12 @@ void flb_test_id_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_id_key,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_id_key,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -837,9 +870,12 @@ void flb_test_div0()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_nothing,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_nothing,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -892,9 +928,12 @@ void flb_test_http_api_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_http_api_key,
-                                                api_key, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_api_key,
+                              api_key, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -964,9 +1003,12 @@ void flb_test_long_index()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_long_index,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_long_index,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -1012,9 +1054,12 @@ void flb_test_logstash_prefix_separator()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_logstash_prefix_separator,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_logstash_prefix_separator,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -1068,9 +1113,12 @@ void flb_test_upstream_write_operation()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_write_op_index,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_write_op_index,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -1182,9 +1230,11 @@ void flb_test_upstream_index_type()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_index_type,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter", cb_check_index_type,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -1248,9 +1298,12 @@ void flb_test_upstream_logstash_format()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_logstash_prefix_separator,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_logstash_prefix_separator,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -1308,9 +1361,11 @@ void flb_test_upstream_replace_dots()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_replace_dots,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter", cb_check_replace_dots,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */
@@ -1362,9 +1417,11 @@ void flb_test_upstream_id_key()
                    NULL);
 
     /* Enable test mode */
-    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
-                                                cb_check_id_key,
-                                                NULL, NULL, cb_flush_context);
+    ret = flb_output_set_test(ctx, out_ffd, "formatter", cb_check_id_key,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_output_set_test_flush_ctx_callback(ctx, out_ffd, "formatter",
+                                                 cb_flush_context, NULL);
     TEST_CHECK(ret == 0);
 
     /* Start */


### PR DESCRIPTION
Implementation of [Upstream](https://docs.fluentbit.io/manual/configuration/upstream_servers) feature for the Elasticsearch output plugin.

This pull request is based on pull request #1560 and Forward output plugin.

It was tested in a local setup with:

1. Fluent Bit without Upstream feature connected to a single node of Elasticsearch cluster consisting of 3 master-eligible/data and 1 coordinating nodes.

    Refer to [elastic-cluster](https://github.com/mabrarov/elastic-stack/tree/main/elastic-cluster) directory of [mabrarov/elastic-stack](https://github.com/mabrarov/elastic-stack) repository for Docker Compose project used to create target Elasticsearch cluster and Kibana.

    fluent-bit.conf Fluent Bit configuration file used for the test - refer to [fluent-bit-es/fluent-bit.conf](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es/fluent-bit.conf) and (same in YAML format) [fluent-bit-es/fluent-bit.yaml](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es/fluent-bit.yaml) in [mabrarov/elastic-stack](https://github.com/mabrarov/elastic-stack) repository.

    Debug log is available at [flb_es.log](https://drive.google.com/file/d/1NHLs1KLRu49yMjrg86uulvQeyhaCoCUd/view?usp=sharing).

1. Fluent Bit with Upstream feature connected to all Elasticsearch data nodes of Elasticsearch cluster consisting of 3 master-eligible/data and 1 coordinating nodes.

    Refer to [elastic-cluster](https://github.com/mabrarov/elastic-stack/tree/main/elastic-cluster) directory of [mabrarov/elastic-stack](https://github.com/mabrarov/elastic-stack) repository for Docker Compose project used to create target Elasticsearch cluster and Kibana.

    fluent-bit.conf Fluent Bit configuration file used for the test - refer to [fluent-bit-es-cluster/fluent-bit.conf](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es-cluster/fluent-bit.conf) and (same in YAML format) [fluent-bit-es-cluster/fluent-bit.yaml](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es-cluster/fluent-bit.yaml) in [mabrarov/elastic-stack](https://github.com/mabrarov/elastic-stack) repository.

    Debug log is available at [flb_es_upstream.log](https://drive.google.com/file/d/1lcdkvTza62scmW7eCBI86_J1r7e7XDQP/view?usp=sharing).

----

**Testing**

- [x] Example configuration files for the change can be found in [mabrarov/elastic-stack](https://github.com/mabrarov/elastic-stack) repository under [fluent-bit-es-cluster](https://github.com/mabrarov/elastic-stack/tree/main/fluent-bit-es-cluster) directory.
- [x] Debug log output from testing the change - see above.
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found - refer to [flb_run_code_analysis.log](https://drive.google.com/file/d/17R4zlWf140y8g1EUpIqr8Ax0CG0vWWV9/view?usp=sharing) for the output of command
    ```bash
    TEST_PRESET=valgrind SKIP_TESTS='flb-rt-out_forward flb-rt-out_td' ./run_code_analysis.sh
    ```
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [x] Documentation required for this feature - refer to https://github.com/fluent/fluent-bit-docs/pull/1143.

**Backporting**

- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HA-aware Elasticsearch output with per-upstream/per-node configuration and upstream-aware formatter flush-context callbacks.

* **Integrations**
  * Cloud ID parsing for Elasticsearch endpoints.
  * Optional AWS SigV4 support with STS and unsigned-headers handling.

* **Configuration**
  * Consolidated ES property names, added upstream option, and corrected default Elasticsearch port to 9200.

* **Quality**
  * Ownership-aware resource handling and improved lifecycle/cleanup.

* **Tests**
  * Expanded upstream-focused tests covering formatter, flush-context, and config scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->