### PR TITLE
in_node_exporter_metrics: Fix registering callback for systemd metrics

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -391,6 +391,7 @@ static int in_ne_init(struct flb_input_instance *in,
     ctx->coll_netdev_fd = -1;
     ctx->coll_filefd_fd = -1;
     ctx->coll_textfile_fd = -1;
+    ctx->coll_systemd_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -680,12 +681,12 @@ static int in_ne_init(struct flb_input_instance *in,
                     }
                     ne_textfile_init(ctx);
                 }
-                else if (strncmp(entry->str, "systemd", 8) == 0) {
+                else if (strncmp(entry->str, "systemd", 7) == 0) {
                     if (ctx->systemd_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 13;
                     }
-                    else if (ctx->textfile_scrape_interval > 0) {
+                    else if (ctx->systemd_scrape_interval > 0) {
                         /* Create the filefd collector */
                         ret = flb_input_set_collector_time(in,
                                                            ne_timer_systemd_metrics_cb,
@@ -782,7 +783,7 @@ static int in_ne_exit(void *data, struct flb_config *config)
                 else if (strncmp(entry->str, "textfile", 8) == 0) {
                     /* nop */
                 }
-                else if (strncmp(entry->str, "systemd", 8) == 0) {
+                else if (strncmp(entry->str, "systemd", 7) == 0) {
                     ne_systemd_exit(ctx);
                 }
                 else {
@@ -812,6 +813,9 @@ static int in_ne_exit(void *data, struct flb_config *config)
     }
     if (ctx->coll_netdev_fd != -1) {
         ne_netdev_exit(ctx);
+    }
+    if (ctx->coll_systemd_fd != -1) {
+        ne_systemd_exit(ctx);
     }
 
     flb_ne_config_destroy(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed for registering callback settings for systemd metrics.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

fluent-bit starts with: `valgrind bin/fluent-bit -i node_exporter_metrics -p metrics=systemd -o stdout`

```
==85698== 
==85698== HEAP SUMMARY:
==85698==     in use at exit: 0 bytes in 0 blocks
==85698==   total heap usage: 128,161 allocs, 128,161 frees, 6,672,526,968 bytes allocated
==85698== 
==85698== All heap blocks were freed -- no leaks are possible
==85698== 
==85698== For lists of detected and suppressed errors, rerun with: -s
==85698== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
