### PR TITLE
out_http: Fix bug where post_all_requests() always returns a value less than 0

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -503,7 +503,7 @@ static int post_all_requests(struct flb_out_http *ctx,
         return -1;
     }
 
-    while ((ret = flb_log_event_decoder_next(
+    while ((flb_log_event_decoder_next(
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
         headers = NULL;


### PR DESCRIPTION
<!-- Provide summary of changes -->
When using body_key and headers_key in output:http, post_all_requests() is called in cb_http_flush(). The exit condition of the while(ret = flb_log_event_decoder_next()) loop is stored in 'ret' and returned as is. This leads to an error being recognized in cb_http_flush(), resulting in a "failed to post requests body" error, and input tasks accumulating in a pending state, causing continuous memory consumption growth. This has been fixed.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
