### PR TITLE
in_node_exporter_metrics: fix referencing wrong interval between cpu and cpufreq

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -422,7 +422,7 @@ static int in_ne_init(struct flb_input_instance *in,
 
             if (ret == FLB_FALSE) {
                 if (strncmp(entry->str, "cpufreq", 7) == 0) {
-                    if (ctx->cpu_scrape_interval == 0) {
+                    if (ctx->cpufreq_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 0;
                     }
@@ -442,7 +442,7 @@ static int in_ne_init(struct flb_input_instance *in,
                     ne_cpufreq_init(ctx);
                 }
                 else if (strncmp(entry->str, "cpu", 3) == 0) {
-                    if (ctx->cpufreq_scrape_interval == 0) {
+                    if (ctx->cpu_scrape_interval == 0) {
                         flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
                         metric_idx = 1;
                     }


### PR DESCRIPTION
This patch is to fix referencing wrong intervals.

Following configuration doesn't output metrics.
We expect that fluent-bit output cpu metrics.
```
[INPUT]
    Name node_exporter_metrics
    Metrics cpu
    collector.cpufreq.scrape_interval 1

[OUTPUT]
    Name stdout
    Match *
```


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name node_exporter_metrics
    Metrics cpu
    collector.cpufreq.scrape_interval 1

[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==39545== Memcheck, a memory error detector
==39545== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==39545== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==39545== Command: bin/fluent-bit -c a.conf
==39545== 
Fluent Bit v2.2.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/09 09:42:37] [ info] [fluent bit] version=2.2.0, commit=a397936438, pid=39545
[2023/10/09 09:42:37] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/09 09:42:37] [ info] [cmetrics] version=0.6.3
[2023/10/09 09:42:37] [ info] [ctraces ] version=0.3.1
[2023/10/09 09:42:37] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/10/09 09:42:37] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/10/09 09:42:37] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/10/09 09:42:37] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/10/09 09:42:37] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/10/09 09:42:37] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/09 09:42:37] [ info] [sp] stream processor started
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="idle"} = 19827.23
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="iowait"} = 48.670000000000002
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="irq"} = 0
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="nice"} = 14.25
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="softirq"} = 0.53000000000000003
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="steal"} = 0
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="system"} = 745.08000000000004
2023-10-09T00:42:42.447867583Z node_cpu_seconds_total{cpu="0",mode="user"} = 3141.9899999999998
2023-10-09T00:42:42.447867583Z node_cpu_guest_seconds_total{cpu="0",mode="user"} = 0
2023-10-09T00:42:42.447867583Z node_cpu_guest_seconds_total{cpu="0",mode="nice"} = 0
^C[2023/10/09 09:42:44] [engine] caught signal (SIGINT)
[2023/10/09 09:42:44] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/09 09:42:44] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/09 09:42:44] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/09 09:42:44] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==39545== 
==39545== HEAP SUMMARY:
==39545==     in use at exit: 0 bytes in 0 blocks
==39545==   total heap usage: 2,148 allocs, 2,148 frees, 810,625 bytes allocated
==39545== 
==39545== All heap blocks were freed -- no leaks are possible
==39545== 
==39545== For lists of detected and suppressed errors, rerun with: -s
==39545== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
