### PR TITLE
flb_utils: add code to get the machine-id on windows machines.

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -168,9 +168,9 @@ int flb_utils_set_daemon(struct flb_config *config)
     pid_t pid;
 
     if ((pid = fork()) < 0){
-		flb_error("Failed creating to switch to daemon mode (fork failed)");
+        flb_error("Failed creating to switch to daemon mode (fork failed)");
         exit(EXIT_FAILURE);
-	}
+    }
 
     if (pid > 0) { /* parent */
         exit(EXIT_SUCCESS);
@@ -185,7 +185,7 @@ int flb_utils_set_daemon(struct flb_config *config)
     if (chdir("/") < 0) { /* make sure we can unmount the inherited filesystem */
         flb_error("Unable to unmount the inherited filesystem");
         exit(EXIT_FAILURE);
-	}
+    }
 
     /* Our last STDOUT messages */
     flb_info("switching to background mode (PID=%ld)", (long) getpid());
@@ -1386,6 +1386,36 @@ int flb_utils_get_machine_id(char **out_id, size_t *out_size)
     if (ret == 0) {
         *out_id = id;
         *out_size = bytes;
+        return 0;
+    }
+#elif defined(FLB_SYSTEM_WINDOWS)
+    LSTATUS status;
+    HKEY hKey = 0;
+    DWORD dwType = REG_SZ;
+    char buf[255] = {0};
+    DWORD dwBufSize = sizeof(buf)-1;
+
+    status = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                          TEXT("SOFTWARE\\Microsoft\\Cryptography"),
+                          0,
+                          KEY_QUERY_VALUE,
+                          &hKey);
+
+    if (status != ERROR_SUCCESS) {
+        return -1;
+    }
+
+    status = RegQueryValueEx(hKey, TEXT("MachineGuid"), 0, &dwType, (LPBYTE)buf, &dwBufSize );
+    RegCloseKey(hKey);
+
+    if (status == ERROR_SUCCESS) {
+        *out_id = flb_calloc(1, dwBufSize+1);
+
+        if (*out_id == NULL) {
+            return -1;
+        }
+
+        *out_size = dwBufSize;
         return 0;
     }
 #endif


### PR DESCRIPTION
# Summary

Add support for windows machines to the flb_utils function `flb_utils_get_machine_id` using the MachineGuid registry key in `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography`.

This is required for better fleet support since the default behavior in `flb_utils_get_machine_id` is to return a new UUID. This will lead to a new fleet configuration directory being created each time a fleet is invoked on a windows machine.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205557967235521