### PR TITLE
in_windows_exporter_metrics: Implement WMI based memory and paging_file metrics

### DIFF
--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -15,6 +15,7 @@ set(src
   we_wmi_logon.c
   we_wmi_system.c
   we_wmi_service.c
+  we_wmi_memory.c
   )
 
 set(libs

--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -16,6 +16,7 @@ set(src
   we_wmi_system.c
   we_wmi_service.c
   we_wmi_memory.c
+  we_wmi_paging_file.c
   )
 
 set(libs

--- a/plugins/in_windows_exporter_metrics/we.c
+++ b/plugins/in_windows_exporter_metrics/we.c
@@ -41,6 +41,7 @@
 #include "we_wmi_system.h"
 #include "we_wmi_thermalzone.h"
 #include "we_wmi_service.h"
+#include "we_wmi_memory.h"
 
 static int we_timer_cpu_metrics_cb(struct flb_input_instance *ins,
                                    struct flb_config *config, void *in_context)
@@ -138,6 +139,16 @@ static int we_timer_wmi_service_metrics_cb(struct flb_input_instance *ins,
     struct flb_ne *ctx = in_context;
 
     we_wmi_service_update(ctx);
+
+    return 0;
+}
+
+static int we_timer_wmi_memory_metrics_cb(struct flb_input_instance *ins,
+                                      struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = in_context;
+
+    we_wmi_memory_update(ctx);
 
     return 0;
 }
@@ -264,6 +275,13 @@ static void we_wmi_service_update_cb(char *name, void *p1, void *p2)
     we_wmi_service_update(ctx);
 }
 
+static void we_wmi_memory_update_cb(char *name, void *p1, void *p2)
+{
+    struct flb_we *ctx = p1;
+
+    we_wmi_memory_update(ctx);
+}
+
 static int we_update_cb(struct flb_we *ctx, char *name)
 {
     int ret;
@@ -287,6 +305,7 @@ struct flb_we_callback ne_callbacks[] = {
     { "logon", we_wmi_logon_update_cb },
     { "system", we_wmi_system_update_cb },
     { "service", we_wmi_service_update_cb },
+    { "memory", we_wmi_memory_update_cb },
     { 0 }
 };
 
@@ -321,6 +340,7 @@ static int in_we_init(struct flb_input_instance *in,
     ctx->coll_wmi_logon_fd = -1;
     ctx->coll_wmi_system_fd = -1;
     ctx->coll_wmi_service_fd = -1;
+    ctx->coll_wmi_memory_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -625,6 +645,30 @@ static int in_we_init(struct flb_input_instance *in,
                         return -1;
                     }
                 }
+                else if (strncmp(entry->str, "memory", 6) == 0) {
+                    if (ctx->wmi_memory_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 10;
+                    } else {
+                        /* Create the memory collector */
+                        ret = flb_input_set_collector_time(in,
+                                                           we_timer_wmi_memory_metrics_cb,
+                                                           ctx->wmi_memory_scrape_interval, 0,
+                                                           config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set memory collector for Windows Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_wmi_memory_fd = ret;
+                    }
+
+                    /* Initialize memory metric collectors */
+                    ret = we_wmi_memory_init(ctx);
+                    if (ret) {
+                        return -1;
+                    }
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                     metric_idx = -1;
@@ -698,6 +742,9 @@ static int in_we_exit(void *data, struct flb_config *config)
                 else if (strncmp(entry->str, "service", 7) == 0) {
                     we_wmi_service_exit(ctx);
                 }
+                else if (strncmp(entry->str, "memory", 6) == 0) {
+                    we_wmi_memory_exit(ctx);
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                 }
@@ -737,6 +784,9 @@ static int in_we_exit(void *data, struct flb_config *config)
     }
     if (ctx->coll_wmi_service_fd != -1) {
         we_wmi_service_exit(ctx);
+    }
+    if (ctx->coll_wmi_memory_fd != -1) {
+        we_wmi_memory_exit(ctx);
     }
 
     flb_we_config_destroy(ctx);
@@ -781,6 +831,9 @@ static void in_we_pause(void *data, struct flb_config *config)
     if (ctx->coll_wmi_service_fd != -1) {
         flb_input_collector_pause(ctx->coll_wmi_service_fd, ctx->ins);
     }
+    if (ctx->coll_wmi_memory_fd != -1) {
+        flb_input_collector_pause(ctx->coll_wmi_memory_fd, ctx->ins);
+    }
 }
 
 static void in_we_resume(void *data, struct flb_config *config)
@@ -819,6 +872,9 @@ static void in_we_resume(void *data, struct flb_config *config)
     }
     if (ctx->coll_wmi_service_fd != -1) {
         flb_input_collector_resume(ctx->coll_wmi_service_fd, ctx->ins);
+    }
+    if (ctx->coll_wmi_memory_fd != -1) {
+        flb_input_collector_resume(ctx->coll_wmi_memory_fd, ctx->ins);
     }
 }
 
@@ -890,6 +946,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_we, wmi_service_scrape_interval),
      "scrape interval to collect service metrics from the node."
     },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.memory.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_we, wmi_memory_scrape_interval),
+     "scrape interval to collect memory metrics from the node."
+    },
+
     {
      FLB_CONFIG_MAP_CLIST, "metrics",
      "cpu,cpu_info,os,net,logical_disk,cs,thermalzone,logon,system,service",

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -154,6 +154,43 @@ struct we_wmi_service_counters {
     int operational;
 };
 
+struct we_wmi_memory_counters {
+    struct wmi_query_spec *info;
+    struct cmt_gauge      *available_bytes;
+    struct cmt_gauge      *cache_bytes;
+    struct cmt_gauge      *cache_bytes_peak;
+    struct cmt_gauge      *cache_faults_total;
+    struct cmt_gauge      *commit_limit;
+    struct cmt_gauge      *committed_bytes;
+    struct cmt_gauge      *demand_zero_faults_total;
+    struct cmt_gauge      *free_and_zero_page_list_bytes;
+    struct cmt_gauge      *free_system_page_table_entries;
+    struct cmt_gauge      *modified_page_list_bytes;
+    struct cmt_gauge      *page_faults_total;
+    struct cmt_gauge      *swap_page_reads_total;
+    struct cmt_gauge      *swap_pages_read_total;
+    struct cmt_gauge      *swap_pages_written_total;
+    struct cmt_gauge      *swap_page_operations_total;
+    struct cmt_gauge      *swap_page_writes_total;
+    struct cmt_gauge      *pool_nonpaged_allocs_total;
+    struct cmt_gauge      *pool_nonpaged_bytes;
+    struct cmt_gauge      *pool_paged_allocs_total;
+    struct cmt_gauge      *pool_paged_bytes;
+    struct cmt_gauge      *pool_paged_resident_bytes;
+    struct cmt_gauge      *standby_cache_core_bytes;
+    struct cmt_gauge      *standby_cache_normal_priority_bytes;
+    struct cmt_gauge      *standby_cache_reserve_bytes;
+    struct cmt_gauge      *system_cache_resident_bytes;
+    struct cmt_gauge      *system_code_resident_bytes;
+    struct cmt_gauge      *system_code_total_bytes;
+    struct cmt_gauge      *system_driver_resident_bytes;
+    struct cmt_gauge      *system_driver_total_bytes;
+    struct cmt_gauge      *transition_faults_total;
+    struct cmt_gauge      *transition_pages_repurposed_total;
+    struct cmt_gauge      *write_copies_total;
+    int                    operational;
+};
+
 struct we_os_counters {
     struct cmt_gauge *info;
     struct cmt_gauge *users;
@@ -220,6 +257,7 @@ struct flb_we {
     int wmi_logon_scrape_interval;
     int wmi_system_scrape_interval;
     int wmi_service_scrape_interval;
+    int wmi_memory_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_net_fd;                                    /* collector fd (net)  */
@@ -231,6 +269,7 @@ struct flb_we {
     int coll_wmi_logon_fd;                              /* collector fd (wmi_logon)    */
     int coll_wmi_system_fd;                             /* collector fd (wmi_system)    */
     int coll_wmi_service_fd;                            /* collector fd (wmi_service) */
+    int coll_wmi_memory_fd;                             /* collector fd (wmi_memory)    */
 
     /*
      * Metrics Contexts
@@ -247,6 +286,7 @@ struct flb_we {
     struct we_wmi_logon_counters *wmi_logon;
     struct we_wmi_system_counters *wmi_system;
     struct we_wmi_service_counters *wmi_service;
+    struct we_wmi_memory_counters *wmi_memory;
 };
 
 typedef int (*collector_cb)(struct flb_we *);

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -191,6 +191,14 @@ struct we_wmi_memory_counters {
     int                    operational;
 };
 
+struct we_wmi_paging_file_counters {
+    struct wmi_query_spec *info;
+    struct cmt_gauge      *allocated_base_size_megabytes;
+    struct cmt_gauge      *current_usage_megabytes;
+    struct cmt_gauge      *peak_usage_megabytes;
+    int                    operational;
+};
+
 struct we_os_counters {
     struct cmt_gauge *info;
     struct cmt_gauge *users;
@@ -258,6 +266,7 @@ struct flb_we {
     int wmi_system_scrape_interval;
     int wmi_service_scrape_interval;
     int wmi_memory_scrape_interval;
+    int wmi_paging_file_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_net_fd;                                    /* collector fd (net)  */
@@ -270,6 +279,7 @@ struct flb_we {
     int coll_wmi_system_fd;                             /* collector fd (wmi_system)    */
     int coll_wmi_service_fd;                            /* collector fd (wmi_service) */
     int coll_wmi_memory_fd;                             /* collector fd (wmi_memory)    */
+    int coll_wmi_paging_file_fd;                        /* collector fd (wmi_paging_file) */
 
     /*
      * Metrics Contexts
@@ -287,6 +297,7 @@ struct flb_we {
     struct we_wmi_system_counters *wmi_system;
     struct we_wmi_service_counters *wmi_service;
     struct we_wmi_memory_counters *wmi_memory;
+    struct we_wmi_paging_file_counters *wmi_paging_file;
 };
 
 typedef int (*collector_cb)(struct flb_we *);

--- a/plugins/in_windows_exporter_metrics/we_wmi_memory.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_memory.c
@@ -443,7 +443,7 @@ int we_wmi_memory_update(struct flb_we *ctx)
     while(enumerator) {
         hr = enumerator->lpVtbl->Next(enumerator, WBEM_INFINITE, 1, &class_obj, &ret);
 
-        if(0 == ret) {
+        if(ret == 0) {
             break;
         }
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_memory.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_memory.c
@@ -36,14 +36,14 @@ static double nop_adjust(double value)
 
 int we_wmi_memory_init(struct flb_we *ctx)
 {
+    struct cmt_gauge *g;
+
     ctx->wmi_memory = flb_calloc(1, sizeof(struct we_wmi_memory_counters));
     if (!ctx->wmi_memory) {
         flb_errno();
         return -1;
     }
     ctx->wmi_memory->operational = FLB_FALSE;
-
-    struct cmt_gauge *g;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "memory", "available_bytes",
                          "The amount of physical memory, in bytes, immediately available " \

--- a/plugins/in_windows_exporter_metrics/we_wmi_memory.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_memory.c
@@ -1,0 +1,557 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "we.h"
+#include "we_wmi.h"
+#include "we_wmi_memory.h"
+#include "we_util.h"
+#include "we_metric.h"
+
+static double nop_adjust(double value)
+{
+    return value;
+}
+
+int we_wmi_memory_init(struct flb_we *ctx)
+{
+    ctx->wmi_memory = flb_calloc(1, sizeof(struct we_wmi_memory_counters));
+    if (!ctx->wmi_memory) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_memory->operational = FLB_FALSE;
+
+    struct cmt_gauge *g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "available_bytes",
+                         "The amount of physical memory, in bytes, immediately available " \
+                         "for allocation to a process or for system use. (AvailableBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->available_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "cache_bytes",
+                         "The size, in bytes, of the portion of the system file cache " \
+                         "which is currently resident and active in physical memory "\
+                         "(CacheBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->cache_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "cache_bytes_peak",
+                         "the maximum number of bytes used by the system file cache " \
+                         "since the system was last restarted (CacheBytesPeak)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->cache_bytes_peak = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "cache_faults_total",
+                         "The rate at which faults occur when a page sought in " \
+                         "the file system cache is not found and must be retrieved " \
+                         "from elsewhere in memory (a soft fault) or from disk (a hard fault)" \
+                         "(CacheFaultsPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->cache_faults_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "commit_limit",
+                         "The amount of virtual memory that can be committed " \
+                         "without having to extend the paging file(s) " \
+                         "(CommitLimit)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->commit_limit = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "committed_bytes",
+                         "The amount of committed virtual memory, in bytes " \
+                         "(CommittedBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->committed_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "demand_zero_faults_total",
+                         "The rate at which a zeroed page is required to satisfy the fault " \
+                         "(DemandZeroFaultsPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->demand_zero_faults_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "free_and_zero_page_list_bytes",
+                         "the amount of physical memory, in bytes, that is assigned to " \
+                         "the free and zero page lists " \
+                         "(FreeAndZeroPageListBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->free_and_zero_page_list_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "free_system_page_table_entries",
+                         "The number of page table entries not currently in used by the system " \
+                         "(FreeSystemPageTableEntries)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->free_system_page_table_entries = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "modified_page_list_bytes",
+                         "The amount of physical memory, in bytes, that is assigned to " \
+                         "the modified page list " \
+                         "(ModifiedPageListBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->modified_page_list_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "page_faults_total",
+                         "The average number of pages faulted per second. " \
+                         "It is measured in number of pages faulted per second " \
+                         "because only one page is faulted in each fault operation, " \
+                         "hence this is also equal to the number of page fault operations " \
+                         "(PageFaultsPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->page_faults_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "swap_page_reads_total",
+                         "The rate at which the disk was read to resolve hard page faults " \
+                         "(PageReadsPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->swap_page_reads_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "swap_pages_read_total",
+                         "The rate at which pages are read from disk to resolve hard page faults " \
+                         "(PagesInputPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->swap_pages_read_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "swap_pages_written_total",
+                         "the rate at which pages are written to disk to free up space "\
+                         "in physical memory (PagesOutputPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->swap_pages_written_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "swap_page_operations_total",
+                         "the rate at which pages are read from or written " \
+                         "to disk to resolve hard page faults (PagesPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->swap_page_operations_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "swap_page_writes_total",
+                         "the rate at which pages are written to disk to free up space " \
+                         "in physical memory (PageWritesPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->swap_page_writes_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "pool_nonpaged_allocs_total",
+                         "Number of calls to allocate space in the nonpaged pool (PoolNonpagedAllocs)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->pool_nonpaged_allocs_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "pool_nonpaged_bytes",
+                         "the size, in bytes, of the nonpaged pool, an area of " \
+                         "the system virtual memory that is used for objects " \
+                         "that cannot be written to disk, but must remain " \
+                         "in physical memory as long as they are allocated " \
+                         "(PoolNonpagedBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->pool_nonpaged_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "pool_nonpaged_allocs_total",
+                         "Number of bytes of allocated space in paged pool (PoolPagedAllocs)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->pool_paged_allocs_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "pool_paged_bytes",
+                         "the size, in bytes, of the paged pool, an area of the system " \
+                         "virtual memory that is used for objects that can be written " \
+                         "to disk when they are not being used (PoolPagedBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->pool_paged_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "pool_paged_resident_bytes",
+                         "the size, in bytes, of the portion of the paged pool " \
+                         "that is currently resident and active in physical memory " \
+                         "(PoolPagedResidentBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->pool_paged_resident_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "standby_cache_core_bytes",
+                         "The amount of physical memory, in bytes, that is assigned " \
+                         "to the core standby cache page lists (StandbyCacheCoreBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->standby_cache_core_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "standby_cache_normal_priority_bytes",
+                         " the amount of physical memory, in bytes, that is assigned " \
+                         "to the normal priority standby cache page lists " \
+                         "(StandbyCacheNormalPriorityBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->standby_cache_normal_priority_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "standby_cache_reserve_bytes",
+                         "Number of physical memory size(bytes) which is assigned to " \
+                         "the reserve standby cache page lists (StandbyCacheReserveBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->standby_cache_reserve_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "system_cache_resident_bytes",
+                         "Number of physical memory size(bytes) of the portion of " \
+                         "the system file cache which is currently resident and active " \
+                         "(SystemCacheResidentBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->system_cache_resident_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "system_code_resident_bytes",
+                         "Number of physical memory size(bytes) of the pageable operating system code "\
+                         "which is currently resident and active (SystemCodeResidentBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->system_code_resident_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "system_code_total_bytes",
+                         "Number of virtual memory size(bytes) of the pageable operating system code " \
+                         "which is mapped into virtual address (SystemCodeTotalBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->system_code_total_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "system_driver_resident_bytes",
+                         "Number of pagable physical memory size(bytes) by used device drivers "\
+                         "(SystemDriverResidentBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->system_driver_resident_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "system_driver_total_bytes",
+                         "Number of virtual memory size(bytes) by used device drivers " \
+                         "(SystemDriverTotalBytes)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->system_driver_total_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "transition_faults_total",
+                         "Number of the rate at which page faults are resolved by recovering pages " \
+                         "that were being used by another process sharing the page, " \
+                         "or were on the modified page list or the standby list, " \
+                         "or were being written to disk at the time of the page fault " \
+                         "(TransitionFaultsPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->transition_faults_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "transition_pages_repurposed_total",
+                         "Number of the rate at which the number of transition cache " \
+                         "pages were reused for a different purpose " \
+                         "(TransitionPagesRePurposedPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->transition_pages_repurposed_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "memory", "write_copies_total",
+                         "Number of the rate at which page faults are caused by "\
+                         "attempts to write that have been satisfied by coping " \
+                         "of the page from elsewhere in physical memory " \
+                         "(WriteCopiesPersec)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_memory->write_copies_total = g;
+
+    ctx->wmi_memory->info = flb_calloc(1, sizeof(struct wmi_query_spec));
+    if (!ctx->wmi_memory->info) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_memory->info->metric_instance = (void *)g;
+    ctx->wmi_memory->info->type = CMT_GAUGE;
+    ctx->wmi_memory->info->value_adjuster = nop_adjust;
+    ctx->wmi_memory->info->wmi_counter = "Win32_PerfRawData_PerfOS_Memory";
+    ctx->wmi_memory->info->wmi_property = "";
+    ctx->wmi_memory->info->label_property_count = 0;
+    ctx->wmi_memory->info->label_property_keys = NULL;
+    ctx->wmi_memory->info->where_clause = NULL;
+
+    ctx->wmi_memory->operational = FLB_TRUE;
+
+    return 0;
+}
+
+int we_wmi_memory_exit(struct flb_we *ctx)
+{
+    ctx->wmi_memory->operational = FLB_FALSE;
+
+    flb_free(ctx->wmi_memory->info);
+    flb_free(ctx->wmi_memory);
+
+    return 0;
+}
+
+int we_wmi_memory_update(struct flb_we *ctx)
+{
+    uint64_t timestamp = 0;
+    IEnumWbemClassObject* enumerator = NULL;
+    HRESULT hr;
+
+    IWbemClassObject *class_obj = NULL;
+    ULONG ret = 0;
+    double val = 0;
+
+    if (!ctx->wmi_memory->operational) {
+        flb_plg_error(ctx->ins, "memory collector not yet in operational state");
+
+        return -1;
+    }
+
+    if (FAILED(we_wmi_coinitialize(ctx))) {
+        return -1;
+    }
+
+    timestamp = cfl_time_now();
+
+    if (FAILED(we_wmi_execute_query(ctx, ctx->wmi_memory->info, &enumerator))) {
+        return -1;
+    }
+
+    while(enumerator) {
+        hr = enumerator->lpVtbl->Next(enumerator, WBEM_INFINITE, 1, &class_obj, &ret);
+
+        if(0 == ret) {
+            break;
+        }
+
+        val = we_wmi_get_property_value(ctx, "AvailableBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->available_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "CacheBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->cache_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "CacheBytesPeak", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->cache_bytes_peak, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "CacheFaultsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->cache_faults_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "CommitLimit", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->commit_limit, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "CommittedBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->committed_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "DemandZeroFaultsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->demand_zero_faults_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "FreeAndZeroPageListBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->free_and_zero_page_list_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "FreeSystemPageTableEntries", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->free_system_page_table_entries, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "ModifiedPageListBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->modified_page_list_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PageFaultsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->page_faults_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PageReadsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->swap_page_reads_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PagesInputPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->swap_pages_read_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PagesOutputPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->swap_pages_written_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PagesPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->swap_page_operations_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PageWritesPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->swap_page_writes_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PoolNonpagedAllocs", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->pool_nonpaged_allocs_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PoolNonpagedBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->pool_nonpaged_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PoolPagedAllocs", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->pool_paged_allocs_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PoolPagedBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->pool_paged_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PoolPagedResidentBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->pool_paged_resident_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "StandbyCacheCoreBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->standby_cache_core_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "StandbyCacheNormalPriorityBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->standby_cache_normal_priority_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "StandbyCacheReserveBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->standby_cache_reserve_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "SystemCacheResidentBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->system_cache_resident_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "SystemCacheResidentBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->system_cache_resident_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "SystemCodeResidentBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->system_code_resident_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "SystemCodeTotalBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->system_code_total_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "SystemDriverResidentBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->system_driver_resident_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "SystemDriverTotalBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->system_driver_total_bytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "TransitionFaultsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->transition_faults_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "TransitionPagesRePurposedPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->transition_pages_repurposed_total, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "WriteCopiesPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_memory->write_copies_total, timestamp, val, 0, NULL);
+
+        class_obj->lpVtbl->Release(class_obj);
+    }
+
+    enumerator->lpVtbl->Release(enumerator);
+
+    we_wmi_cleanup(ctx);
+
+    return 0;
+}

--- a/plugins/in_windows_exporter_metrics/we_wmi_memory.h
+++ b/plugins/in_windows_exporter_metrics/we_wmi_memory.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_WE_WMI_MEMORY_H
+#define FLB_WE_WMI_MEMORY_H
+
+#include "we.h"
+
+int we_wmi_memory_init(struct flb_we *ctx);
+int we_wmi_memory_exit(struct flb_we *ctx);
+int we_wmi_memory_update(struct flb_we *ctx);
+
+#endif

--- a/plugins/in_windows_exporter_metrics/we_wmi_paging_file.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_paging_file.c
@@ -1,0 +1,156 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "we.h"
+#include "we_wmi.h"
+#include "we_wmi_paging_file.h"
+#include "we_util.h"
+#include "we_metric.h"
+
+static double nop_adjust(double value)
+{
+    return value;
+}
+
+int we_wmi_paging_file_init(struct flb_we *ctx)
+{
+    ctx->wmi_paging_file = flb_calloc(1, sizeof(struct we_wmi_paging_file_counters));
+    if (!ctx->wmi_paging_file) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_paging_file->operational = FLB_FALSE;
+
+    struct cmt_gauge *g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "paging_file", "allocated_base_size_megabytes",
+                         "The value indicates the actual amount of disk space allocated "\
+                         "for use with this page file (AllocatedBaseSize)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_paging_file->allocated_base_size_megabytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "paging_file", "current_usage_megabytes",
+                         "The value indicates how much of the total reserved page file " \
+                         "is currently in use (CurrentUsage)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_paging_file->current_usage_megabytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "paging_file", "peak_usage_megabytes",
+                         "The value indicates the highest use page file (PeakUsage)",
+                         0, NULL);
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_paging_file->peak_usage_megabytes = g;
+
+    ctx->wmi_paging_file->info = flb_calloc(1, sizeof(struct wmi_query_spec));
+    if (!ctx->wmi_paging_file->info) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_paging_file->info->metric_instance = (void *)g;
+    ctx->wmi_paging_file->info->type = CMT_GAUGE;
+    ctx->wmi_paging_file->info->value_adjuster = nop_adjust;
+    ctx->wmi_paging_file->info->wmi_counter = "Win32_PageFileUsage";
+    ctx->wmi_paging_file->info->wmi_property = "";
+    ctx->wmi_paging_file->info->label_property_count = 0;
+    ctx->wmi_paging_file->info->label_property_keys = NULL;
+    ctx->wmi_paging_file->info->where_clause = NULL;
+
+    ctx->wmi_paging_file->operational = FLB_TRUE;
+
+    return 0;
+}
+
+int we_wmi_paging_file_exit(struct flb_we *ctx)
+{
+    ctx->wmi_paging_file->operational = FLB_FALSE;
+
+    flb_free(ctx->wmi_paging_file->info);
+    flb_free(ctx->wmi_paging_file);
+
+    return 0;
+}
+
+int we_wmi_paging_file_update(struct flb_we *ctx)
+{
+    uint64_t timestamp = 0;
+    IEnumWbemClassObject* enumerator = NULL;
+    HRESULT hr;
+
+    IWbemClassObject *class_obj = NULL;
+    ULONG ret = 0;
+    double val = 0;
+
+    if (!ctx->wmi_paging_file->operational) {
+        flb_plg_error(ctx->ins, "paging_file collector not yet in operational state");
+
+        return -1;
+    }
+
+    if (FAILED(we_wmi_coinitialize(ctx))) {
+        return -1;
+    }
+
+    timestamp = cfl_time_now();
+
+    if (FAILED(we_wmi_execute_query(ctx, ctx->wmi_paging_file->info, &enumerator))) {
+        return -1;
+    }
+
+    while(enumerator) {
+        hr = enumerator->lpVtbl->Next(enumerator, WBEM_INFINITE, 1, &class_obj, &ret);
+
+        if(0 == ret) {
+            break;
+        }
+
+        val = we_wmi_get_property_value(ctx, "AllocatedBaseSize", class_obj);
+        cmt_gauge_set(ctx->wmi_paging_file->allocated_base_size_megabytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "CurrentUsage", class_obj);
+        cmt_gauge_set(ctx->wmi_paging_file->current_usage_megabytes, timestamp, val, 0, NULL);
+
+        val = we_wmi_get_property_value(ctx, "PeakUsage", class_obj);
+        cmt_gauge_set(ctx->wmi_paging_file->peak_usage_megabytes, timestamp, val, 0, NULL);
+
+        class_obj->lpVtbl->Release(class_obj);
+    }
+
+    enumerator->lpVtbl->Release(enumerator);
+
+    we_wmi_cleanup(ctx);
+
+    return 0;
+}

--- a/plugins/in_windows_exporter_metrics/we_wmi_paging_file.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_paging_file.c
@@ -132,7 +132,7 @@ int we_wmi_paging_file_update(struct flb_we *ctx)
     while(enumerator) {
         hr = enumerator->lpVtbl->Next(enumerator, WBEM_INFINITE, 1, &class_obj, &ret);
 
-        if(0 == ret) {
+        if(ret == 0) {
             break;
         }
 

--- a/plugins/in_windows_exporter_metrics/we_wmi_paging_file.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_paging_file.c
@@ -36,14 +36,14 @@ static double nop_adjust(double value)
 
 int we_wmi_paging_file_init(struct flb_we *ctx)
 {
+    struct cmt_gauge *g;
+
     ctx->wmi_paging_file = flb_calloc(1, sizeof(struct we_wmi_paging_file_counters));
     if (!ctx->wmi_paging_file) {
         flb_errno();
         return -1;
     }
     ctx->wmi_paging_file->operational = FLB_FALSE;
-
-    struct cmt_gauge *g;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "paging_file", "allocated_base_size_megabytes",
                          "The value indicates the actual amount of disk space allocated "\

--- a/plugins/in_windows_exporter_metrics/we_wmi_paging_file.h
+++ b/plugins/in_windows_exporter_metrics/we_wmi_paging_file.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_WE_WMI_PAGING_FILE_H
+#define FLB_WE_WMI_PAGING_FILE_H
+
+#include "we.h"
+
+int we_wmi_paging_file_init(struct flb_we *ctx);
+int we_wmi_paging_file_exit(struct flb_we *ctx);
+int we_wmi_paging_file_update(struct flb_we *ctx);
+
+#endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, there is no memory and paging file metrics to debug memory related issues as describe in:
https://github.com/fluent/fluent-bit/issues/5337#issue-1211255889.
To achieve this, I added two metrics which is memory and paging_file metrics.
They can use to debug memory related issues.

Closes: https://github.com/fluent/fluent-bit/issues/5337

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

These metrics can used as:
```powershell
PS> bin/fluent-bit -i windows_exporter_metrics -pmetrics=memory -pscrape_interval=2 -o stdout -vv
PS> bin/fluent-bit -i windows_exporter_metrics -pmetrics=paging_file -pscrape_interval=2 -o stdout
```
- [x] Debug log output from testing the change
```console
PS> bin/fluent-bit -i windows_exporter_metrics -pmetrics=paging_file -pscrape_interval=2 -o stdout -v
Fluent Bit v2.1.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/08/10 14:35:35] [ info] Configuration:
[2023/08/10 14:35:35] [ info]  flush time     | 1.000000 seconds
[2023/08/10 14:35:35] [ info]  grace          | 5 seconds
[2023/08/10 14:35:35] [ info]  daemon         | 0
[2023/08/10 14:35:35] [ info] ___________
[2023/08/10 14:35:35] [ info]  inputs:
[2023/08/10 14:35:35] [ info]      windows_exporter_metrics
[2023/08/10 14:35:35] [ info] ___________
[2023/08/10 14:35:35] [ info]  filters:
[2023/08/10 14:35:35] [ info] ___________
[2023/08/10 14:35:35] [ info]  outputs:
[2023/08/10 14:35:35] [ info]      stdout.0
[2023/08/10 14:35:35] [ info] ___________
[2023/08/10 14:35:35] [ info]  collectors:
[2023/08/10 14:35:35] [ info] [fluent bit] version=2.1.9, commit=a792dcb821, pid=19160
[2023/08/10 14:35:35] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2023/08/10 14:35:35] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/10 14:35:35] [ info] [cmetrics] version=0.6.3
[2023/08/10 14:35:35] [ info] [ctraces ] version=0.3.1
[2023/08/10 14:35:35] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2023/08/10 14:35:35] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/08/10 14:35:35] [debug] [windows_exporter_metrics:windows_exporter_metrics.0] created event channels: read=856 write=860
[2023/08/10 14:35:35] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics paging_file
[2023/08/10 14:35:35] [debug] [stdout:stdout.0] created event channels: read=1248 write=1232
[2023/08/10 14:35:35] [ info] [sp] stream processor started
[2023/08/10 14:35:35] [ info] [output:stdout:stdout.0] worker #0 started
[2023/08/10 14:35:37] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2023/08/10 14:35:37] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2023/08/10 14:35:37] [debug] [input chunk] update output instances with new chunk size diff=735, records=0, input=windows_exporter_metrics.0
[2023/08/10 14:35:38] [debug] [task] created task=000001F220B5CA60 id=0 OK
[2023/08/10 14:35:38] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2023-08-10T05:35:37.505007700Z windows_paging_file_allocated_base_size_megabytes = 15889
2023-08-10T05:35:37.505007700Z windows_paging_file_current_usage_megabytes = 1013
2023-08-10T05:35:37.505007700Z windows_paging_file_peak_usage_megabytes = 1077
[2023/08/10 14:35:38] [debug] [out flush] cb_destroy coro_id=0
[2023/08/10 14:35:38] [debug] [task] destroy task=000001F220B5CA60 (task_id=0)
[2023/08/10 14:35:39] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2023/08/10 14:35:39] [engine] caught signal (SIGINT)
[2023/08/10 14:35:39] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2023/08/10 14:35:39] [debug] [input chunk] update output instances with new chunk size diff=735, records=0, input=windows_exporter_metrics.0
[2023/08/10 14:35:39] [debug] [task] created task=000001F220B5D0A0 id=0 OK
2023-08-10T05:35:39.503594100Z windows_paging_file_allocated_base_size_megabytes = 15889
2023-08-10T05:35:39.503594100Z windows_paging_file_current_usage_megabytes = 1013
2023-08-10T05:35:39.503594100Z windows_paging_file_peak_usage_megabytes = 1077
[2023/08/10 14:35:39] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/08/10 14:35:39] [ warn] [engine] service will shutdown in max 5 seconds
[2023/08/10 14:35:39] [ info] [input] pausing windows_exporter_metrics.0
[2023/08/10 14:35:39] [debug] [out flush] cb_destroy coro_id=1
[2023/08/10 14:35:39] [debug] [task] destroy task=000001F220B5D0A0 (task_id=0)
[2023/08/10 14:35:40] [ info] [engine] service has stopped (0 pending tasks)
[2023/08/10 14:35:40] [ info] [input] pausing windows_exporter_metrics.0
[2023/08/10 14:35:40] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/08/10 14:35:40] [ info] [output:stdout:stdout.0] thread worker #0 stopped
PS> bin/fluent-bit -i windows_exporter_metrics -pmetrics=memory -pscrape_interval=2 -o stdout -v
Fluent Bit v2.1.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/08/10 14:36:14] [ info] Configuration:
[2023/08/10 14:36:14] [ info]  flush time     | 1.000000 seconds
[2023/08/10 14:36:14] [ info]  grace          | 5 seconds
[2023/08/10 14:36:14] [ info]  daemon         | 0
[2023/08/10 14:36:14] [ info] ___________
[2023/08/10 14:36:14] [ info]  inputs:
[2023/08/10 14:36:14] [ info]      windows_exporter_metrics
[2023/08/10 14:36:14] [ info] ___________
[2023/08/10 14:36:14] [ info]  filters:
[2023/08/10 14:36:14] [ info] ___________
[2023/08/10 14:36:14] [ info]  outputs:
[2023/08/10 14:36:14] [ info]      stdout.0
[2023/08/10 14:36:14] [ info] ___________
[2023/08/10 14:36:14] [ info]  collectors:
[2023/08/10 14:36:14] [ info] [fluent bit] version=2.1.9, commit=a792dcb821, pid=32048
[2023/08/10 14:36:14] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2023/08/10 14:36:14] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/10 14:36:14] [ info] [cmetrics] version=0.6.3
[2023/08/10 14:36:14] [ info] [ctraces ] version=0.3.1
[2023/08/10 14:36:14] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2023/08/10 14:36:14] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/08/10 14:36:14] [debug] [windows_exporter_metrics:windows_exporter_metrics.0] created event channels: read=856 write=860
[2023/08/10 14:36:14] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics memory
[2023/08/10 14:36:14] [debug] [stdout:stdout.0] created event channels: read=1224 write=1248
[2023/08/10 14:36:14] [ info] [sp] stream processor started
[2023/08/10 14:36:14] [ info] [output:stdout:stdout.0] worker #0 started
[2023/08/10 14:36:16] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2023/08/10 14:36:18] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2023/08/10 14:36:18] [debug] [input chunk] update output instances with new chunk size diff=8322, records=0, input=windows_exporter_metrics.0
[2023/08/10 14:36:18] [debug] [task] created task=000001464C3BCC30 id=0 OK
2023-08-10T05:36:16.419798800Z windows_memory_available_bytes = 2964451328
2023-08-10T05:36:16.419798800Z windows_memory_cache_bytes = 347045888
2023-08-10T05:36:16.419798800Z windows_memory_cache_bytes_peak = 759558144
2023-08-10T05:36:16.419798800Z windows_memory_cache_faults_total = 52215279
2023-08-10T05:36:16.419798800Z windows_memory_commit_limit = 33520226304
2023-08-10T05:36:16.419798800Z windows_memory_committed_bytes = 28709236736
2023-08-10T05:36:16.419798800Z windows_memory_demand_zero_faults_total = 512455022
2023-08-10T05:36:16.419798800Z windows_memory_free_and_zero_page_list_bytes = 36667392
2023-08-10T05:36:16.419798800Z windows_memory_free_system_page_table_entries = 14622522
2023-08-10T05:36:16.419798800Z windows_memory_modified_page_list_bytes = 50659328
2023-08-10T05:36:16.419798800Z windows_memory_page_faults_total = 820788075
2023-08-10T05:36:16.419798800Z windows_memory_swap_page_reads_total = 4484595
2023-08-10T05:36:16.419798800Z windows_memory_swap_pages_read_total = 20312558
2023-08-10T05:36:16.419798800Z windows_memory_swap_pages_written_total = 956799
2023-08-10T05:36:16.419798800Z windows_memory_swap_page_operations_total = 21269357
2023-08-10T05:36:16.419798800Z windows_memory_swap_page_writes_total = 4005
2023-08-10T05:36:16.419798800Z windows_memory_pool_nonpaged_allocs_total = 0
2023-08-10T05:36:16.419798800Z windows_memory_pool_nonpaged_bytes = 678252544
2023-08-10T05:36:16.419798800Z windows_memory_pool_nonpaged_allocs_total = 0
2023-08-10T05:36:16.419798800Z windows_memory_pool_paged_bytes = 922673152
2023-08-10T05:36:16.419798800Z windows_memory_pool_paged_resident_bytes = 782942208
2023-08-10T05:36:16.419798800Z windows_memory_standby_cache_core_bytes = 137396224
2023-08-10T05:36:16.419798800Z windows_memory_standby_cache_normal_priority_bytes = 2278600704
2023-08-10T05:36:16.419798800Z windows_memory_standby_cache_reserve_bytes = 511787008
2023-08-10T05:36:16.419798800Z windows_memory_system_cache_resident_bytes = 347045888
2023-08-10T05:36:16.419798800Z windows_memory_system_code_resident_bytes = 17104896
2023-08-10T05:36:16.419798800Z windows_memory_system_code_total_bytes = 8192
2023-08-10T05:36:16.419798800Z windows_memory_system_driver_resident_bytes = 37961728
2023-08-10T05:36:16.419798800Z windows_memory_system_driver_total_bytes = 36286464
2023-08-10T05:36:16.419798800Z windows_memory_transition_faults_total = 266077991
2023-08-10T05:36:16.419798800Z windows_memory_transition_pages_repurposed_total = 21433977
2023-08-10T05:36:16.419798800Z windows_memory_write_copies_total = 10110700
[2023/08/10 14:36:18] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/08/10 14:36:18] [debug] [out flush] cb_destroy coro_id=0
[2023/08/10 14:36:18] [debug] [task] destroy task=000001464C3BCC30 (task_id=0)
[2023/08/10 14:36:18] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2023/08/10 14:36:18] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2023/08/10 14:36:18] [debug] [input chunk] update output instances with new chunk size diff=8322, records=0, input=windows_exporter_metrics.0
[2023/08/10 14:36:19] [debug] [task] created task=000001464C3BC0F0 id=0 OK
2023-08-10T05:36:18.400136300Z windows_memory_available_bytes = 2965467136
2023-08-10T05:36:18.400136300Z windows_memory_cache_bytes = 345399296
2023-08-10T05:36:18.400136300Z windows_memory_cache_bytes_peak = 759558144
2023-08-10T05:36:18.400136300Z windows_memory_cache_faults_total = 52215382
2023-08-10T05:36:18.400136300Z windows_memory_commit_limit = 33520226304
2023-08-10T05:36:18.400136300Z windows_memory_committed_bytes = 28710400000
2023-08-10T05:36:18.400136300Z windows_memory_demand_zero_faults_total = 512455937
2023-08-10T05:36:18.400136300Z windows_memory_free_and_zero_page_list_bytes = 36192256
2023-08-10T05:36:18.400136300Z windows_memory_free_system_page_table_entries = 14622583
2023-08-10T05:36:18.400136300Z windows_memory_modified_page_list_bytes = 50655232
2023-08-10T05:36:18.400136300Z windows_memory_page_faults_total = 820789535
2023-08-10T05:36:18.400136300Z windows_memory_swap_page_reads_total = 4484595
2023-08-10T05:36:18.400136300Z windows_memory_swap_pages_read_total = 20312558
2023-08-10T05:36:18.400136300Z windows_memory_swap_pages_written_total = 956799
2023-08-10T05:36:18.400136300Z windows_memory_swap_page_operations_total = 21269357
2023-08-10T05:36:18.400136300Z windows_memory_swap_page_writes_total = 4005
2023-08-10T05:36:18.400136300Z windows_memory_pool_nonpaged_allocs_total = 0
2023-08-10T05:36:18.400136300Z windows_memory_pool_nonpaged_bytes = 678322176
2023-08-10T05:36:18.400136300Z windows_memory_pool_nonpaged_allocs_total = 0
2023-08-10T05:36:18.400136300Z windows_memory_pool_paged_bytes = 922673152
2023-08-10T05:36:18.400136300Z windows_memory_pool_paged_resident_bytes = 782942208
2023-08-10T05:36:18.400136300Z windows_memory_standby_cache_core_bytes = 137396224
2023-08-10T05:36:18.400136300Z windows_memory_standby_cache_normal_priority_bytes = 2280124416
2023-08-10T05:36:18.400136300Z windows_memory_standby_cache_reserve_bytes = 511754240
2023-08-10T05:36:18.400136300Z windows_memory_system_cache_resident_bytes = 345399296
2023-08-10T05:36:18.400136300Z windows_memory_system_code_resident_bytes = 17104896
2023-08-10T05:36:18.400136300Z windows_memory_system_code_total_bytes = 8192
2023-08-10T05:36:18.400136300Z windows_memory_system_driver_resident_bytes = 37961728
2023-08-10T05:36:18.400136300Z windows_memory_system_driver_total_bytes = 36286464
2023-08-10T05:36:18.400136300Z windows_memory_transition_faults_total = 266078437
2023-08-10T05:36:18.400136300Z windows_memory_transition_pages_repurposed_total = 21433977
2023-08-10T05:36:18.400136300Z windows_memory_write_copies_total = 10110715
[2023/08/10 14:36:19] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/08/10 14:36:19] [debug] [out flush] cb_destroy coro_id=1
[2023/08/10 14:36:19] [debug] [task] destroy task=000001464C3BC0F0 (task_id=0)
[2023/08/10 14:36:19] [engine] caught signal (SIGINT)
[2023/08/10 14:36:19] [ warn] [engine] service will shutdown in max 5 seconds
[2023/08/10 14:36:19] [ info] [input] pausing windows_exporter_metrics.0
[2023/08/10 14:36:20] [ info] [engine] service has stopped (0 pending tasks)
[2023/08/10 14:36:20] [ info] [input] pausing windows_exporter_metrics.0
[2023/08/10 14:36:20] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/08/10 14:36:20] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1176

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
