### PR TITLE
custom_calyptia: allow registering fleets by name instead of id.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -328,6 +328,12 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
     }
 
     if (ctx->fleet_id || ctx->fleet_name) {
+        ctx->fleet =  flb_input_new(config, "calyptia_fleet", NULL, FLB_FALSE);
+        if (!ctx->fleet) {
+            flb_plg_error(ctx->ins, "could not load Calyptia Fleet plugin");
+            return -1;
+        }
+
         if (ctx->fleet_name) {
             // TODO: set this once the fleet_id has been retrieved...
             // flb_output_set_property(ctx->o, "fleet_id", ctx->fleet_id);
@@ -335,12 +341,6 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         } else {
             flb_output_set_property(ctx->o, "fleet_id", ctx->fleet_id);
             flb_input_set_property(ctx->fleet, "fleet_id", ctx->fleet_id);
-        }
-
-        ctx->fleet =  flb_input_new(config, "calyptia_fleet", NULL, FLB_FALSE);
-        if (!ctx->fleet) {
-            flb_plg_error(ctx->ins, "could not load Calyptia Fleet plugin");
-            return -1;
         }
 
         flb_input_set_property(ctx->fleet, "api_key", ctx->api_key);

--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -221,18 +221,95 @@ flb_sds_t custom_calyptia_pipeline_config_get(struct flb_config *ctx)
     return buf;
 }
 
+static struct flb_output_instance *setup_cloud_output(struct flb_config *config, struct calyptia *ctx)
+{
+    int ret;
+    struct flb_output_instance *cloud;
+    struct mk_list *head;
+    struct flb_slist_entry *k = NULL;
+    struct flb_slist_entry *v = NULL;
+    flb_sds_t kv;
+    struct flb_config_map_val *mv;
+
+    cloud = flb_output_new(config, "calyptia", ctx, FLB_FALSE);
+    if (!cloud) {
+        flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    /* direct connect / routing */
+    ret = flb_router_connect_direct(ctx->i, cloud);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
+        flb_free(ctx);
+        return NULL;
+    }
+
+    if (ctx->add_labels && mk_list_size(ctx->add_labels) > 0) {
+        /* iterate all 'add_label' definitions */
+        flb_config_map_foreach(head, mv, ctx->add_labels) {
+            k = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+            v = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+            kv = flb_sds_create_size(strlen(k->str) + strlen(v->str) + 1);
+            if(!kv) {
+                flb_free(ctx);
+                return NULL;
+            }
+
+            flb_sds_printf(&kv, "%s %s", k->str, v->str);
+            flb_output_set_property(cloud, "add_label", kv);
+            flb_sds_destroy(kv);
+        }
+    }
+
+    flb_output_set_property(cloud, "match", "_calyptia_cloud");
+    flb_output_set_property(cloud, "api_key", ctx->api_key);
+    if (ctx->store_path) {
+        flb_output_set_property(cloud, "store_path", ctx->store_path);
+    }
+
+    if (ctx->machine_id) {
+        flb_output_set_property(cloud, "machine_id", ctx->machine_id);
+    }
+
+    /* Override network details: development purposes only */
+    if (ctx->cloud_host) {
+        flb_output_set_property(cloud, "cloud_host", ctx->cloud_host);
+    }
+
+    if (ctx->cloud_port) {
+        flb_output_set_property(cloud, "cloud_port", ctx->cloud_port);
+    }
+
+    if (ctx->cloud_tls) {
+        flb_output_set_property(cloud, "tls", "true");
+    }
+    else {
+        flb_output_set_property(cloud, "tls", "false");
+    }
+
+    if (ctx->cloud_tls_verify) {
+        flb_output_set_property(cloud, "tls.verify", "true");
+    }
+    else {
+        flb_output_set_property(cloud, "tls.verify", "false");
+    }
+
+#ifdef FLB_HAVE_CHUNK_TRACE
+    flb_output_set_property(cloud, "pipeline_id", ctx->pipeline_id);
+#endif /* FLB_HAVE_CHUNK_TRACE */
+
+    return cloud;
+}
+
 static int cb_calyptia_init(struct flb_custom_instance *ins,
                             struct flb_config *config,
                             void *data)
 {
     int ret;
     struct calyptia *ctx;
-    struct mk_list *head;
-    struct flb_config_map_val *mv;
-    struct flb_slist_entry *k = NULL;
-    struct flb_slist_entry *v = NULL;
     (void) data;
-    flb_sds_t kv;
 
     ctx = flb_calloc(1, sizeof(struct calyptia));
     if (!ctx) {
@@ -262,69 +339,11 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
     flb_input_set_property(ctx->i, "scrape_interval", "30");
 
     /* output cloud connector */
-    ctx->o = flb_output_new(config, "calyptia", ctx, FLB_FALSE);
-    if (!ctx->o) {
-        flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
-        flb_free(ctx);
-        return -1;
-    }
-
-    /* direct connect / routing */
-    ret = flb_router_connect_direct(ctx->i, ctx->o);
-    if (ret != 0) {
-        flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
-        flb_free(ctx);
-        return -1;
-    }
-
-    if (ctx->add_labels && mk_list_size(ctx->add_labels) > 0) {
-        /* iterate all 'add_label' definitions */
-        flb_config_map_foreach(head, mv, ctx->add_labels) {
-            k = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
-            v = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
-            kv = flb_sds_create_size(strlen(k->str) + strlen(v->str) + 1);
-            if(!kv) {
-                flb_free(ctx);
-                return -1;
-            }
-
-            flb_sds_printf(&kv, "%s %s", k->str, v->str);
-            flb_output_set_property(ctx->o, "add_label", kv);
-            flb_sds_destroy(kv);
+    if (ctx->fleet_id != NULL) {
+        ctx->o = setup_cloud_output(config, ctx);
+        if (ctx->o == NULL) {
+            return -1;
         }
-    }
-
-    flb_output_set_property(ctx->o, "match", "_calyptia_cloud");
-    flb_output_set_property(ctx->o, "api_key", ctx->api_key);
-    if (ctx->store_path) {
-        flb_output_set_property(ctx->o, "store_path", ctx->store_path);
-    }
-
-    if (ctx->machine_id) {
-        flb_output_set_property(ctx->o, "machine_id", ctx->machine_id);
-    }
-
-    /* Override network details: development purposes only */
-    if (ctx->cloud_host) {
-        flb_output_set_property(ctx->o, "cloud_host", ctx->cloud_host);
-    }
-
-    if (ctx->cloud_port) {
-        flb_output_set_property(ctx->o, "cloud_port", ctx->cloud_port);
-    }
-
-    if (ctx->cloud_tls) {
-        flb_output_set_property(ctx->o, "tls", "true");
-    }
-    else {
-        flb_output_set_property(ctx->o, "tls", "false");
-    }
-
-    if (ctx->cloud_tls_verify) {
-        flb_output_set_property(ctx->o, "tls.verify", "true");
-    }
-    else {
-        flb_output_set_property(ctx->o, "tls.verify", "false");
     }
 
     if (ctx->fleet_id || ctx->fleet_name) {
@@ -361,12 +380,9 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         }
     }
 
-
-#ifdef FLB_HAVE_CHUNK_TRACE
-    flb_output_set_property(ctx->o, "pipeline_id", ctx->pipeline_id);
-#endif /* FLB_HAVE_CHUNK_TRACE */
-
-    flb_router_connect(ctx->i, ctx->o);
+    if (ctx->o) {
+        flb_router_connect(ctx->i, ctx->o);
+    }
     flb_plg_info(ins, "custom initialized!");
     return 0;
 }

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -379,6 +379,7 @@ static flb_sds_t parse_api_key_json(struct flb_in_calyptia_fleet_config *ctx,
     msgpack_unpacked result;
     msgpack_object_kv *cur;
     msgpack_object_str *key;
+    flb_sds_t project_id;
     int i = 0;
 
     /* Initialize packer */
@@ -415,9 +416,11 @@ static flb_sds_t parse_api_key_json(struct flb_in_calyptia_fleet_config *ctx,
                         msgpack_unpacked_destroy(&result);
                         return NULL;
                     }
+                    project_id = flb_sds_create_len(cur->val.via.str.ptr, 
+		                                    cur->val.via.str.size);
                     msgpack_unpacked_destroy(&result);
                     flb_free(pack);
-                    return flb_sds_create(cur->val.via.str.ptr);
+                    return project_id;
                 }
             }
         }

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -685,24 +685,47 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
             goto http_error;
         }
         header = flb_sds_create_size(4096);
-        flb_sds_printf(&header, 
-                       "[CUSTOM]\n"
-                       "    Name          calyptia\n"
-                       "    api_key       %s\n"
-                       "    fleet_id      %s\n"
-                       "    add_label     fleet_id %s\n"
-                       "    Fleet.Config_Dir    %s\n"
-                       "    calyptia_host %s\n"
-                       "    calyptia_port %d\n"
-                       "    calyptia_tls  %s\n",
-                       ctx->api_key,
-                       ctx->fleet_id,
-                       ctx->fleet_id,
-                       ctx->config_dir,
-                       ctx->ins->host.name,
-                       ctx->ins->host.port,
-                       tls_setting_string(ctx->ins->use_tls)
-        );
+        if (ctx->fleet_name == NULL) {
+            flb_sds_printf(&header,
+                        "[CUSTOM]\n"
+                        "    Name          calyptia\n"
+                        "    api_key       %s\n"
+                        "    fleet_id      %s\n"
+                        "    add_label     fleet_id %s\n"
+                        "    Fleet.Config_Dir    %s\n"
+                        "    calyptia_host %s\n"
+                        "    calyptia_port %d\n"
+                        "    calyptia_tls  %s\n",
+                        ctx->api_key,
+                        ctx->fleet_id,
+                        ctx->fleet_id,
+                        ctx->config_dir,
+                        ctx->ins->host.name,
+                        ctx->ins->host.port,
+                        tls_setting_string(ctx->ins->use_tls)
+            );
+        } else {
+            flb_sds_printf(&header,
+                        "[CUSTOM]\n"
+                        "    Name          calyptia\n"
+                        "    api_key       %s\n"
+                        "    fleet_name    %s\n"
+                        "    fleet_id      %s\n"
+                        "    add_label     fleet_id %s\n"
+                        "    Fleet.Config_Dir    %s\n"
+                        "    calyptia_host %s\n"
+                        "    calyptia_port %d\n"
+                        "    calyptia_tls  %s\n",
+                        ctx->api_key,
+                        ctx->fleet_name,
+                        ctx->fleet_id,
+                        ctx->fleet_id,
+                        ctx->config_dir,
+                        ctx->ins->host.name,
+                        ctx->ins->host.port,
+                        tls_setting_string(ctx->ins->use_tls)
+            );
+        }
         fwrite(header, strlen(header), 1, cfgfp);
         flb_sds_destroy(header);
         fwrite(data, client->resp.payload_size, 1, cfgfp);

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -692,7 +692,7 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
                         "    api_key       %s\n"
                         "    fleet_id      %s\n"
                         "    add_label     fleet_id %s\n"
-                        "    Fleet.Config_Dir    %s\n"
+                        "    fleet.config_dir    %s\n"
                         "    calyptia_host %s\n"
                         "    calyptia_port %d\n"
                         "    calyptia_tls  %s\n",
@@ -712,7 +712,7 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
                         "    fleet_name    %s\n"
                         "    fleet_id      %s\n"
                         "    add_label     fleet_id %s\n"
-                        "    Fleet.Config_Dir    %s\n"
+                        "    fleet.config_dir    %s\n"
                         "    calyptia_host %s\n"
                         "    calyptia_port %d\n"
                         "    calyptia_tls  %s\n",


### PR DESCRIPTION
# Summary

This PR adds the parameter `fleet_name` which allows registering an instance of fluent-bit with a fleet using it's name instead by ID.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
