### PR TITLE
storage: file trimming improvement

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -202,7 +202,8 @@ struct flb_config {
     char *storage_max_chunk_size_str; /* chunk size limit */
     char *storage_bl_mem_limit;       /* storage backlog memory limit */
     struct flb_storage_metrics *storage_metrics_ctx; /* storage metrics context */
-    size_t storage_max_chunk_size;   /* chunk size limit */
+    size_t storage_max_chunk_size;    /* chunk size limit */
+    int   storage_trim_files;         /* enable/disable file trimming */
 
     /* Embedded SQL Database support (SQLite3) */
 #ifdef FLB_HAVE_SQLDB
@@ -307,6 +308,7 @@ enum conf_type {
 #define FLB_CONF_STORAGE_BL_MEM_LIMIT   "storage.backlog.mem_limit"
 #define FLB_CONF_STORAGE_MAX_CHUNKS_UP  "storage.max_chunks_up"
 #define FLB_CONF_STORAGE_MAX_CHUNK_SIZE "storage.max_chunk_size"
+#define FLB_CONF_STORAGE_TRIM_FILES     "storage.trim_files"
 
 /* Coroutines */
 #define FLB_CONF_STR_CORO_STACK_SIZE "Coro_Stack_Size"

--- a/lib/chunkio/include/chunkio/chunkio.h
+++ b/lib/chunkio/include/chunkio/chunkio.h
@@ -43,6 +43,7 @@
 #define CIO_OPEN_RD         2         /* open and read/mmap content if exists */
 #define CIO_CHECKSUM        4         /* enable checksum verification (crc32) */
 #define CIO_FULL_SYNC       8         /* force sync to fs through MAP_SYNC */
+#define CIO_TRIM_FILES     16         /* trim files to their required size */
 
 /* Return status */
 #define CIO_CORRUPTED      -3         /* Indicate that a chunk is corrupted */
@@ -99,6 +100,9 @@ int cio_qsort(struct cio_ctx *ctx, int (*compar)(const void *, const void *));
 void cio_set_log_callback(struct cio_ctx *ctx, void (*log_cb));
 int cio_set_log_level(struct cio_ctx *ctx, int level);
 int cio_set_max_chunks_up(struct cio_ctx *ctx, int n);
+
+void cio_enable_file_trimming(struct cio_ctx *ctx);
+void cio_disable_file_trimming(struct cio_ctx *ctx);
 
 int cio_meta_write(struct cio_chunk *ch, char *buf, size_t size);
 int cio_meta_cmp(struct cio_chunk *ch, char *meta_buf, int meta_len);

--- a/lib/chunkio/include/chunkio/cio_file_st.h
+++ b/lib/chunkio/include/chunkio/cio_file_st.h
@@ -36,9 +36,10 @@
  *    +--------------+----------------+
  *    |     0xC1     |     0x00       +--> Header 2 bytes
  *    +--------------+----------------+
- *    |   4 BYTES CHECKSUM            +--> CRC32(Content)
- *    |   4 BYTES CONTENT LENGHT      +--> Content length
- *    |   12 BYTES                    +--> Padding
+ *    |           4 BYTES             +--> CRC32(Content)
+ *    |           4 BYTES             +--> CRC32(Padding)
+ *    |           4 BYTES             +--> Content length
+ *    |           8 BYTES             +--> Padding
  *    +-------------------------------+
  *    |            Content            |
  *    |  +-------------------------+  |
@@ -61,7 +62,7 @@
 #define CIO_FILE_ID_01                 0x00 /* header: second byte */
 #define CIO_FILE_HEADER_MIN              24 /* 24 bytes for the header */
 #define CIO_FILE_CONTENT_OFFSET          22
-#define CIO_FILE_CONTENT_LENGTH_OFFSET    6 /* We store the content length
+#define CIO_FILE_CONTENT_LENGTH_OFFSET   10 /* We store the content length
                                              * right after the checksum in
                                              * what used to be padding
                                              */

--- a/lib/chunkio/src/chunkio.c
+++ b/lib/chunkio/src/chunkio.c
@@ -227,3 +227,13 @@ int cio_set_max_chunks_up(struct cio_ctx *ctx, int n)
     ctx->max_chunks_up = n;
     return 0;
 }
+
+void cio_enable_file_trimming(struct cio_ctx *ctx)
+{
+    ctx->flags |= CIO_TRIM_FILES;
+}
+
+void cio_disable_file_trimming(struct cio_ctx *ctx)
+{
+    ctx->flags &= ~CIO_TRIM_FILES;
+}

--- a/lib/chunkio/src/cio_file.c
+++ b/lib/chunkio/src/cio_file.c
@@ -390,7 +390,6 @@ static int mmap_file(struct cio_ctx *ctx, struct cio_chunk *ch, size_t size)
     }
 
     /* Map the file */
-    size = ROUND_UP(size, ctx->page_size);
     cf->map = mmap(0, size, oflags, MAP_SHARED, cf->fd, 0);
     if (cf->map == MAP_FAILED) {
         cio_errno();

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -141,6 +141,9 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STORAGE_MAX_CHUNK_SIZE,
      FLB_CONF_TYPE_STR,
      offsetof(struct flb_config, storage_max_chunk_size_str)},
+    {FLB_CONF_STORAGE_TRIM_FILES,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, storage_trim_files)},
 
     /* Coroutines */
     {FLB_CONF_STR_CORO_STACK_SIZE,

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1105,17 +1105,6 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
         }
     }
 
-    if (ic != NULL) {
-        new_chunk_size = flb_input_chunk_get_real_size(ic);
-        new_chunk_size += chunk_size;
-
-        if (in->config->storage_max_chunk_size > 0 &&
-            in->config->storage_max_chunk_size < new_chunk_size) {
-            ic = NULL;
-        }
-    }
-
-
     /* No chunk was found, we need to create a new one */
     if (!ic) {
         ic = flb_input_chunk_create(in, (char *) tag, tag_len);

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -506,6 +506,11 @@ int flb_storage_create(struct flb_config *ctx)
         flags |= CIO_CHECKSUM;
     }
 
+    /* file trimming */
+    if (ctx->storage_trim_files == FLB_TRUE) {
+        flags |= CIO_TRIM_FILES;
+    }
+
     /* Create chunkio context */
     cio = cio_create(ctx->storage_path, log_cb, CIO_LOG_DEBUG, flags);
     if (!cio) {


### PR DESCRIPTION
This PR adds a new option named `storage.trim_files` which can be used to control the file trimming behavior in chunkio.

This is necessary in order to address an issue where excessive file fragmentation was caused by over zealously trimming chunk files in certain XFS deployments.

The default behavior for `storage.trim_files` is `off` which is a deviation from the previous default behavior which is something we might want to be mindful of.