### PR TITLE
workflows: windows: Use vcpkg to install dependencies

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -73,19 +73,16 @@ jobs:
           - name: "Windows 32bit"
             arch: x86
             openssl_dir: C:\vcpkg\packages\openssl_x86-windows-static
-            chocolatey_opt: --x86
             cmake_additional_opt: ""
             vcpkg_triplet: x86-windows-static
           - name: "Windows 64bit"
             arch: x64
-            openssl_dir: C:\Program Files\OpenSSL-Win64
-            chocolatey_opt: --x64
+            openssl_dir: C:\vcpkg\packages\openssl_x64-windows-static
             cmake_additional_opt: ""
             vcpkg_triplet: x64-windows-static
           - name: "Windows 64bit (Arm64)"
             arch: amd64_arm64
             openssl_dir: C:\vcpkg\packages\openssl_arm64-windows-static
-            chocolatey_opt: ""
             cmake_additional_opt: "-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64"
             vcpkg_triplet: arm64-windows-static
     permissions:
@@ -110,19 +107,12 @@ jobs:
           WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
         shell: pwsh
 
-      - name: Get dependencies w/ chocolatey
-        if: ${{ matrix.config.arch == 'x64' }}
-        uses: crazy-max/ghaction-chocolatey@v2
-        with:
-          args: install ${{ matrix.config.chocolatey_opt }} openssl -y
-
       - name: Set up with Developer Command Prompt for Microsoft Visual C++
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.config.arch }}
 
       - name: Build openssl with vcpkg
-        if: ${{ matrix.config.arch != 'x64' }}
         run: |
           C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Recently, I migrated to use vcpkg to install OpenSSL in Windows 32bit.
Also, I migrate to use vcpkg for same operations in Windows 64bit.

GitHub Actions result is: https://github.com/fluent/fluent-bit/actions/runs/5688172289

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
