### PR TITLE
workflows: windows: Implement cache mechanism for source packages of vcpkg

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -117,6 +117,13 @@ jobs:
         with:
           args: install gzip -y
 
+      # http://man7.org/linux/man-pages/man1/date.1.html
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Restore cached packages of vcpkg
         id: cache-vcpkg-sources
         uses: actions/cache/restore@v3
@@ -142,7 +149,7 @@ jobs:
         with:
           path: |
             C:\vcpkg\packages
-          key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
+          key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}-${{ steps.get-date.outputs.date }}
           enableCrossOsArchive: false
 
       - name: Build Fluent Bit packages

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -119,6 +119,7 @@ jobs:
           path: |
             C:\vcpkg\packages
           key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg
+          enableCrossOsArchive: false
 
       - name: Build openssl with vcpkg
         run: |
@@ -137,6 +138,7 @@ jobs:
           path: |
             C:\vcpkg\packages
           key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
+          enableCrossOsArchive: false
 
       - name: Build Fluent Bit packages
         # If we are using 2.0.* or earlier we need to exclude the ARM64 build as the dependencies fail to compile.

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -112,6 +112,11 @@ jobs:
         with:
           arch: ${{ matrix.config.arch }}
 
+      - name: Get gzip command w/ chocolatey
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: install gzip -y
+
       - name: Restore cached packages of vcpkg
         id: cache-vcpkg-sources
         uses: actions/cache/restore@v3

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -112,6 +112,14 @@ jobs:
         with:
           arch: ${{ matrix.config.arch }}
 
+      - name: Restore cached packages of vcpkg
+        id: cache-vcpkg-sources
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            C:\vcpkg\packages
+          key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg
+
       - name: Build openssl with vcpkg
         run: |
           C:\vcpkg\vcpkg install --recurse openssl --triplet ${{ matrix.config.vcpkg_triplet }}
@@ -121,6 +129,14 @@ jobs:
         run: |
           C:\vcpkg\vcpkg install --recurse libyaml --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
+
+      - name: Save packages of vcpkg
+        id: save-vcpkg-sources
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            C:\vcpkg\packages
+          key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
 
       - name: Build Fluent Bit packages
         # If we are using 2.0.* or earlier we need to exclude the ARM64 build as the dependencies fail to compile.


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, nasm.us is occasionally down.
To improve our CI stability, we have to implement caching mechanism for source packages to stabilize vcpkg installations.

CI result is here: https://github.com/fluent/fluent-bit/actions/runs/5710860698

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
