### PR TITLE
tests: internal: input_chunk: Use the different storage.path per tests

### DIFF
--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -162,6 +162,7 @@ void do_test(char *system, const char *target, ...)
     int out_ffd;
     char path[PATH_MAX];
     struct tail_test_result result = {0};
+    char storage_path[PATH_MAX];
 
     result.nMatched = 0;
     result.target = target;
@@ -175,10 +176,12 @@ void do_test(char *system, const char *target, ...)
 
     ctx = flb_create();
 
+    snprintf(storage_path, sizeof(storage_path) - 1, "/tmp/input-chunk-test-%s", target);
+
     /* create chunks in /tmp folder */
     ret = flb_service_set(ctx,
                           "Parsers_File", DPATH "parser.conf",
-                          "storage.path", "/tmp/input-chunk-test/",
+                          "storage.path", storage_path,
                           "Log_Level", "error",
                           NULL);
     TEST_CHECK_(ret == 0, "setting service options");


### PR DESCRIPTION
This is because different storage.paths should be used per test. Sometimes this cause failure for retrieving the file contents to prepare the data for test cases:

```log
Test input_chunk_exceed_limit...                [ FAILED ]
  input_chunk.c:91: Check getting output file content: ~/GitHub/fluent-bit/tests/internal/data/input_chunk/out/a_thousand_plus_one_bytes.out... failed
[2023/07/28 00:03:09] [error] [~/GitHub/fluent-bit/tests/internal/input_chunk.c:56 errno=0] Success
```

After splitting the storage.path per test case, this error won't happen.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
