### PR TITLE
output: concurrent coroutine limit implementation

### DIFF
--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -43,4 +43,8 @@ void flb_engine_evl_init();
 struct mk_event_loop *flb_engine_evl_get();
 void flb_engine_evl_set(struct mk_event_loop *evl);
 
+void flb_engine_scheduled_flush_list_init();
+struct mk_list *flb_engine_scheduled_flush_list_get();
+void flb_engine_scheduled_flush_list_set(struct mk_list *list);
+
 #endif

--- a/include/fluent-bit/flb_engine_macros.h
+++ b/include/fluent-bit/flb_engine_macros.h
@@ -36,6 +36,7 @@
 #define FLB_ENGINE_EV_OUTPUT        32768
 #define FLB_ENGINE_EV_THREAD_OUTPUT 65536
 #define FLB_ENGINE_EV_THREAD_ENGINE 131072
+#define FLB_ENGINE_EV_THREAD_WAKEUP 262144
 
 /* Engine events: all engine events set the left 32 bits to '1' */
 #define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */

--- a/include/fluent-bit/flb_output_thread.h
+++ b/include/fluent-bit/flb_output_thread.h
@@ -60,9 +60,10 @@ struct flb_out_thread_upstream {
 struct flb_out_thread_instance {
     struct mk_event event;               /* event context to associate events */
     struct mk_event_loop *evl;           /* thread event loop context */
-    struct flb_bucket_queue *evl_bktq;    /* bucket queue for evl track event priority */
+    struct flb_bucket_queue *evl_bktq;   /* bucket queue for evl track event priority */
     flb_pipefd_t ch_parent_events[2];    /* channel to receive parent notifications */
     flb_pipefd_t ch_thread_events[2];    /* channel to send messages local event loop */
+    flb_pipefd_t ch_coroutine_events[2]; /* channel to schedule delayed flush coroutines */
     struct flb_output_instance *ins;     /* output plugin instance */
     struct flb_config *config;
     struct flb_tp_thread *th;

--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -120,4 +120,7 @@ void flb_upstream_set_busy_connections_gauge(
         struct flb_upstream *stream,
         struct cmt_gauge *gauge_instance);
 
+int flb_upstream_acquire_lock(struct flb_upstream *stream, int wait_flag);
+int flb_upstream_release_lock(struct flb_upstream *stream);
+
 #endif

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -257,10 +257,17 @@ int flb_engine_dispatch(uint64_t id, struct flb_input_instance *in,
     struct flb_input_plugin *p;
     struct flb_input_chunk *ic;
     struct flb_task *task = NULL;
+    struct flb_output_instance *o_ins;
 
     p = in->p;
     if (!p) {
         return 0;
+    }
+
+    mk_list_foreach(head, &config->outputs) {
+        o_ins = mk_list_entry(head, struct flb_output_instance, _head);
+
+        flb_output_schedule_delayed_flush_coroutines(o_ins, FLB_TRUE);
     }
 
     /* Look for chunks ready to go */


### PR DESCRIPTION
This PR adds a mechanism to control how many flush coroutines can be executed concurrently in each output plugin.

In order to achieve this, we added a lock to the output plugin instance structure and a check that's executed by the flush prolog (`output_pre_cb_flush`). 

The main idea is that before executing the actual flush callback `output_pre_cb_flush checks` ensures that the concurrency limit has not been exceeded and if it has, it yields and waits to be awakened to try again.

Delayed flushes are gradually resumed both when active flushes return and when the flush timer ticks.

Note about connection limits :

This PR modifies the behavior of `net.max_worker_connections` in these ways :

1. Transforming it into a flag that enables idle keepalive connection sharing between worker threads.
2. Using it to enable and automatically set `concurrent_flush_limit` to a value that ensures that the limit won't be exceeded.
