### PR TITLE
forward: Handle to forward for compressed non log types of chunks

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -451,6 +451,48 @@ static size_t receiver_to_unpacker(struct fw_conn *conn, size_t request_size,
     return recv_len;
 }
 
+static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
+                      int event_type,
+                      flb_sds_t out_tag, const void *data, size_t len)
+{
+    int ret;
+    size_t off = 0;
+    struct cmt *cmt;
+    struct ctrace *ctr;
+
+    if (event_type == FLB_EVENT_TYPE_LOGS) {
+        flb_input_log_append(conn->in,
+                             out_tag, flb_sds_len(out_tag),
+                             data, len);
+
+        return 0;
+    }
+    else if (event_type == FLB_EVENT_TYPE_METRICS) {
+        ret = cmt_decode_msgpack_create(&cmt, (char *) data, len, &off);
+        if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
+            flb_error("cmt_decode_msgpack_create failed. ret=%d", ret);
+            return -1;
+        }
+        flb_input_metrics_append(conn->in,
+                                 out_tag, flb_sds_len(out_tag),
+                                 cmt);
+    }
+    else if (event_type == FLB_EVENT_TYPE_TRACES) {
+        off = 0;
+        ret = ctr_decode_msgpack_create(&ctr, (char *) data, len, &off);
+        if (ret == -1) {
+            return -1;
+        }
+
+        flb_input_trace_append(ins,
+                               out_tag, flb_sds_len(out_tag),
+                               ctr);
+    }
+
+    return 0;
+}
+
+
 int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
 {
     int ret;
@@ -458,7 +500,6 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
     int event_type;
     int contain_options = FLB_FALSE;
     size_t index = 0;
-    size_t off = 0;
     size_t chunk_id = -1;
     size_t metadata_id = -1;
     const char *stag;
@@ -476,8 +517,6 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
     msgpack_unpacker *unp;
     size_t all_used = 0;
     struct flb_in_fw_config *ctx = conn->ctx;
-    struct cmt *cmt;
-    struct ctrace *ctr;
 
     /*
      * [tag, time, record]
@@ -759,48 +798,23 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                                 msgpack_unpacked_destroy(&result);
                                 msgpack_unpacker_free(unp);
                                 flb_sds_destroy(out_tag);
+                                flb_free(gz_data);
                                 return -1;
                             }
                             event_type = ret;
                         }
 
-                        if (event_type == FLB_EVENT_TYPE_LOGS) {
-                            /* Append uncompressed data */
-                            flb_input_log_append(conn->in,
-                                                 out_tag, flb_sds_len(out_tag),
-                                                 gz_data, gz_size);
+                        ret = append_log(ins, conn,
+                                         event_type,
+                                         out_tag, gz_data, gz_size);
+                        if (ret == -1) {
+                            msgpack_unpacked_destroy(&result);
+                            msgpack_unpacker_free(unp);
+                            flb_sds_destroy(out_tag);
                             flb_free(gz_data);
+                            return -1;
                         }
-                        else if (event_type == FLB_EVENT_TYPE_METRICS) {
-                            ret = cmt_decode_msgpack_create(&cmt, (char *) gz_data, gz_size, &off);
-                            if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
-                                flb_error("cmt_decode_msgpack_create failed. ret=%d", ret);
-                                msgpack_unpacked_destroy(&result);
-                                msgpack_unpacker_free(unp);
-                                flb_sds_destroy(out_tag);
-                                return -1;
-                            }
-                            flb_input_metrics_append(conn->in,
-                                                     out_tag, flb_sds_len(out_tag),
-                                                     cmt);
-                            flb_free(gz_data);
-                        }
-                        else if (event_type == FLB_EVENT_TYPE_TRACES) {
-                            off = 0;
-                            ret = ctr_decode_msgpack_create(&ctr, (char *) gz_data, gz_size, &off);
-                            if (ret == -1) {
-                                msgpack_unpacked_destroy(&result);
-                                msgpack_unpacker_free(unp);
-                                flb_sds_destroy(out_tag);
-                                return -1;
-                            }
-
-                            flb_input_trace_append(ins,
-                                                   out_tag, flb_sds_len(out_tag),
-                                                   ctr);
-
-                            flb_free(gz_data);
-                        }
+                        flb_free(gz_data);
                     }
                     else {
                         event_type = FLB_EVENT_TYPE_LOGS;
@@ -815,37 +829,14 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                             event_type = ret;
                         }
 
-                        if (event_type == FLB_EVENT_TYPE_LOGS) {
-                            flb_input_log_append(conn->in,
-                                                 out_tag, flb_sds_len(out_tag),
-                                                 data, len);
-                        }
-                        else if (event_type == FLB_EVENT_TYPE_METRICS) {
-                            ret = cmt_decode_msgpack_create(&cmt, (char *) data, len, &off);
-                            if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
-                                flb_error("cmt_decode_msgpack_create failed. ret=%d", ret);
-                                msgpack_unpacked_destroy(&result);
-                                msgpack_unpacker_free(unp);
-                                flb_sds_destroy(out_tag);
-                                return -1;
-                            }
-                            flb_input_metrics_append(conn->in,
-                                                     out_tag, flb_sds_len(out_tag),
-                                                     cmt);
-                        }
-                        else if (event_type == FLB_EVENT_TYPE_TRACES) {
-                            off = 0;
-                            ret = ctr_decode_msgpack_create(&ctr, (char *) data, len, &off);
-                            if (ret == -1) {
-                                msgpack_unpacked_destroy(&result);
-                                msgpack_unpacker_free(unp);
-                                flb_sds_destroy(out_tag);
-                                return -1;
-                            }
-
-                            flb_input_trace_append(ins,
-                                                   out_tag, flb_sds_len(out_tag),
-                                                   ctr);
+                        ret = append_log(ins, conn,
+                                         event_type,
+                                         out_tag, data, len);
+                        if (ret == -1) {
+                            msgpack_unpacked_destroy(&result);
+                            msgpack_unpacker_free(unp);
+                            flb_sds_destroy(out_tag);
+                            return -1;
                         }
                     }
 

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -149,6 +149,17 @@ static int append_options(struct flb_forward *ctx,
         msgpack_pack_str(mp_pck, 4);
         msgpack_pack_str_body(mp_pck, "gzip", 4);
     }
+    else if (fc->compress == COMPRESS_GZIP &&
+             /* for metrics or traces, we're also able to send as
+              * gzipped payloads */
+             (event_type == FLB_EVENT_TYPE_METRICS ||
+              event_type == FLB_EVENT_TYPE_TRACES)) {
+        flb_mp_map_header_append(&mh);
+        msgpack_pack_str(mp_pck, 10);
+        msgpack_pack_str_body(mp_pck, "compressed", 10);
+        msgpack_pack_str(mp_pck, 4);
+        msgpack_pack_str_body(mp_pck, "gzip", 4);
+    }
 
     /* event type (FLB_EVENT_TYPE_LOGS, FLB_EVENT_TYPE_METRICS, FLB_EVENT_TYPE_TRACES) */
     flb_mp_map_header_append(&mh);


### PR DESCRIPTION
<!-- Provide summary of changes -->

In the current forward plugins' implementations, they don't handle to forward gzip compressed chunks.
To achieve this, we have to handle this issue as follows:

* Add compress=gzip option for non logs type of chunks in out_forward
* Handle event_type correctly on gzip compressed case in in_forward 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes #8000 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

For scraping metrics:

```ini
[SERVICE]
    flush        1
    daemon       Off
    log_level    debug
    parsers_file /path/to/parsers.conf
    http_server  Off

[INPUT]
    name prometheus_scrape
    tag metrics.foobar
    host 0.0.0.0
    port 9090
    scrape_interval 15s

[OUTPUT]
    Name forward
    Match metrics.*
    Host 127.0.0.1
    Port 24225
    Compress gzip
```

For receiving metrics type of events:

```ini
[SERVICE]
    flush        1
    daemon       Off
    log_level    debug
    parsers_file /path/to/parsers.conf
    http_server  Off

[INPUT]
    Name forward
    Listen 0.0.0.0
    Port 24225

[OUTPUT]
    name stdout
    match *
```

- [x] Debug log output from testing the change

```log
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/18 17:37:12] [ info] Configuration:
[2023/10/18 17:37:12] [ info]  flush time     | 1.000000 seconds
[2023/10/18 17:37:12] [ info]  grace          | 5 seconds
[2023/10/18 17:37:12] [ info]  daemon         | 0
[2023/10/18 17:37:12] [ info] ___________
[2023/10/18 17:37:12] [ info]  inputs:
[2023/10/18 17:37:12] [ info]      forward
[2023/10/18 17:37:12] [ info] ___________
[2023/10/18 17:37:12] [ info]  filters:
[2023/10/18 17:37:12] [ info] ___________
[2023/10/18 17:37:12] [ info]  outputs:
[2023/10/18 17:37:12] [ info]      stdout.0
[2023/10/18 17:37:12] [ info] ___________
[2023/10/18 17:37:12] [ info]  collectors:
[2023/10/18 17:37:12] [ info] [fluent bit] version=2.2.0, commit=92b9053a54, pid=110963
[2023/10/18 17:37:12] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/10/18 17:37:12] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/18 17:37:12] [ info] [cmetrics] version=0.6.3
[2023/10/18 17:37:12] [ info] [ctraces ] version=0.3.1
[2023/10/18 17:37:12] [ info] [input:forward:forward.0] initializing
[2023/10/18 17:37:12] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2023/10/18 17:37:12] [debug] [forward:forward.0] created event channels: read=21 write=22
[2023/10/18 17:37:12] [debug] [in_fw] Listen='0.0.0.0' TCP_Port=24225
[2023/10/18 17:37:12] [debug] [downstream] listening on 0.0.0.0:24225
[2023/10/18 17:37:12] [ info] [input:forward:forward.0] listening on 0.0.0.0:24225
[2023/10/18 17:37:12] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/10/18 17:37:12] [ info] [sp] stream processor started
[2023/10/18 17:37:12] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/18 17:37:27] [debug] [input chunk] update output instances with new chunk size diff=47358, records=0, input=forward.0
[2023/10/18 17:37:28] [debug] [task] created task=0x7f8c6c01a490 id=0 OK
[2023/10/18 17:37:28] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2023-10-18T08:37:26.714400407Z go_memstats_alloc_bytes_total = 589044576
2023-10-18T08:37:26.714400407Z go_memstats_frees_total = 3886681
2023-10-18T08:37:26.714400407Z go_memstats_lookups_total = 0
2023-10-18T08:37:26.714400407Z go_memstats_mallocs_total = 3978102
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_attempted_total{dialer_name="alertmanager"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_attempted_total{dialer_name="default"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_attempted_total{dialer_name="prometheus"} = 1
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_closed_total{dialer_name="alertmanager"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_closed_total{dialer_name="default"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_closed_total{dialer_name="prometheus"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_established_total{dialer_name="alertmanager"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_established_total{dialer_name="default"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_established_total{dialer_name="prometheus"} = 1
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="alertmanager",reason="refused"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="alertmanager",reason="resolution"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="alertmanager",reason="timeout"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="alertmanager",reason="unknown"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="default",reason="refused"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="default",reason="resolution"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="default",reason="timeout"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="default",reason="unknown"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="prometheus",reason="refused"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="prometheus",reason="resolution"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="prometheus",reason="timeout"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_dialer_conn_failed_total{dialer_name="prometheus",reason="unknown"} = 0
2023-10-18T08:37:26.714400407Z net_conntrack_listener_conn_accepted_total{listener_name="http"} = 29
2023-10-18T08:37:26.714400407Z net_conntrack_listener_conn_closed_total{listener_name="http"} = 27
2023-10-18T08:37:26.714400407Z process_cpu_seconds_total = 11.68
2023-10-18T08:37:26.714400407Z prometheus_engine_query_log_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_engine_query_samples_total = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/-/healthy"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/-/quit"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/-/ready"} = 1
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/-/reload"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/alerts"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/*path"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/admin/tsdb/clean_tombstones"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/admin/tsdb/delete_series"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/admin/tsdb/snapshot"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/alertmanagers"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/alerts"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/format_query"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/label/:name/values"} = 1
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/labels"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/metadata"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/otlp/v1/metrics"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/query"} = 1
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/query_exemplars"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/query_range"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/read"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/rules"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/scrape_pools"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/series"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/status/buildinfo"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/status/config"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/status/flags"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/status/runtimeinfo"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/status/tsdb"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/status/walreplay"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/targets"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/targets/metadata"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/api/v1/write"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/classic/static/*filepath"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/config"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/consoles/*filepath"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/debug/*subpath"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/favicon.ico"} = 1
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/federate"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/flags"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/graph"} = 1
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/manifest.json"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/metrics"} = 816
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/rules"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/service-discovery"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/starting"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/static/*filepath"} = 2
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/status"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/targets"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/tsdb-status"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="200",handler="/version"} = 0
2023-10-18T08:37:26.714400407Z prometheus_http_requests_total{code="302",handler="/"} = 1
2023-10-18T08:37:26.714400407Z prometheus_notifications_dropped_total = 0
2023-10-18T08:37:26.714400407Z prometheus_remote_storage_exemplars_in_total = 0
2023-10-18T08:37:26.714400407Z prometheus_remote_storage_histograms_in_total = 0
2023-10-18T08:37:26.714400407Z prometheus_remote_storage_samples_in_total = 475219
2023-10-18T08:37:26.714400407Z prometheus_remote_storage_string_interner_zero_reference_releases_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_azure_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_consul_rpc_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_dns_lookup_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_dns_lookups_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_file_read_errors_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_file_watcher_errors_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_http_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="add",role="endpoints"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="add",role="endpointslice"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="add",role="ingress"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="add",role="node"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="add",role="pod"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="add",role="service"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="delete",role="endpoints"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="delete",role="endpointslice"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="delete",role="ingress"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="delete",role="node"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="delete",role="pod"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="delete",role="service"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="update",role="endpoints"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="update",role="endpointslice"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="update",role="ingress"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="update",role="node"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="update",role="pod"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kubernetes_events_total{event="update",role="service"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kuma_fetch_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_kuma_fetch_skipped_updates_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_linode_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_nomad_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_received_updates_total{name="notify"} = 2
2023-10-18T08:37:26.714400407Z prometheus_sd_received_updates_total{name="scrape"} = 2
2023-10-18T08:37:26.714400407Z prometheus_sd_updates_total{name="notify"} = 1
2023-10-18T08:37:26.714400407Z prometheus_sd_updates_total{name="scrape"} = 1
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_exceeded_label_limits_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_exceeded_target_limit_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_reloads_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_reloads_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_sync_total{scrape_job="prometheus"} = 1
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pools_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pools_total = 1
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_cache_flush_forced_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_exceeded_body_size_limit_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_exceeded_native_histogram_bucket_limit_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_exceeded_sample_limit_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_exemplar_out_of_order_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_sample_duplicate_timestamp_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_sample_out_of_bounds_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrapes_sample_out_of_order_total = 0
2023-10-18T08:37:26.714400407Z prometheus_target_sync_failed_total{scrape_job="prometheus"} = 0
2023-10-18T08:37:26.714400407Z prometheus_template_text_expansion_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_template_text_expansions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_treecache_zookeeper_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_checkpoint_creations_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_checkpoint_creations_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_checkpoint_deletions_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_checkpoint_deletions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compactions_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compactions_skipped_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compactions_total = 1
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compactions_triggered_total = 198
2023-10-18T08:37:26.714400407Z prometheus_tsdb_exemplar_exemplars_appended_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_exemplar_out_of_order_exemplars_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_chunks_created_total = 4220
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_chunks_removed_total = 607
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_out_of_order_samples_appended_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_samples_appended_total{type="float"} = 475219
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_samples_appended_total{type="histogram"} = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_series_created_total = 602
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_series_not_found_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_series_removed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_truncations_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_truncations_total = 1
2023-10-18T08:37:26.714400407Z prometheus_tsdb_mmap_chunk_corruptions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_mmap_chunks_total = 3618
2023-10-18T08:37:26.714400407Z prometheus_tsdb_out_of_bound_samples_total{type="float"} = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_out_of_order_samples_total{type="float"} = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_out_of_order_samples_total{type="histogram"} = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_reloads_failures_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_reloads_total = 199
2023-10-18T08:37:26.714400407Z prometheus_tsdb_size_retentions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_snapshot_replay_error_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_time_retentions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_too_old_samples_total{type="float"} = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_vertical_compactions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_completed_pages_total = 73
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_corruptions_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_page_flushes_total = 866
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_truncations_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_truncations_total = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_writes_failed_total = 0
2023-10-18T08:37:26.714400407Z prometheus_web_federation_errors_total = 0
2023-10-18T08:37:26.714400407Z prometheus_web_federation_warnings_total = 0
2023-10-18T08:37:26.714400407Z promhttp_metric_handler_requests_total{code="200"} = 816
2023-10-18T08:37:26.714400407Z promhttp_metric_handler_requests_total{code="500"} = 0
2023-10-18T08:37:26.714400407Z promhttp_metric_handler_requests_total{code="503"} = 0
2023-10-18T08:37:26.714400407Z go_goroutines = 31
2023-10-18T08:37:26.714400407Z go_info{version="go1.21.3"} = 1
2023-10-18T08:37:26.714400407Z go_memstats_alloc_bytes = 22340784
2023-10-18T08:37:26.714400407Z go_memstats_buck_hash_sys_bytes = 1512599
2023-10-18T08:37:26.714400407Z go_memstats_gc_sys_bytes = 4808304
2023-10-18T08:37:26.714400407Z go_memstats_heap_alloc_bytes = 22340784
2023-10-18T08:37:26.714400407Z go_memstats_heap_idle_bytes = 35086336
2023-10-18T08:37:26.714400407Z go_memstats_heap_inuse_bytes = 26288128
2023-10-18T08:37:26.714400407Z go_memstats_heap_objects = 91421
2023-10-18T08:37:26.714400407Z go_memstats_heap_released_bytes = 31571968
2023-10-18T08:37:26.714400407Z go_memstats_heap_sys_bytes = 61374464
2023-10-18T08:37:26.714400407Z go_memstats_last_gc_time_seconds = 1697618177.3084028
2023-10-18T08:37:26.714400407Z go_memstats_mcache_inuse_bytes = 14400
2023-10-18T08:37:26.714400407Z go_memstats_mcache_sys_bytes = 15600
2023-10-18T08:37:26.714400407Z go_memstats_mspan_inuse_bytes = 361872
2023-10-18T08:37:26.714400407Z go_memstats_mspan_sys_bytes = 423696
2023-10-18T08:37:26.714400407Z go_memstats_next_gc_bytes = 38335408
2023-10-18T08:37:26.714400407Z go_memstats_other_sys_bytes = 2518529
2023-10-18T08:37:26.714400407Z go_memstats_stack_inuse_bytes = 1540096
2023-10-18T08:37:26.714400407Z go_memstats_stack_sys_bytes = 1540096
2023-10-18T08:37:26.714400407Z go_memstats_sys_bytes = 72193288
2023-10-18T08:37:26.714400407Z go_threads = 18
2023-10-18T08:37:26.714400407Z process_max_fds = 65535
2023-10-18T08:37:26.714400407Z process_open_fds = 21
2023-10-18T08:37:26.714400407Z process_resident_memory_bytes = 84811776
2023-10-18T08:37:26.714400407Z process_start_time_seconds = 1697606387.22
2023-10-18T08:37:26.714400407Z process_virtual_memory_bytes = 1618923520
2023-10-18T08:37:26.714400407Z process_virtual_memory_max_bytes = 1.8446744073709552e+19
2023-10-18T08:37:26.714400407Z prometheus_api_remote_read_queries = 0
2023-10-18T08:37:26.714400407Z prometheus_build_info{branch="HEAD",goarch="amd64",goos="linux",goversion="go1.21.3",revision="3f3172cde1ee37f1c7b3a5f3d9b031190509b3ad",tags="netgo,builtinassets,stringlabels",version="2.47.2"} = 1
2023-10-18T08:37:26.714400407Z prometheus_config_last_reload_success_timestamp_seconds = 1697606387.3207192
2023-10-18T08:37:26.714400407Z prometheus_config_last_reload_successful = 1
2023-10-18T08:37:26.714400407Z prometheus_engine_queries = 0
2023-10-18T08:37:26.714400407Z prometheus_engine_queries_concurrent_max = 20
2023-10-18T08:37:26.714400407Z prometheus_engine_query_log_enabled = 0
2023-10-18T08:37:26.714400407Z prometheus_notifications_alertmanagers_discovered = 0
2023-10-18T08:37:26.714400407Z prometheus_notifications_queue_capacity = 10000
2023-10-18T08:37:26.714400407Z prometheus_notifications_queue_length = 0
2023-10-18T08:37:26.714400407Z prometheus_ready = 1
2023-10-18T08:37:26.714400407Z prometheus_remote_storage_highest_timestamp_in_seconds = 1697618237
2023-10-18T08:37:26.714400407Z prometheus_sd_discovered_targets{config="config-0",name="notify"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_discovered_targets{config="prometheus",name="scrape"} = 1
2023-10-18T08:37:26.714400407Z prometheus_sd_failed_configs{name="notify"} = 0
2023-10-18T08:37:26.714400407Z prometheus_sd_failed_configs{name="scrape"} = 0
2023-10-18T08:37:26.714400407Z prometheus_target_metadata_cache_bytes{scrape_job="prometheus"} = 11255
2023-10-18T08:37:26.714400407Z prometheus_target_metadata_cache_entries{scrape_job="prometheus"} = 183
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_target_limit{scrape_job="prometheus"} = 0
2023-10-18T08:37:26.714400407Z prometheus_target_scrape_pool_targets{scrape_job="prometheus"} = 1
2023-10-18T08:37:26.714400407Z prometheus_treecache_watcher_goroutines = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_blocks_loaded = 1
2023-10-18T08:37:26.714400407Z prometheus_tsdb_clean_start = 1
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compaction_populating_block = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_data_replay_duration_seconds = 0.00029172900000000001
2023-10-18T08:37:26.714400407Z prometheus_tsdb_exemplar_exemplars_in_storage = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_exemplar_last_exemplars_timestamp_seconds = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_exemplar_max_exemplars = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_exemplar_series_with_exemplars_in_storage = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_active_appenders = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_chunks = 3613
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_chunks_storage_size_bytes = 895108
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_max_time = 1697618237000
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_max_time_seconds = 1697618237
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_min_time = 1697608802001
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_min_time_seconds = 1697608802
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_series = 602
2023-10-18T08:37:26.714400407Z prometheus_tsdb_isolation_high_watermark = 790
2023-10-18T08:37:26.714400407Z prometheus_tsdb_isolation_low_watermark = 790
2023-10-18T08:37:26.714400407Z prometheus_tsdb_lowest_timestamp = 1697606401996
2023-10-18T08:37:26.714400407Z prometheus_tsdb_lowest_timestamp_seconds = 1697606401
2023-10-18T08:37:26.714400407Z prometheus_tsdb_retention_limit_bytes = 0
2023-10-18T08:37:26.714400407Z prometheus_tsdb_storage_blocks_bytes = 240456
2023-10-18T08:37:26.714400407Z prometheus_tsdb_symbol_table_size_bytes = 112
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_segment_current = 1
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_storage_size_bytes = 2411260
2023-10-18T08:37:26.714400407Z promhttp_metric_handler_requests_in_flight = 1
2023-10-18T08:37:26.714400407Z go_gc_duration_seconds = { quantiles = { 0=3.1967e-05, 0.25=8.2527e-05, 0.5=8.5477e-05, 0.75=0.000131563, 1=0.000238116 }, sum=0.0107662, count=105 }
2023-10-18T08:37:26.714400407Z prometheus_engine_query_duration_seconds{slice="inner_eval"} = { quantiles = { 0.5=nan, 0.9=nan, 0.99=nan }, sum=4.739e-06, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_engine_query_duration_seconds{slice="prepare_time"} = { quantiles = { 0.5=0, 0.9=0, 0.99=0 }, sum=4.636e-06, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_engine_query_duration_seconds{slice="queue_time"} = { quantiles = { 0.5=0, 0.9=0, 0.99=0 }, sum=4.7422e-05, count=2 }
2023-10-18T08:37:26.714400407Z prometheus_engine_query_duration_seconds{slice="result_sort"} = { quantiles = { 0.5=0, 0.9=0, 0.99=0 }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_rule_evaluation_duration_seconds = { quantiles = { 0.5=nan, 0.9=nan, 0.99=nan }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_rule_group_duration_seconds = { quantiles = { 0.01=nan, 0.05=nan, 0.5=nan, 0.9=nan, 0.99=nan }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_sd_consul_rpc_duration_seconds{call="service",endpoint="catalog"} = { quantiles = { 0.5=nan, 0.9=nan, 0.99=nan }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_sd_consul_rpc_duration_seconds{call="services",endpoint="catalog"} = { quantiles = { 0.5=0, 0.9=0, 0.99=0 }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_sd_file_scan_duration_seconds = { quantiles = { 0.5=nan, 0.9=nan, 0.99=nan }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_sd_kuma_fetch_duration_seconds = { quantiles = { 0.5=nan, 0.9=nan, 0.99=nan }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_target_interval_length_seconds{interval="15s"} = { quantiles = { 0.01=14.9962, 0.05=14.9967, 0.5=15, 0.9=15.0032, 0.99=15.0033 }, sum=11835, count=789 }
2023-10-18T08:37:26.714400407Z prometheus_target_sync_length_seconds{scrape_job="prometheus"} = { quantiles = { 0.01=nan, 0.05=nan, 0.5=nan, 0.9=nan, 0.99=nan }, sum=0.00023323, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_head_gc_duration_seconds = { quantiles = { }, sum=0.00563568, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_fsync_duration_seconds = { quantiles = { 0.5=nan, 0.9=nan, 0.99=nan }, sum=0.00240361, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_wal_truncate_duration_seconds = { quantiles = { }, sum=0, count=0 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/"} = { buckets = { 0.1=1, 0.2=1, 0.4=1, 1=1, 3=1, 8=1, 20=1, 60=1, 120=1, +Inf=1 }, sum=2.9273e-05, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/-/ready"} = { buckets = { 0.1=1, 0.2=1, 0.4=1, 1=1, 3=1, 8=1, 20=1, 60=1, 120=1, +Inf=1 }, sum=6.978e-06, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/api/v1/label/:name/values"} = { buckets = { 0.1=1, 0.2=1, 0.4=1, 1=1, 3=1, 8=1, 20=1, 60=1, 120=1, +Inf=1 }, sum=0.000688082, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/api/v1/query"} = { buckets = { 0.1=1, 0.2=1, 0.4=1, 1=1, 3=1, 8=1, 20=1, 60=1, 120=1, +Inf=1 }, sum=0.00043749, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/favicon.ico"} = { buckets = { 0.1=1, 0.2=1, 0.4=1, 1=1, 3=1, 8=1, 20=1, 60=1, 120=1, +Inf=1 }, sum=0.000303446, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/graph"} = { buckets = { 0.1=1, 0.2=1, 0.4=1, 1=1, 3=1, 8=1, 20=1, 60=1, 120=1, +Inf=1 }, sum=9.0488e-05, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/metrics"} = { buckets = { 0.1=816, 0.2=816, 0.4=816, 1=816, 3=816, 8=816, 20=816, 60=816, 120=816, +Inf=816 }, sum=4.59003, count=816 }
2023-10-18T08:37:26.714400407Z prometheus_http_request_duration_seconds{handler="/static/*filepath"} = { buckets = { 0.1=2, 0.2=2, 0.4=2, 1=2, 3=2, 8=2, 20=2, 60=2, 120=2, +Inf=2 }, sum=0.0257191, count=2 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/"} = { buckets = { 100=1, 1000=1, 10000=1, 100000=1, 1e+06=1, 1e+07=1, 1e+08=1, 1e+09=1, +Inf=1 }, sum=29, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/-/ready"} = { buckets = { 100=1, 1000=1, 10000=1, 100000=1, 1e+06=1, 1e+07=1, 1e+08=1, 1e+09=1, +Inf=1 }, sum=28, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/api/v1/label/:name/values"} = { buckets = { 100=0, 1000=0, 10000=1, 100000=1, 1e+06=1, 1e+07=1, 1e+08=1, 1e+09=1, +Inf=1 }, sum=1634, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/api/v1/query"} = { buckets = { 100=0, 1000=1, 10000=1, 100000=1, 1e+06=1, 1e+07=1, 1e+08=1, 1e+09=1, +Inf=1 }, sum=104, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/favicon.ico"} = { buckets = { 100=0, 1000=0, 10000=0, 100000=1, 1e+06=1, 1e+07=1, 1e+08=1, 1e+09=1, +Inf=1 }, sum=15086, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/graph"} = { buckets = { 100=0, 1000=1, 10000=1, 100000=1, 1e+06=1, 1e+07=1, 1e+08=1, 1e+09=1, +Inf=1 }, sum=734, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/metrics"} = { buckets = { 100=0, 1000=0, 10000=791, 100000=816, 1e+06=816, 1e+07=816, 1e+08=816, 1e+09=816, +Inf=816 }, sum=8.69329e+06, count=816 }
2023-10-18T08:37:26.714400407Z prometheus_http_response_size_bytes{handler="/static/*filepath"} = { buckets = { 100=0, 1000=0, 10000=0, 100000=0, 1e+06=1, 1e+07=2, 1e+08=2, 1e+09=2, +Inf=2 }, sum=2.6914e+06, count=2 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compaction_chunk_range_seconds = { buckets = { 100=0, 400=0, 1600=0, 6400=0, 25600=0, 102400=0, 409600=1, 1.6384e+06=6, 6.5536e+06=607, 2.62144e+07=607, +Inf=607 }, sum=1.43028e+09, count=607 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compaction_chunk_samples = { buckets = { 4=0, 6=0, 9=0, 13.5=0, 20.25=0, 30.375=1, 45.5625=4, 68.3438=5, 102.516=5, 153.773=10, 230.66=607, 345.99=607, +Inf=607 }, sum=95959, count=607 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compaction_chunk_size_bytes = { buckets = { 32=0, 48=0, 72=0, 108=0, 162=0, 243=171, 364.5=557, 546.75=590, 820.125=602, 1230.19=607, 1845.28=607, 2767.92=607, +Inf=607 }, sum=163957, count=607 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_compaction_duration_seconds = { buckets = { 1=1, 2=1, 4=1, 8=1, 16=1, 32=1, 64=1, 128=1, 256=1, 512=1, 1024=1, 2048=1, 4096=1, 8192=1, +Inf=1 }, sum=0.0634981, count=1 }
2023-10-18T08:37:26.714400407Z prometheus_tsdb_tombstone_cleanup_seconds = { buckets = { 0.005=0, 0.01=0, 0.025=0, 0.05=0, 0.1=0, 0.25=0, 0.5=0, 1=0, 2.5=0, 5=0, 10=0, +Inf=0 }, sum=0, count=0 }
[2023/10/18 17:37:28] [debug] [out flush] cb_destroy coro_id=0
[2023/10/18 17:37:28] [debug] [task] destroy task=0x7f8c6c01a490 (task_id=0)
```

<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==110913== 
==110913== HEAP SUMMARY:
==110913==     in use at exit: 0 bytes in 0 blocks
==110913==   total heap usage: 12,170 allocs, 12,170 frees, 3,371,204 bytes allocated
==110913== 
==110913== All heap blocks were freed -- no leaks are possible
==110913== 
==110913== For lists of detected and suppressed errors, rerun with: -s
==110913== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
