### PR TITLE
in_tail: Don't append records if sl_log_event_encoder buffer is 0

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -600,14 +600,16 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
         /* Append buffer content to a chunk */
         *bytes = processed_bytes;
 
-        flb_input_log_append_records(ctx->ins,
-                                     lines,
-                                     file->tag_buf,
-                                     file->tag_len,
-                                     file->sl_log_event_encoder->output_buffer,
-                                     file->sl_log_event_encoder->output_length);
+        if (file->sl_log_event_encoder->output_length > 0) {
+            flb_input_log_append_records(ctx->ins,
+                                         lines,
+                                         file->tag_buf,
+                                         file->tag_len,
+                                         file->sl_log_event_encoder->output_buffer,
+                                         file->sl_log_event_encoder->output_length);
 
-        flb_log_event_encoder_reset(file->sl_log_event_encoder);
+            flb_log_event_encoder_reset(file->sl_log_event_encoder);
+        }
     }
     else if (file->skip_next) {
         *bytes = file->buf_len;


### PR DESCRIPTION
I was getting the following errors when threaded was enabled for input tail plugin while using multiline.parser.

```
[2023/07/18 22:44:53] [error] [/usr/src/fluent-bit/src/flb_input_chunk.c:1875 errno=11] Resource temporarily unavailable
[2023/07/18 22:44:53] [error] [/usr/src/fluent-bit/src/flb_input_chunk.c:1875 errno=11] Resource temporarily unavailable
[2023/07/18 22:44:53] [error] [/usr/src/fluent-bit/src/flb_input_chunk.c:1875 errno=11] Resource temporarily unavailable
[2023/07/18 22:44:53] [error] [/usr/src/fluent-bit/src/flb_input_chunk.c:1875 errno=11] Resource temporarily unavailable
[2023/07/18 22:44:53] [error] [/usr/src/fluent-bit/src/flb_input_chunk.c:1875 errno=11] Resource temporarily unavailable
[2023/07/18 22:44:53] [error] [/usr/src/fluent-bit/src/flb_input_chunk.c:1875 errno=11] Resource temporarily unavailable
```

To reproduce the issue, this is the most minimal config I used
```
[SERVICE]
  Log_Level                  info
  Daemon                     Off

[INPUT]
  Name              tail
  Tag               kubernetes.*
  Path              /var/log/containers/*.log
  multiline.parser  cri
  threaded          Off

[OUTPUT]
  Name   null
  Match  *
  ```
  
The above errors were being triggered due to flb_malloc() trying to allocate 0 bytes.
The errno message is a bit misleading since malloc() is not a syscall, so the errno information is from a previous syscall done on that thread.



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
