### PR TITLE
CODEOWNERS: Google owners for out_stackdriver test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,13 +63,14 @@
 /plugins/out_datadog     @nokute78 @edsiper
 /plugins/out_es          @pettitwesley @edsiper
 /plugins/out_pgsql       @sxd
+/plugins/out_stackdriver @braydonk @igorpeshansky @qingling128
+
 # AWS Plugins 
 /plugins/out_s3               @pettitwesley
 /plugins/out_cloudwatch_logs  @pettitwesley
 /plugins/out_kinesis_firehose @pettitwesley
 /plugins/out_kinesis_streams  @pettitwesley
 /plugins/out_opensearch       @pettitwesley @edsiper
-/plugins/out_stackdriver      @braydonk @igorpeshansky @qingling128
 
 # AWS test code
 /tests/internal/aws             @pettitwesley
@@ -81,6 +82,10 @@
 /tests/runtime/out_kinesis.c    @pettitwesley
 /tests/runtime/out_opensearch.c @pettitwesley @edsiper
 /tests/runtime/out_s3.c         @pettitwesley
+
+# Google test code
+# --------------
+/tests/runtime/out_stackdriver.c @braydonk @igorpeshansky @qingling128
 
 # Devcontainer
 /.devcontainer                  @patrick-stephens @niedbalski @edsiper


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the previous PR I forgot to add Google owners to the `out_stackdriver` tests as well. I also accidentally put the row in the AWS section before so I've fixed that here.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
