### PR TITLE
out_kinesis_streams: remove dead stores

### DIFF
--- a/plugins/out_kinesis_streams/kinesis_api.c
+++ b/plugins/out_kinesis_streams/kinesis_api.c
@@ -309,8 +309,6 @@ static int process_event(struct flb_kinesis *ctx, struct flush *buf,
             time_key_ptr += strlen(ctx->time_key);
             memcpy(time_key_ptr, "\":\"", 3);
             time_key_ptr += 3;
-            tmp_size = buf->tmp_buf_size - buf->tmp_buf_offset;
-            tmp_size -= (time_key_ptr - tmp_buf_ptr);
 
             /* merge out_buf to time_key_ptr */
             memcpy(time_key_ptr, out_buf, len);


### PR DESCRIPTION
`tmp_size` is assigned twice where each of the assignments are not used.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
