### PR TITLE
workflows: fix up OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/cron-scorecards-analysis.yaml
+++ b/.github/workflows/cron-scorecards-analysis.yaml
@@ -36,7 +36,7 @@ jobs:
           # (Optional) fine-grained personal access token. Uncomment the `repo_token` line below if:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           #
           # Publish the results for public repositories to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.

--- a/.github/workflows/cron-scorecards-analysis.yaml
+++ b/.github/workflows/cron-scorecards-analysis.yaml
@@ -20,9 +20,8 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      actions: read
-      contents: read
-
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
@@ -34,9 +33,11 @@ jobs:
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN || github.token }}
+          # (Optional) fine-grained personal access token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          #
           # Publish the results for public repositories to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`, regardless


### PR DESCRIPTION
Resolves failing runs due to changes in OpenSSF scorecard action.

----

**Testing**


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
