### PR TITLE
[Bug-7178] Tls.vhost is not validating the common name of the server 

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -529,9 +529,15 @@ static int tls_net_handshake(struct flb_tls *tls,
             pthread_mutex_unlock(&ctx->mutex);
             return -1;
         }
-
-        if (vhost != NULL) {
-            SSL_set_tlsext_host_name(session->ssl, vhost);
+        if (tls->vhost != NULL) {
+            SSL_set_tlsext_host_name(session->ssl, tls->vhost);
+            /* set host name validation only if vhost is configured
+             * explicitely */
+            X509_VERIFY_PARAM *param = SSL_get0_param(session->ssl);
+            if (!X509_VERIFY_PARAM_set1_host(param, tls->vhost, 0)) {
+                flb_error("[tls] error: vhost parameter set failed : %s", vhost);
+                return -1;
+            }
         }
         else if (tls->vhost) {
             SSL_set_tlsext_host_name(session->ssl, tls->vhost);


### PR DESCRIPTION
While using the TLS, we set verify to true if we want to verify server certificate. What fluent-bit verifies here is mostly only the validity and authenticity (signed by known CA or not) or not. But If vhost is configured and verify is set to true, it does not validate hostname/common-name field of server certificate.



<!-- Provide summary of changes -->

As part of this commit, if verify is set and vhost is configured, the server will be validated against the configuerd hostname. If it does not match then TLS handshake fails with invalid certificate error.
Code change details:
Using `X509_VERIFY_PARAM_set1_host` to set verification of host parameter so that server certificate is validated during the handshake

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#7178 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
Configuration at Client:
<!--
- [INPUT]
    Name Tail
    Tag local3_2.3.4.5
    Path /var/log/firewall
    DB /tmp/local3_2.3.4.5
    Buffer_Max_Size 64k
    Buffer_Chunk_Size 64k
    Mem_Buf_Limit 512
    Refresh_Interval 30

[OUTPUT]
    Name Syslog
    Match local3_2.3.4.5
    Host 10.10.10.30
    Port 38867
    Mode TCP
    Syslog_Format rfc3164
    Syslog_Message_Key log
    net.connect_timeout 50
    tls on
    tls.verify true
    tls.vhost devserver.com
    tls.ca_file /home/mhosur/keys/ca.crt
    tls.crt_file /home/mhosur/keys/flb_client.crt
    tls.key_file /home/mhosur/keys/flb_client.key 
- Configuration of Server

[INPUT]
        Name Tail
        Tag local3_2.3.4.5
        Path /var/log/firewall
        DB /tmp/local3_2.3.4.5
        Buffer_Max_Size 64k
        Buffer_Chunk_Size 64k
        Mem_Buf_Limit 512
        Refresh_Interval 30

[INPUT]
        Name syslog
        #Tag local3_2.3.4.5
        Listen 10.10.10.30
        Port 38867
        Parser syslog-rfc3164
        Mode TCP
        Buffer_Chunk_Size   64KB
        tls on
        tls.ca_file /home/mhosur/keys/ca.crt
        tls.crt_file /home/mhosur/keys/server.crt
        tls.key_file /home/mhosur/keys/server.key

-->
- [*] Debug log output from testing the change
-<!--
Jul 10 05:35:23 2023 ECVB tunneld[25199]: CPU 2 TID 140225103783424: [tunneld.ERR]: cids_bkp_cbuf_b4_tap_write: cbuf data(0x5874d2a4e8) - header(0x5874d2a4d8) doesnt have enough space to store L2 header of 18 bytes
Jul 10 05:35:23 2023 ECVB tunneld[25199]: CPU 2 TID 140225103783424: [tunneld.ERR]: cids_rewrite_cbuf_after_tap_write: This should never hit. While taking bkp code should have errored out and this func should not have been called for len 18
Jul 10 05:35:33 2023 ECVB tunneld[25199]: CPU 2 TID 140225103783424: [tunneld.ERR]: cids_bkp_cbuf_b4_tap_write: cbuf data(0x58711ba4e8) - header(0x58711ba4d8) doesnt have enough space to store L2 header of 18 bytes
Jul 10 05:35:33 2023 ECVB tunneld[25199]: CPU 2 TID 140225103783424: [tunneld.ERR]: cids_rewrite_cbuf_after_tap_write: This should never hit. While taking bkp code should have errored out and this func should not have been called for len 18
Jul 10 05:35:43 2023 ECVB tunneld[25199]: CPU 2 TID 140225103783424: [tunneld.ERR]: cids_bkp_cbuf_b4_tap_write: cbuf data(0x586bb8a4e8) - header(0x586bb8a4d8) doesnt have enough space to store L2 header of 18 bytes
Jul 10 05:35:43 2023 ECVB tunneld[25199]: CPU 2 TID 140225103783424: [tunneld.ERR]: cids_rewrite_cbuf_after_tap_write: This should never hit. While taking bkp code should have errored out and this func should not have been called for len 18


 /usr/local/bin/fluent-bit -f1 -c /usr/local/etc/fluent-bit/fluent-bit.conf
 
 [[1m[^[[0m2023/06/28 16:41:07^[[1m]^[[0m [^[[92m info^[[0m] [sp] stream processor started
^[[1m[^[[0m2023/06/28 16:41:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] inode=2270112 file=/var/log/firewall promote to TAIL_EVENT
^[[1m[^[[0m2023/06/28 16:41:07^[[1m]^[[0m [^[[92m info^[[0m] [input:tail:tail.0] inotify_fs_add(): inode=2270112 watch_fd=1 name=/var/log/firewall
^[[1m[^[[0m2023/06/28 16:41:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] [static files] processed 0b, done
^[[1m[^[[0m2023/06/28 16:41:07^[[1m]^[[0m [^[[92m info^[[0m] [output:stdout:stdout.1] worker #0 started
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] inode=2270112 events: IN_MODIFY
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [input chunk] update output instances with new chunk size diff=28
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [task] created task=0x7f56f412f020 id=0 OK
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [output:stdout:stdout.1] task_id=0 assigned to thread #0
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[91merror^[[0m] XXX the value of tls vhost devserver.com and vhost (null)
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=0
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=0
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [task] destroy task=0x7f56f412f020 (task_id=0)
^[[1m[^[[0m2023/06/28 16:41:09^[[1m]^[[0m [^[[93mdebug^[[0m] [socket] could not validate socket status for #56 (don't worry)
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] inode=2270112 events: IN_MODIFY
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [input chunk] update output instances with new chunk size diff=28
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [task] created task=0x7f56f4158e40 id=0 OK
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [output:stdout:stdout.1] task_id=0 assigned to thread #0
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=1
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[91merror^[[0m] XXX the value of tls vhost devserver.com and vhost (null)
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] inode=2270112 events: IN_MODIFY
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [input chunk] update output instances with new chunk size diff=28
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=1
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [task] destroy task=0x7f56f4158e40 (task_id=0)
^[[1m[^[[0m2023/06/28 16:41:21^[[1m]^[[0m [^[[93mdebug^[[0m] [socket] could not validate socket status for #56 (don't worry)
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [task] created task=0x7f56f4156d10 id=0 OK
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [output:stdout:stdout.1] task_id=0 assigned to thread #0
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=2
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[91merror^[[0m] XXX the value of tls vhost devserver.com and vhost (null)
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=2

[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[91merror^[[0m] XXX the value of tls vhost devserver.com and vhost (null)
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [out flush] cb_destroy coro_id=2
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [task] destroy task=0x7f56f4156d10 (task_id=0)
^[[1m[^[[0m2023/06/28 16:41:22^[[1m]^[[0m [^[[93mdebug^[[0m] [socket] could not validate socket status for #56 (don't worry)
^[[1m[^[[0m2023/06/28 16:41:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:41:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:41:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:42:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:42:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:42:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:42:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:42:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:42:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:43:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:43:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:43:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:43:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:43:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:43:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:44:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:44:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:44:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:44:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:44:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:44:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:45:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:45:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:45:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:45:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:45:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:45:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:46:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:46:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:46:07^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
^[[1m[^[[0m2023/06/28 16:46:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scanning path /var/log/firewall
^[[1m[^[[0m2023/06/28 16:46:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] scan_blog add(): dismissed: /var/log/firewall, inode 2270112
^[[1m[^[[0m2023/06/28 16:46:37^[[1m]^[[0m [^[[93mdebug^[[0m] [input:tail:tail.0] 0 new files found on path '/var/log/firewall'
-->
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [*] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [*
![Server_cert_details](https://github.com/fluent/fluent-bit/assets/52408441/a6c5b3c0-93c2-4bcd-8646-31d4b5568d56)
![Validation_pass](https://github.com/fluent/fluent-bit/assets/52408441/512f524e-85cc-4223-ad64-278b2af03481)
![Handshake_failure_bec_of_validation](https://github.com/fluent/fluent-bit/assets/52408441/932d4eb2-5bec-4936-847e-d93c88193aa4)
] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
