### PR TITLE
workflows: switch Raspbian to Actuated builds

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -105,8 +105,8 @@ jobs:
   call-build-linux-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
-    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-latest usage.
-    runs-on: ${{ (contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit') && 'actuated-aarch64') || 'ubuntu-latest' }}
+    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM/Raspbian builds, for forks it should keep existing ubuntu-latest usage.
+    runs-on: ${{ ( ( contains(matrix.distro, 'arm' ) || contains(matrix.distro, 'raspbian') ) && (github.repository == 'fluent/fluent-bit') && 'actuated-aarch64') || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_BUILDER
 # Lookup the name to use below but should follow the '<distro>-base' convention with slashes replaced.
 # Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
 
-FROM balenalib/rpi-raspbian3:buster as raspbian-buster-base
+FROM balenalib/raspberrypi3:buster as raspbian-buster-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # Builder image so dependencies can be latest, recommended and no need to wipe
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # raspbian/bullseye base image
-FROM balenalib/rpi-raspbian3:bullseye as raspbian-bullseye-base
+FROM balenalib/raspberrypi3::bullseye as raspbian-bullseye-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008,DL3015

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_BUILDER
 # Lookup the name to use below but should follow the '<distro>-base' convention with slashes replaced.
 # Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
 
-FROM balenalib/rpi-raspbian:buster as raspbian-buster-base
+FROM balenalib/rpi-raspbian3:buster as raspbian-buster-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # Builder image so dependencies can be latest, recommended and no need to wipe
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # raspbian/bullseye base image
-FROM balenalib/rpi-raspbian:bullseye as raspbian-bullseye-base
+FROM balenalib/rpi-raspbian3:bullseye as raspbian-bullseye-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008,DL3015

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # raspbian/bullseye base image
-FROM balenalib/raspberrypi3::bullseye as raspbian-bullseye-base
+FROM balenalib/raspberrypi3:bullseye as raspbian-bullseye-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008,DL3015


### PR DESCRIPTION
Speed up Raspbian builds by ensuring they run on dedicated ARM Actuated managed runners.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

See https://github.com/fluent/fluent-bit/actions/runs/5597572585/jobs/10236117275 for a run of this PR on the dedicated Actuated runner.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
