### PR TITLE
custom_calyptia: correctly set fleet_id for out_calyptia when fleet_name is set.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -313,7 +313,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
     }
 
     if (ctx->fleet_id) {
-        flb_output_set_property(cloud, "fleet_id", ctx->fleet_id);
         label = flb_sds_create_size(strlen("fleet_id") + strlen(ctx->fleet_id) + 1);
 
         if (!label) {
@@ -469,11 +468,10 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         }
 
         if (ctx->fleet_name) {
-            // TODO: set this once the fleet_id has been retrieved...
-            // flb_output_set_property(ctx->o, "fleet_id", ctx->fleet_id);
             flb_input_set_property(ctx->fleet, "fleet_name", ctx->fleet_name);            
         }
-        else {
+
+        if (ctx->fleet_id) {
             flb_output_set_property(ctx->o, "fleet_id", ctx->fleet_id);
             flb_input_set_property(ctx->fleet, "fleet_id", ctx->fleet_id);
         }


### PR DESCRIPTION
# Summary

Setting the `fleet_id` for the output plugin was done in two places as well as hidden behind an else condition that would never execute. This change should more reliably set `fleet_id` for the calyptia output plugin.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
