### PR TITLE
emitter_create: exit and destroy instance on fail

### DIFF
--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -97,6 +97,8 @@ static int emitter_create(struct ml_ctx *ctx)
     if (ret == -1) {
         flb_plg_error(ctx->ins, "cannot initialize storage for stream '%s'",
                       ctx->emitter_name);
+        flb_input_instance_exit(ins, ctx->config);
+        flb_input_instance_destroy(ins);
         return -1;
     }
     ctx->ins_emitter = ins;

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -97,6 +97,8 @@ static int emitter_create(struct flb_rewrite_tag *ctx)
     if (ret == -1) {
         flb_plg_error(ctx->ins, "cannot initialize storage for stream '%s'",
                       ctx->emitter_name);
+        flb_input_instance_exit(ins, ctx->config);
+        flb_input_instance_destroy(ins);
         return -1;
     }
     ctx->ins_emitter = ins;


### PR DESCRIPTION
Minor bugfix/cleanup

Noticing that [the input instance is destroyed here on fail](https://github.com/fluent/fluent-bit/blob/5686334b56ee9d92f0654b0a621113943b175b94/plugins/filter_rewrite_tag/rewrite_tag.c#L81) but not [here, later in the code](https://github.com/fluent/fluent-bit/blob/5686334b56ee9d92f0654b0a621113943b175b94/plugins/filter_rewrite_tag/rewrite_tag.c#L100), I spoke with @leonardo-albertovich.

There is a [global teardown for input instances](https://github.com/fluent/fluent-bit/blob/5686334b56ee9d92f0654b0a621113943b175b94/src/flb_engine.c#L1086), but regardless this cleanup should happen on exit as a best practice and in case that behavior changes. Also, "filters included in the processor stack unlink themselves from the global list" so would may not be cleaned up in the global shutdown.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ N/A ] Documentation required for this feature

**Backporting**
- [ N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
