### PR TITLE
in_exec_wasi: fix possible NULL deref

### DIFF
--- a/plugins/in_exec_wasi/in_exec_wasi.c
+++ b/plugins/in_exec_wasi/in_exec_wasi.c
@@ -59,6 +59,11 @@ static int in_exec_wasi_collect(struct flb_input_instance *ins,
     size_t out_size = 0;
     struct flb_time out_time;
 
+    /* Validate the temporary file was created */
+    if (stdoutp == NULL) {
+        return -1;
+    }
+
     if (ctx->oneshot == FLB_TRUE) {
         ret = flb_pipe_r(ctx->ch_manager[0], &val, sizeof(val));
         if (ret == -1) {

--- a/plugins/in_exec_wasi/in_exec_wasi.c
+++ b/plugins/in_exec_wasi/in_exec_wasi.c
@@ -61,6 +61,7 @@ static int in_exec_wasi_collect(struct flb_input_instance *ins,
 
     /* Validate the temporary file was created */
     if (stdoutp == NULL) {
+        flb_plg_error(ctx->ins, "failed to created temporary file");
         return -1;
     }
 


### PR DESCRIPTION
`tmpfile()` can return NULL and this is not checked for at the moment. If indeed it returns NULL then the call on line 70 `fileno(stdoutp)` will cause a NULL dereference.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
