### PR TITLE
tests: internal: sp: added environment initialization calls

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.c
+++ b/plugins/filter_log_to_metrics/log_to_metrics.c
@@ -268,7 +268,7 @@ static int set_labels(struct log_to_metrics_ctx *ctx,
             snprintf(label_keys[counter], MAX_LABEL_LENGTH - 1, "%s", kv->val);
             counter++;
         }
-        else if (strcasecmp(kv->key, "label") == 0) {
+        else if (strcasecmp(kv->key, "add_label") == 0) {
             split = flb_utils_split(kv->val, ' ', 1);
             if (mk_list_size(split) != 2) {
                 flb_plg_error(ctx->ins, "invalid label, expected name and key");

--- a/tests/internal/fuzzers/fstore_fuzzer.c
+++ b/tests/internal/fuzzers/fstore_fuzzer.c
@@ -45,6 +45,20 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     struct flb_fstore_stream *st;
     struct flb_fstore_file *fsf;
 
+    /* Set flb_malloc_mod to be fuzzer-data dependent */
+    if (size < 4) {
+        return 0;
+    }
+    flb_malloc_p = 0;
+    flb_malloc_mod = *(int*)data;
+    data += 4;
+    size -= 4;
+
+    /* Avoid division by zero for modulo operations */
+    if (flb_malloc_mod == 0) {
+        flb_malloc_mod = 1;
+    }
+
     cio_utils_recursive_delete(FSF_STORE_PATH);
     fs = flb_fstore_create(FSF_STORE_PATH, FLB_FSTORE_FS);
     st = flb_fstore_stream_create(fs, "abc");

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -18,6 +18,7 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_pack.h>
@@ -200,6 +201,8 @@ static void invalid_queries()
     struct flb_sp *sp;
     struct flb_sp_task *task;
 
+    flb_init_env();
+
     /* Total number of checks for invalid queries */
     checks = sizeof(invalid_query_checks) / sizeof(char *);
 
@@ -243,6 +246,8 @@ static void test_select_keys()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    flb_init_env();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -329,6 +334,8 @@ static void test_select_subkeys()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    flb_init_env();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -457,6 +464,8 @@ static void test_window()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    flb_init_env();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -611,6 +620,8 @@ static void test_snapshot()
 #ifdef _WIN32
     WSADATA wsa_data;
 #endif
+
+    flb_init_env();
 
     config = flb_calloc(1, sizeof(struct flb_config));
     if (!config) {
@@ -772,6 +783,8 @@ static void test_conv_from_str_to_num()
     WSAStartup(0x0201, &wsa_data);
 #endif
     out_buf.buffer = NULL;
+
+    flb_init_env();
 
     config = flb_config_init();
     config->evl = mk_event_loop_create(256);

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -526,6 +526,13 @@ static void test_window()
                 usleep(800000);
             }
 
+            if (out_buf.buffer != NULL) {
+                flb_free(out_buf.buffer);
+
+                out_buf.buffer = NULL;
+                out_buf.size = 0;
+            }
+
             flb_sp_fd_event_test(task->window.fd, task, &out_buf);
 
             flb_info("[sp test] id=%i, SQL => '%s'", check->id, check->exec);
@@ -569,13 +576,26 @@ static void test_window()
 
                 /* Hopping event */
                 if ((t + 1) % check->window_hop_sec == 0) {
+                    if (out_buf.buffer != NULL) {
+                        flb_free(out_buf.buffer);
+
+                        out_buf.buffer = NULL;
+                        out_buf.size = 0;
+                    }
+
                     flb_sp_fd_event_test(task->window.fd_hop, task, &out_buf);
                 }
 
                 /* Window event */
                 if ((t + 1) % check->window_size_sec == 0 ||
                     (t + 1 > check->window_size_sec && (t + 1 - check->window_size_sec) % check->window_hop_sec == 0)) {
-                    flb_free(out_buf.buffer);
+                    if (out_buf.buffer != NULL) {
+                        flb_free(out_buf.buffer);
+
+                        out_buf.buffer = NULL;
+                        out_buf.size = 0;
+                    }
+
                     flb_sp_fd_event_test(task->window.fd, task, &out_buf);
                 }
                 flb_free(data_buf.buffer);

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -512,6 +512,13 @@ static void test_window()
 
             /* We ingest the buffer every second */
             for (t = 0; t < check->window_size_sec; t++) {
+                if (out_buf.buffer != NULL) {
+                    flb_free(out_buf.buffer);
+
+                    out_buf.buffer = NULL;
+                    out_buf.size = 0;
+                }
+
                 ret = flb_sp_do_test(sp, task,
                                      "samples", strlen("samples"),
                                      &data_buf, &out_buf);

--- a/tests/runtime/filter_log_to_metrics.c
+++ b/tests/runtime/filter_log_to_metrics.c
@@ -669,7 +669,7 @@ void flb_test_log_to_metrics_label(void)
                          "metric_name", "test",
                          "metric_description", "Counts messages",
                          "kubernetes_mode", "off",
-                         "label", "pod_name $kubernetes['pod_name']",
+                         "add_label", "pod_name $kubernetes['pod_name']",
                          NULL);
 
     out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);


### PR DESCRIPTION
This PR adds missing fluent-bit and library initialization calls to test cases that require them.