### PR TITLE
http_server: metrics: add null-dereference guards

### DIFF
--- a/src/http_server/api/v1/metrics.c
+++ b/src/http_server/api/v1/metrics.c
@@ -397,15 +397,45 @@ void cb_metrics_prometheus(mk_request_t *request, void *data)
                 }
 
                 sds_metric = flb_sds_cat(sds_metric, "fluentbit_", 10);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, k.via.str.ptr, k.via.str.size);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, "_", 1);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, mk.via.str.ptr, mk.via.str.size);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, "_total{name=\"", 13);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, sk.via.str.ptr, sk.via.str.size);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, "\"} ", 3);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, tmp, len);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, time_str, time_len);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 sds_metric = flb_sds_cat(sds_metric, "\n", 1);
+                if (sds_metric == NULL) {
+                    goto error;
+                }
                 metrics_arr[index] = sds_metric;
                 index++;
             }


### PR DESCRIPTION
`flb_sds_cat` can fail and return NULL, this should be checked to avoid NULL dereferences.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
