### PR TITLE
in_thermal: support hwmon

### DIFF
--- a/plugins/in_thermal/in_thermal.c
+++ b/plugins/in_thermal/in_thermal.c
@@ -49,8 +49,149 @@ struct temp_info
     double temp;                          /* from /sys/class/thermal/thermal_zoneX/temp */
 };
 
+/*
+ * Retrieve temperature(s) from the system (via /sys/class/hwmon)
+ * https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
+ *
+ * e.g.
+ *  name: hwmon2_temp1_input (via /sys/class/hwmon/hwmon2/temp1_input)
+ *  type: gpu_thermal (via /sys/class/hwmon/hwmon2/name)
+ */
+static inline int proc_temperature_hwmon(struct flb_in_thermal_config *ctx,
+                                         struct temp_info *info, int n)
+{
+    int temp_info_i = -1;
+    int i;
+    int temp_i;
+    DIR *sysfs_hwmon_d;
+    struct dirent *hwmon_e;
+    flb_sds_t filename = NULL;
+
+    FILE *f;
+    int temp;
+    int ret;
+    flb_sds_t name = NULL;
+    flb_sds_t type = NULL;
+
+    sysfs_hwmon_d = opendir("/sys/class/hwmon");
+    if (sysfs_hwmon_d == NULL) {
+        return -1;
+    }
+    name = flb_sds_create_size(IN_THERMAL_FILENAME_LEN);
+    if (name == NULL) {
+        flb_errno();
+        goto proc_temperature_hwmon_end;
+    }
+    type = flb_sds_create_size(IN_THERMAL_TYPE_LEN);
+    if (name == NULL) {
+        flb_errno();
+        goto proc_temperature_hwmon_end;
+    }
+    filename = flb_sds_create_size(IN_THERMAL_FILENAME_LEN);
+    if (filename == NULL) {
+        flb_errno();
+        goto proc_temperature_hwmon_end;
+    }
+
+    temp_info_i = 0;
+    while (temp_info_i<n && (hwmon_e = readdir(sysfs_hwmon_d))) {
+        if (hwmon_e->d_type == DT_REG) {
+            continue;
+        }
+
+#ifdef FLB_HAVE_REGEX
+        if (ctx->name_regex && !flb_regex_match(ctx->name_regex,
+                                                (unsigned char *) hwmon_e->d_name,
+                                                strlen(hwmon_e->d_name))) {
+            continue;
+        }
+#endif
+
+        if (!strncmp(hwmon_e->d_name, "hwmon", 5)) {
+            /* e.g. hwmon_e->d_name is hwmon0 */
+            ret = flb_sds_snprintf(&filename, IN_THERMAL_FILENAME_LEN, "/sys/class/hwmon/%s/name",
+                                   hwmon_e->d_name);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "flb_sds_snprintf error");
+                continue;
+            }
+
+            f = fopen(filename, "r");
+            if (f == NULL) {
+                flb_errno();
+                flb_plg_error(ctx->ins, "cannot open %s", filename);
+                continue;
+            }
+
+            if (fgets(type, IN_THERMAL_TYPE_LEN, f) &&
+                strlen(type) > 1 /* fgets doesn't update length of sds */) {
+                /* Remove trailing \n */
+                for (i = 0; type[i]; i++) {
+                    if (type[i] == '\n') {
+                        type[i] = 0;
+                        break;
+                    }
+                }
+            }
+            fclose(f);
+
+#ifdef FLB_HAVE_REGEX
+            if (ctx->type_regex &&
+                !flb_regex_match(ctx->type_regex,
+                                 (unsigned char *) type,
+                                 flb_sds_len(type))) {
+                continue;
+            }
+#endif
+            for (temp_i=0; temp_i<10; temp_i++) {
+                ret = flb_sds_snprintf(&filename, IN_THERMAL_FILENAME_LEN,
+                                       "/sys/class/hwmon/%s/temp%d_input", hwmon_e->d_name, temp_i);
+                if (ret < 0) {
+                    continue;
+                }
+
+                /* e.g. name will be hwmon0_temp2_input (via /sys/class/hwmon/hwmon0/temp2_input */
+                ret = flb_sds_snprintf(&name, IN_THERMAL_FILENAME_LEN, "%s_temp%d_input",
+                                        hwmon_e->d_name, temp_i);
+                if (ret < 0) {
+                    continue;
+                }
+
+                f = fopen(filename, "r");
+                if (f == NULL) {
+                    continue;
+                }
+                if (fscanf(f, "%d", &temp) != 1) {
+                    fclose(f);
+                    continue;
+                }
+                strncpy(info[temp_info_i].name, name, IN_THERMAL_FILENAME_LEN);
+                strncpy(info[temp_info_i].type, type, IN_THERMAL_TYPE_LEN);
+                info[temp_info_i].temp = temp/1000.0;
+
+                ++temp_info_i;
+                fclose(f);
+            }
+        }
+    }
+
+ proc_temperature_hwmon_end:
+    if (name != NULL) {
+        flb_sds_destroy(name);
+    }
+    if (type != NULL) {
+        flb_sds_destroy(type);
+    }
+    if (filename != NULL) {
+        flb_sds_destroy(filename);
+    }
+
+    closedir(sysfs_hwmon_d);
+    return temp_info_i;
+}
+
 /* Retrieve temperature(s) from the system (via /sys/class/thermal) */
-static inline int proc_temperature(struct flb_in_thermal_config *ctx,
+static inline int proc_temperature_thermal_zone(struct flb_in_thermal_config *ctx,
                                    struct temp_info *info, int n)
 {
     int i, j;
@@ -196,9 +337,12 @@ static int in_thermal_init(struct flb_input_instance *in,
     }
 #endif
 
-    ctx->prev_device_num = proc_temperature(ctx, info,  IN_THERMAL_N_MAX);
+    ctx->prev_device_num = proc_temperature_thermal_zone(ctx, info,  IN_THERMAL_N_MAX);
     if (!ctx->prev_device_num) {
-        flb_plg_warn(ctx->ins, "thermal device file not found");
+        ctx->prev_device_num = proc_temperature_hwmon(ctx, info, IN_THERMAL_N_MAX); 
+       if (!ctx->prev_device_num) {
+            flb_plg_warn(ctx->ins, "thermal device file not found");
+        }
     }
 
     /* Set the context */
@@ -237,7 +381,10 @@ int in_thermal_collect(struct flb_input_instance *i_ins,
     (void) config;
 
     /* Get the current temperature(s) */
-    n = proc_temperature(ctx, info, IN_THERMAL_N_MAX);
+    n = proc_temperature_thermal_zone(ctx, info, IN_THERMAL_N_MAX);
+    if (n == 0) {
+        n = proc_temperature_hwmon(ctx, info, IN_THERMAL_N_MAX);
+    }
     if (n != ctx->prev_device_num) {
         flb_plg_info(ctx->ins, "the number of thermal devices changed %d -> %d",
                      ctx->prev_device_num, n);


### PR DESCRIPTION
This patch is to support to read a temperature from hwmon subsystem. See also https://github.com/fluent/fluent-bit/issues/7955
https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface

in_thermal tries to read a temperature from `/sys/class/thermal` first.
If in_thermal can't read it, in_thermal tries to read `/sys/class/hwmon`.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
## Debug/Valgrind output

Note: I modified source not to read `/sys/class/thermal` to enforce reading from `/sys/class/hwmon`.

```
$ valgrind --leak-check=full bin/fluent-bit -i thermal -o stdout
==25894== Memcheck, a memory error detector
==25894== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25894== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==25894== Command: bin/fluent-bit -i thermal -o stdout
==25894== 
Fluent Bit v2.2.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/08 10:22:15] [ info] [fluent bit] version=2.2.0, commit=cfca7ca8ac, pid=25894
[2023/10/08 10:22:15] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/08 10:22:15] [ info] [cmetrics] version=0.6.3
[2023/10/08 10:22:15] [ info] [ctraces ] version=0.3.1
[2023/10/08 10:22:15] [ info] [input:thermal:thermal.0] initializing
[2023/10/08 10:22:15] [ info] [input:thermal:thermal.0] storage_strategy='memory' (memory only)
[2023/10/08 10:22:15] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/08 10:22:15] [ info] [sp] stream processor started
==25894== Warning: client switching stacks?  SP change: 0x6f68ba0 --> 0x54c5df0
==25894==          to suppress, use: --max-stackframe=27930032 or greater
==25894== Warning: client switching stacks?  SP change: 0x54c5cf0 --> 0x6f68ba0
==25894==          to suppress, use: --max-stackframe=27930288 or greater
==25894== Warning: client switching stacks?  SP change: 0x6f68ba0 --> 0x54c5cf0
==25894==          to suppress, use: --max-stackframe=27930288 or greater
==25894==          further instances of this message will not be shown.
[0] thermal.0: [[1696728135.681488126, {}], {"name"=>"hwmon6_temp1_input", "type"=>"npu_thermal", "temp"=>39.769000}]
[1] thermal.0: [[1696728135.699476030, {}], {"name"=>"hwmon4_temp1_input", "type"=>"center_thermal", "temp"=>39.769000}]
[2] thermal.0: [[1696728135.699658327, {}], {"name"=>"hwmon2_temp1_input", "type"=>"bigcore1_thermal", "temp"=>40.692000}]
[3] thermal.0: [[1696728135.699734454, {}], {"name"=>"hwmon0_temp1_input", "type"=>"soc_thermal", "temp"=>40.692000}]
[4] thermal.0: [[1696728135.699821956, {}], {"name"=>"hwmon5_temp1_input", "type"=>"gpu_thermal", "temp"=>39.769000}]
[5] thermal.0: [[1696728135.699894292, {}], {"name"=>"hwmon3_temp1_input", "type"=>"littlecore_thermal", "temp"=>39.769000}]
[6] thermal.0: [[1696728135.699965169, {}], {"name"=>"hwmon1_temp1_input", "type"=>"bigcore0_thermal", "temp"=>39.769000}]
^C[2023/10/08 10:22:17] [engine] caught signal (SIGINT)
[2023/10/08 10:22:17] [ warn] [engine] service will shutdown in max 5 seconds
[0] thermal.0: [[1696728136.677026745, {}], {"name"=>"hwmon6_temp1_input", "type"=>"npu_thermal", "temp"=>39.769000}]
[1] thermal.0: [[1696728136.677146040, {}], {"name"=>"hwmon4_temp1_input", "type"=>"center_thermal", "temp"=>39.769000}]
[2] thermal.0: [[1696728136.677217500, {}], {"name"=>"hwmon2_temp1_input", "type"=>"bigcore1_thermal", "temp"=>39.769000}]
[3] thermal.0: [[1696728136.677286336, {}], {"name"=>"hwmon0_temp1_input", "type"=>"soc_thermal", "temp"=>39.769000}]
[4] thermal.0: [[1696728136.677356046, {}], {"name"=>"hwmon5_temp1_input", "type"=>"gpu_thermal", "temp"=>38.846000}]
[5] thermal.0: [[1696728136.677429840, {}], {"name"=>"hwmon3_temp1_input", "type"=>"littlecore_thermal", "temp"=>39.769000}]
[6] thermal.0: [[1696728136.677496925, {}], {"name"=>"hwmon1_temp1_input", "type"=>"bigcore0_thermal", "temp"=>39.769000}]
[2023/10/08 10:22:17] [ info] [input] pausing thermal.0
[2023/10/08 10:22:17] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/08 10:22:17] [ info] [input] pausing thermal.0
[2023/10/08 10:22:17] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/08 10:22:17] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==25894== 
==25894== HEAP SUMMARY:
==25894==     in use at exit: 0 bytes in 0 blocks
==25894==   total heap usage: 1,926 allocs, 1,926 frees, 1,800,381 bytes allocated
==25894== 
==25894== All heap blocks were freed -- no leaks are possible
==25894== 
==25894== For lists of detected and suppressed errors, rerun with: -s
==25894== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
