### PR TITLE
filter_lua: support enable_flb_null

### DIFF
--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -29,6 +29,9 @@
 #include <monkey/mk_core/mk_list.h>
 #include <msgpack/pack.h>
 
+/* global variables in Lua */
+#define FLB_LUA_VAR_FLB_NULL "flb_null"
+
 #define FLB_LUA_L2C_TYPES_NUM_MAX   16
 
 enum flb_lua_l2c_type_enum {
@@ -74,5 +77,6 @@ void flb_lua_tompack(lua_State *l,
                      int index,
                      struct flb_lua_l2c_config *l2cc);
 void flb_lua_dump_stack(FILE *out, lua_State *l);
+int flb_lua_enable_flb_null(lua_State *l);
 
 #endif

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -61,6 +61,10 @@ static int cb_lua_init(struct flb_filter_instance *f_ins,
     }
     ctx->lua = lj;
 
+    if (ctx->enable_flb_null) {
+        flb_lua_enable_flb_null(lj->state);
+    }
+
     /* Lua script source code */
     if (ctx->code) {
         ret = flb_luajit_load_buffer(ctx->lua,
@@ -682,6 +686,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct lua_filter, time_as_table),
      "If enabled, Fluent-bit will pass the timestamp as a Lua table "
      "with keys \"sec\" for seconds since epoch and \"nsec\" for nanoseconds."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "enable_flb_null", "false",
+     0, FLB_TRUE, offsetof(struct lua_filter, enable_flb_null),
+     "If enabled, null will be converted to flb_null in Lua. "
+     "It is useful to prevent removing key/value "
+     "since nil is a special value to remove key value from map in Lua."
     },
 
     {0}

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -35,6 +35,7 @@ struct lua_filter {
     flb_sds_t buffer;                 /* json dec buffer */
     int    protected_mode;            /* exec lua function in protected mode */
     int    time_as_table;             /* timestamp as a Lua table */
+    int    enable_flb_null;           /* Use flb_null in Lua */
     struct flb_lua_l2c_config l2cc;   /* lua -> C config */
     struct flb_luajit *lua;           /* state context   */
     struct flb_filter_instance *ins;  /* filter instance */

--- a/src/flb_lua.c
+++ b/src/flb_lua.c
@@ -25,6 +25,17 @@
 #include <fluent-bit/flb_lua.h>
 #include <stdint.h>
 
+int flb_lua_enable_flb_null(lua_State *l)
+{
+    /* set flb.null */
+    lua_pushlightuserdata(l, NULL);
+
+    flb_info("[%s] set %s", __FUNCTION__, FLB_LUA_VAR_FLB_NULL);
+    lua_setglobal(l, FLB_LUA_VAR_FLB_NULL);
+
+    return 0;
+}
+
 void flb_lua_pushtimetable(lua_State *l, struct flb_time *tm)
 {
     lua_createtable(l, 0, 2);
@@ -63,7 +74,7 @@ int flb_lua_pushmpack(lua_State *l, mpack_reader_t *reader)
     tag = mpack_read_tag(reader);
     switch (mpack_tag_type(&tag)) {
         case mpack_type_nil:
-            lua_pushnil(l);
+            lua_getglobal(l, FLB_LUA_VAR_FLB_NULL);
             break;
         case mpack_type_bool:
             lua_pushboolean(l, mpack_tag_bool_value(&tag));
@@ -128,7 +139,7 @@ void flb_lua_pushmsgpack(lua_State *l, msgpack_object *o)
 
     switch(o->type) {
         case MSGPACK_OBJECT_NIL:
-            lua_pushnil(l);
+            lua_getglobal(l, FLB_LUA_VAR_FLB_NULL);
             break;
 
         case MSGPACK_OBJECT_BOOLEAN:

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -677,6 +677,76 @@ void flb_test_drop_all_records(void)
     flb_destroy(ctx);
 }
 
+void flb_test_enable_flb_null(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *output = NULL;
+    char *input = "[0, {\"hello\":null}]";
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    return 1, timestamp, record\n"
+      "end\n";
+
+    clear_output();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "script", TMP_LUA_PATH,
+                         "enable_flb_null", "true",
+                         NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Lib output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret==0);
+
+    flb_lib_push(ctx, in_ffd, input, strlen(input));
+    wait_with_timeout(2000, &output);
+    result = strstr(output, "\"hello\":null");
+    if(!TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    /* clean up */
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* https://github.com/fluent/fluent-bit/issues/5496 */
 void flb_test_split_record(void)
 {
@@ -761,6 +831,7 @@ TEST_LIST = {
     {"type_array_key", flb_test_type_array_key},
     {"array_contains_null", flb_test_array_contains_null},
     {"drop_all_records", flb_test_drop_all_records},
+    {"enable_flb_null", flb_test_enable_flb_null},
     {"split_record", flb_test_split_record},
     {NULL, NULL}
 };


### PR DESCRIPTION
#7708  https://github.com/fluent/fluent-bit/pull/7799#issuecomment-1702469588
In Lua, nil value is a special value to delete key/value pair from associative array.
https://www.lua.org/pil/2.5.html
```
you can assign nil to a table field to delete it.
```
It means the key/value will be removed from record if its value is null.
e.g. If record is `{"aaa":null, "bbb":"cccc"}` ,`"aaa":null` will be removed in Lua.

This patch is to support `enable_flb_null`.
If set, fluent-bit pass a lightuserdata `flb_null` as a nil value to prevent removing key/value.

Default value is false to keep backward compatibility. 
|Value |Description|Default|
|--|--|--|
|`enable_flb_null`|If enabled, null will be converted to flb_null in Lua. It is useful to prevent removing key/value since nil is a special value to remove key value from map in Lua.|false|



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    name dummy
    dummy {"null":null}

[FILTER]
    name lua
    match *
    call append_null
    code function append_null(tag, timestamp, record) new_record = record new_record["lua_null"] = flb_null return 1, timestamp, new_record end
    enable_flb_null true

[OUTPUT]
    name stdout
    match *
```

## Debug/Valgrind output 

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==3175== Memcheck, a memory error detector
==3175== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3175== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==3175== Command: bin/fluent-bit -c a.conf
==3175== 
Fluent Bit v2.1.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/09 07:47:20] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3175
[2023/09/09 07:47:21] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:47:21] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:47:21] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:47:21] [ info] [input:dummy:dummy.0] initializing
[2023/09/09 07:47:21] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/09/09 07:47:21] [ info] [flb_lua_enable_flb_null] set flb_null
[2023/09/09 07:47:21] [ info] [output:stdout:stdout.0] worker #0 started
[2023/09/09 07:47:21] [ info] [sp] stream processor started
[0] dummy.0: [[1694213242.034084558, {}], {"null"=>nil, "lua_null"=>nil}]
[0] dummy.0: [[1694213243.033679723, {}], {"null"=>nil, "lua_null"=>nil}]
^C[2023/09/09 07:47:24] [engine] caught signal (SIGINT)
[2023/09/09 07:47:24] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [[1694213244.005583047, {}], {"null"=>nil, "lua_null"=>nil}]
[2023/09/09 07:47:24] [ info] [input] pausing dummy.0
[2023/09/09 07:47:25] [ info] [engine] service has stopped (0 pending tasks)
[2023/09/09 07:47:25] [ info] [input] pausing dummy.0
[2023/09/09 07:47:25] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/09/09 07:47:25] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==3175== 
==3175== HEAP SUMMARY:
==3175==     in use at exit: 0 bytes in 0 blocks
==3175==   total heap usage: 1,826 allocs, 1,826 frees, 1,636,127 bytes allocated
==3175== 
==3175== All heap blocks were freed -- no leaks are possible
==3175== 
==3175== For lists of detected and suppressed errors, rerun with: -s
==3175== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --leak-check=full bin/flb-rt-filter_lua 
==3184== Memcheck, a memory error detector
==3184== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3184== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==3184== Command: bin/flb-rt-filter_lua
==3184== 
Test hello_world...                             [2023/09/09 07:48:23] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:24] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:24] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:24] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:24] [ info] [input:dummy:dummy.0] initializing
[2023/09/09 07:48:24] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:24] [ info] [output:stdout:stdout.0] worker #0 started
[2023/09/09 07:48:24] [ info] [sp] stream processor started
[2023/09/09 07:48:24] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:24] [ info] [input] pausing dummy.0
[2023/09/09 07:48:25] [ info] [engine] service has stopped (0 pending tasks)
[2023/09/09 07:48:25] [ info] [input] pausing dummy.0
[2023/09/09 07:48:25] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/09/09 07:48:25] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2023/09/09 07:48:25] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:25] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:25] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:25] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:25] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:25] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:25] [ info] [sp] stream processor started
[2023/09/09 07:48:26] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:27] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key...                            [2023/09/09 07:48:27] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:27] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:27] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:27] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:27] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:27] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:27] [ info] [sp] stream processor started
[2023/09/09 07:48:28] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:29] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_int_key_multi...                      [2023/09/09 07:48:29] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:29] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:29] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:29] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:29] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:29] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:29] [ info] [sp] stream processor started
[2023/09/09 07:48:30] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:31] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test type_array_key...                          [2023/09/09 07:48:31] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:31] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:31] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:31] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:31] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:31] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:31] [ info] [sp] stream processor started
[2023/09/09 07:48:32] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:33] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     [2023/09/09 07:48:33] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:33] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:33] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:33] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:33] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:33] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:33] [ info] [sp] stream processor started
[2023/09/09 07:48:34] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:35] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2023/09/09 07:48:35] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:35] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:35] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:35] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:35] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:35] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:35] [ info] [sp] stream processor started
[2023/09/09 07:48:36] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:37] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test enable_flb_null...                         [2023/09/09 07:48:37] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:37] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:37] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:37] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:37] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:37] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:37] [ info] [flb_lua_enable_flb_null] set flb_null
[2023/09/09 07:48:37] [ info] [sp] stream processor started
[2023/09/09 07:48:38] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:39] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test split_record...                            [2023/09/09 07:48:39] [ info] [fluent bit] version=2.1.9, commit=f7731f3f81, pid=3184
[2023/09/09 07:48:39] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/09 07:48:39] [ info] [cmetrics] version=0.6.3
[2023/09/09 07:48:39] [ info] [ctraces ] version=0.3.1
[2023/09/09 07:48:39] [ info] [input:lib:lib.0] initializing
[2023/09/09 07:48:39] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2023/09/09 07:48:39] [ info] [sp] stream processor started
[2023/09/09 07:48:41] [ warn] [timeout] elapsed_time: 2006
[2023/09/09 07:48:41] [ warn] [engine] service will shutdown in max 1 seconds
[2023/09/09 07:48:42] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==3184== 
==3184== HEAP SUMMARY:
==3184==     in use at exit: 0 bytes in 0 blocks
==3184==   total heap usage: 14,138 allocs, 14,138 frees, 6,744,973 bytes allocated
==3184== 
==3184== All heap blocks were freed -- no leaks are possible
==3184== 
==3184== For lists of detected and suppressed errors, rerun with: -s
==3184== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
