### PR TITLE
in_splunk: fix warnings

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -715,10 +715,10 @@ int splunk_prot_handle(struct flb_splunk *ctx, struct splunk_conn *conn,
     if (ret < 0){
         send_response(conn, 401, "error: unauthroized\n");
         if (ret == SPLUNK_AUTH_MISSING_CRED) {
-            flb_plg_warn(ctx->ins, "missing credentials in request headers", ret);
+            flb_plg_warn(ctx->ins, "missing credentials in request headers");
         }
         else if (ret == SPLUNK_AUTH_UNAUTHORIZED) {
-            flb_plg_warn(ctx->ins, "wrong credentials in request headers", ret);
+            flb_plg_warn(ctx->ins, "wrong credentials in request headers");
         }
 
         flb_sds_destroy(tag);

--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -314,7 +314,6 @@ static void process_flb_log_append(struct flb_splunk *ctx, msgpack_object *recor
 
 static int process_json_payload_pack(struct flb_splunk *ctx, flb_sds_t tag, char *buf, size_t size)
 {
-    int ret;
     size_t off = 0;
     msgpack_unpacked result;
     struct flb_time tm;
@@ -546,7 +545,6 @@ static int process_hec_raw_payload(struct flb_splunk *ctx, struct splunk_conn *c
                                    struct mk_http_request *request)
 {
     int ret = -1;
-    int type = -1;
     struct mk_http_header *header;
 
     header = &session->parser.headers[MK_HEADER_CONTENT_TYPE];
@@ -554,14 +552,10 @@ static int process_hec_raw_payload(struct flb_splunk *ctx, struct splunk_conn *c
         send_response(conn, 400, "error: header 'Content-Type' is not set\n");
         return -1;
     }
-    else if (header->val.len == 10 &&
-        strncasecmp(header->val.data, "text/plain", 10) == 0) {
-        type = HTTP_CONTENT_TEXT;
-    }
-    else {
+    else if (header->val.len != 10 ||
+             strncasecmp(header->val.data, "text/plain", 10) != 0) {
         /* Not neccesary to specify content-type for Splunk HEC. */
         flb_plg_debug(ctx->ins, "Mark as unknown type for ingested payloads");
-        type = HTTP_CONTENT_UNKNOWN;
     }
 
     if (request->data.len <= 0) {


### PR DESCRIPTION
This patch is to fix following warnings.

```
[ 59%] Building C object plugins/in_splunk/CMakeFiles/flb-plugin-in_splunk.dir/splunk_prot.c.o
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c: In function ‘process_json_payload_pack’:
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c:317:9: warning: unused variable ‘ret’ [-Wunused-variable]
  317 |     int ret;
      |         ^~~
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c: In function ‘process_hec_raw_payload’:
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c:549:9: warning: variable ‘type’ set but not used [-Wunused-but-set-variable]
  549 |     int type = -1;
      |         ^~~~
In file included from /home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c:20:
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c: In function ‘splunk_prot_handle’:
/home/taka/git/fluent-bit/include/fluent-bit/flb_input_plugin.h:41:50: warning: too many arguments for format [-Wformat-extra-args]
   41 |             flb_log_print(FLB_LOG_WARN, NULL, 0, "[input:%s:%s] " fmt,  \
      |                                                  ^~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c:718:13: note: in expansion of macro ‘flb_plg_warn’
  718 |             flb_plg_warn(ctx->ins, "missing credentials in request headers", ret);
      |             ^~~~~~~~~~~~
/home/taka/git/fluent-bit/include/fluent-bit/flb_input_plugin.h:41:50: warning: too many arguments for format [-Wformat-extra-args]
   41 |             flb_log_print(FLB_LOG_WARN, NULL, 0, "[input:%s:%s] " fmt,  \
      |                                                  ^~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/plugins/in_splunk/splunk_prot.c:721:13: note: in expansion of macro ‘flb_plg_warn’
  721 |             flb_plg_warn(ctx->ins, "wrong credentials in request headers", ret);
      |             ^~~~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_splunk 
==26710== Memcheck, a memory error detector
==26710== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==26710== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==26710== Command: bin/flb-rt-in_splunk
==26710== 
Test health...                                  ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector...                               ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector_event...                         ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector_raw...                           ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector_raw_multilines...                ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector_gzip...                          ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector_event_gzip...                    ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test collector_raw_multilines_gzip...           ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test tag_key...                                 ==26710== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==26710== 
==26710== HEAP SUMMARY:
==26710==     in use at exit: 0 bytes in 0 blocks
==26710==   total heap usage: 20,730 allocs, 20,730 frees, 12,062,092 bytes allocated
==26710== 
==26710== All heap blocks were freed -- no leaks are possible
==26710== 
==26710== For lists of detected and suppressed errors, rerun with: -s
==26710== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
