### PR TITLE
in_docker: Implement a capability for cgroups V2

### DIFF
--- a/plugins/in_docker/CMakeLists.txt
+++ b/plugins/in_docker/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(src
   docker.c
   cgroup_v1.c
+  cgroup_v2.c
   )
 
 FLB_PLUGIN(in_docker "${src}" "")

--- a/plugins/in_docker/cgroup_v2.c
+++ b/plugins/in_docker/cgroup_v2.c
@@ -1,0 +1,446 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2023 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include <dirent.h>
+#include <string.h>
+#include "docker.h"
+
+/* This method returns list of currently running docker ids. */
+static struct mk_list *get_active_dockers()
+{
+    DIR *dp;
+    struct dirent *ep;
+    struct mk_list *list;
+    docker_info *docker;
+    char *p = NULL;
+    char *container_id = NULL;
+
+    list = flb_malloc(sizeof(struct mk_list));
+    if (!list) {
+        flb_errno();
+        return NULL;
+    }
+    mk_list_init(list);
+
+    dp = opendir(DOCKER_CGROUP_V2_DOCKER_SERVICE_DIR);
+    if (dp != NULL) {
+        ep = readdir(dp);
+
+        while(ep != NULL) {
+            if (ep->d_type == OS_DIR_TYPE) {
+                if (strcmp(ep->d_name, CURRENT_DIR) != 0
+                    && strcmp(ep->d_name, PREV_DIR) != 0
+                    && strlen(ep->d_name) == DOCKER_CGROUP_V2_LONG_ID_LEN) { /* precautionary check */
+
+                    p = strstr(ep->d_name, "-");
+                    if (p == NULL) {
+                        continue;
+                    }
+                    /* get rid of the prefix "-" and the suffix ".scope" */
+                    container_id = strtok(p+1, ".");
+                    if (container_id != NULL) {
+                        docker = in_docker_init_docker_info(container_id);
+                        mk_list_add(&docker->_head, list);
+                    }
+
+                }
+            }
+            ep = readdir(dp);
+        }
+        closedir(dp);
+    }
+
+    return list;
+}
+
+static char *read_line(FILE *fin)
+{
+    char *buffer;
+    char *tmp;
+    int read_chars = 0;
+    int bufsize = 1215;
+    char *line;
+
+    line = (char *) flb_calloc(bufsize, sizeof(char));
+    if (!line) {
+        flb_errno();
+        return NULL;
+    }
+
+    buffer = line;
+
+    while (fgets(buffer, bufsize - read_chars, fin)) {
+        read_chars = strlen(line);
+
+        if (line[read_chars - 1] == '\n') {
+            line[read_chars - 1] = '\0';
+            return line;
+        }
+        else {
+            bufsize = 2 * bufsize;
+            tmp = flb_realloc(line, bufsize);
+            if (!tmp) {
+                flb_errno();
+                return NULL;
+            }
+            else {
+                line = tmp;
+                buffer = line + read_chars;
+            }
+        }
+    }
+
+    flb_free(line);
+    return NULL;
+}
+
+/* This routine returns path to docker's cgroup CPU usage file. */
+static char *get_cpu_used_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(115, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+
+    strcat(path, DOCKER_CGROUP_V2_DOCKER_SERVICE_DIR);
+    strcat(path, "/");
+    strcat(path, "docker-");
+    strcat(path, id);
+    strcat(path, ".scope");
+    strcat(path, "/");
+    strcat(path, DOCKER_CGROUP_V2_CPU_USAGE_FILE);
+
+    return path;
+}
+
+/* This routine returns path to docker's cgroup memory limit file. */
+static char *get_mem_limit_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(121, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+    strcat(path, DOCKER_CGROUP_V2_DOCKER_SERVICE_DIR);
+    strcat(path, "/");
+    strcat(path, "docker-");
+    strcat(path, id);
+    strcat(path, ".scope");
+    strcat(path, "/");
+    strcat(path, DOCKER_CGROUP_V2_MEM_MAX_FILE);
+
+    return path;
+}
+
+/* This routine returns path to docker's cgroup memory used file. */
+static char *get_mem_used_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(121, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+    strcat(path, DOCKER_CGROUP_V2_DOCKER_SERVICE_DIR);
+    strcat(path, "/");
+    strcat(path, "docker-");
+    strcat(path, id);
+    strcat(path, ".scope");
+    strcat(path, "/");
+    strcat(path, DOCKER_CGROUP_V2_MEM_USAGE_FILE);
+
+    return path;
+}
+
+static char *get_config_file(char *id)
+{
+    char *path;
+
+    if (!id) {
+        return NULL;
+    }
+
+    path = (char *) flb_calloc(107, sizeof(char));
+    if (!path) {
+        flb_errno();
+        return NULL;
+    }
+    strcat(path, DOCKER_LIB_ROOT);
+    strcat(path, "/");
+    strcat(path, id);
+    strcat(path, "/");
+    strcat(path, DOCKER_CONFIG_JSON);
+
+    return path;
+}
+
+static char *extract_name(char *line, char *start)
+{
+    int skip = 9;
+    int len = 0;
+    char *name;
+    char buff[256];
+    char *curr;
+
+    if (start != NULL) {
+        curr = start + skip;
+        while (*curr != '"') {
+            buff[len++] = *curr;
+            curr++;
+        }
+
+        if (len > 0) {
+            name = (char *) flb_calloc(len + 1, sizeof(char));
+            if (!name) {
+                flb_errno();
+                return NULL;
+            }
+            memcpy(name, buff, len);
+
+            return name;
+        }
+    }
+
+    return NULL;
+}
+
+static char *get_container_name(struct flb_docker *ctx, char *id)
+{
+    char *container_name = NULL;
+    char *config_file;
+    FILE *f = NULL;
+    char *line;
+
+    config_file = get_config_file(id);
+    if (!config_file) {
+        return NULL;
+    }
+
+    f = fopen(config_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "cannot open %s", config_file);
+        flb_free(config_file);
+        return NULL;
+    }
+
+    while ((line = read_line(f))) {
+        char *index = strstr(line, DOCKER_NAME_ARG);
+        if (index != NULL) {
+            container_name = extract_name(line, index);
+            flb_free(line);
+            break;
+        }
+        flb_free(line);
+    }
+
+    flb_free(config_file);
+    fclose(f);
+
+    return container_name;
+}
+
+/* Returns CPU metrics for docker id. */
+static cpu_snapshot *get_docker_cpu_snapshot(struct flb_docker *ctx, char *id)
+{
+    int c;
+    unsigned long cpu_used = 0;
+    char *usage_file;
+    cpu_snapshot *snapshot = NULL;
+    FILE *f;
+    char *line = NULL;
+
+    usage_file = get_cpu_used_file(id);
+    if (!usage_file) {
+        return NULL;
+    }
+
+    f = fopen(usage_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "error gathering CPU data from %s",
+                      usage_file);
+        flb_free(usage_file);
+        return NULL;
+    }
+
+    /* Read the content */
+    while ((line = read_line(f))) {
+        if (strncmp(line, DOCKER_CGROUP_V2_CPU_USAGE_KEY, 10) == 0) {
+            c = sscanf(line, DOCKER_CGROUP_V2_CPU_USAGE_TEMPLATE, &cpu_used);
+            if (c != 1) {
+                flb_plg_error(ctx->ins, "error scanning used CPU value from %s with key = %s",
+                              usage_file, DOCKER_CGROUP_V2_CPU_USAGE_KEY);
+                flb_free(usage_file);
+                fclose(f);
+                return NULL;
+            }
+            flb_free(line);
+
+            break;
+        }
+        flb_free(line);
+    }
+
+    snapshot = (cpu_snapshot *) flb_calloc(1, sizeof(cpu_snapshot));
+    if (!snapshot) {
+        flb_errno();
+        fclose(f);
+        flb_free(usage_file);
+        return NULL;
+    }
+
+    snapshot->used = cpu_used;
+
+    flb_free(usage_file);
+    fclose(f);
+    return snapshot;
+}
+
+static uint64_t read_file_uint64(struct flb_docker *ctx, flb_sds_t path)
+{
+    int c;
+    uint64_t value = UINT64_MAX;
+    FILE *fp;
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        flb_errno();
+        flb_plg_warn(ctx->ins, "Failed to read %s", path);
+        return value;
+    }
+
+    c = fscanf(fp, "%lu", &value);
+    fclose(fp);
+    if (c != 1) {
+        flb_plg_warn(ctx->ins, "Failed to read a number from %s", path);
+        return value;
+    }
+
+    return value;
+}
+
+/* Returns memory used by a docker in bytes. */
+static uint64_t get_docker_mem_used(struct flb_docker *ctx, char *id)
+{
+    char *usage_file = NULL;
+    uint64_t mem_used = 0;
+
+    usage_file = get_mem_used_file(id);
+    if (!usage_file) {
+        return 0;
+    }
+
+    mem_used = read_file_uint64(ctx, usage_file);
+    flb_free(usage_file);
+
+    return mem_used;
+}
+
+/* Returns memory limit for a docker in bytes. */
+static uint64_t get_docker_mem_limit(struct flb_docker *ctx, char *id)
+{
+    int c;
+    char *limit_file = get_mem_limit_file(id);
+    uint64_t mem_limit;
+    char *line = NULL;
+    FILE *f;
+
+    if (!limit_file) {
+        return 0;
+    }
+
+    f = fopen(limit_file, "r");
+    if (!f) {
+        flb_errno();
+        flb_free(limit_file);
+        return 0;
+    }
+
+    while ((line = read_line(f))) {
+        if (strncmp(line, "max", 3) == 0) {
+            mem_limit = UINT64_MAX;
+        }
+        else {
+            c = sscanf(line, "%lu", &mem_limit);
+            if (c != 1) {
+                flb_plg_error(ctx->ins, "error scanning used mem_limit from %s",
+                              limit_file);
+                flb_free(limit_file);
+                fclose(f);
+                return 0;
+            }
+        }
+        flb_free(line);
+    }
+
+    flb_free(limit_file);
+    fclose(f);
+
+    return mem_limit;
+}
+
+/* Get memory snapshot for a docker id. */
+static mem_snapshot *get_docker_mem_snapshot(struct flb_docker *ctx, char *id)
+{
+    mem_snapshot *snapshot = NULL;
+
+    snapshot = (mem_snapshot *) flb_calloc(1, sizeof(mem_snapshot));
+    if (!snapshot) {
+        flb_errno();
+        return NULL;
+    }
+
+    snapshot->used = get_docker_mem_used(ctx, id);
+    snapshot->limit = get_docker_mem_limit(ctx, id);
+
+    return snapshot;
+}
+
+int in_docker_set_cgroup_api_v2(struct cgroup_api *api)
+{
+    api->cgroup_version = 2;
+    api->get_active_docker_ids = get_active_dockers;
+    api->get_container_name = get_container_name;
+    api->get_cpu_snapshot = get_docker_cpu_snapshot;
+    api->get_mem_snapshot = get_docker_mem_snapshot;
+
+    return 0;
+}

--- a/plugins/in_docker/docker.c
+++ b/plugins/in_docker/docker.c
@@ -278,6 +278,17 @@ static struct mk_list *apply_filters(struct flb_docker *ctx,
     return filtered;
 }
 
+/*
+ * Calculate which cgroup version is used on host by checing existence of
+ * cgroup.controllers file (if it exists, it is V2).
+ */
+static int get_cgroup_version(struct flb_docker *ctx)
+{
+    char path[SYSFS_FILE_PATH_SIZE];
+    snprintf(path, sizeof(path), "%s/%s", ctx->sysfs_path, CGROUP_V2_PATH);
+    return (access(path, F_OK) == 0) ? CGROUP_V2 : CGROUP_V1;
+}
+
 /* Init Docker input */
 static int cb_docker_init(struct flb_input_instance *in,
                           struct flb_config *config, void *data)
@@ -292,24 +303,35 @@ static int cb_docker_init(struct flb_input_instance *in,
         return -1;
     }
     ctx->ins = in;
-    in_docker_set_cgroup_api_v1(&ctx->cgroup_api); /* TODO: support cgroup v2*/
 
     init_filter_lists(in, ctx);
 
     /* Set the context */
     flb_input_set_context(in, ctx);
-    
+
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *)ctx);
     if (ret == -1) {
         flb_free(ctx);
         flb_plg_error(in, "unable to load configuration.");
         return -1;
-    }    
-    
+    }
+
     if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
         ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
+    }
+
+    /* Detect cgroups version v2 or v1 */
+    if (get_cgroup_version(ctx) == CGROUP_V2) {
+        flb_plg_info(ctx->ins, "Detected cgroups v2");
+        in_docker_set_cgroup_api_v2(&ctx->cgroup_api);
+        ctx->cgroup_version = CGROUP_V2;
+    }
+    else {
+        flb_plg_info(ctx->ins, "Detected cgroups v1");
+        in_docker_set_cgroup_api_v1(&ctx->cgroup_api);
+        ctx->cgroup_version = CGROUP_V1;
     }
 
     /* Set our collector based on time, CPU usage every 1 second */
@@ -540,6 +562,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "exclude", NULL,
       0, FLB_FALSE, 0,
       "A space-separated list of containers to exclude"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "path.sysfs", SYSFS_PATH,
+      0, FLB_TRUE, offsetof(struct flb_docker, sysfs_path),
+      "sysfs mount point"
     },
     /* EOF */
     {0}


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, in_docker does not provide cgroups v2.
In this PR, I added a capability to handle cgroups v2 metrics for Docker.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
This is related for https://github.com/fluent/fluent-bit/issues/5949.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
```console
$  sudo bin/fluent-bit -i docker -o stdout 
```
- [x] Debug log output from testing the change

In other terminals:

```console
$ docker run -it --rm ubuntu:jammy bash
```

```console
$ docker run -it --memory 300MB --rm debian:bullseye bash
```

fluent-bit log:

```log
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/10/26 15:18:53] [ info] Configuration:
[2023/10/26 15:18:53] [ info]  flush time     | 1.000000 seconds
[2023/10/26 15:18:53] [ info]  grace          | 5 seconds
[2023/10/26 15:18:53] [ info]  daemon         | 0
[2023/10/26 15:18:53] [ info] ___________
[2023/10/26 15:18:53] [ info]  inputs:
[2023/10/26 15:18:53] [ info]      docker
[2023/10/26 15:18:53] [ info] ___________
[2023/10/26 15:18:53] [ info]  filters:
[2023/10/26 15:18:53] [ info] ___________
[2023/10/26 15:18:53] [ info]  outputs:
[2023/10/26 15:18:53] [ info]      stdout.0
[2023/10/26 15:18:53] [ info] ___________
[2023/10/26 15:18:53] [ info]  collectors:
[2023/10/26 15:18:53] [ info] [fluent bit] version=2.2.0, commit=4acd344399, pid=335975
[2023/10/26 15:18:53] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/10/26 15:18:53] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/10/26 15:18:53] [ info] [cmetrics] version=0.6.4
[2023/10/26 15:18:53] [ info] [ctraces ] version=0.3.1
[2023/10/26 15:18:53] [ info] [input:docker:docker.0] initializing
[2023/10/26 15:18:53] [ info] [input:docker:docker.0] storage_strategy='memory' (memory only)
[2023/10/26 15:18:53] [debug] [docker:docker.0] created event channels: read=21 write=22
[2023/10/26 15:18:53] [ info] [input:docker:docker.0] Detected cgroups v2
[2023/10/26 15:18:53] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2023/10/26 15:18:53] [ info] [sp] stream processor started
[2023/10/26 15:18:53] [ info] [output:stdout:stdout.0] worker #0 started
[2023/10/26 15:18:54] [debug] [input chunk] update output instances with new chunk size diff=109, records=1, input=docker.0
[2023/10/26 15:18:54] [debug] [input chunk] update output instances with new chunk size diff=112, records=1, input=docker.0
[2023/10/26 15:18:55] [debug] [task] created task=0x7f13e801ece0 id=0 OK
[2023/10/26 15:18:55] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] docker.0: [[1698301134.146797664, {}], {"id"=>"1a38a7677732", "name"=>"confident_snyder", "cpu_used"=>22631, "mem_used"=>823296, "mem_limit"=>314572800}]
[1] docker.0: [[1698301134.147009000, {}], {"id"=>"043b521509b6", "name"=>"objective_bassi", "cpu_used"=>53562, "mem_used"=>1208320, "mem_limit"=>18446744073709551615}]
[2023/10/26 15:18:55] [debug] [out flush] cb_destroy coro_id=0
[2023/10/26 15:18:55] [debug] [input chunk] update output instances with new chunk size diff=109, records=1, input=docker.0
[2023/10/26 15:18:55] [debug] [input chunk] update output instances with new chunk size diff=112, records=1, input=docker.0
[2023/10/26 15:18:55] [debug] [task] destroy task=0x7f13e801ece0 (task_id=0)
^C[2023/10/26 15:18:55] [engine] caught signal (SIGINT)
[2023/10/26 15:18:55] [debug] [task] created task=0x7f13e801f3e0 id=0 OK
[2023/10/26 15:18:55] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/10/26 15:18:55] [ warn] [engine] service will shutdown in max 5 seconds
[2023/10/26 15:18:55] [ info] [input] pausing docker.0
[0] docker.0: [[1698301135.146551719, {}], {"id"=>"1a38a7677732", "name"=>"confident_snyder", "cpu_used"=>22631, "mem_used"=>823296, "mem_limit"=>314572800}]
[1] docker.0: [[1698301135.146633514, {}], {"id"=>"043b521509b6", "name"=>"objective_bassi", "cpu_used"=>53562, "mem_used"=>1208320, "mem_limit"=>18446744073709551615}]
[2023/10/26 15:18:55] [debug] [out flush] cb_destroy coro_id=1
[2023/10/26 15:18:55] [debug] [task] destroy task=0x7f13e801f3e0 (task_id=0)
[2023/10/26 15:18:56] [ info] [engine] service has stopped (0 pending tasks)
[2023/10/26 15:18:56] [ info] [input] pausing docker.0
[2023/10/26 15:18:56] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/10/26 15:18:56] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```log
==339923== 
==339923== HEAP SUMMARY:
==339923==     in use at exit: 0 bytes in 0 blocks
==339923==   total heap usage: 2,933 allocs, 2,933 frees, 838,012 bytes allocated
==339923== 
==339923== All heap blocks were freed -- no leaks are possible
==339923== 
==339923== For lists of detected and suppressed errors, rerun with: -s
==339923== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
