### PR TITLE
yaml/v2: use stack based parser.

### DIFF
--- a/include/fluent-bit/flb_processor.h
+++ b/include/fluent-bit/flb_processor.h
@@ -207,7 +207,7 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
                                                      int event_type,
                                                      char *unit_name);
 void flb_processor_unit_destroy(struct flb_processor_unit *pu);
-int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k, const char *v);
+int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k, struct cfl_variant *v);
 
 int flb_processors_load_from_config_format_group(struct flb_processor *proc, struct flb_cf_group *g);
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -491,6 +491,7 @@ static void print_current_properties(struct parser_state *s)
     struct cfl_list *head;
     struct cfl_kvpair *kv;
     struct cfl_variant *var;
+    int idx;
 
     flb_debug("%*s[%s] PROPERTIES:", s->level*2, "", section_names[s->section]);
 
@@ -502,8 +503,8 @@ static void print_current_properties(struct parser_state *s)
             break;
         case CFL_VARIANT_ARRAY:
             flb_debug("%*s%s: [", (s->level+2)*2, "", kv->key);
-            for (int i = 0; i < kv->val->data.as_array->entry_count; i++) {
-                var = cfl_array_fetch_by_index(kv->val->data.as_array, i);
+            for (idx = 0; idx < kv->val->data.as_array->entry_count; idx++) {
+                var = cfl_array_fetch_by_index(kv->val->data.as_array, idx);
                 flb_debug("%*s%s", (s->level+3)*2, "", var->data.as_string);
             }
             flb_debug("%*s]", (s->level+2)*2, "");
@@ -525,6 +526,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     struct parser_state *s;
     struct parser_state *g;
     int ret;
+    int idx;
     char *value;
     struct flb_kv *kv;
     char *last_included = get_last_included_file(ctx);
@@ -884,8 +886,8 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                         break;
                     case CFL_VARIANT_ARRAY:
                         carr = cfl_array_create(kvp->val->data.as_array->entry_count);
-                        for (int i = 0; i < kvp->val->data.as_array->entry_count; i++) {
-                            var = cfl_array_fetch_by_index(kvp->val->data.as_array, i);
+                        for (idx = 0; idx < kvp->val->data.as_array->entry_count; idx++) {
+                            var = cfl_array_fetch_by_index(kvp->val->data.as_array, idx);
                             switch (var->type) {
                             case CFL_VARIANT_STRING:
                                 cfl_array_append_string(carr, var->data.as_string);
@@ -926,8 +928,8 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 case CFL_VARIANT_ARRAY:
                     arr = flb_cf_section_property_add_list(cf, s->cf_section->properties,
                                                            kvp->key, cfl_sds_len(kvp->key));
-                    for (int i = 0; i < kvp->val->data.as_array->entry_count; i++) {
-                        var = cfl_array_fetch_by_index(kvp->val->data.as_array, i);
+                    for (idx = 0; idx < kvp->val->data.as_array->entry_count; idx++) {
+                        var = cfl_array_fetch_by_index(kvp->val->data.as_array, idx);
                         switch (var->type) {
                         case CFL_VARIANT_STRING:
                             cfl_array_append_string(arr, var->data.as_string);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -922,6 +922,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             struct cfl_list *head;
             struct cfl_kvpair *kv;
             struct cfl_variant *var;
+            struct cfl_variant *varr;
             struct cfl_array *arr;
             struct cfl_array *carr;
 
@@ -935,11 +936,13 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                     return YAML_FAILURE;
                 }
 
-                arr = cfl_kvlist_fetch(s->cf_group->properties, s->key);
-                if (arr == NULL) {
+                varr = cfl_kvlist_fetch(s->cf_group->properties, s->key);
+                if (varr == NULL) {
                     arr = cfl_array_create(1);
                     cfl_array_resizable(arr, CFL_TRUE);
                     cfl_kvlist_insert_array(s->cf_group->properties, s->key, arr);
+                } else {
+                    arr = varr->data.as_array;
                 }
 
                 copy = cfl_kvlist_create();

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -152,8 +152,6 @@ static char *state_names[] = {
 
 static char *state_str(enum state val)
 {
-    char* ret;
-
     if (val < 0 || val > STATE_STOP) {
 	return "unknown";
     }
@@ -484,8 +482,6 @@ static int read_glob(struct flb_cf *cf, struct parser_state *ctx, const char *pa
 static void print_current_state(struct local_ctx *ctx, struct parser_state *s,
                                 yaml_event_t *event)
 {
-    int i;
-
     flb_debug("%*s%s->%s", s->level*2, "", state_str(s->state),
              event_type_str(event));
 }
@@ -1209,13 +1205,6 @@ static char *get_real_path(char *file, char *path, size_t size)
     return path;
 }
 
-static void file_state_destroy(struct file_state *f)
-{
-    flb_sds_destroy(f->name);
-    flb_sds_destroy(f->path);
-    flb_free(f);
-}
-
 static struct parser_state *state_start(struct local_ctx *ctx, struct file_state *file)
 {
     struct parser_state *s;
@@ -1357,8 +1346,6 @@ static void state_destroy(struct parser_state *s)
 
 static struct parser_state *state_create(struct file_state *parent, struct file_state *file)
 {
-    int ret;
-    char *p;
     struct parser_state *s;
 
     /* allocate context */

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -523,6 +523,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                          yaml_event_t *event)
 {
     struct parser_state *s;
+    struct parser_state *g;
     int ret;
     char *value;
     struct flb_kv *kv;
@@ -1006,7 +1007,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             s = state_push_witharr(ctx, s, STATE_PLUGIN_VAL_LIST);
             break;
         case YAML_MAPPING_START_EVENT:
-            struct parser_state *g;
             /* Special handling for input processor */
             if (strcmp(s->key, "processors") == 0) {
                 s = state_push(ctx, STATE_INPUT_PROCESSORS);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -150,6 +150,17 @@ static char *state_names[] = {
     "stop"            /* end state */
 };
 
+static char *state_str(enum state val)
+{
+    char* ret;
+
+    if (val < 0 || val > STATE_STOP) {
+	return "unknown";
+    }
+
+    return state_names[val];
+}
+
 struct file_state {
     /* file */
     flb_sds_t name;                /* file name */
@@ -279,83 +290,6 @@ static char *event_type_str(yaml_event_t *event)
     default:
         return "unknown";
     }
-}
-
-static char *state_str(enum state val)
-{
-    char* ret;
-    switch(val) {
-    case STATE_START:
-        ret = "start";
-        break;
-    case STATE_STREAM:
-        ret = "stream";
-        break;
-    case STATE_DOCUMENT:
-        ret = "document";
-        break;
-    case STATE_SECTION:
-        ret = "section";
-        break;
-    case STATE_SECTION_KEY:
-        ret = "section-key";
-        break;
-    case STATE_SECTION_VAL:
-        ret = "section-val";
-        break;
-    case STATE_SERVICE:
-        ret = "service";
-        break;
-    case STATE_INCLUDE:
-        ret = "include";
-        break;
-    case STATE_OTHER:
-        ret = "other";
-        break;
-    case STATE_PIPELINE:
-        ret = "pipeline";
-        break;
-    case STATE_PLUGIN_INPUT:
-        ret = "plugin-input";
-        break;
-    case STATE_PLUGIN_FILTER:
-        ret = "plugin-filter";
-        break;
-    case STATE_PLUGIN_OUTPUT:
-        ret = "plugin-output";
-        break;
-    case STATE_CUSTOM:
-        ret = "custom";
-        break;
-    case STATE_PLUGIN_KEY:
-        ret = "plugin-key";
-        break;
-    case STATE_PLUGIN_VAL:
-        ret = "plugin-val";
-        break;
-    case STATE_PLUGIN_VAL_LIST:
-        ret = "plugin-val-list";
-        break;
-    case STATE_GROUP_KEY:
-        ret = "group-key";
-        break;
-    case STATE_GROUP_VAL:
-        ret = "group-val";
-        break;
-    case STATE_INPUT_PROCESSOR:
-        ret = "input-processor";
-        break;
-    case STATE_ENV:
-        ret = "env";
-        break;
-    case STATE_STOP:
-        ret = "stop";
-        break;
-
-    default:
-        ret = "UNKNOWN";
-    }
-    return ret;
 }
 
 static char *get_last_included_file(struct local_ctx *ctx)
@@ -552,7 +486,7 @@ static void print_current_state(struct local_ctx *ctx, struct parser_state *s,
 {
     int i;
 
-    flb_debug("%*s%s->%s", s->level*2, "", state_names[s->state], 
+    flb_debug("%*s%s->%s", s->level*2, "", state_str(s->state),
              event_type_str(event));
 }
 
@@ -831,7 +765,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             case STATE_OTHER:
                 break;
             default:
-                printf("BAD STATE FOR SECTION KEY POP=%s\n", state_names[s->state]);
+                printf("BAD STATE FOR SECTION KEY POP=%s\n", state_str(s->state));
                 yaml_error_event(ctx, s, event);
                 return YAML_FAILURE;
             }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -552,12 +552,8 @@ static void print_current_state(struct local_ctx *ctx, struct parser_state *s,
 {
     int i;
 
-    s = cfl_list_entry_last(&ctx->states, struct parser_state, _head);
-    for (i = 0; i < s->level; i++) {
-        putchar(' ');
-        putchar(' ');
-    }
-    printf("%s->%s\n", state_names[s->state], event_type_str(event));
+    flb_debug("%*s%s->%s", s->level*2, "", state_names[s->state], 
+             event_type_str(event));
 }
 
 static void print_current_properties(struct parser_state *s)
@@ -566,41 +562,21 @@ static void print_current_properties(struct parser_state *s)
     struct cfl_kvpair *kv;
     struct cfl_variant *var;
 
-    for (int i = 0; i < s->level; i++ ) {
-        putchar(' ');
-        putchar(' ');
-    }
-    printf("[%s] PROPERTIES:\n", section_names[s->section]);
+    flb_debug("%*s[%s] PROPERTIES:", s->level*2, "", section_names[s->section]);
 
     cfl_list_foreach(head, &s->keyvals->list) {
         kv = cfl_list_entry(head, struct cfl_kvpair, _head);
         switch (kv->val->type) {
         case CFL_VARIANT_STRING:
-            for (int i = 0; i < s->level+2; i++) {
-                putchar(' ');
-                putchar(' ');
-            }
-            printf("%s: %s\n", kv->key, kv->val->data.as_string);
+            flb_debug("%*s%s: %s", (s->level+2)*2, "", kv->key, kv->val->data.as_string);
             break;
         case CFL_VARIANT_ARRAY:
-            for (int i = 0; i < s->level+2; i++) {
-                putchar(' ');
-                putchar(' ');
-            }
-            printf("%s: [\n", kv->key);
+            flb_debug("%*s%s: [", (s->level+2)*2, "", kv->key);
             for (int i = 0; i < kv->val->data.as_array->entry_count; i++) {
                 var = cfl_array_fetch_by_index(kv->val->data.as_array, i);
-                for (int i = 0; i < s->level+3; i++) {
-                    putchar(' ');
-                    putchar(' ');
-                }
-                printf("%s\n", var->data.as_string);
+                flb_debug("%*s%s", (s->level+3)*2, "", var->data.as_string);
             }
-            for (int i = 0; i < s->level+2; i++) {
-                putchar(' ');
-                putchar(' ');
-            }
-            printf("]\n");
+            flb_debug("%*s]", (s->level+2)*2, "");
             break;
         }
     }
@@ -1537,7 +1513,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
         return -1;
     }
 
-    printf("============ %s ============\n", cfg_file);
+    flb_debug("============ %s ============", cfg_file);
     fh = fopen(include_file, "r");
     if (!fh) {
         flb_errno();
@@ -1575,7 +1551,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
         state = cfl_list_entry_last(&ctx->states, struct parser_state, _head);
     } while (state->state != STATE_STOP);
 
-    printf("==============================\n");
+    flb_debug("==============================");
 done:
     if (code == -1) {
         yaml_event_delete(&event);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -111,37 +111,6 @@ enum state {
     STATE_STOP            /* end state */
 };
 
-static char *state_str(enum state val)
-{
-    switch (val) {
-        case STATE_START: return "start";
-        case STATE_STREAM: return "stream";
-        case STATE_DOCUMENT: return "document";
-        case STATE_SECTION: return "section";
-        case STATE_SECTION_KEY: return "section-key";
-        case STATE_SECTION_VAL: return "section-value";
-        case STATE_SERVICE: return "service";
-        case STATE_INCLUDE: return "include";
-        case STATE_OTHER: return "other";
-        case STATE_CUSTOM: return "custom";
-        case STATE_PIPELINE: return "pipeline";
-        case STATE_PLUGIN_INPUT: return "input";
-        case STATE_PLUGIN_FILTER: return "filter";
-        case STATE_PLUGIN_OUTPUT: return "output";
-        case STATE_PLUGIN_START: return "plugin-start";
-        case STATE_PLUGIN_KEY: return "plugin-key";
-        case STATE_PLUGIN_VAL: return "plugin-value";
-        case STATE_PLUGIN_VAL_LIST: return "plugin-values";
-        case STATE_GROUP_KEY: return "group-key";
-        case STATE_GROUP_VAL: return "group-val";
-        case STATE_INPUT_PROCESSORS: return "processors";
-        case STATE_INPUT_PROCESSOR: return "processor";
-        case STATE_ENV: return "env";
-        case STATE_STOP: return "stop";
-        default: return "unknown";
-    }
-}
-
 struct file_state {
     /* file */
     flb_sds_t name;                /* file name */
@@ -193,6 +162,12 @@ struct local_ctx {
     int service_set;
 };
 
+/* yaml_* functions return 1 on success and 0 on failure. */
+enum status {
+    YAML_SUCCESS = 1,
+    YAML_FAILURE = 0
+};
+
 static struct parser_state *state_push(struct local_ctx *, enum state);
 static struct parser_state *state_push_withvals(struct local_ctx *,
                                                 struct parser_state *,
@@ -210,14 +185,40 @@ static struct parser_state *state_pop(struct local_ctx *ctx);
 static struct parser_state *state_create(struct file_state *parent, struct file_state *file);
 static void state_destroy(struct parser_state *s);
 
-/* yaml_* functions return 1 on success and 0 on failure. */
-enum status {
-    YAML_SUCCESS = 1,
-    YAML_FAILURE = 0
-};
 
 static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
                        struct file_state *parent, char *cfg_file);
+
+static char *state_str(enum state val)
+{
+    switch (val) {
+        case STATE_START: return "start";
+        case STATE_STREAM: return "stream";
+        case STATE_DOCUMENT: return "document";
+        case STATE_SECTION: return "section";
+        case STATE_SECTION_KEY: return "section-key";
+        case STATE_SECTION_VAL: return "section-value";
+        case STATE_SERVICE: return "service";
+        case STATE_INCLUDE: return "include";
+        case STATE_OTHER: return "other";
+        case STATE_CUSTOM: return "custom";
+        case STATE_PIPELINE: return "pipeline";
+        case STATE_PLUGIN_INPUT: return "input";
+        case STATE_PLUGIN_FILTER: return "filter";
+        case STATE_PLUGIN_OUTPUT: return "output";
+        case STATE_PLUGIN_START: return "plugin-start";
+        case STATE_PLUGIN_KEY: return "plugin-key";
+        case STATE_PLUGIN_VAL: return "plugin-value";
+        case STATE_PLUGIN_VAL_LIST: return "plugin-values";
+        case STATE_GROUP_KEY: return "group-key";
+        case STATE_GROUP_VAL: return "group-val";
+        case STATE_INPUT_PROCESSORS: return "processors";
+        case STATE_INPUT_PROCESSOR: return "processor";
+        case STATE_ENV: return "env";
+        case STATE_STOP: return "stop";
+        default: return "unknown";
+    }
+}
 
 static int add_section_type(struct flb_cf *cf, struct parser_state *state)
 {

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -393,7 +393,21 @@ static int read_glob(struct flb_cf *cf, struct local_ctx *ctx,
     return ret;
 }
 #else
-static int read_glob(struct flb_cf *cf, struct parser_state *ctx, const char *path)
+static char *dirname(char *path)
+{
+	char *ptr;
+	
+	
+	ptr = strrchr(path, '\\');
+	if (ptr == NULL) {
+		return path;
+	}
+	*ptr++='\0';
+	return path;
+}
+
+static int read_glob(struct flb_cf *cf, struct local_ctx *ctx,
+                     struct parser_state *state, const char *path)
 {
     char *star, *p0, *p1;
     char pattern[MAX_PATH];
@@ -461,13 +475,13 @@ static int read_glob(struct flb_cf *cf, struct parser_state *ctx, const char *pa
         }
 
         if (strchr(p1, '*')) {
-            read_glob(cf, ctx, buf); /* recursive */
+            read_glob(cf, ctx, state, buf); /* recursive */
             continue;
         }
 
         ret = stat(buf, &st);
         if (ret == 0 && (st.st_mode & S_IFMT) == S_IFREG) {
-            if (read_config(cf, ctx, state->file, buf) < 0) {
+            if (read_config(cf, ctx, state, buf) < 0) {
                 return -1;
             }
         }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -273,7 +273,7 @@ static char *event_type_str(yaml_event_t *event)
     }
 }
 
-static char *get_last_included_file(struct local_ctx *ctx)
+static char *state_get_last(struct local_ctx *ctx)
 {
     struct flb_slist_entry *e;
 
@@ -526,7 +526,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     int idx;
     char *value;
     struct flb_kv *kv;
-    char *last_included = get_last_included_file(ctx);
+    char *last_included = state_get_last(ctx);
     struct cfl_list *head;
     struct cfl_kvpair *kvp;
     struct cfl_variant *var;

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1518,7 +1518,7 @@ static struct parser_state *state_push_witharr(struct local_ctx *ctx,
     parent->values = cfl_array_create(4);
     if (parent->values == NULL) {
         flb_error("no value");
-        return YAML_FAILURE;
+        return NULL;
     }
     cfl_array_resizable(parent->values, CFL_TRUE);
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1659,7 +1659,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     state = state_start(ctx, &fstate);
     if (!state) {
         flb_error("unable to push initial include file state: %s", cfg_file);
-        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(file);
         flb_sds_destroy(include_file);
         return -1;
     }
@@ -1668,7 +1668,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     ret = is_file_included(ctx, include_file);
     if (ret) {
         flb_error("[config] file '%s' is already included", cfg_file);
-        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(file);
         flb_sds_destroy(include_file);
         state_destroy(state);
         return -1;
@@ -1678,7 +1678,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     fh = fopen(include_file, "r");
     if (!fh) {
         flb_errno();
-        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(file);
         flb_sds_destroy(include_file);
         state_destroy(state);
         return -1;
@@ -1689,7 +1689,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     if (ret == -1) {
         flb_error("[config] could not register file %s", cfg_file);
         fclose(fh);
-        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(file);
         flb_sds_destroy(include_file);
         state_destroy(state);
         return -1;

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -300,9 +300,12 @@ static char *event_type_str(yaml_event_t *event)
 
 static char *state_get_last(struct local_ctx *ctx)
 {
-    struct flb_slist_entry *e;
+    struct flb_slist_entry *entry;
 
-    e = mk_list_entry_last(&ctx->includes, struct flb_slist_entry, _head);
+    entry = mk_list_entry_last(&ctx->includes, struct flb_slist_entry, _head);
+    if (entry == NULL) {
+        return NULL;
+    }
     return e->str;
 }
 
@@ -686,6 +689,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     char *last_included;
 
     last_included = state_get_last(ctx);
+    if (last_included == NULL) {
+        last_included = "**unknown**";
+    }
+
     state = get_current_state(ctx);
     if (state == NULL) {
         flb_error("unable to parse yaml: no state");

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1105,6 +1105,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 return YAML_FAILURE;
         };
         break;
+
     case STATE_INPUT_PROCESSOR:
         switch(event->type) {
             case YAML_SEQUENCE_START_EVENT:

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -334,14 +334,17 @@ static int read_glob(struct flb_cf *cf, struct local_ctx *ctx,
 {
     int ret = -1;
     glob_t glb;
-    char tmp[PATH_MAX];
+    char tmp[PATH_MAX+1];
 
     const char *glb_path;
     size_t idx;
     int ret_glb = -1;
 
     if (state->file->path && path[0] != '/') {
-        snprintf(tmp, PATH_MAX, "%s/%s", state->file->path, path);
+        ret = snprintf(tmp, PATH_MAX, "%s/%s", state->file->path, path);
+        if (ret > PATH_MAX) {
+            return -1;
+        }
         glb_path = tmp;
     }
     else {

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -568,6 +568,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
 
     last_included = state_get_last(ctx)
     state = get_current_state(ctx);
+    if (state == NULL) {
+        flb_error("unable to parse yaml: no state");
+        return YAML_FAILURE;
+    }
     print_current_state(ctx, state, event);
 
     switch (state->state) {

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1634,6 +1634,8 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     state = state_start(ctx, &fstate);
     if (!state) {
         flb_error("unable to push initial include file state: %s", cfg_file);
+        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(include_file);
         return -1;
     }
 
@@ -1641,6 +1643,8 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     ret = is_file_included(ctx, include_file);
     if (ret) {
         flb_error("[config] file '%s' is already included", cfg_file);
+        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(include_file);
         state_destroy(state);
         return -1;
     }
@@ -1649,6 +1653,8 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     fh = fopen(include_file, "r");
     if (!fh) {
         flb_errno();
+        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(include_file);
         state_destroy(state);
         return -1;
     }
@@ -1658,6 +1664,8 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
     if (ret == -1) {
         flb_error("[config] could not register file %s", cfg_file);
         fclose(fh);
+        flb_sds_destroy(cfg_file);
+        flb_sds_destroy(include_file);
         state_destroy(state);
         return -1;
     }
@@ -1690,7 +1698,6 @@ done:
     }
 
     yaml_parser_delete(&parser);
-    // state_destroy(state);
     state_pop(ctx);
 
     fclose(fh);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -73,6 +73,31 @@ static char *section_names[] = {
     "other"
 };
 
+struct file_state {
+    /* file */
+    flb_sds_t name;                /* file name */
+    flb_sds_t path;           /* file root path */
+
+    /* parent file state */
+    struct file_state *parent;
+};
+
+struct local_ctx {
+    int level;                     /* inclusion level */
+
+    struct cfl_list states;
+
+    struct mk_list includes;
+
+    int service_set;
+};
+
+/* yaml_* functions return 1 on success and 0 on failure. */
+enum status {
+    YAML_SUCCESS = 1,
+    YAML_FAILURE = 0
+};
+
 enum state {
     STATE_START,           /* start state */
     STATE_STREAM,          /* start/end stream */
@@ -111,15 +136,6 @@ enum state {
     STATE_STOP            /* end state */
 };
 
-struct file_state {
-    /* file */
-    flb_sds_t name;                /* file name */
-    flb_sds_t path;           /* file root path */
-
-    /* parent file state */
-    struct file_state *parent;
-};
-
 // state allocation flags
 #define HAS_KEY     (1 << 0)
 #define HAS_KEYVALS (1 << 1)
@@ -152,22 +168,6 @@ struct parser_state {
     struct cfl_list _head;
 };
 
-struct local_ctx {
-    int level;                     /* inclusion level */
-
-    struct cfl_list states;
-
-    struct mk_list includes;
-
-    int service_set;
-};
-
-/* yaml_* functions return 1 on success and 0 on failure. */
-enum status {
-    YAML_SUCCESS = 1,
-    YAML_FAILURE = 0
-};
-
 static struct parser_state *state_push(struct local_ctx *, enum state);
 static struct parser_state *state_push_withvals(struct local_ctx *,
                                                 struct parser_state *,
@@ -192,31 +192,56 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
 static char *state_str(enum state val)
 {
     switch (val) {
-        case STATE_START: return "start";
-        case STATE_STREAM: return "stream";
-        case STATE_DOCUMENT: return "document";
-        case STATE_SECTION: return "section";
-        case STATE_SECTION_KEY: return "section-key";
-        case STATE_SECTION_VAL: return "section-value";
-        case STATE_SERVICE: return "service";
-        case STATE_INCLUDE: return "include";
-        case STATE_OTHER: return "other";
-        case STATE_CUSTOM: return "custom";
-        case STATE_PIPELINE: return "pipeline";
-        case STATE_PLUGIN_INPUT: return "input";
-        case STATE_PLUGIN_FILTER: return "filter";
-        case STATE_PLUGIN_OUTPUT: return "output";
-        case STATE_PLUGIN_START: return "plugin-start";
-        case STATE_PLUGIN_KEY: return "plugin-key";
-        case STATE_PLUGIN_VAL: return "plugin-value";
-        case STATE_PLUGIN_VAL_LIST: return "plugin-values";
-        case STATE_GROUP_KEY: return "group-key";
-        case STATE_GROUP_VAL: return "group-val";
-        case STATE_INPUT_PROCESSORS: return "processors";
-        case STATE_INPUT_PROCESSOR: return "processor";
-        case STATE_ENV: return "env";
-        case STATE_STOP: return "stop";
-        default: return "unknown";
+    case STATE_START:
+        return "start";
+    case STATE_STREAM:
+        return "stream";
+    case STATE_DOCUMENT:
+        return "document";
+    case STATE_SECTION:
+        return "section";
+    case STATE_SECTION_KEY:
+        return "section-key";
+    case STATE_SECTION_VAL:
+        return "section-value";
+    case STATE_SERVICE:
+        return "service";
+    case STATE_INCLUDE:
+        return "include";
+    case STATE_OTHER:
+        return "other";
+    case STATE_CUSTOM:
+        return "custom";
+    case STATE_PIPELINE:
+        return "pipeline";
+    case STATE_PLUGIN_INPUT:
+        return "input";
+    case STATE_PLUGIN_FILTER:
+        return "filter";
+    case STATE_PLUGIN_OUTPUT:
+        return "output";
+    case STATE_PLUGIN_START:
+        return "plugin-start";
+    case STATE_PLUGIN_KEY:
+        return "plugin-key";
+    case STATE_PLUGIN_VAL:
+        return "plugin-value";
+    case STATE_PLUGIN_VAL_LIST:
+        return "plugin-values";
+    case STATE_GROUP_KEY:
+        return "group-key";
+    case STATE_GROUP_VAL:
+        return "group-val";
+    case STATE_INPUT_PROCESSORS:
+        return "processors";
+    case STATE_INPUT_PROCESSOR:
+        return "processor";
+    case STATE_ENV:
+        return "env";
+    case STATE_STOP:
+        return "stop";
+    default:
+        return "unknown";
     }
 }
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -566,7 +566,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     struct cfl_array *carr;
     struct cfl_kvlist *copy;
 
-    last_included = state_get_last(ctx)
+    last_included = state_get_last(ctx);
     state = get_current_state(ctx);
     if (state == NULL) {
         flb_error("unable to parse yaml: no state");
@@ -838,6 +838,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
         switch(event->type) {
         case YAML_MAPPING_START_EVENT:
             state = state_push(ctx, STATE_SECTION_KEY);
+            if (state == NULL) {
+                flb_error("unable to allocate state");
+                return YAML_FAILURE;
+            }
             break;
         case YAML_MAPPING_END_EVENT:
             state = state_pop(ctx);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -535,22 +535,22 @@ static void print_current_state(struct local_ctx *ctx, struct parser_state *stat
 static void print_current_properties(struct parser_state *state)
 {
     struct cfl_list *head;
-    struct cfl_kvpair *kv;
+    struct cfl_kvpair *prop;
     struct cfl_variant *var;
     int idx;
 
     flb_error("%*s[%s] PROPERTIES:", state->level*2, "", section_names[state->section]);
 
     cfl_list_foreach(head, &state->keyvals->list) {
-        kv = cfl_list_entry(head, struct cfl_kvpair, _head);
-        switch (kv->val->type) {
+        prop = cfl_list_entry(head, struct cfl_kvpair, _head);
+        switch (prop->val->type) {
         case CFL_VARIANT_STRING:
-            flb_error("%*s%s: %s", (state->level+2)*2, "", kv->key, kv->val->data.as_string);
+            flb_error("%*s%s: %s", (state->level+2)*2, "", prop->key, prop->val->data.as_string);
             break;
         case CFL_VARIANT_ARRAY:
-            flb_error("%*s%s: [", (state->level+2)*2, "", kv->key);
-            for (idx = 0; idx < kv->val->data.as_array->entry_count; idx++) {
-                var = cfl_array_fetch_by_index(kv->val->data.as_array, idx);
+            flb_error("%*s%s: [", (state->level+2)*2, "", prop->key);
+            for (idx = 0; idx < prop->val->data.as_array->entry_count; idx++) {
+                var = cfl_array_fetch_by_index(prop->val->data.as_array, idx);
                 flb_error("%*s%s", (state->level+3)*2, "", var->data.as_string);
             }
             flb_error("%*s]", (state->level+2)*2, "");
@@ -684,7 +684,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     struct parser_state *group_key;
     int ret;
     char *value;
-    struct flb_kv *kv;
+    struct flb_kv *prop;
     char *last_included;
 
     last_included = state_get_last(ctx);
@@ -1025,10 +1025,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
             value = (char *) event->data.scalar.value;
             /* Check if the incoming k/v pair set a config environment variable */
             if (state->section == SECTION_ENV) {
-                kv = flb_cf_env_property_add(cf,
-                                             state->key, flb_sds_len(state->key),
-                                             value, strlen(value));
-                if (kv == NULL) {
+                prop = flb_cf_env_property_add(cf,
+                                               state->key, flb_sds_len(state->key),
+                                               value, strlen(value));
+                if (prop == NULL) {
                     flb_error("unable to add key value");
                     return YAML_FAILURE;
                 }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -151,10 +151,9 @@ struct file_state {
     struct file_state *parent;
 };
 
-enum parser_state_allocations {
-    HAS_KEY     = (1 << 0),
-    HAS_KEYVALS = (1 << 1)
-};
+// state allocation flags
+#define HAS_KEY     (1 << 0)
+#define HAS_KEYVALS (1 << 1)
 
 struct parser_state {
     /* tokens state */

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -142,7 +142,6 @@ static char *state_names[] = {
     "processors",
     "processor",
     "processor-map",
-
     /* environment variables */
     "env",
 
@@ -541,6 +540,9 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     s = get_current_state(ctx);
     print_current_state(ctx, s, event);
 
+    s = get_current_state(ctx);
+    print_current_state(ctx, s, event);
+
     switch (s->state) {
     case STATE_START:
         switch (event->type) {
@@ -803,7 +805,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                     return YAML_FAILURE;
                 }
             }
-
             s = state_pop(ctx);
             if (s->state != STATE_SECTION_KEY) {
                 yaml_error_event(ctx, s, event);
@@ -1104,7 +1105,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 return YAML_FAILURE;
         };
         break;
-
     case STATE_INPUT_PROCESSOR:
         switch(event->type) {
             case YAML_SEQUENCE_START_EVENT:
@@ -1114,10 +1114,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 break;
             case YAML_MAPPING_START_EVENT:
                 s = state_push_withvals(ctx, s, STATE_PLUGIN_START);
-                s->section = SECTION_PROCESSOR;
-                break;
-            case YAML_MAPPING_END_EVENT:
-                return YAML_FAILURE;
                 break;
             default:
                 yaml_error_event(ctx, s, event);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -142,6 +142,7 @@ static char *state_names[] = {
     "processors",
     "processor",
     "processor-map",
+
     /* environment variables */
     "env",
 
@@ -554,9 +555,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     s = get_current_state(ctx);
     print_current_state(ctx, s, event);
 
-    s = get_current_state(ctx);
-    print_current_state(ctx, s, event);
-
     switch (s->state) {
     case STATE_START:
         switch (event->type) {
@@ -819,6 +817,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                     return YAML_FAILURE;
                 }
             }
+
             s = state_pop(ctx);
             if (s->state != STATE_SECTION_KEY) {
                 yaml_error_event(ctx, s, event);
@@ -1129,6 +1128,10 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
                 break;
             case YAML_MAPPING_START_EVENT:
                 s = state_push_withvals(ctx, s, STATE_PLUGIN_START);
+                s->section = SECTION_PROCESSOR;
+                break;
+            case YAML_MAPPING_END_EVENT:
+                return YAML_FAILURE;
                 break;
             default:
                 yaml_error_event(ctx, s, event);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -136,46 +136,6 @@ enum state {
     STATE_STOP            /* end state */
 };
 
-static char *state_str(enum state val)
-{
-    switch (val) {
-        case STATE_START: return "start";
-        case STATE_STREAM: return "stream";
-        case STATE_DOCUMENT: return "document";
-        case STATE_SECTION: return "section";
-        case STATE_SECTION_KEY: return "section-key";
-        case STATE_SECTION_VAL: return "section-value";
-        case STATE_SERVICE: return "service";
-        case STATE_INCLUDE: return "include";
-        case STATE_OTHER: return "other";
-        case STATE_CUSTOM: return "custom";
-        case STATE_PIPELINE: return "pipeline";
-        case STATE_PLUGIN_INPUT: return "input";
-        case STATE_PLUGIN_FILTER: return "filter";
-        case STATE_PLUGIN_OUTPUT: return "output";
-        case STATE_PLUGIN_START: return "plugin-start";
-        case STATE_PLUGIN_KEY: return "plugin-key";
-        case STATE_PLUGIN_VAL: return "plugin-value";
-        case STATE_PLUGIN_VAL_LIST: return "plugin-values";
-        case STATE_GROUP_KEY: return "group-key";
-        case STATE_GROUP_VAL: return "group-val";
-        case STATE_INPUT_PROCESSORS: return "processors";
-        case STATE_INPUT_PROCESSOR: return "processor";
-        case STATE_ENV: return "env";
-        case STATE_STOP: return "stop";
-        default: return "unknown";
-    }
-}
-
-struct file_state {
-    /* file */
-    flb_sds_t name;                /* file name */
-    flb_sds_t path;           /* file root path */
-
-    /* parent file state */
-    struct file_state *parent;
-};
-
 // parser state allocation flags
 #define HAS_KEY     (1 << 0)
 #define HAS_KEYVALS (1 << 1)

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -111,52 +111,35 @@ enum state {
     STATE_STOP            /* end state */
 };
 
-static char *state_names[] = {
-    "start",           /* start state */
-    "stream",          /* start/end stream */
-    "document",        /* start/end document */
-
-    "section",         /* top level */
-    "section-key",
-    "section-value",
-
-    "service",         /* 'service' section */
-    "include",         /* 'includes' section */
-    "other",           /* any other unknown section */
-
-    "custom",          /* custom plugins */
-    "pipeline",        /* pipeline groups customs inputs, filters and outputs */
-
-    "input",    /* input plugins section */
-    "filter",   /* filter plugins section */
-    "output",   /* output plugins section */
-
-    "plugin-start",
-    "plugin-key",
-    "plugin-value",
-    "plugin-values",
-
-    "group-key",
-    "group-value",
-
-    "processors",
-    "processor",
-    "processor-map",
-
-    /* environment variables */
-    "env",
-
-
-    "stop"            /* end state */
-};
-
 static char *state_str(enum state val)
 {
-    if (val < 0 || val > STATE_STOP) {
-	return "unknown";
+    switch (val) {
+        case STATE_START: return "start";
+        case STATE_STREAM: return "stream";
+        case STATE_DOCUMENT: return "document";
+        case STATE_SECTION: return "section";
+        case STATE_SECTION_KEY: return "section-key";
+        case STATE_SECTION_VAL: return "section-value";
+        case STATE_SERVICE: return "service";
+        case STATE_INCLUDE: return "include";
+        case STATE_OTHER: return "other";
+        case STATE_CUSTOM: return "custom";
+        case STATE_PIPELINE: return "pipeline";
+        case STATE_PLUGIN_INPUT: return "input";
+        case STATE_PLUGIN_FILTER: return "filter";
+        case STATE_PLUGIN_OUTPUT: return "output";
+        case STATE_PLUGIN_START: return "plugin-start";
+        case STATE_PLUGIN_KEY: return "plugin-key";
+        case STATE_PLUGIN_VAL: return "plugin-value";
+        case STATE_PLUGIN_VAL_LIST: return "plugin-values";
+        case STATE_GROUP_KEY: return "group-key";
+        case STATE_GROUP_VAL: return "group-val";
+        case STATE_INPUT_PROCESSORS: return "processors";
+        case STATE_INPUT_PROCESSOR: return "processor";
+        case STATE_ENV: return "env";
+        case STATE_STOP: return "stop";
+        default: return "unknown";
     }
-
-    return state_names[val];
 }
 
 struct file_state {

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -136,7 +136,47 @@ enum state {
     STATE_STOP            /* end state */
 };
 
-// state allocation flags
+static char *state_str(enum state val)
+{
+    switch (val) {
+        case STATE_START: return "start";
+        case STATE_STREAM: return "stream";
+        case STATE_DOCUMENT: return "document";
+        case STATE_SECTION: return "section";
+        case STATE_SECTION_KEY: return "section-key";
+        case STATE_SECTION_VAL: return "section-value";
+        case STATE_SERVICE: return "service";
+        case STATE_INCLUDE: return "include";
+        case STATE_OTHER: return "other";
+        case STATE_CUSTOM: return "custom";
+        case STATE_PIPELINE: return "pipeline";
+        case STATE_PLUGIN_INPUT: return "input";
+        case STATE_PLUGIN_FILTER: return "filter";
+        case STATE_PLUGIN_OUTPUT: return "output";
+        case STATE_PLUGIN_START: return "plugin-start";
+        case STATE_PLUGIN_KEY: return "plugin-key";
+        case STATE_PLUGIN_VAL: return "plugin-value";
+        case STATE_PLUGIN_VAL_LIST: return "plugin-values";
+        case STATE_GROUP_KEY: return "group-key";
+        case STATE_GROUP_VAL: return "group-val";
+        case STATE_INPUT_PROCESSORS: return "processors";
+        case STATE_INPUT_PROCESSOR: return "processor";
+        case STATE_ENV: return "env";
+        case STATE_STOP: return "stop";
+        default: return "unknown";
+    }
+}
+
+struct file_state {
+    /* file */
+    flb_sds_t name;                /* file name */
+    flb_sds_t path;           /* file root path */
+
+    /* parent file state */
+    struct file_state *parent;
+};
+
+// parser state allocation flags
 #define HAS_KEY     (1 << 0)
 #define HAS_KEYVALS (1 << 1)
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1653,7 +1653,10 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
             flb_error("unable to create filename");
             return -1;
         }
-        flb_sds_printf(&file, "%s/%s", parent->path, cfg_file);
+        if (flb_sds_printf(&file, "%s/%s", parent->path, cfg_file) == NULL) {
+            flb_error("unable to create full filename");
+            return -1;
+        }
     } else {
         file = flb_sds_create(cfg_file);
     }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -557,7 +557,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     int idx;
     char *value;
     struct flb_kv *kv;
-    char *last_included = state_get_last(ctx);
+    char *last_included;
     struct cfl_list *head;
     struct cfl_kvpair *kvp;
     struct cfl_variant *var;
@@ -566,6 +566,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     struct cfl_array *carr;
     struct cfl_kvlist *copy;
 
+    last_included = state_get_last(ctx)
     state = get_current_state(ctx);
     print_current_state(ctx, state, event);
 

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -541,6 +541,9 @@ static void print_current_properties(struct parser_state *state)
 static struct parser_state *get_current_state(struct local_ctx *ctx)
 {
     struct parser_state *state;
+    if (cfl_list_size(&ctx->states) <= 0) {
+        return NULL;
+    }
     state = cfl_list_entry_last(&ctx->states, struct parser_state, _head);
     return state;
 }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -306,7 +306,7 @@ static char *state_get_last(struct local_ctx *ctx)
     if (entry == NULL) {
         return NULL;
     }
-    return e->str;
+    return entry->str;
 }
 
 static void yaml_error_event(struct local_ctx *ctx, struct parser_state *state,
@@ -683,7 +683,6 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
     struct parser_state *state;
     struct parser_state *group_key;
     int ret;
-    int idx;
     char *value;
     struct flb_kv *kv;
     char *last_included;

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -136,7 +136,7 @@ enum state {
     STATE_STOP            /* end state */
 };
 
-// parser state allocation flags
+/* parser state allocation flags */
 #define HAS_KEY     (1 << 0)
 #define HAS_KEYVALS (1 << 1)
 
@@ -1456,7 +1456,7 @@ static int consume_event(struct flb_cf *cf, struct local_ctx *ctx,
         };
         break;
 
-    // groups: a group is a sub-section and here we handle the key/value pairs.
+    /* groups: a group is a sub-section and here we handle the key/value pairs. */
     case STATE_GROUP_KEY:
         switch(event->type) {
         case YAML_SCALAR_EVENT:

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -449,6 +449,10 @@ struct flb_cf_group *flb_cf_group_create(struct flb_cf *cf, struct flb_cf_sectio
 
     /* initialize lists */
     g->properties = cfl_kvlist_create();
+    if (g->properties == NULL) {
+	flb_free(g);
+	return NULL;
+    }
 
     /* determinate type by name */
     if (len <= 0) {
@@ -458,6 +462,7 @@ struct flb_cf_group *flb_cf_group_create(struct flb_cf *cf, struct flb_cf_sectio
     /* create a NULL terminated name */
     g->name = flb_sds_create_len(name, len);
     if (!g->name) {
+        cfl_kvlist_destroy(g->properties);
         flb_free(g);
         return NULL;
     }

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -287,7 +287,7 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
 
     return flb_processor_instance_set_property(
             (struct flb_processor_instance *) pu->ctx,
-            k, v);
+            k, v->data.as_string);
 }
 
 void flb_processor_unit_destroy(struct flb_processor_unit *pu)

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -3,6 +3,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_str.h>
 #include <fluent-bit/flb_config_format.h>
 
 #include <cfl/cfl.h>
@@ -247,7 +248,7 @@ void test_parser_conf()
 
     config = flb_config_init();
     TEST_CHECK(config != NULL);
-    config->conf_path = FLB_TESTS_CONF_PATH "/parsers/";
+    config->conf_path = flb_strdup(FLB_TESTS_CONF_PATH "/parsers/");
 
     // count the parsers registered automatically by fluent-bit
     cnt = mk_list_size(&config->parsers);
@@ -266,6 +267,7 @@ void test_parser_conf()
 
     flb_cf_dump(cf);
     flb_cf_destroy(cf);
+    flb_config_exit(config);
 }
 
 TEST_LIST = {

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -232,10 +232,30 @@ void test_slist_odd()
     flb_cf_destroy(cf);
 }
 
+void test_parser_conf()
+{
+    struct flb_cf *cf;
+
+    cf = flb_cf_yaml_create(NULL, FLB_TESTS_CONF_PATH "/parsers/parsers-conf.yaml", NULL, 0);
+    TEST_CHECK(cf != NULL);
+    if (!cf) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Total number of inputs */
+    if(!TEST_CHECK(mk_list_size(&cf->parsers) == 1)) {
+        TEST_MSG("Section number error. Got=%d expect=1", mk_list_size(&cf->parsers));
+    }
+
+    flb_cf_dump(cf);
+    flb_cf_destroy(cf);
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
     { "customs section", test_customs_section},
     { "slist odd", test_slist_odd},
     { "slist even", test_slist_even},
+    { "parsers file conf", test_parser_conf},
     { 0 }
 };

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -235,6 +235,9 @@ void test_slist_odd()
 void test_parser_conf()
 {
     struct flb_cf *cf;
+    struct flb_config *config;
+    int ret;
+    int cnt;
 
     cf = flb_cf_yaml_create(NULL, FLB_TESTS_CONF_PATH "/parsers/parsers-conf.yaml", NULL, 0);
     TEST_CHECK(cf != NULL);
@@ -242,9 +245,23 @@ void test_parser_conf()
         exit(EXIT_FAILURE);
     }
 
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    config->conf_path = FLB_TESTS_CONF_PATH "/parsers/";
+
+    // count the parsers registered automatically by fluent-bit
+    cnt = mk_list_size(&config->parsers);
+    // load the parsers from the configuration
+    ret = flb_config_load_config_format(config, cf);
+    if (ret != 0) {
+        exit(EXIT_FAILURE);;
+    }
+
     /* Total number of inputs */
-    if(!TEST_CHECK(mk_list_size(&cf->parsers) == 1)) {
-        TEST_MSG("Section number error. Got=%d expect=1", mk_list_size(&cf->parsers));
+    if(!TEST_CHECK(mk_list_size(&config->parsers) == cnt+1)) {
+        TEST_MSG("Section number error. Got=%d expect=%d", 
+	         mk_list_size(&config->parsers),
+		 cnt+1);
     }
 
     flb_cf_dump(cf);

--- a/tests/internal/data/config_format/yaml/fluent-bit.yaml
+++ b/tests/internal/data/config_format/yaml/fluent-bit.yaml
@@ -5,25 +5,25 @@ includes:
     - service.yaml
 
 customs:
-    - ${observability}:
-        api_key: zyJUb2tlbklEItoiY2ZlMTcx
+    - name: ${observability}
+      api_key: zyJUb2tlbklEItoiY2ZlMTcx
 
 pipeline:
     inputs:
-        - tail:
-            path: ./test.log
-            parser: json
-            read_from_head: true
-        - tail:
-            path: ./test.log
-            parser: json
-            read_from_head: true
+        - name: tail
+          path: ./test.log
+          parser: json
+          read_from_head: true
+        - name: tail
+          path: ./test.log
+          parser: json
+          read_from_head: true
 
     filters:
-        - record_modifier:
-            match: "*"
-            record: powered_by calyptia
+        - name: record_modifier
+          match: "*"
+          record: powered_by calyptia
 
     outputs:
-        - stdout:
-            match: "*"
+        - name: stdout
+          match: "*"

--- a/tests/internal/data/config_format/yaml/parsers/parsers-conf.yaml
+++ b/tests/internal/data/config_format/yaml/parsers/parsers-conf.yaml
@@ -1,0 +1,3 @@
+---
+service:
+  parsers_file: parsers.conf

--- a/tests/internal/data/config_format/yaml/parsers/parsers.conf
+++ b/tests/internal/data/config_format/yaml/parsers/parsers.conf
@@ -1,0 +1,6 @@
+[PARSER]
+    Name        docker
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On

--- a/tests/internal/data/config_format/yaml/pipelines/slist/even.yaml
+++ b/tests/internal/data/config_format/yaml/pipelines/slist/even.yaml
@@ -1,0 +1,7 @@
+---
+pipeline:
+  inputs:
+    - name: http
+      success_header:
+        - foo bar
+        - bar foo

--- a/tests/internal/data/config_format/yaml/pipelines/slist/odd.yaml
+++ b/tests/internal/data/config_format/yaml/pipelines/slist/odd.yaml
@@ -1,0 +1,8 @@
+---
+pipeline:
+  inputs:
+    - name: http
+      success_header:
+        - foo bar
+        - bar foo
+        - foobar barfoo

--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -67,14 +67,19 @@ static void processor()
     size_t mp_size;
     void *out_buf = NULL;
     size_t out_size;
+    flb_sds_t hostname_prop_key;
     struct cfl_variant var = {
         .type = CFL_VARIANT_STRING,
-        .data.as_string = flb_sds_create("hostname monox")
+        .data.as_string = NULL,
     };
 
     printf("\n\n");
 
     flb_init_env();
+
+    hostname_prop_key = flb_sds_create("hostname monox");
+    TEST_CHECK(hostname_prop_key != NULL);
+    var.data.as_string = hostname_prop_key;
 
     config = flb_config_init();
     TEST_CHECK(config != NULL);
@@ -111,6 +116,7 @@ static void processor()
     flb_processor_destroy(proc);
     flb_config_exit(config);
 
+    flb_sds_destroy(hostname_prop_key);
 }
 
 TEST_LIST = {

--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -67,6 +67,10 @@ static void processor()
     size_t mp_size;
     void *out_buf = NULL;
     size_t out_size;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = flb_sds_create("hostname monox")
+    };
 
     printf("\n\n");
 
@@ -84,7 +88,7 @@ static void processor()
     pu = flb_processor_unit_create(proc, FLB_PROCESSOR_LOGS, "modify");
     TEST_CHECK(pu != NULL);
 
-    ret = flb_processor_unit_set_property(pu, "add", "hostname monox");
+    ret = flb_processor_unit_set_property(pu, "add", &var);
     TEST_CHECK(ret == 0);
 
     pu = flb_processor_unit_create(proc, FLB_PROCESSOR_LOGS, "stdout");


### PR DESCRIPTION
# Summary

This PR includes a refactoring of the YAML parser to use a stack based parser instead of using a single state that is continuously modified. 

This simplifies the code as well as allowing the reuse of code where appropriate, ie: properties for customs, inputs, filters, outputs, processors.

I also introduced debug output for the parser which requires a modification to fluent-bit to allow setting verbose mode when parsing command line arguments. A PR to do so is forthcoming.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205171678259551