### PR TITLE
in_tail: Preventing incorrect inode usage from db. #8025

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -372,6 +372,15 @@ static int in_tail_init(struct flb_input_instance *in,
     /* Scan path */
     flb_tail_scan(ctx->path_list, ctx);
 
+#ifdef FLB_HAVE_SQLDB
+    /* Delete stale files that are not monitored from the database */
+    ret = flb_tail_db_stale_file_delete(in, config, ctx);
+    if (ret == -1) {
+        flb_tail_config_destroy(ctx);
+        return -1;
+    }
+#endif
+
     /*
      * After the first scan (on start time), all new files discovered needs to be
      * read from head, so we switch the 'read_from_head' flag to true so any

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -734,6 +734,14 @@ static struct flb_config_map config_map[] = {
      "provides higher performance. Note that WAL is not compatible with "
      "shared network file systems."
     },
+    {
+     FLB_CONFIG_MAP_BOOL, "db.compare_filename", "false",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, compare_filename),
+     "This option determines whether to check both the inode and the filename "
+     "when retrieving file information from the db."
+     "'true' verifies both the inode and filename, while 'false' checks only "
+     "the inode (default)."
+    },
 #endif
 
     /* Multiline Options */

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -107,6 +107,7 @@ struct flb_tail_config {
     struct flb_sqldb *db;
     int db_sync;
     int db_locking;
+    int compare_filename;
     flb_sds_t db_journal_mode;
     sqlite3_stmt *stmt_get_file;
     sqlite3_stmt *stmt_insert_file;

--- a/plugins/in_tail/tail_db.h
+++ b/plugins/in_tail/tail_db.h
@@ -40,4 +40,7 @@ int flb_tail_db_file_rotate(const char *new_name,
                             struct flb_tail_config *ctx);
 int flb_tail_db_file_delete(struct flb_tail_file *file,
                             struct flb_tail_config *ctx);
+int flb_tail_db_stale_file_delete(struct flb_input_instance *ins,
+                                  struct flb_config *config,
+                                  struct flb_tail_config *ctx);
 #endif

--- a/plugins/in_tail/tail_sql.h
+++ b/plugins/in_tail/tail_sql.h
@@ -53,6 +53,28 @@
 #define SQL_DELETE_FILE                                                 \
     "DELETE FROM in_tail_files WHERE id=@id;"
 
+#define SQL_STMT_START_PARAM "(?"
+#define SQL_STMT_START_PARAM_LEN (sizeof(SQL_STMT_START_PARAM) - 1)
+
+#define SQL_STMT_ADD_PARAM ",?"
+#define SQL_STMT_ADD_PARAM_LEN (sizeof(SQL_STMT_ADD_PARAM) - 1)
+
+#define SQL_STMT_PARAM_END ")"
+#define SQL_STMT_PARAM_END_LEN (sizeof(SQL_STMT_PARAM_END) - 1)
+
+#define SQL_STMT_END ";"
+#define SQL_STMT_END_LEN (sizeof(SQL_STMT_END) - 1)
+
+#define SQL_DELETE_STALE_FILE_START                                     \
+    "DELETE FROM in_tail_files "
+#define SQL_DELETE_STALE_FILE_START_LEN                                 \
+    (sizeof(SQL_DELETE_STALE_FILE_START) - 1)
+
+#define SQL_DELETE_STALE_FILE_WHERE                                     \
+    "WHERE inode NOT IN "
+#define SQL_DELETE_STALE_FILE_WHERE_LEN                                 \
+    (sizeof(SQL_DELETE_STALE_FILE_WHERE) - 1)
+
 #define SQL_PRAGMA_SYNC                         \
     "PRAGMA synchronous=%i;"
 

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -1545,6 +1545,194 @@ void flb_test_db()
     test_tail_ctx_destroy(ctx);
     unlink(db);
 }
+
+void flb_test_db_delete_stale_file()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *org_file[] = {"test_db.log", "test_db_stale.log"};
+    char *tmp_file[] = {"test_db.log"};
+    char *path = "test_db.log, test_db_stale.log";
+    char *move_file[] = {"test_db_stale.log", "test_db_stale_new.log"};
+    char *new_file[] = {"test_db.log", "test_db_stale_new.log"};
+    char *new_path = "test_db.log, test_db_stale_new.log";
+    char *db = "test_db.db";
+    char *msg_init = "hello world";
+    char *msg_end = "hello db end";
+    int i;
+    int ret;
+    int num;
+    int unused;
+
+    unlink(db);
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data,
+                               &org_file[0],
+                               sizeof(org_file)/sizeof(char *),
+                               FLB_FALSE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->o_ffd,
+                        "path", path,
+                        "read_from_head", "true",
+                        "db", db,
+                        "db.sync", "full",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ret = write_msg(ctx, msg_init, strlen(msg_init));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        unlink(db);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no output");
+    }
+
+    if (ctx->fds != NULL) {
+        for (i=0; i<ctx->fd_num; i++) {
+            close(ctx->fds[i]);
+        }
+        flb_free(ctx->fds);
+    }
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+
+    /* re-init to use db */
+    clear_output_num();
+
+    /*
+     * Changing the file name from 'test_db_stale.log' to
+     * 'test_db_stale_new.log.' In this scenario, it is assumed that the 
+     * file was deleted after the FluentBit was terminated. However, since
+     * the FluentBit was shutdown, the inode remains in the database.
+     * The reason for renaming is to preserve the existing file for later use.
+     */
+    ret = rename(move_file[0], move_file[1]);
+    TEST_CHECK(ret == 0);
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data,
+                               &tmp_file[0],
+                               sizeof(tmp_file)/sizeof(char *),
+                               FLB_FALSE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        unlink(db);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->o_ffd,
+                        "path", path,
+                        "read_from_head", "true",
+                        "db", db,
+                        "db.sync", "full",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * Start the engine
+     * FluentBit will delete stale inodes.
+     */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    if (ctx->fds != NULL) {
+        for (i=0; i<ctx->fd_num; i++) {
+            close(ctx->fds[i]);
+        }
+        flb_free(ctx->fds);
+    }
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+
+    /* re-init to use db */
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data,
+                               &new_file[0],
+                               sizeof(new_file)/sizeof(char *),
+                               FLB_FALSE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        unlink(db);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->o_ffd,
+                        "path", new_path,
+                        "read_from_head", "true",
+                        "db", db,
+                        "db.sync", "full",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    /*
+     * Start the engine
+     * 'test_db_stale_new.log.' is a new file.
+     * The inode of 'test_db_stale.log' was deleted previously.
+     * So, it reads from the beginning of the file.
+     */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg_end, strlen(msg_end));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        unlink(db);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 3))  {
+        /* 3 = 
+         * test_db.log : "hello db end"
+         * test_db_stale.log : "msg_init" + "hello db end"
+         */
+        TEST_MSG("num error. expect=3 got=%d", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+    unlink(db);
+}
 #endif /* FLB_HAVE_SQLDB */
 
 /* Test list */
@@ -1569,6 +1757,7 @@ TEST_LIST = {
 
 #ifdef FLB_HAVE_SQLDB
     {"db", flb_test_db},
+    {"db_delete_stale_file", flb_test_db_delete_stale_file},
 #endif
 
 #ifdef in_tail


### PR DESCRIPTION
<!-- Provide summary of changes -->

Preventing incorrect inode usage from db.

The first commit involves deleting items that are not being monitored by Fluent-Bit when it starts.

The second commit involves considering already running Fluent-Bit instances, preventing incorrect inode usage during execution.
This commit is more about enhancement option than fixing a bug. That's why 'true' and 'false' may be needed depending on the user's use case.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8025

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

- fluent-bit-test.conf

```

[SERVICE]
    flush        1
    daemon       Off
    log_level    info

    parsers_file parsers.conf
    plugins_file plugins.conf
    storage.metrics on
    storage.path /tmp/storage
    storage.sync normal
    storage.checksum off
    storage.backlog.mem_limit 5M

[INPUT]
    Name tail
    Path /tmp/testing/bulk*
    Exclude_Path *.gz,*.zip
    log_level    info
    Offset_Key   offset

    Read_from_Head true
    Refresh_Interval 1
    Rotate_Wait 1
    Inotify_Watcher false
    
    storage.type filesystem
    storage.pause_on_chunks_overlimit true

    DB /tmp/input.db
    DB.sync normal
    DB.locking false
    # new config
    DB.compare_filename true

[OUTPUT]
    name  stdout
    match *

```

- gen.sh
To account for situations where file events may not be properly detected, the creation and deletion process is repeated without using 'sleep'.
```

#!/bin/bash

max_iterations=100000

for ((iteration = 1; iteration <= max_iterations; iteration++)); do
    start_range=$((($iteration - 1) * 100 + 1))
    end_range=$(($iteration * 100))

    for i in $(seq $start_range $end_range); do
        filename="bulk$i.log"
        echo "$i." >> "$filename"
        stat -c%i "$filename"
    done

    sleep 0

    for i in $(seq $start_range $end_range); do
        filename="bulk$i.log"
        rm "$filename"
    done
done

```

- (1/2) delete stale inode from db
```
mkdir -p  /tmp/testing/
cd /tmp/testing/
rm -f /tmp/input.db
rm -f /tmp/testing/*.log

# fluentbit start
/opt/fluent-bit/bin/fluent-bit_fixed -c /opt/fluent-bit/etc/fluent-bit/fluent-bit-test.conf

# write
echo "1" > /tmp/testing/bulk.log;stat -c %i /tmp/testing/bulk.log

# fluentbit stop

# logroate and create new one.
rm -f /tmp/testing/bulk.log

# fluentbit start
/opt/fluent-bit/bin/fluent-bit_fixed -c /opt/fluent-bit/etc/fluent-bit/fluent-bit-test.conf

# log
[2023/10/19 05:50:40] [ info] [input:tail:tail.0] db: delete unmonitored stale inodes from the database: count=1

```

- (2/2) If the filename differs when retrieving the inode from the database, the inode is deleted.
```
mkdir -p  /tmp/testing/
cd /tmp/testing/
rm -f /tmp/input.db
rm -f /tmp/testing/*.log

# fluentbit start
/opt/fluent-bit/bin/fluent-bit_fixed -c /opt/fluent-bit/etc/fluent-bit/fluent-bit-test.conf

# run gen script
while true; do sh ./gen.sh; sleep 0; done

# log
# Fluentbit can read or may fail to read, but it must not read incorrectly.
[2023/10/19 06:24:14] [ info] [input:tail:tail.0] db: exists stale file from database: id=19 inode=4491280 offset=5 name=/tmp/testing/bulk126.log file_inode=4491280 file_name=/tmp/testing/bulk925.log
[2023/10/19 06:24:14] [ info] [input:tail:tail.0] db: stale file deleted from database: id=19
[2023/10/19 06:24:14] [ info] [input:tail:tail.0] db: exists stale file from database: id=20 inode=4491305 offset=5 name=/tmp/testing/bulk127.log file_inode=4491305 file_name=/tmp/testing/bulk926.log
[2023/10/19 06:24:14] [ info] [input:tail:tail.0] db: stale file deleted from database: id=20
```

- [x] Debug log output from testing the change

```
(1/2) commit
[2023/10/19 05:13:58] [ info] [input:tail:tail.0] db: delete unmonitored stale inodes from the database: count=1
```

```
(2/2) commit
[2023/10/19 05:14:03] [ info] [input:tail:tail.0] db: exists stale file from database: id=1 inode=29632163 offset=12 name=test_db.log file_inode=29632163 file_name=test_db_moved.log
[2023/10/19 05:14:03] [ info] [input:tail:tail.0] db: stale file deleted from database: id=1
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
valgrind --leak-check=full ./bin/flb-rt-in_tail
...
==120724== HEAP SUMMARY:
==120724==     in use at exit: 0 bytes in 0 blocks
==120724==   total heap usage: 98,919 allocs, 98,919 frees, 32,217,198 bytes allocated
==120724== 
==120724== All heap blocks were freed -- no leaks are possible
==120724== 
==120724== For lists of detected and suppressed errors, rerun with: -s
==120724== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [`N/A`] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [`N/A`] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
[#1238](https://github.com/fluent/fluent-bit-docs/pull/1238)

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [`N/A`] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
