### PR TITLE
in_calyptia_fleet: windows support.

### DIFF
--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -60,8 +60,6 @@ if(FLB_WINDOWS_DEFAULTS)
   set(FLB_IN_EMITTER            Yes)
   set(FLB_IN_PODMAN_METRICS      No)
   set(FLB_IN_ELASTICSEARCH      Yes)
-  # disable calyptia fleet management for now
-  set(FLB_IN_CALYPTIA_FLEET     No)
   set(FLB_IN_SPLUNK             Yes)
 
   # OUTPUT plugins

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -348,8 +348,11 @@ static void *do_reload(void *data)
     reload->flb->config->conf_path_file = reload->cfg_path;
 
     sleep(5);
+#ifndef FLB_SYSTEM_WINDOWS
     kill(getpid(), SIGHUP);
-
+#else
+	GenerateConsoleCtrlEvent(1 /* CTRL_BREAK_EVENT_1 */, 0);
+#endif
     return NULL;
 }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -695,6 +695,29 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
 
 #ifdef FLB_SYSTEM_WINDOWS
 #define link(a, b) CreateHardLinkA(b, a, 0)
+
+ssize_t readlink(const char *path, char *realpath, size_t srealpath) {
+    HANDLE hFile;
+    DWORD ret;
+
+    hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 
+                       FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return -1;
+    }
+
+    ret = GetFinalPathNameByHandleA(hFile, realpath, srealpath, VOLUME_NAME_NT);
+
+    if (ret < srealpath) {
+        CloseHandle(hFile);
+        return -1;
+    }
+
+    CloseHandle(hFile);
+    return ret;
+}
+
 #endif
 
 /* cb_collect callback */

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -632,9 +632,9 @@ void flb_console_handler_set_ctx(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 static bool flb_console_handler(DWORD evType)
 {
     switch(evType) {
-	case 1 /* CTRL_BREAK_EVENT_1 */:
-		if (flb_bin_restarting == FLB_RELOAD_IDLE) {
-			flb_bin_restarting = FLB_RELOAD_IN_PROGRESS;
+    case 1 /* CTRL_BREAK_EVENT_1 */:
+        if (flb_bin_restarting == FLB_RELOAD_IDLE) {
+            flb_bin_restarting = FLB_RELOAD_IN_PROGRESS;
             /* signal the main loop to execute reload. this is necessary since
              * all signal handlers in win32 are executed on their own thread.
              */
@@ -645,7 +645,7 @@ static bool flb_console_handler(DWORD evType)
             flb_utils_error(FLB_ERR_RELOADING_IN_PROGRESS);
         }
         break;
-	}
+    }
     return 1;
 }
 #endif
@@ -658,8 +658,8 @@ static void flb_signal_init()
     signal(SIGHUP,  &flb_signal_handler);
     signal(SIGCONT, &flb_signal_handler);
 #else
-	/* Use SetConsoleCtrlHandler on windows to simulate SIGHUP */
-	SetConsoleCtrlHandler(flb_console_handler, 1);
+    /* Use SetConsoleCtrlHandler on windows to simulate SIGHUP */
+    SetConsoleCtrlHandler(flb_console_handler, 1);
 #endif
     signal(SIGTERM, &flb_signal_handler_break_loop);
     signal(SIGSEGV, &flb_signal_handler);
@@ -873,12 +873,15 @@ static int parse_trace_pipeline(flb_ctx_t *ctx, const char *pipeline, char **tra
     }
 
     mk_list_foreach(cur, parts) {
-	key = NULL;
-	value = NULL;
+        key = NULL;
+        value = NULL;
+
         part = mk_list_entry(cur, struct flb_split_entry, _head);
+
         if (parse_trace_pipeline_prop(ctx, part->value, &key, &value) == FLB_ERROR) {
             return FLB_ERROR;
         }
+
         if (strcmp(key, "input") == 0) {
             if (*trace_input != NULL) {
                 flb_free(*trace_input);
@@ -911,12 +914,14 @@ static int parse_trace_pipeline(flb_ctx_t *ctx, const char *pipeline, char **tra
                                    (char *)propname, strlen(propname),
                                    (char *)propval, strlen(propval));
         }
-	if (key != NULL) {
-		mk_mem_free(key);
-	}
-	if (value != NULL) {
-		flb_free(value);
-	}
+
+        if (key != NULL) {
+            mk_mem_free(key);
+        }
+
+        if (value != NULL) {
+            flb_free(value);
+        }
     }
 
     flb_utils_split_free(parts);

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -629,7 +629,7 @@ void flb_console_handler_set_ctx(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     handler_opts = cf_opts;
 }
 
-static bool flb_console_handler(DWORD evType)
+static BOOL WINAPI flb_console_handler(DWORD evType)
 {
     switch(evType) {
     case 1 /* CTRL_BREAK_EVENT_1 */:


### PR DESCRIPTION
# Summary

This PR implemenets hot reload in windows for the `in_calyptia_fleet` plugin. It includes the necessary changes for the plugin itself as well as rudimentary support for hot-reload under win32.

# Obstacles

The calyptia fleet plugin reloads configuration taken from calyptia, which requires hot-reload in windows. This requires two major changes:

- fixing TLS under windows: monkey/monkey#408.
- Simulating the SIGHUP signal.

## Solutions

### TLS

The first concern was fixed in monkey and is still awaiting merging upstream to fluent-bit.

### SIGHUP

I used GenerateConsoleCtrlEvent to simulate the behavior of the SIGHUP signal in windows and implemented a simple mechanism to signal the main thread from the GenerateConsoleCtrlEvent handler. This is so the main thread can execute flb_reload.

The implementation I went with uses a simple `int` to mark that the signal has been raised. The main  loop then checks it, marks it as zero and then executes `flb_reload`. This is, admittedly, functional but not elegant.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
