### PR TITLE
fleet: correctly register fleet agent.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -264,7 +264,7 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
 
             label = flb_sds_create_size(strlen(key->str) + strlen(val->str) + 1);
 
-            if(!label) {
+            if (!label) {
                 flb_free(ctx);
                 return NULL;
             }
@@ -307,6 +307,20 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
     }
     else {
         flb_output_set_property(cloud, "tls.verify", "false");
+    }
+
+    if (ctx->fleet_id) {
+        flb_output_set_property(cloud, "fleet_id", ctx->fleet_id);
+        label = flb_sds_create_size(strlen("fleet_id") + strlen(ctx->fleet_id) + 1);
+
+        if (!label) {
+            flb_free(ctx);
+            return NULL;
+        }
+
+        flb_sds_printf(&label, "fleet_id %s", ctx->fleet_id);
+        flb_output_set_property(cloud, "add_label", label);
+        flb_sds_destroy(label);
     }
 
 #ifdef FLB_HAVE_CHUNK_TRACE


### PR DESCRIPTION
# Summary

This PR passes the `fleet_id` parameter to the calyptia output plugin when joining a fleet so it can be correctly registered as an agent.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
