### PR TITLE
in_tcp: Add a capability to inject source IP

### DIFF
--- a/include/fluent-bit/flb_msgpack_append_message.h
+++ b/include/fluent-bit/flb_msgpack_append_message.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_MSGPACK_APPEND_MESSAGE_H
+#define FLB_MSGPACK_APPEND_MESSAGE_H
+
+/* Error codes */
+#define FLB_MAP_EXPAND_SUCCESS   0
+#define FLB_MAP_NOT_MODIFIED    -1
+#define FLB_MAP_EXPANSION_ERROR -2
+#define FLB_MAP_EXPANSION_INVALID_VALUE_TYPE -3
+
+#include <fluent-bit/flb_pack.h>
+
+int flb_msgpack_append_message_to_record(char **result_buffer,
+                                         size_t *result_size,
+                                         flb_sds_t message_key_name,
+                                         char *base_object_buffer,
+                                         size_t base_object_size,
+                                         char *message_buffer,
+                                         size_t message_size,
+                                         int message_type);
+#endif

--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -166,6 +166,11 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct flb_in_tcp_config, buffer_size_str),
       "Set the buffer size"
     },
+    {
+      FLB_CONFIG_MAP_STR, "source_address_key", (char *) NULL,
+      0, FLB_TRUE, offsetof(struct flb_in_tcp_config, source_address_key),
+      "Key where the source address will be injected"
+    },
     /* EOF */
     {0}
 };

--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -40,6 +40,7 @@ struct flb_in_tcp_config {
     char *tcp_port;                    /* TCP Port                    */
     flb_sds_t raw_separator;           /* Unescaped string delimiterr */
     flb_sds_t separator;               /* String delimiter            */
+    flb_sds_t source_address_key;      /* Source IP address           */
     int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager */
     struct mk_list connections;        /* List of active connections  */

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -32,14 +32,84 @@ static inline void consume_bytes(char *buf, int bytes, int length)
     memmove(buf, buf + bytes, length - bytes);
 }
 
+static int append_message_to_record_data(char **result_buffer,
+                                         size_t *result_size,
+                                         flb_sds_t message_key_name,
+                                         char *base_object_buffer,
+                                         size_t base_object_size,
+                                         char *message_buffer,
+                                         size_t message_size,
+                                         int message_type)
+{
+    int                result;
+    char              *modified_data_buffer;
+    int                modified_data_size;
+    msgpack_object_kv *new_map_entries[1];
+    msgpack_object_kv  message_entry;
+    *result_buffer = NULL;
+    *result_size = 0;
+    modified_data_buffer = NULL;
+
+    if (message_key_name != NULL) {
+        new_map_entries[0] = &message_entry;
+
+        message_entry.key.type = MSGPACK_OBJECT_STR;
+        message_entry.key.via.str.size = flb_sds_len(message_key_name);
+        message_entry.key.via.str.ptr  = message_key_name;
+
+        if (message_type == MSGPACK_OBJECT_BIN) {
+            message_entry.val.type = MSGPACK_OBJECT_BIN;
+            message_entry.val.via.bin.size = message_size;
+            message_entry.val.via.bin.ptr  = message_buffer;
+        }
+        else if (message_type == MSGPACK_OBJECT_STR) {
+            message_entry.val.type = MSGPACK_OBJECT_BIN;
+            message_entry.val.via.str.size = message_size;
+            message_entry.val.via.str.ptr  = message_buffer;
+        }
+        else {
+            result = FLB_MAP_NOT_MODIFIED;
+
+            return result;
+        }
+
+        result = flb_msgpack_expand_map(base_object_buffer,
+                                        base_object_size,
+                                        new_map_entries, 1,
+                                        &modified_data_buffer,
+                                        &modified_data_size);
+        if (result == 0) {
+            result = FLB_MAP_EXPAND_SUCCESS;
+        }
+    }
+
+    if (result != FLB_MAP_EXPAND_SUCCESS) {
+        result = FLB_MAP_EXPANSION_ERROR;
+
+        return result;
+    }
+
+    *result_buffer = modified_data_buffer;
+    *result_size = modified_data_size;
+
+    return result;
+}
+
 static inline int process_pack(struct tcp_conn *conn,
                                char *pack, size_t size)
 {
     int ret;
     size_t off = 0;
     msgpack_unpacked result;
+    msgpack_sbuffer sbuf;
+    msgpack_packer  pck;
     msgpack_object entry;
     struct flb_in_tcp_config *ctx;
+    char   *appended_address_buffer;
+    size_t  appended_address_size;
+    char   *source_address;
+    int i;
+    int len;
 
     ctx = conn->ctx;
 
@@ -50,22 +120,72 @@ static inline int process_pack(struct tcp_conn *conn,
     while (msgpack_unpack_next(&result, pack, size, &off) == MSGPACK_UNPACK_SUCCESS) {
         entry = result.data;
 
+        appended_address_buffer = NULL;
+        source_address = NULL;
+
         ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
         if (ret == FLB_EVENT_ENCODER_SUCCESS) {
             ret = flb_log_event_encoder_set_current_timestamp(ctx->log_encoder);
         }
 
+        if (ctx->source_address_key != NULL) {
+            source_address = flb_connection_get_remote_address(conn->connection);
+        }
+
         if (ret == FLB_EVENT_ENCODER_SUCCESS) {
             if (entry.type == MSGPACK_OBJECT_MAP) {
-                ret = flb_log_event_encoder_set_body_from_msgpack_object(
-                        ctx->log_encoder, &entry);
+                if (source_address != NULL) {
+                    msgpack_sbuffer_init(&sbuf);
+                    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+
+                    len = entry.via.map.size;
+                    msgpack_pack_map(&pck, len);
+
+                    for (i=0; i<len; i++) {
+                        msgpack_pack_object(&pck, entry.via.map.ptr[i].key);
+                        msgpack_pack_object(&pck, entry.via.map.ptr[i].val);
+                    }
+
+                    ret = append_message_to_record_data(&appended_address_buffer,
+                                                        &appended_address_size,
+                                                        ctx->source_address_key,
+                                                        sbuf.data,
+                                                        sbuf.size,
+                                                        source_address,
+                                                        strlen(source_address),
+                                                        MSGPACK_OBJECT_STR);
+                    msgpack_sbuffer_destroy(&sbuf);
+                }
+
+                if (ret == FLB_MAP_EXPANSION_ERROR) {
+                    flb_plg_debug(ctx->ins, "error expanding source_address : %d", ret);
+                }
+
+                if (appended_address_buffer != NULL) {
+                    ret = flb_log_event_encoder_set_body_from_raw_msgpack(
+                            ctx->log_encoder, appended_address_buffer, appended_address_size);
+                }
+                else {
+                    ret = flb_log_event_encoder_set_body_from_msgpack_object(
+                            ctx->log_encoder, &entry);
+                }
             }
             else if (entry.type == MSGPACK_OBJECT_ARRAY) {
-                ret = flb_log_event_encoder_append_body_values(
+                if (source_address != NULL) {
+                    ret = flb_log_event_encoder_append_body_values(
+                        ctx->log_encoder,
+                        FLB_LOG_EVENT_CSTRING_VALUE("msg"),
+                        FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE(&entry),
+                        FLB_LOG_EVENT_CSTRING_VALUE(ctx->source_address_key),
+                        FLB_LOG_EVENT_CSTRING_VALUE(source_address));
+                }
+                else {
+                    ret = flb_log_event_encoder_append_body_values(
                         ctx->log_encoder,
                         FLB_LOG_EVENT_CSTRING_VALUE("msg"),
                         FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE(&entry));
+                }
             }
             else {
                 ret = FLB_EVENT_ENCODER_ERROR_INVALID_VALUE_TYPE;
@@ -73,6 +193,10 @@ static inline int process_pack(struct tcp_conn *conn,
 
             if (ret == FLB_EVENT_ENCODER_SUCCESS) {
                 ret = flb_log_event_encoder_commit_record(ctx->log_encoder);
+            }
+
+            if (appended_address_buffer != NULL) {
+                flb_free(appended_address_buffer);
             }
 
             if (ret != FLB_EVENT_ENCODER_SUCCESS) {

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -85,12 +85,10 @@ static int append_message_to_record_data(char **result_buffer,
 
     if (result != FLB_MAP_EXPAND_SUCCESS) {
         result = FLB_MAP_EXPANSION_ERROR;
-
-        return result;
+    } else {
+        *result_buffer = modified_data_buffer;
+        *result_size = modified_data_size;
     }
-
-    *result_buffer = modified_data_buffer;
-    *result_size = modified_data_size;
 
     return result;
 }

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -63,7 +63,7 @@ static int append_message_to_record_data(char **result_buffer,
             message_entry.val.via.bin.ptr  = message_buffer;
         }
         else if (message_type == MSGPACK_OBJECT_STR) {
-            message_entry.val.type = MSGPACK_OBJECT_BIN;
+            message_entry.val.type = MSGPACK_OBJECT_STR;
             message_entry.val.via.str.size = message_size;
             message_entry.val.via.str.ptr  = message_buffer;
         }

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -134,7 +134,7 @@ static inline int process_pack(struct tcp_conn *conn,
 
         if (ret == FLB_EVENT_ENCODER_SUCCESS) {
             if (entry.type == MSGPACK_OBJECT_MAP) {
-                if (source_address != NULL) {
+                if (ctx->source_address_key != NULL && source_address != NULL) {
                     msgpack_sbuffer_init(&sbuf);
                     msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
 
@@ -171,7 +171,7 @@ static inline int process_pack(struct tcp_conn *conn,
                 }
             }
             else if (entry.type == MSGPACK_OBJECT_ARRAY) {
-                if (source_address != NULL) {
+                if (ctx->source_address_key != NULL && source_address != NULL) {
                     ret = flb_log_event_encoder_append_body_values(
                         ctx->log_encoder,
                         FLB_LOG_EVENT_CSTRING_VALUE("msg"),

--- a/plugins/in_tcp/tcp_conn.h
+++ b/plugins/in_tcp/tcp_conn.h
@@ -25,11 +25,6 @@
 
 #define FLB_IN_TCP_CHUNK "32768"
 
-#define FLB_MAP_EXPAND_SUCCESS   0
-#define FLB_MAP_NOT_MODIFIED    -1
-#define FLB_MAP_EXPANSION_ERROR -2
-#define FLB_MAP_EXPANSION_INVALID_VALUE_TYPE -3
-
 enum {
     TCP_NEW        = 1,  /* it's a new connection                */
     TCP_CONNECTED  = 2,  /* MQTT connection per protocol spec OK */

--- a/plugins/in_tcp/tcp_conn.h
+++ b/plugins/in_tcp/tcp_conn.h
@@ -25,6 +25,10 @@
 
 #define FLB_IN_TCP_CHUNK "32768"
 
+#define FLB_MAP_EXPAND_SUCCESS   0
+#define FLB_MAP_NOT_MODIFIED    -1
+#define FLB_MAP_EXPANSION_ERROR -2
+
 enum {
     TCP_NEW        = 1,  /* it's a new connection                */
     TCP_CONNECTED  = 2,  /* MQTT connection per protocol spec OK */

--- a/plugins/in_tcp/tcp_conn.h
+++ b/plugins/in_tcp/tcp_conn.h
@@ -28,6 +28,7 @@
 #define FLB_MAP_EXPAND_SUCCESS   0
 #define FLB_MAP_NOT_MODIFIED    -1
 #define FLB_MAP_EXPANSION_ERROR -2
+#define FLB_MAP_EXPANSION_INVALID_VALUE_TYPE -3
 
 enum {
     TCP_NEW        = 1,  /* it's a new connection                */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(src
   flb_log_event_encoder_dynamic_field.c
   flb_processor.c
   flb_reload.c
+  flb_msgpack_append_message.c
   )
 
 # Config format

--- a/src/flb_msgpack_append_message.c
+++ b/src/flb_msgpack_append_message.c
@@ -1,0 +1,82 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_msgpack_append_message.h>
+
+int flb_msgpack_append_message_to_record(char **result_buffer,
+                                         size_t *result_size,
+                                         flb_sds_t message_key_name,
+                                         char *base_object_buffer,
+                                         size_t base_object_size,
+                                         char *message_buffer,
+                                         size_t message_size,
+                                         int message_type)
+{
+    int                result = FLB_MAP_NOT_MODIFIED;
+    char              *modified_data_buffer;
+    int                modified_data_size;
+    msgpack_object_kv *new_map_entries[1];
+    msgpack_object_kv  message_entry;
+    *result_buffer = NULL;
+    *result_size = 0;
+    modified_data_buffer = NULL;
+
+    if (message_key_name != NULL) {
+        new_map_entries[0] = &message_entry;
+
+        message_entry.key.type = MSGPACK_OBJECT_STR;
+        message_entry.key.via.str.size = flb_sds_len(message_key_name);
+        message_entry.key.via.str.ptr  = message_key_name;
+
+        if (message_type == MSGPACK_OBJECT_BIN) {
+            message_entry.val.type = MSGPACK_OBJECT_BIN;
+            message_entry.val.via.bin.size = message_size;
+            message_entry.val.via.bin.ptr  = message_buffer;
+        }
+        else if (message_type == MSGPACK_OBJECT_STR) {
+            message_entry.val.type = MSGPACK_OBJECT_STR;
+            message_entry.val.via.str.size = message_size;
+            message_entry.val.via.str.ptr  = message_buffer;
+        }
+        else {
+            result = FLB_MAP_EXPANSION_INVALID_VALUE_TYPE;
+        }
+
+        if (result == FLB_MAP_NOT_MODIFIED) {
+            result = flb_msgpack_expand_map(base_object_buffer,
+                                            base_object_size,
+                                            new_map_entries, 1,
+                                            &modified_data_buffer,
+                                            &modified_data_size);
+            if (result == 0) {
+                result = FLB_MAP_EXPAND_SUCCESS;
+            }
+            else {
+                result = FLB_MAP_EXPANSION_ERROR;
+            }
+        }
+    }
+
+    if (result == FLB_MAP_EXPAND_SUCCESS) {
+        *result_buffer = modified_data_buffer;
+        *result_size = modified_data_size;
+    }
+
+    return result;
+}

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -41,6 +41,7 @@ set(UNIT_TESTS_FILES
   log_event_decoder.c
   processor.c
   uri.c
+  msgpack_append_message.c
   )
 
 # Config format

--- a/tests/internal/data/msgpack_append_message/map1.json
+++ b/tests/internal/data/msgpack_append_message/map1.json
@@ -1,0 +1,5 @@
+{"key1": 123456789,
+ "key2": 0.999887766,
+ "key3": "abcdefghijklmnopqrstuvwxyz",
+ "key4": [{"a": 10, "b": 20}, {"c": 30, "d": 40}]
+}

--- a/tests/internal/msgpack_append_message.c
+++ b/tests/internal/msgpack_append_message.c
@@ -1,0 +1,113 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_msgpack_append_message.h>
+#include <monkey/mk_core.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <math.h> /* for NAN */
+
+/* JSON tests data */
+#define JSON_MAP1 FLB_TESTS_DATA_PATH "/data/msgpack_append_message/map1.json"
+
+#include "flb_tests_internal.h"
+
+struct msgpack_append_message_test {
+    char *msgpack;
+    char *json;
+};
+
+static inline int process_pack(char *pack, size_t size)
+{
+    int ret;
+    msgpack_unpacked result;
+    char   *appended_buffer = NULL;
+    size_t  appended_size;
+    char *inject_message = "injected";
+    char *inject_key_name = "expanding";
+    flb_sds_t inject_key;
+    size_t off = 0;
+    size_t prev_off = 0;
+    flb_sds_t out_buf;
+    char *p = NULL;
+
+    inject_key = flb_sds_create_len(inject_key_name, strlen(inject_key_name));
+    if (!inject_key) {
+        flb_errno();
+        return -1;
+    }
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, pack, size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        if (result.data.type == MSGPACK_OBJECT_MAP) {
+            ret = flb_msgpack_append_message_to_record(&appended_buffer,
+                                                       &appended_size,
+                                                       inject_key,
+                                                       pack + prev_off,
+                                                       size,
+                                                       inject_message,
+                                                       8,
+                                                       MSGPACK_OBJECT_STR);
+            TEST_CHECK(ret == 0);
+
+            out_buf = flb_msgpack_raw_to_json_sds(appended_buffer, appended_size);
+            TEST_CHECK(out_buf != NULL);
+            p = strstr(out_buf, "\"expanding\":\"injected\"");
+            if (!TEST_CHECK(p != NULL)) {
+                TEST_MSG("\"expanding\":\"injected\" should be appended. out_buf=%s", out_buf);
+            }
+            if (out_buf) {
+                flb_sds_destroy(out_buf);
+            }
+        }
+        prev_off = off;
+    }
+
+    msgpack_unpacked_destroy(&result);
+
+    flb_sds_destroy(inject_key);
+    flb_free(appended_buffer);
+
+    return ret;
+}
+
+/* Append a single key-value pair into msgpack map */
+void test_append_basic()
+{
+    int ret;
+    size_t len;
+    char *data;
+    char *pack;
+    int   out_size;
+    struct flb_pack_state state;
+
+    data = mk_file_to_buffer(JSON_MAP1);
+    TEST_CHECK(data != NULL);
+
+    len = strlen(data);
+
+    ret = flb_pack_state_init(&state);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_pack_json_state(data, len, &pack, &out_size, &state);
+    TEST_CHECK(ret == 0);
+
+    ret = process_pack(pack, out_size);
+    TEST_CHECK(ret == 0);
+
+    flb_pack_state_reset(&state);
+    flb_free(data);
+    flb_free(pack);
+}
+
+TEST_LIST = {
+    { "basic", test_append_basic },
+    { 0 }
+};

--- a/tests/internal/msgpack_append_message.c
+++ b/tests/internal/msgpack_append_message.c
@@ -10,10 +10,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <dirent.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <math.h> /* for NAN */
 
 /* JSON tests data */
 #define JSON_MAP1 FLB_TESTS_DATA_PATH "/data/msgpack_append_message/map1.json"

--- a/tests/runtime/in_tcp.c
+++ b/tests/runtime/in_tcp.c
@@ -255,6 +255,69 @@ void flb_test_tcp()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_tcp_with_source_address()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    flb_sockfd_t fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+
+    char *buf = "{\"test\":\"msg\"}";
+    size_t size = strlen(buf);
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\",\"source_host\":\"tcp://";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "source_address_key", "source_host",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* use default host/port */
+    fd = connect_tcp(NULL, -1);
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+
+    w_size = send(fd, buf, size, 0);
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        flb_socket_close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    flb_socket_close(fd);
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_tcp_with_tls()
 {
     struct flb_connection *client_connection;
@@ -552,6 +615,7 @@ void flb_test_issue_5336()
 
 TEST_LIST = {
     {"tcp", flb_test_tcp},
+    {"tcp_with_source_address", flb_test_tcp_with_source_address},
     {"tcp_with_tls", flb_test_tcp_with_tls},
     {"format_none", flb_test_format_none},
     {"format_none_separator", flb_test_format_none_separator},


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, in_tcp plugin does not offer adding source address feature.
This PR provides this feature.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```python
[INPUT]
    Name        tcp
    Listen      0.0.0.0
    Port        5170
    Chunk_Size  32
    Buffer_Size 64
    Format      json
    Source_Address_Key source_host

[OUTPUT]
    Name        stdout
    Match       *
```
- [x] Debug log output from testing the change
```log
Fluent Bit v2.1.7
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/07/10 14:30:42] [ info] Configuration:
[2023/07/10 14:30:42] [ info]  flush time     | 1.000000 seconds
[2023/07/10 14:30:42] [ info]  grace          | 5 seconds
[2023/07/10 14:30:42] [ info]  daemon         | 0
[2023/07/10 14:30:42] [ info] ___________
[2023/07/10 14:30:42] [ info]  inputs:
[2023/07/10 14:30:42] [ info]      tcp
[2023/07/10 14:30:42] [ info] ___________
[2023/07/10 14:30:42] [ info]  filters:
[2023/07/10 14:30:42] [ info] ___________
[2023/07/10 14:30:42] [ info]  outputs:
[2023/07/10 14:30:42] [ info]      stdout.0
[2023/07/10 14:30:42] [ info] ___________
[2023/07/10 14:30:42] [ info]  collectors:
[2023/07/10 14:30:42] [ info] [fluent bit] version=2.1.7, commit=0714d10889, pid=372853
[2023/07/10 14:30:42] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/07/10 14:30:42] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/07/10 14:30:42] [ info] [cmetrics] version=0.6.3
[2023/07/10 14:30:42] [ info] [ctraces ] version=0.3.1
[2023/07/10 14:30:42] [ info] [input:tcp:tcp.0] initializing
[2023/07/10 14:30:42] [ info] [input:tcp:tcp.0] storage_strategy='memory' (memory only)
[2023/07/10 14:30:42] [debug] [tcp:tcp.0] created event channels: read=21 write=22
[2023/07/10 14:30:42] [debug] [downstream] listening on 0.0.0.0:5170
[2023/07/10 14:30:42] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/07/10 14:30:42] [ info] [sp] stream processor started
[2023/07/10 14:30:42] [ info] [output:stdout:stdout.0] worker #0 started
[2023/07/10 14:30:44] [debug] [input chunk] update output instances with new chunk size diff=86, records=1, input=tcp.0
[2023/07/10 14:30:44] [debug] [task] created task=0x7f5a4802a4b0 id=0 OK
[2023/07/10 14:30:44] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] tcp.0: [[1688967044.132801215, {}], {"key 1"=>123456789, "key 2"=>"abcdefg", "source_host"=>"tcp://127.0.0.1:46958"}]
[2023/07/10 14:30:44] [debug] [out flush] cb_destroy coro_id=0
[2023/07/10 14:30:44] [debug] [task] destroy task=0x7f5a4802a4b0 (task_id=0)
[2023/07/10 14:30:57] [debug] [input chunk] update output instances with new chunk size diff=95, records=1, input=tcp.0
[2023/07/10 14:30:58] [debug] [task] created task=0x7f5a4802bda0 id=0 OK
[2023/07/10 14:30:58] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] tcp.0: [[1688967057.809867670, {}], {"msg"=>[{"key 1"=>123456789, "key 2"=>"abcdefg"}], "source_host"=>"tcp://127.0.0.1:35472"}]
[2023/07/10 14:30:58] [debug] [out flush] cb_destroy coro_id=1
[2023/07/10 14:30:58] [debug] [task] destroy task=0x7f5a4802bda0 (task_id=0)
^C[2023/07/10 14:30:59] [engine] caught signal (SIGINT)
[2023/07/10 14:30:59] [ warn] [engine] service will shutdown in max 5 seconds
[2023/07/10 14:31:00] [ info] [engine] service has stopped (0 pending tasks)
[2023/07/10 14:31:00] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/07/10 14:31:00] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==373310== 
==373310== HEAP SUMMARY:
==373310==     in use at exit: 95,170 bytes in 702 blocks
==373310==   total heap usage: 2,921 allocs, 2,219 frees, 1,306,526 bytes allocated
==373310== 
==373310== LEAK SUMMARY:
==373310==    definitely lost: 0 bytes in 0 blocks
==373310==    indirectly lost: 0 bytes in 0 blocks
==373310==      possibly lost: 0 bytes in 0 blocks
==373310==    still reachable: 95,170 bytes in 702 blocks
==373310==         suppressed: 0 bytes in 0 blocks
==373310== Reachable blocks (those to which a pointer was found) are not shown.
==373310== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==373310== 
==373310== For lists of detected and suppressed errors, rerun with: -s
==373310== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1155

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
