### PR TITLE
in_calyptia_fleet: remove unused event_fd configuration property.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -82,8 +82,6 @@ struct flb_in_calyptia_fleet_config {
     /* Networking */
     struct flb_upstream *u;
 
-    int event_fd;
-
     int collect_fd;
 };
 
@@ -1233,11 +1231,6 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "machine_id", NULL,
      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, machine_id),
      "Agent Machine ID."
-    },
-    {
-      FLB_CONFIG_MAP_INT, "event_fd", "-1",
-      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, event_fd),
-      "Used internally to set the event fd."
     },
     {
       FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -912,7 +912,6 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
     if (ctx->config_timestamp < time_last_modified) {
         flb_plg_debug(ctx->ins, "new configuration is newer than current: %ld < %ld",
                       ctx->config_timestamp, time_last_modified);
-        flb_plg_info(ctx->ins, "force the reloading of the configuration file=%d.", ctx->event_fd);
         flb_sds_destroy(data);
 
         if (execute_reload(ctx, cfgname) == FLB_FALSE) {


### PR DESCRIPTION
# Summary

The  `in_calyptia_fleet` plugin has a configuration property `event_fd` which it makes no use of. This code drops it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
