### PR TITLE
workflows: disable provenance for legacy format images

### DIFF
--- a/.github/workflows/build-legacy-branch.yaml
+++ b/.github/workflows/build-legacy-branch.yaml
@@ -86,6 +86,7 @@ jobs:
           context: .
           tags: ${{ steps.debug-meta.outputs.tags }}
           labels: ${{ steps.debug-meta.outputs.labels }}
+          provenance: false
           platforms: linux/amd64
           push: true
           load: false
@@ -108,6 +109,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/${{ matrix.arch }}
+          provenance: false
           push: true
           load: false
           build-args: |

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -122,6 +122,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64, linux/arm64, linux/arm/v7
           target: production
+          # Must be disabled to provide legacy format images from the registry
+          provenance: false
           push: true
           load: false
           build-args: |
@@ -146,6 +148,8 @@ jobs:
           tags: ${{ steps.debug-meta.outputs.tags }}
           labels: ${{ steps.debug-meta.outputs.labels }}
           platforms: linux/amd64, linux/arm64, linux/arm/v7
+          # Must be disabled to provide legacy format images from the registry
+          provenance: false
           target: debug
           push: true
           load: false
@@ -285,7 +289,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        windows-base-version: 
+        windows-base-version:
           - '2019'
           - '2022'
     permissions:
@@ -308,7 +312,7 @@ jobs:
         run: |
           docker build -t ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-${{ inputs.version }} --build-arg FLB_NIGHTLY_BUILD=${{ inputs.unstable }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/Dockerfile.windows .
           docker push ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-${{ inputs.version }}
-        
+
         # We cannot use this action as it requires privileged mode
         # uses: docker/build-push-action@v4
         # with:

--- a/.github/workflows/call-integration-image-build.yaml
+++ b/.github/workflows/call-integration-image-build.yaml
@@ -70,6 +70,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           target: production
+          provenance: false
           push: true
           load: false
 
@@ -103,6 +104,7 @@ jobs:
           context: .
           tags: ${{ steps.meta-debug.outputs.tags }}
           labels: ${{ steps.meta-debug.outputs.labels }}
+          provenance: false
           target: debug
           platforms: linux/amd64
           push: true

--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -29,3 +29,4 @@ jobs:
         # No need to use after this so discard completely
         push: false
         load: false
+        provenance: false

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -33,7 +33,7 @@ jobs:
             images: ${{ github.repository }}/pr-${{ github.event.pull_request.number }}
             tags: |
               type=sha
-    
+
         - name: Build the multi-arch images
           id: build
           uses: docker/build-push-action@v4
@@ -42,6 +42,7 @@ jobs:
             context: .
             platforms: linux/amd64
             target: production
+            provenance: false
             push: false
             load: true
             tags: ${{ steps.meta.outputs.tags }}
@@ -52,7 +53,7 @@ jobs:
           run: |
             docker run --rm -t ${{ steps.meta.outputs.tags }} --help
           shell: bash
-        
+
         - name: Build the debug multi-arch images
           uses: docker/build-push-action@v4
           with:
@@ -60,6 +61,7 @@ jobs:
             context: .
             platforms: linux/amd64
             target: debug
+            provenance: false
             push: false
             load: false
 
@@ -86,7 +88,7 @@ jobs:
       strategy:
         fail-fast: true
         matrix:
-          windows-base-version: 
+          windows-base-version:
             # https://github.com/fluent/fluent-bit/blob/1d366594a889624ec3003819fe18588aac3f17cd/dockerfiles/Dockerfile.windows#L3
             - '2019'
             - '2022'
@@ -105,7 +107,7 @@ jobs:
               type=sha
             flavor: |
               suffix=-windows-${{ matrix.windows-base-version }}
-    
+
         - name: Build the windows images
           id: build
           run: |


### PR DESCRIPTION
Resolves #7748 by ensuring the registry will provide images in a legacy and non-OCI format, i.e. Docker v1 & v2.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205158744450533