### PR TITLE
macos: core: macOS coroutine unstability fixes

### DIFF
--- a/include/fluent-bit/flb_coro.h
+++ b/include/fluent-bit/flb_coro.h
@@ -61,10 +61,20 @@ struct flb_coro {
     void *data;
 };
 
+#ifdef FLB_SYSTEM_MACOS
+#ifdef __aarch64__
+#define STACK_FACTOR 1.5 /* Use 36KiB for coro stacks */
+#else
+#define STACK_FACTOR 2   /* Use 24KiB for coro stacks */
+#endif
+#else
+#define STACK_FACTOR 1
+#endif
+
 #ifdef FLB_CORO_STACK_SIZE
 #define FLB_CORO_STACK_SIZE_BYTE      FLB_CORO_STACK_SIZE
 #else
-#define FLB_CORO_STACK_SIZE_BYTE      ((3 * PTHREAD_STACK_MIN) / 2)
+#define FLB_CORO_STACK_SIZE_BYTE      ((3 * STACK_FACTOR * PTHREAD_STACK_MIN) / 2)
 #endif
 
 #define FLB_CORO_DATA(coro)      (((char *) coro) + sizeof(struct flb_coro))

--- a/plugins/in_event_test/event_test.c
+++ b/plugins/in_event_test/event_test.c
@@ -109,7 +109,9 @@ static int cb_collector_time(struct flb_input_instance *ins,
 
     now = time(NULL);
     diff = now - config->init_time;
-    if (diff > CALLBACK_TIME) {
+    /* For macOS, we sometimes get the +1 longer time elapse.
+     * To handle this, we simply add +1 as a delta for checking interval. */
+    if (diff > (CALLBACK_TIME + 1)) {
         flb_plg_error(ins, "cb_collector_time difference failed: %i seconds", diff);
         set_unit_test_status(ctx, 0, STATUS_ERROR);
         flb_engine_exit(config);


### PR DESCRIPTION
<!-- Provide summary of changes -->
In macOS, the size of pthread stack min of Intel Mac (x64) and Apple Silicon (M1/M2) is smaller than the Linux one.
This means that the concrete values are:

#### Intel Mac

PTHREAD_STACK_MIN = 8192
(3 * PTHREAD_STACK_MIN) / 2 = 12288 which means fluent-bit's minimum stack size

#### Apple Silicon

PTHREAD_STACK_MIN = 16384
(3 * PTHREAD_STACK_MIN) / 2 = 24576 which means fluent-bit's minimum stack size

They shouldn't be enough for libresolv API which needs to use heap memories: `res_ninit(statep)`.

When increasing the coroutine size to:

24576 bytes (24KiB) on Intel Mac and 36864 bytes (36KiB) on Apple Silicon respectively, the heap memory corruptions are not occurred.

Related to https://github.com/fluent/fluent-bit/issues/7670.

### additional contexts

I tested for the minimum code:

```c
#include <stdio.h>
#include <limits.h>

#ifdef FLB_CORO_STACK_SIZE
#define FLB_CORO_STACK_SIZE_BYTE      FLB_CORO_STACK_SIZE
#else
#define FLB_CORO_STACK_SIZE_BYTE      ((3 * PTHREAD_STACK_MIN) / 2)
#endif

int main(void)
{
    unsigned int size = FLB_CORO_STACK_SIZE_BYTE;

    printf("pthread stack min size = %u\n", PTHREAD_STACK_MIN);

    size = (size + 1023) & ~1023;
    printf("flb stack size = %u\n", size);

    return 0;
}
```

The canary CI results are:
https://github.com/fluent/fluent-bit/actions/runs/5832454631
https://github.com/fluent/fluent-bit/actions/runs/5832456028
https://github.com/fluent/fluent-bit/actions/runs/5832457491

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
