### PR TITLE
calyptia: submit metrics when not in fleet mode.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -339,7 +339,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
     flb_input_set_property(ctx->i, "scrape_interval", "30");
 
     /* output cloud connector */
-    if (ctx->fleet_id != NULL) {
+    if (ctx->fleet_id != NULL || ctx->fleet_name == NULL) {
         ctx->o = setup_cloud_output(config, ctx);
         if (ctx->o == NULL) {
             return -1;

--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -309,6 +309,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
 {
     int ret;
     struct calyptia *ctx;
+    int is_fleet_mode;
     (void) data;
 
     ctx = flb_calloc(1, sizeof(struct calyptia));
@@ -338,8 +339,14 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
     flb_input_set_property(ctx->i, "scrape_on_start", "true");
     flb_input_set_property(ctx->i, "scrape_interval", "30");
 
+    if (ctx->fleet_name || ctx->fleet_id) {
+        is_fleet_mode = FLB_TRUE;
+    } else {
+        is_fleet_mode = FLB_FALSE;
+    }
     /* output cloud connector */
-    if (ctx->fleet_id != NULL || ctx->fleet_name == NULL) {
+    if ((is_fleet_mode == FLB_TRUE && ctx->fleet_id != NULL) ||
+        (is_fleet_mode == FLB_FALSE)) {
         ctx->o = setup_cloud_output(config, ctx);
         if (ctx->o == NULL) {
             return -1;


### PR DESCRIPTION
# Summary

Submit metrics to calyptia cloud when not in fleet mode.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205285584289449