### PR TITLE
log_evnet_encoder: fix typo

### DIFF
--- a/src/flb_log_event_encoder.c
+++ b/src/flb_log_event_encoder.c
@@ -376,7 +376,7 @@ const char *flb_log_event_encoder_get_error_description(int error_code)
         break;
 
     case FLB_EVENT_ENCODER_ERROR_SERIALIZATION_FAILURE:
-        ret = "Serializatoin failure";
+        ret = "Serialization failure";
         break;
 
     case FLB_EVENT_ENCODER_ERROR_INVALID_VALUE_TYPE:


### PR DESCRIPTION
This patch is to fix typo. 
"Serializatoin" -> "Serialization"

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
