### PR TITLE
upstream: Remove unused variables

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1031,7 +1031,6 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
     int new_chunk = FLB_FALSE;
     size_t out_size;
     struct flb_input_chunk *ic = NULL;
-    size_t expected_chunk_size;
 
     if (tag_len > FLB_INPUT_CHUNK_TAG_MAX) {
         flb_plg_warn(in,

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -442,10 +442,6 @@ struct flb_upstream *flb_upstream_create_url(struct flb_config *config,
  */
 static void shutdown_connection(struct flb_connection *u_conn)
 {
-    struct flb_upstream *u;
-
-    u = u_conn->upstream;
-
     if (u_conn->fd > 0 &&
         !u_conn->shutdown_flag) {
         shutdown(u_conn->fd, SHUT_RDWR);

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -262,7 +262,6 @@ void not_current_dir_files()
 /* data/config_format/nolimitline.conf */
 void test_nolimit_line()
 {
-    struct mk_list *head;
     struct flb_cf *cf;
     struct flb_cf_section *s;
     struct cfl_list *p_head;


### PR DESCRIPTION
This patch is to address following warinngs.

tests/internal/config_format_fluentbit.c:
```
[ 95%] Building C object tests/internal/CMakeFiles/flb-it-config_format_fluentbit.dir/config_format_fluentbit.c.o
/home/taka/git/fluent-bit/tests/internal/config_format_fluentbit.c: In function ‘test_nolimit_line’:
/home/taka/git/fluent-bit/tests/internal/config_format_fluentbit.c:265:21: warning: unused variable ‘head’ [-Wunused-variable]
  265 |     struct mk_list *head;
      |                     ^~~~
```

flb_upstream.c:
```
[ 70%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_upstream.c.o
/home/taka/git/fluent-bit/src/flb_upstream.c: In function ‘shutdown_connection’:
/home/taka/git/fluent-bit/src/flb_upstream.c:445:26: warning: variable ‘u’ set but not used [-Wunused-but-set-variable]
  445 |     struct flb_upstream *u;
      |                          ^
```

input_chunk.c:
```
[ 68%] Building C object src/CMakeFiles/fluent-bit-shared.dir/flb_input_chunk.c.o
/home/taka/git/fluent-bit/src/flb_input_chunk.c: In function ‘input_chunk_get’:
/home/taka/git/fluent-bit/src/flb_input_chunk.c:1034:12: warning: unused variable ‘expected_chunk_size’ [-Wunused-variable]
 1034 |     size_t expected_chunk_size;
      |            ^~~~~~~~~~~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
