### PR TITLE
sp: fix missing key names when query contains GROUP BY

### DIFF
--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -266,8 +266,8 @@ static int sp_cmd_aggregated_keys(struct flb_sp_cmd *cmd)
     }
 
     /*
-     * if some aggregated function is required, not aggregated keys are
-     * not allowed so we return an error (-1).
+     * If aggregated functions are included in the query, non-aggregated keys are
+     * not allowed (except for the ones inside GROUP BY statement).
      */
     if (aggr > 0 && not_aggr == 0) {
         return aggr;
@@ -490,7 +490,7 @@ struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
     /* Check and validate aggregated keys */
     ret = sp_cmd_aggregated_keys(task->cmd);
     if (ret == -1) {
-        flb_error("[sp] aggregated query cannot mix not aggregated keys: %s",
+        flb_error("[sp] aggregated query cannot include the aggregated keys: %s",
                   query);
         flb_sp_task_destroy(task);
         return NULL;
@@ -506,10 +506,10 @@ struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
             event = &task->window.event;
             MK_EVENT_ZERO(event);
 
-            /* Run every 'size' seconds */
+            /* Run every 'window size' seconds */
             fd = mk_event_timeout_create(sp->config->evl,
                                          cmd->window.size, (long) 0,
-                                         &task->window.event);
+                                         event);
             if (fd == -1) {
                 flb_error("[sp] registration for task %s failed", task->name);
                 flb_free(task);
@@ -525,7 +525,7 @@ struct flb_sp_task *flb_sp_task_create(struct flb_sp *sp, const char *name,
                 /* Run every 'size' seconds */
                 fd = mk_event_timeout_create(sp->config->evl,
                                              cmd->window.advance_by, (long) 0,
-                                             &task->window.event_hop);
+                                             event);
                 if (fd == -1) {
                     flb_error("[sp] registration for task %s failed", task->name);
                     flb_free(task);
@@ -624,8 +624,7 @@ void flb_sp_aggregate_node_destroy(struct flb_sp_cmd *cmd,
     flb_free(aggr_node);
 }
 
-void flb_sp_window_destroy(struct flb_sp_cmd *cmd,
-                           struct flb_sp_task_window *window)
+void flb_sp_window_destroy(struct flb_sp_task *task)
 {
     struct flb_sp_window_data *data;
     struct aggregate_node *aggr_node;
@@ -635,39 +634,45 @@ void flb_sp_window_destroy(struct flb_sp_cmd *cmd,
     struct mk_list *head_hs;
     struct mk_list *tmp_hs;
 
-    mk_list_foreach_safe(head, tmp, &window->data) {
+    mk_list_foreach_safe(head, tmp, &task->window.data) {
         data = mk_list_entry(head, struct flb_sp_window_data, _head);
         flb_free(data->buf_data);
         mk_list_del(&data->_head);
         flb_free(data);
     }
 
-    mk_list_foreach_safe(head, tmp, &window->aggregate_list) {
+    mk_list_foreach_safe(head, tmp, &task->window.aggregate_list) {
         aggr_node = mk_list_entry(head, struct aggregate_node, _head);
         mk_list_del(&aggr_node->_head);
-        flb_sp_aggregate_node_destroy(cmd, aggr_node);
+        flb_sp_aggregate_node_destroy(task->cmd, aggr_node);
     }
 
-    mk_list_foreach_safe(head, tmp, &window->hopping_slot) {
+    mk_list_foreach_safe(head, tmp, &task->window.hopping_slot) {
         hs = mk_list_entry(head, struct flb_sp_hopping_slot, _head);
         mk_list_foreach_safe(head_hs, tmp_hs, &hs->aggregate_list) {
             aggr_node = mk_list_entry(head_hs, struct aggregate_node, _head);
             mk_list_del(&aggr_node->_head);
-            flb_sp_aggregate_node_destroy(cmd, aggr_node);
+            flb_sp_aggregate_node_destroy(task->cmd, aggr_node);
         }
         rb_tree_destroy(&hs->aggregate_tree);
         flb_free(hs);
     }
 
-    rb_tree_destroy(&window->aggregate_tree);
+    if (task->window.fd > 0) {
+        mk_event_timeout_destroy(task->sp->config->evl, &task->window.event);
+        mk_event_closesocket(task->window.fd);
+    }
+
+    rb_tree_destroy(&task->window.aggregate_tree);
 }
 
 void flb_sp_task_destroy(struct flb_sp_task *task)
 {
     flb_sds_destroy(task->name);
     flb_sds_destroy(task->query);
-    flb_sp_window_destroy(task->cmd, &task->window);
+    flb_sp_window_destroy(task);
     flb_sp_snapshot_destroy(task->snapshot);
+
     mk_list_del(&task->_head);
 
     if (task->stream) {
@@ -1114,6 +1119,7 @@ void package_results(const char *tag, int tag_len,
                      char **out_buf, size_t *out_size,
                      struct flb_sp_task *task)
 {
+    char *c_name;
     int i;
     int len;
     int map_entries;
@@ -1165,14 +1171,13 @@ void package_results(const char *tag, int tag_len,
                                       flb_sds_len(ckey->alias));
             }
             else {
-                len = 0;
-                char *c_name;
                 if (!ckey->name) {
                     c_name = "*";
                 }
                 else {
                     c_name = ckey->name;
                 }
+                len = strlen(c_name);
 
                 msgpack_pack_str(&mp_pck, len);
                 msgpack_pack_str_body(&mp_pck, c_name, len);

--- a/src/stream_processor/parser/flb_sp_parser.c
+++ b/src/stream_processor/parser/flb_sp_parser.c
@@ -139,8 +139,8 @@ struct flb_sp_cmd_key *flb_sp_key_create(struct flb_sp_cmd *cmd, int func,
     struct flb_sp_cmd_key *key;
     struct flb_slist_entry *entry;
 
-    /* aggregation function ? */
     if (func >= FLB_SP_AVG && func <= FLB_SP_FORECAST) {
+        /* Aggregation function */
         aggr_func = func;
     }
     else if (func >= FLB_SP_NOW && func <= FLB_SP_UNIX_TIMESTAMP) {

--- a/tests/internal/include/sp_cb_functions.h
+++ b/tests/internal/include/sp_cb_functions.h
@@ -535,6 +535,20 @@ static void cb_select_groupby(int id, struct task_check *check,
     ret = mp_count_rows(buf, size);
     TEST_CHECK(ret == 2);
 
+    /* bool is 1 for record 0 (bool=true) */
+    ret = mp_record_key_cmp(buf, size,
+                            0, "bool",
+                            MSGPACK_OBJECT_POSITIVE_INTEGER,
+                            NULL, 1, 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* bool is 0 for record 1 (bool=false) */
+    ret = mp_record_key_cmp(buf, size,
+                            1, "bool",
+                            MSGPACK_OBJECT_POSITIVE_INTEGER,
+                            NULL, 0, 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
     /* MIN(id) is 0 for record 0 (bool=true) */
     ret = mp_record_key_cmp(buf, size,
                             0, "MIN(id)",
@@ -556,7 +570,7 @@ static void cb_select_groupby(int id, struct task_check *check,
                             NULL, 8, 0);
     TEST_CHECK(ret == FLB_TRUE);
 
-    /* MAX(id) is i9 for record 1 (bool=false)  */
+    /* MAX(id) is 9 for record 1 (bool=false)  */
     ret = mp_record_key_cmp(buf, size,
                             1, "MAX(id)",
                             MSGPACK_OBJECT_POSITIVE_INTEGER,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Key names are missing from the output record for the keys inside GROUP BY statement.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #7459 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
# valgrind --leak-check=full ./bin/fluent-bit -c ../conf/bug
==98401== Memcheck, a memory error detector
==98401== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==98401== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==98401== Command: ./bin/fluent-bit -c ../conf/bug
==98401== 
Fluent Bit v2.2.0
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/12 03:39:28] [ info] [fluent bit] version=2.2.0, commit=da569ea7d0, pid=98401
[2023/10/12 03:39:28] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/12 03:39:28] [ info] [cmetrics] version=0.6.3
[2023/10/12 03:39:28] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/12 03:39:28] [ info] [ctraces ] version=0.3.1
[2023/10/12 03:39:28] [ info] [input:tail:tail.0] initializing
[2023/10/12 03:39:28] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/10/12 03:39:28] [ info] [input:stream_processor:agg.logs] initializing
[2023/10/12 03:39:28] [ info] [input:stream_processor:agg.logs] storage_strategy=(null)
[2023/10/12 03:39:28] [ info] [sp] stream processor started
[2023/10/12 03:39:28] [ info] [sp] registered task: agg_stream
[2023/10/12 03:39:28] [ info] [input:tail:tail.0] inotify_fs_add(): inode=3547685 watch_fd=1 name=/var/log/bug
[0] logs.acc: [[1697081971.254292876, {}], {"server"=>"stage01", "host"=>"host1.com", "size_sent"=>"1", "body_size"=>"9"}]
[1] logs.acc: [[1697081971.747697882, {}], {"server"=>"stage01", "host"=>"host1.com", "size_sent"=>"1", "body_size"=>"8"}]
[0] logs.acc: [[1697081972.251094097, {}], {"server"=>"stage01", "host"=>"host1.com", "size_sent"=>"1", "body_size"=>"7"}]
[0] agg.logs: [[1697081971.902873596, {}], {"server"=>"stage01", "host"=>"host1.com", "SUM(size_sent)"=>2}]
[0] agg.logs: [[1697081972.906615055, {}], {"server"=>"stage01", "host"=>"host1.com", "SUM(size_sent)"=>1}]
^C[2023/10/12 03:39:40] [engine] caught signal (SIGINT)
[2023/10/12 03:39:40] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/12 03:39:40] [ info] [input] pausing tail.0
[2023/10/12 03:39:40] [ info] [input] pausing agg.logs
[2023/10/12 03:39:40] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/12 03:39:40] [ info] [input] pausing tail.0
[2023/10/12 03:39:40] [ info] [input] pausing agg.logs
[2023/10/12 03:39:40] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
==98401== 
==98401== HEAP SUMMARY:
==98401==     in use at exit: 0 bytes in 0 blocks
==98401==   total heap usage: 5,091 allocs, 5,091 frees, 2,695,507 bytes allocated
==98401== 
==98401== All heap blocks were freed -- no leaks are possible
==98401== 
==98401== For lists of detected and suppressed errors, rerun with: -s
==98401== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
