### PR TITLE
log_event_decoder: fix wrong api name

### DIFF
--- a/include/fluent-bit/flb_log_event_decoder.h
+++ b/include/fluent-bit/flb_log_event_decoder.h
@@ -83,6 +83,6 @@ int flb_log_event_decoder_get_last_result(struct flb_log_event_decoder *context)
 int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
                                struct flb_log_event *record);
 
-const char *flb_log_event_encoder_strerror(int error_code);
+const char *flb_log_event_decoder_get_error_description(int error_code);
 
 #endif


### PR DESCRIPTION
This patch is to rename wrong function name.
It should be `flb_log_event_decoder_get_error_description`.
https://github.com/fluent/fluent-bit/blob/v2.1.6/src/flb_log_event_decoder.c#L304

It was reviewed and I thought it was fixed..
https://github.com/fluent/fluent-bit/pull/7539#discussion_r1225263275

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
