### PR TITLE
 tests: internal: stream_processor: fix when test path is too long.

### DIFF
--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -446,7 +446,7 @@ static void test_window()
     int t;
     int checks;
     int ret;
-    char datafile[100];
+    char datafile[PATH_MAX];
     struct sp_buffer data_buf;
     struct sp_buffer out_buf;
     struct task_check *check;
@@ -529,8 +529,13 @@ static void test_window()
             task->window.fd_hop = 1;
             double record_timestamp = 1.0;
             for (t = 0; t < check->window_size_sec + check->window_hop_sec; t++) {
-                sprintf(datafile, "%s%d.mp",
+                ret = snprintf(datafile, sizeof(datafile)-1, "%s%d.mp",
                         DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
+                TEST_CHECK(ret <= sizeof(datafile)-1);
+
+                if (ret > sizeof(datafile)-1) {
+                    exit(1);
+                }
                 ret = file_to_buf(datafile, &data_buf);
                 if (ret == -1) {
                     flb_error("[sp test] cannot open DATA_SAMPLES file %s", datafile);
@@ -592,7 +597,7 @@ static void test_snapshot()
     int t;
     int checks;
     int ret;
-    char datafile[100];
+    char datafile[PATH_MAX];
     char stream_name[100];
     char window_val[3];
     struct sp_buffer data_buf;
@@ -666,8 +671,14 @@ static void test_snapshot()
 
         /* Read 1.mp -> 5.mp message pack buffers created for window tests */
         for (t = 0; t < 5; t++) {
-            sprintf(datafile, "%s%d.mp",
+
+            ret = snprintf(datafile, sizeof(datafile)-1, "%s%d.mp",
                     DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
+            TEST_CHECK(ret <= sizeof(datafile)-1);
+
+            if (ret > sizeof(datafile)-1) {
+                exit(1);
+            }
 
             if (data_buf.buffer) {
                 flb_free(data_buf.buffer);

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -531,9 +531,7 @@ static void test_window()
             for (t = 0; t < check->window_size_sec + check->window_hop_sec; t++) {
                 ret = snprintf(datafile, sizeof(datafile)-1, "%s%d.mp",
                         DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
-                TEST_CHECK(ret <= sizeof(datafile)-1);
-
-                if (ret > sizeof(datafile)-1) {
+                if (!TEST_CHECK(ret <= sizeof(datafile)-1)) {
                     exit(1);
                 }
                 ret = file_to_buf(datafile, &data_buf);
@@ -674,9 +672,7 @@ static void test_snapshot()
 
             ret = snprintf(datafile, sizeof(datafile)-1, "%s%d.mp",
                     DATA_SAMPLES_HOPPING_WINDOW_PATH, t + 1);
-            TEST_CHECK(ret <= sizeof(datafile)-1);
-
-            if (ret > sizeof(datafile)-1) {
+            if (!TEST_CHECK(ret <= sizeof(datafile)-1)) {
                 exit(1);
             }
 


### PR DESCRIPTION
# Summary

Fix the usage of datafile so it will not overflow when testing from a long repository path. This patch uses snprintf as well as defining the size of the string with PATH_MAX.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
