### PR TITLE
in_calyptia_fleet: add old configuration file to checks.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -267,6 +267,27 @@ static int is_cur_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct 
     return ret;
 }
 
+static int is_old_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_config *cfg)
+{
+    flb_sds_t cfgcurname;
+    int ret = FLB_FALSE;
+
+
+    if (cfg->conf_path_file == NULL) {
+        return FLB_FALSE;
+    }
+
+    cfgcurname = old_fleet_config_filename(ctx);
+
+    if (strcmp(cfgcurname, cfg->conf_path_file) == 0) {
+        ret = FLB_TRUE;
+    }
+
+    flb_sds_destroy(cfgcurname);
+
+    return ret;
+}
+
 static int is_timestamped_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_config *cfg)
 {
     char *fname;
@@ -309,6 +330,7 @@ static int is_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct flb_
 
     return is_new_fleet_config(ctx, cfg) ||
            is_cur_fleet_config(ctx, cfg) ||
+           is_old_fleet_config(ctx, cfg) ||
            is_timestamped_fleet_config(ctx, cfg);
 }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -278,6 +278,10 @@ static int is_old_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct 
     }
 
     cfgcurname = old_fleet_config_filename(ctx);
+    if (cfgcurname == NULL) {
+        flb_plg_error(ctx->ins, "unable to allocate configuration name");
+        return FLB_FALSE;
+    }
 
     if (strcmp(cfgcurname, cfg->conf_path_file) == 0) {
         ret = FLB_TRUE;

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -273,6 +273,10 @@ static int is_old_fleet_config(struct flb_in_calyptia_fleet_config *ctx, struct 
     int ret = FLB_FALSE;
 
 
+    if (cfg == NULL) {
+        return FLB_FALSE;
+    }
+
     if (cfg->conf_path_file == NULL) {
         return FLB_FALSE;
     }


### PR DESCRIPTION
# Summary

Check if we are using the old configuration when checking the currently used configuration file.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
