### PR TITLE
in_process_exporter_metrics: implement process exporter metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ option(FLB_IN_OPENTELEMETRY            "Enable OpenTelemetry input plugin"      
 option(FLB_IN_ELASTICSEARCH            "Enable Elasticsearch (Bulk API) input plugin" Yes)
 option(FLB_IN_CALYPTIA_FLEET           "Enable Calyptia Fleet input plugin"           Yes)
 option(FLB_IN_SPLUNK                   "Enable Splunk HTTP HEC input plugin"          Yes)
+option(FLB_IN_PROCESS_EXPORTER_METRICS "Enable process exporter metrics input plugin" Yes)
 option(FLB_OUT_AZURE                   "Enable Azure output plugin"                   Yes)
 option(FLB_OUT_AZURE_BLOB              "Enable Azure output plugin"                   Yes)
 option(FLB_OUT_AZURE_LOGS_INGESTION    "Enable Azure Logs Ingestion output plugin"    Yes)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -206,6 +206,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   REGISTER_IN_PLUGIN("in_docker")
   REGISTER_IN_PLUGIN("in_docker_events")
   REGISTER_IN_PLUGIN("in_podman_metrics")
+  REGISTER_IN_PLUGIN("in_process_exporter_metrics")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/plugins/in_process_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_process_exporter_metrics/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(src
+  pe.c
+  pe_config.c
+  pe_process.c
+  pe_utils.c
+  )
+
+FLB_PLUGIN(in_process_exporter_metrics "${src}" "")

--- a/plugins/in_process_exporter_metrics/pe.c
+++ b/plugins/in_process_exporter_metrics/pe.c
@@ -1,0 +1,166 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_pack.h>
+
+#include "pe.h"
+#include "pe_config.h"
+
+#include "pe_process.h"
+
+static void update_metrics(struct flb_input_instance *ins, struct flb_pe *ctx)
+{
+    pe_process_update(ctx);
+}
+
+/*
+ * Update the metrics, this function is invoked every time 'scrape_interval'
+ * expires.
+ */
+static int cb_pe_collect(struct flb_input_instance *ins,
+                         struct flb_config *config, void *in_context)
+{
+    int ret;
+    struct flb_pe *ctx = in_context;
+
+    update_metrics(ins, ctx);
+
+    /* Append the updated metrics */
+    ret = flb_input_metrics_append(ins, NULL, 0, ctx->cmt);
+    if (ret != 0) {
+        flb_plg_error(ins, "could not append metrics");
+    }
+
+    return 0;
+}
+
+static int in_pe_init(struct flb_input_instance *in,
+                      struct flb_config *config, void *data)
+{
+    int ret;
+    struct flb_pe *ctx;
+
+    /* Create plugin context */
+    ctx = flb_pe_config_create(in, config);
+    if (!ctx) {
+        flb_errno();
+        return -1;
+    }
+
+    /* Initialize fds */
+    ctx->coll_fd = -1;
+
+    /* Associate context with the instance */
+    flb_input_set_context(in, ctx);
+
+    /* Create the collector */
+    ret = flb_input_set_collector_time(in,
+                                       cb_pe_collect,
+                                       ctx->scrape_interval, 0,
+                                       config);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins,
+                      "could not set collector for Node Exporter Metrics plugin");
+        return -1;
+    }
+    ctx->coll_fd = ret;
+
+    /* Initialize process metric collectors */
+    pe_process_init(ctx);
+
+    update_metrics(in, ctx);
+
+    return 0;
+}
+
+static int in_pe_exit(void *data, struct flb_config *config)
+{
+    struct flb_pe *ctx = data;
+
+    if (!ctx) {
+        return 0;
+    }
+
+    pe_process_exit(ctx);
+
+    flb_pe_config_destroy(ctx);
+
+    return 0;
+}
+
+static void in_pe_pause(void *data, struct flb_config *config)
+{
+    struct flb_pe *ctx = data;
+
+    flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+}
+
+static void in_pe_resume(void *data, struct flb_config *config)
+{
+    struct flb_pe *ctx = data;
+
+    flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+}
+
+/* Configuration properties map */
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_TIME, "scrape_interval", "5",
+     0, FLB_TRUE, offsetof(struct flb_pe, scrape_interval),
+     "scrape interval to collect metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "path.procfs", "/proc",
+     0, FLB_TRUE, offsetof(struct flb_pe, path_procfs),
+     "procfs mount point"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "process_include_pattern",  ".+",
+     0, FLB_TRUE, offsetof(struct flb_pe, process_regex_include_list_text),
+     "include list regular expression"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "process_exclude_pattern", NULL,
+     0, FLB_TRUE, offsetof(struct flb_pe, process_regex_exclude_list_text),
+     "exclude list regular expression"
+    },
+    /* EOF */
+    {0}
+};
+
+struct flb_input_plugin in_process_exporter_metrics_plugin = {
+    .name         = "process_exporter_metrics",
+    .description  = "Process Exporter Metrics (Prometheus Compatible)",
+    .cb_init      = in_pe_init,
+    .cb_pre_run   = NULL,
+    .cb_collect   = cb_pe_collect,
+    .cb_flush_buf = NULL,
+    .config_map   = config_map,
+    .cb_pause     = in_pe_pause,
+    .cb_resume    = in_pe_resume,
+    .cb_exit      = in_pe_exit,
+    .flags        = FLB_INPUT_THREADED
+};

--- a/plugins/in_process_exporter_metrics/pe.c
+++ b/plugins/in_process_exporter_metrics/pe.c
@@ -147,6 +147,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_pe, process_regex_exclude_list_text),
      "exclude list regular expression"
     },
+
+    {
+     FLB_CONFIG_MAP_CLIST, "metrics",
+     PE_DEFAULT_ENABLED_METRICS,
+     0, FLB_TRUE, offsetof(struct flb_pe, metrics),
+     "Comma separated list of keys to enable metrics."
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/in_process_exporter_metrics/pe.h
+++ b/plugins/in_process_exporter_metrics/pe.h
@@ -1,0 +1,75 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PROCESS_EXPORTER_H
+#define FLB_PROCESS_EXPORTER_H
+
+/* utils: scan content type expected */
+#define NE_SCAN_FILE      1
+#define NE_SCAN_DIR       2
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_hash_table.h>
+#include <fluent-bit/flb_metrics.h>
+
+struct flb_pe {
+    /* configuration */
+    flb_sds_t path_procfs;
+    int scrape_interval;
+
+    int coll_fd;                                      /* collector fd     */
+    struct cmt *cmt;                                  /* cmetrics context */
+    struct flb_input_instance *ins;                   /* input instance   */
+
+    /*
+     * Metrics Contexts
+     * ----------------
+     */
+
+    /* process */
+    struct cmt_gauge *memory_bytes;
+    struct cmt_gauge *start_time;
+    struct cmt_gauge *open_fds;
+    struct cmt_gauge *fd_ratio;
+    struct cmt_counter *cpu_seconds;
+    struct cmt_counter *read_bytes;
+    struct cmt_counter *write_bytes;
+    struct cmt_counter *major_page_faults;
+    struct cmt_counter *minor_page_faults;
+    struct cmt_counter *context_switches;
+    struct cmt_gauge *num_threads;
+    struct cmt_gauge *states;
+
+    /* thread */
+    struct cmt_gauge *thread_wchan;
+    struct cmt_counter *thread_cpu_seconds;
+    struct cmt_counter *thread_io_bytes;
+    struct cmt_counter *thread_major_page_faults;
+    struct cmt_counter *thread_minor_page_faults;
+    struct cmt_counter *thread_context_switches;
+
+    flb_sds_t           process_regex_include_list_text;
+    flb_sds_t           process_regex_exclude_list_text;
+    struct flb_regex   *process_regex_include_list;
+    struct flb_regex   *process_regex_exclude_list;
+};
+
+#endif

--- a/plugins/in_process_exporter_metrics/pe.h
+++ b/plugins/in_process_exporter_metrics/pe.h
@@ -30,14 +30,28 @@
 #include <fluent-bit/flb_hash_table.h>
 #include <fluent-bit/flb_metrics.h>
 
+#define PE_DEFAULT_ENABLED_METRICS "cpu,io,memory,state,context_switches,fd,start_time,thread_wchan,thread"
+
+#define METRIC_CPU          (1 << 0)
+#define METRIC_IO           (1 << 1)
+#define METRIC_MEMORY       (1 << 2)
+#define METRIC_STATE        (1 << 3)
+#define METRIC_CTXT         (1 << 4)
+#define METRIC_FD           (1 << 5)
+#define METRIC_START_TIME   (1 << 6)
+#define METRIC_THREAD_WCHAN (1 << 7)
+#define METRIC_THREAD       (1 << 8)
+
 struct flb_pe {
     /* configuration */
     flb_sds_t path_procfs;
     int scrape_interval;
 
-    int coll_fd;                                      /* collector fd     */
-    struct cmt *cmt;                                  /* cmetrics context */
-    struct flb_input_instance *ins;                   /* input instance   */
+    int coll_fd;                    /* collector fd     */
+    struct cmt *cmt;                /* cmetrics context */
+    struct flb_input_instance *ins; /* input instance   */
+    struct mk_list *metrics;        /* enabled metrics */
+    int enabled_flag;               /* indicate enabled metrics */
 
     /*
      * Metrics Contexts

--- a/plugins/in_process_exporter_metrics/pe_config.c
+++ b/plugins/in_process_exporter_metrics/pe_config.c
@@ -1,0 +1,70 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2022 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include "pe.h"
+
+struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
+                                    struct flb_config *config)
+{
+    int ret;
+    struct flb_pe *ctx;
+
+    ctx = flb_calloc(1, sizeof(struct flb_pe));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->ins = ins;
+    ctx->process_regex_include_list = NULL;
+    ctx->process_regex_exclude_list = NULL;
+
+    /* Load the config map */
+    ret = flb_input_config_map_set(ins, (void *) ctx);
+    if (ret == -1) {
+        flb_free(ctx);
+        return NULL;
+    }
+
+    /* mount points */
+    flb_plg_info(ins, "path.procfs = %s", ctx->path_procfs);
+
+    ctx->cmt = cmt_create();
+    if (!ctx->cmt) {
+        flb_plg_error(ins, "could not initialize CMetrics");
+        flb_free(ctx);
+        return NULL;
+    }
+
+
+    return ctx;
+}
+
+void flb_pe_config_destroy(struct flb_pe *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    if (ctx->cmt) {
+        cmt_destroy(ctx->cmt);
+    }
+
+    flb_free(ctx);
+}

--- a/plugins/in_process_exporter_metrics/pe_config.c
+++ b/plugins/in_process_exporter_metrics/pe_config.c
@@ -25,6 +25,8 @@ struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
 {
     int ret;
     struct flb_pe *ctx;
+    struct mk_list *head;
+    struct flb_slist_entry *entry;
 
     ctx = flb_calloc(1, sizeof(struct flb_pe));
     if (!ctx) {
@@ -42,6 +44,52 @@ struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
         return NULL;
     }
 
+    /* Check and initialize enabled metrics */
+    if (ctx->metrics) {
+        mk_list_foreach(head, ctx->metrics) {
+            entry = mk_list_entry(head, struct flb_slist_entry, _head);
+            if (strncasecmp(entry->str, "cpu", 3) == 0) {
+                ctx->enabled_flag |= METRIC_CPU;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "io", 2) == 0) {
+                ctx->enabled_flag |= METRIC_IO;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "memory", 6) == 0) {
+                ctx->enabled_flag |= METRIC_MEMORY;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "state", 5) == 0) {
+                ctx->enabled_flag |= METRIC_STATE;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "context_switches", 16) == 0) {
+                ctx->enabled_flag |= METRIC_CTXT;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "fd", 2) == 0) {
+                ctx->enabled_flag |= METRIC_FD;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "start_time", 9) == 0) {
+                ctx->enabled_flag |= METRIC_START_TIME;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "thread_wchan", 12) == 0) {
+                ctx->enabled_flag |= METRIC_THREAD_WCHAN;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else if (strncasecmp(entry->str, "thread", 6) == 0) {
+                ctx->enabled_flag |= METRIC_THREAD;
+                flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+            }
+            else {
+                flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
+            }
+        }
+    }
+
     /* mount points */
     flb_plg_info(ins, "path.procfs = %s", ctx->path_procfs);
 
@@ -51,7 +99,6 @@ struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
         flb_free(ctx);
         return NULL;
     }
-
 
     return ctx;
 }

--- a/plugins/in_process_exporter_metrics/pe_config.h
+++ b/plugins/in_process_exporter_metrics/pe_config.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PE_CONFIG_H
+#define FLB_PE_CONFIG_H
+
+#include <fluent-bit/flb_input_plugin.h>
+#include "pe.h"
+
+struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
+                                    struct flb_config *config);
+
+void flb_pe_config_destroy(struct flb_pe *ctx);
+
+#endif

--- a/plugins/in_process_exporter_metrics/pe_process.c
+++ b/plugins/in_process_exporter_metrics/pe_process.c
@@ -1,0 +1,1076 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "pe.h"
+#include "pe_utils.h"
+
+#include <unistd.h>
+#include <dirent.h>
+
+#define USER_HZ 100
+
+static int process_configure(struct flb_pe *ctx)
+{
+    struct cmt_gauge *g;
+    struct cmt_counter *c;
+
+    /* Initialize regex for the list of including process */
+    ctx->process_regex_include_list = flb_regex_create(ctx->process_regex_include_list_text);
+    if (!ctx->process_regex_include_list) {
+        flb_plg_error(ctx->ins,
+                      "could not initialize regex pattern for the list of including "
+                      "process: '%s'",
+                      ctx->process_regex_include_list_text);
+        return -1;
+    }
+
+    /* Initialize regex for the list of excluding process */
+    if (ctx->process_regex_exclude_list_text != NULL) {
+        ctx->process_regex_exclude_list = flb_regex_create(ctx->process_regex_exclude_list_text);
+        if (!ctx->process_regex_exclude_list) {
+            flb_plg_error(ctx->ins,
+                          "could not initialize regex pattern for the list of excluding "
+                          "process: '%s'",
+                          ctx->process_regex_exclude_list_text);
+            return -1;
+        }
+    }
+
+    /* process_cpu_seconds_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "cpu_seconds_total",
+                           "CPU usage in seconds",
+                           4, (char *[]){"name", "pid", "ppid", "mode"});
+    if (!c) {
+        return -1;
+    }
+    ctx->cpu_seconds = c;
+
+    /* process_read_bytes_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "read_bytes_total",
+                           "number of bytes read",
+                           3, (char *[]){"name", "pid", "ppid"});
+    if (!c) {
+        return -1;
+    }
+    ctx->read_bytes = c;
+
+    /* process_write_bytes_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "write_bytes_total",
+                           "number of bytes write",
+                           3, (char *[]){"name", "pid", "ppid"});
+    if (!c) {
+        return -1;
+    }
+    ctx->write_bytes = c;
+
+    /* process_major_page_faults_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "major_page_faults_total",
+                           "Major page fault",
+                           3, (char *[]){"name", "pid", "ppid"});
+    if (!c) {
+        return -1;
+    }
+    ctx->major_page_faults = c;
+
+    /* process_minor_page_faults_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "minor_page_faults_total",
+                           "Minor page fault",
+                           3, (char *[]){"name", "pid", "ppid"});
+    if (!c) {
+        return -1;
+    }
+    ctx->minor_page_faults = c;
+
+    /* process_context_switches_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "context_switches_total",
+                           "Context switches",
+                           3, (char *[]){"name", "pid", "context_switch_type"});
+    if (!c) {
+        return -1;
+    }
+    ctx->context_switches = c;
+
+    /* process_memory_bytes */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "memory_bytes",
+                         "number of bytes of memory in use per type (VirtualMemory, RSS)",
+                         4, (char *[]){"name", "pid", "ppid", "type"});
+    if (!g) {
+        return -1;
+    }
+    ctx->memory_bytes = g;
+
+    /* process_open_filedesc */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "open_filedesc",
+                         "number of open file descriptors",
+                         3, (char *[]){"name", "pid", "ppid"});
+    if (!g) {
+        return -1;
+    }
+    ctx->open_fds = g;
+
+    /* process_fd_ratio */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "fd_ratio",
+                         "the ratio between open fds and max fds",
+                         3, (char *[]){"name", "pid", "ppid"});
+    if (!g) {
+        return -1;
+    }
+    ctx->fd_ratio = g;
+
+    /* process_start_time_seconds */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "start_time_seconds",
+                         "start time in seconds since 1970/01/01",
+                         3, (char *[]){"name", "pid", "ppid"});
+    if (!g) {
+        return -1;
+    }
+    ctx->start_time = g;
+
+    /* process_num_threads */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "num_threads",
+                         "Number of threads",
+                         3, (char *[]){"name", "pid", "ppid"});
+    if (!g) {
+        return -1;
+    }
+    ctx->num_threads = g;
+
+    /* process_states */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "states",
+                         "Process in states Running, Sleeping, Waiting, Zombie, or Other",
+                         4, (char *[]){"name", "pid", "ppid", "state"});
+    if (!g) {
+        return -1;
+    }
+    ctx->states = g;
+
+    /*
+     * Thread metrics
+     */
+
+    /* process_thread_wchan */
+    g = cmt_gauge_create(ctx->cmt, "process", "", "thread_wchan",
+                         "Number of threads in this process waiting on each wchan",
+                         3, (char *[]){"name", "pid", "wchan"});
+    if (!g) {
+        return -1;
+    }
+    ctx->thread_wchan = g;
+
+    /* process_thread_cpu_seconds_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "thread_cpu_seconds_total",
+                           "CPU user/system usage in seconds with the same threadname",
+                           4, (char *[]){"name", "threadname", "thread_id", "mode"});
+    if (!c) {
+        return -1;
+    }
+    ctx->thread_cpu_seconds = c;
+
+    /* process_thread_io_bytes_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "thread_io_bytes_total",
+                           "number of bytes read/written by these threads",
+                           4, (char *[]){"name", "threadname", "thread_id", "iomode"});
+    if (!c) {
+        return -1;
+    }
+    ctx->thread_io_bytes = c;
+
+    /* process_thread_major_page_faults_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "thread_major_page_faults_total",
+                           "Major page fault for these threads",
+                           3, (char *[]){"name", "threadname", "thread_id"});
+    if (!c) {
+        return -1;
+    }
+    ctx->thread_major_page_faults = c;
+
+    /* process_thread_minor_page_faults_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "thread_minor_page_faults_total",
+                           "Minor page fault for these threads",
+                           3, (char *[]){"name", "threadname", "thread_id"});
+    if (!c) {
+        return -1;
+    }
+    ctx->thread_minor_page_faults = c;
+
+    /* process_thread_context_switches_total */
+    c = cmt_counter_create(ctx->cmt, "process", "", "thread_context_switches_total",
+                           "Context switches",
+                           4, (char *[]){"name", "threadname", "thread_id", "context_switch_type"});
+    if (!c) {
+        return -1;
+    }
+    ctx->thread_context_switches = c;
+
+    return 0;
+}
+
+int pe_process_init(struct flb_pe *ctx)
+{
+    process_configure(ctx);
+
+    return 0;
+}
+
+struct proc_state {
+    int64_t running;
+    int64_t interruptible_sleeping;
+    int64_t uninterruptible_sleeping;
+    int64_t zombie;
+    int64_t stopped;
+    int64_t idle;
+};
+
+static int update_process_proc_state(struct flb_pe *ctx, struct proc_state *state, char* state_str)
+{
+    if (strcmp(state_str, "R") == 0) {
+        state->running++;
+    }
+    else if (strcmp(state_str, "S") == 0) {
+        state->interruptible_sleeping++;
+    }
+    else if (strcmp(state_str, "D") == 0) {
+        state->uninterruptible_sleeping++;
+    }
+    else if (strcmp(state_str, "Z") == 0) {
+        state->zombie++;
+    }
+    else if (strcmp(state_str, "T") == 0) {
+        state->stopped++;
+    }
+    else if (strcmp(state_str, "I") == 0) {
+        state->idle++;
+    }
+
+    return 0;
+}
+
+static void reset_proc_state(struct proc_state *state) {
+    state->running = 0;
+    state->interruptible_sleeping = 0;
+    state->uninterruptible_sleeping = 0;
+    state->zombie = 0;
+    state->stopped = 0;
+    state->idle = 0;
+}
+
+static int check_path_for_proc(struct flb_pe *ctx, const char *prefix, const char *path)
+{
+    int len;
+    flb_sds_t p;
+
+    /* Compose the proc path */
+    p = flb_sds_create(prefix);
+    if (!p) {
+        return -1;
+    }
+
+    if (path) {
+        flb_sds_cat_safe(&p, "/", 1);
+        len = strlen(path);
+        flb_sds_cat_safe(&p, path, len);
+    }
+
+    if (access(p, F_OK) == -1 &&
+        (errno == ENOENT || errno == ESRCH)) {
+        flb_sds_destroy(p);
+
+        return -1;
+    }
+
+    flb_sds_destroy(p);
+    return 0;
+}
+
+static int get_name(const char *entry, char **out_name, char *id_entry)
+{
+    flb_sds_t tmp;
+    flb_sds_t tmp_name;
+
+    tmp = strdup(entry);
+    tmp_name = strtok(tmp, ")");
+    if (tmp_name == NULL) {
+        return -1;
+    }
+
+    *out_name = strdup(tmp_name + strlen(id_entry) + 2);
+    flb_free(tmp);
+
+    return 0;
+}
+
+static int process_proc_thread_io(struct flb_pe *ctx, uint64_t ts,
+                                  flb_sds_t name, flb_sds_t thread_name, flb_sds_t thread_id,
+                                  struct flb_slist_entry *thread)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t status;
+    uint64_t val;
+    struct mk_list io_list;
+    struct mk_list *ihead;
+    struct flb_slist_entry *entry;
+
+    if (check_path_for_proc(ctx, thread->str, "io") != 0) {
+        return -1;
+    }
+
+    mk_list_init(&io_list);
+    ret = pe_utils_file_read_lines(thread->str, "/io", &io_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(ihead, &io_list) {
+        entry = mk_list_entry(ihead, struct flb_slist_entry, _head);
+
+        if (strncmp("read_bytes", entry->str, 10) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->thread_io_bytes, ts, val, 4, (char *[]){ name, thread_name, thread_id, "read" });
+            }
+            flb_sds_destroy(status);
+        }
+
+        if (strncmp("write_bytes", entry->str, 11) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->thread_io_bytes, ts, val, 4, (char *[]){ name, thread_name, thread_id, "write" });
+            }
+            flb_sds_destroy(status);
+        }
+    }
+    flb_slist_destroy(&io_list);
+
+    return 0;
+}
+
+static int process_proc_thread_status(struct flb_pe *ctx, uint64_t ts,
+                                      flb_sds_t thread_name, flb_sds_t thread_id,
+                                      struct flb_slist_entry *thread)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t name;
+    flb_sds_t status;
+    uint64_t val;
+    struct mk_list status_list;
+    struct mk_list *shead;
+    struct flb_slist_entry *entry;
+
+    if (check_path_for_proc(ctx, thread->str, "status") != 0) {
+        return -1;
+    }
+
+    mk_list_init(&status_list);
+    ret = pe_utils_file_read_lines(thread->str, "/status", &status_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(shead, &status_list) {
+        entry = mk_list_entry(shead, struct flb_slist_entry, _head);
+
+        if (strncmp("Name", entry->str, 4) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            name = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(name);
+        }
+
+        if (strncmp("voluntary_ctxt_switches", entry->str, 23) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->thread_context_switches, ts, val,
+                                4, (char *[]){ name, thread_name, thread_id, "voluntary_ctxt_switches" });
+            }
+            flb_sds_destroy(status);
+        }
+
+        if (strncmp("nonvoluntary_ctxt_switches", entry->str, 26) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->thread_context_switches, ts, val,
+                                4, (char *[]){ name, thread_name, thread_id, "nonvoluntary_ctxt_switches" });
+            }
+            flb_sds_destroy(status);
+        }
+    }
+    flb_sds_destroy(name);
+    flb_slist_destroy(&status_list);
+
+    return 0;
+}
+
+static int process_thread_update(struct flb_pe *ctx, uint64_t ts, flb_sds_t pid, flb_sds_t name)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t thread_name;
+    flb_sds_t tid_str;
+    uint64_t val;
+    const char *pattern = "/[0-9]*";
+    struct mk_list *head;
+    struct mk_list *ehead;
+    struct mk_list thread_list;
+    struct mk_list stat_list;
+    struct mk_list split_list;
+    struct flb_slist_entry *thread;
+    struct flb_slist_entry *entry;
+    char thread_procfs[PATH_MAX];
+
+    snprintf(thread_procfs, sizeof(thread_procfs) - 1, "%s/%s/task", ctx->path_procfs, pid);
+
+    /* scan thread entries */
+    ret = pe_utils_path_scan(ctx, thread_procfs, pattern, NE_SCAN_DIR, &thread_list);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (mk_list_size(&thread_list) == 0) {
+        return 0;
+    }
+
+    /* thread entries */
+    mk_list_foreach(head, &thread_list) {
+        thread = mk_list_entry(head, struct flb_slist_entry, _head);
+        tid_str = thread->str + strlen(thread_procfs) + 1;
+
+        /* When pid and tid are equal, the state of the thread should be the same
+         * for pid's. */
+        if (strcmp(tid_str, pid) == 0) {
+            continue;
+        }
+
+        if (check_path_for_proc(ctx, thread->str, "stat") != 0) {
+            continue;
+        }
+
+        mk_list_init(&stat_list);
+        ret = pe_utils_file_read_lines(thread->str, "/stat", &stat_list);
+        if (ret == -1) {
+            continue;
+        }
+
+        mk_list_foreach(ehead, &stat_list) {
+            entry = mk_list_entry(ehead, struct flb_slist_entry, _head);
+
+            if (get_name(entry->str, &thread_name, tid_str) != 0) {
+                continue;
+            }
+
+            /* split with the close parenthesis.
+             * The entry of processes stat will start after that. */
+            tmp = strstr(entry->str, ")");
+            if (tmp == NULL) {
+                continue;
+            }
+
+            mk_list_init(&split_list);
+            ret = flb_slist_split_string(&split_list, tmp+2, ' ', -1);
+            if (ret == -1) {
+                continue;
+            }
+
+            /* Thread CPU Seconds (user) */
+            entry = flb_slist_entry_get(&split_list, 11);
+            tmp = entry->str;
+            /* Collect the number of cpu_seconds per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->thread_cpu_seconds, ts, val/USER_HZ, 4, (char *[]){ name, thread_name, tid_str, "user" });
+            }
+
+            /* Thread CPU Seconds (system) */
+            entry = flb_slist_entry_get(&split_list, 12);
+            tmp = entry->str;
+            /* Collect the number of cpu_seconds per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->thread_cpu_seconds, ts, val/USER_HZ, 4, (char *[]){ name, thread_name, tid_str, "system" });
+            }
+
+            /* Thread Major Page Faults */
+            entry = flb_slist_entry_get(&split_list, 9);
+            tmp = entry->str;
+            /* Collect the number of major page faults per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->thread_major_page_faults, ts, val, 3, (char *[]){ name, thread_name, tid_str });
+            }
+
+            /* Thread Minor Page Faults */
+            entry = flb_slist_entry_get(&split_list, 7);
+            tmp = entry->str;
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->thread_minor_page_faults, ts, val, 3, (char *[]){ name, thread_name, tid_str });
+            }
+
+            ret = process_proc_thread_io(ctx, ts,
+                                         name, thread_name, tid_str,
+                                         thread);
+            if (ret == -1) {
+                goto cleanup;
+            }
+
+            ret = process_proc_thread_status(ctx, ts,
+                                             thread_name, tid_str,
+                                             thread);
+            if (ret == -1) {
+                goto cleanup;
+            }
+
+        cleanup:
+            /* Teardown */
+            flb_free(thread_name);
+            flb_slist_destroy(&split_list);
+        }
+        flb_slist_destroy(&stat_list);
+    }
+
+    flb_slist_destroy(&thread_list);
+
+    return 0;
+}
+
+static int process_proc_wchan(struct flb_pe *ctx, uint64_t ts,
+                              flb_sds_t pid, flb_sds_t name, struct flb_slist_entry *process)
+{
+    int ret;
+    struct mk_list wchan_list;
+    struct mk_list *whead;
+    struct flb_slist_entry *entry;
+
+    if (check_path_for_proc(ctx, process->str, "wchan") != 0) {
+        return -1;
+    }
+
+    /* Collect wchan status */
+    mk_list_init(&wchan_list);
+    ret = pe_utils_file_read_lines(process->str, "/wchan", &wchan_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(whead, &wchan_list) {
+        entry = mk_list_entry(whead, struct flb_slist_entry, _head);
+        if (strcmp("0", entry->str) == 0 ||
+            strcmp("", entry->str) == 0) {
+            cmt_gauge_set(ctx->thread_wchan, ts, 1, 3, (char *[]) { name, pid, "" });
+        }
+        else {
+            cmt_gauge_set(ctx->thread_wchan, ts, 1, 3, (char *[]) { name, pid, entry->str });
+        }
+    }
+    flb_slist_destroy(&wchan_list);
+
+    return 0;
+}
+
+static int process_proc_io(struct flb_pe *ctx, uint64_t ts,
+                           flb_sds_t pid, flb_sds_t ppid, flb_sds_t name,
+                           struct flb_slist_entry *process)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t status;
+    uint64_t val;
+    struct mk_list io_list;
+    struct mk_list *ihead;
+    struct flb_slist_entry *entry;
+
+    if (check_path_for_proc(ctx, process->str, "io") != 0) {
+        return -1;
+    }
+
+    mk_list_init(&io_list);
+    ret = pe_utils_file_read_lines(process->str, "/io", &io_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(ihead, &io_list) {
+        entry = mk_list_entry(ihead, struct flb_slist_entry, _head);
+
+        if (strncmp("read_bytes", entry->str, 10) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->read_bytes, ts, val, 3, (char *[]){ name, pid, ppid });
+            }
+            flb_sds_destroy(status);
+        }
+
+        if (strncmp("write_bytes", entry->str, 11) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->write_bytes, ts, val, 3, (char *[]){ name, pid, ppid });
+            }
+            flb_sds_destroy(status);
+        }
+    }
+    flb_slist_destroy(&io_list);
+
+    return 0;
+}
+
+static int process_proc_limit_fd(struct flb_pe *ctx, flb_sds_t pid,
+                                 struct flb_slist_entry *process,
+                                 uint64_t *out_val)
+{
+    int ret;
+    uint64_t val;
+    flb_sds_t status;
+    struct mk_list limits_list;
+    struct mk_list split_list;
+    struct mk_list *lhead;
+    struct flb_slist_entry *entry;
+    struct flb_slist_entry *limit;
+
+    mk_list_init(&limits_list);
+    ret = pe_utils_file_read_lines(process->str, "/limits", &limits_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(lhead, &limits_list) {
+        entry = mk_list_entry(lhead, struct flb_slist_entry, _head);
+
+        mk_list_init(&split_list);
+        if (strncmp("Max open files", entry->str, 14) == 0) {
+            ret = flb_slist_split_string(&split_list, entry->str, ' ', -1);
+            if (ret == -1) {
+                continue;
+            }
+
+            limit = flb_slist_entry_get(&split_list, 4);
+            status = flb_sds_create_len(limit->str, strlen(limit->str));
+            flb_sds_trim(status);
+            /* Collect the limit of max open files */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                *out_val = val;
+            }
+            flb_sds_destroy(status);
+            flb_slist_destroy(&split_list);
+        }
+    }
+    flb_slist_destroy(&limits_list);
+
+    return 0;
+}
+
+static int process_proc_fds(struct flb_pe *ctx, uint64_t ts,
+                            flb_sds_t pid, flb_sds_t ppid, flb_sds_t name,
+                            struct flb_slist_entry *process)
+{
+    int ret;
+    size_t fds = 0;
+    uint64_t max_fd = 0;
+    DIR *dir;
+    struct dirent *ent;
+    char fd_procfs[PATH_MAX] = {0};
+
+    snprintf(fd_procfs, sizeof(fd_procfs) - 1, "%s/%s", process->str, "fd");
+    dir = opendir(fd_procfs);
+    if (dir == NULL && errno == EACCES) {
+        flb_plg_debug(ctx->ins, "NO read access for path: %s", fd_procfs);
+        return -1;
+    }
+
+    while ((ent = readdir(dir)) != NULL) {
+        if (ent->d_type == DT_LNK) {
+            fds++;
+        }
+    }
+    closedir(dir);
+
+    cmt_gauge_set(ctx->open_fds, ts, (double)fds, 3, (char *[]){ name, pid, ppid });
+
+    ret = process_proc_limit_fd(ctx, pid, process, &max_fd);
+    if (ret != -1) {
+        cmt_gauge_set(ctx->fd_ratio, ts, (double)fds/max_fd, 3, (char *[]){ name, pid, ppid });
+    }
+
+    return 0;
+}
+
+static int process_proc_status(struct flb_pe *ctx, uint64_t ts, flb_sds_t pid, struct flb_slist_entry *process)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t name;
+    flb_sds_t status;
+    uint64_t val;
+    struct mk_list status_list;
+    struct mk_list *shead;
+    struct flb_slist_entry *entry;
+
+    if (check_path_for_proc(ctx, process->str, "status") != 0) {
+        return -1;
+    }
+
+    mk_list_init(&status_list);
+    ret = pe_utils_file_read_lines(process->str, "/status", &status_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(shead, &status_list) {
+        entry = mk_list_entry(shead, struct flb_slist_entry, _head);
+
+        if (strncmp("Name", entry->str, 4) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            name = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(name);
+        }
+
+        if (strncmp("voluntary_ctxt_switches", entry->str, 23) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->context_switches, ts, val, 3, (char *[]){ name, pid, "voluntary_ctxt_switches" });
+            }
+            flb_sds_destroy(status);
+        }
+
+        if (strncmp("nonvoluntary_ctxt_switches", entry->str, 26) == 0) {
+            tmp = strstr(entry->str, ":");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                cmt_counter_set(ctx->context_switches, ts, val, 3, (char *[]){ name, pid, "nonvoluntary_ctxt_switches" });
+            }
+            flb_sds_destroy(status);
+        }
+    }
+    flb_sds_destroy(name);
+    flb_slist_destroy(&status_list);
+
+    return 0;
+}
+
+static int process_proc_boot_time(struct flb_pe *ctx, uint64_t *out_boot_time)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t status;
+    uint64_t val;
+    struct mk_list stat_list;
+    struct mk_list *rshead;
+    struct flb_slist_entry *entry;
+
+    if (check_path_for_proc(ctx, ctx->path_procfs, "stat") != 0) {
+        return -1;
+    }
+
+    mk_list_init(&stat_list);
+    ret = pe_utils_file_read_lines(ctx->path_procfs, "/stat", &stat_list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    mk_list_foreach(rshead, &stat_list) {
+        entry = mk_list_entry(rshead, struct flb_slist_entry, _head);
+
+        if (strncmp("btime", entry->str, 5) == 0) {
+            tmp = strstr(entry->str, " ");
+            if (tmp == NULL) {
+                continue;
+            }
+            status = flb_sds_create_len(tmp+1, strlen(tmp+1));
+            flb_sds_trim(status);
+            /* Collect the number of btime */
+            if (pe_utils_str_to_uint64(status, &val) != -1) {
+                *out_boot_time = val;
+            }
+            flb_sds_destroy(status);
+        }
+    }
+    flb_slist_destroy(&stat_list);
+
+    return 0;
+}
+
+static int process_update(struct flb_pe *ctx)
+{
+    int ret;
+    flb_sds_t tmp;
+    flb_sds_t name;
+    flb_sds_t pid_str;
+    flb_sds_t state_str;
+    flb_sds_t ppid_str;
+    flb_sds_t thread_str;
+    struct mk_list *head;
+    struct mk_list *ehead;
+    struct mk_list procfs_list;
+    struct mk_list stat_list;
+    struct mk_list split_list;
+    struct flb_slist_entry *process;
+    struct flb_slist_entry *entry;
+    uint64_t val;
+    uint64_t ts;
+    const char *pattern = "/[0-9]*";
+    struct proc_state pstate;
+    uint64_t boot_time = 0;
+
+    mk_list_init(&procfs_list);
+
+    ts = cfl_time_now();
+
+    /* scan pid entries */
+    ret = pe_utils_path_scan(ctx, ctx->path_procfs, pattern, NE_SCAN_DIR, &procfs_list);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (mk_list_size(&procfs_list) == 0) {
+        return 0;
+    }
+
+    /* Collect boot_time (btime) */
+    ret = process_proc_boot_time(ctx, &boot_time);
+    if (ret != 0) {
+        boot_time = 0;
+    }
+
+    /* PID entries */
+    mk_list_foreach(head, &procfs_list) {
+        process = mk_list_entry(head, struct flb_slist_entry, _head);
+        pid_str = process->str + strlen(ctx->path_procfs) + 1;
+
+        if (check_path_for_proc(ctx, process->str, "stat") != 0) {
+            continue;
+        }
+
+        mk_list_init(&stat_list);
+        ret = pe_utils_file_read_lines(process->str, "/stat", &stat_list);
+        if (ret == -1) {
+            continue;
+        }
+
+        mk_list_foreach(ehead, &stat_list) {
+            entry = mk_list_entry(ehead, struct flb_slist_entry, _head);
+
+            if (get_name(entry->str, &name, pid_str) != 0) {
+                continue;
+            }
+
+            mk_list_init(&split_list);
+
+            /* split with the close parenthesis.
+             * The entry of processes stat will start after that. */
+            tmp = strstr(entry->str, ")");
+            if (tmp == NULL) {
+                goto cleanup;
+            }
+
+            ret = flb_slist_split_string(&split_list, tmp+2, ' ', -1);
+            if (ret == -1) {
+                goto cleanup;
+            }
+
+            /* State */
+            reset_proc_state(&pstate);
+            entry = flb_slist_entry_get(&split_list, 0);
+            state_str = entry->str;
+            update_process_proc_state(ctx, &pstate, state_str);
+
+            entry = flb_slist_entry_get(&split_list, 1);
+            ppid_str = entry->str;
+
+            /* node_processes_state
+             * Note: we don't use hash table for it. Because we need to update
+             * every state of the processes due to architecture reasons of cmetrics.
+             */
+            cmt_gauge_set(ctx->states, ts, pstate.running,                  4, (char *[]){ name, pid_str, ppid_str, "R" });
+            cmt_gauge_set(ctx->states, ts, pstate.interruptible_sleeping,   4, (char *[]){ name, pid_str, ppid_str, "S" });
+            cmt_gauge_set(ctx->states, ts, pstate.uninterruptible_sleeping, 4, (char *[]){ name, pid_str, ppid_str, "D" });
+            cmt_gauge_set(ctx->states, ts, pstate.zombie,                   4, (char *[]){ name, pid_str, ppid_str, "Z" });
+            cmt_gauge_set(ctx->states, ts, pstate.stopped,                  4, (char *[]){ name, pid_str, ppid_str, "T" });
+            cmt_gauge_set(ctx->states, ts, pstate.idle,                     4, (char *[]){ name, pid_str, ppid_str, "I" });
+
+            /* CPU Seconds (user) */
+            entry = flb_slist_entry_get(&split_list, 11);
+            tmp = entry->str;
+            /* Collect the number of cpu_seconds per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->cpu_seconds, ts, val/USER_HZ, 4, (char *[]){ name, pid_str, ppid_str, "user" });
+            }
+
+            /* CPU Seconds (system) */
+            entry = flb_slist_entry_get(&split_list, 12);
+            tmp = entry->str;
+            /* Collect the number of cpu_seconds per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->cpu_seconds, ts, val/USER_HZ, 4, (char *[]){ name, pid_str, ppid_str, "system" });
+            }
+
+            /* StartTime */
+            entry = flb_slist_entry_get(&split_list, 19);
+            tmp = entry->str;
+            /* Collect the number of cpu_seconds per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_gauge_set(ctx->start_time, ts, (boot_time + val/USER_HZ), 3, (char *[]){ name, pid_str, ppid_str });
+            }
+
+            /* Threads */
+            entry = flb_slist_entry_get(&split_list, 17);
+            thread_str = entry->str;
+            /* Collect the number of threads per process */
+            if (pe_utils_str_to_uint64(thread_str, &val) != -1) {
+                cmt_gauge_set(ctx->num_threads, ts, val, 3, (char *[]){ name, pid_str, ppid_str });
+            }
+
+            /* Memory Size */
+            entry = flb_slist_entry_get(&split_list, 20);
+            tmp = entry->str;
+            /* Collect the number of Virtual Memory per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_gauge_set(ctx->memory_bytes, ts, val, 4, (char *[]){ name, pid_str, ppid_str, "virtual_memory" });
+            }
+
+            entry = flb_slist_entry_get(&split_list, 21);
+            tmp = entry->str;
+            /* Collect the number of RSS per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_gauge_set(ctx->memory_bytes, ts, val, 4, (char *[]){ name, pid_str, ppid_str, "rss" });
+            }
+
+            /* Major Page Faults */
+            entry = flb_slist_entry_get(&split_list, 9);
+            tmp = entry->str;
+            /* Collect the number of major page faults per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->major_page_faults, ts, val, 3, (char *[]){ name, pid_str, ppid_str });
+            }
+
+            /* Minor Page Faults */
+            entry = flb_slist_entry_get(&split_list, 7);
+            tmp = entry->str;
+            /* Collect the number of minor page faults per process */
+            if (pe_utils_str_to_uint64(tmp, &val) != -1) {
+                cmt_counter_set(ctx->minor_page_faults, ts, val, 3, (char *[]){ name, pid_str, ppid_str });
+            }
+
+            /* Collect fds */
+            ret = process_proc_fds(ctx, ts, pid_str, ppid_str, name, process);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "collect fds is failed on the pid = %s", pid_str);
+            }
+
+            /* Collect thread_wchan */
+            ret = process_proc_wchan(ctx, ts, pid_str, name, process);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "collect wchan is failed on the pid = %s", pid_str);
+            }
+
+            /* Collect IO status */
+            ret = process_proc_io(ctx, ts, pid_str, ppid_str, name, process);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "collect process io procfs is failed on the pid = %s", pid_str);
+            }
+
+            /* Collect the states of threads */
+            ret = process_thread_update(ctx, ts, pid_str, name);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "collect thread procfs is failed on the pid = %s", pid_str);
+            }
+
+        cleanup:
+            /* Teardown */
+            flb_slist_destroy(&split_list);
+            flb_free(name);
+        }
+        flb_slist_destroy(&stat_list);
+
+        process_proc_status(ctx, ts, pid_str, process);
+    }
+
+    flb_slist_destroy(&procfs_list);
+
+    return 0;
+}
+
+int pe_process_update(struct flb_pe *ctx)
+{
+    process_update(ctx);
+    return 0;
+}
+
+int pe_process_exit(struct flb_pe *ctx)
+{
+    if (ctx->process_regex_include_list != NULL) {
+        flb_regex_destroy(ctx->process_regex_include_list);
+    }
+    if (ctx->process_regex_exclude_list != NULL) {
+        flb_regex_destroy(ctx->process_regex_exclude_list);
+    }
+
+    return 0;
+}

--- a/plugins/in_process_exporter_metrics/pe_process.h
+++ b/plugins/in_process_exporter_metrics/pe_process.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_PE_PROCESS_H
+#define FLB_IN_PE_PROCESS_H
+
+#include "pe.h"
+
+int pe_process_init(struct flb_pe *ctx);
+int pe_process_update(struct flb_pe *ctx);
+int pe_process_exit(struct flb_pe *ctx);
+
+#endif

--- a/plugins/in_process_exporter_metrics/pe_utils.c
+++ b/plugins/in_process_exporter_metrics/pe_utils.c
@@ -1,0 +1,261 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_sds.h>
+#include "pe.h"
+
+/* required by stat(2), open(2) */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <glob.h>
+
+int pe_utils_str_to_double(char *str, double *out_val)
+{
+    double val;
+    char *end;
+
+    errno = 0;
+    val = strtod(str, &end);
+    if (errno != 0 || *end != '\0') {
+        return -1;
+    }
+    *out_val = val;
+    return 0;
+}
+
+int pe_utils_str_to_uint64(char *str, uint64_t *out_val)
+{
+    uint64_t val;
+    char *end;
+
+    errno = 0;
+    val = strtoll(str, &end, 10);
+    if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN))
+        || (errno != 0 && val == 0)) {
+        flb_errno();
+        return -1;
+    }
+
+    if (end == str) {
+        return -1;
+    }
+
+    *out_val = val;
+    return 0;
+}
+
+int pe_utils_file_read_uint64(const char *mount,
+                              const char *path,
+                              const char *join_a, const char *join_b,
+                              uint64_t *out_val)
+{
+    int fd;
+    int len;
+    int ret;
+    flb_sds_t p;
+    uint64_t val;
+    ssize_t bytes;
+    char tmp[32];
+
+    /* Check the path starts with the mount point to prevent duplication. */
+    if (strncasecmp(path, mount, strlen(mount)) == 0 &&
+        path[strlen(mount)] == '/') {
+        mount = "";
+    }
+
+    /* Compose the final path */
+    p = flb_sds_create(mount);
+    if (!p) {
+        return -1;
+    }
+
+    len = strlen(path);
+    flb_sds_cat_safe(&p, path, len);
+
+    if (join_a) {
+        flb_sds_cat_safe(&p, "/", 1);
+        len = strlen(join_a);
+        flb_sds_cat_safe(&p, join_a, len);
+    }
+
+    if (join_b) {
+        flb_sds_cat_safe(&p, "/", 1);
+        len = strlen(join_b);
+        flb_sds_cat_safe(&p, join_b, len);
+    }
+
+    fd = open(p, O_RDONLY);
+    if (fd == -1) {
+        flb_sds_destroy(p);
+        return -1;
+    }
+    flb_sds_destroy(p);
+
+    bytes = read(fd, &tmp, sizeof(tmp));
+    if (bytes == -1) {
+        flb_errno();
+        close(fd);
+        return -1;
+    }
+    close(fd);
+
+    ret = pe_utils_str_to_uint64(tmp, &val);
+    if (ret == -1) {
+        return -1;
+    }
+
+    *out_val = val;
+    return 0;
+}
+
+/*
+ * Read a file and every non-empty line is stored as a flb_slist_entry in the
+ * given list.
+ */
+int pe_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list)
+{
+    int len;
+    int ret;
+    FILE *f;
+    char line[512];
+    char real_path[2048];
+
+    mk_list_init(list);
+
+    /* Check the path starts with the mount point to prevent duplication. */
+    if (strncasecmp(path, mount, strlen(mount)) == 0 &&
+        path[strlen(mount)] == '/') {
+        mount = "";
+    }
+
+    snprintf(real_path, sizeof(real_path) - 1, "%s%s", mount, path);
+    f = fopen(real_path, "r");
+    if (f == NULL) {
+        if (errno == EACCES) {
+            flb_debug("error reading procfs for path %s. errno = %d", real_path, errno);
+        }
+        else {
+            flb_errno();
+        }
+        return -1;
+    }
+
+    /* Read the content */
+    while (fgets(line, sizeof(line) - 1, f)) {
+        len = strlen(line);
+        if (line[len - 1] == '\n') {
+            line[--len] = 0;
+            if (len && line[len - 1] == '\r') {
+                line[--len] = 0;
+            }
+        }
+
+        ret = flb_slist_add(list, line);
+        if (ret == -1) {
+            fclose(f);
+            flb_slist_destroy(list);
+            return -1;
+        }
+    }
+
+    fclose(f);
+    return 0;
+}
+
+int pe_utils_path_scan(struct flb_pe *ctx, const char *mount, const char *path,
+                       int expected, struct mk_list *list)
+{
+    int i;
+    int ret;
+    glob_t globbuf;
+    struct stat st;
+    char real_path[2048];
+
+    if (!path) {
+        return -1;
+    }
+
+    /* Safe reset for globfree() */
+    globbuf.gl_pathv = NULL;
+
+    /* Scan the real path */
+    snprintf(real_path, sizeof(real_path) - 1, "%s%s", mount, path);
+    ret = glob(real_path, GLOB_TILDE | GLOB_ERR, NULL, &globbuf);
+    if (ret != 0) {
+        switch (ret) {
+        case GLOB_NOSPACE:
+            flb_plg_error(ctx->ins, "no memory space available");
+            return -1;
+        case GLOB_ABORTED:
+            flb_plg_error(ctx->ins, "read error, check permissions: %s", path);
+            return -1;;
+        case GLOB_NOMATCH:
+            ret = stat(path, &st);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
+            }
+            else {
+                ret = access(path, R_OK);
+                if (ret == -1 && errno == EACCES) {
+                    flb_plg_error(ctx->ins, "NO read access for path: %s", path);
+                }
+                else {
+                    flb_plg_debug(ctx->ins, "NO matches for path: %s", path);
+                }
+            }
+            return -1;
+        }
+    }
+
+    if (globbuf.gl_pathc <= 0) {
+        globfree(&globbuf);
+        return -1;
+    }
+
+    /* Initialize list */
+    flb_slist_create(list);
+
+    /* For every entry found, generate an output list */
+    for (i = 0; i < globbuf.gl_pathc; i++) {
+        ret = stat(globbuf.gl_pathv[i], &st);
+        if (ret != 0) {
+            continue;
+        }
+
+        if ((expected == NE_SCAN_FILE && S_ISREG(st.st_mode)) ||
+            (expected == NE_SCAN_DIR && S_ISDIR(st.st_mode))) {
+
+            /* Compose the path */
+            ret = flb_slist_add(list, globbuf.gl_pathv[i]);
+            if (ret != 0) {
+                globfree(&globbuf);
+                flb_slist_destroy(list);
+                return -1;
+            }
+        }
+    }
+
+    globfree(&globbuf);
+    return 0;
+}

--- a/plugins/in_process_exporter_metrics/pe_utils.h
+++ b/plugins/in_process_exporter_metrics/pe_utils.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PROCESS_EXPORTER_UTILS_H
+#define FLB_PROCESS_EXPORTER_UTILS_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_sds.h>
+#include "pe.h"
+
+int pe_utils_str_to_double(char *str, double *out_val);
+int pe_utils_str_to_uint64(char *str, uint64_t *out_val);
+
+int pe_utils_file_read_uint64(const char *mount,
+                              const char *path,
+                              const char *join_a, const char *join_b,
+                              uint64_t *out_val);
+
+int pe_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list);
+int pe_utils_path_scan(struct flb_pe *ctx, const char *mount, const char *path,
+                       int expected, struct mk_list *list);
+#endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the official node_exporter, process level of metrics exporter is not provided. the 3rd party exporter is provided. However, the 3rd party exporter is still not process level but for process group level of exporter.
We try to provide genuine process level of exporter in Linux.

Closes  https://github.com/fluent/fluent-bit/issues/7870

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```console
# For retrieving all of the processes' metrics
$ bin/fluent-bit -i process_exporter_metrics -o stdout
# For excluding some of the parts of the processes' metrics
$ bin/fluent-bit -i process_exporter_metrics -p 'process_exclude_pattern=/chrome|kworker|firefox|gsd|Co/' -o stdout
# For including some of the parts of the processes' metrics
$ bin/fluent-bit -i process_exporter_metrics -p 'process_include_pattern=/fluent-bit/' -o stdout
```

- [x] Debug log output from testing the change

e.g.)

```
$ bin/fluent-bit -i process_exporter_metrics -p 'process_include_pattern=/memcheck-amd64/' -o stdout -vv 
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/25 16:06:37] [ info] Configuration:
[2023/10/25 16:06:37] [ info]  flush time     | 1.000000 seconds
[2023/10/25 16:06:37] [ info]  grace          | 5 seconds
[2023/10/25 16:06:37] [ info]  daemon         | 0
[2023/10/25 16:06:37] [ info] ___________
[2023/10/25 16:06:37] [ info]  inputs:
[2023/10/25 16:06:37] [ info]      process_exporter_metrics
[2023/10/25 16:06:37] [ info] ___________
[2023/10/25 16:06:37] [ info]  filters:
[2023/10/25 16:06:37] [ info] ___________
[2023/10/25 16:06:37] [ info]  outputs:
[2023/10/25 16:06:37] [ info]      stdout.0
[2023/10/25 16:06:37] [ info] ___________
[2023/10/25 16:06:37] [ info]  collectors:
[2023/10/25 16:06:37] [ info] [fluent bit] version=2.2.0, commit=6708c732f1, pid=406585
[2023/10/25 16:06:37] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/10/25 16:06:37] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/25 16:06:37] [ info] [cmetrics] version=0.6.4
[2023/10/25 16:06:37] [ info] [ctraces ] version=0.3.1
[2023/10/25 16:06:37] [ info] [input:process_exporter_metrics:process_exporter_metrics.0] initializing
[2023/10/25 16:06:37] [ info] [input:process_exporter_metrics:process_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics cpu
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics io
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics memory
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics state
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics context_switches
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics fd
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics start_time
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics thread_wchan
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] enabled metrics thread
[2023/10/25 16:06:37] [ info] [input:process_exporter_metrics:process_exporter_metrics.0] path.procfs = /proc
[2023/10/25 16:06:37] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] [thread init] initialization OK
[2023/10/25 16:06:37] [ info] [input:process_exporter_metrics:process_exporter_metrics.0] thread instance initialized
[2023/10/25 16:06:37] [debug] [process_exporter_metrics:process_exporter_metrics.0] created event channels: read=30 write=31
[2023/10/25 16:06:37] [debug] [stdout:stdout.0] created event channels: read=34 write=35
[2023/10/25 16:06:37] [ info] [sp] stream processor started
[2023/10/25 16:06:37] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/25 16:06:42] [debug] [input chunk] update output instances with new chunk size diff=6550, records=0, input=process_exporter_metrics.0
[2023/10/25 16:06:43] [trace] [task 0x7f880c020790] created (id=0)
[2023/10/25 16:06:43] [debug] [task] created task=0x7f880c020790 id=0 OK
[2023/10/25 16:06:43] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2023-10-25T07:06:42.518438676Z process_cpu_seconds_total{name="fluent-bit",pid="406585",ppid="8832",mode="user"} = 0
2023-10-25T07:06:42.518438676Z process_cpu_seconds_total{name="fluent-bit",pid="406585",ppid="8832",mode="system"} = 0
2023-10-25T07:06:42.518438676Z process_read_bytes_total{name="fluent-bit",pid="406585",ppid="8832"} = 0
2023-10-25T07:06:42.518438676Z process_write_bytes_total{name="fluent-bit",pid="406585",ppid="8832"} = 0
2023-10-25T07:06:42.518438676Z process_major_page_faults_total{name="fluent-bit",pid="406585",ppid="8832"} = 0
2023-10-25T07:06:42.518438676Z process_minor_page_faults_total{name="fluent-bit",pid="406585",ppid="8832"} = 966
2023-10-25T07:06:42.518438676Z process_context_switches_total{name="fluent-bit",pid="406585",context_switch_type="voluntary_ctxt_switches"} = 6
2023-10-25T07:06:42.518438676Z process_context_switches_total{name="fluent-bit",pid="406585",context_switch_type="nonvoluntary_ctxt_switches"} = 2
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-pipeline",thread_id="406586",mode="user"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-pipeline",thread_id="406586",mode="system"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-logger",thread_id="406587",mode="user"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-logger",thread_id="406587",mode="system"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-in-process_",thread_id="406588",mode="user"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-in-process_",thread_id="406588",mode="system"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-out-stdout.",thread_id="406589",mode="user"} = 0
2023-10-25T07:06:42.518438676Z process_thread_cpu_seconds_total{name="fluent-bit",threadname="flb-out-stdout.",thread_id="406589",mode="system"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-pipeline",thread_id="406586",iomode="read"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-pipeline",thread_id="406586",iomode="write"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-logger",thread_id="406587",iomode="read"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-logger",thread_id="406587",iomode="write"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-in-process_",thread_id="406588",iomode="read"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-in-process_",thread_id="406588",iomode="write"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-out-stdout.",thread_id="406589",iomode="read"} = 0
2023-10-25T07:06:42.518438676Z process_thread_io_bytes_total{name="fluent-bit",threadname="flb-out-stdout.",thread_id="406589",iomode="write"} = 0
2023-10-25T07:06:42.518438676Z process_thread_major_page_faults_total{name="fluent-bit",threadname="flb-pipeline",thread_id="406586"} = 0
2023-10-25T07:06:42.518438676Z process_thread_major_page_faults_total{name="fluent-bit",threadname="flb-logger",thread_id="406587"} = 0
2023-10-25T07:06:42.518438676Z process_thread_major_page_faults_total{name="fluent-bit",threadname="flb-in-process_",thread_id="406588"} = 0
2023-10-25T07:06:42.518438676Z process_thread_major_page_faults_total{name="fluent-bit",threadname="flb-out-stdout.",thread_id="406589"} = 0
2023-10-25T07:06:42.518438676Z process_thread_minor_page_faults_total{name="fluent-bit",threadname="flb-pipeline",thread_id="406586"} = 86
2023-10-25T07:06:42.518438676Z process_thread_minor_page_faults_total{name="fluent-bit",threadname="flb-logger",thread_id="406587"} = 1
2023-10-25T07:06:42.518438676Z process_thread_minor_page_faults_total{name="fluent-bit",threadname="flb-in-process_",thread_id="406588"} = 39
2023-10-25T07:06:42.518438676Z process_thread_minor_page_faults_total{name="fluent-bit",threadname="flb-out-stdout.",thread_id="406589"} = 3
2023-10-25T07:06:42.518438676Z process_memory_bytes{name="fluent-bit",pid="406585",ppid="8832",type="virtual_memory"} = 278450176
2023-10-25T07:06:42.518438676Z process_memory_bytes{name="fluent-bit",pid="406585",ppid="8832",type="rss"} = 3412
2023-10-25T07:06:42.518438676Z process_open_filedesc{name="fluent-bit",pid="406585",ppid="8832"} = 52
2023-10-25T07:06:42.518438676Z process_fd_ratio{name="fluent-bit",pid="406585",ppid="8832"} = 0.00079346913862821393
2023-10-25T07:06:42.518438676Z process_start_time_seconds{name="fluent-bit",pid="406585",ppid="8832"} = 1698217597
2023-10-25T07:06:42.518438676Z process_num_threads{name="fluent-bit",pid="406585",ppid="8832"} = 5
2023-10-25T07:06:42.518438676Z process_states{name="fluent-bit",pid="406585",ppid="8832",state="R"} = 0
2023-10-25T07:06:42.518438676Z process_states{name="fluent-bit",pid="406585",ppid="8832",state="S"} = 1
2023-10-25T07:06:42.518438676Z process_states{name="fluent-bit",pid="406585",ppid="8832",state="D"} = 0
2023-10-25T07:06:42.518438676Z process_states{name="fluent-bit",pid="406585",ppid="8832",state="Z"} = 0
2023-10-25T07:06:42.518438676Z process_states{name="fluent-bit",pid="406585",ppid="8832",state="T"} = 0
2023-10-25T07:06:42.518438676Z process_states{name="fluent-bit",pid="406585",ppid="8832",state="I"} = 0
2023-10-25T07:06:37.681669047Z process_thread_wchan{name="fluent-bit",pid="406585",wchan="ep_poll"} = 1
2023-10-25T07:06:42.518438676Z process_thread_wchan{name="fluent-bit",pid="406585",wchan="hrtimer_nanosleep"} = 1
[2023/10/25 16:06:43] [debug] [out flush] cb_destroy coro_id=0
[2023/10/25 16:06:43] [trace] [coro] destroy coroutine=0x7f8800001040 data=0x7f8800001060
[2023/10/25 16:06:43] [trace] [engine] [task event] task_id=0 out_id=0 return=OK
[2023/10/25 16:06:43] [debug] [task] destroy task=0x7f880c020790 (task_id=0)
^C[2023/10/25 16:06:43] [engine] caught signal (SIGINT)
[2023/10/25 16:06:43] [trace] [engine] flush enqueued data
[2023/10/25 16:06:43] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/25 16:06:43] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] thread pause instance
[2023/10/25 16:06:44] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/25 16:06:44] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] thread pause instance
[2023/10/25 16:06:44] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/25 16:06:44] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2023/10/25 16:06:44] [debug] [input:process_exporter_metrics:process_exporter_metrics.0] thread exit instance
```

<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```console
$ valgrind --leak-check=full bin/fluent-bit -i process_exporter_metrics -p 'process_include_pattern=/memcheck-amd64/' -o stdout -vv
<snip>
==406479== 
==406479== HEAP SUMMARY:
==406479==     in use at exit: 0 bytes in 0 blocks
==406479==   total heap usage: 138,480 allocs, 138,480 frees, 11,935,269 bytes allocated
==406479== 
==406479== All heap blocks were freed -- no leaks are possible
==406479== 
==406479== For lists of detected and suppressed errors, rerun with: -s
==406479== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

$ valgrind --leak-check=full  bin/fluent-bit -i process_exporter_metrics -p 'process_exclude_pattern=/chrome|kworker|firefox|gsd|Co/' -o stdout -vv
<snip>
==406758== 
==406758== HEAP SUMMARY:
==406758==     in use at exit: 0 bytes in 0 blocks
==406758==   total heap usage: 1,318,556 allocs, 1,318,556 frees, 198,553,082,179 bytes allocated
==406758== 
==406758== All heap blocks were freed -- no leaks are possible
==406758== 
==406758== For lists of detected and suppressed errors, rerun with: -s
==406758== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

$ valgrind bin/fluent-bit -i process_exporter_metrics -o stdout -vv
==407194== 
==407194== HEAP SUMMARY:
==407194==     in use at exit: 0 bytes in 0 blocks
==407194==   total heap usage: 4,838,135 allocs, 4,838,135 frees, 1,770,625,735,478 bytes allocated
==407194== 
==407194== All heap blocks were freed -- no leaks are possible
==407194== 
==407194== For lists of detected and suppressed errors, rerun with: -s
==407194== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1198

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
