### PR TITLE
config_format: yaml: fix null dereference

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1285,13 +1285,13 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
             break;
         case YAML_SEQUENCE_START_EVENT: /* start a new group */
 
-            if (strcmp(state->key, "processors") == 0) {
-                yaml_error_event(ctx, state, event);
+            if (state->key == NULL) {
+                flb_error("no key");
                 return YAML_FAILURE;
             }
 
-            if (state->key == NULL) {
-                flb_error("no key");
+            if (strcmp(state->key, "processors") == 0) {
+                yaml_error_event(ctx, state, event);
                 return YAML_FAILURE;
             }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
The NULL check has to happen before the call to `strcmp` as otherwise a NULL dereference exists in `strcmp`.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61733

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
