### PR TITLE
lua: add dump lua stack function and extract flb_lua_arraylength

### DIFF
--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -47,6 +47,19 @@ struct flb_lua_l2c_config {
     struct mk_list l2c_types;  /* data types (lua -> C) */
 };
 
+/* convert from negative index to positive index */
+static inline int flb_lua_absindex(lua_State *l , int index)
+{
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM < 520
+    if (index < 0) {
+        index = lua_gettop(l) + index + 1;
+    }
+#else
+    index = lua_absindex(l, index);
+#endif
+    return index;
+}
+
 int flb_lua_arraylength(lua_State *l);
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm);
 int flb_lua_is_valid_func(lua_State *l, flb_sds_t func);
@@ -60,5 +73,6 @@ void flb_lua_tompack(lua_State *l,
                      mpack_writer_t *writer,
                      int index,
                      struct flb_lua_l2c_config *l2cc);
+void flb_lua_dump_stack(FILE *out, lua_State *l);
 
 #endif

--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -60,7 +60,7 @@ static inline int flb_lua_absindex(lua_State *l , int index)
     return index;
 }
 
-int flb_lua_arraylength(lua_State *l);
+int flb_lua_arraylength(lua_State *l, int index);
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm);
 int flb_lua_is_valid_func(lua_State *l, flb_sds_t func);
 int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader);

--- a/tests/internal/lua.c
+++ b/tests/internal/lua.c
@@ -228,7 +228,43 @@ static void test_lua_arraylength()
         lua_settable(l, -3); /* points created table */
     }
 
-    len = flb_lua_arraylength(l);
+    len = flb_lua_arraylength(l, -1);
+    if (!TEST_CHECK(len == size)) {
+        TEST_MSG("size error. got=%d expect=%d", len, size);
+    }
+    lua_pop(l, 1);
+
+    lua_close(l);
+}
+
+static void test_lua_arraylength_with_index()
+{
+    lua_State *l;
+    int i;
+    int len;
+    int size = 10;
+
+    l = luaL_newstate();
+    if (!TEST_CHECK(l != NULL)) {
+        TEST_MSG("luaL_newstate faild");
+        return;
+    }
+    luaL_openlibs(l);
+
+    /* create array. */
+    lua_createtable(l, size, 0);
+
+    for (i=1; i<=size; i++) {
+        lua_pushinteger(l, i); /* set an index of array */
+        lua_pushinteger(l, 3+i); /* set a value */
+        lua_settable(l, -3); /* points created table */
+    }
+
+    /* push 2 values */
+    lua_pushinteger(l, 100);
+    lua_pushinteger(l, 101);
+
+    len = flb_lua_arraylength(l, -3); /* points array. -1 points 101, -2 points 100 */
     if (!TEST_CHECK(len == size)) {
         TEST_MSG("size error. got=%d expect=%d", len, size);
     }
@@ -265,7 +301,7 @@ static void test_lua_arraylength_for_array_contains_nil()
         lua_settable(l, -3); /* points created table */
     }
 
-    len = flb_lua_arraylength(l);
+    len = flb_lua_arraylength(l, -1);
     if (!TEST_CHECK(len == size)) {
         TEST_MSG("size error. got=%d expect=%d", len, size);
     }
@@ -283,6 +319,7 @@ TEST_LIST = {
     { "lua_tomsgpack" , test_tomsgpack },
     { "lua_tompack" , test_tompack },
     { "lua_arraylength" , test_lua_arraylength },
+    { "lua_arraylength_with_index" , test_lua_arraylength_with_index },
     { "lua_arraylength_for_array_contains_nil", test_lua_arraylength_for_array_contains_nil},
     { 0 }
 };

--- a/tests/internal/lua.c
+++ b/tests/internal/lua.c
@@ -204,6 +204,77 @@ static void test_tompack()
     lua_close(l);
 }
 
+
+static void test_lua_arraylength()
+{
+    lua_State *l;
+    int i;
+    int len;
+    int size = 10;
+
+    l = luaL_newstate();
+    if (!TEST_CHECK(l != NULL)) {
+        TEST_MSG("luaL_newstate faild");
+        return;
+    }
+    luaL_openlibs(l);
+
+    /* create array. */
+    lua_createtable(l, size, 0);
+
+    for (i=1; i<=size; i++) {
+        lua_pushinteger(l, i); /* set an index of array */
+        lua_pushinteger(l, 3+i); /* set a value */
+        lua_settable(l, -3); /* points created table */
+    }
+
+    len = flb_lua_arraylength(l);
+    if (!TEST_CHECK(len == size)) {
+        TEST_MSG("size error. got=%d expect=%d", len, size);
+    }
+    lua_pop(l, 1);
+
+    lua_close(l);
+}
+
+static void test_lua_arraylength_for_array_contains_nil()
+{
+    lua_State *l;
+    int i;
+    int len;
+    int size = 10;
+
+    l = luaL_newstate();
+    if (!TEST_CHECK(l != NULL)) {
+        TEST_MSG("luaL_newstate faild");
+        return;
+    }
+    luaL_openlibs(l);
+
+    /* create array. */
+    lua_createtable(l, size, 0);
+
+    for (i=1; i<=size; i++) {
+        lua_pushinteger(l, i); /* set an index of array */
+        if (i == 7) {
+            lua_pushnil(l);
+        }
+        else {
+            lua_pushinteger(l, 3+i); /* set a value */
+        }
+        lua_settable(l, -3); /* points created table */
+    }
+
+    len = flb_lua_arraylength(l);
+    if (!TEST_CHECK(len == size)) {
+        TEST_MSG("size error. got=%d expect=%d", len, size);
+    }
+    lua_pop(l, 1);
+
+    lua_close(l);
+}
+
+
 TEST_LIST = {
     { "lua_is_valid_func" , test_is_valid_func},
     { "lua_pushtimetable" , test_pushtimetable},
@@ -211,5 +282,7 @@ TEST_LIST = {
     { "lua_pushmpack" , test_pushmpack },
     { "lua_tomsgpack" , test_tomsgpack },
     { "lua_tompack" , test_tompack },
+    { "lua_arraylength" , test_lua_arraylength },
+    { "lua_arraylength_for_array_contains_nil", test_lua_arraylength_for_array_contains_nil},
     { 0 }
 };


### PR DESCRIPTION
I need a debug function to add new feature for flb_lua to fix issue 7708.

This patch is to
- add `flb_lua_dump_stack`
- modify `flb_lua_arraylength` to be able to pass index of stack
- add `flb_lua_absindex` 

`flb_lua_dump_stack` is to dump lua stack for debug.

It needs to modify `flb_lua_arraylength` since the function expects an array should be on the top of the stack.
`flb_lua_dump_stack` needs to dump an array in the middle of the stack.

This patch also supports `flb_lua_absindex`.
In some cases, we use negative index to point from a top of the stack. e.g. `lua_next(l, -2)` of `flb_lua_arraylength`.
It can cause an error when the top of stack is added/deleted.
`flb_lua_absindex` is to prevent it since it returns a positive index from the bottom of the stack.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-lua 
==93371== Memcheck, a memory error detector
==93371== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==93371== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==93371== Command: bin/flb-it-lua
==93371== 
Test lua_is_valid_func...                       [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_pushtimetable...                       [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_pushmsgpack...                         [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_pushmpack...                           [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_tomsgpack...                           [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_tompack...                             [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_arraylength...                         [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_arraylength_with_index...              [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
Test lua_arraylength_for_array_contains_nil...  [ OK ]
==93371== Warning: invalid file descriptor -1 in syscall close()
SUCCESS: All unit tests have passed.
==93371== 
==93371== HEAP SUMMARY:
==93371==     in use at exit: 0 bytes in 0 blocks
==93371==   total heap usage: 7,563 allocs, 7,563 frees, 821,606 bytes allocated
==93371== 
==93371== All heap blocks were freed -- no leaks are possible
==93371== 
==93371== For lists of detected and suppressed errors, rerun with: -s
==93371== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --leak-check=full bin/flb-rt-filter_lua 
==93377== Memcheck, a memory error detector
==93377== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==93377== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==93377== Command: bin/flb-rt-filter_lua
==93377== 
Test hello_world...                             [2023/08/13 10:24:59] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:24:59] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:24:59] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:24:59] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:24:59] [ info] [input:dummy:dummy.0] initializing
[2023/08/13 10:24:59] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/08/13 10:24:59] [ info] [output:stdout:stdout.0] worker #0 started
[2023/08/13 10:24:59] [ info] [sp] stream processor started
[2023/08/13 10:24:59] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:24:59] [ info] [input] pausing dummy.0
[2023/08/13 10:24:59] [ info] [engine] service has stopped (0 pending tasks)
[2023/08/13 10:24:59] [ info] [input] pausing dummy.0
[2023/08/13 10:24:59] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/08/13 10:24:59] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2023/08/13 10:25:00] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:00] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:00] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:00] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:00] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:00] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:00] [ info] [sp] stream processor started
[2023/08/13 10:25:00] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:01] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key...                            [2023/08/13 10:25:01] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:01] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:01] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:01] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:01] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:01] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:01] [ info] [sp] stream processor started
[2023/08/13 10:25:02] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:03] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key_multi...                      [2023/08/13 10:25:03] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:03] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:03] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:03] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:03] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:03] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:03] [ info] [sp] stream processor started
[2023/08/13 10:25:04] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:05] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_array_key...                          [2023/08/13 10:25:05] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:05] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:05] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:05] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:05] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:05] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:05] [ info] [sp] stream processor started
[2023/08/13 10:25:06] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:07] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     [2023/08/13 10:25:07] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:07] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:07] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:07] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:07] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:07] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:07] [ info] [sp] stream processor started
[2023/08/13 10:25:08] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:09] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2023/08/13 10:25:09] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:09] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:09] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:09] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:09] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:09] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:09] [ info] [sp] stream processor started
[2023/08/13 10:25:11] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:11] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test split_record...                            [2023/08/13 10:25:11] [ info] [fluent bit] version=2.1.9, commit=7c46a40e17, pid=93377
[2023/08/13 10:25:11] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/13 10:25:11] [ info] [cmetrics] version=0.6.3
[2023/08/13 10:25:11] [ info] [ctraces ] version=0.3.1
[2023/08/13 10:25:11] [ info] [input:lib:lib.0] initializing
[2023/08/13 10:25:11] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/08/13 10:25:11] [ info] [sp] stream processor started
[2023/08/13 10:25:13] [ warn] [timeout] elapsed_time: 2005
[2023/08/13 10:25:13] [ warn] [engine] service will shutdown in max 1 seconds
[2023/08/13 10:25:14] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==93377== 
==93377== HEAP SUMMARY:
==93377==     in use at exit: 0 bytes in 0 blocks
==93377==   total heap usage: 12,532 allocs, 12,532 frees, 5,934,382 bytes allocated
==93377== 
==93377== All heap blocks were freed -- no leaks are possible
==93377== 
==93377== For lists of detected and suppressed errors, rerun with: -s
==93377== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
