### PR TITLE
upstream: premature connection destruction fix

### DIFF
--- a/include/fluent-bit/flb_connection.h
+++ b/include/fluent-bit/flb_connection.h
@@ -95,6 +95,14 @@ struct flb_connection {
      */
     int busy_flag;
 
+    /* This flag is used to determine if the connection was shut down to ensure we
+     * don't do it twice when a timeout is detected.
+     *
+     * This is required in order to overcome a limitation in the async read / write
+     * functions that will be addressed as soon as possible.
+     */
+    int shutdown_flag;
+
     /*
      * Recycle: if the connection is keepalive, this flag is always on, but if
      * the caller wants to drop the connection once is released, it can set

--- a/src/flb_connection.c
+++ b/src/flb_connection.c
@@ -24,6 +24,8 @@ int flb_connection_setup(struct flb_connection *connection,
     connection->tls_session             = NULL;
     connection->ts_created              = time(NULL);
     connection->ts_assigned             = time(NULL);
+    connection->busy_flag               = FLB_FALSE;
+    connection->shutdown_flag           = FLB_FALSE;
 
     connection->net = &connection->stream->net;
 


### PR DESCRIPTION
This PR addresses an issue caused by `flb_upstream_conn_timeouts` when a connection times out in a cycle where  `FLB_ENGINE_LOOP_MAX_ITER` is exceeded. 

What this means is the priority event loop will defer processing of the event for the next overall iteration which happens after `flb_upstream_conn_pending_destroy_list` is invoked by the thread which results in a coroutine being left suspended indefinitely.

The main issue was that `flb_upstream_conn_timeouts` immediately performed most of the connection disposal and marked the connection to be reaped at the end of the cycle.

In order to prevent this while retaining some of the required functionality we now only perform the connection shutdown and inject an event in order to force the engine to resume the coroutine as soon as possible.
