### PR TITLE
filter_log_to_metrics: fix log to metrics label test.

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.c
+++ b/plugins/filter_log_to_metrics/log_to_metrics.c
@@ -268,7 +268,7 @@ static int set_labels(struct log_to_metrics_ctx *ctx,
             snprintf(label_keys[counter], MAX_LABEL_LENGTH - 1, "%s", kv->val);
             counter++;
         }
-        else if (strcasecmp(kv->key, "label") == 0) {
+        else if (strcasecmp(kv->key, "add_label") == 0) {
             split = flb_utils_split(kv->val, ' ', 1);
             if (mk_list_size(split) != 2) {
                 flb_plg_error(ctx->ins, "invalid label, expected name and key");

--- a/tests/runtime/filter_log_to_metrics.c
+++ b/tests/runtime/filter_log_to_metrics.c
@@ -669,7 +669,7 @@ void flb_test_log_to_metrics_label(void)
                          "metric_name", "test",
                          "metric_description", "Counts messages",
                          "kubernetes_mode", "off",
-                         "label", "pod_name $kubernetes['pod_name']",
+                         "add_label", "pod_name $kubernetes['pod_name']",
                          NULL);
 
     out_ffd = flb_output(ctx, (char *) "lib", (void *)&cb_data);


### PR DESCRIPTION
# Summary

The 'label' property for the `log to metrics` filter was renamed to 'add_label' for consistency with the rest of the plugins. This PR updates the code to use the new property and updates the test to work with the new property name.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
