### PR TITLE
in_syslog: Provide appending source address parameter

### DIFF
--- a/plugins/in_syslog/syslog.c
+++ b/plugins/in_syslog/syslog.c
@@ -239,6 +239,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_syslog, raw_message_key),
      "Key where the raw message will be preserved"
     },
+    {
+     FLB_CONFIG_MAP_STR, "source_address_key", (char *) NULL,
+     0, FLB_TRUE, offsetof(struct flb_syslog, source_address_key),
+     "Key where the source address will be injected"
+    },
 
 
     /* EOF */

--- a/plugins/in_syslog/syslog.h
+++ b/plugins/in_syslog/syslog.h
@@ -65,6 +65,7 @@ struct flb_syslog {
     flb_sds_t parser_name;
     struct flb_parser *parser;
     flb_sds_t raw_message_key;
+    flb_sds_t source_address_key;
 
     int dgram_mode_flag;
     int collector_id;

--- a/plugins/in_syslog/syslog_conn.c
+++ b/plugins/in_syslog/syslog_conn.c
@@ -144,7 +144,7 @@ int syslog_dgram_conn_event(void *data)
         conn->buf_data[bytes] = '\0';
         conn->buf_len = bytes;
 
-        syslog_prot_process_udp(conn->buf_data, conn->buf_len, ctx);
+        syslog_prot_process_udp(conn->buf_data, conn->buf_len, ctx, connection);
     }
     else {
         flb_errno();

--- a/plugins/in_syslog/syslog_conn.c
+++ b/plugins/in_syslog/syslog_conn.c
@@ -128,13 +128,10 @@ int syslog_dgram_conn_event(void *data)
     struct flb_connection *connection;
     int                    bytes;
     struct syslog_conn    *conn;
-    struct flb_syslog     *ctx;
 
     connection = (struct flb_connection *) data;
 
     conn = connection->user_data;
-
-    ctx = conn->ctx;
 
     bytes = flb_io_net_read(connection,
                             (void *) &conn->buf_data[conn->buf_len],
@@ -144,7 +141,7 @@ int syslog_dgram_conn_event(void *data)
         conn->buf_data[bytes] = '\0';
         conn->buf_len = bytes;
 
-        syslog_prot_process_udp(conn->buf_data, conn->buf_len, ctx, connection);
+        syslog_prot_process_udp(conn);
     }
     else {
         flb_errno();

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -47,7 +47,6 @@ static int append_message_to_record_data(char **result_buffer,
     int                modified_data_size;
     msgpack_object_kv *new_map_entries[1];
     msgpack_object_kv  message_entry;
-    msgpack_sbuffer    mp_sbuf;
     *result_buffer = NULL;
     *result_size = 0;
     modified_data_buffer = NULL;

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -154,6 +154,7 @@ static inline int pack_line(struct flb_syslog *ctx,
     int     result;
     char   *source_address;
 
+    source_address = NULL;
     modified_data_buffer = NULL;
     appended_address_buffer = NULL;
 

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -124,8 +124,8 @@ static inline int pack_line(struct flb_syslog *ctx,
                                                raw_data_size,
                                                MSGPACK_OBJECT_BIN);
 
-        if (result != 0) {
-            flb_plg_debug(ctx->ins, "error appending raw message : %d", result);
+        if (result == FLB_MAP_EXPANSION_ERROR) {
+            flb_plg_debug(ctx->ins, "error expanding raw message : %d", result);
         }
     }
 
@@ -153,8 +153,8 @@ static inline int pack_line(struct flb_syslog *ctx,
                                                        MSGPACK_OBJECT_STR);
             }
 
-            if (result != 0) {
-                flb_plg_debug(ctx->ins, "error appending source_address : %d", result);
+            if (result == FLB_MAP_EXPANSION_ERROR) {
+                flb_plg_debug(ctx->ins, "error expanding source_address : %d", result);
             }
         }
     }

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -333,13 +333,21 @@ int syslog_prot_process(struct syslog_conn *conn)
     return 0;
 }
 
-int syslog_prot_process_udp(char *buf, size_t size,
-                            struct flb_syslog *ctx, struct flb_connection *connection)
+int syslog_prot_process_udp(struct syslog_conn *conn)
 {
     int ret;
     void *out_buf;
     size_t out_size;
     struct flb_time out_time = {0};
+    char *buf;
+    size_t size;
+    struct flb_syslog *ctx;
+    struct flb_connection *connection;
+
+    buf = conn->buf_data;
+    size = conn->buf_len;
+    ctx = conn->ctx;
+    connection = conn->connection;
 
     ret = flb_parser_do(ctx->parser, buf, size,
                         &out_buf, &out_size, &out_time);

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -64,7 +64,7 @@ static int append_message_to_record_data(char **result_buffer,
             message_entry.val.via.bin.ptr  = message_buffer;
         }
         else if (message_type == MSGPACK_OBJECT_STR) {
-            message_entry.val.type = MSGPACK_OBJECT_BIN;
+            message_entry.val.type = MSGPACK_OBJECT_STR;
             message_entry.val.via.str.size = message_size;
             message_entry.val.via.str.ptr  = message_buffer;
         }

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -42,7 +42,7 @@ static int append_message_to_record_data(char **result_buffer,
                                          size_t message_size,
                                          int message_type)
 {
-    int                result;
+    int                result = FLB_MAP_NOT_MODIFIED;
     char              *modified_data_buffer;
     int                modified_data_size;
     msgpack_object_kv *new_map_entries[1];
@@ -69,24 +69,25 @@ static int append_message_to_record_data(char **result_buffer,
             message_entry.val.via.str.ptr  = message_buffer;
         }
         else {
-            result = FLB_MAP_NOT_MODIFIED;
-
-            return result;
+            result = FLB_MAP_EXPANSION_INVALID_VALUE_TYPE;
         }
 
-        result = flb_msgpack_expand_map(base_object_buffer,
-                                        base_object_size,
-                                        new_map_entries, 1,
-                                        &modified_data_buffer,
-                                        &modified_data_size);
-        if (result == 0) {
-            result = FLB_MAP_EXPAND_SUCCESS;
+        if (result == FLB_MAP_NOT_MODIFIED) {
+            result = flb_msgpack_expand_map(base_object_buffer,
+                                            base_object_size,
+                                            new_map_entries, 1,
+                                            &modified_data_buffer,
+                                            &modified_data_size);
+            if (result == 0) {
+                result = FLB_MAP_EXPAND_SUCCESS;
+            }
+            else {
+                result = FLB_MAP_EXPANSION_ERROR;
+            }
         }
     }
 
-    if (result != FLB_MAP_EXPAND_SUCCESS) {
-        result = FLB_MAP_EXPANSION_ERROR;
-    } else {
+    if (result == FLB_MAP_EXPAND_SUCCESS) {
         *result_buffer = modified_data_buffer;
         *result_size = modified_data_size;
     }

--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -86,12 +86,10 @@ static int append_message_to_record_data(char **result_buffer,
 
     if (result != FLB_MAP_EXPAND_SUCCESS) {
         result = FLB_MAP_EXPANSION_ERROR;
-
-        return result;
+    } else {
+        *result_buffer = modified_data_buffer;
+        *result_size = modified_data_size;
     }
-
-    *result_buffer = modified_data_buffer;
-    *result_size = modified_data_size;
 
     return result;
 }

--- a/plugins/in_syslog/syslog_prot.h
+++ b/plugins/in_syslog/syslog_prot.h
@@ -25,6 +25,7 @@
 #include "syslog.h"
 
 int syslog_prot_process(struct syslog_conn *conn);
-int syslog_prot_process_udp(char *buf, size_t size, struct flb_syslog *ctx);
+int syslog_prot_process_udp(char *buf, size_t size,
+                            struct flb_syslog *ctx, struct flb_connection *connection);
 
 #endif

--- a/plugins/in_syslog/syslog_prot.h
+++ b/plugins/in_syslog/syslog_prot.h
@@ -25,7 +25,6 @@
 #include "syslog.h"
 
 int syslog_prot_process(struct syslog_conn *conn);
-int syslog_prot_process_udp(char *buf, size_t size,
-                            struct flb_syslog *ctx, struct flb_connection *connection);
+int syslog_prot_process_udp(struct syslog_conn *conn);
 
 #endif

--- a/plugins/in_syslog/syslog_prot.h
+++ b/plugins/in_syslog/syslog_prot.h
@@ -27,6 +27,7 @@
 #define FLB_MAP_EXPAND_SUCCESS   0
 #define FLB_MAP_NOT_MODIFIED    -1
 #define FLB_MAP_EXPANSION_ERROR -2
+#define FLB_MAP_EXPANSION_INVALID_VALUE_TYPE -3
 
 int syslog_prot_process(struct syslog_conn *conn);
 int syslog_prot_process_udp(struct syslog_conn *conn);

--- a/plugins/in_syslog/syslog_prot.h
+++ b/plugins/in_syslog/syslog_prot.h
@@ -24,6 +24,10 @@
 
 #include "syslog.h"
 
+#define FLB_MAP_EXPAND_SUCCESS   0
+#define FLB_MAP_NOT_MODIFIED    -1
+#define FLB_MAP_EXPANSION_ERROR -2
+
 int syslog_prot_process(struct syslog_conn *conn);
 int syslog_prot_process_udp(struct syslog_conn *conn);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Closes https://github.com/fluent/fluent-bit/issues/7581

Currently, in_syslog plugin does not offer adding source address feature.
This PR provides this feature.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[SERVICE]
  Parsers_File  /path/to/parsers.conf # For example, /etc/fluent-bit/parsers.conf

[INPUT]
  Name syslog
  Port 5140
  Listen   0.0.0.0
  Parser syslog-rfc5424
  Mode     tcp
  Source_Address_Key source_host
  # Raw_Message_Key raw # Also, it can be working with this parameter.

[OUTPUT]
  Name stdout
```
- [x] Debug log output from testing the change
```log
Fluent Bit v2.1.7
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/07/05 19:01:35] [ info] Configuration:
[2023/07/05 19:01:35] [ info]  flush time     | 1.000000 seconds
[2023/07/05 19:01:35] [ info]  grace          | 5 seconds
[2023/07/05 19:01:35] [ info]  daemon         | 0
[2023/07/05 19:01:35] [ info] ___________
[2023/07/05 19:01:35] [ info]  inputs:
[2023/07/05 19:01:35] [ info]      syslog
[2023/07/05 19:01:35] [ info] ___________
[2023/07/05 19:01:35] [ info]  filters:
[2023/07/05 19:01:35] [ info] ___________
[2023/07/05 19:01:35] [ info]  outputs:
[2023/07/05 19:01:35] [ info]      stdout.0
[2023/07/05 19:01:35] [ info] ___________
[2023/07/05 19:01:35] [ info]  collectors:
[2023/07/05 19:01:35] [ info] [fluent bit] version=2.1.7, commit=0714d10889, pid=110032
[2023/07/05 19:01:35] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/07/05 19:01:35] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/07/05 19:01:35] [ info] [cmetrics] version=0.6.3
[2023/07/05 19:01:35] [ info] [ctraces ] version=0.3.1
[2023/07/05 19:01:35] [ info] [input:syslog:syslog.0] initializing
[2023/07/05 19:01:35] [ info] [input:syslog:syslog.0] storage_strategy='memory' (memory only)
[2023/07/05 19:01:35] [debug] [syslog:syslog.0] created event channels: read=21 write=22
[2023/07/05 19:01:35] [debug] [downstream] listening on 0.0.0.0:5140
[2023/07/05 19:01:35] [ info] [in_syslog] TCP server binding 0.0.0.0:5140
[2023/07/05 19:01:35] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/07/05 19:01:35] [ info] [sp] stream processor started
[2023/07/05 19:01:35] [ info] [output:stdout:stdout.0] worker #0 started
[2023/07/05 19:01:39] [debug] [input:syslog:syslog.0] error appending source_address : 2
[2023/07/05 19:01:39] [debug] [input chunk] update output instances with new chunk size diff=161, records=1, input=syslog.0
[2023/07/05 19:01:40] [debug] [task] created task=0x7f066401fcd0 id=0 OK
[2023/07/05 19:01:40] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] syslog.0: [[1688551296.281394000, {}], {"pri"=>"14", "time"=>"2023-07-05T10:01:36.281394Z", "host"=>"-", "ident"=>"-", "pid"=>"-", "msgid"=>"-", "extradata"=>"-", "message"=>"﻿dummy", "source_host"=>"tcp://192.168.11.5:52195"}]
[2023/07/05 19:01:40] [debug] [out flush] cb_destroy coro_id=0
[2023/07/05 19:01:40] [debug] [task] destroy task=0x7f066401fcd0 (task_id=0)
[2023/07/05 19:01:40] [debug] [input:syslog:syslog.0] error appending source_address : 2
[2023/07/05 19:01:40] [debug] [input chunk] update output instances with new chunk size diff=161, records=1, input=syslog.0
[2023/07/05 19:01:41] [debug] [task] created task=0x7f06640242a0 id=0 OK
[2023/07/05 19:01:41] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] syslog.0: [[1688551297.279265000, {}], {"pri"=>"14", "time"=>"2023-07-05T10:01:37.279265Z", "host"=>"-", "ident"=>"-", "pid"=>"-", "msgid"=>"-", "extradata"=>"-", "message"=>"﻿dummy", "source_host"=>"tcp://192.168.11.5:52195"}]
[2023/07/05 19:01:41] [debug] [out flush] cb_destroy coro_id=1
[2023/07/05 19:01:41] [debug] [task] destroy task=0x7f06640242a0 (task_id=0)
^C[2023/07/05 19:01:46] [engine] caught signal (SIGINT)
[2023/07/05 19:01:46] [ warn] [engine] service will shutdown in max 5 seconds
[2023/07/05 19:01:46] [ info] [engine] service has stopped (0 pending tasks)
[2023/07/05 19:01:46] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/07/05 19:01:46] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```log
==110164== 
==110164== HEAP SUMMARY:
==110164==     in use at exit: 95,170 bytes in 702 blocks
==110164==   total heap usage: 5,646 allocs, 4,944 frees, 1,791,261 bytes allocated
==110164== 
==110164== LEAK SUMMARY:
==110164==    definitely lost: 0 bytes in 0 blocks
==110164==    indirectly lost: 0 bytes in 0 blocks
==110164==      possibly lost: 0 bytes in 0 blocks
==110164==    still reachable: 95,170 bytes in 702 blocks
==110164==         suppressed: 0 bytes in 0 blocks
==110164== Reachable blocks (those to which a pointer was found) are not shown.
==110164== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==110164== 
==110164== For lists of detected and suppressed errors, rerun with: -s
==110164== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1151

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
