### PR TITLE
lib: monkey: upgrade to v1.7.2

### DIFF
--- a/lib/monkey/CMakeLists.txt
+++ b/lib/monkey/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 # Monkey Version
 set(MK_VERSION_MAJOR  1)
 set(MK_VERSION_MINOR  7)
-set(MK_VERSION_PATCH  1)
+set(MK_VERSION_PATCH  2)
 set(MK_VERSION_STR "${MK_VERSION_MAJOR}.${MK_VERSION_MINOR}.${MK_VERSION_PATCH}")
 
 # Output paths

--- a/lib/monkey/mk_core/external/winpthreads.c
+++ b/lib/monkey/mk_core/external/winpthreads.c
@@ -1098,7 +1098,7 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 {
   pthread_t t = pthread_self();
 
-  if (key > t->keymax)
+  if (key >= t->keymax)
   {
     int keymax = (key + 1) * 2;
     void **kv = (void**)realloc(t->keyval, keymax * sizeof(void *));


### PR DESCRIPTION
# Summary

Monkey v1.7.2 includes a fix to `pthread_setspecific` which fixes a crash in win32 in the co-routines API. This is a blocker for #7929.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
