### PR TITLE
fluent-bit: modify hot reload handler

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -557,7 +557,6 @@ static void flb_signal_handler_status_line(struct flb_cf *cf_opts)
     char s[] = "[engine] caught signal (";
     time_t now;
     struct tm *cur;
-    flb_ctx_t *ctx = flb_context_get();
 
     now = time(NULL);
     cur = localtime(&now);
@@ -609,9 +608,6 @@ static void flb_signal_handler(int signal)
 #ifndef FLB_HAVE_STATIC_CONF
         if (flb_bin_restarting == FLB_RELOAD_IDLE) {
             flb_bin_restarting = FLB_RELOAD_IN_PROGRESS;
-            /* reload by using same config files/path */
-            flb_reload(ctx, cf_opts);
-            flb_bin_restarting = FLB_RELOAD_IDLE;
         }
         else {
             flb_utils_error(FLB_ERR_RELOADING_IN_PROGRESS);
@@ -1396,12 +1392,18 @@ int flb_main(int argc, char **argv)
 #ifdef FLB_SYSTEM_WINDOWS
         flb_console_handler_set_ctx(ctx, cf_opts);
 #endif
+        if (flb_bin_restarting == FLB_RELOAD_IN_PROGRESS) {
+            /* reload by using same config files/path */
+            flb_reload(ctx, cf_opts);
+            ctx = flb_context_get();
+            flb_bin_restarting = FLB_RELOAD_IDLE;
+        }
     }
 
     if (exit_signal) {
         flb_signal_exit(exit_signal);
     }
-    ret = config->exit_status_code;
+    ret = ctx->config->exit_status_code;
 
     cf_opts = flb_cf_context_get();
 


### PR DESCRIPTION
This patch is to modify signal handler for hot reloading.

Multiple SIGHUP can cause SIGSEGV like following log.
This patch is to prevent it. 
```
$ bin/fluent-bit -c a.conf 
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/14 10:26:43] [ info] [fluent bit] version=2.2.0, commit=8401076f11, pid=33322
[2023/10/14 10:26:43] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/14 10:26:43] [ info] [cmetrics] version=0.6.3
[2023/10/14 10:26:43] [ info] [ctraces ] version=0.3.1
[2023/10/14 10:26:43] [ info] [input:cpu:cpu.0] initializing
[2023/10/14 10:26:43] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/10/14 10:26:43] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/14 10:26:43] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2023/10/14 10:26:43] [ info] [sp] stream processor started
[2023/10/14 10:26:48] [engine] caught signal (SIGHUP)
[2023/10/14 10:26:48] [ info] reloading instance pid=33322 tid=0x7fde55899fc0
[2023/10/14 10:26:48] [ info] [reload] stop everything of the old context
[2023/10/14 10:26:48] [ warn] [engine] service will shutdown when all remaining tasks are flushed
(snip)
[2023/10/14 10:26:51] [ info] [reload] start everything
[2023/10/14 10:26:51] [  Error] epoll_wait: Bad file descriptor, errno=9 at /home/taka/git/fluent-bit/lib/monkey/mk_core/mk_event_epoll.c:449
[2023/10/14 10:26:51] [engine] caught signal (SIGSEGV)
[2023/10/14 10:26:51] [engine] caught signal (SIGSEGV)
[2023/10/14 10:26:51] [engine] caught signal (SIGHUP)
[2023/10/14 10:26:51] [ warn] [reload] hot reloading is not enabled
[2023/10/14 10:26:51] [engine] caught signal (SIGHUP)
[2023/10/14 10:26:51] [ warn] [reload] hot reloading is not enabled
#0  0x557d4c1114cd      in  mk_rconf_free() at lib/monkey/mk_core/mk_rconf.c:673
#1  0x557d4b499dd6      in  flb_stop() at src/flb_lib.c:772
#2  0x557d4b48354b      in  flb_main() at src/fluent-bit.c:1426
#3  0x557d4b48359b      in  main() at src/fluent-bit.c:1437
#4  0x7fde55629d8f      in  __libc_start_call_main() at _call_main.h:58
#5  0x7fde55629e3f      in  __libc_start_main_impl() at sr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h:392
#6  0x557d4b47c374      in  ???() at ???:0
#7  0xffffffffffffffff  in  ???() at ???:0
[2]+  Killed                  bin/fluent-bit -c a.conf
Aborted (core dumped)
taka@taka-VirtualBox:~/git/fluent-bit/build$ 
```

Note: SIG31-C. Do not access shared objects in signal handlers
https://wiki.sei.cmu.edu/confluence/x/VdYxBQ

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration

```
[SERVICE]
    Http_Server on
    Hot_reload on

[INPUT]
    Name cpu
    Interval_sec 10

[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind log 

Valgrind reported an error that is not related this PR.
The error is also occurred on [current master](https://github.com/fluent/fluent-bit/commit/8401076f11b5cc0ee2bfe6539d835ffeac575784)

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==35224== Memcheck, a memory error detector
==35224== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==35224== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==35224== Command: bin/fluent-bit -c a.conf
==35224== 
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/14 10:32:09] [ info] [fluent bit] version=2.2.0, commit=8401076f11, pid=35224
[2023/10/14 10:32:09] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/14 10:32:09] [ info] [cmetrics] version=0.6.3
[2023/10/14 10:32:09] [ info] [ctraces ] version=0.3.1
[2023/10/14 10:32:09] [ info] [input:cpu:cpu.0] initializing
[2023/10/14 10:32:09] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/10/14 10:32:09] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/14 10:32:10] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2023/10/14 10:32:10] [ info] [sp] stream processor started
[2023/10/14 10:32:11] [engine] caught signal (SIGHUP)
[2023/10/14 10:32:11] [ info] reloading instance pid=35224 tid=0x541c940
[2023/10/14 10:32:11] [ info] [reload] stop everything of the old context
[2023/10/14 10:32:11] [ warn] [engine] service will shutdown when all remaining tasks are flushed
[2023/10/14 10:32:11] [ info] [input] pausing cpu.0
[2023/10/14 10:32:11] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/14 10:32:11] [ info] [input] pausing cpu.0
[2023/10/14 10:32:12] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/14 10:32:12] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2023/10/14 10:32:12] [ info] [reload] start everything
[2023/10/14 10:32:12] [ info] [fluent bit] version=2.2.0, commit=8401076f11, pid=35224
[2023/10/14 10:32:12] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/14 10:32:12] [ info] [cmetrics] version=0.6.3
[2023/10/14 10:32:12] [ info] [ctraces ] version=0.3.1
[2023/10/14 10:32:12] [ info] [input:cpu:cpu.0] initializing
[2023/10/14 10:32:12] [ info] [input:cpu:cpu.0] storage_strategy='memory' (memory only)
[2023/10/14 10:32:12] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/14 10:32:12] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2023/10/14 10:32:12] [ info] [sp] stream processor started
^C[2023/10/14 10:32:13] [engine] caught signal (SIGINT)
[2023/10/14 10:32:13] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/14 10:32:13] [ info] [input] pausing cpu.0
[2023/10/14 10:32:13] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/14 10:32:13] [ info] [input] pausing cpu.0
[2023/10/14 10:32:13] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/14 10:32:13] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==35224== 
==35224== HEAP SUMMARY:
==35224==     in use at exit: 56 bytes in 1 blocks
==35224==   total heap usage: 7,050 allocs, 7,049 frees, 1,210,602 bytes allocated
==35224== 
==35224== 56 bytes in 1 blocks are definitely lost in loss record 1 of 1
==35224==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==35224==    by 0xE4D375: mk_mem_alloc_z (mk_memory.h:70)
==35224==    by 0xE4D766: thread_get_libco_params (mk_http_thread.c:60)
==35224==    by 0xE4D956: thread_params_set (mk_http_thread.c:168)
==35224==    by 0xE4DC15: mk_http_thread_create (mk_http_thread.c:226)
==35224==    by 0xE49A71: mk_http_init (mk_http.c:748)
==35224==    by 0xE4889D: mk_http_request_prepare (mk_http.c:232)
==35224==    by 0xE4B8DC: mk_http_sched_read (mk_http.c:1576)
==35224==    by 0xE47215: mk_sched_event_read (mk_scheduler.c:695)
==35224==    by 0xE50959: mk_server_worker_loop (mk_server.c:523)
==35224==    by 0xE46B38: mk_sched_launch_worker_loop (mk_scheduler.c:417)
==35224==    by 0x4FF3AC2: start_thread (pthread_create.c:442)
==35224== 
==35224== LEAK SUMMARY:
==35224==    definitely lost: 56 bytes in 1 blocks
==35224==    indirectly lost: 0 bytes in 0 blocks
==35224==      possibly lost: 0 bytes in 0 blocks
==35224==    still reachable: 0 bytes in 0 blocks
==35224==         suppressed: 0 bytes in 0 blocks
==35224== 
==35224== For lists of detected and suppressed errors, rerun with: -s
==35224== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
