### PR TITLE
input: send resume signal to the input thread event loop if plugin is threaded

### DIFF
--- a/include/fluent-bit/flb_input_thread.h
+++ b/include/fluent-bit/flb_input_thread.h
@@ -93,6 +93,7 @@ int flb_input_thread_instance_init(struct flb_config *config,
 int flb_input_thread_instance_pre_run(struct flb_config *config, struct flb_input_instance *ins);
 
 int flb_input_thread_instance_pause(struct flb_input_instance *ins);
+int flb_input_thread_instance_resume(struct flb_input_instance *ins);
 int flb_input_thread_instance_exit(struct flb_input_instance *ins);
 
 int flb_input_thread_collectors_signal_start(struct flb_input_instance *ins);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1695,7 +1695,13 @@ int flb_input_pause(struct flb_input_instance *ins)
 int flb_input_resume(struct flb_input_instance *ins)
 {
     if (ins->p->cb_resume) {
-        ins->p->cb_resume(ins->context, ins->config);
+        if (flb_input_is_threaded(ins)) {
+            /* signal the thread event loop about the 'resume' operation */
+            flb_input_thread_instance_resume(ins);
+        }
+        else {
+            ins->p->cb_resume(ins->context, ins->config);
+        }
     }
 
     return 0;

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1185,7 +1185,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
         in->mem_buf_status == FLB_INPUT_PAUSED) {
         in->mem_buf_status = FLB_INPUT_RUNNING;
         if (in->p->cb_resume) {
-            in->p->cb_resume(in->context, in->config);
+            flb_input_resume(in);
             flb_info("[input] %s resume (mem buf overlimit)",
                       in->name);
         }
@@ -1196,7 +1196,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
         in->storage_buf_status == FLB_INPUT_PAUSED) {
         in->storage_buf_status = FLB_INPUT_RUNNING;
         if (in->p->cb_resume) {
-            in->p->cb_resume(in->context, in->config);
+            flb_input_resume(in);
             flb_info("[input] %s resume (storage buf overlimit %zu/%zu)",
                       in->name,
                       ((struct flb_storage_input *)in->storage)->cio->total_chunks_up,


### PR DESCRIPTION
Fixes #7071

I was getting the following error.
```
[2023/08/09 06:48:50] [ warn] [input] tail.0 paused (mem buf overlimit)
[2023/08/09 06:48:50] [ info] [input] tail.0 resume (mem buf overlimit)
[2023/08/09 06:48:50] [ warn] [input] tail.0 paused (mem buf overlimit)
[2023/08/09 06:48:50] [error] [input] cannot resume collector tail.0:2, already running
```

Log processing would start going to standstill once the "cannot resume collector" line was logged.
After looking at the code, I found a race condition around pause/resume.

flb_input_pause sends a signal to input thread event loop
https://github.com/fluent/fluent-bit/blob/v2.1.8/src/flb_input.c#L1673

flb_input_resume is done by the main thread instead of sending signal to input thread event loop
https://github.com/fluent/fluent-bit/blob/v2.1.8/src/flb_input.c#L1695

The fix is to have flb_input_resume also send signal to the input thread, so pause and resume don't happen out of order or stomp on each other.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
