### PR TITLE
core: metrics: Provide capabilities for returning the count of hot reloaded in REST API and its metrics

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -258,6 +258,7 @@ struct flb_config {
 
     int enable_hot_reload;
     int ensure_thread_safety_on_hot_reloading;
+    unsigned int hot_reloaded_count;
 
     /* Co-routines */
     unsigned int coro_stack_size;

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -274,6 +274,7 @@ struct flb_config *flb_config_init()
 
     /* reload */
     config->ensure_thread_safety_on_hot_reloading = FLB_TRUE;
+    config->hot_reloaded_count = 0;
 
 #ifdef FLB_HAVE_SQLDB
     mk_list_init(&config->sqldb_list);

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -320,6 +320,25 @@ static int attach_build_info(struct flb_config *ctx, struct cmt *cmt, uint64_t t
     return 0;
 }
 
+static int attach_hot_reload_info(struct flb_config *ctx, struct cmt *cmt, uint64_t ts,
+                                  char *hostname)
+{
+    double val;
+    struct cmt_gauge *g;
+
+    g = cmt_gauge_create(cmt, "fluentbit", "", "hot_reloaded_times",
+                         "Collect the count of hot reloaded times.",
+                         1, (char *[]) {"hostname"});
+    if (!g) {
+        return -1;
+    }
+
+    val = (double) ctx->hot_reloaded_count;
+
+    cmt_gauge_set(g, ts, val, 1, (char *[]) {hostname});
+    return 0;
+}
+
 /* Append internal Fluent Bit metrics to context */
 int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt)
 {
@@ -340,6 +359,7 @@ int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt)
     attach_uptime(ctx, cmt, ts, hostname);
     attach_process_start_time_seconds(ctx, cmt, ts, hostname);
     attach_build_info(ctx, cmt, ts, hostname);
+    attach_hot_reload_info(ctx, cmt, ts, hostname);
 
     return 0;
 }

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -367,6 +367,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     struct flb_cf *new_cf;
     struct flb_cf *original_cf;
     int verbose;
+    int reloaded_count = 0;
 
     if (ctx == NULL) {
         flb_error("[reload] given flb context is NULL");
@@ -425,6 +426,8 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     /* Inherit verbose from the old ctx instance */
     verbose = ctx->config->verbose;
     new_config->verbose = verbose;
+    /* Increment and store the number of hot reloaded times */
+    reloaded_count = ctx->config->hot_reloaded_count + 1;
 
 #ifdef FLB_HAVE_STREAM_PROCESSOR
     /* Inherit stream processor definitions from command line */
@@ -503,6 +506,12 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     flb_info("[reload] start everything");
 
     ret = flb_start(new_ctx);
+
+    /* Store the new value of hot reloading times into the new context */
+    if (ret == 0) {
+        new_config->hot_reloaded_count = reloaded_count;
+        flb_debug("[reload] hot reloaded %d time(s)", reloaded_count);
+    }
 
     return 0;
 }

--- a/src/http_server/api/v2/reload.c
+++ b/src/http_server/api/v2/reload.c
@@ -33,22 +33,13 @@
 
 #include <fluent-bit/flb_http_server.h>
 
-static void cb_reload(mk_request_t *request, void *data)
+static void handle_reload_request(mk_request_t *request, struct flb_config *config)
 {
     int ret;
     flb_sds_t out_buf;
     size_t out_size;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
-    struct flb_hs *hs = data;
-    struct flb_config *config = hs->config;
-
-    if (request->method != MK_METHOD_POST &&
-        request->method != MK_METHOD_PUT) {
-        mk_http_status(request, 400);
-        mk_http_done(request);
-        return;
-    }
 
     /* initialize buffers */
     msgpack_sbuffer_init(&mp_sbuf);
@@ -107,6 +98,58 @@ static void cb_reload(mk_request_t *request, void *data)
     mk_http_done(request);
 
     flb_sds_destroy(out_buf);
+}
+
+static void handle_get_reload_status(mk_request_t *request, struct flb_config *config)
+{
+    flb_sds_t out_buf;
+    size_t out_size;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&mp_pck, 1);
+    msgpack_pack_str(&mp_pck, 12);
+    msgpack_pack_str_body(&mp_pck, "hot_reloaded", 12);
+    msgpack_pack_int64(&mp_pck, config->hot_reloaded_count);
+
+    /* Export to JSON */
+    out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    if (!out_buf) {
+        mk_http_status(request, 400);
+        mk_http_done(request);
+        return;
+    }
+    out_size = flb_sds_len(out_buf);
+
+    mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_JSON);
+    mk_http_send(request, out_buf, out_size, NULL);
+    mk_http_done(request);
+
+    flb_sds_destroy(out_buf);
+}
+
+static void cb_reload(mk_request_t *request, void *data)
+{
+    struct flb_hs *hs = data;
+    struct flb_config *config = hs->config;
+
+    if (request->method == MK_METHOD_POST ||
+        request->method == MK_METHOD_PUT) {
+        handle_reload_request(request, config);
+    }
+    else if (request->method == MK_METHOD_GET) {
+        handle_get_reload_status(request, config);
+    }
+    else {
+        mk_http_status(request, 400);
+        mk_http_done(request);
+    }
 }
 
 /* Perform registration */

--- a/src/http_server/api/v2/reload.c
+++ b/src/http_server/api/v2/reload.c
@@ -112,8 +112,8 @@ static void handle_get_reload_status(mk_request_t *request, struct flb_config *c
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     msgpack_pack_map(&mp_pck, 1);
-    msgpack_pack_str(&mp_pck, 12);
-    msgpack_pack_str_body(&mp_pck, "hot_reloaded", 12);
+    msgpack_pack_str(&mp_pck, 16);
+    msgpack_pack_str_body(&mp_pck, "hot_reload_count", 16);
     msgpack_pack_int64(&mp_pck, config->hot_reloaded_count);
 
     /* Export to JSON */


### PR DESCRIPTION
<!-- Provide summary of changes -->
For HTTP REST API users, there is lack of capability to confirm that the status of hot-reloading.
It would be nice to have the endpoint which can handle the request for returning the count of the hot-reloading times.
 
Also, we need to provide the metrics for the status of hot-reloading counts.
 
In this PR, I added two capabilities.
One is providing an endpoint which can handle GET method to return the count of hot-reloading.
This can be called with:
```console
$ curl -XGET <hostname>:2020/api/v2/reload 
```

The other is provide a v2 metrics which includes the count of hot-reloading.
This can be called by:
```console
$ curl -XGET <hostname>:2020/api/v2/metrics
```

Then, the metrics can be displayed as follows:

```log
<snip>
2023-09-06T07:25:45.332832481Z fluentbit_hot_reloaded_times{hostname="fluent-bit-dev"} = <the number of reloaded times>
<snip>
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020
    Hot_Reload On

[INPUT]
    Name dummy
    Tag dummy.locals

[FILTER]
    Name record_modifier
    Match *
    Record hostname ${HOSTNAME}

[OUTPUT]
    Name  stdout
    Match *
```

- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

A documentation for newly added endpoint: https://github.com/fluent/fluent-bit-docs/pull/1192
A documentation for v2 endpoint and v2 metrics: https://github.com/fluent/fluent-bit-docs/pull/1193

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
