### PR TITLE
kernel: add release function

### DIFF
--- a/include/fluent-bit/flb_kernel.h
+++ b/include/fluent-bit/flb_kernel.h
@@ -35,5 +35,6 @@ struct flb_kernel {
 };
 
 struct flb_kernel *flb_kernel_info();
+void flb_kernel_destroy(struct flb_kernel *kernel);
 
 #endif

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -393,8 +393,7 @@ void flb_config_exit(struct flb_config *config)
     }
 
     if (config->kernel) {
-        flb_free(config->kernel->s_version.data);
-        flb_free(config->kernel);
+        flb_kernel_destroy(config->kernel);
     }
 
     /* release resources */

--- a/src/flb_kernel.c
+++ b/src/flb_kernel.c
@@ -147,3 +147,15 @@ struct flb_kernel *flb_kernel_info()
 }
 
 #endif
+
+void flb_kernel_destroy(struct flb_kernel *kernel)
+{
+    if (kernel == NULL) {
+        return;
+    }
+
+    if (kernel->s_version.data) {
+        flb_free(kernel->s_version.data);
+    }
+    flb_free(kernel);
+}


### PR DESCRIPTION
This patch is to add releasing function for flb_kernel.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output 

```
$ valgrind --leak-check=full bin/fluent-bit -i cpu -o stdout
==71676== Memcheck, a memory error detector
==71676== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==71676== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==71676== Command: bin/fluent-bit -i cpu -o stdout
==71676== 
Fluent Bit v2.1.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/18 09:08:41] [ info] [fluent bit] version=2.1.10, commit=47b42dd4df, pid=71676
[2023/09/18 09:08:42] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/18 09:08:42] [ info] [cmetrics] version=0.6.3
[2023/09/18 09:08:42] [ info] [ctraces ] version=0.3.1
[2023/09/18 09:08:42] [ info] [input:cpu:cpu.0] initializing
[2023/09/18 09:08:42] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/09/18 09:08:42] [ info] [output:stdout:stdout.0] worker #0 started
[2023/09/18 09:08:42] [ info] [sp] stream processor started
[0] cpu.0: [[1694995723.119274183, {}], {"cpu_p"=>24.000000, "user_p"=>22.000000, "system_p"=>2.000000, "cpu0.p_cpu"=>24.000000, "cpu0.p_user"=>22.000000, "cpu0.p_system"=>2.000000}]
^C[2023/09/18 09:08:44] [engine] caught signal (SIGINT)
[2023/09/18 09:08:44] [ warn] [engine] service will shutdown in max 5 seconds
[0] cpu.0: [[1694995724.129985281, {}], {"cpu_p"=>16.000000, "user_p"=>16.000000, "system_p"=>0.000000, "cpu0.p_cpu"=>16.000000, "cpu0.p_user"=>16.000000, "cpu0.p_system"=>0.000000}]
[2023/09/18 09:08:44] [ info] [input] pausing cpu.0
[2023/09/18 09:08:45] [ info] [engine] service has stopped (0 pending tasks)
[2023/09/18 09:08:45] [ info] [input] pausing cpu.0
[2023/09/18 09:08:45] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/09/18 09:08:45] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==71676== 
==71676== HEAP SUMMARY:
==71676==     in use at exit: 0 bytes in 0 blocks
==71676==   total heap usage: 1,574 allocs, 1,574 frees, 969,267 bytes allocated
==71676== 
==71676== All heap blocks were freed -- no leaks are possible
==71676== 
==71676== For lists of detected and suppressed errors, rerun with: -s
==71676== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
