### PR TITLE
Add expire time to metrics in prometheus_exporter

### DIFF
--- a/include/fluent-bit/flb_hash_table.h
+++ b/include/fluent-bit/flb_hash_table.h
@@ -86,4 +86,6 @@ int flb_hash_table_del(struct flb_hash_table *ht, const char *key);
 int flb_hash_table_del_ptr(struct flb_hash_table *ht, const char *key, int key_len,
                            void *ptr);
 
+void flb_hash_table_clear(struct flb_hash_table *ht);
+
 #endif

--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -97,7 +97,7 @@ static int cb_prom_init(struct flb_output_instance *ins,
     }
 
     /* Hash table for metrics */
-    ctx->ht_metrics = flb_hash_table_create(FLB_HASH_TABLE_EVICT_NONE, 32, 0);
+    ctx->ht_metrics = flb_hash_table_create_with_ttl(ctx->ttl, FLB_HASH_TABLE_EVICT_NONE, 32, 0);
     if (!ctx->ht_metrics) {
         flb_plg_error(ctx->ins, "could not initialize hash table for metrics");
         return -1;
@@ -179,6 +179,9 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     struct cmt *cmt;
     struct prom_exporter *ctx = out_context;
 
+    /* Clear old metrics */
+    flb_hash_table_clear(ctx->ht_metrics);
+
     /*
      * A new set of metrics has arrived, perform decoding, apply labels,
      * convert to Prometheus text format and store the output in the
@@ -229,6 +232,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
 
     /* retrieve a full copy of all metrics */
     metrics = hash_format_metrics(ctx);
+
     if (!metrics) {
         flb_plg_error(ctx->ins, "could not retrieve metrics");
         FLB_OUTPUT_RETURN(FLB_ERROR);
@@ -279,6 +283,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_SLIST_1, "add_label", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct prom_exporter, add_labels),
      "TCP port for listening for HTTP connections."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "ttl", "0s",
+     0, FLB_TRUE, offsetof(struct prom_exporter, ttl),
+     "Expiring time for metrics"
     },
 
     /* EOF */

--- a/plugins/out_prometheus_exporter/prom.h
+++ b/plugins/out_prometheus_exporter/prom.h
@@ -33,6 +33,9 @@ struct prom_exporter {
     /* add timestamp to every metric */
     int add_timestamp;
 
+    /* expiry time for metrics in the hash table */
+    time_t ttl;
+
     /* config reader for 'add_label' */
     struct mk_list *add_labels;
 

--- a/src/flb_hash_table.c
+++ b/src/flb_hash_table.c
@@ -537,3 +537,30 @@ int flb_hash_table_del(struct flb_hash_table *ht, const char *key)
 
     return 0;
 }
+
+void flb_hash_table_clear(struct flb_hash_table *ht)
+{
+    int i;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_hash_table_entry *entry;
+    struct flb_hash_table_chain *table;
+    time_t expiration;
+
+    if (ht->cache_ttl <= 0) {
+        return;
+    }
+
+    for (i = 0; i < ht->size; i++) {
+        table = &ht->table[i];
+        mk_list_foreach_safe(head, tmp, &table->chains) {
+            entry = mk_list_entry(head, struct flb_hash_table_entry, _head);
+            
+            expiration = entry->created + ht->cache_ttl;
+
+            if (time(NULL) > expiration) {
+                flb_hash_table_entry_free(ht, entry);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Add expire time for metrics in prometheus_exporter. 
These improvements are related to the fact that when some data sources are hit, the last value of the metric remains on the graphs, which worsens the understanding of the situation

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
```
[SERVICE]
    flush       1
    log_level   info

[INPUT]
    Name          dummy
    Dummy         {"log": "dummy"}
    tag           dummy

[INPUT]
    Name              tail
    Path              fluent.log
    tag               logs

[FILTER]
    name               log_to_metrics
    tag                metrics
    match              logs
    metric_mode        gauge
    metric_name        message
    metric_description last message
    value_field        log

[FILTER]
    name               log_to_metrics
    tag                metric
    match              dummy
    metric_mode        gauge
    metric_name        dummy-message
    metric_description last dummy-message
    value_field        log

[OUTPUT]
    name            prometheus_exporter
    match           metrics
    host            0.0.0.0
    port            2021
    ttl             10s
```
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
