### PR TITLE
bin: windows: restore ctrl c behavior on windows [backport 2.1]

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -550,7 +550,7 @@ static void flb_signal_exit(int signal)
     };
 }
 
-static void flb_signal_handler_status_line()
+static void flb_signal_handler_status_line(struct flb_cf *cf_opts)
 {
     int len;
     char ts[32];
@@ -558,7 +558,6 @@ static void flb_signal_handler_status_line()
     time_t now;
     struct tm *cur;
     flb_ctx_t *ctx = flb_context_get();
-    struct flb_cf *cf_opts = flb_cf_context_get();
 
     now = time(NULL);
     cur = localtime(&now);
@@ -577,7 +576,8 @@ static void flb_signal_handler_status_line()
 
 static void flb_signal_handler(int signal)
 {
-    flb_signal_handler_status_line();
+    struct flb_cf *cf_opts = flb_cf_context_get();
+    flb_signal_handler_status_line(cf_opts);
 
     switch (signal) {
         flb_print_signal(SIGINT);
@@ -637,9 +637,12 @@ void flb_console_handler_set_ctx(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
 static BOOL WINAPI flb_console_handler(DWORD evType)
 {
+    struct flb_cf *cf_opts;
+
     switch(evType) {
     case 0 /* CTRL_C_EVENT_0 */:
-        flb_signal_handler_status_line();
+        cf_opts = flb_cf_context_get();
+        flb_signal_handler_status_line(cf_opts);
         write (STDERR_FILENO, "SIGINT)\n", sizeof("SIGINT)\n")-1);
         /* signal the main loop to execute reload even if CTRL_C event.
          * This is necessary because all signal handlers in win32


### PR DESCRIPTION
<!-- Provide summary of changes -->
this is a backport of https://github.com/fluent/fluent-bit/pull/7986

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
