### PR TITLE
input: apply back pressure if input threaded plugin is paused

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1766,9 +1766,18 @@ void flb_input_chunk_ring_buffer_collector(struct flb_config *ctx, void *data)
         ins = mk_list_entry(head, struct flb_input_instance, _head);
         cr = NULL;
 
-        while ((ret = flb_ring_buffer_read(ins->rb,
-                                           (void *) &cr,
-                                           sizeof(cr))) == 0) {
+        while (1) {
+            if (flb_input_buf_paused(ins) == FLB_TRUE) {
+                break;
+            }
+
+            ret = flb_ring_buffer_read(ins->rb,
+                                       (void *) &cr,
+                                       sizeof(cr));
+            if (ret != 0) {
+                break;
+            }
+
             if (cr) {
                 if (cr->tag) {
                     tag_len = flb_sds_len(cr->tag);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes only second scenario described in #7846

If a threaded input plugin is paused due to memory buf limits, dont read chunks/records from the ring buffer.
This will prevent this debug message from being logged.

```
[2023/08/21 20:35:35] [ info] [task]   task_id=36 still running on route(s): kafka/kafka.0
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
[2023/08/21 19:55:57] [debug] [input chunk] tail.0 is paused, cannot append records
```

The fix should replicate similar back pressure as done in non-threaded input plugins.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
