### PR TITLE
custom_calyptia: free machine_id when it is automatically set.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -37,6 +37,7 @@ struct calyptia {
     flb_sds_t cloud_host;
     flb_sds_t cloud_port;
     flb_sds_t machine_id;
+    int machine_id_auto_configured;
 
 /* used for reporting chunk trace records. */
 #ifdef FLB_HAVE_CHUNK_TRACE
@@ -426,6 +427,8 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
             flb_plg_error(ctx->ins, "unable to retrieve machine_id");
             return -1;
         }
+
+        ctx->machine_id_auto_configured = 1;
     }
 
     /* input collector */
@@ -515,6 +518,10 @@ static int cb_calyptia_exit(void *data, struct flb_config *config)
 
     if (!ctx) {
         return 0;
+    }
+
+    if (ctx->machine_id && ctx->machine_id_auto_configured) {
+        flb_sds_destroy(ctx->machine_id);
     }
 
     flb_free(ctx);


### PR DESCRIPTION
# Summary

The `machine_id` is configured and extracted automatically using the `flb_utils_get_machine_id` function when it is not set explicitly via `config_map`. When this occurs the value is not freed. This PR fixes that.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
