### PR TITLE
out_logdna: refactored LogDNA URI formation to support configurable endpoints

### DIFF
--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -405,7 +405,8 @@ static void cb_logdna_flush(struct flb_event_chunk *event_chunk,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
     tmp = flb_sds_printf(&uri,
-                         "/logs/ingest?hostname=%s&mac=%s&ip=%s&now=%lu&tags=%s",
+                         "%s?hostname=%s&mac=%s&ip=%s&now=%lu&tags=%s",
+                         ctx->logdna_endpoint,
                          ctx->_hostname,
                          ctx->mac_addr,
                          ctx->ip_addr,
@@ -530,6 +531,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_INT, "logdna_port", FLB_LOGDNA_PORT,
      0, FLB_TRUE, offsetof(struct flb_logdna, logdna_port),
      "LogDNA TCP port"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "logdna_endpoint", FLB_LOGDNA_ENDPOINT,
+     0, FLB_TRUE, offsetof(struct flb_logdna, logdna_endpoint),
+     "LogDNA endpoint to send logs"
     },
 
     {

--- a/plugins/out_logdna/logdna.h
+++ b/plugins/out_logdna/logdna.h
@@ -25,6 +25,7 @@
 
 #define FLB_LOGDNA_HOST      "logs.logdna.com"
 #define FLB_LOGDNA_PORT      "443"
+#define FLB_LOGDNA_ENDPOINT  "/logs/ingest"
 #define FLB_LOGDNA_CT        "Content-Type"
 #define FLB_LOGDNA_CT_JSON   "application/json; charset=UTF-8"
 
@@ -32,6 +33,7 @@ struct flb_logdna {
     /* Incoming Configuration Properties */
     flb_sds_t logdna_host;
     int       logdna_port;
+    flb_sds_t logdna_endpoint;
     flb_sds_t api_key;
     flb_sds_t hostname;
     flb_sds_t mac_addr;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously, the LogDNA URI was hardcoded to use the `/logs/ingest` endpoint. This change introduces flexibility by allowing users to specify their own endpoint through the `logdna_endpoint` configuration. This can be particularly useful for users with different LogDNA setups or those using Super Tenancy.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/1236

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
