### PR TITLE
in_dummy: Add interval settings.

### DIFF
--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -201,6 +201,7 @@ static int configure(struct flb_dummy *ctx,
                      struct timespec *tm)
 {
     const char *msg;
+    double tmfrac;
     int root_type;
     int ret = -1;
 
@@ -214,12 +215,13 @@ static int configure(struct flb_dummy *ctx,
     }
 
     /* interval settings */
-    tm->tv_sec  = 1;
+    tm->tv_sec  = ctx->time_interval;
     tm->tv_nsec = 0;
 
     if (ctx->rate > 1) {
-        tm->tv_sec = 0;
-        tm->tv_nsec = 1000000000 / ctx->rate;
+        tmfrac = (double) ctx->time_interval / ctx->rate;
+        tm->tv_sec = tmfrac;
+        tm->tv_nsec = (tmfrac - (int) tmfrac) * 1000000000;
     }
 
     /* dummy timestamp */
@@ -398,7 +400,12 @@ static struct flb_config_map config_map[] = {
    {
     FLB_CONFIG_MAP_INT, "rate", "1",
     0, FLB_TRUE, offsetof(struct flb_dummy, rate),
-    "set a number of events per second."
+    "set a number of events per time interval."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "time_interval", "1",
+    0, FLB_TRUE, offsetof(struct flb_dummy, time_interval),
+    "set time interval to generate logs at the set rate."
    },
    {
     FLB_CONFIG_MAP_INT, "copies", "1",

--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -201,7 +201,8 @@ static int configure(struct flb_dummy *ctx,
                      struct timespec *tm)
 {
     const char *msg;
-    double tmfrac;
+    double tm_interval_fractional;
+    int tm_interval_seconds;
     int root_type;
     int ret = -1;
 
@@ -219,9 +220,10 @@ static int configure(struct flb_dummy *ctx,
     tm->tv_nsec = 0;
 
     if (ctx->rate > 1) {
-        tmfrac = (double) ctx->time_interval / ctx->rate;
-        tm->tv_sec = tmfrac;
-        tm->tv_nsec = (tmfrac - (int) tmfrac) * 1000000000;
+        tm_interval_fractional = (double) ctx->time_interval / ctx->rate;
+        tm_interval_seconds = (int) tm_interval_fractional;
+        tm->tv_sec = tm_interval_seconds;
+        tm->tv_nsec = (tm_interval_fractional - tm_interval_seconds) * 1000000000;
     }
 
     /* dummy timestamp */

--- a/plugins/in_dummy/in_dummy.h
+++ b/plugins/in_dummy/in_dummy.h
@@ -26,6 +26,9 @@
 
 #define DEFAULT_DUMMY_MESSAGE  "{\"message\":\"dummy\"}"
 #define DEFAULT_DUMMY_METADATA "{}"
+#define DEFAULT_RATE  "1"
+#define DEFAULT_INTERVAL_SEC "0"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 struct flb_dummy {
     int  coll_fd;
@@ -34,7 +37,8 @@ struct flb_dummy {
     int  copies;
     int  samples;
     int  samples_count;
-    int  time_interval;
+    int  interval_sec;
+    int  interval_nsec;
 
     int dummy_timestamp_set;
     struct flb_time base_timestamp;

--- a/plugins/in_dummy/in_dummy.h
+++ b/plugins/in_dummy/in_dummy.h
@@ -34,6 +34,7 @@ struct flb_dummy {
     int  copies;
     int  samples;
     int  samples_count;
+    int  time_interval;
 
     int dummy_timestamp_set;
     struct flb_time base_timestamp;

--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -340,8 +340,8 @@ void do_test_records_wait_time(char *system, int wait_time, void (*records_cb)(s
     /* Start test */
     TEST_CHECK(flb_start(ctx) == 0);
 
-    /* Set wait_time plus 4 sec passed. It must have flushed */
-    sleep(wait_time + 4);
+    /* Set wait_time plus 2 sec passed. It must have flushed */
+    sleep(wait_time + 2);
 
     records_cb(records);
 
@@ -533,17 +533,12 @@ void flb_test_dummy_records_message_copies_100(struct callback_records *records)
     TEST_CHECK(records->num_records >= 100);
 }
 
-void flb_test_dummy_records_message_time_interval_3_rate_1(struct callback_records *records)
+void flb_test_dummy_records_message_time_interval_2_rate_5(struct callback_records *records)
 {
-    TEST_CHECK(records->num_records >= 1);
+    TEST_CHECK(records->num_records >= 5);
 }
 
-void flb_test_dummy_records_message_time_interval_3_rate_10(struct callback_records *records)
-{
-    TEST_CHECK(records->num_records >= 10);
-}
-
-void flb_test_dummy_records_message_time_interval_6_rate_100(struct callback_records *records)
+void flb_test_dummy_records_message_time_interval_3_rate_100(struct callback_records *records)
 {
     TEST_CHECK(records->num_records >= 100);
 }
@@ -578,16 +573,12 @@ void flb_test_in_dummy_flush()
     do_test_records_single("dummy", flb_test_dummy_records_message_copies_100,
                     "copies", "100",
                     NULL);
-    do_test_records_wait_time("dummy", 3, flb_test_dummy_records_message_time_interval_3_rate_1,
-                    "time_interval", "3",
-                    "rate", "1",
+    do_test_records_wait_time("dummy", 2, flb_test_dummy_records_message_time_interval_2_rate_5,
+                    "time_interval", "2",
+                    "rate", "5",
                     NULL);
-    do_test_records_wait_time("dummy", 3, flb_test_dummy_records_message_time_interval_3_rate_10,
+    do_test_records_wait_time("dummy", 3, flb_test_dummy_records_message_time_interval_3_rate_100,
                     "time_interval", "3",
-                    "rate", "10",
-                    NULL);
-    do_test_records_wait_time("dummy", 6, flb_test_dummy_records_message_time_interval_6_rate_100,
-                    "time_interval", "6",
                     "rate", "100",
                     NULL);
 }

--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -294,6 +294,68 @@ void do_test_records_single(char *system, void (*records_cb)(struct callback_rec
     flb_destroy(ctx);
 }
 
+void do_test_records_wait_time(char *system, int wait_time, void (*records_cb)(struct callback_records *), ...)
+{
+    flb_ctx_t    *ctx    = NULL;
+    int in_ffd;
+    int out_ffd;
+    va_list va;
+    char *key;
+    char *value;
+    int i;
+    struct flb_lib_out_cb cb;
+    struct callback_records *records;
+
+    records = flb_calloc(1, sizeof(struct callback_records));
+    records->num_records = 0;
+    records->records = NULL;
+    cb.cb   = callback_add_record;
+    cb.data = (void *)records;
+
+    /* initialize */
+    set_result(0);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) system, NULL);
+    TEST_CHECK(in_ffd >= 0);
+    TEST_CHECK(flb_input_set(ctx, in_ffd, "tag", "test", NULL) == 0);
+
+    va_start(va, records_cb);
+    while ((key = va_arg(va, char *))) {
+        value = va_arg(va, char *);
+        TEST_CHECK(value != NULL);
+        TEST_CHECK(flb_input_set(ctx, in_ffd, key, value, NULL) == 0);
+    }
+    va_end(va);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "test", NULL) == 0);
+
+    TEST_CHECK(flb_service_set(ctx, "Flush", "1",
+                                    "Grace", "1",
+                                    NULL) == 0);
+
+    /* Start test */
+    TEST_CHECK(flb_start(ctx) == 0);
+
+    /* Set wait_time plus 4 sec passed. It must have flushed */
+    sleep(wait_time + 4);
+
+    records_cb(records);
+
+    flb_stop(ctx);
+
+    for (i = 0; i < records->num_records; i++) {
+        flb_lib_free(records->records[i].data);
+    }
+    flb_free(records->records);
+    flb_free(records);
+
+    flb_destroy(ctx);
+}
+
 void flb_test_in_disk_flush()
 {
     do_test("disk",
@@ -471,6 +533,21 @@ void flb_test_dummy_records_message_copies_100(struct callback_records *records)
     TEST_CHECK(records->num_records >= 100);
 }
 
+void flb_test_dummy_records_message_time_interval_3_rate_1(struct callback_records *records)
+{
+    TEST_CHECK(records->num_records >= 1);
+}
+
+void flb_test_dummy_records_message_time_interval_3_rate_10(struct callback_records *records)
+{
+    TEST_CHECK(records->num_records >= 10);
+}
+
+void flb_test_dummy_records_message_time_interval_6_rate_100(struct callback_records *records)
+{
+    TEST_CHECK(records->num_records >= 100);
+}
+
 void flb_test_in_dummy_flush()
 {
     do_test("dummy", NULL);
@@ -493,14 +570,26 @@ void flb_test_in_dummy_flush()
                     "fixed_timestamp", "on",
                     NULL);
     do_test_records_single("dummy", flb_test_dummy_records_message_copies_1,
-	                   "copies", "1",
-	                   NULL);
+                    "copies", "1",
+                    NULL);
     do_test_records_single("dummy", flb_test_dummy_records_message_copies_5,
-	                   "copies", "5",
-	                   NULL);
+                    "copies", "5",
+                    NULL);
     do_test_records_single("dummy", flb_test_dummy_records_message_copies_100,
-	                   "copies", "100",
-	                   NULL);
+                    "copies", "100",
+                    NULL);
+    do_test_records_wait_time("dummy", 3, flb_test_dummy_records_message_time_interval_3_rate_1,
+                    "time_interval", "3",
+                    "rate", "1",
+                    NULL);
+    do_test_records_wait_time("dummy", 3, flb_test_dummy_records_message_time_interval_3_rate_10,
+                    "time_interval", "3",
+                    "rate", "10",
+                    NULL);
+    do_test_records_wait_time("dummy", 6, flb_test_dummy_records_message_time_interval_6_rate_100,
+                    "time_interval", "6",
+                    "rate", "100",
+                    NULL);
 }
 
 void flb_test_in_dummy_thread_flush()

--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -533,14 +533,19 @@ void flb_test_dummy_records_message_copies_100(struct callback_records *records)
     TEST_CHECK(records->num_records >= 100);
 }
 
-void flb_test_dummy_records_message_time_interval_2_rate_5(struct callback_records *records)
+void flb_test_dummy_records_message_rate(struct callback_records *records)
 {
-    TEST_CHECK(records->num_records >= 5);
+    TEST_CHECK(records->num_records >= 20);
 }
 
-void flb_test_dummy_records_message_time_interval_3_rate_100(struct callback_records *records)
+void flb_test_dummy_records_message_interval_sec(struct callback_records *records)
 {
-    TEST_CHECK(records->num_records >= 100);
+    TEST_CHECK(records->num_records >= 1);
+}
+
+void flb_test_dummy_records_message_interval_nsec(struct callback_records *records)
+{
+    TEST_CHECK(records->num_records >= 1);
 }
 
 void flb_test_in_dummy_flush()
@@ -573,13 +578,16 @@ void flb_test_in_dummy_flush()
     do_test_records_single("dummy", flb_test_dummy_records_message_copies_100,
                     "copies", "100",
                     NULL);
-    do_test_records_wait_time("dummy", 2, flb_test_dummy_records_message_time_interval_2_rate_5,
-                    "time_interval", "2",
-                    "rate", "5",
+    do_test_records_wait_time("dummy", 1, flb_test_dummy_records_message_rate,
+                    "rate", "20",
                     NULL);
-    do_test_records_wait_time("dummy", 3, flb_test_dummy_records_message_time_interval_3_rate_100,
-                    "time_interval", "3",
-                    "rate", "100",
+    do_test_records_wait_time("dummy", 2, flb_test_dummy_records_message_interval_sec,
+                    "interval_sec", "2",
+                    "interval_nsec", "0",
+                    NULL);
+    do_test_records_wait_time("dummy", 1, flb_test_dummy_records_message_interval_nsec,
+                    "interval_sec", "0",
+                    "interval_nsec", "700000000",
                     NULL);
 }
 


### PR DESCRIPTION
This PR adds new `interval_sec` and `interval_nsec` settings to the `in_dummy` input plugin. This settings enable to set an arbitrary time interval in which to generate dummy logs. When `interval_sec/nsec` is set correctly, the `rate` configuration is ignored.
Documentation update in https://github.com/fluent/fluent-bit-docs/pull/1239.

### Configuration
```
[INPUT]
    Name          dummy
    Dummy         {"message": "custom dummy"}
    Interval_sec  1
    Interval_nsec 500000000
    Rate          0

[OUTPUT]
    Name   stdout
    Match  *
```

### Output Log
With this config a log message is generated every 1.5 seconds).

```
./fluent-bit -c fluent-bit.conf
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/27 18:06:56] [ info] [fluent bit] version=2.2.0, commit=785f45a16d, pid=1533032
[2023/10/27 18:06:56] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/27 18:06:56] [ info] [cmetrics] version=0.6.3
[2023/10/27 18:06:56] [ info] [ctraces ] version=0.3.1
[2023/10/27 18:06:56] [ info] [input:dummy:dummy.0] initializing
[2023/10/27 18:06:56] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/10/27 18:06:56] [ info] [sp] stream processor started
[2023/10/27 18:06:56] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [[1698430017.644439396, {}], {"message"=>"custom dummy"}]
[0] dummy.0: [[1698430019.144370981, {}], {"message"=>"custom dummy"}]
[0] dummy.0: [[1698430020.644434995, {}], {"message"=>"custom dummy"}]
[0] dummy.0: [[1698430022.144357678, {}], {"message"=>"custom dummy"}]
^C[2023/10/27 18:07:03] [engine] caught signal (SIGINT)
[2023/10/27 18:07:03] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/27 18:07:03] [ info] [input] pausing dummy.0
[2023/10/27 18:07:03] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/27 18:07:03] [ info] [input] pausing dummy.0
[2023/10/27 18:07:03] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/27 18:07:03] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

### Valgrind Output
```
valgrind --leak-check=yes ./fluent-bit   --config ./fluent-bit.conf
==1533023== Memcheck, a memory error detector
==1533023== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1533023== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==1533023== Command: ./fluent-bit --config ./fluent-bit.conf
==1533023==
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/27 18:06:01] [ info] [fluent bit] version=2.2.0, commit=785f45a16d, pid=1533023
[2023/10/27 18:06:01] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/27 18:06:01] [ info] [cmetrics] version=0.6.3
[2023/10/27 18:06:01] [ info] [ctraces ] version=0.3.1
[2023/10/27 18:06:01] [ info] [input:dummy:dummy.0] initializing
[2023/10/27 18:06:01] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/10/27 18:06:01] [ info] [sp] stream processor started
[2023/10/27 18:06:01] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [[1698429961.660134534, {}], {"message"=>"custom dummy"}]
[0] dummy.0: [[1698429963.144432977, {}], {"message"=>"custom dummy"}]
[0] dummy.0: [[1698429964.644634450, {}], {"message"=>"custom dummy"}]
[0] dummy.0: [[1698429966.144556969, {}], {"message"=>"custom dummy"}]
^C[2023/10/27 18:06:07] [engine] caught signal (SIGINT)
[2023/10/27 18:06:07] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/27 18:06:07] [ info] [input] pausing dummy.0
[2023/10/27 18:06:07] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/27 18:06:07] [ info] [input] pausing dummy.0
[2023/10/27 18:06:07] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/27 18:06:07] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==1533023==
==1533023== HEAP SUMMARY:
==1533023==     in use at exit: 0 bytes in 0 blocks
==1533023==   total heap usage: 1,716 allocs, 1,716 frees, 1,779,752 bytes allocated
==1533023==
==1533023== All heap blocks were freed -- no leaks are possible
==1533023==
==1533023== For lists of detected and suppressed errors, rerun with: -s
==1533023== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
