### PR TITLE
Adds support for Content-Encoding: gzip to in_http

### DIFF
--- a/include/fluent-bit/flb_gzip.h
+++ b/include/fluent-bit/flb_gzip.h
@@ -21,7 +21,8 @@
 #define FLB_GZIP_H
 
 #include <fluent-bit/flb_info.h>
-#include <stdio.h>
+#include <fluent-bit/flb_macros.h>
+#include <monkey/mk_http.h>
 
 struct flb_decompression_context;
 
@@ -35,5 +36,7 @@ void flb_gzip_decompression_context_destroy(void *context);
 
 int flb_gzip_decompressor_dispatch(struct flb_decompression_context *context,
                                    void *out_data, size_t *out_size);
+
+int flb_is_http_session_gzip_compressed(struct mk_http_session *session);
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

This change adds support for gzipped content to in_http. I discovered this by accident when attempting to send gzipped JSON from another fluent-bit, and found that fluent-bit responded with an invalid JSON error. With this PR, fluent-bit will now appropriately handle gzipped content on the HTTP input.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
