### PR TITLE
out_syslog: check error after flb_log_event_decoder_next

### DIFF
--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -991,9 +991,9 @@ static int cb_syslog_format_test(struct flb_config *config,
         return -1;
     }
 
-    if ((ret = flb_log_event_decoder_next(
-                &log_decoder,
-                &log_event)) != FLB_EVENT_DECODER_SUCCESS) {
+    flb_log_event_decoder_next(&log_decoder, &log_event);
+    ret = flb_log_event_decoder_get_last_result(&log_decoder);
+    if (ret != FLB_EVENT_DECODER_SUCCESS) {
         flb_error("msgpack_unpack_next failed");
 
         flb_log_event_decoder_destroy(&log_decoder);


### PR DESCRIPTION
This patch is to fix error verification after flb_log_event_decoder_next.
See also #7636 

No error verification except for test code.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug / Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-out_syslog 
==10974== Memcheck, a memory error detector
==10974== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10974== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==10974== Command: bin/flb-rt-out_syslog
==10974== 
Test format_severity_key_rfc3164...             [ OK ]
Test format_facility_key_rfc3164...             [ OK ]
Test format_severity_facility_key_rfc3164...    [ OK ]
Test format_hostname_key_rfc3164...             [ OK ]
Test format_appname_key_rfc3164...              [ OK ]
Test format_severity_preset_rfc3164...          [ OK ]
Test format_facility_preset_rfc3164...          [ OK ]
Test format_hostname_preset_rfc3164...          [ OK ]
Test format_appname_preset_rfc3164...           [ OK ]
Test format_syslog_rfc5424...                   [ OK ]
Test format_severity_key_rfc5424...             [ OK ]
Test format_facility_key_rfc5424...             [ OK ]
Test format_severity_facility_key_rfc5424...    [ OK ]
Test format_hostname_key_rfc5424...             [ OK ]
Test format_appname_key_rfc5424...              [ OK ]
Test format_procid_key_rfc5424...               [ OK ]
Test format_msgid_key_rfc5424...                [ OK ]
Test format_sd_key_rfc5424...                   [ OK ]
Test format_severity_preset_rfc5424...          [ OK ]
Test format_facility_preset_rfc5424...          [ OK ]
Test format_hostname_preset_rfc5424...          [ OK ]
Test format_appname_preset_rfc5424...           [ OK ]
Test format_procid_preset_rfc5424...            [ OK ]
Test format_msgid_preset_rfc5424...             [ OK ]
Test allow_longer_sd_id_rfc5424...              [ OK ]
Test malformed_longer_sd_id_rfc5424...          [ OK ]
SUCCESS: All unit tests have passed.
==10974== 
==10974== HEAP SUMMARY:
==10974==     in use at exit: 0 bytes in 0 blocks
==10974==   total heap usage: 37,882 allocs, 37,882 frees, 18,071,290 bytes allocated
==10974== 
==10974== All heap blocks were freed -- no leaks are possible
==10974== 
==10974== For lists of detected and suppressed errors, rerun with: -s
==10974== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
