### PR TITLE
bin: windows: Restore Ctrl-C behavior on windows

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -550,7 +550,7 @@ static void flb_signal_exit(int signal)
     };
 }
 
-static void flb_signal_handler_status_line()
+static void flb_signal_handler_status_line(struct flb_cf *cf_opts)
 {
     int len;
     char ts[32];
@@ -558,7 +558,6 @@ static void flb_signal_handler_status_line()
     time_t now;
     struct tm *cur;
     flb_ctx_t *ctx = flb_context_get();
-    struct flb_cf *cf_opts = flb_cf_context_get();
 
     now = time(NULL);
     cur = localtime(&now);
@@ -577,7 +576,8 @@ static void flb_signal_handler_status_line()
 
 static void flb_signal_handler(int signal)
 {
-    flb_signal_handler_status_line();
+    struct flb_cf *cf_opts = flb_cf_context_get();
+    flb_signal_handler_status_line(cf_opts);
 
     switch (signal) {
         flb_print_signal(SIGINT);
@@ -637,9 +637,12 @@ void flb_console_handler_set_ctx(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
 static BOOL WINAPI flb_console_handler(DWORD evType)
 {
+    struct flb_cf *cf_opts;
+
     switch(evType) {
     case 0 /* CTRL_C_EVENT_0 */:
-        flb_signal_handler_status_line();
+        cf_opts = flb_cf_context_get();
+        flb_signal_handler_status_line(cf_opts);
         write (STDERR_FILENO, "SIGINT)\n", sizeof("SIGINT)\n")-1);
         /* signal the main loop to execute reload even if CTRL_C event.
          * This is necessary because all signal handlers in win32


### PR DESCRIPTION
After supporting fleet management on Windows,
Ctrl-C events won't be caught up.
This commit re-enables for the behavior.
Windows' ctrl event handlers stolen signals which are overlapped ones. So, we need to handle Ctrl-C events on the newly added event handler for Windows.

In Windows, SIGINT and SIGBREAK are valid ctrl events on their terminal. This is why we only need to handle CTRL_C_EVENT and CTRL_BREAK_EVENT events on console handler.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes #7985 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```console
PS> bin/fluent-bit -i random -o stdout -v
```

- [x] Debug log output from testing the change
```log
Fluent Bit v2.1.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/09/28 16:19:48] [ info] Configuration:
[2023/09/28 16:19:48] [ info]  flush time     | 1.000000 seconds
[2023/09/28 16:19:48] [ info]  grace          | 5 seconds
[2023/09/28 16:19:48] [ info]  daemon         | 0
[2023/09/28 16:19:48] [ info] ___________
[2023/09/28 16:19:48] [ info]  inputs:
[2023/09/28 16:19:48] [ info]      random
[2023/09/28 16:19:48] [ info] ___________
[2023/09/28 16:19:48] [ info]  filters:
[2023/09/28 16:19:48] [ info] ___________
[2023/09/28 16:19:48] [ info]  outputs:
[2023/09/28 16:19:48] [ info]      stdout.0
[2023/09/28 16:19:48] [ info] ___________
[2023/09/28 16:19:48] [ info]  collectors:
[2023/09/28 16:19:48] [ info] [fluent bit] version=2.1.10, commit=b19e9ce674, pid=14180
[2023/09/28 16:19:48] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2023/09/28 16:19:48] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/09/28 16:19:48] [ info] [cmetrics] version=0.6.3
[2023/09/28 16:19:48] [ info] [ctraces ] version=0.3.1
[2023/09/28 16:19:48] [ info] [input:random:random.0] initializing
[2023/09/28 16:19:48] [ info] [input:random:random.0] storage_strategy='memory' (memory only)
[2023/09/28 16:19:48] [debug] [random:random.0] created event channels: read=848 write=852
[2023/09/28 16:19:48] [debug] [input:random:random.0] interval_sec=1 interval_nsec=0
[2023/09/28 16:19:48] [debug] [stdout:stdout.0] created event channels: read=856 write=860
[2023/09/28 16:19:48] [ info] [sp] stream processor started
[2023/09/28 16:19:48] [ info] [output:stdout:stdout.0] worker #0 started
[2023/09/28 16:19:49] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
[2023/09/28 16:19:50] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[0] random.0: [[1695885589.156550400, {}], {"rand_value"=>8010636517080299662}]
[2023/09/28 16:19:50] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:50] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
[2023/09/28 16:19:50] [debug] [out flush] cb_destroy coro_id=0
[2023/09/28 16:19:50] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:51] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[0] random.0: [[[2023/09/28 16:19:51] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1695885590.151422100, {}], {"rand_value"=>[2023/09/28 16:19:51] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
16483654022445272261}]
[2023/09/28 16:19:51] [debug] [out flush] cb_destroy coro_id=1
[2023/09/28 16:19:51] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:52] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[2023/09/28 16:19:52] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:52] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
[0] random.0: [[1695885591.136284300, {}], {"rand_value"=>14687638350890635559}]
[2023/09/28 16:19:52] [debug] [out flush] cb_destroy coro_id=2
[2023/09/28 16:19:52] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:53] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[2023/09/28 16:19:53] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:53] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
[0] random.0: [[1695885592.148192900, {}], {"rand_value"=>2570721039374198827}]
[2023/09/28 16:19:53] [debug] [out flush] cb_destroy coro_id=3
[2023/09/28 16:19:53] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:54] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[0] random.0: [[1695885593.146608200, {}[2023/09/28 16:19:54] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:54] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
], {"rand_value"=>14232029138453562000}]
[2023/09/28 16:19:54] [debug] [out flush] cb_destroy coro_id=4
[2023/09/28 16:19:54] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:55] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[0] random.0: [[[2023/09/28 16:19:55] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:55] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
1695885594.156011400, {}], {"rand_value"=>12405196442465117108}]
[2023/09/28 16:19:55] [debug] [out flush] cb_destroy coro_id=5
[2023/09/28 16:19:55] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:55] [engine] caught signal (SIGINT)
[2023/09/28 16:19:56] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[2023/09/28 16:19:56] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:56] [debug] [input chunk] update output instances with new chunk size diff=50, records=1, input=random.0
[0] random.0: [[1695885595.150238200, {}], {"rand_value"=>1524614499674638143}]
[2023/09/28 16:19:56] [debug] [out flush] cb_destroy coro_id=6
[2023/09/28 16:19:56] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:56] [debug] [task] created task=0000024A94EC3ED0 id=0 OK
[0] random.0: [[1695885596.161630400, {}], {"rand_value"=>10902648771393957905}]
[2023/09/28 16:19:56] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/09/28 16:19:56] [ warn] [engine] service will shutdown in max 5 seconds
[2023/09/28 16:19:56] [debug] [out flush] cb_destroy coro_id=7
[2023/09/28 16:19:56] [ info] [input] pausing random.0
[2023/09/28 16:19:56] [debug] [task] destroy task=0000024A94EC3ED0 (task_id=0)
[2023/09/28 16:19:57] [ info] [engine] service has stopped (0 pending tasks)
[2023/09/28 16:19:57] [ info] [input] pausing random.0
[2023/09/28 16:19:57] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/09/28 16:19:57] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
