### PR TITLE
out_chronicle: remove redundant code

### DIFF
--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -518,7 +518,6 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
     int i;
     int map_size;
     int check = FLB_FALSE;
-    int found = FLB_FALSE;
     int log_key_missing = 0;
     int ret;
     struct flb_chronicle *ctx = out_context;
@@ -568,7 +567,6 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
 
         if (check == FLB_TRUE) {
             if (strncmp(ctx->log_key, key_str, key_str_size) == 0) {
-                found = FLB_TRUE;
 
                 /*
                  * Copy contents of value into buffer. Necessary to copy

--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -603,9 +603,7 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
         }
 
         /* If log_key was not found in the current record, mark log key as missing */
-        if (found == FLB_FALSE) {
-            log_key_missing++;
-        }
+        log_key_missing++;
     }
 
     if (log_key_missing > 0) {

--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -550,10 +550,6 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
 
     map_size = map.via.map.size;
 
-    /* Reset variables for found log_key and correct type */
-    found = FLB_FALSE;
-    check = FLB_FALSE;
-
     /* Extract log_key from record and append to output buffer */
     for (i = 0; i < map_size; i++) {
         key = map.via.map.ptr[i].key;


### PR DESCRIPTION
* Remove redundant initializations in
https://github.com/fluent/fluent-bit/blob/92e0435f4ab45ee2ecd19732935f9ff02b808979/plugins/out_chronicle/chronicle.c#L553-L555
The variables are already initialized with these values, and there's no code that could change them until this point.

* Remove unnecessary if

https://github.com/fluent/fluent-bit/blob/92e0435f4ab45ee2ecd19732935f9ff02b808979/plugins/out_chronicle/chronicle.c#L610-L612
At this point, `found` will always be `FLB_FALSE` (hence, the expression will always be true).
It's only changed in one line, and that block ends with a break https://github.com/fluent/fluent-bit/blob/92e0435f4ab45ee2ecd19732935f9ff02b808979/plugins/out_chronicle/chronicle.c#L605 hence never reaching the removed if statement

* Following the reasoning above, the found variable is not needed.
If the record is found, a break is issued. If it's not, then it must always log_key_missing++.


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
