### PR TITLE
config_format: fix possible heap overflow

### DIFF
--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -420,6 +420,9 @@ struct flb_kv *flb_cf_meta_property_add(struct flb_cf *cf, char *meta, int len)
 
     p = meta;
     tmp = strchr(p, ' ');
+    if (tmp == NULL) {
+        return NULL;
+    }
     xlen = (tmp - p);
 
     /* create k/v pair */


### PR DESCRIPTION
The return value of `strchr` is not checked for failure. If it's failure then `tmp` will be `0` in the `(tmp-p)` calculation, causing `xlen` to be `p`. `xlen` is later  used for copying memory by way of `memcpy` in string creation using `flb_sds_create_len`. This fixes it.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
