### PR TITLE
out_logdna: remove unused store

### DIFF
--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -305,7 +305,6 @@ static struct flb_logdna *logdna_config_create(struct flb_output_instance *ins,
         tmp = NULL;
         hostname = (char *) flb_env_get(config->env, "HOSTNAME");
         if (hostname) {
-            len = strlen(hostname);
             ctx->_hostname = flb_sds_create(hostname);
         }
         else {

--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -310,13 +310,15 @@ static struct flb_logdna *logdna_config_create(struct flb_output_instance *ins,
         else {
             ctx->_hostname = flb_sds_create("unknown");
         }
-        if (!ctx->_hostname) {
-            flb_free(ctx);
-            return NULL;
-        }
     }
     else {
         ctx->_hostname = flb_sds_create(ctx->hostname);
+    }
+
+    /* Bail if unsuccessful hostname creation */
+    if (!ctx->_hostname) {
+        flb_free(ctx);
+        return NULL;
     }
 
     /* Create Upstream connection context */


### PR DESCRIPTION
`len` is assigned but never used. No need for the operations related to this.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
