### PR TITLE
out_gelf: fix releasing function handling

### DIFF
--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -237,7 +237,6 @@ static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
     int ret;
     flb_sds_t s;
     flb_sds_t tmp;
-    msgpack_unpacked result;
     size_t off = 0;
     size_t prev_off = 0;
     size_t size = 0;
@@ -271,8 +270,6 @@ static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    msgpack_unpacked_init(&result);
-
     while ((ret = flb_log_event_decoder_next(
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
@@ -285,7 +282,7 @@ static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
         size = (size * 1.4);
         s = flb_sds_create_size(size);
         if (s == NULL) {
-            msgpack_unpacked_destroy(&result);
+            flb_log_event_decoder_destroy(&log_decoder);
             FLB_OUTPUT_RETURN(FLB_ERROR);
         }
 
@@ -333,7 +330,7 @@ static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
         flb_sds_destroy(s);
     }
 
-    msgpack_unpacked_destroy(&result);
+    flb_log_event_decoder_destroy(&log_decoder);
 
     if (ctx->mode != FLB_GELF_UDP) {
         flb_upstream_conn_release(u_conn);


### PR DESCRIPTION
This patch is to fix following valgrind error.
- Remove unused msgpack_unpacked
- Add missing `flb_log_event_decoder_destroy`

```
==17050== 
==17050== HEAP SUMMARY:
==17050==     in use at exit: 41,280 bytes in 10 blocks
==17050==   total heap usage: 1,693 allocs, 1,683 frees, 2,151,921 bytes allocated
==17050== 
==17050== 41,280 (280 direct, 41,000 indirect) bytes in 5 blocks are definitely lost in loss record 2 of 2
==17050==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==17050==    by 0xBB320C: msgpack_zone_new (zone.c:199)
==17050==    by 0xBB0CFC: template_callback_map (unpack.c:252)
==17050==    by 0xBB1567: template_execute (unpack_template.h:233)
==17050==    by 0xBB2C34: msgpack_unpack_next (unpack.c:677)
==17050==    by 0x2DC420: create_empty_map (flb_log_event_decoder.c:46)
==17050==    by 0x2DC552: flb_log_event_decoder_init (flb_log_event_decoder.c:95)
==17050==    by 0x685302: cb_gelf_flush (gelf.c:259)
==17050==    by 0x1DF480: output_pre_cb_flush (flb_output.h:559)
==17050==    by 0xBD0B2A: co_init (amd64.c:117)
==17050== 
==17050== LEAK SUMMARY:
==17050==    definitely lost: 280 bytes in 5 blocks
==17050==    indirectly lost: 41,000 bytes in 5 blocks
==17050==      possibly lost: 0 bytes in 0 blocks
==17050==    still reachable: 0 bytes in 0 blocks
==17050==         suppressed: 0 bytes in 0 blocks
==17050== 
==17050== For lists of detected and suppressed errors, rerun with: -s
==17050== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

```
[INPUT]
    name dummy
    Dummy {"short_message":"short"}

[OUTPUT]
    name gelf
    match *
    Mode tcp
```

## Debug/Valgrind output

```
nc -l 12201
```

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==14396== Memcheck, a memory error detector
==14396== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==14396== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==14396== Command: bin/fluent-bit -c a.conf
==14396== 
Fluent Bit v2.1.7
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/07/02 08:57:20] [ info] [fluent bit] version=2.1.7, commit=f70462c100, pid=14396
[2023/07/02 08:57:21] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/07/02 08:57:21] [ info] [cmetrics] version=0.6.2
[2023/07/02 08:57:21] [ info] [ctraces ] version=0.3.1
[2023/07/02 08:57:21] [ info] [input:dummy:dummy.0] initializing
[2023/07/02 08:57:21] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/07/02 08:57:21] [ info] [sp] stream processor started
^C[2023/07/02 08:57:24] [engine] caught signal (SIGINT)
[2023/07/02 08:57:24] [ warn] [engine] service will shutdown in max 5 seconds
[2023/07/02 08:57:24] [ info] [input] pausing dummy.0
[2023/07/02 08:57:24] [ info] [engine] service has stopped (0 pending tasks)
[2023/07/02 08:57:24] [ info] [input] pausing dummy.0
==14396== 
==14396== HEAP SUMMARY:
==14396==     in use at exit: 0 bytes in 0 blocks
==14396==   total heap usage: 1,630 allocs, 1,630 frees, 1,452,001 bytes allocated
==14396== 
==14396== All heap blocks were freed -- no leaks are possible
==14396== 
==14396== For lists of detected and suppressed errors, rerun with: -s
==14396== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
