### PR TITLE
engine: output: Add metrics for displaying the available capacity of chunks as percent

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -365,6 +365,8 @@ struct flb_output_instance {
     struct cmt_gauge   *cmt_upstream_total_connections;
     /* m: output_upstream_busy_connections */
     struct cmt_gauge   *cmt_upstream_busy_connections;
+    /* m: output_chunk_available_capacity_percent */
+    struct cmt_gauge   *cmt_chunk_available_capacity_percent;
 
     /* OLD Metrics API */
 #ifdef FLB_HAVE_METRICS

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -209,7 +209,9 @@ static inline int handle_input_event(flb_pipefd_t fd, uint64_t ts,
 
 static inline double calculate_chunk_capacity_percent(struct flb_output_instance *ins)
 {
-    if (ins->total_limit_size == -1) {
+    /* Currently, total_limit_size 0(K|M)B will be translated as no
+     * limit. So, we need to handle this situation to be unlimited. */
+    if (ins->total_limit_size <= 0) {
         return 100.0;
     }
 

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -207,6 +207,16 @@ static inline int handle_input_event(flb_pipefd_t fd, uint64_t ts,
     return 0;
 }
 
+static inline double calculate_chunk_capacity_percent(struct flb_output_instance *ins)
+{
+    if (ins->total_limit_size == -1) {
+        return 100.0;
+    }
+
+    return 100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
+                  ((double)ins->total_limit_size));
+}
+
 static inline int handle_output_event(uint64_t ts,
                                       struct flb_config *config,
                                       uint64_t val)
@@ -313,8 +323,7 @@ static inline int handle_output_event(uint64_t ts,
         }
 
         cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
-                      (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
-                              ((double)ins->total_limit_size))),
+                      calculate_chunk_capacity_percent(ins),
                       1, (char *[]) {name});
 
         flb_task_retry_clean(task, ins);
@@ -327,8 +336,7 @@ static inline int handle_output_event(uint64_t ts,
                             1, (char *[]) {name});
 
             cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
-                          (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
-                                  ((double)ins->total_limit_size))),
+                          calculate_chunk_capacity_percent(ins),
                           1, (char *[]) {name});
 
             /* OLD metrics API */
@@ -364,8 +372,7 @@ static inline int handle_output_event(uint64_t ts,
                             1, (char *[]) {name});
 
             cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
-                          (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
-                                  ((double)ins->total_limit_size))),
+                          calculate_chunk_capacity_percent(ins),
                           1, (char *[]) {name});
 
             /* OLD metrics API */
@@ -425,8 +432,7 @@ static inline int handle_output_event(uint64_t ts,
                             1, (char *[]) {name});
 
             cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
-                          (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
-                                  ((double)ins->total_limit_size))),
+                          calculate_chunk_capacity_percent(ins),
                           1, (char *[]) {name});
 
             /* OLD metrics API: update the metrics since a new retry is coming */
@@ -443,8 +449,7 @@ static inline int handle_output_event(uint64_t ts,
                         1, (char *[]) {name});
 
         cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
-                      (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
-                              ((double)ins->total_limit_size))),
+                      calculate_chunk_capacity_percent(ins),
                       1, (char *[]) {name});
 
         /* OLD API */

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -312,6 +312,11 @@ static inline int handle_output_event(uint64_t ts,
                      flb_output_name(ins), out_id);
         }
 
+        cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
+                      (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
+                              ((double)ins->total_limit_size))),
+                      1, (char *[]) {name});
+
         flb_task_retry_clean(task, ins);
         flb_task_users_dec(task, FLB_TRUE);
     }
@@ -320,6 +325,11 @@ static inline int handle_output_event(uint64_t ts,
             /* cmetrics: output_dropped_records_total */
             cmt_counter_add(ins->cmt_dropped_records, ts, task->records,
                             1, (char *[]) {name});
+
+            cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
+                          (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
+                                  ((double)ins->total_limit_size))),
+                          1, (char *[]) {name});
 
             /* OLD metrics API */
 #ifdef FLB_HAVE_METRICS
@@ -352,6 +362,11 @@ static inline int handle_output_event(uint64_t ts,
             cmt_counter_inc(ins->cmt_retries_failed, ts, 1, (char *[]) {name});
             cmt_counter_add(ins->cmt_dropped_records, ts, task->records,
                             1, (char *[]) {name});
+
+            cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
+                          (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
+                                  ((double)ins->total_limit_size))),
+                          1, (char *[]) {name});
 
             /* OLD metrics API */
 #ifdef FLB_HAVE_METRICS
@@ -409,6 +424,11 @@ static inline int handle_output_event(uint64_t ts,
             cmt_counter_add(ins->cmt_retried_records, ts, task->records,
                             1, (char *[]) {name});
 
+            cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
+                          (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
+                                  ((double)ins->total_limit_size))),
+                          1, (char *[]) {name});
+
             /* OLD metrics API: update the metrics since a new retry is coming */
 #ifdef FLB_HAVE_METRICS
             flb_metrics_sum(FLB_METRIC_OUT_RETRY, 1, ins->metrics);
@@ -421,6 +441,11 @@ static inline int handle_output_event(uint64_t ts,
         cmt_counter_inc(ins->cmt_errors, ts, 1, (char *[]) {name});
         cmt_counter_add(ins->cmt_dropped_records, ts, task->records,
                         1, (char *[]) {name});
+
+        cmt_gauge_set(ins->cmt_chunk_available_capacity_percent, ts,
+                      (100 * (1.0 - (ins->fs_backlog_chunks_size + ins->fs_chunks_size)/
+                              ((double)ins->total_limit_size))),
+                      1, (char *[]) {name});
 
         /* OLD API */
 #ifdef FLB_HAVE_METRICS

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1200,6 +1200,18 @@ int flb_output_init_all(struct flb_config *config)
                       0,
                       1, (char *[]) {name});
 
+        /* output_chunk_available_capacity_percent */
+        ins->cmt_chunk_available_capacity_percent = cmt_gauge_create(ins->cmt,
+                                                        "fluentbit",
+                                                        "output",
+                                                        "chunk_available_capacity_percent",
+                                                        "Available chunk capacity (percent)",
+                                                        1, (char *[]) {"name"});
+        cmt_gauge_set(ins->cmt_chunk_available_capacity_percent,
+                      ts,
+                      100.0,
+                      1, (char *[]) {name});
+
         /* old API */
         ins->metrics = flb_metrics_create(name);
         if (ins->metrics) {


### PR DESCRIPTION
Currently, the capacity of chunks are not explicitly collected in metrics of fluent bit. This should be collected and described for non fluent-bit expert. Note that the capacity of chunks as percent should be collected per plugins. This is because Fluent Bit can set up different capacity of total limit of chunks per plugin.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change

```ini
[SERVICE]
    HTTP_Server On
    HTTP_Port 2021
    Hot_Reload On
    Log_Level debug

[INPUT]
    Name dummy
    rate 1000

[OUTPUT]
    Name http
    storage.total_limit_size 1MB
```
- [x] Debug log output from testing the change

<details>

```log
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/19 18:48:15] [ info] Configuration:
[2023/10/19 18:48:15] [ info]  flush time     | 1.000000 seconds
[2023/10/19 18:48:15] [ info]  grace          | 5 seconds
[2023/10/19 18:48:15] [ info]  daemon         | 0
[2023/10/19 18:48:15] [ info] ___________
[2023/10/19 18:48:15] [ info]  inputs:
[2023/10/19 18:48:15] [ info]      dummy
[2023/10/19 18:48:15] [ info] ___________
[2023/10/19 18:48:15] [ info]  filters:
[2023/10/19 18:48:15] [ info] ___________
[2023/10/19 18:48:15] [ info]  outputs:
[2023/10/19 18:48:15] [ info]      http.0
[2023/10/19 18:48:15] [ info] ___________
[2023/10/19 18:48:15] [ info]  collectors:
[2023/10/19 18:48:15] [ info] [fluent bit] version=2.2.0, commit=92b9053a54, pid=75696
[2023/10/19 18:48:15] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2023/10/19 18:48:15] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/19 18:48:15] [ info] [cmetrics] version=0.6.3
[2023/10/19 18:48:15] [ info] [ctraces ] version=0.3.1
[2023/10/19 18:48:15] [ info] [input:dummy:dummy.0] initializing
[2023/10/19 18:48:15] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/10/19 18:48:15] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2023/10/19 18:48:15] [debug] [http:http.0] created event channels: read=23 write=24
[2023/10/19 18:48:15] [ info] [output:http:http.0] worker #0 started
[2023/10/19 18:48:15] [ info] [output:http:http.0] worker #1 started
[2023/10/19 18:48:15] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2021
[2023/10/19 18:48:15] [ info] [sp] stream processor started
[2023/10/19 18:48:15] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/10/19 18:48:15] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
<snip>
```

</details>

This newly added metrics should be collected as follows after some of the period of runing:

```log
% curl localhost:2021/api/v2/metrics                                                                                                                                                   
2023-10-19T09:41:49.595623923Z fluentbit_uptime{hostname="Hiroshi-no-MacBook-Air-M2.local"} = 7
2023-10-19T09:41:49.595350585Z fluentbit_input_bytes_total{name="dummy.0"} = 248724
2023-10-19T09:41:49.595350585Z fluentbit_input_records_total{name="dummy.0"} = 6909
2023-10-19T09:41:42.592963316Z fluentbit_output_proc_records_total{name="http.0"} = 0
2023-10-19T09:41:42.592963316Z fluentbit_output_proc_bytes_total{name="http.0"} = 0
2023-10-19T09:41:42.592963316Z fluentbit_output_errors_total{name="http.0"} = 0
2023-10-19T09:41:48.605878156Z fluentbit_output_retries_total{name="http.0"} = 6
2023-10-19T09:41:42.592963316Z fluentbit_output_retries_failed_total{name="http.0"} = 0
2023-10-19T09:41:42.592963316Z fluentbit_output_dropped_records_total{name="http.0"} = 0
2023-10-19T09:41:48.605878156Z fluentbit_output_retried_records_total{name="http.0"} = 5914
2023-10-19T09:41:49.595623923Z fluentbit_process_start_time_seconds{hostname="Hiroshi-no-MacBook-Air-M2.local"} = 1697708502
2023-10-19T09:41:49.595623923Z fluentbit_build_info{hostname="Hiroshi-no-MacBook-Air-M2.local",version="2.2.0",os="macos"} = 1697708502
2023-10-19T09:41:49.595623923Z fluentbit_hot_reloaded_times{hostname="Hiroshi-no-MacBook-Air-M2.local"} = 0
2023-10-19T09:41:49.595680758Z fluentbit_storage_chunks = 7
2023-10-19T09:41:49.595680758Z fluentbit_storage_mem_chunks = 7
2023-10-19T09:41:49.595680758Z fluentbit_storage_fs_chunks = 0
2023-10-19T09:41:49.595680758Z fluentbit_storage_fs_chunks_up = 0
2023-10-19T09:41:49.595680758Z fluentbit_storage_fs_chunks_down = 0
2023-10-19T09:41:42.592427681Z fluentbit_input_ingestion_paused{name="dummy.0"} = 0
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_overlimit{name="dummy.0"} = 0
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_memory_bytes{name="dummy.0"} = 177156
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_chunks{name="dummy.0"} = 5
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_chunks_up{name="dummy.0"} = 5
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_chunks_down{name="dummy.0"} = 0
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_chunks_busy{name="dummy.0"} = 4
2023-10-19T09:41:47.596394122Z fluentbit_input_storage_chunks_busy_bytes{name="dummy.0"} = 141120
2023-10-19T09:41:49.595606881Z fluentbit_output_upstream_total_connections{name="http.0"} = 1
2023-10-19T09:41:42.592963316Z fluentbit_output_upstream_busy_connections{name="http.0"} = 0
2023-10-19T09:41:48.605878156Z fluentbit_output_chunk_available_capacity_percent{name="http.0"} = 78.673599999999993
```

<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
