### PR TITLE
tests: internal: fuzzers: cmetrics_fuzzer: extend

### DIFF
--- a/tests/internal/fuzzers/cmetrics_decode_fuzz.c
+++ b/tests/internal/fuzzers/cmetrics_decode_fuzz.c
@@ -18,6 +18,7 @@
  */
 
 #include <cmetrics/cmt_decode_opentelemetry.h>
+#include <cmetrics/cmt_decode_prometheus.h>
 
 
 int
@@ -34,7 +35,7 @@ LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
         return 0;
     }
 
-    decider = data[0] % 2;
+    decider = data[0] % 3;
 
     /* Adjust data pointer since the first byte is used */
     data += 1;
@@ -52,6 +53,16 @@ LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
         result = cmt_decode_msgpack_create(&cmt, (char *) data, size, &off);
         if (result == 0) {
             cmt_destroy(cmt);
+        }
+    }
+    else if (decider == 2) {
+        if (size == 0) {
+            return 0;
+        }
+        struct cmt_decode_prometheus_parse_opts opts;
+        result = cmt_decode_prometheus_create(&cmt, data, size, &opts);
+        if (result == CMT_DECODE_PROMETHEUS_SUCCESS) {
+            cmt_decode_prometheus_destroy(cmt);
         }
     }
     return 0;


### PR DESCRIPTION
Extend cmetrics_fuzzer so it reaches prometheus decoding logic as well.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
