### PR TITLE
fluent-bit: remove cleanup code from flb_signal_exit

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -524,8 +524,6 @@ static void flb_signal_exit(int signal)
     char s[] = "[engine] caught signal (";
     time_t now;
     struct tm *cur;
-    flb_ctx_t *ctx = flb_context_get();
-    struct flb_cf *cf_opts = flb_cf_context_get();
 
     now = time(NULL);
     cur = localtime(&now);
@@ -550,25 +548,6 @@ static void flb_signal_exit(int signal)
         flb_print_signal(SIGTERM);
         flb_print_signal(SIGSEGV);
     };
-
-    /* Signal handlers */
-    /* SIGSEGV is not handled here to preserve stacktrace */
-    switch (signal) {
-    case SIGINT:
-    case SIGTERM:
-#ifndef FLB_SYSTEM_WINDOWS
-    case SIGQUIT:
-    case SIGHUP:
-#endif
-        if (cf_opts != NULL) {
-            flb_cf_destroy(cf_opts);
-        }
-        flb_stop(ctx);
-        flb_destroy(ctx);
-        _exit(EXIT_SUCCESS);
-    default:
-        break;
-    }
 }
 
 static void flb_signal_handler(int signal)

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1338,6 +1338,10 @@ int flb_main(int argc, char **argv)
      if (trace_output) {
          flb_free(trace_output);
      }
+     if (trace_props != NULL) {
+         flb_kv_release(trace_props);
+         flb_free(trace_props);
+     }
 #endif
 
     flb_stop(ctx);


### PR DESCRIPTION
This patch is to fix following valgrind error.
```
==20919== 
==20919== HEAP SUMMARY:
==20919==     in use at exit: 7 bytes in 1 blocks
==20919==   total heap usage: 1,572 allocs, 1,571 frees, 968,794 bytes allocated
==20919== 
==20919== 7 bytes in 1 blocks are still reachable in loss record 1 of 1
==20919==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20919==    by 0x18E880: flb_malloc (flb_mem.h:80)
==20919==    by 0x18EB6A: flb_strndup (flb_str.h:34)
==20919==    by 0x18EBD1: flb_strdup (flb_str.h:46)
==20919==    by 0x1912B7: flb_main (fluent-bit.c:949)
==20919==    by 0x192012: main (fluent-bit.c:1375)
==20919== 
==20919== LEAK SUMMARY:
==20919==    definitely lost: 0 bytes in 0 blocks
==20919==    indirectly lost: 0 bytes in 0 blocks
==20919==      possibly lost: 0 bytes in 0 blocks
==20919==    still reachable: 7 bytes in 1 blocks
==20919==         suppressed: 0 bytes in 0 blocks
==20919== 
==20919== For lists of detected and suppressed errors, rerun with: -s
==20919== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

This is a leak of `trace_output`
https://github.com/fluent/fluent-bit/blob/824ba3dd084e2a72a2f2e2a833d5d44d46f61341/src/fluent-bit.c#L949
It should be released here. But it isn't.
https://github.com/fluent/fluent-bit/blob/824ba3dd084e2a72a2f2e2a833d5d44d46f61341/src/fluent-bit.c#L1359-L1361

This is caused by `flb_signal_exit`. It calls `_exit`.

This patch is to cleanup `flb_signal_exit`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full --show-leak-kinds=all bin/fluent-bit -i cpu -o stdout
==22743== Memcheck, a memory error detector
==22743== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==22743== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==22743== Command: bin/fluent-bit -i cpu -o stdout
==22743== 
Fluent Bit v2.1.8
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/07/22 07:45:31] [ info] [fluent bit] version=2.1.8, commit=824ba3dd08, pid=22743
[2023/07/22 07:45:31] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/07/22 07:45:31] [ info] [cmetrics] version=0.6.3
[2023/07/22 07:45:31] [ info] [ctraces ] version=0.3.1
[2023/07/22 07:45:31] [ info] [input:cpu:cpu.0] initializing
[2023/07/22 07:45:31] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/07/22 07:45:31] [ info] [sp] stream processor started
[2023/07/22 07:45:31] [ info] [output:stdout:stdout.0] worker #0 started
[0] cpu.0: [[1689979532.658521026, {}], {"cpu_p"=>30.000000, "user_p"=>29.000000, "system_p"=>1.000000, "cpu0.p_cpu"=>30.000000, "cpu0.p_user"=>29.000000, "cpu0.p_system"=>1.000000}]
^C[2023/07/22 07:45:34] [engine] caught signal (SIGINT)
[0] cpu.0: [[1689979533.675362867, {}], {"cpu_p"=>17.000000, "user_p"=>17.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>17.000000, "cpu0.p_user"=>17.000000, "cpu0.p_system"=>0.000000}]
[2023/07/22 07:45:34] [ warn] [engine] service will shutdown in max 5 seconds
[2023/07/22 07:45:34] [ info] [input] pausing cpu.0
[2023/07/22 07:45:34] [ info] [engine] service has stopped (0 pending tasks)
[2023/07/22 07:45:34] [ info] [input] pausing cpu.0
[2023/07/22 07:45:34] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/07/22 07:45:34] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==22743== 
==22743== HEAP SUMMARY:
==22743==     in use at exit: 0 bytes in 0 blocks
==22743==   total heap usage: 1,572 allocs, 1,572 frees, 968,794 bytes allocated
==22743== 
==22743== All heap blocks were freed -- no leaks are possible
==22743== 
==22743== For lists of detected and suppressed errors, rerun with: -s
==22743== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
