### PR TITLE
Link jemalloc only to binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -915,7 +915,6 @@ endif()
 # Memory Allocator
 # ================
 if(FLB_JEMALLOC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  FLB_DEFINITION(FLB_HAVE_JEMALLOC)
   FLB_DEFINITION(JEMALLOC_MANGLE)
 
   # Add support for options like page size, if empty we default it

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -27,10 +27,6 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_macros.h>
 
-#ifdef FLB_HAVE_JEMALLOC
-#include <jemalloc/jemalloc.h>
-#endif
-
 #include <stdlib.h>
 
 /*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,12 +202,6 @@ set(extra_libs
   ${extra_libs}
   "rbtree")
 
-if(FLB_JEMALLOC)
-  set(extra_libs
-    ${extra_libs}
-    "libjemalloc")
-endif()
-
 if(FLB_REGEX)
   set(FLB_DEPS
     ${FLB_DEPSS}
@@ -466,10 +460,6 @@ if(MSVC)
 else()
   set_target_properties(fluent-bit-static PROPERTIES OUTPUT_NAME fluent-bit)
 endif(MSVC)
-
-if(FLB_JEMALLOC)
-  target_link_libraries(fluent-bit-static libjemalloc)
-endif()
 
 # Binary / Executable
 if(FLB_BINARY)


### PR DESCRIPTION
Baking a custom malloc into a library can cause problems because client binaries can easily end up with multiple malloc implementations. Quoting jemalloc dev David Goldblatt from their chat channel:

> I sort of think that dynamic libraries have no business defining
> their own malloc independent of the process malloc

https://app.element.io/#/room/#jemalloc_jemalloc:gitter.im/$LubsysDtwVeAfQgOkJDfdkUP4E9O554PX5rH-qq1VRQ

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
