### PR TITLE
in_winevtlog: Support XML query parameter for filtering events

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -78,7 +78,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
         tmp = "Application";
     }
 
-    ctx->active_channel = winevtlog_open_all(tmp, ctx->read_existing_events, ctx->ignore_missing_channels);
+    ctx->active_channel = winevtlog_open_all(tmp, ctx);
     if (!ctx->active_channel) {
         flb_plg_error(ctx->ins, "failed to open channels");
         flb_log_event_encoder_destroy(ctx->log_encoder);
@@ -256,7 +256,11 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct winevtlog_config, ignore_missing_channels),
       "Whether to ignore channels missing in eventlog"
     },
-
+    {
+      FLB_CONFIG_MAP_STR, "event_query", "*",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, event_query),
+      "Specify XML query for filtering events"
+    },
     /* EOF */
     {0}
 };

--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -33,6 +33,7 @@ struct winevtlog_config {
     int render_event_as_xml;
     int use_ansi;
     int ignore_missing_channels;
+    flb_sds_t event_query;
 
     struct mk_list *active_channel;
     struct flb_sqldb *db;
@@ -54,6 +55,7 @@ struct winevtlog_channel {
     int count;
 
     char *name;
+    char *query;
     unsigned int time_updated;
     unsigned int time_created;
     struct mk_list _head;
@@ -83,7 +85,7 @@ int winevtlog_read(struct winevtlog_channel *ch,
  *
  * "channels" are comma-separated names like "Setup,Security".
  */
-struct mk_list *winevtlog_open_all(const char *channels, int read_exising_events, int ignore_missing_channels);
+struct mk_list *winevtlog_open_all(const char *channels, struct winevtlog_config *ctx);
 void winevtlog_close_all(struct mk_list *list);
 
 void winevtlog_pack_xml_event(WCHAR *system_xml, WCHAR *message,


### PR DESCRIPTION
<!-- Provide summary of changes -->
I implemented XML query capability for filtering Windows EventLog.
This is because filter_grep and type converter should be difficult to use when the types of records are unknown.
Instead, we also are able to provide a capability of XML query language to filter events.
EvtSubscribe API which is defined in winevt.h can handle that XML query.
ref: https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtsubscribe

The advantage of the parameter is using in_winevtlog plugin only and not consuming for unneeded events on that plugin.

This feature is also a parity of fluent-plugin-windows-eventlog plugin's event_query parameter: https://github.com/fluent/fluent-plugin-windows-eventlog#configuration

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

This is related to https://github.com/fluent/fluent-bit/issues/7271.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

To filter an event which has EventID 1040 within in_winevtlog plugin, we can use the following query in `Event_Query` parameter:
```ini
[SERVICE]
    Log_Level   debug
[INPUT]
    Name        winevtlog
    channels    Application
    Use_ANSI    True
    Event_Query Event/System[EventID!=1040]

[OUTPUT]
    Name stdout
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1179

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
