### PR TITLE
config_format: yaml: add support for idiomatic Yaml camelCase (fix #7593)

### DIFF
--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -50,6 +50,8 @@ enum cf_file_format {
 #endif
 };
 
+#define FLB_CF_CLASSIC FLB_CF_FLUENTBIT
+
 enum section_type {
     FLB_CF_SERVICE = 0,           /* [SERVICE]           */
     FLB_CF_PARSER,                /* [PARSER]            */
@@ -79,6 +81,9 @@ struct flb_cf_section {
 };
 
 struct flb_cf {
+    /* origin format */
+    int format;
+
     /* global service */
     struct flb_cf_section *service;
 
@@ -117,9 +122,11 @@ struct flb_cf {
 
 struct flb_cf *flb_cf_create();
 struct flb_cf *flb_cf_create_from_file(struct flb_cf *cf, char *file);
+flb_sds_t flb_cf_key_translate(struct flb_cf *cf, char *key, int len);
 
 void flb_cf_destroy(struct flb_cf *cf);
 
+int flb_cf_set_origin_format(struct flb_cf *cf, int format);
 void flb_cf_dump(struct flb_cf *cf);
 
 struct flb_kv *flb_cf_env_property_add(struct flb_cf *cf,

--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -776,6 +776,8 @@ struct flb_cf *flb_cf_fluentbit_create(struct flb_cf *cf,
         if (!cf) {
             return NULL;
         }
+
+        flb_cf_set_origin_format(cf, FLB_CF_CLASSIC);
     }
 
     ret = local_init(&ctx, file_path);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2074,10 +2074,11 @@ struct flb_cf *flb_cf_yaml_create(struct flb_cf *conf, char *file_path,
 
     if (!conf) {
         conf = flb_cf_create();
-
         if (!conf) {
             return NULL;
         }
+
+        flb_cf_set_origin_format(conf, FLB_CF_YAML);
     }
 
     /* initialize the parser state */

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -146,7 +146,11 @@ void flb_cf_destroy(struct flb_cf *cf)
 
 int flb_cf_set_origin_format(struct flb_cf *cf, int format)
 {
+#ifdef FLB_HAVE_LIBYAML
     if (format != FLB_CF_CLASSIC && format != FLB_CF_YAML) {
+#else
+    if (format != FLB_CF_CLASSIC) {
+#endif
         return -1;
     }
 

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -104,7 +104,7 @@ struct flb_cf *flb_cf_create()
         flb_errno();
         return NULL;
     }
-    ctx->format = -1;
+    ctx->format = FLB_CF_CLASSIC;
 
     /* env vars */
     mk_list_init(&ctx->env);

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -34,6 +34,67 @@ int flb_cf_file_read()
     return 0;
 }
 
+/* Retrieve the proper key name, it tries to auto-detect Yaml camelcase and convert it to snake_case */
+flb_sds_t flb_cf_key_translate(struct flb_cf *cf, char *key, int len)
+{
+    int i;
+    int x = 0;
+    int is_upper;
+    flb_sds_t out;
+
+    if (!key || len <= 0) {
+        return NULL;
+    }
+
+    /* If we got something in classic format, just convert it to lowercase and return */
+    if (cf->format == FLB_CF_CLASSIC) {
+        out = flb_sds_create_len(key, len);
+        if (!out) {
+            return NULL;
+        }
+
+        for (i = 0; i < len; i++) {
+            out[i] = tolower(key[i]);
+        }
+        flb_sds_len_set(out, len);
+        return out;
+    }
+
+    /*
+     * First step is try to identify if the incoming key is a strict Yaml camelcase format
+     */
+
+    /* does it start with a lowercase character ? */
+    if (!islower(key[0])) {
+        return flb_sds_create_len(key, len);
+    }
+
+    /* copy content and check if we have underscores */
+    out = flb_sds_create_len(key, len);
+    for (i = 0; i < len; i++) {
+        if (key[i] == '_') {
+            /* the config is classic mode, so it's safe to return the same copy of the content */
+            for (i = 0; i < len; i++) {
+                out[i] = tolower(key[i]);
+            }
+            flb_sds_len_set(out, len);
+            return out;
+        }
+    }
+
+    /* translate from camelCase to snake_case */
+    for (i = 0; i < len; i++) {
+        is_upper = isupper(key[i]);
+        if (is_upper && i > 0) {
+            out[x++] = '_';
+        }
+        out[x++] = tolower(key[i]);
+
+    }
+    flb_sds_len_set(out, x);
+    return out;
+}
+
 struct flb_cf *flb_cf_create()
 {
     struct flb_cf *ctx;
@@ -43,6 +104,7 @@ struct flb_cf *flb_cf_create()
         flb_errno();
         return NULL;
     }
+    ctx->format = -1;
 
     /* env vars */
     mk_list_init(&ctx->env);
@@ -77,6 +139,16 @@ void flb_cf_destroy(struct flb_cf *cf)
     flb_kv_release(&cf->metas);
     flb_cf_section_destroy_all(cf);
     flb_free(cf);
+}
+
+int flb_cf_set_origin_format(struct flb_cf *cf, int format)
+{
+    if (format != FLB_CF_CLASSIC && format != FLB_CF_YAML) {
+        return -1;
+    }
+
+    cf->format = format;
+    return 0;
 }
 
 static enum section_type get_section_type(char *name, int len)
@@ -126,7 +198,8 @@ int flb_cf_plugin_property_add(struct flb_cf *cf,
         v_len = strlen(v_buf);
     }
 
-    key = flb_sds_create_len(k_buf, k_len);
+
+    key = flb_cf_key_translate(cf, k_buf, k_len);
     if (key == NULL) {
         return -1;
     }
@@ -165,17 +238,16 @@ struct cfl_variant *flb_cf_section_property_add(struct flb_cf *cf,
                                               char *k_buf, size_t k_len,
                                               char *v_buf, size_t v_len)
 {
-    int i;
     int rc;
     flb_sds_t key;
     flb_sds_t val;
     struct cfl_variant *var;
 
-
     if (k_len == 0) {
         k_len = strlen(k_buf);
     }
-    key = flb_sds_create_len(k_buf, k_len);
+
+    key = flb_cf_key_translate(cf, k_buf, k_len);
     if (key == NULL) {
         goto key_error;
     }
@@ -185,10 +257,6 @@ struct cfl_variant *flb_cf_section_property_add(struct flb_cf *cf,
     if (rc == -1) {
         flb_cf_error_set(cf, FLB_CF_ERROR_KV_INVALID_KEY);
         goto val_error;
-    }
-
-    for (i = 0; i < flb_sds_len(key); i++) {
-        key[i] = tolower(key[i]);
     }
 
     if (v_len == 0) {
@@ -241,7 +309,8 @@ struct cfl_array *flb_cf_section_property_add_list(struct flb_cf *cf,
     if (k_len == 0) {
         k_len = strlen(k_buf);
     }
-    key = flb_sds_create_len(k_buf, k_len);
+
+    key = flb_cf_key_translate(cf, k_buf, k_len);
     if (key == NULL) {
         goto key_error;
     }
@@ -284,12 +353,10 @@ flb_sds_t flb_cf_section_property_get_string(struct flb_cf *cf, struct flb_cf_se
     flb_sds_t ret = NULL;
     struct cfl_variant *entry;
     int i;
+    int len;
 
-
-    tkey = flb_sds_create(key);
-    for (i = 0; i < strlen(key); i++) {
-        tkey[i] = tolower(key[i]);
-    }
+    len = strlen(key);
+    tkey = flb_cf_key_translate(cf, key, len);
 
     val = cfl_kvlist_fetch(s->properties, key);
     flb_sds_destroy(tkey);

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -70,7 +70,9 @@ flb_sds_t flb_cf_key_translate(struct flb_cf *cf, char *key, int len)
     }
 
     /* copy content and check if we have underscores */
-    out = flb_sds_create_len(key, len);
+    out = flb_sds_create_size(len * 2);
+    flb_sds_cat_safe(&out, key, len);
+
     for (i = 0; i < len; i++) {
         if (key[i] == '_') {
             /* the config is classic mode, so it's safe to return the same copy of the content */
@@ -91,6 +93,7 @@ flb_sds_t flb_cf_key_translate(struct flb_cf *cf, char *key, int len)
         out[x++] = tolower(key[i]);
 
     }
+    out[x] = '\0';
     flb_sds_len_set(out, x);
     return out;
 }

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -323,6 +323,8 @@ static inline int check_snake_case(char *input, char *output)
 
     flb_sds_destroy(out);
 
+    flb_cf_destroy(cf);
+
     if (ret == 0) {
         return FLB_TRUE;
     }

--- a/tests/internal/config_format_fluentbit.c
+++ b/tests/internal/config_format_fluentbit.c
@@ -262,7 +262,6 @@ void not_current_dir_files()
 /* data/config_format/nolimitline.conf */
 void test_nolimit_line()
 {
-    struct mk_list *head;
     struct flb_cf *cf;
     struct flb_cf_section *s;
     struct cfl_list *p_head;
@@ -306,6 +305,40 @@ void test_nolimit_line()
     flb_cf_destroy(cf);
 }
 
+static inline int check_snake_case(char *input, char *output)
+{
+    int len;
+    int ret;
+    flb_sds_t out;
+    struct flb_cf *cf;
+
+
+    cf = flb_cf_create();
+    flb_cf_set_origin_format(cf, FLB_CF_CLASSIC);
+
+    len = strlen(input);
+    out = flb_cf_key_translate(cf, input, len);
+
+    ret = strcmp(out, output);
+
+    flb_sds_destroy(out);
+
+    if (ret == 0) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+static void test_snake_case_key()
+{
+    /* normal conversion */
+    TEST_CHECK(check_snake_case("a", "a") == FLB_TRUE);
+    TEST_CHECK(check_snake_case("aB", "ab") == FLB_TRUE);
+    TEST_CHECK(check_snake_case("aBc", "abc") == FLB_TRUE);
+    TEST_CHECK(check_snake_case("interval_Sec", "interval_sec") == FLB_TRUE);
+}
+
 TEST_LIST = {
     { "basic"    , test_basic},
     { "missing_value_issue5880" , missing_value},
@@ -313,5 +346,6 @@ TEST_LIST = {
     { "recursion" , recursion},
     { "not_current_dir_files", not_current_dir_files},
     { "no_limit_line", test_nolimit_line},
+    { "snake_case_key", test_snake_case_key},
     { 0 }
 };

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -274,10 +274,9 @@ static void test_parser_conf()
 static inline int check_camel_to_snake(char *input, char *output)
 {
     int len;
-    int ret;
+    int ret = -1;
     flb_sds_t out;
     struct flb_cf *cf;
-
 
     cf = flb_cf_create();
     flb_cf_set_origin_format(cf, FLB_CF_YAML);
@@ -286,8 +285,9 @@ static inline int check_camel_to_snake(char *input, char *output)
     out = flb_cf_key_translate(cf, input, len);
 
     ret = strcmp(out, output);
-
     flb_sds_destroy(out);
+
+    flb_cf_destroy(cf);
 
     if (ret == 0) {
         return FLB_TRUE;


### PR DESCRIPTION
The current Yaml reader is agnostic from the keys format, it only cares to convert them to lower
case so the backend layer can configure the properties properly. The following is an non-idiomatic
example:

```yaml
    env:
        flushInterval: 1

    service:
        flush: ${flushInterval}

    pipeline:
        inputs:
            - name: random
              Interval_Sec: 1

        filters:
            - name: record_modifier
              match: "*"
              record: powered_by calyptia
              uuid_key: abc

        outputs:
            - name: stdout
              match: "*"
```

The following patch make the Yaml parser to be idiomatic by supporting a compatible layer with
camelCase style for key names, e.g:

```yaml
    env:
        flushInterval: 1

    service:
        flush: ${flushInterval}

    pipeline:
        inputs:
            - name: random
              intervalSec: 1

        filters:
            - name: record_modifier
              match: "*"
              record: powered_by calyptia
              uuidKey: abc

        outputs:
            - name: stdout
              match: "*"        
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
