### PR TITLE
in_tail: ingestion interruption fix

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1774,7 +1774,6 @@ static int check_purge_deleted_file(struct flb_tail_config *ctx,
                                     struct flb_tail_file *file, time_t ts)
 {
     int ret;
-    int64_t mtime;
     struct stat st;
 
     ret = fstat(file->fd, &st);
@@ -1796,18 +1795,6 @@ static int check_purge_deleted_file(struct flb_tail_config *ctx,
         /* Remove file from the monitored list */
         flb_tail_file_remove(file);
         return FLB_TRUE;
-    }
-
-    if (ctx->ignore_older > 0) {
-        mtime = flb_tail_stat_mtime(&st);
-        if (mtime > 0) {
-            if ((ts - ctx->ignore_older) > mtime) {
-                flb_plg_debug(ctx->ins, "purge: monitored file (ignore older): %s",
-                              file->name);
-                flb_tail_file_remove(file);
-                return FLB_TRUE;
-            }
-        }
     }
 
     return FLB_FALSE;


### PR DESCRIPTION
This PR addresses two individual issues : 

1. When `ignore_older` is set and a file that was deemed viable is being ingested (while no one is appending data to it) fluent-bit will drop the file as soon as the modification time exceeds the limit imposed by `ignore_older`.
2. When a file is being ingested in event mode yet it's not being written to, the ingestion rate is severely limited by the progress timer frequency.

It's important to keep in mind that point number one has been a long standing default behavior which means changing it could cause disruptions so please, request the change if we need to add a new option to opt-out of the old behavior.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205273257137240