### PR TITLE
calyptia_fleet: fix non existent plugin name.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -270,6 +270,7 @@ static void *do_reload(void *data)
 {
     struct reload_ctx *reload = (struct reload_ctx *)data;
     // avoid reloading the current configuration... just use our new one!
+    flb_context_set(reload->flb);
     reload->flb->config->enable_hot_reload = FLB_TRUE;
     reload->flb->config->conf_path_file = reload->cfg_path;
     sleep(5);
@@ -328,6 +329,10 @@ static int execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cf
     flb_ctx_t *flb = flb_context_get();
 
 
+    if (flb == NULL) {
+        flb_plg_error(ctx->ins, "unable to get fluent-bit context.");
+        return FLB_FALSE;
+    }
     // fix execution in valgrind...
     // otherwise flb_reload errors out with:
     //    [error] [reload] given flb context is NULL
@@ -372,7 +377,7 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
     FILE *cfgfp;
     const char *fbit_last_modified;
     int fbit_last_modified_len;
-    struct flb_tm tm_last_modified;
+    struct flb_tm tm_last_modified = { 0 };
     time_t time_last_modified;
     char *data;
     size_t b_sent;


### PR DESCRIPTION
# Summary

Due to the change in #7524 the `calyptia_fleet` input plugin is now private. The reload configuration was still using that plugin. Fix it to use the custom calyptia plugin instead.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
