### PR TITLE
http-client: fix heap overflow caused by large URLs.

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -26,6 +26,7 @@
 
 /* Buffer size */
 #define FLB_HTTP_BUF_SIZE        2048
+#define FLB_HTTP_BUF_MAX         8192
 #define FLB_HTTP_DATA_SIZE_MAX   4096
 #define FLB_HTTP_DATA_CHUNK     32768
 


### PR DESCRIPTION
The function flb_http_client allocates a buffer for the method, URL and headers and uses snprintf to expand the first line of the http request. When it does so it uses the ret value from snprintf as the header_len for the length of the used buffer, but snprintf returns the size it wants to create the entire string not how long the string it writes is. This can lead to a heap overflow when adding headers.

This PR fixes that by running snprintf initially without a buffer to calculate how large a buffer we actually need.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
