### PR TITLE
config: throw an error if a configuration property is not applied.

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -781,7 +781,9 @@ static int configure_plugins_type(struct flb_config *config, struct flb_cf *cf, 
                 continue;
             }
 
-            // mark as error by default.
+            /* set ret to -1 to ensure that we treat any unhandled plugin or
+             * value types as errors.
+             */
             ret = -1;
 
             if (type == FLB_CF_CUSTOM) {

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -781,6 +781,9 @@ static int configure_plugins_type(struct flb_config *config, struct flb_cf *cf, 
                 continue;
             }
 
+            // mark as error by default.
+            ret = -1;
+
             if (type == FLB_CF_CUSTOM) {
                 if (kv->val->type == CFL_VARIANT_STRING) {
                     ret = flb_custom_set_property(ins, kv->key, kv->val->data.as_string);


### PR DESCRIPTION
# Summary

Add a one-liner so if for some reason a property is not properly checked or applied an error is raised nonetheless.

With this configuration:
```yaml
---
pipeline:
  inputs:
    - name: dummy
      dummy:
        message: '{"message: "my custom dummy"}'
  outputs:
    - name: stdout
      match: "*"
      format: json_lines
```

Without this change the fact that `dummy` is set as a key/value map is silently ignored, even though it is set as a string in the dummy plugin `config_map`. This change does not check the types but at least it does raise an error when the type is ignored, ie:

```shell
./bin/fluent-bit -c bad-dummy.yml
Fluent Bit v2.1.8
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/08/02 15:44:22] [error] [config] could not configure property 'dummy' on input plugin with section name 'dummy'
[2023/08/02 15:44:22] [ info] [fluent bit] version=2.1.8, commit=1d83649441, pid=766101
[2023/08/02 15:44:22] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/02 15:44:22] [ info] [cmetrics] version=0.6.3
[2023/08/02 15:44:22] [ info] [ctraces ] version=0.3.1
[2023/08/02 15:44:22] [ info] [input:dummy:dummy.0] initializing
[2023/08/02 15:44:22] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/08/02 15:44:22] [ info] [sp] stream processor started
[2023/08/02 15:44:22] [ info] [output:stdout:stdout.0] worker #0 started
{"date":1691005462.537879,"message":"dummy"}
{"date":1691005463.537903,"message":"dummy"}
^C[2023/08/02 15:44:24] [engine] caught signal (SIGINT)
[2023/08/02 15:44:24] [ warn] [engine] service will shutdown in max 5 seconds
[2023/08/02 15:44:24] [ info] [input] pausing dummy.0
{"date":1691005464.537889,"message":"dummy"}
[2023/08/02 15:44:25] [ info] [engine] service has stopped (0 pending tasks)
[2023/08/02 15:44:25] [ info] [input] pausing dummy.0
[2023/08/02 15:44:25] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/08/02 15:44:25] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

This is the error that is reported in this case:

**[2023/08/02 15:44:22] [error] [config] could not configure property 'dummy' on input plugin with section name 'dummy'**

Fluent-bit continues on, but this is the default behaviour for any and all invalid properties.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205198055022929