### PR TITLE
utils: suppress errno when file is empty but readable.

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1303,7 +1303,9 @@ int flb_utils_read_file(char *path, char **out_buf, size_t *out_size)
 
     bytes = fread(buf, st.st_size, 1, fp);
     if (bytes < 1) {
-        flb_errno();
+        if (bytes < 0) {
+            flb_errno();
+        }
         flb_free(buf);
         fclose(fp);
         return -1;

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1303,7 +1303,7 @@ int flb_utils_read_file(char *path, char **out_buf, size_t *out_size)
 
     bytes = fread(buf, st.st_size, 1, fp);
     if (bytes < 1) {
-        if (bytes < 0) {
+        if (ferror(fp)) {
             flb_errno();
         }
         flb_free(buf);


### PR DESCRIPTION
# Summary

Suppress a false error log when flb_utils_read_file reads empty files. This affects custom_calyptia when it attempts to read /etc/machine-id inside docker containers when it is present but empty.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
