### PR TITLE
out_splunk: release flb_ra_translate result buffer on failure

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -275,6 +275,10 @@ static inline int pack_event_key(struct flb_splunk *ctx, msgpack_packer *mp_pck,
     t = flb_time_to_double(tm);
     val = flb_ra_translate(ctx->ra_event_key, tag, tag_len, map, NULL);
     if (!val || flb_sds_len(val) == 0) {
+        if (val != NULL) {
+            flb_sds_destroy(val);
+        }
+
         return -1;
     }
 


### PR DESCRIPTION
This PR fixes a memory leak in the splunk output plugin that triggers when the key provided in the event_key option does not match a map key in the log event body.