### PR TITLE
tests: internal: log_event_encoder: Add test code

### DIFF
--- a/include/fluent-bit/flb_log_event_encoder.h
+++ b/include/fluent-bit/flb_log_event_encoder.h
@@ -25,7 +25,7 @@
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_log_event.h>
 #include <fluent-bit/flb_log_event_encoder_dynamic_field.h>
-
+#include <inttypes.h>
 #include <msgpack.h>
 
 #define FLB_EVENT_ENCODER_SUCCESS                        0
@@ -75,112 +75,114 @@
 
 #define FLB_LOG_EVENT_APPEND_UNTIL_TERMINATOR            -1
 
+#define flb_log_event_type_t int32_t
+
 #define FLB_LOG_EVENT_VALUE_LIST_TERMINATOR() \
-            (int) FLB_LOG_EVENT_APPEND_TERMINATOR_VALUE_TYPE
+            (flb_log_event_type_t) FLB_LOG_EVENT_APPEND_TERMINATOR_VALUE_TYPE
 
 #define FLB_LOG_EVENT_STRING_LENGTH_VALUE(length) \
-            (int) FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE, \
             (size_t) length
 
 #define FLB_LOG_EVENT_STRING_BODY_VALUE(buffer, length) \
-            (int) FLB_LOG_EVENT_STRING_BODY_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_STRING_BODY_VALUE_TYPE, \
             (char *) buffer, \
             (size_t) length
 
 #define FLB_LOG_EVENT_BINARY_LENGTH_VALUE(length) \
-            (int) FLB_LOG_EVENT_BINARY_LENGTH_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_BINARY_LENGTH_VALUE_TYPE, \
             (size_t) length
 
 #define FLB_LOG_EVENT_BINARY_BODY_VALUE(buffer, length) \
-            (int) FLB_LOG_EVENT_BINARY_BODY_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_BINARY_BODY_VALUE_TYPE, \
             (char *) buffer, \
             (size_t) length
 
 #define FLB_LOG_EVENT_EXT_LENGTH_VALUE(type_, length) \
-            (int) FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE, \
-            (int) type_, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE, \
+            (int8_t) type_, \
             (size_t) length
 
 #define FLB_LOG_EVENT_EXT_BODY_VALUE(buffer, length) \
-            (int) FLB_LOG_EVENT_EXT_BODY_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_EXT_BODY_VALUE_TYPE, \
             (char *) buffer, \
             (size_t) length
 
 #define FLB_LOG_EVENT_TIMESTAMP_VALUE(value) \
-            (int) FLB_LOG_EVENT_TIMESTAMP_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_TIMESTAMP_VALUE_TYPE, \
             (char *) value
 
 #define FLB_LOG_EVENT_LEGACY_TIMESTAMP_VALUE(value) \
-            (int) FLB_LOG_EVENT_LEGACY_TIMESTAMP_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_LEGACY_TIMESTAMP_VALUE_TYPE, \
             (char *) value
 
 #define FLB_LOG_EVENT_FORWARD_V1_TIMESTAMP_VALUE(value) \
-            (int) FLB_LOG_EVENT_FORWARD_V1_TIMESTAMP_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_FORWARD_V1_TIMESTAMP_VALUE_TYPE, \
             (char *) value
 
 #define FLB_LOG_EVENT_FLUENT_BIT_V1_TIMESTAMP_VALUE(value) \
-            (int) FLB_LOG_EVENT_FLUENT_BIT_V1_TIMESTAMP_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_FLUENT_BIT_V1_TIMESTAMP_VALUE_TYPE, \
             (char *) value
 
 #define FLB_LOG_EVENT_NULL_VALUE() \
-            (int) FLB_LOG_EVENT_NULL_VALUE_TYPE
+            (flb_log_event_type_t) FLB_LOG_EVENT_NULL_VALUE_TYPE
 
 #define FLB_LOG_EVENT_CHAR_VALUE(value) \
-            (int) FLB_LOG_EVENT_CHAR_VALUE_TYPE, \
-            (int) value
+            (flb_log_event_type_t) FLB_LOG_EVENT_CHAR_VALUE_TYPE, \
+            (int32_t) value
 
 #define FLB_LOG_EVENT_INT8_VALUE(value) \
-            (int) FLB_LOG_EVENT_INT8_VALUE_TYPE, \
-            (int) value
+            (flb_log_event_type_t) FLB_LOG_EVENT_INT8_VALUE_TYPE, \
+            (int32_t) value
 
 #define FLB_LOG_EVENT_INT16_VALUE(value) \
-            (int) FLB_LOG_EVENT_INT16_VALUE_TYPE, \
-            (int) value
+            (flb_log_event_type_t) FLB_LOG_EVENT_INT16_VALUE_TYPE, \
+            (int32_t) value
 
 #define FLB_LOG_EVENT_INT32_VALUE(value) \
-            (int) FLB_LOG_EVENT_INT32_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_INT32_VALUE_TYPE, \
             (int32_t) value
 
 #define FLB_LOG_EVENT_INT64_VALUE(value) \
-            (int) FLB_LOG_EVENT_INT64_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_INT64_VALUE_TYPE, \
             (int64_t) value
 
 #define FLB_LOG_EVENT_UINT8_VALUE(value) \
-            (int) FLB_LOG_EVENT_UINT8_VALUE_TYPE, \
-            (unsigned int) value
+            (flb_log_event_type_t) FLB_LOG_EVENT_UINT8_VALUE_TYPE, \
+            (uint32_t) value
 
 #define FLB_LOG_EVENT_UINT16_VALUE(value) \
-            (int) FLB_LOG_EVENT_UINT16_VALUE_TYPE, \
-            (unsigned int) value
+            (flb_log_event_type_t) FLB_LOG_EVENT_UINT16_VALUE_TYPE, \
+            (uint32_t) value
 
 #define FLB_LOG_EVENT_UINT32_VALUE(value) \
-            (int) FLB_LOG_EVENT_UINT32_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_UINT32_VALUE_TYPE, \
             (uint32_t) value
 
 #define FLB_LOG_EVENT_UINT64_VALUE(value) \
-            (int) FLB_LOG_EVENT_UINT64_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_UINT64_VALUE_TYPE, \
             (uint64_t) value
 
 #define FLB_LOG_EVENT_DOUBLE_VALUE(value) \
-            (int) FLB_LOG_EVENT_DOUBLE_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_DOUBLE_VALUE_TYPE, \
             (double) value
 
 #define FLB_LOG_EVENT_BOOLEAN_VALUE(value) \
-            (int) FLB_LOG_EVENT_BOOLEAN_VALUE_TYPE, \
-            (int) value
+            (flb_log_event_type_t) FLB_LOG_EVENT_BOOLEAN_VALUE_TYPE, \
+            (int32_t) value
 
 #define FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE(value) \
-            (int) FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE, \
             (char *) value
 
 #define FLB_LOG_EVENT_MSGPACK_RAW_VALUE(buffer, length) \
-            (int) FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE, \
+            (flb_log_event_type_t) FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE, \
             (char *) buffer, \
             (size_t) length
 
 #define FLB_LOG_EVENT_STRING_VALUE(buffer, length) \
-            FLB_LOG_EVENT_STRING_LENGTH_VALUE(length), \
-            FLB_LOG_EVENT_STRING_BODY_VALUE(buffer, length)
+            FLB_LOG_EVENT_STRING_LENGTH_VALUE((size_t)length),      \
+            FLB_LOG_EVENT_STRING_BODY_VALUE(buffer, (size_t)length)
 
 #define FLB_LOG_EVENT_BINARY_VALUE(buffer, length) \
             FLB_LOG_EVENT_BINARY_LENGTH_VALUE(length), \

--- a/include/fluent-bit/flb_log_event_encoder.h
+++ b/include/fluent-bit/flb_log_event_encoder.h
@@ -84,31 +84,31 @@
 
 #define FLB_LOG_EVENT_STRING_LENGTH_VALUE(length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_STRING_BODY_VALUE(buffer, length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_STRING_BODY_VALUE_TYPE, \
             (char *) buffer, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_BINARY_LENGTH_VALUE(length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_BINARY_LENGTH_VALUE_TYPE, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_BINARY_BODY_VALUE(buffer, length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_BINARY_BODY_VALUE_TYPE, \
             (char *) buffer, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_EXT_LENGTH_VALUE(type_, length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE, \
             (int8_t) type_, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_EXT_BODY_VALUE(buffer, length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_EXT_BODY_VALUE_TYPE, \
             (char *) buffer, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_TIMESTAMP_VALUE(value) \
             (flb_log_event_type_t) FLB_LOG_EVENT_TIMESTAMP_VALUE_TYPE, \
@@ -180,11 +180,11 @@
 #define FLB_LOG_EVENT_MSGPACK_RAW_VALUE(buffer, length) \
             (flb_log_event_type_t) FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE, \
             (char *) buffer, \
-            (size_t) length
+            (flb_log_event_size_t) length
 
 #define FLB_LOG_EVENT_STRING_VALUE(buffer, length) \
-            FLB_LOG_EVENT_STRING_LENGTH_VALUE((size_t)length),      \
-            FLB_LOG_EVENT_STRING_BODY_VALUE(buffer, (size_t)length)
+            FLB_LOG_EVENT_STRING_LENGTH_VALUE((flb_log_event_size_t)length),      \
+            FLB_LOG_EVENT_STRING_BODY_VALUE(buffer, (flb_log_event_size_t)length)
 
 #define FLB_LOG_EVENT_BINARY_VALUE(buffer, length) \
             FLB_LOG_EVENT_BINARY_LENGTH_VALUE(length), \

--- a/include/fluent-bit/flb_log_event_encoder.h
+++ b/include/fluent-bit/flb_log_event_encoder.h
@@ -36,33 +36,35 @@
 #define FLB_EVENT_ENCODER_ERROR_SERIALIZATION_FAILURE   -5
 #define FLB_EVENT_ENCODER_ERROR_INVALID_VALUE_TYPE      -6
 
-#define FLB_LOG_EVENT_APPEND_TERMINATOR_VALUE_TYPE       0
+#define flb_log_event_type_t int32_t
 
-#define FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE           1
-#define FLB_LOG_EVENT_STRING_BODY_VALUE_TYPE             2
-#define FLB_LOG_EVENT_BINARY_LENGTH_VALUE_TYPE           3
-#define FLB_LOG_EVENT_BINARY_BODY_VALUE_TYPE             4
-#define FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE              5
-#define FLB_LOG_EVENT_EXT_BODY_VALUE_TYPE                6
-#define FLB_LOG_EVENT_NULL_VALUE_TYPE                    7
-#define FLB_LOG_EVENT_CHAR_VALUE_TYPE                    8
-#define FLB_LOG_EVENT_INT8_VALUE_TYPE                    9
-#define FLB_LOG_EVENT_INT16_VALUE_TYPE                   10
-#define FLB_LOG_EVENT_INT32_VALUE_TYPE                   11
-#define FLB_LOG_EVENT_INT64_VALUE_TYPE                   12
-#define FLB_LOG_EVENT_UINT8_VALUE_TYPE                   13
-#define FLB_LOG_EVENT_UINT16_VALUE_TYPE                  14
-#define FLB_LOG_EVENT_UINT32_VALUE_TYPE                  15
-#define FLB_LOG_EVENT_UINT64_VALUE_TYPE                  16
-#define FLB_LOG_EVENT_DOUBLE_VALUE_TYPE                  17
-#define FLB_LOG_EVENT_BOOLEAN_VALUE_TYPE                 18
-#define FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE          19
-#define FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE             20
-#define FLB_LOG_EVENT_TIMESTAMP_VALUE_TYPE               21
-#define FLB_LOG_EVENT_LEGACY_TIMESTAMP_VALUE_TYPE        22
-#define FLB_LOG_EVENT_FORWARD_V1_TIMESTAMP_VALUE_TYPE    23
-#define FLB_LOG_EVENT_FLUENT_BIT_V1_TIMESTAMP_VALUE_TYPE 24
-#define FLB_LOG_EVENT_FLUENT_BIT_V2_TIMESTAMP_VALUE_TYPE 25
+#define FLB_LOG_EVENT_APPEND_TERMINATOR_VALUE_TYPE       (flb_log_event_type_t)0
+
+#define FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE           (flb_log_event_type_t)1
+#define FLB_LOG_EVENT_STRING_BODY_VALUE_TYPE             (flb_log_event_type_t)2
+#define FLB_LOG_EVENT_BINARY_LENGTH_VALUE_TYPE           (flb_log_event_type_t)3
+#define FLB_LOG_EVENT_BINARY_BODY_VALUE_TYPE             (flb_log_event_type_t)4
+#define FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE              (flb_log_event_type_t)5
+#define FLB_LOG_EVENT_EXT_BODY_VALUE_TYPE                (flb_log_event_type_t)6
+#define FLB_LOG_EVENT_NULL_VALUE_TYPE                    (flb_log_event_type_t)7
+#define FLB_LOG_EVENT_CHAR_VALUE_TYPE                    (flb_log_event_type_t)8
+#define FLB_LOG_EVENT_INT8_VALUE_TYPE                    (flb_log_event_type_t)9
+#define FLB_LOG_EVENT_INT16_VALUE_TYPE                   (flb_log_event_type_t)10
+#define FLB_LOG_EVENT_INT32_VALUE_TYPE                   (flb_log_event_type_t)11
+#define FLB_LOG_EVENT_INT64_VALUE_TYPE                   (flb_log_event_type_t)12
+#define FLB_LOG_EVENT_UINT8_VALUE_TYPE                   (flb_log_event_type_t)13
+#define FLB_LOG_EVENT_UINT16_VALUE_TYPE                  (flb_log_event_type_t)14
+#define FLB_LOG_EVENT_UINT32_VALUE_TYPE                  (flb_log_event_type_t)15
+#define FLB_LOG_EVENT_UINT64_VALUE_TYPE                  (flb_log_event_type_t)16
+#define FLB_LOG_EVENT_DOUBLE_VALUE_TYPE                  (flb_log_event_type_t)17
+#define FLB_LOG_EVENT_BOOLEAN_VALUE_TYPE                 (flb_log_event_type_t)18
+#define FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE          (flb_log_event_type_t)19
+#define FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE             (flb_log_event_type_t)20
+#define FLB_LOG_EVENT_TIMESTAMP_VALUE_TYPE               (flb_log_event_type_t)21
+#define FLB_LOG_EVENT_LEGACY_TIMESTAMP_VALUE_TYPE        (flb_log_event_type_t)22
+#define FLB_LOG_EVENT_FORWARD_V1_TIMESTAMP_VALUE_TYPE    (flb_log_event_type_t)23
+#define FLB_LOG_EVENT_FLUENT_BIT_V1_TIMESTAMP_VALUE_TYPE (flb_log_event_type_t)24
+#define FLB_LOG_EVENT_FLUENT_BIT_V2_TIMESTAMP_VALUE_TYPE (flb_log_event_type_t)25
 
 #define FLB_LOG_EVENT_STRING_MIN_VALUE_TYPE              FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE
 #define FLB_LOG_EVENT_STRING_MAX_VALUE_TYPE              FLB_LOG_EVENT_FLUENT_BIT_V2_TIMESTAMP_VALUE_TYPE
@@ -75,7 +77,7 @@
 
 #define FLB_LOG_EVENT_APPEND_UNTIL_TERMINATOR            -1
 
-#define flb_log_event_type_t int32_t
+
 
 #define FLB_LOG_EVENT_VALUE_LIST_TERMINATOR() \
             (flb_log_event_type_t) FLB_LOG_EVENT_APPEND_TERMINATOR_VALUE_TYPE

--- a/include/fluent-bit/flb_log_event_encoder_primitives.h
+++ b/include/fluent-bit/flb_log_event_encoder_primitives.h
@@ -20,6 +20,16 @@
 #ifndef FLB_LOG_EVENT_ENCODER_PRIMITIVES_H
 #define FLB_LOG_EVENT_ENCODER_PRIMITIVES_H
 
+#ifdef FLB_SYSTEM_WINDOWS
+/* Fluent-bit on Windows x86_64 passes size_t as dword if it is compiled using /O2.
+ * It causes encoder error since encoder functions handles size_t as qword.
+ * We define dword size flb_log_event_size_t to prevent invalid casting as a workaround.
+ */
+#define flb_log_event_size_t uint32_t
+#else
+#define flb_log_event_size_t size_t
+#endif
+
 int flb_log_event_encoder_append_values_unsafe(
         struct flb_log_event_encoder *context,
         int field,
@@ -28,36 +38,36 @@ int flb_log_event_encoder_append_values_unsafe(
 int flb_log_event_encoder_append_binary_length(
         struct flb_log_event_encoder *context,
         int target_field,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_binary_body(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_ext_length(
         struct flb_log_event_encoder *context,
         int target_field,
         int8_t type,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_ext_body(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_string_length(
         struct flb_log_event_encoder *context,
         int target_field,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_string_body(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_int8(
         struct flb_log_event_encoder *context,
@@ -118,20 +128,20 @@ int flb_log_event_encoder_append_binary(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_string(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_ext(
         struct flb_log_event_encoder *context,
         int target_field,
         int8_t type,
         char *value,
-        size_t length);
+        flb_log_event_size_t length);
 
 int flb_log_event_encoder_append_cstring(
         struct flb_log_event_encoder *context,
@@ -151,7 +161,7 @@ int flb_log_event_encoder_append_raw_msgpack(
     struct flb_log_event_encoder *context,
     int target_field,
     char *value_buffer,
-    size_t value_size);
+    flb_log_event_size_t value_size);
 
 int flb_log_event_encoder_append_timestamp(
     struct flb_log_event_encoder *context,

--- a/include/fluent-bit/flb_log_event_encoder_primitives.h
+++ b/include/fluent-bit/flb_log_event_encoder_primitives.h
@@ -107,7 +107,7 @@ int flb_log_event_encoder_append_double(
 int flb_log_event_encoder_append_boolean(
     struct flb_log_event_encoder *context,
     int target_field,
-    int value);
+    char value);
 
 int flb_log_event_encoder_append_character(
         struct flb_log_event_encoder *context,

--- a/src/flb_log_event_encoder.c
+++ b/src/flb_log_event_encoder.c
@@ -129,6 +129,14 @@ int flb_log_event_encoder_emit_raw_record(struct flb_log_event_encoder *context,
 {
     int result;
 
+    if (context == NULL) {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_CONTEXT;
+    }
+
+    if (buffer == NULL || length == 0) {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
+    }
+
     result = msgpack_pack_str_body(&context->packer, buffer, length);
 
     if (result != 0) {
@@ -229,6 +237,10 @@ int flb_log_event_encoder_emit_record(struct flb_log_event_encoder *context)
 
 int flb_log_event_encoder_reset_record(struct flb_log_event_encoder *context)
 {
+    if (context == NULL) {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_CONTEXT;
+    }
+
     flb_log_event_encoder_dynamic_field_reset(&context->metadata);
     flb_log_event_encoder_dynamic_field_reset(&context->body);
     flb_log_event_encoder_dynamic_field_reset(&context->root);

--- a/src/flb_log_event_encoder_primitives.c
+++ b/src/flb_log_event_encoder_primitives.c
@@ -36,7 +36,7 @@ int flb_log_event_encoder_append_value(
         struct flb_log_event_encoder *context,
         int target_field,
         int increment_entry_count,
-        int value_type,
+        flb_log_event_type_t value_type,
         char *value_buffer,
         size_t value_length)
 {
@@ -450,7 +450,7 @@ int flb_log_event_encoder_append_msgpack_object(
     int target_field,
     msgpack_object *value)
 {
-    const int value_type = FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE;
+    const flb_log_event_type_t value_type = FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE;
 
     return flb_log_event_encoder_append_value(context, target_field,
                                               FLB_TRUE, value_type,
@@ -463,7 +463,7 @@ int flb_log_event_encoder_append_raw_msgpack(
     char *value_buffer,
     size_t value_size)
 {
-    const int value_type = FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE;
+    const flb_log_event_type_t value_type = FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE;
 
     return flb_log_event_encoder_append_value(context, target_field,
                                               FLB_TRUE, value_type,
@@ -502,7 +502,7 @@ int flb_log_event_encoder_append_legacy_timestamp(
     int target_field,
     struct flb_time *value)
 {
-    const int value_type = FLB_LOG_EVENT_UINT64_VALUE_TYPE;
+    const flb_log_event_type_t value_type = FLB_LOG_EVENT_UINT64_VALUE_TYPE;
     uint64_t  timestamp;
 
     timestamp = value->tm.tv_sec;

--- a/src/flb_log_event_encoder_primitives.c
+++ b/src/flb_log_event_encoder_primitives.c
@@ -38,7 +38,7 @@ int flb_log_event_encoder_append_value(
         int increment_entry_count,
         flb_log_event_type_t value_type,
         char *value_buffer,
-        size_t value_length)
+        flb_log_event_size_t value_length)
 {
     int                                         result;
     struct flb_log_event_encoder_dynamic_field *field;
@@ -162,7 +162,7 @@ int flb_log_event_encoder_append_value(
 int flb_log_event_encoder_append_binary_length(
         struct flb_log_event_encoder *context,
         int target_field,
-        size_t length)
+        flb_log_event_size_t length)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_TRUE,
@@ -174,7 +174,7 @@ int flb_log_event_encoder_append_binary_body(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length)
+        flb_log_event_size_t length)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_FALSE,
@@ -186,7 +186,7 @@ int flb_log_event_encoder_append_ext_length(
         struct flb_log_event_encoder *context,
         int target_field,
         int8_t type,
-        size_t length)
+        flb_log_event_size_t length)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_TRUE,
@@ -198,7 +198,7 @@ int flb_log_event_encoder_append_ext_body(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length)
+        flb_log_event_size_t length)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_FALSE,
@@ -209,7 +209,7 @@ int flb_log_event_encoder_append_ext_body(
 int flb_log_event_encoder_append_string_length(
         struct flb_log_event_encoder *context,
         int target_field,
-        size_t length)
+        flb_log_event_size_t length)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_TRUE,
@@ -221,7 +221,7 @@ int flb_log_event_encoder_append_string_body(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length)
+        flb_log_event_size_t length)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_FALSE,
@@ -363,7 +363,7 @@ int flb_log_event_encoder_append_binary(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length)
+        flb_log_event_size_t length)
 {
     int result;
 
@@ -387,7 +387,7 @@ int flb_log_event_encoder_append_string(
         struct flb_log_event_encoder *context,
         int target_field,
         char *value,
-        size_t length)
+        flb_log_event_size_t length)
 {
     int result;
 
@@ -412,7 +412,7 @@ int flb_log_event_encoder_append_ext(
         int target_field,
         int8_t type,
         char *value,
-        size_t length)
+        flb_log_event_size_t length)
 {
     int result;
 
@@ -461,7 +461,7 @@ int flb_log_event_encoder_append_raw_msgpack(
     struct flb_log_event_encoder *context,
     int target_field,
     char *value_buffer,
-    size_t value_size)
+    flb_log_event_size_t value_size)
 {
     const flb_log_event_type_t value_type = FLB_LOG_EVENT_MSGPACK_RAW_VALUE_TYPE;
 
@@ -572,7 +572,7 @@ int flb_log_event_encoder_append_values_unsafe(
         else if (value_type == FLB_LOG_EVENT_STRING_LENGTH_VALUE_TYPE) {
             result = flb_log_event_encoder_append_string_length(context,
                         target_field,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_STRING_BODY_VALUE_TYPE) {
             buffer_address = va_arg(arguments, char *);
@@ -580,12 +580,12 @@ int flb_log_event_encoder_append_values_unsafe(
             result = flb_log_event_encoder_append_string_body(context,
                         target_field,
                         buffer_address,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_BINARY_LENGTH_VALUE_TYPE) {
             result = flb_log_event_encoder_append_binary_length(context,
                         target_field,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_BINARY_BODY_VALUE_TYPE) {
             buffer_address = va_arg(arguments, char *);
@@ -593,7 +593,7 @@ int flb_log_event_encoder_append_values_unsafe(
             result = flb_log_event_encoder_append_binary_body(context,
                         target_field,
                         buffer_address,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE) {
             current_ext_type = (int8_t)va_arg(arguments, int32_t);
@@ -601,7 +601,7 @@ int flb_log_event_encoder_append_values_unsafe(
             result = flb_log_event_encoder_append_ext_length(context,
                         target_field,
                         current_ext_type,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_EXT_BODY_VALUE_TYPE) {
             buffer_address = va_arg(arguments, char *);
@@ -609,7 +609,7 @@ int flb_log_event_encoder_append_values_unsafe(
             result = flb_log_event_encoder_append_ext_body(context,
                         target_field,
                         buffer_address,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_NULL_VALUE_TYPE) {
             result = flb_log_event_encoder_append_null(context,
@@ -681,7 +681,7 @@ int flb_log_event_encoder_append_values_unsafe(
             result = flb_log_event_encoder_append_raw_msgpack(context,
                         target_field,
                         buffer_address,
-                        va_arg(arguments, size_t));
+                        va_arg(arguments, flb_log_event_size_t));
         }
         else if (value_type == FLB_LOG_EVENT_TIMESTAMP_VALUE_TYPE) {
             result = flb_log_event_encoder_append_timestamp(context,

--- a/src/flb_log_event_encoder_primitives.c
+++ b/src/flb_log_event_encoder_primitives.c
@@ -130,7 +130,7 @@ int flb_log_event_encoder_append_value(
                                                  *((double *) value_buffer));
                 }
                 else if (value_type == FLB_LOG_EVENT_BOOLEAN_VALUE_TYPE) {
-                    if (*((int *) value_buffer)) {
+                    if (*((char *) value_buffer)) {
                         result = msgpack_pack_true(&field->packer);
                     }
                     else {
@@ -330,7 +330,7 @@ int flb_log_event_encoder_append_double(
 int flb_log_event_encoder_append_boolean(
     struct flb_log_event_encoder *context,
     int target_field,
-    int value)
+    char value)
 {
     return flb_log_event_encoder_append_value(
             context, target_field, FLB_TRUE,
@@ -554,7 +554,7 @@ int flb_log_event_encoder_append_values_unsafe(
     int8_t  current_ext_type;
     size_t  processed_values;
     char   *buffer_address;
-    int     value_type;
+    flb_log_event_type_t value_type;
     int     result;
 
     processed_values = 0;
@@ -564,7 +564,7 @@ int flb_log_event_encoder_append_values_unsafe(
          processed_values < FLB_EVENT_ENCODER_VALUE_LIMIT &&
          result == FLB_EVENT_ENCODER_SUCCESS ;
          processed_values++) {
-        value_type = va_arg(arguments, int);
+        value_type = va_arg(arguments, flb_log_event_type_t);
 
         if (value_type == FLB_LOG_EVENT_APPEND_TERMINATOR_VALUE_TYPE) {
             break;
@@ -596,7 +596,7 @@ int flb_log_event_encoder_append_values_unsafe(
                         va_arg(arguments, size_t));
         }
         else if (value_type == FLB_LOG_EVENT_EXT_LENGTH_VALUE_TYPE) {
-            current_ext_type = (int8_t) va_arg(arguments, int);
+            current_ext_type = (int8_t)va_arg(arguments, int32_t);
 
             result = flb_log_event_encoder_append_ext_length(context,
                         target_field,
@@ -618,17 +618,17 @@ int flb_log_event_encoder_append_values_unsafe(
         else if (value_type == FLB_LOG_EVENT_CHAR_VALUE_TYPE) {
             result = flb_log_event_encoder_append_character(context,
                         target_field,
-                        (char) va_arg(arguments, int));
+                        (char)va_arg(arguments, int32_t));
         }
         else if (value_type == FLB_LOG_EVENT_INT8_VALUE_TYPE) {
             result = flb_log_event_encoder_append_int8(context,
                         target_field,
-                        (int8_t) va_arg(arguments, int));
+                        (int8_t)va_arg(arguments, int32_t));
         }
         else if (value_type == FLB_LOG_EVENT_INT16_VALUE_TYPE) {
             result = flb_log_event_encoder_append_int16(context,
                         target_field,
-                        (int16_t) va_arg(arguments, int));
+                        (int16_t)va_arg(arguments, int32_t));
         }
         else if (value_type == FLB_LOG_EVENT_INT32_VALUE_TYPE) {
             result = flb_log_event_encoder_append_int32(context,
@@ -643,12 +643,12 @@ int flb_log_event_encoder_append_values_unsafe(
         else if (value_type == FLB_LOG_EVENT_UINT8_VALUE_TYPE) {
             result = flb_log_event_encoder_append_uint8(context,
                         target_field,
-                        (uint8_t) va_arg(arguments, unsigned int));
+                        (uint8_t)va_arg(arguments, uint32_t));
         }
         else if (value_type == FLB_LOG_EVENT_UINT16_VALUE_TYPE) {
             result = flb_log_event_encoder_append_uint16(context,
                         target_field,
-                        (uint16_t) va_arg(arguments, unsigned int));
+                        (uint16_t)va_arg(arguments, uint32_t));
         }
         else if (value_type == FLB_LOG_EVENT_UINT32_VALUE_TYPE) {
             result = flb_log_event_encoder_append_uint32(context,
@@ -668,7 +668,7 @@ int flb_log_event_encoder_append_values_unsafe(
         else if (value_type == FLB_LOG_EVENT_BOOLEAN_VALUE_TYPE) {
             result = flb_log_event_encoder_append_boolean(context,
                         target_field,
-                        va_arg(arguments, int));
+                        (char)va_arg(arguments, int32_t));
         }
         else if (value_type == FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE_TYPE) {
             result = flb_log_event_encoder_append_msgpack_object(context,

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -38,6 +38,7 @@ set(UNIT_TESTS_FILES
   parser_logfmt.c
   env.c
   log.c
+  log_event_encoder.c
   processor.c
   )
 

--- a/tests/internal/log_event_encoder.c
+++ b/tests/internal/log_event_encoder.c
@@ -1,0 +1,663 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2023 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+#include <fluent-bit.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+#include <msgpack.h>
+#include <float.h>
+#include <math.h>
+#include "flb_tests_internal.h"
+
+static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
+{
+    int ret = -1;
+
+    if (str == NULL) {
+        flb_error("str is NULL");
+        return -1;
+    }
+
+    switch (obj.type)  {
+    case MSGPACK_OBJECT_STR:
+        if (obj.via.str.size != str_len) {
+            return -1;
+        }
+        ret = strncmp(str, obj.via.str.ptr, str_len);
+        break;
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        {
+            unsigned long val = strtoul(str, NULL, 10);
+            if (val == (unsigned long)obj.via.u64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        {
+            long long val = strtoll(str, NULL, 10);
+            if (val == (unsigned long)obj.via.i64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        {
+            double val = strtod(str, NULL);
+            if (fabs(val - obj.via.f64) < DBL_EPSILON) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (obj.via.boolean) {
+            if (str_len != 4 /*true*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "true", 4);
+        }
+        else {
+            if (str_len != 5 /*false*/) {
+                return -1;
+            }
+            ret = strncasecmp(str, "false", 5);
+        }
+        break;
+    default:
+        flb_error("not supported");
+    }
+
+    return ret;
+}
+
+struct str_list {
+    size_t size;
+    char **lists;
+};
+
+static int compare_msgpack_map(msgpack_object *map, struct str_list *l)
+{
+    int map_size;
+    int i_map;
+    int i_list;
+    int num = 0;
+
+    if (!TEST_CHECK(map->type == MSGPACK_OBJECT_MAP)) {
+        TEST_MSG("type is not map. type = %d", map->type);
+        return -1;
+    }
+
+    map_size = map->via.map.size;
+    for (i_map=0; i_map<map_size; i_map++) {
+        if (!TEST_CHECK(map->via.map.ptr[i_map].key.type == MSGPACK_OBJECT_STR)) {
+            TEST_MSG("key is not string. type =%d", map->via.map.ptr[i_map].key.type);
+            continue;
+        }
+        for (i_list=0; i_list< l->size/2; i_list++)  {
+            if (msgpack_strncmp(l->lists[i_list*2], strlen(l->lists[i_list*2]),
+                                map->via.map.ptr[i_map].key) == 0 &&
+                msgpack_strncmp(l->lists[i_list*2+1], strlen(l->lists[i_list*2+1]),
+                                map->via.map.ptr[i_map].val) == 0) {
+                num++;
+            }
+        }
+    }
+    if (!TEST_CHECK(num == l->size/2)) {
+        msgpack_object_print(stdout, *map);
+        putchar('\n');
+        TEST_MSG("compare failed. matched_num=%d expect=%lu", num, l->size/2);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int compare_msgpack_format_fluentbit_v2(void *msgpack_data, size_t msgpack_size,
+                                               struct str_list *metadata,
+                                               struct str_list *body)
+{
+    msgpack_unpacked result;
+    msgpack_object obj;
+    msgpack_object root;
+    size_t off = 0;
+    int ret;
+
+    if (!TEST_CHECK(msgpack_data != NULL)) {
+        TEST_MSG("msgpack_data is NULL");
+        return -1;
+    }
+    else if (!TEST_CHECK(msgpack_size > 0)) {
+        TEST_MSG("msgpack_size is 0");
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, msgpack_data, msgpack_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        root = result.data;
+        /*
+        msgpack_object_print(stdout, obj);
+        */
+
+        /* format v2: [[timestamp, {metadata}], {record}]*/
+
+        if (!TEST_CHECK(root.type == MSGPACK_OBJECT_ARRAY)) {
+            TEST_MSG("type is not array. type = %d", root.type);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+        if (!TEST_CHECK(root.via.array.size == 2)) {
+            TEST_MSG("array size error. size = %d", root.via.array.size);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        obj = root.via.array.ptr[0]; /* [timestamp, {metadata}] */
+        if (!TEST_CHECK(root.type == MSGPACK_OBJECT_ARRAY)) {
+            TEST_MSG("type is not array. type = %d", root.type);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+        if (!TEST_CHECK(root.via.array.size == 2)) {
+            TEST_MSG("array size error. size = %d", root.via.array.size);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        obj = root.via.array.ptr[0].via.array.ptr[0]; /* timestamp */
+        if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_EXT ||
+                        obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER)) {
+            TEST_MSG("timestamp format error. type = %d", obj.type);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+        obj = root.via.array.ptr[0].via.array.ptr[1]; /* metadata */
+        if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_MAP)) {
+            TEST_MSG("type is not map. type = %d", obj.type);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+        if (metadata != NULL) {
+            ret = compare_msgpack_map(&obj, metadata);
+            if (!TEST_CHECK(ret == 0)) {
+                TEST_MSG("compare_msgpack_body failed");
+                msgpack_unpacked_destroy(&result);
+                return -1;
+            }
+        }
+        else if (!TEST_CHECK(obj.via.map.size == 0)) {
+            TEST_MSG("map size error. size = %d", root.via.map.size);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        obj = root.via.array.ptr[1]; /* {record} */
+        ret = compare_msgpack_map(&obj, body);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("compare_msgpack_body failed");
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+    }
+    msgpack_unpacked_destroy(&result);
+
+    return 0;
+}
+
+static int compare_msgpack_format_fluentbit_v1(void *msgpack_data, size_t msgpack_size,
+                                               struct str_list *body)
+{
+    msgpack_unpacked result;
+    msgpack_object obj;
+    msgpack_object root;
+    size_t off = 0;
+    int ret;
+
+    if (!TEST_CHECK(msgpack_data != NULL)) {
+        TEST_MSG("msgpack_data is NULL");
+        return -1;
+    }
+    else if (!TEST_CHECK(msgpack_size > 0)) {
+        TEST_MSG("msgpack_size is 0");
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    while (msgpack_unpack_next(&result, msgpack_data, msgpack_size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        root = result.data;
+        /*
+        msgpack_object_print(stdout, obj);
+        */
+
+        /* format v1: [timestamp, {record}]*/
+
+        if (!TEST_CHECK(root.type == MSGPACK_OBJECT_ARRAY)) {
+            TEST_MSG("type is not array. type = %d", root.type);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+        if (!TEST_CHECK(root.via.array.size == 2)) {
+            TEST_MSG("array size error. size = %d", root.via.array.size);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        obj = root.via.array.ptr[0]; /* timestamp */
+        if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_EXT ||
+                        obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER)) {
+            TEST_MSG("timestamp format error. type = %d", obj.type);
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        obj = root.via.array.ptr[1]; /* {record} */
+        ret = compare_msgpack_map(&obj, body);
+        if (!TEST_CHECK(ret == 0)) {
+            TEST_MSG("compare_msgpack_body failed");
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+    }
+    msgpack_unpacked_destroy(&result);
+
+    return 0;
+}
+
+
+static void create_destroy()
+{
+    struct flb_log_event_encoder *encoder = NULL;
+    int index;
+    int formats[] = {
+        FLB_LOG_EVENT_FORMAT_DEFAULT,
+        FLB_LOG_EVENT_FORMAT_FORWARD,
+        FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V1,
+        FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V2,
+        -1,
+    };
+
+    for (index=0; formats[index] != -1; index++) {
+        encoder = flb_log_event_encoder_create(formats[index]);
+        if (!TEST_CHECK(encoder != NULL)) {
+            TEST_MSG("%d: flb_log_event_encoder_create failed. format=%d", index, formats[index]);
+        }
+        flb_log_event_encoder_destroy(encoder);
+    }
+}
+
+static void create_unsupported_format()
+{
+    struct flb_log_event_encoder *encoder = NULL;
+    int index;
+    int formats[] = {
+        FLB_LOG_EVENT_FORMAT_UNKNOWN,
+        FLB_LOG_EVENT_FORMAT_FORWARD_LEGACY,
+        -1,
+    };
+
+    for (index=0; formats[index] != -1; index++) {
+        encoder = flb_log_event_encoder_create(formats[index]);
+        if (!TEST_CHECK(encoder == NULL)) {
+            TEST_MSG("%d: flb_log_event_encoder_create should be failed. format=%d", index, formats[index]);
+            flb_log_event_encoder_destroy(encoder);
+        }
+    }
+}
+
+static void init_destroy()
+{
+    struct flb_log_event_encoder encoder;
+    int index;
+    int ret;
+    int formats[] = {
+        FLB_LOG_EVENT_FORMAT_DEFAULT,
+        FLB_LOG_EVENT_FORMAT_FORWARD,
+        FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V1,
+        FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V2,
+        -1,
+    };
+
+    for (index=0; formats[index] != -1; index++) {
+        ret = flb_log_event_encoder_init(&encoder, formats[index]);
+        if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+            TEST_MSG("%d: flb_log_event_encoder_init failed. format=%d", index, formats[index]);
+        }
+        flb_log_event_encoder_destroy(&encoder);
+    }
+}
+
+static void init_unsupported_format()
+{
+    struct flb_log_event_encoder encoder;
+    int index;
+    int ret;
+    int formats[] = {
+        FLB_LOG_EVENT_FORMAT_UNKNOWN,
+        FLB_LOG_EVENT_FORMAT_FORWARD_LEGACY,
+        -1,
+    };
+
+    for (index=0; formats[index] != -1; index++) {
+        ret = flb_log_event_encoder_init(&encoder, formats[index]);
+        if (!TEST_CHECK(ret != FLB_EVENT_ENCODER_SUCCESS)) {
+            TEST_MSG("%d: flb_log_event_encoder_init should be failed. format=%d", index, formats[index]);
+        }
+    }
+}
+
+static void basic_format_fluent_bit_v2()
+{
+    struct flb_log_event_encoder encoder;
+    int ret;
+    char *expected_strs[] = {"key1", "value1", "key2", "value2"};
+    struct str_list expected_body = {
+                     .size = sizeof(expected_strs)/sizeof(char*),
+                     .lists = &expected_strs[0],
+    };
+
+    ret = flb_log_event_encoder_init(&encoder, FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V2);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_init failed");
+        return;
+    }
+
+    ret = flb_log_event_encoder_begin_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_begin_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_set_current_timestamp(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_set_current_timestamp failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_append_body_values(
+                &encoder,
+                FLB_LOG_EVENT_CSTRING_VALUE("key1"),
+                FLB_LOG_EVENT_CSTRING_VALUE("value1"),
+
+                FLB_LOG_EVENT_STRING_VALUE("key2", 4),
+                FLB_LOG_EVENT_STRING_VALUE("value2", 6));
+
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_append_body_values failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_commit_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_commit_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = compare_msgpack_format_fluentbit_v2(encoder.output_buffer, encoder.output_length,
+                                              NULL, &expected_body);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare error");
+    }
+
+    flb_log_event_encoder_destroy(&encoder);
+}
+
+static void basic_format_fluent_bit_v1()
+{
+    struct flb_log_event_encoder encoder;
+    int ret;
+    char *expected_strs[] = {"key1", "value1", "key2", "value2"};
+    struct str_list expected_body = {
+                     .size = sizeof(expected_strs)/sizeof(char*),
+                     .lists = &expected_strs[0],
+    };
+
+    ret = flb_log_event_encoder_init(&encoder, FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V1);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_init failed");
+        return;
+    }
+
+    ret = flb_log_event_encoder_begin_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_begin_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_set_current_timestamp(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_set_current_timestamp failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_append_body_values(
+                &encoder,
+                FLB_LOG_EVENT_CSTRING_VALUE("key1"),
+                FLB_LOG_EVENT_CSTRING_VALUE("value1"),
+
+                FLB_LOG_EVENT_STRING_VALUE("key2", 4),
+                FLB_LOG_EVENT_STRING_VALUE("value2", 6));
+
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_append_body_values failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_commit_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_commit_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = compare_msgpack_format_fluentbit_v1(encoder.output_buffer, encoder.output_length,
+                                              &expected_body);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare error");
+    }
+
+    flb_log_event_encoder_destroy(&encoder);
+}
+
+static void basic_metadata_format_fluent_bit_v2()
+{
+    struct flb_log_event_encoder encoder;
+    int ret;
+    char *expected_strs_body[] = {"key1", "value1", "key2", "value2"};
+    struct str_list expected_body = {
+                     .size = sizeof(expected_strs_body)/sizeof(char*),
+                     .lists = &expected_strs_body[0],
+    };
+    char *expected_strs_metadata[] = {"version", "2.1", "debug", "false"};
+    struct str_list expected_metadata = {
+                     .size = sizeof(expected_strs_metadata)/sizeof(char*),
+                     .lists = &expected_strs_metadata[0],
+    };
+
+
+    ret = flb_log_event_encoder_init(&encoder, FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V2);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_init failed");
+        return;
+    }
+
+    ret = flb_log_event_encoder_begin_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_begin_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_set_current_timestamp(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_set_current_timestamp failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_append_body_values(
+                &encoder,
+                FLB_LOG_EVENT_CSTRING_VALUE("key1"),
+                FLB_LOG_EVENT_CSTRING_VALUE("value1"),
+
+                FLB_LOG_EVENT_STRING_VALUE("key2", 4),
+                FLB_LOG_EVENT_STRING_VALUE("value2", 6));
+
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_append_body_values failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_append_metadata_values(
+                &encoder,
+                FLB_LOG_EVENT_CSTRING_VALUE("version"),
+                FLB_LOG_EVENT_DOUBLE_VALUE(2.1),
+
+                FLB_LOG_EVENT_STRING_VALUE("debug", 5),
+                FLB_LOG_EVENT_BOOLEAN_VALUE(FLB_FALSE));
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_append_metadata_values failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+
+    ret = flb_log_event_encoder_commit_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_commit_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = compare_msgpack_format_fluentbit_v2(encoder.output_buffer, encoder.output_length,
+                                              &expected_metadata, &expected_body);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare error");
+    }
+
+    flb_log_event_encoder_destroy(&encoder);
+}
+
+static void emit_raw_record()
+{
+    struct flb_log_event_encoder encoder;
+    int ret;
+    int unused_type = 0;
+    char *json = "{\"key\":\"value\"}";
+    char *buf = NULL;
+    size_t buf_size = 0;
+
+    ret = flb_log_event_encoder_init(&encoder, FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_init failed");
+        return;
+    }
+
+    if (!TEST_CHECK(encoder.output_length == 0)) {
+        TEST_MSG("output_length is not 0");
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_begin_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_begin_record failed. ret=%d", ret);
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_set_current_timestamp(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_set_current_timestamp failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_pack_json(json, strlen(json), &buf, &buf_size, &unused_type, NULL);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_pack_json failed. ret=%d", ret);
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+    if (!TEST_CHECK(buf_size > 0)) {
+        TEST_MSG("msgpack size is 0");
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_emit_raw_record(&encoder, buf, buf_size);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_emit_raw_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_free(buf);
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    ret = flb_log_event_encoder_commit_record(&encoder);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_commit_record failed. ret=%s",
+                 flb_log_event_encoder_get_error_description(ret));
+        flb_free(buf);
+        flb_log_event_encoder_destroy(&encoder);
+        return;
+    }
+
+    if (!TEST_CHECK(encoder.output_length > 0)) {
+        TEST_MSG("output_length is 0");
+    }
+    flb_free(buf);
+    flb_log_event_encoder_destroy(&encoder);
+}
+
+TEST_LIST = {
+    { "basic_format_fluent_bit_v2", basic_format_fluent_bit_v2},
+    { "basic_format_fluent_bit_v1", basic_format_fluent_bit_v1},
+    { "basic_metadata_format_fluent_bit_v2", basic_metadata_format_fluent_bit_v2},
+    { "create_destroy", create_destroy},
+    { "create_unsupported_format", create_unsupported_format},
+    { "init_destroy", init_destroy},
+    { "init_unsupported_format", init_unsupported_format},
+    { "emit_raw_record", emit_raw_record},
+    { NULL, NULL }
+};

--- a/tests/internal/log_event_encoder.c
+++ b/tests/internal/log_event_encoder.c
@@ -401,8 +401,8 @@ static void basic_format_fluent_bit_v2()
                 FLB_LOG_EVENT_CSTRING_VALUE("key1"),
                 FLB_LOG_EVENT_CSTRING_VALUE("value1"),
 
-                FLB_LOG_EVENT_STRING_VALUE("key2", 4),
-                FLB_LOG_EVENT_STRING_VALUE("value2", 6));
+                FLB_LOG_EVENT_STRING_VALUE("key2", (size_t)4),
+                FLB_LOG_EVENT_STRING_VALUE("value2", (size_t)6));
 
     if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
         TEST_MSG("flb_log_event_encoder_append_body_values failed. ret=%s",
@@ -465,8 +465,8 @@ static void basic_format_fluent_bit_v1()
                 FLB_LOG_EVENT_CSTRING_VALUE("key1"),
                 FLB_LOG_EVENT_CSTRING_VALUE("value1"),
 
-                FLB_LOG_EVENT_STRING_VALUE("key2", 4),
-                FLB_LOG_EVENT_STRING_VALUE("value2", 6));
+                FLB_LOG_EVENT_STRING_VALUE("key2", (size_t)4),
+                FLB_LOG_EVENT_STRING_VALUE("value2", (size_t)6));
 
     if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
         TEST_MSG("flb_log_event_encoder_append_body_values failed. ret=%s",
@@ -535,8 +535,8 @@ static void basic_metadata_format_fluent_bit_v2()
                 FLB_LOG_EVENT_CSTRING_VALUE("key1"),
                 FLB_LOG_EVENT_CSTRING_VALUE("value1"),
 
-                FLB_LOG_EVENT_STRING_VALUE("key2", 4),
-                FLB_LOG_EVENT_STRING_VALUE("value2", 6));
+                FLB_LOG_EVENT_STRING_VALUE("key2", (size_t)4),
+                FLB_LOG_EVENT_STRING_VALUE("value2", (size_t)6));
 
     if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
         TEST_MSG("flb_log_event_encoder_append_body_values failed. ret=%s",


### PR DESCRIPTION
This is a refactor PR for #7584

This patch is to add test code for log_event_encoder.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
