### PR TITLE
Pwhelan fix input coroutine params

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -456,14 +456,14 @@ struct flb_input_coro *flb_input_coro_create(struct flb_input_instance *ins,
     return input_coro;
 }
 
-struct flb_libco_in_params {
+struct flb_in_collect_params {
     struct flb_config *config;
     struct flb_input_collector *coll;
     struct flb_coro *coro;
 };
 
-extern pthread_key_t libco_in_param_key;
-extern struct flb_libco_in_params libco_in_param;
+extern FLB_TLS_DEFINE(struct flb_in_collect_params, in_collect_params);
+
 void flb_input_coro_prepare_destroy(struct flb_input_coro *input_coro);
 
 static FLB_INLINE void input_params_set(struct flb_coro *coro,
@@ -471,16 +471,16 @@ static FLB_INLINE void input_params_set(struct flb_coro *coro,
                              struct flb_config *config,
                              void *context)
 {
-    struct flb_libco_in_params *params;
+    struct flb_in_collect_params *params;
 
-    params = pthread_getspecific(libco_in_param_key);
+    params = (struct flb_in_collect_params *) FLB_TLS_GET(in_collect_params);
     if (params == NULL) {
-        params = flb_calloc(1, sizeof(struct flb_libco_in_params));
+        params = flb_calloc(1, sizeof(struct flb_in_collect_params));
         if (params == NULL) {
             flb_errno();
             return;
         }
-        pthread_setspecific(libco_in_param_key, params);
+        FLB_TLS_SET(in_collect_params, params);
     }
 
     /* Set callback parameters */
@@ -495,16 +495,12 @@ static FLB_INLINE void input_pre_cb_collect(void)
     struct flb_input_collector *coll;
     struct flb_config *config;
     struct flb_coro *coro;
-    struct flb_libco_in_params *params;
+    struct flb_in_collect_params *params;
 
-    params = pthread_getspecific(libco_in_param_key);
+    params = (struct flb_in_collect_params *)FLB_TLS_GET(in_collect_params);
     if (params == NULL) {
-        params = flb_calloc(1, sizeof(struct flb_libco_in_params));
-        if (params == NULL) {
-            flb_errno();
-            return;
-        }
-        pthread_setspecific(libco_in_param_key, params);
+        flb_errno();
+        return;
     }
     coll = params->coll;
     config = params->config;
@@ -519,13 +515,6 @@ static FLB_INLINE void flb_input_coro_resume(struct flb_input_coro *input_coro)
     flb_coro_resume(input_coro->coro);
 }
 
-static void libco_in_param_key_destroy(void *data)
-{
-    struct flb_libco_inparams *params = (struct flb_libco_inparams*)data;
-
-    flb_free(params);
-}
-
 static FLB_INLINE
 struct flb_input_coro *flb_input_coro_collect(struct flb_input_collector *coll,
                                               struct flb_config *config)
@@ -538,8 +527,6 @@ struct flb_input_coro *flb_input_coro_collect(struct flb_input_collector *coll,
     if (!input_coro) {
         return NULL;
     }
-
-    pthread_key_create(&libco_in_param_key, libco_in_param_key_destroy);
 
     coro = input_coro->coro;
     if (!coro) {
@@ -647,6 +634,9 @@ static inline int flb_input_config_map_set(struct flb_input_instance *ins,
 
     return ret;
 }
+
+void flb_input_prepare();
+void flb_input_unprepare();
 
 int flb_input_register_all(struct flb_config *config);
 struct flb_input_instance *flb_input_new(struct flb_config *config,

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -49,8 +49,7 @@
 #include <fluent-bit/flb_chunk_trace.h>
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
-struct flb_libco_in_params libco_in_param;
-pthread_key_t libco_in_param_key;
+FLB_TLS_DEFINE(struct flb_in_collect_params, in_collect_params);
 
 #define protcmp(a, b)  strncasecmp(a, b, strlen(a))
 
@@ -139,6 +138,23 @@ int flb_input_log_check(struct flb_input_instance *ins, int l)
     }
 
     return FLB_TRUE;
+}
+
+/* Prepare input co-routines for the thread. */
+void flb_input_prepare()
+{
+    FLB_TLS_INIT(in_collect_params);
+}
+
+void flb_input_unprepare()
+{
+    struct flb_in_collect_params *params;
+
+    params = (struct flb_in_collect_params *)FLB_TLS_GET(in_collect_params);
+    if (params) {
+        flb_free(params);
+        FLB_TLS_SET(in_collect_params, NULL);
+    }
 }
 
 /* Create an input plugin instance */
@@ -1313,6 +1329,8 @@ void flb_input_exit_all(struct flb_config *config)
         /* destroy the instance */
         flb_input_instance_destroy(ins);
     }
+
+   flb_input_unprepare();
 }
 
 /* Check that at least one Input is enabled */

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -459,6 +459,7 @@ static void input_thread(void *data)
     flb_bucket_queue_destroy(evl_bktq);
     flb_sched_destroy(sched);
     input_thread_instance_destroy(thi);
+    flb_input_unprepare();
 }
 
 

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -127,6 +127,7 @@ void flb_init_env()
     flb_upstream_init();
     flb_downstream_init();
     flb_output_prepare();
+    flb_input_prepare();
 
     FLB_TLS_INIT(flb_lib_active_context);
     FLB_TLS_INIT(flb_lib_active_cf_context);


### PR DESCRIPTION
# Summary

Refactor the `flb_input` coroutine parameters to follow the same pattern as `flb_output` and use the FLB_TLS set of macros. 

This is not only to standardize the code but to fix a bug where fluent-bit can crash when using input coroutines. Input coroutines can initialize fast enough to reset the libco key which leads to a `NULL` dereference in `input_pre_cb_collect` leading to a crash in `co_switch`.

# Issues

This fixes a bug found in #7954.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
