### PR TITLE
custom_calyptia: generate the machine_id in custom_calyptia so machines can register to multiple fleets.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -64,6 +64,7 @@ struct flb_in_calyptia_fleet_config {
     flb_sds_t api_key;
     flb_sds_t fleet_id;
     flb_sds_t fleet_name;
+    flb_sds_t machine_id;
     flb_sds_t config_dir;
     flb_sds_t cloud_host;
     flb_sds_t cloud_port;
@@ -641,6 +642,7 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
     flb_sds_t cfgoldname;
     flb_sds_t cfgcurname;
     flb_sds_t header;
+    flb_sds_t hdr;
     FILE *cfgfp;
     const char *fbit_last_modified;
     int fbit_last_modified_len;
@@ -737,16 +739,16 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
         header = flb_sds_create_size(4096);
 
         if (ctx->fleet_name == NULL) {
-            flb_sds_printf(&header,
+            hdr = flb_sds_printf(&header,
                         "[CUSTOM]\n"
-                        "    Name          calyptia\n"
-                        "    api_key       %s\n"
-                        "    fleet_id      %s\n"
-                        "    add_label     fleet_id %s\n"
-                        "    fleet.config_dir    %s\n"
-                        "    calyptia_host %s\n"
-                        "    calyptia_port %d\n"
-                        "    calyptia_tls  %s\n",
+                        "    Name             calyptia\n"
+                        "    api_key          %s\n"
+                        "    fleet_id         %s\n"
+                        "    add_label        fleet_id %s\n"
+                        "    fleet.config_dir %s\n"
+                        "    calyptia_host    %s\n"
+                        "    calyptia_port    %d\n"
+                        "    calyptia_tls     %s\n",
                         ctx->api_key,
                         ctx->fleet_id,
                         ctx->fleet_id,
@@ -757,7 +759,7 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
             );
         }
         else {
-            flb_sds_printf(&header,
+            hdr = flb_sds_printf(&header,
                         "[CUSTOM]\n"
                         "    Name          calyptia\n"
                         "    api_key       %s\n"
@@ -777,6 +779,17 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
                         ctx->ins->host.port,
                         tls_setting_string(ctx->ins->use_tls)
             );
+        }
+        if (hdr == NULL) {
+            fclose(cfgfp);
+            goto http_error;
+        }
+        if (ctx->machine_id) {
+            hdr = flb_sds_printf(&header, "    machine_id %s\n", ctx->machine_id);
+            if (hdr == NULL) {
+                fclose(cfgfp);
+                goto http_error;
+            }
         }
         fwrite(header, strlen(header), 1, cfgfp);
         flb_sds_destroy(header);
@@ -1009,6 +1022,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "fleet_name", NULL,
      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, fleet_name),
      "Calyptia Fleet Name (used to lookup the fleet ID via the cloud API)."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "machine_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, machine_id),
+     "Agent Machine ID."
     },
     {
       FLB_CONFIG_MAP_INT, "event_fd", "-1",


### PR DESCRIPTION
# Summary

Refactor the logic behind the machine_id in the calyptia plugins so it is generated by `custom_calyptia` so that it is consistent across all of them and can be used by `in_calyptia_fleet` for the purposes of registering a single machine in several fleets without any conflicts in the directory that fluent-bit uses to store the configuration locally.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
