### PR TITLE
plugins: in_exec: enable on win32

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -30,7 +30,7 @@ if(FLB_WINDOWS_DEFAULTS)
   # =============
   set(FLB_IN_CPU                 No)
   set(FLB_IN_DISK                No)
-  set(FLB_IN_EXEC                No)
+  set(FLB_IN_EXEC                Yes)
   set(FLB_IN_EXEC_WASI           No)
   set(FLB_IN_FORWARD            Yes)
   set(FLB_IN_HEALTH              No)


### PR DESCRIPTION
<!-- Provide summary of changes -->

Work done as part of #7207 made the in_exec plugin build-able on Windows, but did not enable it as part of the build.

Enable its compliation on Windows per request of @patrick-stephens .

Please also merge related Windows PR https://github.com/fluent/fluent-bit/pull/7463

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**`master` is totally valgrind-unclean so please remove this from the PR template^^**

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
