### PR TITLE
filter_lua: support nil_str to replace null value by nil_str string

### DIFF
--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -44,14 +44,15 @@ struct flb_lua_l2c_type {
 
 struct flb_lua_l2c_config {
     int    l2c_types_num;      /* number of l2c_types */
+    flb_sds_t l2c_nil_str;     /* string to represent nil value */
     struct mk_list l2c_types;  /* data types (lua -> C) */
 };
 
 int flb_lua_arraylength(lua_State *l);
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm);
 int flb_lua_is_valid_func(lua_State *l, flb_sds_t func);
-int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader);
-void flb_lua_pushmsgpack(lua_State *l, msgpack_object *o);
+int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader, flb_sds_t nil_str);
+void flb_lua_pushmsgpack(lua_State *l, msgpack_object *o, flb_sds_t nil_str);
 void flb_lua_tomsgpack(lua_State *l,
                        msgpack_packer *pck,
                        int index,

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -503,7 +503,7 @@ static int cb_lua_filter(const void *data, size_t bytes,
             lua_pushnumber(ctx->lua->state, ts);
         }
 
-        flb_lua_pushmsgpack(ctx->lua->state, log_event.body);
+        flb_lua_pushmsgpack(ctx->lua->state, log_event.body, ctx->l2cc.l2c_nil_str);
         if (ctx->protected_mode) {
             ret = lua_pcall(ctx->lua->state, 3, 3, 0);
             if (ret != 0) {
@@ -670,6 +670,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "If these keys are matched, the fields are converted to array. "
      "If more than one key, delimit by space."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "nil_str", NULL,
+     0, FLB_TRUE, offsetof(struct lua_filter, nil_str),
+     "If set, nil value will be replaced by this string in Lua. "
+     "It is to prevent remove nil value from record "
+     "since nil value is to delete key/value from associative array in Lua."
     },
     {
      FLB_CONFIG_MAP_BOOL, "protected_mode", "true",

--- a/plugins/filter_lua/lua_config.c
+++ b/plugins/filter_lua/lua_config.c
@@ -127,6 +127,12 @@ struct lua_filter *lua_config_create(struct flb_filter_instance *ins,
     }
 
     lf->l2cc.l2c_types_num = 0;
+    if (lf->nil_str) {
+        lf->l2cc.l2c_nil_str = flb_sds_create(lf->nil_str);
+    }
+    else {
+        lf->l2cc.l2c_nil_str = NULL;
+    }
     tmp = flb_filter_get_property("type_int_key", ins);
     if (tmp) {
         split = flb_utils_split(tmp, ' ', FLB_LUA_L2C_TYPES_NUM_MAX);
@@ -188,6 +194,9 @@ void lua_config_destroy(struct lua_filter *lf)
 
     if (lf->buffer) {
         flb_sds_destroy(lf->buffer);
+    }
+    if (lf->l2cc.l2c_nil_str) {
+        flb_sds_destroy(lf->l2cc.l2c_nil_str);
     }
 
     mk_list_foreach_safe(head, tmp_list, &lf->l2cc.l2c_types) {

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -33,6 +33,7 @@ struct lua_filter {
     flb_sds_t script;                 /* lua script path */
     flb_sds_t call;                   /* function name   */
     flb_sds_t buffer;                 /* json dec buffer */
+    flb_sds_t nil_str;                /* The string to represent nil value in Lua */
     int    protected_mode;            /* exec lua function in protected mode */
     int    time_as_table;             /* timestamp as a Lua table */
     struct flb_lua_l2c_config l2cc;   /* lua -> C config */

--- a/tests/internal/lua.c
+++ b/tests/internal/lua.c
@@ -112,7 +112,7 @@ static void test_pushmsgpack()
 
     msgpack_unpacked_init(&msg);
     msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL);
-    flb_lua_pushmsgpack(l, &msg.data);
+    flb_lua_pushmsgpack(l, &msg.data, NULL);
     check_equals(l, "{ [1] = { [key] = value } [2] = msgpack-str [3] = 4 }");
 
     msgpack_unpacked_destroy(&msg);
@@ -137,7 +137,7 @@ static void test_pushmpack()
     msgpack_pack_int(&pck, 4);
 
     mpack_reader_init_data(&reader, sbuf.data, sbuf.size);
-    flb_lua_pushmpack(l, &reader);
+    flb_lua_pushmpack(l, &reader, NULL);
     check_equals(l, "{ [1] = { [key] = value } [2] = msgpack-str [3] = 4 }");
 
     msgpack_sbuffer_destroy(&sbuf);
@@ -158,6 +158,7 @@ static void test_tomsgpack()
     msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
     mk_list_init(&l2cc.l2c_types);
     l2cc.l2c_types_num = 0;
+    l2cc.l2c_nil_str = NULL;
 
     lua_getglobal(l, "obj");
     flb_lua_tomsgpack(l, &pck, 0, &l2cc);
@@ -188,6 +189,7 @@ static void test_tompack()
     mpack_writer_init(&writer, buf, sizeof(buf));
     mk_list_init(&l2cc.l2c_types);
     l2cc.l2c_types_num = 0;
+    l2cc.l2c_nil_str = NULL;
 
     lua_getglobal(l, "obj");
     flb_lua_tompack(l, &writer, 0, &l2cc);

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -753,12 +753,85 @@ void flb_test_split_record(void)
     flb_sds_destroy(outbuf);
 }
 
+/* https://github.com/fluent/fluent-bit/issues/7708 */
+void flb_test_nil_str(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *output = NULL;
+    char *input = "[0, {\"key\":\"val\", \"nil_key\":null}]";
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    new_record = record\n"
+      "    return 1, timestamp, new_record\n"
+      "end\n";
+
+    clear_output();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "nil_str", "nil",
+                         "script", TMP_LUA_PATH,
+                         NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret==0);
+
+    flb_lib_push(ctx, in_ffd, input, strlen(input));
+    wait_with_timeout(2000, &output);
+    result = strstr(output, "\"nil_key\":null");
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    /* clean up */
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 TEST_LIST = {
     {"hello_world",  flb_test_helloworld},
     {"append_tag",   flb_test_append_tag},
     {"type_int_key", flb_test_type_int_key},
     {"type_int_key_multi", flb_test_type_int_key_multi},
     {"type_array_key", flb_test_type_array_key},
+    {"nil_str", flb_test_nil_str},
     {"array_contains_null", flb_test_array_contains_null},
     {"drop_all_records", flb_test_drop_all_records},
     {"split_record", flb_test_split_record},


### PR DESCRIPTION
#7708 
In Lua, nil value is a special value to delete key/value pair from associative array.
https://www.lua.org/pil/2.5.html
```
you can assign nil to a table field to delete it.
```
It means the key/value will be removed from record if its value is null.
e.g. If record is `{"aaa":null, "bbb":"cccc"}` ,`"aaa":null` will be removed in Lua.

This patch is to add `nil_str` property to prevent it.
Default value is NULL to keep backward compatibility. 
|Value |Description|Default|
|--|--|--|
|`nil_str`|If set, nil value will be replaced by this string in Lua. It is to prevent remove nil value from record since nil value is to delete key/value from associative array in Lua.|NULL|

1. null value is replaced by `nil_str` if set when record is converted from msgpack to Lua value.
2. The string is replaced by null value if the string is `nil_str` when record is converted from Lua value to msgpack.
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```lua
[INPUT]
    Name dummy
    Dummy {"aaa":null, "bbb":"cccc"}

[FILTER]
    Name    Lua
    Match   *
    call    append_tag
    code    function append_tag(tag, timestamp, record) new_record = record new_record["extra"] = {} return 1, timestamp, new_record end
    Nil_Str nil

[OUTPUT]
    Name            stdout
    Match           *
    format          json_lines

```

## Debug/Valgrind output
`"aaa":null` is not removed by `nil_str`.
```
$ valgrind --leak-check=full bin/fluent-bit -c ~/git/fluentbit-issue-conf/7708/a.conf 
==73292== Memcheck, a memory error detector
==73292== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==73292== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==73292== Command: bin/fluent-bit -c /home/taka/git/fluentbit-issue-conf/7708/a.conf
==73292== 
Fluent Bit v2.1.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/08/06 13:25:51] [ info] [fluent bit] version=2.1.9, commit=5686334b56, pid=73292
[2023/08/06 13:25:51] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/06 13:25:51] [ info] [cmetrics] version=0.6.3
[2023/08/06 13:25:51] [ info] [ctraces ] version=0.3.1
[2023/08/06 13:25:51] [ info] [input:dummy:dummy.0] initializing
[2023/08/06 13:25:51] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/08/06 13:25:51] [ info] [output:stdout:stdout.0] worker #0 started
[2023/08/06 13:25:51] [ info] [sp] stream processor started
{"date":1691295951.670228,"bbb":"cccc","extra":{},"aaa":null}
{"date":1691295952.684662,"bbb":"cccc","extra":{},"aaa":null}
^C[2023/08/06 13:25:53] [engine] caught signal (SIGINT)
{"date":1691295953.647959,"bbb":"cccc","extra":{},"aaa":null}
[2023/08/06 13:25:53] [ warn] [engine] service will shutdown in max 5 seconds
[2023/08/06 13:25:53] [ info] [input] pausing dummy.0
[2023/08/06 13:25:54] [ info] [engine] service has stopped (0 pending tasks)
[2023/08/06 13:25:54] [ info] [input] pausing dummy.0
[2023/08/06 13:25:54] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/08/06 13:25:54] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==73292== 
==73292== HEAP SUMMARY:
==73292==     in use at exit: 0 bytes in 0 blocks
==73292==   total heap usage: 1,841 allocs, 1,841 frees, 1,636,032 bytes allocated
==73292== 
==73292== All heap blocks were freed -- no leaks are possible
==73292== 
==73292== For lists of detected and suppressed errors, rerun with: -s
==73292== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
