### PR TITLE
core: transition event loop to max live iters soft threshold

### DIFF
--- a/include/fluent-bit/flb_engine_macros.h
+++ b/include/fluent-bit/flb_engine_macros.h
@@ -54,7 +54,7 @@
 #define FLB_ENGINE_IN_CORO      3
 
 /* Engine priority queue configuration */
-#define FLB_ENGINE_LOOP_MAX_ITER        10 /* Max events processed per round */
+#define FLB_ENGINE_LOOP_MAX_LIVE_ITER   10 /* Max events processed per round */
 
 /* Engine event priorities: min value prioritized */
 #define FLB_ENGINE_PRIORITY_DEFAULT     MK_EVENT_PRIORITY_DEFAULT

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -860,8 +860,13 @@ int flb_engine_start(struct flb_config *config)
     while (1) {
         rb_flush_flag = FLB_FALSE;
 
-        mk_event_wait(evl); /* potentially conditional mk_event_wait or mk_event_wait_2 based on bucket queue capacity for one shot events */
-        flb_event_priority_live_foreach(event, evl_bktq, evl, FLB_ENGINE_LOOP_MAX_ITER) {
+        /* 
+         * note: add conditional mk_event_wait or mk_event_wait_2 based on bucket
+         * queue capacity for one shot events (currently oneshot events not used)
+         **/
+        mk_event_wait(evl);
+        flb_event_priority_live_foreach(event, evl_bktq, evl,
+                                        FLB_ENGINE_LOOP_MAX_LIVE_ITER) {
             if (event->type == FLB_ENGINE_EV_CORE) {
                 ret = flb_engine_handle_event(event->fd, event->mask, config);
                 if (ret == FLB_ENGINE_STOP) {

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -371,7 +371,8 @@ static void input_thread(void *data)
 
     while (1) {
         mk_event_wait(thi->evl);
-        flb_event_priority_live_foreach(event, evl_bktq, thi->evl, FLB_ENGINE_LOOP_MAX_ITER) {
+        flb_event_priority_live_foreach(event, evl_bktq, thi->evl,
+                                        FLB_ENGINE_LOOP_MAX_LIVE_ITER) {
             if (event->type == FLB_ENGINE_EV_CORE) {
                 ret = engine_handle_event(event->fd, event->mask,
                                           ins, thi->config);

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -249,7 +249,7 @@ static void output_thread(void *data)
     while (running) {
         mk_event_wait(th_ins->evl);
         flb_event_priority_live_foreach(event, th_ins->evl_bktq, th_ins->evl,
-                                      FLB_ENGINE_LOOP_MAX_ITER) {
+                                      FLB_ENGINE_LOOP_MAX_LIVE_ITER) {
             /*
              * FIXME
              * -----


### PR DESCRIPTION
<!-- Provide summary of changes -->
Issue Flagged by Leonardo and previously spotted by team.

## Problem
Event loop possibly does not process all injected events before end of an event loop cycle because of max iters causing cleanup to prematurely occur.


## Old No Priority System
Before priority events were added, one mk_event_wait was called and all events were processed. Clean up starts after all events processed

## Current Priority System
Now mk_event_wait_2, non-blocking, is called many times to pick up new events of higher priority. In one round of processing, if more than max iter events are processed the loop will break and the rest of the events will be processed in the next cycle. This is a problem. All picked up events should be finished processed within one cycle of the event loop to finish remaining work.

## Problems with Current System
This is mainly a problem for Injected events related to networking. Injected events are used to squeeze some work into the scheduler before any of the cleanup functions run (network related cleanup functions, timeout related iirc). Capping the amount of iters can corrupt this model where the work is pushed after the cleanup functions which means it will be too late.

## Solution & Updated System
**Sloppy/Soft Prioritization**
The solution is a simple one. We switch from a hard max iteration limit to a soft max iteration limit.

After reaching some limit on the event loop, the event loop stops picking up newly triggered events, but continues to process all already triggered events. It continues to accept incoming injected events.

The loop ends when there are no more events to be processed, meaning that there could be a few more cycles to complete the remaining already accepted work before exiting the event loop and moving on to the cleanup functions.

## How the Solution Helps
This means that all accepted and injected work will be completed before any of the cleanup functions are run. Thus resolving problems.
 

## Side Effects

**Sloppy Prioritization**
This change breaks the priority event loop abstraction slightly. If some low priority events are triggered after the live iteration limit has been reached, the priority event loop will not admit this work for the current round of processing but will continue to process lower priority events before the next round where high priority events are admitted.

The maintainers should carefully consider this.

*Guarantees*
- All events picked up by mk_event_wait[_2] and injected will be processed before the cleanup code

*Non-Guarantees*
- Events no longer are guaranteed to be processed in priority order if # of events exceeds FLB_ENGINE_LOOP_MAX_LIVE_ITER


## Other Options

**Strict Prioritization via Event 0 Event Processing**
A way to trade off is to make all injected events of Priority 0 and to only process priority 0 events after pausing event intake on the event loop.

How does this help: Since only top priority events are processed we GUARANTEE that events are processed in order of priority. However we also guarantee that high priority work admitted to the event loop or injected will be processed.

This may be a good compromise, so long as all injected events or work that must be completed in the round will be of Priority 0. 

*Guarantees*
- All priority 0 events picked up by mk_event_wait[_2] and priority 0 injected will be processed before the cleanup code
- Events are guaranteed to be processed in order of priority

*Non Guarantees*
- Injected events and events picked up by mk_event_wait[_2] of priority greater than 0 are NOT guaranteed to be processed before the cleanup code (only priority 0 events)



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
