### PR TITLE
out_loki: add compress option for gzip

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -28,6 +28,7 @@
 #include <fluent-bit/record_accessor/flb_ra_parser.h>
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_gzip.h>
 
 #include <ctype.h>
 #include <sys/stat.h>
@@ -905,6 +906,7 @@ static struct flb_loki *loki_config_create(struct flb_output_instance *ins,
     int io_flags = 0;
     struct flb_loki *ctx;
     struct flb_upstream *upstream;
+    char *compress;
 
     /* Create context */
     ctx = flb_calloc(1, sizeof(struct flb_loki));
@@ -948,6 +950,15 @@ static struct flb_loki *loki_config_create(struct flb_output_instance *ins,
         if (!ctx->ra_tenant_id_key) {
             flb_plg_error(ctx->ins,
                           "could not create record accessor for Tenant ID");
+        }
+    }
+
+    /* Compress (gzip) */
+    compress = (char *) flb_output_get_property("compress", ins);
+    ctx->compress_gzip = FLB_FALSE;
+    if (compress) {
+        if (strcasecmp(compress, "gzip") == 0) {
+            ctx->compress_gzip = FLB_TRUE;
         }
     }
 
@@ -1487,6 +1498,9 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     int out_ret = FLB_OK;
     size_t b_sent;
     flb_sds_t payload = NULL;
+    flb_sds_t out_buf = NULL;
+    size_t out_size;
+    int compressed = FLB_FALSE;
     struct flb_loki *ctx = out_context;
     struct flb_connection *u_conn;
     struct flb_http_client *c;
@@ -1520,10 +1534,28 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
                                    flb_sds_len(event_chunk->tag),
                                    event_chunk->data, event_chunk->size,
                                    &dynamic_tenant_id->value);
+
+
     if (!payload) {
         flb_plg_error(ctx->ins, "cannot compose request payload");
 
         FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    /* Map buffer */
+    out_buf = payload;
+    out_size = flb_sds_len(payload);
+
+    if (ctx->compress_gzip == FLB_TRUE) {
+        ret = flb_gzip_compress((void *) payload, flb_sds_len(payload), (void **) &out_buf, &out_size);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins,
+                          "cannot gzip payload, disabling compression");
+        } else {
+            compressed = FLB_TRUE;
+            /* payload is not longer needed */
+            flb_sds_destroy(payload);
+        }
     }
 
     /* Lookup an available connection context */
@@ -1531,20 +1563,25 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     if (!u_conn) {
         flb_plg_error(ctx->ins, "no upstream connections available");
 
-        flb_sds_destroy(payload);
+        if (compressed) {
+          flb_free(out_buf);
+        }
+        else {
+          flb_sds_destroy(out_buf);
+        }
 
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
     /* Create HTTP client context */
     c = flb_http_client(u_conn, FLB_HTTP_POST, FLB_LOKI_URI,
-                        payload, flb_sds_len(payload),
+                        out_buf, out_size,
                         ctx->tcp_host, ctx->tcp_port,
                         NULL, 0);
     if (!c) {
         flb_plg_error(ctx->ins, "cannot create HTTP client context");
 
-        flb_sds_destroy(payload);
+        flb_sds_destroy(out_buf);
         flb_upstream_conn_release(u_conn);
 
         FLB_OUTPUT_RETURN(FLB_RETRY);
@@ -1568,6 +1605,12 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
                         FLB_LOKI_CT, sizeof(FLB_LOKI_CT) - 1,
                         FLB_LOKI_CT_JSON, sizeof(FLB_LOKI_CT_JSON) - 1);
 
+    if (compressed == FLB_TRUE) {
+        flb_http_add_header(c,
+                            FLB_LOKI_HEADER_CE, sizeof(FLB_LOKI_HEADER_CE) - 1,
+                            FLB_LOKI_CE_GZIP, sizeof(FLB_LOKI_CE_GZIP) - 1);
+    }
+
     /* Add X-Scope-OrgID header */
     if (dynamic_tenant_id->value != NULL) {
         flb_http_add_header(c,
@@ -1583,7 +1626,12 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
-    flb_sds_destroy(payload);
+    if (compressed) {
+      flb_free(out_buf);
+    }
+    else {
+      flb_sds_destroy(out_buf);
+    }
 
     /* Validate HTTP client return status */
     if (ret == 0) {
@@ -1758,6 +1806,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "bearer_token", NULL,
      0, FLB_TRUE, offsetof(struct flb_loki, bearer_token),
      "Set bearer token auth"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "compress", NULL,
+     0, FLB_FALSE, 0,
+     "Set payload compression in network transfer. Option available is 'gzip'"
     },
 
     /* EOF */

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1535,7 +1535,6 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
                                    event_chunk->data, event_chunk->size,
                                    &dynamic_tenant_id->value);
 
-
     if (!payload) {
         flb_plg_error(ctx->ins, "cannot compose request payload");
 
@@ -1564,10 +1563,10 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
         flb_plg_error(ctx->ins, "no upstream connections available");
 
         if (compressed) {
-          flb_free(out_buf);
+            flb_free(out_buf);
         }
         else {
-          flb_sds_destroy(out_buf);
+            flb_sds_destroy(out_buf);
         }
 
         FLB_OUTPUT_RETURN(FLB_RETRY);
@@ -1581,7 +1580,12 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     if (!c) {
         flb_plg_error(ctx->ins, "cannot create HTTP client context");
 
-        flb_sds_destroy(out_buf);
+        if (compressed) {
+            flb_free(out_buf);
+        }
+        else {
+            flb_sds_destroy(out_buf);
+        }
         flb_upstream_conn_release(u_conn);
 
         FLB_OUTPUT_RETURN(FLB_RETRY);
@@ -1606,9 +1610,7 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
                         FLB_LOKI_CT_JSON, sizeof(FLB_LOKI_CT_JSON) - 1);
 
     if (compressed == FLB_TRUE) {
-        flb_http_add_header(c,
-                            FLB_LOKI_HEADER_CE, sizeof(FLB_LOKI_HEADER_CE) - 1,
-                            FLB_LOKI_CE_GZIP, sizeof(FLB_LOKI_CE_GZIP) - 1);
+        flb_http_set_content_encoding_gzip(c);
     }
 
     /* Add X-Scope-OrgID header */
@@ -1627,10 +1629,10 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
     if (compressed) {
-      flb_free(out_buf);
+        flb_free(out_buf);
     }
     else {
-      flb_sds_destroy(out_buf);
+        flb_sds_destroy(out_buf);
     }
 
     /* Validate HTTP client return status */

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -32,6 +32,8 @@
 #define FLB_LOKI_HOST            "127.0.0.1"
 #define FLB_LOKI_PORT            3100
 #define FLB_LOKI_HEADER_SCOPE    "X-Scope-OrgID"
+#define FLB_LOKI_HEADER_CE       "Content-Encoding"
+#define FLB_LOKI_CE_GZIP         "gzip"
 
 #define FLB_LOKI_KV_STR    0     /* sds string */
 #define FLB_LOKI_KV_RA     1     /* record accessor */
@@ -58,6 +60,7 @@ struct flb_loki {
     flb_sds_t line_format;
     flb_sds_t tenant_id;
     flb_sds_t tenant_id_key_config;
+    int compress_gzip;
 
     /* HTTP Auth */
     flb_sds_t http_user;

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -32,8 +32,6 @@
 #define FLB_LOKI_HOST            "127.0.0.1"
 #define FLB_LOKI_PORT            3100
 #define FLB_LOKI_HEADER_SCOPE    "X-Scope-OrgID"
-#define FLB_LOKI_HEADER_CE       "Content-Encoding"
-#define FLB_LOKI_CE_GZIP         "gzip"
 
 #define FLB_LOKI_KV_STR    0     /* sds string */
 #define FLB_LOKI_KV_RA     1     /* record accessor */


### PR DESCRIPTION
<!-- Provide summary of changes -->

Add compress option for gzip compression in out_loki

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #7917

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change

#### Run loki

```
docker run --rm --net=host grafana/loki
```

- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->

I'm not sure what I should write here. Any example?

- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
<details>
<summary>with gzip</summary>

```
% valgrind  bin/fluent-bit -i dummy -p rate=60 -o loki -p match='*' -p labels="job=gzip" -p compress=gzip

==61990== Memcheck, a memory error detector
==61990== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==61990== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==61990== Command: bin/fluent-bit -i dummy -p rate=60 -o loki -p match=* -p labels=job=gzip -p compress=gzip
==61990== 
Fluent Bit v2.1.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/20 21:11:00] [ info] [fluent bit] version=2.1.10, commit=47b42dd4df, pid=61990
[2023/09/20 21:11:00] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/20 21:11:00] [ info] [cmetrics] version=0.6.3
[2023/09/20 21:11:00] [ info] [ctraces ] version=0.3.1
[2023/09/20 21:11:00] [ info] [input:dummy:dummy.0] initializing
[2023/09/20 21:11:00] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/09/20 21:11:00] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2023/09/20 21:11:00] [ info] [sp] stream processor started
^C[2023/09/20 21:11:13] [engine] caught signal (SIGINT)
[2023/09/20 21:11:13] [ warn] [engine] service will shutdown in max 5 seconds
[2023/09/20 21:11:13] [ info] [input] pausing dummy.0
[2023/09/20 21:11:13] [ info] [engine] service has stopped (0 pending tasks)
[2023/09/20 21:11:13] [ info] [input] pausing dummy.0
==61990== 
==61990== HEAP SUMMARY:
==61990==     in use at exit: 0 bytes in 0 blocks
==61990==   total heap usage: 9,767 allocs, 9,767 frees, 23,202,347 bytes allocated
==61990== 
==61990== All heap blocks were freed -- no leaks are possible
==61990== 
==61990== For lists of detected and suppressed errors, rerun with: -s
==61990== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


```
</details>

<details>
<summary>without gzip</summary>

```
% valgrind  bin/fluent-bit -i dummy -p rate=60 -o loki -p match='*' -p labels="job=plain"                  

==64340== Memcheck, a memory error detector
==64340== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==64340== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==64340== Command: bin/fluent-bit -i dummy -p rate=60 -o loki -p match=* -p labels=job=plain
==64340== 
Fluent Bit v2.1.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/20 21:11:50] [ info] [fluent bit] version=2.1.10, commit=47b42dd4df, pid=64340
[2023/09/20 21:11:50] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/20 21:11:50] [ info] [cmetrics] version=0.6.3
[2023/09/20 21:11:50] [ info] [ctraces ] version=0.3.1
[2023/09/20 21:11:50] [ info] [input:dummy:dummy.0] initializing
[2023/09/20 21:11:50] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/09/20 21:11:50] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2023/09/20 21:11:50] [ info] [sp] stream processor started
^C[2023/09/20 21:12:04] [engine] caught signal (SIGINT)
[2023/09/20 21:12:04] [ warn] [engine] service will shutdown in max 5 seconds
[2023/09/20 21:12:04] [ info] [input] pausing dummy.0
[2023/09/20 21:12:04] [ info] [engine] service has stopped (0 pending tasks)
[2023/09/20 21:12:04] [ info] [input] pausing dummy.0
==64340== 
==64340== HEAP SUMMARY:
==64340==     in use at exit: 0 bytes in 0 blocks
==64340==   total heap usage: 10,984 allocs, 10,984 frees, 21,295,881 bytes allocated
==64340== 
==64340== All heap blocks were freed -- no leaks are possible
==64340== 
==64340== For lists of detected and suppressed errors, rerun with: -s
==64340== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

</details>

#### how to query loki

with gzip

```
% curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode 'query={job="gzip"}' --data 'limit=2' | jq '.data.result'
[
  {
    "stream": {
      "job": "gzip"
    },
    "values": [
      [
        "1695211873416884326",
        "{\"message\":\"dummy\"}"
      ],
      [
        "1695211873400239362",
        "{\"message\":\"dummy\"}"
      ]
    ]
  }
]
```

without gzip

```
% curl -G -s  "http://localhost:3100/loki/api/v1/query_range" --data-urlencode 'query={job="plain"}' --data 'limit=2' | jq '.data.result'
[
  {
    "stream": {
      "job": "plain"
    },
    "values": [
      [
        "1695211924850171543",
        "{\"message\":\"dummy\"}"
      ],
      [
        "1695211924833646667",
        "{\"message\":\"dummy\"}"
      ]
    ]
  }
]

```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

https://github.com/fluent/fluent-bit-docs/pull/1199

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
