### PR TITLE
workflows: update Actuated sizes and use CNCF runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,4 +1,3 @@
 self-hosted-runner:
   labels:
-    - actuated
-    - actuated-aarch64
+    - actuated-arm64-8cpu-16gb

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -106,7 +106,7 @@ jobs:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
     # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-latest usage.
-    runs-on: ${{ (contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit') && 'actuated-aarch64') || 'ubuntu-latest' }}
+    runs-on: ${{ (contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit') && 'actuated-arm64-8cpu-16gb') || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Actuated mirror
         if: contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit')
         uses: self-actuated/hub-mirror@master
-  
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -137,7 +137,7 @@ jobs:
           echo "$INPUT --> $output"
           echo "replaced=$output" >> "$GITHUB_OUTPUT"
         shell: bash
-        env: 
+        env:
           INPUT: ${{ matrix.distro }}
 
       - name: fluent-bit - ${{ matrix.distro }} artifacts


### PR DESCRIPTION
CNCF is sponsoring Actuated runners now so moving to using those instead of the Calyptia-provided ones. Requires tweaking the size of the VMs slightly.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
![Screenshot from 2023-10-20 09-12-25](https://github.com/fluent/fluent-bit/assets/6388272/298977e0-5c49-435b-8e6b-6140232ca3b9)
![Screenshot from 2023-10-20 09-12-14](https://github.com/fluent/fluent-bit/assets/6388272/cd74d2e1-cb71-490e-b18b-cda38da3fe13)


**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
