### PR TITLE
yaml/v2: suppress debug messages.

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -546,7 +546,7 @@ static int read_glob(struct flb_cf *conf, struct local_ctx *ctx,
 static void print_current_state(struct local_ctx *ctx, struct parser_state *state,
                                 yaml_event_t *event)
 {
-    flb_error("%*s%s->%s", state->level*2, "", state_str(state->state),
+    flb_debug("%*s%s->%s", state->level*2, "", state_str(state->state),
              event_type_str(event));
 }
 
@@ -557,21 +557,21 @@ static void print_current_properties(struct parser_state *state)
     struct cfl_variant *var;
     int idx;
 
-    flb_error("%*s[%s] PROPERTIES:", state->level*2, "", section_names[state->section]);
+    flb_debug("%*s[%s] PROPERTIES:", state->level*2, "", section_names[state->section]);
 
     cfl_list_foreach(head, &state->keyvals->list) {
         prop = cfl_list_entry(head, struct cfl_kvpair, _head);
         switch (prop->val->type) {
         case CFL_VARIANT_STRING:
-            flb_error("%*s%s: %s", (state->level+2)*2, "", prop->key, prop->val->data.as_string);
+            flb_debug("%*s%s: %s", (state->level+2)*2, "", prop->key, prop->val->data.as_string);
             break;
         case CFL_VARIANT_ARRAY:
-            flb_error("%*s%s: [", (state->level+2)*2, "", prop->key);
+            flb_debug("%*s%s: [", (state->level+2)*2, "", prop->key);
             for (idx = 0; idx < prop->val->data.as_array->entry_count; idx++) {
                 var = cfl_array_fetch_by_index(prop->val->data.as_array, idx);
-                flb_error("%*s%s", (state->level+3)*2, "", var->data.as_string);
+                flb_debug("%*s%s", (state->level+3)*2, "", var->data.as_string);
             }
-            flb_error("%*s]", (state->level+2)*2, "");
+            flb_debug("%*s]", (state->level+2)*2, "");
             break;
         }
     }
@@ -1982,7 +1982,7 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
         return -1;
     }
 
-    flb_error("============ %s ============", cfg_file);
+    flb_debug("============ %s ============", cfg_file);
     fh = fopen(include_file, "r");
 
     if (!fh) {
@@ -2031,7 +2031,7 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
 
     } while (state->state != STATE_STOP);
 
-    flb_error("==============================");
+    flb_debug("==============================");
 done:
 
     if (code == -1) {


### PR DESCRIPTION
# Summary

During development to debug the parser many messages were left as error messages. This is due to the fact that the log level is not actually configured in `flb_main` until after parsing configuration files. I will open a PR with a possible fix for that later. For now the messages will be demoted to debugging for now.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
