### PR TITLE
core: event loop integrity strict priority

### DIFF
--- a/include/fluent-bit/flb_bucket_queue.h
+++ b/include/fluent-bit/flb_bucket_queue.h
@@ -70,11 +70,14 @@ static inline int flb_bucket_queue_is_empty(struct flb_bucket_queue *bucket_queu
     return bucket_queue->top == (bucket_queue->buckets + bucket_queue->n_buckets);
 }
 
-static inline void flb_bucket_queue_seek(struct flb_bucket_queue *bucket_queue) {
+static inline int flb_bucket_queue_seek(struct flb_bucket_queue *bucket_queue) {
+    size_t top_priority = 0;
     while (!flb_bucket_queue_is_empty(bucket_queue)
           && (mk_list_is_empty(bucket_queue->top) == 0)) {
         ++bucket_queue->top;
     }
+    top_priority = bucket_queue->top - bucket_queue->buckets;
+    return top_priority;
 }
 
 static inline int flb_bucket_queue_add(struct flb_bucket_queue *bucket_queue,

--- a/include/fluent-bit/flb_engine_macros.h
+++ b/include/fluent-bit/flb_engine_macros.h
@@ -54,7 +54,7 @@
 #define FLB_ENGINE_IN_CORO      3
 
 /* Engine priority queue configuration */
-#define FLB_ENGINE_LOOP_MAX_ITER        10 /* Max events processed per round */
+#define FLB_ENGINE_LOOP_MAX_LIVE_ITER   10 /* Max events processed per round */
 
 /* Engine event priorities: min value prioritized */
 #define FLB_ENGINE_PRIORITY_DEFAULT     MK_EVENT_PRIORITY_DEFAULT

--- a/include/fluent-bit/flb_event_loop.h
+++ b/include/fluent-bit/flb_event_loop.h
@@ -93,9 +93,13 @@ static inline void flb_event_load_injected_events(struct flb_bucket_queue *bktq,
             mk_event_wait_2(evl, 0),                                                    \
             flb_event_load_bucket_queue(bktq, evl) : 0,                                 \
         __flb_event_priority_live_foreach_n_events = evl->n_events,                     \
-        event = flb_bucket_queue_find_min(bktq) ?                                       \
-                mk_list_entry(                                                          \
-                    flb_bucket_queue_pop_min(bktq), struct mk_event, _priority_head) :  \
+        event = (__flb_event_priority_live_foreach_iter < live_iters ||                 \
+                flb_bucket_queue_seek(bktq) == 0) ?                                     \
+                    (flb_bucket_queue_find_min(bktq) ?                                  \
+                        mk_list_entry(                                                  \
+                            flb_bucket_queue_pop_min(bktq), struct mk_event,            \
+                            _priority_head) :                                           \
+                        NULL) :                                                         \
                 NULL                                                                    \
     )
 

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -860,8 +860,13 @@ int flb_engine_start(struct flb_config *config)
     while (1) {
         rb_flush_flag = FLB_FALSE;
 
-        mk_event_wait(evl); /* potentially conditional mk_event_wait or mk_event_wait_2 based on bucket queue capacity for one shot events */
-        flb_event_priority_live_foreach(event, evl_bktq, evl, FLB_ENGINE_LOOP_MAX_ITER) {
+        /* 
+         * note: add conditional mk_event_wait or mk_event_wait_2 based on bucket
+         * queue capacity for one shot events (currently oneshot events not used)
+         **/
+        mk_event_wait(evl);
+        flb_event_priority_live_foreach(event, evl_bktq, evl,
+                                        FLB_ENGINE_LOOP_MAX_LIVE_ITER) {
             if (event->type == FLB_ENGINE_EV_CORE) {
                 ret = flb_engine_handle_event(event->fd, event->mask, config);
                 if (ret == FLB_ENGINE_STOP) {

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -371,7 +371,8 @@ static void input_thread(void *data)
 
     while (1) {
         mk_event_wait(thi->evl);
-        flb_event_priority_live_foreach(event, evl_bktq, thi->evl, FLB_ENGINE_LOOP_MAX_ITER) {
+        flb_event_priority_live_foreach(event, evl_bktq, thi->evl,
+                                        FLB_ENGINE_LOOP_MAX_LIVE_ITER) {
             if (event->type == FLB_ENGINE_EV_CORE) {
                 ret = engine_handle_event(event->fd, event->mask,
                                           ins, thi->config);

--- a/src/flb_output_thread.c
+++ b/src/flb_output_thread.c
@@ -249,7 +249,7 @@ static void output_thread(void *data)
     while (running) {
         mk_event_wait(th_ins->evl);
         flb_event_priority_live_foreach(event, th_ins->evl_bktq, th_ins->evl,
-                                      FLB_ENGINE_LOOP_MAX_ITER) {
+                                      FLB_ENGINE_LOOP_MAX_LIVE_ITER) {
             /*
              * FIXME
              * -----


### PR DESCRIPTION
This is the alternate solution to https://github.com/fluent/fluent-bit/pull/7701


**Strict Prioritization via Event 0 Event Processing**
A way to trade off is to make all injected events of Priority 0 and to only process priority 0 events after pausing event intake on the event loop.

How does this help: Since only top priority events are processed we GUARANTEE that events are processed in order of priority. However we also guarantee that high priority work admitted to the event loop or injected will be processed.

This may be a good compromise, so long as all injected events or work that must be completed in the round will be of Priority 0. 

*Guarantees*
- [New] All priority 0 events picked up by mk_event_wait[_2] and priority 0 injected will be processed before the cleanup code
- [Unchanged] Events are guaranteed to be processed in order of priority

*Non Guarantees*
- [Unchanged] Injected events and events picked up by mk_event_wait[_2] of priority greater than 0 are NOT guaranteed to be processed before the cleanup code (only priority 0 events)

## Comments
Please see https://github.com/fluent/fluent-bit/pull/7701 for a comprehensive rundown of the problem and proposed solutions.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
