### PR TITLE
config_format: yaml: fix 'customs' section handling(#7559)

### DIFF
--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -11,6 +11,7 @@
 #include "flb_tests_internal.h"
 
 #define FLB_000 FLB_TESTS_DATA_PATH "/data/config_format/yaml/fluent-bit.yaml"
+#define FLB_001 FLB_TESTS_DATA_PATH "/data/config_format/yaml/issue_7559.yaml"
 
 /* data/config_format/fluent-bit.yaml */
 void test_basic()
@@ -59,7 +60,35 @@ void test_basic()
     flb_cf_destroy(cf);
 }
 
+/* https://github.com/fluent/fluent-bit/issues/7559 */
+void test_customs_section()
+{
+    struct flb_cf *cf;
+    struct flb_cf_section *s;
+
+    cf = flb_cf_yaml_create(NULL, FLB_001, NULL, 0);
+    TEST_CHECK(cf != NULL);
+    if (!cf) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Total number of sections */
+    if(!TEST_CHECK(mk_list_size(&cf->sections) == 3)) {
+        TEST_MSG("Section number error. Got=%d expect=3", mk_list_size(&cf->sections));
+    }
+
+    s = flb_cf_section_get_by_name(cf, "customs");
+    TEST_CHECK(s != NULL);
+    if (!TEST_CHECK(s->type == FLB_CF_CUSTOM)) {
+        TEST_MSG("Section type error. Got=%d expect=%d", s->type, FLB_CF_CUSTOM);
+    }
+
+    flb_cf_dump(cf);
+    flb_cf_destroy(cf);
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
+    { "customs section", test_customs_section},
     { 0 }
 };

--- a/tests/internal/data/config_format/yaml/issue_7559.yaml
+++ b/tests/internal/data/config_format/yaml/issue_7559.yaml
@@ -1,0 +1,14 @@
+customs:
+  - name: calyptia
+
+pipeline:
+  inputs:
+    - name: fluentbit_metrics
+      scrape_interval: 30
+      scrape_on_start: true
+      tag: _calyptia_cloud
+service:
+  HTTP_Listen: 0.0.0.0
+  HTTP_PORT: 2020
+  HTTP_Server: 'On'
+  Log_Level: debug


### PR DESCRIPTION
Fixes #7559 

This patch is to fix yaml config file parser to handle 'customs' section.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration 

```
customs:
  - name: calyptia

pipeline:
  inputs:
    - name: fluentbit_metrics
      scrape_interval: 30
      scrape_on_start: true
      tag: _calyptia_cloud
service:
  HTTP_Listen: 0.0.0.0
  HTTP_PORT: 2020
  HTTP_Server: 'On'
  Log_Level: debug
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-config_format_yaml
Test customs section...                         > section:
  name: customs
  type: CUSTOM
  properties:
    - name           : calyptia
  groups    : NONE
> section:
  name: INPUT
  type: INPUT
  properties:
    - name           : fluentbit_metrics
    - scrape_interval: 30
    - scrape_on_start: true
    - tag            : _calyptia_cloud
  groups    : NONE
> section:
  name: service
  type: SERVICE
  properties:
    - http_listen    : 0.0.0.0
    - http_port      : 2020
    - http_server    : On
    - log_level      : debug
  groups    : NONE
[ OK ]
==58970== Warning: invalid file descriptor -1 in syscall close()
==58970== 
==58970== HEAP SUMMARY:
==58970==     in use at exit: 0 bytes in 0 blocks
==58970==   total heap usage: 1,036 allocs, 1,036 frees, 163,766 bytes allocated
==58970== 
==58970== All heap blocks were freed -- no leaks are possible
==58970== 
==58970== For lists of detected and suppressed errors, rerun with: -s
==58970== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==58968== 
==58968== HEAP SUMMARY:
==58968==     in use at exit: 0 bytes in 0 blocks
==58968==   total heap usage: 3 allocs, 3 frees, 1,093 bytes allocated
==58968== 
==58968== All heap blocks were freed -- no leaks are possible
==58968== 
==58968== For lists of detected and suppressed errors, rerun with: -s
==58968== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
