### PR TITLE
aws: macos: prevent buffer overflow on address sanitier

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -908,8 +908,8 @@ flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
     flb_sds_destroy(tmp);
     tmp = NULL;
 
-    /* A string no longer than S3_KEY_SIZE is created to store the formatted timestamp. */
-    key = flb_calloc(1, S3_KEY_SIZE * sizeof(char));
+    /* A string no longer than S3_KEY_SIZE + 1 is created to store the formatted timestamp. */
+    key = flb_calloc(1, (S3_KEY_SIZE + 1) * sizeof(char));
     if (!key) {
         goto error;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This issue is reported by addrress sanitizer on macOS.
On Linux, this isue won't be happened.
```
Test flb_get_s3_key_invalid_key_length...       [2023/07/31 17:50:07] [ warn] [s3_key] Object key length is longer than the 1024 character limit.
=================================================================
==67093==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x000109409580 at pc 0x000106924088 bp 0x00016b48e020 sp 0x00016b48d7e0
READ of size 1025 at 0x000109409580 thread T0
    #0 0x106924084 in wrap_strlen+0x164 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x18084) (BuildId: f0a7ac5c49bc3abc851181b6f92b308a32000000200000000100000000000b00)
    #1 0x1049899b0 in flb_get_s3_key flb_aws_util.c:923
    #2 0x10497fa18 in test_flb_get_s3_key_invalid_key_length aws_util.c:278
    #3 0x10497cbe8 in acutest_do_run_ acutest.h:1034
    #4 0x10497ab90 in acutest_run_ acutest.h:1130
    #5 0x1049779c8 in main acutest.h:1769
    #6 0x188db7f24  (<unknown module>)

0x000109409580 is located 0 bytes to the right of 1024-byte region [0x000109409180,0x000109409580)
allocated by thread T0 here:
    #0 0x10694f234 in wrap_calloc+0x9c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x43234) (BuildId: f0a7ac5c49bc3abc851181b6f92b308a32000000200000000100000000000b00)
    #1 0x104987270 in flb_calloc flb_mem.h:95
    #2 0x10498991c in flb_get_s3_key flb_aws_util.c:912
    #3 0x10497fa18 in test_flb_get_s3_key_invalid_key_length aws_util.c:278
    #4 0x10497cbe8 in acutest_do_run_ acutest.h:1034
    #5 0x10497ab90 in acutest_run_ acutest.h:1130
    #6 0x1049779c8 in main acutest.h:1769
    #7 0x188db7f24  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x18084) (BuildId: f0a7ac5c49bc3abc851181b6f92b308a32000000200000000100000000000b00) in wrap_strlen+0x164
Shadow bytes around the buggy address:
  0x0070212a1260: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070212a1270: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070212a1280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070212a1290: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0070212a12a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0070212a12b0:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070212a12c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0070212a12d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0070212a12e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0070212a12f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0070212a1300: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==67093==ABORTING
  Test interrupted by SIGABRT.
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
