### PR TITLE
tests: internal: stream_processor: fixed memory leak

### DIFF
--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -517,6 +517,13 @@ static void test_window()
                 usleep(800000);
             }
 
+            if (out_buf.buffer != NULL) {
+                flb_free(out_buf.buffer);
+
+                out_buf.buffer = NULL;
+                out_buf.size = 0;
+            }
+
             flb_sp_fd_event_test(task->window.fd, task, &out_buf);
 
             flb_info("[sp test] id=%i, SQL => '%s'", check->id, check->exec);
@@ -560,13 +567,26 @@ static void test_window()
 
                 /* Hopping event */
                 if ((t + 1) % check->window_hop_sec == 0) {
+                    if (out_buf.buffer != NULL) {
+                        flb_free(out_buf.buffer);
+
+                        out_buf.buffer = NULL;
+                        out_buf.size = 0;
+                    }
+
                     flb_sp_fd_event_test(task->window.fd_hop, task, &out_buf);
                 }
 
                 /* Window event */
                 if ((t + 1) % check->window_size_sec == 0 ||
                     (t + 1 > check->window_size_sec && (t + 1 - check->window_size_sec) % check->window_hop_sec == 0)) {
-                    flb_free(out_buf.buffer);
+                    if (out_buf.buffer != NULL) {
+                        flb_free(out_buf.buffer);
+
+                        out_buf.buffer = NULL;
+                        out_buf.size = 0;
+                    }
+
                     flb_sp_fd_event_test(task->window.fd, task, &out_buf);
                 }
                 flb_free(data_buf.buffer);

--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -503,6 +503,13 @@ static void test_window()
 
             /* We ingest the buffer every second */
             for (t = 0; t < check->window_size_sec; t++) {
+                if (out_buf.buffer != NULL) {
+                    flb_free(out_buf.buffer);
+
+                    out_buf.buffer = NULL;
+                    out_buf.size = 0;
+                }
+
                 ret = flb_sp_do_test(sp, task,
                                      "samples", strlen("samples"),
                                      &data_buf, &out_buf);


### PR DESCRIPTION
This PR addresses the following leak reported by ASAN : 

```
Direct leak of 65536 byte(s) in 8 object(s) allocated from:
    #0 0x7fb487452d40 in realloc (/lib/x86_64-linux-gnu/libasan.so.4+0xdfd40)
    #1 0x56098a10d88a in msgpack_sbuffer_write /home/runner/work/fluent-bit/fluent-bit/lib/msgpack-c/include/msgpack/sbuffer.h:81
    #2 0x56098a10d3ef in msgpack_pack_array /home/runner/work/fluent-bit/fluent-bit/lib/msgpack-c/include/msgpack/pack_template.h:724
    #3 0x56098a10fd70 in package_results /home/runner/work/fluent-bit/fluent-bit/src/stream_processor/flb_sp.c:1139
    #4 0x56098a101e80 in flb_sp_do_test /home/runner/work/fluent-bit/fluent-bit/tests/internal/stream_processor.c:125
    #5 0x56098a1040d4 in test_window /home/runner/work/fluent-bit/fluent-bit/tests/internal/stream_processor.c:506
    #6 0x56098a0fb83c in acutest_do_run_ /home/runner/work/fluent-bit/fluent-bit/tests/internal/../lib/acutest/acutest.h:1034
    #7 0x56098a0fbc68 in acutest_run_ /home/runner/work/fluent-bit/fluent-bit/tests/internal/../lib/acutest/acutest.h:1130
    #8 0x56098a0fe5d4 in main /home/runner/work/fluent-bit/fluent-bit/tests/internal/../lib/acutest/acutest.h:1769
    #9 0x7fb486bd5082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
```