### PR TITLE
engine: add sleep to output logs on init

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -597,6 +597,9 @@ int flb_engine_failed(struct flb_config *config)
         flb_error("[engine] fail to dispatch FAILED message");
     }
 
+    /* Waiting flushing log */
+    sleep(1);
+
     return ret;
 }
 


### PR DESCRIPTION
This patch is a workaround to output initialization error logs.

Example:
```
$ bin/fluent-bit -i dummy -p aaa=bbb -o stdout
Fluent Bit v2.1.9
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io
[2023/09/16 09:43:38] [error] [lib] backend failed
[2023/09/16 09:43:38] [ info] [fluent bit] version=2.1.9, commit=3c2c5004b1, pid=24686
$
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

## Debug output
```
$ bin/fluent-bit -i dummy -p aaa=bbb -o stdout
Fluent Bit v2.1.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/16 09:45:58] [error] [lib] backend failed
[2023/09/16 09:45:58] [ info] [fluent bit] version=2.1.10, commit=47b42dd4df, pid=24709
[2023/09/16 09:45:58] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/16 09:45:58] [ info] [cmetrics] version=0.6.3
[2023/09/16 09:45:58] [ info] [ctraces ] version=0.3.1
[2023/09/16 09:45:58] [error] [config] dummy: unknown configuration property 'aaa'. The following properties are allowed: samples, dummy, metadata, rate, copies, start_time_sec, start_time_nsec, and fixed_timestamp.
[2023/09/16 09:45:58] [ help] try the command: bin/fluent-bit -i dummy -h

[2023/09/16 09:45:58] [error] [engine] input initialization failed
```

## Valgrind output

Valgrind reported a leak that is not related this PR.
```
$ valgrind --leak-check=full bin/fluent-bit -i dummy -p aaa=bbb -o stdout
==24723== Memcheck, a memory error detector
==24723== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==24723== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==24723== Command: bin/fluent-bit -i dummy -p aaa=bbb -o stdout
==24723== 
Fluent Bit v2.1.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/16 09:46:36] [ info] [fluent bit] version=2.1.10, commit=47b42dd4df, pid=24723
[2023/09/16 09:46:36] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/16 09:46:36] [ info] [cmetrics] version=0.6.3
[2023/09/16 09:46:36] [ info] [ctraces ] version=0.3.1
[2023/09/16 09:46:36] [error] [config] dummy: unknown configuration property 'aaa'. The following properties are allowed: samples, dummy, metadata, rate, copies, start_time_sec, start_time_nsec, and fixed_timestamp.
[2023/09/16 09:46:36] [ help] try the command: bin/fluent-bit -i dummy -h

[2023/09/16 09:46:36] [error] [engine] input initialization failed
[2023/09/16 09:46:36] [error] [lib] backend failed
==24723== 
==24723== HEAP SUMMARY:
==24723==     in use at exit: 7 bytes in 1 blocks
==24723==   total heap usage: 1,178 allocs, 1,177 frees, 221,010 bytes allocated
==24723== 
==24723== 7 bytes in 1 blocks are definitely lost in loss record 1 of 1
==24723==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==24723==    by 0x1C3E60: flb_malloc (flb_mem.h:80)
==24723==    by 0x1C414A: flb_strndup (flb_str.h:34)
==24723==    by 0x1C41B1: flb_strdup (flb_str.h:46)
==24723==    by 0x1C681C: flb_main (fluent-bit.c:928)
==24723==    by 0x1C7594: main (fluent-bit.c:1358)
==24723== 
==24723== LEAK SUMMARY:
==24723==    definitely lost: 7 bytes in 1 blocks
==24723==    indirectly lost: 0 bytes in 0 blocks
==24723==      possibly lost: 0 bytes in 0 blocks
==24723==    still reachable: 0 bytes in 0 blocks
==24723==         suppressed: 0 bytes in 0 blocks
==24723== 
==24723== For lists of detected and suppressed errors, rerun with: -s
==24723== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
