### PR TITLE
in_collectd/out_statsd: set the FLB_INPUT_NET_SERVER flag to fix their schema.

### DIFF
--- a/plugins/in_collectd/in_collectd.c
+++ b/plugins/in_collectd/in_collectd.c
@@ -221,5 +221,6 @@ struct flb_input_plugin in_collectd_plugin = {
     .cb_pause     = NULL,
     .cb_resume    = NULL,
     .config_map   = config_map,
+    .flags        = FLB_INPUT_NET_SERVER,
     .cb_exit      = in_collectd_exit
 };

--- a/plugins/in_statsd/statsd.c
+++ b/plugins/in_statsd/statsd.c
@@ -382,5 +382,5 @@ struct flb_input_plugin in_statsd_plugin = {
     .cb_resume    = cb_statsd_resume,
     .cb_exit      = cb_statsd_exit,
     .config_map   = config_map,
-    .flags        = 0
+    .flags        = FLB_INPUT_NET_SERVER,
 };


### PR DESCRIPTION
# Summary

Add the FLB_INPUT_NET_SERVER to the `in_collectd` and `out_statsd` plugins, which do use UDP instead of TCP, so the schema includes the network properties for them. 

The `FLB_IO_TLS` flag should not and is not set which should avoid most special cased code. If not we need another way to express they use network properties so the correct schema and help options can be output for them.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
