### PR TITLE
workflow: windows: Make more rigid handling for caches

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -151,7 +151,7 @@ jobs:
         with:
           path: |
             C:\vcpkg\packages
-          key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}-${{ steps.get-date.outputs.date }}
+          key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
           enableCrossOsArchive: false
 
       - name: Build Fluent Bit packages

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -130,7 +130,9 @@ jobs:
         with:
           path: |
             C:\vcpkg\packages
-          key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg
+          key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-
           enableCrossOsArchive: false
 
       - name: Build openssl with vcpkg


### PR DESCRIPTION
<!-- Provide summary of changes -->

The previous PR #7773 might not handle restoring caches for vcpkgs correctly.
Adding `restore-keys` should handle to restore the caches of vcpkg.
It behaves for the searching prefix for specifying which is the most appropriate cache.

CI result is here:

* Restoring: https://github.com/fluent/fluent-bit/actions/runs/5734470706/job/15540703740#step:7:62
* Saving: https://github.com/fluent/fluent-bit/actions/runs/5734470706/job/15540703740#step:10:54 (already existed
 another cache which already had been created with the same key)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
