### PR TITLE
Add interval to dummy events

### DIFF
--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -214,13 +214,19 @@ static int configure(struct flb_dummy *ctx,
     }
 
     /* interval settings */
-    tm->tv_sec  = 1;
-    tm->tv_nsec = 0;
+    if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
+        /* Illegal settings. Override them. */
+        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
+    }
+
+    tm->tv_sec  = ctx->interval_sec;
+    tm->tv_nsec = ctx->interval_nsec;
 
     if (ctx->rate > 1) {
         tm->tv_sec = 0;
         tm->tv_nsec = 1000000000 / ctx->rate;
-    }
+    }     
 
     /* dummy timestamp */
     flb_time_zero(&ctx->dummy_timestamp);
@@ -419,6 +425,16 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_BOOL, "fixed_timestamp", "off",
     0, FLB_TRUE, offsetof(struct flb_dummy, fixed_timestamp),
     "used a fixed timestamp, allows the message to pre-generated once."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,
+    0, FLB_TRUE, offsetof(struct flb_dummy, interval_sec),
+    "Set the collector interval"
+   },
+   {
+    FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
+    0, FLB_TRUE, offsetof(struct flb_dummy, interval_nsec),
+    "Set the collector interval (sub seconds)"
    },
    {0}
 };

--- a/plugins/in_dummy/in_dummy.h
+++ b/plugins/in_dummy/in_dummy.h
@@ -27,6 +27,9 @@
 #define DEFAULT_DUMMY_MESSAGE  "{\"message\":\"dummy\"}"
 #define DEFAULT_DUMMY_METADATA "{}"
 
+#define DEFAULT_INTERVAL_SEC  "1"
+#define DEFAULT_INTERVAL_NSEC "0"
+
 struct flb_dummy {
     int  coll_fd;
 
@@ -34,6 +37,9 @@ struct flb_dummy {
     int  copies;
     int  samples;
     int  samples_count;
+
+    int  interval_sec;
+    int  interval_nsec;
 
     int dummy_timestamp_set;
     struct flb_time base_timestamp;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Add interval option fro dummy input. Main idea is to use it to generate heartbeats of the system (flush outputs).

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
```
[SERVICE]
    flush       1
    log_level   info

[INPUT]
    Name          dummy
    Dummy         {"log": "dummy"}
    Interval_Sec  10
    Interval_NSec 0

[OUTPUT]
    name            stdout
    Match           *
```
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
