### PR TITLE
in_windows_exporter_metrics: Implement WMI based process metrics

### DIFF
--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -17,6 +17,7 @@ set(src
   we_wmi_service.c
   we_wmi_memory.c
   we_wmi_paging_file.c
+  we_wmi_process.c
   )
 
 set(libs

--- a/plugins/in_windows_exporter_metrics/we.c
+++ b/plugins/in_windows_exporter_metrics/we.c
@@ -565,7 +565,8 @@ static int in_we_init(struct flb_input_instance *in,
                     if (ctx->cs_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 5;
-                    } else {
+                    }
+                    else {
                         /* Create the logical_disk collector */
                         ret = flb_input_set_collector_time(in,
                                                            we_timer_cs_metrics_cb,
@@ -689,7 +690,8 @@ static int in_we_init(struct flb_input_instance *in,
                     if (ctx->wmi_memory_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 10;
-                    } else {
+                    }
+                    else {
                         /* Create the memory collector */
                         ret = flb_input_set_collector_time(in,
                                                            we_timer_wmi_memory_metrics_cb,
@@ -713,7 +715,8 @@ static int in_we_init(struct flb_input_instance *in,
                     if (ctx->wmi_paging_file_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 11;
-                    } else {
+                    }
+                    else {
                         /* Create the paging_file collector */
                         ret = flb_input_set_collector_time(in,
                                                            we_timer_wmi_paging_file_metrics_cb,
@@ -737,7 +740,8 @@ static int in_we_init(struct flb_input_instance *in,
                     if (ctx->wmi_process_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 12;
-                    } else {
+                    }
+                    else {
                         /* Create the process collector */
                         ret = flb_input_set_collector_time(in,
                                                            we_timer_wmi_process_metrics_cb,

--- a/plugins/in_windows_exporter_metrics/we.c
+++ b/plugins/in_windows_exporter_metrics/we.c
@@ -1115,12 +1115,12 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "we.process.allow_process_regex", "/.+/",
      0, FLB_TRUE, offsetof(struct flb_we, raw_allowing_process),
-     "Specify to be scribable regex for process metrics."
+     "Specify the regex covering the process metrics to collect."
     },
     {
      FLB_CONFIG_MAP_STR, "we.process.deny_process_regex", NULL,
      0, FLB_TRUE, offsetof(struct flb_we, raw_denying_process),
-     "Specify to be denied regex for process metrics."
+     "Specify the regex for process metrics to prevent collection of/ignore."
     },
     /* EOF */
     {0}

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -199,6 +199,26 @@ struct we_wmi_paging_file_counters {
     int                    operational;
 };
 
+struct we_wmi_process_counters {
+    struct wmi_query_spec *info;
+    struct cmt_gauge      *start_time;
+    struct cmt_gauge      *handles;
+    struct cmt_gauge      *cpu_time_total;
+    struct cmt_gauge      *io_bytes_total;
+    struct cmt_gauge      *io_operations_total;
+    struct cmt_gauge      *page_faults_total;
+    struct cmt_gauge      *page_file_bytes;
+    struct cmt_gauge      *pool_bytes;
+    struct cmt_gauge      *priority_base;
+    struct cmt_gauge      *thread_count;
+    struct cmt_gauge      *private_bytes;
+    struct cmt_gauge      *virtual_bytes;
+    struct cmt_gauge      *working_set_private_bytes;
+    struct cmt_gauge      *working_set_peak_bytes;
+    struct cmt_gauge      *working_set_bytes;
+    int                    operational;
+};
+
 struct we_os_counters {
     struct cmt_gauge *info;
     struct cmt_gauge *users;
@@ -235,6 +255,8 @@ struct flb_we {
     char *raw_where_clause;
     char *raw_service_include;
     char *raw_service_exclude;
+    char *raw_allowing_process;
+    char *raw_denying_process;
     char *service_include_buffer;
     int   service_include_buffer_size;
     char *service_exclude_buffer;
@@ -243,6 +265,8 @@ struct flb_we {
     struct flb_regex *allowing_disk_regex;
     struct flb_regex *denying_disk_regex;
     struct flb_regex *allowing_nic_regex;
+    struct flb_regex *allowing_process_regex;
+    struct flb_regex *denying_process_regex;
 
     struct we_perflib_context perflib_context;
     /* WMI locator and service contexts */
@@ -267,6 +291,7 @@ struct flb_we {
     int wmi_service_scrape_interval;
     int wmi_memory_scrape_interval;
     int wmi_paging_file_scrape_interval;
+    int wmi_process_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_net_fd;                                    /* collector fd (net)  */
@@ -280,6 +305,7 @@ struct flb_we {
     int coll_wmi_service_fd;                            /* collector fd (wmi_service) */
     int coll_wmi_memory_fd;                             /* collector fd (wmi_memory)    */
     int coll_wmi_paging_file_fd;                        /* collector fd (wmi_paging_file) */
+    int coll_wmi_process_fd;                            /* collector fd (wmi_process) */
 
     /*
      * Metrics Contexts
@@ -298,6 +324,7 @@ struct flb_we {
     struct we_wmi_service_counters *wmi_service;
     struct we_wmi_memory_counters *wmi_memory;
     struct we_wmi_paging_file_counters *wmi_paging_file;
+    struct we_wmi_process_counters *wmi_process;
 };
 
 typedef int (*collector_cb)(struct flb_we *);

--- a/plugins/in_windows_exporter_metrics/we_config.c
+++ b/plugins/in_windows_exporter_metrics/we_config.c
@@ -42,6 +42,8 @@ struct flb_we *flb_we_config_create(struct flb_input_instance *ins,
     ctx->service_include_buffer_size = 0;
     ctx->service_exclude_buffer = NULL;
     ctx->service_exclude_buffer_size = 0;
+    ctx->allowing_process_regex = NULL;
+    ctx->denying_process_regex = NULL;
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *) ctx);
@@ -91,6 +93,15 @@ struct flb_we *flb_we_config_create(struct flb_input_instance *ins,
         }
     }
 
+    /* Process allow/deny regex rules for process metrics */
+    if (ctx->raw_allowing_process != NULL) {
+        ctx->allowing_process_regex = flb_regex_create(ctx->raw_allowing_process);
+    }
+
+    if (ctx->raw_denying_process != NULL) {
+        ctx->denying_process_regex = flb_regex_create(ctx->raw_denying_process);
+    }
+
     ctx->cmt = cmt_create();
     if (!ctx->cmt) {
         flb_plg_error(ins, "could not initialize CMetrics");
@@ -125,6 +136,14 @@ void flb_we_config_destroy(struct flb_we *ctx)
 
     if (ctx->service_exclude_buffer != NULL) {
         flb_free(ctx->service_exclude_buffer);
+    }
+
+    if (ctx->allowing_process_regex != NULL) {
+        flb_regex_destroy(ctx->allowing_process_regex);
+    }
+
+    if (ctx->denying_disk_regex != NULL) {
+        flb_regex_destroy(ctx->denying_disk_regex);
     }
 
     if (ctx->cmt) {

--- a/plugins/in_windows_exporter_metrics/we_wmi_process.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_process.c
@@ -1,0 +1,417 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "we.h"
+#include "we_wmi.h"
+#include "we_wmi_process.h"
+#include "we_util.h"
+#include "we_metric.h"
+
+static double nop_adjust(double value)
+{
+    return value;
+}
+
+int we_wmi_process_init(struct flb_we *ctx)
+{
+    struct cmt_gauge *g;
+
+    ctx->wmi_process = flb_calloc(1, sizeof(struct we_wmi_process_counters));
+    if (!ctx->wmi_process) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_process->operational = FLB_FALSE;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "start_time",
+                         "Time of process start",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->start_time = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "handles",
+                         "Total number of handles the process has open. " \
+                         "This number is the sum of the handles currently " \
+                         "open by each thread in the process.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->handles = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "cpu_time_total",
+                        "Returns elapsed time that all of the threads of this process " \
+                         "used the processor to execute instructions by mode " \
+                         "(privileged, user). An instruction is the basic unit " \
+                         "of execution in a computer, a thread is the object " \
+                         "that executes instructions, and a process is " \
+                         "the object created when a program is run. "   \
+                         "Code executed to handle some hardware interrupts " \
+                         "and trap conditions is included in this count.",
+                         4, (char *[]) {"process", "process_id", "creating_process_id", "mode"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->cpu_time_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "io_bytes_total",
+                         "Bytes issued to I/O operations in different modes "\
+                         "(read, write, other).",
+                         4, (char *[]) {"process", "process_id", "creating_process_id", "mode"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->io_bytes_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "io_operations_total",
+                         "I/O operations issued in different modes (read, write, other).",
+                         4, (char *[]) {"process", "process_id", "creating_process_id", "mode"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->io_operations_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "page_faults_total",
+                         "Page faults by the threads executing in this process.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->page_faults_total = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "page_file_bytes",
+                         "Current number of bytes this process has used " \
+                         "in the paging file(s).",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->page_file_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "pool_bytes",
+                         "Pool Bytes is the last observed number of bytes " \
+                         "in the paged or nonpaged pool.",
+                         4, (char *[]) {"process", "process_id", "creating_process_id", "pool"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->pool_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "priority_base",
+                         "Current base priority of this process. "      \
+                         "Threads within a process can raise and "      \
+                         "lower their own base priority relative to "   \
+                         "the process base priority of the process.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->priority_base = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "private_bytes",
+                         "Current number of bytes this process has allocated " \
+                         "that cannot be shared with other processes.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->private_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "thread_count",
+                         "Number of threads currently active in this process.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->thread_count = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "virtual_bytes",
+                         "Current size, in bytes, of the virtual address space " \
+                         "that the process is using.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->virtual_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "working_set_private_bytes",
+                         "Size of the working set, in bytes, that is "  \
+                         "use for this process only and not shared nor " \
+                         "shareable by other processes.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->working_set_private_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "working_set_peak_bytes",
+                         "Maximum size, in bytes, of the Working Set of " \
+                         "this process at any point in time. "          \
+                         "The Working Set is the set of memory pages touched recently " \
+                         "by the threads in the process.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->working_set_peak_bytes = g;
+
+    g = cmt_gauge_create(ctx->cmt, "windows", "process", "working_set_bytes",
+                         "Maximum number of bytes in the working set of " \
+                         "this process at any point in time. "          \
+                         "The working set is the set of memory pages touched recently " \
+                         "by the threads in the process.",
+                         3, (char *[]) {"process", "process_id", "creating_process_id"});
+
+    if (!g) {
+        return -1;
+    }
+    ctx->wmi_process->working_set_bytes = g;
+
+    ctx->wmi_process->info = flb_calloc(1, sizeof(struct wmi_query_spec));
+    if (!ctx->wmi_process->info) {
+        flb_errno();
+        return -1;
+    }
+    ctx->wmi_process->info->metric_instance = (void *)g;
+    ctx->wmi_process->info->type = CMT_GAUGE;
+    ctx->wmi_process->info->value_adjuster = nop_adjust;
+    ctx->wmi_process->info->wmi_counter = "Win32_PerfRawData_PerfProc_Process";
+    ctx->wmi_process->info->wmi_property = "";
+    ctx->wmi_process->info->label_property_count = 0;
+    ctx->wmi_process->info->label_property_keys = NULL;
+    ctx->wmi_process->info->where_clause = NULL;
+
+    ctx->wmi_process->operational = FLB_TRUE;
+
+    return 0;
+}
+
+int we_wmi_process_exit(struct flb_we *ctx)
+{
+    ctx->wmi_process->operational = FLB_FALSE;
+
+    flb_free(ctx->wmi_process->info);
+    flb_free(ctx->wmi_process);
+
+    return 0;
+}
+
+static int wmi_process_regex_match(struct flb_regex *regex, char *name)
+{
+    if (regex == NULL) {
+        return 0;
+    }
+
+    if (name == NULL) {
+        return 0;
+    }
+
+    return flb_regex_match(regex, name, strlen(name));
+}
+
+int we_wmi_process_filter(char *name, struct flb_we *ctx)
+{
+    if (strcasestr(name, "_Total") != NULL) {
+        return 1;
+    }
+
+    if (wmi_process_regex_match(ctx->denying_process_regex, name) ||
+        !wmi_process_regex_match(ctx->allowing_process_regex, name)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+int we_wmi_process_update(struct flb_we *ctx)
+{
+    uint64_t timestamp = 0;
+    IEnumWbemClassObject* enumerator = NULL;
+    HRESULT hr;
+
+    IWbemClassObject *class_obj = NULL;
+    ULONG ret = 0;
+    double val = 0;
+    char *name = NULL;
+    char *process_name = NULL;
+    char *process_id = NULL;
+    char *creating_process_id = NULL;
+    double freq = 0;
+    double ticks_to_seconds = 1 / 1e7;
+    char *state;
+
+    if (!ctx->wmi_process->operational) {
+        flb_plg_error(ctx->ins, "process collector not yet in operational state");
+
+        return -1;
+    }
+
+    if (FAILED(we_wmi_coinitialize(ctx))) {
+        return -1;
+    }
+
+    timestamp = cfl_time_now();
+
+    if (FAILED(we_wmi_execute_query(ctx, ctx->wmi_process->info, &enumerator))) {
+        return -1;
+    }
+
+    while(enumerator) {
+        hr = enumerator->lpVtbl->Next(enumerator, WBEM_INFINITE, 1, &class_obj, &ret);
+
+        if(ret == 0) {
+            break;
+        }
+
+        name = we_wmi_get_property_str_value(ctx, "Name", class_obj);
+        if (!name) {
+            continue;
+        }
+        /* Remove # from the duplicated process names */
+        process_name = strtok_s(name, "#", &state);
+        if (we_wmi_process_filter(process_name, ctx) == 1) {
+            flb_free(name);
+
+            continue;
+        }
+
+        process_id = we_wmi_get_property_str_value(ctx, "IDProcess", class_obj);
+        creating_process_id = we_wmi_get_property_str_value(ctx, "CreatingProcessID", class_obj);
+        freq = we_wmi_get_property_value(ctx, "Frequency_Object", class_obj);
+
+        val = we_wmi_get_property_value(ctx, "ElapsedTime", class_obj);
+        cmt_gauge_set(ctx->wmi_process->start_time, timestamp,
+                      (double)((val-116444736000000000)/freq),
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "HandleCount", class_obj);
+        cmt_gauge_set(ctx->wmi_process->handles, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "PercentUserTime", class_obj);
+        cmt_gauge_set(ctx->wmi_process->cpu_time_total, timestamp, val * ticks_to_seconds,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "user"});
+
+        val = we_wmi_get_property_value(ctx, "PercentPrivilegedTime", class_obj);
+        cmt_gauge_set(ctx->wmi_process->cpu_time_total, timestamp, val * ticks_to_seconds,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "privileged"});
+
+        val = we_wmi_get_property_value(ctx, "IOOtherBytesPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->io_bytes_total, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "other"});
+
+        val = we_wmi_get_property_value(ctx, "IOOtherOperationsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->io_operations_total, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "other"});
+
+        val = we_wmi_get_property_value(ctx, "IOReadBytesPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->io_bytes_total, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "read"});
+
+        val = we_wmi_get_property_value(ctx, "IOReadOperationsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->io_operations_total, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "read"});
+
+        val = we_wmi_get_property_value(ctx, "IOWriteBytesPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->io_bytes_total, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "write"});
+
+        val = we_wmi_get_property_value(ctx, "IOWriteOperationsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->io_operations_total, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "write"});
+
+        val = we_wmi_get_property_value(ctx, "PageFaultsPersec", class_obj);
+        cmt_gauge_set(ctx->wmi_process->page_faults_total, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "PageFileBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_process->page_file_bytes, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "PoolNonpagedBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_process->pool_bytes, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "nonpaged"});
+
+        val = we_wmi_get_property_value(ctx, "PoolPagedBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_process->pool_bytes, timestamp, val,
+                      4, (char *[]) {process_name, process_id, creating_process_id, "paged"});
+
+        val = we_wmi_get_property_value(ctx, "PriorityBase", class_obj);
+        cmt_gauge_set(ctx->wmi_process->priority_base, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "ThreadCount", class_obj);
+        cmt_gauge_set(ctx->wmi_process->thread_count, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "PrivateBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_process->private_bytes, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "VirtualBytes", class_obj);
+        cmt_gauge_set(ctx->wmi_process->virtual_bytes, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "WorkingSetPrivate", class_obj);
+        cmt_gauge_set(ctx->wmi_process->working_set_private_bytes, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "WorkingSetPeak", class_obj);
+        cmt_gauge_set(ctx->wmi_process->working_set_peak_bytes, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        val = we_wmi_get_property_value(ctx, "WorkingSet", class_obj);
+        cmt_gauge_set(ctx->wmi_process->working_set_bytes, timestamp, val,
+                      3, (char *[]) {process_name, process_id, creating_process_id});
+
+        class_obj->lpVtbl->Release(class_obj);
+
+        flb_free(name);
+        flb_free(process_id);
+        flb_free(creating_process_id);
+    }
+
+    enumerator->lpVtbl->Release(enumerator);
+
+    we_wmi_cleanup(ctx);
+
+    return 0;
+}

--- a/plugins/in_windows_exporter_metrics/we_wmi_process.h
+++ b/plugins/in_windows_exporter_metrics/we_wmi_process.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_WE_WMI_PROCESS_INFO_H
+#define FLB_WE_WMI_PROCESS_INFO_H
+
+#include "we.h"
+
+int we_wmi_process_info_init(struct flb_we *ctx);
+int we_wmi_process_info_exit(struct flb_we *ctx);
+int we_wmi_process_info_update(struct flb_we *ctx);
+
+#endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
To monitor per process work loads, we need to implement process metrics on in_windows_exporter_metrics plugin.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes https://github.com/fluent/fluent-bit/issues/7855

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```ini
[SERVICE]
   flush_interval 10s
   log_level debug

[INPUT]
   Name windows_exporter_metrics
   scrape_interval 2s
   metrics process
   we.process.allow_process_regex /firefox|svchost/
   # we.process.deny_process_regex /firefox|svchost/

[OUTPUT]
   Name stdout
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1182

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
