### PR TITLE
processor: replace tab with white space

### DIFF
--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -283,13 +283,13 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
         if (v->type == CFL_VARIANT_STRING) {
             return flb_filter_set_property(pu->ctx, k, v->data.as_string);
         }
-	else if (v->type == CFL_VARIANT_ARRAY) {
+        else if (v->type == CFL_VARIANT_ARRAY) {
 
             for (i = 0; i < v->data.as_array->entry_count; i++) {
                 val = v->data.as_array->entries[i];
                 ret = flb_filter_set_property(pu->ctx, k, val->data.as_string);
                 
-		if (ret == -1) {
+                if (ret == -1) {
                     return ret;
                 }
             }
@@ -336,7 +336,7 @@ int flb_processor_unit_init(struct flb_processor_unit *pu)
     if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
         ret = flb_filter_init(proc->config, pu->ctx);
         
-	if (ret == -1) {
+        if (ret == -1) {
             flb_error("[processor] error initializing unit filter %s", pu->name);
             return -1;
         }
@@ -372,7 +372,7 @@ int flb_processor_init(struct flb_processor *proc)
         pu = mk_list_entry(head, struct flb_processor_unit, _head);
         ret = flb_processor_unit_init(pu);
         
-	if (ret == -1) {
+        if (ret == -1) {
             return -1;
         }
         count++;
@@ -382,7 +382,7 @@ int flb_processor_init(struct flb_processor *proc)
         pu = mk_list_entry(head, struct flb_processor_unit, _head);
         ret = flb_processor_unit_init(pu);
         
-	if (ret == -1) {
+        if (ret == -1) {
             return -1;
         }
         count++;
@@ -392,7 +392,7 @@ int flb_processor_init(struct flb_processor *proc)
         pu = mk_list_entry(head, struct flb_processor_unit, _head);
         ret = flb_processor_unit_init(pu);
         
-	if (ret == -1) {
+        if (ret == -1) {
             return -1;
         }
         count++;
@@ -501,7 +501,7 @@ int flb_processor_run(struct flb_processor *proc,
              */
             if (ret == FLB_FILTER_MODIFIED) {
                 
-		/* release intermediate buffer */
+                /* release intermediate buffer */
                 if (cur_buf != data) {
                     flb_free(cur_buf);
                 }
@@ -615,7 +615,7 @@ int flb_processor_run(struct flb_processor *proc,
             }
             else if (type == FLB_PROCESSOR_METRICS) {
                 
-		if (p_ins->p->cb_process_metrics != NULL) {
+                if (p_ins->p->cb_process_metrics != NULL) {
                     ret = p_ins->p->cb_process_metrics(p_ins,
                                                        (struct cmt *) cur_buf,
                                                        tag,
@@ -632,7 +632,7 @@ int flb_processor_run(struct flb_processor *proc,
             }
             else if (type == FLB_PROCESSOR_TRACES) {
                 
-		if (p_ins->p->cb_process_traces != NULL) {
+                if (p_ins->p->cb_process_traces != NULL) {
                     ret = p_ins->p->cb_process_traces(p_ins,
                                                       (struct ctrace *) cur_buf,
                                                       tag,
@@ -715,7 +715,7 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
         /* every entry in the array must be a map */
         tmp = array->entries[i];
         
-	if (tmp->type != CFL_VARIANT_KVLIST) {
+        if (tmp->type != CFL_VARIANT_KVLIST) {
             return -1;
         }
 
@@ -724,7 +724,7 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
         /* get the processor name, this is a mandatory config field */
         tmp = cfl_kvlist_fetch(kvlist, "name");
         
-	if (!tmp) {
+        if (!tmp) {
             flb_error("processor configuration don't have a 'name' defined");
             return -1;
         }
@@ -733,7 +733,7 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
         name = tmp->data.as_string;
         pu = flb_processor_unit_create(proc, type, name);
         
-	if (!pu) {
+        if (!pu) {
             flb_error("cannot create '%s' processor unit", name);
             return -1;
         }
@@ -742,7 +742,7 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
         cfl_list_foreach(head, &kvlist->list) {
             pair = cfl_list_entry(head, struct cfl_kvpair, _head);
             
-	    if (strcmp(pair->key, "name") == 0) {
+            if (strcmp(pair->key, "name") == 0) {
                 continue;
             }
 
@@ -751,10 +751,10 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
              */
             if (pu->unit_type == FLB_PROCESSOR_UNIT_FILTER) {
                 
-		if (strcmp(pair->key, "match") == 0) {
+                if (strcmp(pair->key, "match") == 0) {
                     f_ins = (struct flb_filter_instance *)pu->ctx;
                     
-		    if (f_ins->match != NULL) {
+                    if (f_ins->match != NULL) {
                         flb_sds_destroy(f_ins->match);
                         f_ins->match = NULL;
                     }
@@ -763,7 +763,7 @@ static int load_from_config_format_group(struct flb_processor *proc, int type, s
 
             ret = flb_processor_unit_set_property(pu, pair->key, pair->val);
             
-	    if (ret == -1) {
+            if (ret == -1) {
                 flb_error("cannot set property '%s' for processor '%s'", pair->key, name);
                 return -1;
             }
@@ -786,7 +786,7 @@ int flb_processors_load_from_config_format_group(struct flb_processor *proc, str
     if (val) {
         ret = load_from_config_format_group(proc, FLB_PROCESSOR_LOGS, val);
         
-	if (ret == -1) {
+        if (ret == -1) {
             flb_error("failed to load 'logs' processors");
             return -1;
         }
@@ -798,7 +798,7 @@ int flb_processors_load_from_config_format_group(struct flb_processor *proc, str
     if (val) {
         ret = load_from_config_format_group(proc, FLB_PROCESSOR_METRICS, val);
         
-	if (ret == -1) {
+        if (ret == -1) {
             flb_error("failed to load 'metrics' processors");
             return -1;
         }
@@ -809,7 +809,7 @@ int flb_processors_load_from_config_format_group(struct flb_processor *proc, str
     if (val) {
         ret = load_from_config_format_group(proc, FLB_PROCESSOR_TRACES, val);
         
-	if (ret == -1) {
+        if (ret == -1) {
             flb_error("failed to load 'traces' processors");
             return -1;
         }
@@ -860,7 +860,7 @@ int flb_processor_instance_set_property(struct flb_processor_instance *ins,
         ret = flb_log_get_level_str(tmp);
         flb_sds_destroy(tmp);
         
-	if (ret == -1) {
+        if (ret == -1) {
             return -1;
         }
         ins->log_level = ret;
@@ -872,9 +872,9 @@ int flb_processor_instance_set_property(struct flb_processor_instance *ins,
          */
         kv = flb_kv_item_create(&ins->properties, (char *) k, NULL);
         
-	if (!kv) {
+        if (!kv) {
             
-	    if (tmp) {
+            if (tmp) {
                 flb_sds_destroy(tmp);
             }
             return -1;
@@ -1004,7 +1004,7 @@ int flb_processor_instance_check_properties(
          */
         config_map = flb_config_map_create(config, p->config_map);
         
-	if (!config_map) {
+        if (!config_map) {
             flb_error("[native processor] error loading config map for '%s' plugin",
                       p->name);
             return -1;
@@ -1016,9 +1016,9 @@ int flb_processor_instance_check_properties(
                                               &ins->properties,
                                               ins->config_map);
         
-	if (ret == -1) {
+        if (ret == -1) {
             
-	    if (config->program_name) {
+            if (config->program_name) {
                 flb_helper("try the command: %s -F %s -h\n",
                            config->program_name, ins->p->name);
             }


### PR DESCRIPTION
This patch is to replace tab for readability.
https://github.com/fluent/fluent-bit/blob/master/CONTRIBUTING.md#coding-style
```
You have to pay attention to the code indentation, tabs are 4 spaces, spaces on conditionals, etc. If your code submission is not aligned, it will be rejected.
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
