### PR TITLE
in_node_exporter_metrics: implement processes metrics

### DIFF
--- a/plugins/in_node_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_node_exporter_metrics/CMakeLists.txt
@@ -11,6 +11,7 @@ set(src
   ne_loadavg.c
   ne_filefd_linux.c
   ne_textfile.c
+  ne_processes.c
   ne_utils.c
   ne_config.c
   ne.c

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -66,6 +66,7 @@ struct flb_ne {
     int filefd_scrape_interval;
     int textfile_scrape_interval;
     int systemd_scrape_interval;
+    int processes_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_cpufreq_fd;                                /* collector fd (cpufreq)  */
@@ -81,6 +82,7 @@ struct flb_ne {
     int coll_filefd_fd;                                 /* collector fd (filefd)    */
     int coll_textfile_fd;                               /* collector fd (textfile)  */
     int coll_systemd_fd ;                               /* collector fd (systemd)  */
+    int coll_processes_fd ;                             /* collector fd (processes)  */
 
     /*
      * Metrics Contexts
@@ -186,6 +188,14 @@ struct flb_ne {
     struct flb_regex   *systemd_regex_exclude_list;
     double              libsystemd_version;
     char               *libsystemd_version_text;
+
+    /* processes */
+    struct cmt_gauge   *processes_thread_alloc;
+    struct cmt_gauge   *processes_threads_limit;
+    struct cmt_gauge   *processes_threads_state;
+    struct cmt_gauge   *processes_procs_state;
+    struct cmt_gauge   *processes_pid_used;
+    struct cmt_gauge   *processes_pid_max;
 };
 
 #endif

--- a/plugins/in_node_exporter_metrics/ne_processes.c
+++ b/plugins/in_node_exporter_metrics/ne_processes.c
@@ -1,0 +1,22 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef __linux__
+#include "ne_processes_linux.c"
+#endif

--- a/plugins/in_node_exporter_metrics/ne_processes.h
+++ b/plugins/in_node_exporter_metrics/ne_processes.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_PROCESSES_H
+#define FLB_IN_NE_PROCESSES_H
+
+#include "ne.h"
+
+int ne_processes_init(struct flb_ne *ctx);
+int ne_processes_update(struct flb_ne *ctx);
+int ne_processes_exit(struct flb_ne *ctx);
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_processes_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_processes_linux.c
@@ -1,0 +1,379 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "ne.h"
+#include "ne_utils.h"
+
+#include <unistd.h>
+
+static int processes_configure(struct flb_ne *ctx)
+{
+    struct cmt_gauge *g;
+
+    /* node_processes_threads_max */
+    g = cmt_gauge_create(ctx->cmt, "node", "processes", "threads",
+                         "Allocated threads in the system",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->processes_thread_alloc = g;
+
+    /* node_processes_threads_max */
+    g = cmt_gauge_create(ctx->cmt, "node", "processes", "max_threads",
+                         "Limit of threads in the system",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->processes_threads_limit = g;
+
+    /* node_processes_threads_state */
+    g = cmt_gauge_create(ctx->cmt, "node", "processes", "threads_state",
+                         "The number of processes in each thread state",
+                         1, (char *[]) {"thread_state"});
+    if (!g) {
+        return -1;
+    }
+    ctx->processes_threads_state = g;
+
+    /* node_processes_state */
+    g = cmt_gauge_create(ctx->cmt, "node", "processes", "state",
+                         "The number of processes in each state",
+                         1, (char *[]) {"state"});
+    if (!g) {
+        return -1;
+    }
+    ctx->processes_procs_state = g;
+
+    /* node_processes_pids */
+    g = cmt_gauge_create(ctx->cmt, "node", "processes", "pids",
+                         "The number of PIDs in the system",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->processes_pid_used = g;
+
+    /* node_processes_max_processeses */
+    g = cmt_gauge_create(ctx->cmt, "node", "processes", "max_processeses",
+                         "Limit of PID in the system",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->processes_pid_max = g;
+
+    return 0;
+}
+
+struct proc_state {
+    int64_t running;
+    int64_t interruptible_sleeping;
+    int64_t uninterruptible_sleeping;
+    int64_t zombie;
+    int64_t stopped;
+    int64_t idle;
+};
+
+static int update_processes_proc_state(struct flb_ne *ctx, struct proc_state *state, char* state_str)
+{
+    if (strcmp(state_str, "R") == 0) {
+        state->running++;
+    }
+    else if (strcmp(state_str, "S") == 0) {
+        state->interruptible_sleeping++;
+    }
+    else if (strcmp(state_str, "D") == 0) {
+        state->uninterruptible_sleeping++;
+    }
+    else if (strcmp(state_str, "Z") == 0) {
+        state->zombie++;
+    }
+    else if (strcmp(state_str, "T") == 0) {
+        state->stopped++;
+    }
+    else if (strcmp(state_str, "I") == 0) {
+        state->idle++;
+    }
+
+    return 0;
+}
+
+static int processes_thread_update(struct flb_ne *ctx, flb_sds_t pid_str, flb_sds_t pstate_str,
+                                   struct proc_state *tstate)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t tid_str;
+    flb_sds_t state_str;
+    const char *pattern = "/[0-9]*";
+    struct mk_list *head;
+    struct mk_list *ehead;
+    struct mk_list thread_list;
+    struct mk_list stat_list;
+    struct mk_list split_list;
+    struct flb_slist_entry *thread;
+    struct flb_slist_entry *entry;
+    char thread_procfs[PATH_MAX];
+
+    snprintf(thread_procfs, sizeof(thread_procfs) - 1, "%s/%s/task", ctx->path_procfs, pid_str);
+
+    /* scan thread entries */
+    ret = ne_utils_path_scan(ctx, thread_procfs, pattern, NE_SCAN_DIR, &thread_list);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (mk_list_size(&thread_list) == 0) {
+        return 0;
+    }
+
+    /* thread entries */
+    mk_list_foreach(head, &thread_list) {
+        thread = mk_list_entry(head, struct flb_slist_entry, _head);
+        tid_str = thread->str + strlen(thread_procfs) + 1;
+
+        /* When pid and tid are equal, the state of the thread should be the same
+         * for pid's. */
+        if (strcmp(tid_str, pid_str) == 0) {
+            update_processes_proc_state(ctx, tstate, pstate_str);
+            continue;
+        }
+
+        mk_list_init(&stat_list);
+        ret = ne_utils_file_read_lines(thread->str, "/stat", &stat_list);
+        if (ret == -1) {
+            continue;
+        }
+
+        mk_list_foreach(ehead, &stat_list) {
+            entry = mk_list_entry(ehead, struct flb_slist_entry, _head);
+
+            /* split with the close parenthesis.
+             * The entry of processes stat will start after that. */
+            tmp = strstr(entry->str, ")");
+            if (tmp == NULL) {
+                continue;
+            }
+
+            mk_list_init(&split_list);
+            ret = flb_slist_split_string(&split_list, tmp+2, ' ', -1);
+            if (ret == -1) {
+                continue;
+            }
+
+            /* Thread State */
+            entry = flb_slist_entry_get(&split_list, 0);
+            state_str = entry->str;
+            update_processes_proc_state(ctx, tstate, state_str);
+
+            flb_slist_destroy(&split_list);
+        }
+        flb_slist_destroy(&stat_list);
+    }
+
+    flb_slist_destroy(&thread_list);
+
+    return 0;
+}
+
+static int processes_update(struct flb_ne *ctx)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t pid_str;
+    flb_sds_t state_str;
+    flb_sds_t thread_str;
+    struct mk_list *head;
+    struct mk_list *ehead;
+    struct mk_list procfs_list;
+    struct mk_list stat_list;
+    struct mk_list split_list;
+    struct flb_slist_entry *process;
+    struct flb_slist_entry *entry;
+    uint64_t val;
+    uint64_t ts;
+    const char *pattern = "/[0-9]*";
+    int64_t pids = 0;
+    int64_t threads = 0;
+    struct proc_state pstate = {
+        .running = 0,
+        .interruptible_sleeping = 0,
+        .uninterruptible_sleeping = 0,
+        .zombie = 0,
+        .stopped = 0,
+        .idle = 0
+    };
+    struct proc_state tstate = {
+        .running = 0,
+        .interruptible_sleeping = 0,
+        .uninterruptible_sleeping = 0,
+        .zombie = 0,
+        .stopped = 0,
+        .idle = 0
+    };
+
+    mk_list_init(&procfs_list);
+
+    ts = cfl_time_now();
+
+    ret = ne_utils_file_read_uint64(ctx->path_procfs, "/sys", "kernel", "threads-max", &val);
+    if (ret == -1) {
+        return -1;
+    }
+
+    /* node_processes_threads_max */
+    if (ret == 0) {
+        cmt_gauge_set(ctx->processes_threads_limit, ts,
+                      (double)val, 0, NULL);
+    }
+
+    ret = ne_utils_file_read_uint64(ctx->path_procfs, "/sys", "kernel", "pid_max", &val);
+    if (ret == -1) {
+        return -1;
+    }
+
+    /* node_processes_max_processes */
+    if (ret == 0) {
+        cmt_gauge_set(ctx->processes_pid_max, ts,
+                      (double)val, 0, NULL);
+    }
+
+    /* scan pid entries */
+    ret = ne_utils_path_scan(ctx, ctx->path_procfs, pattern, NE_SCAN_DIR, &procfs_list);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (mk_list_size(&procfs_list) == 0) {
+        return 0;
+    }
+
+    /* PID entries */
+    mk_list_foreach(head, &procfs_list) {
+        process = mk_list_entry(head, struct flb_slist_entry, _head);
+        pid_str = process->str + strlen(ctx->path_procfs) + 1;
+
+        mk_list_init(&stat_list);
+        ret = ne_utils_file_read_lines(process->str, "/stat", &stat_list);
+        if (ret == -1) {
+            continue;
+        }
+
+        mk_list_foreach(ehead, &stat_list) {
+            entry = mk_list_entry(ehead, struct flb_slist_entry, _head);
+
+            /* split with the close parenthesis.
+             * The entry of processes stat will start after that. */
+            tmp = strstr(entry->str, ")");
+            if (tmp == NULL) {
+                continue;
+            }
+
+            mk_list_init(&split_list);
+            ret = flb_slist_split_string(&split_list, tmp+2, ' ', -1);
+            if (ret == -1) {
+                continue;
+            }
+
+            /* State */
+            entry = flb_slist_entry_get(&split_list, 0);
+            state_str = entry->str;
+            update_processes_proc_state(ctx, &pstate, state_str);
+
+            /* Threads */
+            entry = flb_slist_entry_get(&split_list, 17);
+            thread_str = entry->str;
+
+            /* Collect the number of threads */
+            if (ne_utils_str_to_uint64(thread_str, &val) != -1) {
+                threads += val;
+            }
+
+            /* Collect the states of threads */
+            ret = processes_thread_update(ctx, pid_str, state_str, &tstate);
+            if (ret != 0) {
+                flb_slist_destroy(&split_list);
+                continue;
+            }
+
+            flb_slist_destroy(&split_list);
+        }
+        flb_slist_destroy(&stat_list);
+
+        pids++;
+    }
+
+    /* node_processes_state
+     * Note: we don't use hash table for it. Because we need to update
+     * every state of the processes due to architecture reasons of cmetrics.
+     */
+    cmt_gauge_set(ctx->processes_procs_state, ts, pstate.running,                  1, (char *[]){ "R" });
+    cmt_gauge_set(ctx->processes_procs_state, ts, pstate.interruptible_sleeping,   1, (char *[]){ "S" });
+    cmt_gauge_set(ctx->processes_procs_state, ts, pstate.uninterruptible_sleeping, 1, (char *[]){ "D" });
+    cmt_gauge_set(ctx->processes_procs_state, ts, pstate.zombie,                   1, (char *[]){ "Z" });
+    cmt_gauge_set(ctx->processes_procs_state, ts, pstate.stopped,                  1, (char *[]){ "T" });
+    cmt_gauge_set(ctx->processes_procs_state, ts, pstate.idle,                     1, (char *[]){ "I" });
+
+    /* node_processes_threads_state
+     * Note: we don't use hash table for it. Because we need to update
+     * every state of the processes due to architecture reasons of cmetrics.
+     */
+    cmt_gauge_set(ctx->processes_threads_state, ts, tstate.running,                  1, (char *[]){ "R" });
+    cmt_gauge_set(ctx->processes_threads_state, ts, tstate.interruptible_sleeping,   1, (char *[]){ "S" });
+    cmt_gauge_set(ctx->processes_threads_state, ts, tstate.uninterruptible_sleeping, 1, (char *[]){ "D" });
+    cmt_gauge_set(ctx->processes_threads_state, ts, tstate.zombie,                   1, (char *[]){ "Z" });
+    cmt_gauge_set(ctx->processes_threads_state, ts, tstate.stopped,                  1, (char *[]){ "T" });
+    cmt_gauge_set(ctx->processes_threads_state, ts, tstate.idle,                     1, (char *[]){ "I" });
+
+    /* node_processes_threads */
+    cmt_gauge_set(ctx->processes_thread_alloc, ts,
+                  (double)threads, 0, NULL);
+
+    /* node_processes_pids */
+    cmt_gauge_set(ctx->processes_pid_used, ts,
+                  (double)pids, 0, NULL);
+
+
+    flb_slist_destroy(&procfs_list);
+
+    return 0;
+}
+
+int ne_processes_init(struct flb_ne *ctx)
+{
+    processes_configure(ctx);
+    return 0;
+}
+
+int ne_processes_update(struct flb_ne *ctx)
+{
+    processes_update(ctx);
+    return 0;
+}
+
+int ne_processes_exit(struct flb_ne *ctx)
+{
+    return 0;
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
To monitor for statuses of processes and threads, we need to implement processes metrics on in_node_exporter_metrics plugin.

Fixes https://github.com/fluent/fluent-bit/issues/7866

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change

```console
$ bin/fluent-bit -i node_exporter_metrics -p metrics=processes -o stdout
```

- [x] Debug log output from testing the change

```log
Fluent Bit v2.1.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/08/31 11:02:00] [ info] Configuration:
[2023/08/31 11:02:00] [ info]  flush time     | 1.000000 seconds
[2023/08/31 11:02:00] [ info]  grace          | 5 seconds
[2023/08/31 11:02:00] [ info]  daemon         | 0
[2023/08/31 11:02:00] [ info] ___________
[2023/08/31 11:02:00] [ info]  inputs:
[2023/08/31 11:02:00] [ info]      node_exporter_metrics
[2023/08/31 11:02:00] [ info] ___________
[2023/08/31 11:02:00] [ info]  filters:
[2023/08/31 11:02:00] [ info] ___________
[2023/08/31 11:02:00] [ info]  outputs:
[2023/08/31 11:02:00] [ info]      stdout.0
[2023/08/31 11:02:00] [ info] ___________
[2023/08/31 11:02:00] [ info]  collectors:
[2023/08/31 11:02:00] [ info] [fluent bit] version=2.1.9, commit=eb36c698a2, pid=606478
[2023/08/31 11:02:00] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/08/31 11:02:00] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/08/31 11:02:00] [ info] [cmetrics] version=0.6.3
[2023/08/31 11:02:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/08/31 11:02:00] [ info] [ctraces ] version=0.3.1
[2023/08/31 11:02:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/08/31 11:02:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/08/31 11:02:01] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics processes
[2023/08/31 11:02:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/08/31 11:02:01] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2023/08/31 11:02:01] [ info] [output:stdout:stdout.0] worker #0 started
[2023/08/31 11:02:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/08/31 11:02:01] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=30 write=31
[2023/08/31 11:02:01] [debug] [stdout:stdout.0] created event channels: read=34 write=35
[2023/08/31 11:02:01] [ info] [sp] stream processor started
[2023/08/31 11:02:06] [debug] [input chunk] update output instances with new chunk size diff=1538, records=0, input=node_exporter_metrics.0
[2023/08/31 11:02:06] [debug] [task] created task=0x8447660 id=0 OK
2023-08-31T02:02:05.589311697Z node_processes_threads = 1684
2023-08-31T02:02:05.589311697Z node_processes_max_threads = 513122
2023-08-31T02:02:05.589311697Z node_processes_threads_state{thread_state="R"} = 1
2023-08-31T02:02:05.589311697Z node_processes_threads_state{thread_state="S"} = 1573
2023-08-31T02:02:05.589311697Z node_processes_threads_state{thread_state="D"} = 0
2023-08-31T02:02:05.589311697Z node_processes_threads_state{thread_state="Z"} = 3
2023-08-31T02:02:05.589311697Z node_processes_threads_state{thread_state="T"} = 0
2023-08-31T02:02:05.589311697Z node_processes_threads_state{thread_state="I"} = 107
2023-08-31T02:02:05.589311697Z node_processes_state{state="R"} = 0
2023-08-31T02:02:05.589311697Z node_processes_state{state="S"} = 369
2023-08-31T02:02:05.589311697Z node_processes_state{state="D"} = 0
2023-08-31T02:02:05.589311697Z node_processes_state{state="Z"} = 3
2023-08-31T02:02:05.589311697Z node_processes_state{state="T"} = 0
2023-08-31T02:02:05.589311697Z node_processes_state{state="I"} = 107
2023-08-31T02:02:05.589311697Z node_processes_pids = 479
2023-08-31T02:02:05.589311697Z node_processes_max_processeses = 4194304
[2023/08/31 11:02:06] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/08/31 11:02:06] [debug] [out flush] cb_destroy coro_id=0
[2023/08/31 11:02:06] [debug] [task] destroy task=0x8447660 (task_id=0)
^C[2023/08/31 11:02:07] [engine] caught signal (SIGINT)
[2023/08/31 11:02:07] [ warn] [engine] service will shutdown in max 5 seconds
[2023/08/31 11:02:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/08/31 11:02:07] [ info] [engine] service has stopped (0 pending tasks)
[2023/08/31 11:02:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/08/31 11:02:07] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/08/31 11:02:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
[2023/08/31 11:02:07] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==606478== 
==606478== HEAP SUMMARY:
==606478==     in use at exit: 0 bytes in 0 blocks
==606478==   total heap usage: 188,120 allocs, 188,120 frees, 23,613,784 bytes allocated
==606478== 
==606478== All heap blocks were freed -- no leaks are possible
==606478== 
==606478== For lists of detected and suppressed errors, rerun with: -s
==606478== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1184

<!--  Doc PR (not required but highly recommended) -->



**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
