### PR TITLE
tests: internal: uri: add test code

### DIFF
--- a/src/flb_uri.c
+++ b/src/flb_uri.c
@@ -71,6 +71,11 @@ flb_sds_t flb_uri_encode(const char *uri, size_t len)
 /* Retrieve a given field based on it expected position in the URI */
 struct flb_uri_field *flb_uri_get(struct flb_uri *uri, int pos)
 {
+    if (pos < 0) {
+        flb_trace("[uri] negative pos");
+        return NULL;
+    }
+
     if (pos >= FLB_URI_MAX || pos > uri->count) {
         flb_trace("[uri] requested position > FLB_URI_MAX");
         return NULL;

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -40,6 +40,7 @@ set(UNIT_TESTS_FILES
   log.c
   log_event_decoder.c
   processor.c
+  uri.c
   )
 
 # Config format

--- a/tests/internal/uri.c
+++ b/tests/internal/uri.c
@@ -1,0 +1,87 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_uri.h>
+#include <string.h>
+
+#include "flb_tests_internal.h"
+
+void uri_create_destroy()
+{
+    struct flb_uri *uri;
+    const char *uri_str = "https://fluentbit.io";
+
+    uri = flb_uri_create(uri_str);
+    if (!TEST_CHECK(uri != NULL)) {
+        TEST_MSG("flb_uri_create failed");
+        return;
+    }
+
+    flb_uri_destroy(uri);
+}
+
+void uri_get()
+{
+    struct flb_uri *uri;
+    struct flb_uri_field *field;
+    const char *uri_str = "https://fluentbit.io";
+
+    uri = flb_uri_create(uri_str);
+    if (!TEST_CHECK(uri != NULL)) {
+        TEST_MSG("flb_uri_create failed");
+        return;
+    }
+
+    field = flb_uri_get(uri, 0);
+    if (!TEST_CHECK(field != NULL)) {
+        TEST_MSG("flb_uri_get failed");
+        return;
+    }
+
+    field = flb_uri_get(uri, -1);
+    if (!TEST_CHECK(field == NULL)) {
+        TEST_MSG("flb_uri_get should fail");
+        return;
+    }
+
+    flb_uri_destroy(uri);
+}
+
+void uri_encode()
+{
+    flb_sds_t encoded_uri;
+    const char *input = "&# ";
+    const char *expect = "%26%23%20";
+
+    encoded_uri = flb_uri_encode(input, strlen(input));
+    if (!TEST_CHECK(encoded_uri != NULL)) {
+        TEST_MSG("flb_uri_encode failed");
+        return;
+    }
+
+    flb_sds_destroy(encoded_uri);
+}
+
+TEST_LIST = {
+    { "uri_create_destroy", uri_create_destroy },
+    { "uri_get", uri_get },
+    { "uri_encode", uri_encode },
+    { 0 }
+};


### PR DESCRIPTION
This patch is to 
- Add test code for flb_uri
- Prevent passing negative pos

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
d$ valgrind --leak-check=full bin/flb-it-uri 
==28059== Memcheck, a memory error detector
==28059== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==28059== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==28059== Command: bin/flb-it-uri
==28059== 
Test uri_create_destroy...                      [ OK ]
==28060== Warning: invalid file descriptor -1 in syscall close()
==28060== 
==28060== HEAP SUMMARY:
==28060==     in use at exit: 0 bytes in 0 blocks
==28060==   total heap usage: 850 allocs, 850 frees, 87,507 bytes allocated
==28060== 
==28060== All heap blocks were freed -- no leaks are possible
==28060== 
==28060== For lists of detected and suppressed errors, rerun with: -s
==28060== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test uri_get...                                 [ OK ]
==28061== Warning: invalid file descriptor -1 in syscall close()
==28061== 
==28061== HEAP SUMMARY:
==28061==     in use at exit: 0 bytes in 0 blocks
==28061==   total heap usage: 850 allocs, 850 frees, 87,507 bytes allocated
==28061== 
==28061== All heap blocks were freed -- no leaks are possible
==28061== 
==28061== For lists of detected and suppressed errors, rerun with: -s
==28061== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test uri_encode...                              [ OK ]
==28062== Warning: invalid file descriptor -1 in syscall close()
==28062== 
==28062== HEAP SUMMARY:
==28062==     in use at exit: 0 bytes in 0 blocks
==28062==   total heap usage: 847 allocs, 847 frees, 87,340 bytes allocated
==28062== 
==28062== All heap blocks were freed -- no leaks are possible
==28062== 
==28062== For lists of detected and suppressed errors, rerun with: -s
==28062== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==28059== 
==28059== HEAP SUMMARY:
==28059==     in use at exit: 0 bytes in 0 blocks
==28059==   total heap usage: 3 allocs, 3 frees, 1,109 bytes allocated
==28059== 
==28059== All heap blocks were freed -- no leaks are possible
==28059== 
==28059== For lists of detected and suppressed errors, rerun with: -s
==28059== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
