### PR TITLE
in_calyptia_fleet: support multiple files for configurations.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -633,7 +633,7 @@ static int execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cf
 
     reload = flb_calloc(1, sizeof(struct reload_ctx));
     reload->flb = flb;
-    reload->cfg_path = flb_sds_create(cfgpath);
+    reload->cfg_path = cfgpath;
 
     if (ctx->collect_fd > 0) {
         flb_input_collector_pause(ctx->collect_fd, ctx->ins);

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -194,8 +194,13 @@ struct reload_ctx {
     flb_sds_t cfg_path;
 };
 
-static flb_sds_t generate_fleet_directory(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t *fleet_dir)
+static flb_sds_t generate_base_fleet_directory(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t *fleet_dir)
 {
+    *fleet_dir = flb_sds_create_size(4096);
+    if (*fleet_dir == NULL) {
+        return NULL;
+    }
+
     if (ctx->fleet_name != NULL) {
         return flb_sds_printf(fleet_dir, "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s",
                        ctx->config_dir, ctx->machine_id, ctx->fleet_name);
@@ -1149,12 +1154,7 @@ static int calyptia_config_delete_old(struct flb_in_calyptia_fleet_config *ctx)
     flb_sds_t glob_ini;
     int idx;
 
-    glob_ini = flb_sds_create_size(128);
-    if (glob_ini == NULL) {
-        return -1;
-    }
-
-    if (generate_fleet_directory(ctx, &glob_ini) == NULL) {
+    if (generate_base_fleet_directory(ctx, &glob_ini) == NULL) {
         flb_sds_destroy(glob_ini);
         return -1;
     }
@@ -1178,6 +1178,7 @@ static int calyptia_config_delete_old(struct flb_in_calyptia_fleet_config *ctx)
         unlink(inis->entries[idx]->data.as_string);
     }
 
+    flb_sds_destroy(glob_ini);
     return 0;
 }
 
@@ -1364,9 +1365,7 @@ static int create_fleet_directory(struct flb_in_calyptia_fleet_config *ctx)
         }
     }
 
-    myfleetdir = flb_sds_create_size(256);
-
-    if (generate_fleet_directory(ctx, &myfleetdir) == NULL) {
+    if (generate_base_fleet_directory(ctx, &myfleetdir) == NULL) {
         flb_sds_destroy(myfleetdir);
         return -1;
     }

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1632,6 +1632,7 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
                     "    api_key       %s\n"
                     "    fleet_id      %s\n"
                     "    add_label     fleet_id %s\n"
+                    "    machine_id    %s\n"
                     "    fleet.config_dir    %s\n"
                     "    calyptia_host %s\n"
                     "    calyptia_port %d\n"
@@ -1639,6 +1640,7 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
                     ctx->api_key,
                     ctx->fleet_id,
                     ctx->fleet_id,
+                    ctx->machine_id,
                     ctx->config_dir,
                     ctx->ins->host.name,
                     ctx->ins->host.port,
@@ -1653,6 +1655,7 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
                     "    fleet_name    %s\n"
                     "    fleet_id      %s\n"
                     "    add_label     fleet_id %s\n"
+                    "    machine_id    %s\n"
                     "    fleet.config_dir    %s\n"
                     "    calyptia_host %s\n"
                     "    calyptia_port %d\n"
@@ -1661,6 +1664,7 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
                     ctx->fleet_name,
                     ctx->fleet_id,
                     ctx->fleet_id,
+                    ctx->machine_id,
                     ctx->config_dir,
                     ctx->ins->host.name,
                     ctx->ins->host.port,

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -127,29 +127,6 @@ static int is_link(const char *path) {
 static int is_link(const char *path) {
     return FLB_FALSE;
 }
-
-/* we include readlink just in case... and also so it can link. */
-ssize_t readlink(const char *path, char *realpath, size_t srealpath) {
-    HANDLE hFile;
-    DWORD ret;
-
-    hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
-                       FILE_ATTRIBUTE_NORMAL, NULL);
-
-    if (hFile == INVALID_HANDLE_VALUE) {
-        return -1;
-    }
-
-    ret = GetFinalPathNameByHandleA(hFile, realpath, srealpath, VOLUME_NAME_NT);
-
-    if (ret < srealpath) {
-        CloseHandle(hFile);
-        return -1;
-    }
-
-    CloseHandle(hFile);
-    return ret;
-}
 #endif
 
 
@@ -988,34 +965,6 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
 
     return 0;
 }
-
-#ifdef FLB_SYSTEM_WINDOWS
-#define link(a, b) CreateHardLinkA(b, a, 0)
-#define symlink(a, b) CreateSymLinkA(b, a, 0)
-
-ssize_t readlink(const char *path, char *realpath, size_t srealpath) {
-    HANDLE hFile;
-    DWORD ret;
-
-    hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 
-                       FILE_ATTRIBUTE_NORMAL, NULL);
-
-    if (hFile == INVALID_HANDLE_VALUE) {
-        return -1;
-    }
-
-    ret = GetFinalPathNameByHandleA(hFile, realpath, srealpath, VOLUME_NAME_NT);
-
-    if (ret < srealpath) {
-        CloseHandle(hFile);
-        return -1;
-    }
-
-    CloseHandle(hFile);
-    return ret;
-}
-
-#endif
 
 #ifdef FLB_SYSTEM_WINDOWS
 #define _mkdir(a, b) mkdir(a)

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -204,53 +204,46 @@ struct reload_ctx {
 
 static flb_sds_t generate_base_fleet_directory(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t *fleet_dir)
 {
-    *fleet_dir = flb_sds_create_size(4096);
-    if (*fleet_dir == NULL) {
+    if (fleet_dir == NULL) {
         return NULL;
+    }
+
+    if (*fleet_dir == NULL) {
+        *fleet_dir = flb_sds_create_size(4096);
+        if (*fleet_dir == NULL) {
+            return NULL;
+        }
     }
 
     if (ctx->fleet_name != NULL) {
         return flb_sds_printf(fleet_dir, "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s",
-                       ctx->config_dir, ctx->machine_id, ctx->fleet_name);
+                              ctx->config_dir, ctx->machine_id, ctx->fleet_name);
     }
     return flb_sds_printf(fleet_dir, "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s",
-                    ctx->config_dir, ctx->machine_id, ctx->fleet_id);
+                          ctx->config_dir, ctx->machine_id, ctx->fleet_id);
 }
 
 static flb_sds_t fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx, char *fname)
 {
-    flb_sds_t cfgname;
+    flb_sds_t cfgname = NULL;
+    flb_sds_t ret;
 
-    cfgname = flb_sds_create_size(4096);
-
-    if (ctx->fleet_name != NULL) {
-        flb_sds_printf(&cfgname,
-                       "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s.ini",
-                       ctx->config_dir, ctx->machine_id, ctx->fleet_name, fname);
+    if (generate_base_fleet_directory(ctx, &cfgname) == NULL) {
+        return NULL;
     }
-    else {
-        flb_sds_printf(&cfgname,
-                       "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s" PATH_SEPARATOR "%s.ini",
-                       ctx->config_dir, ctx->machine_id, ctx->fleet_id, fname);
+
+    ret = flb_sds_printf(&cfgname, PATH_SEPARATOR "%s.ini", fname);
+    if (ret == NULL) {
+        flb_sds_destroy(cfgname);
+        return NULL;
     }
 
     return cfgname;
 }
 
-static flb_sds_t new_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx)
-{
-    return fleet_config_filename(ctx, "new");
-}
-
-static flb_sds_t cur_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx)
-{
-    return fleet_config_filename(ctx, "cur");
-}
-
-static flb_sds_t old_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx)
-{
-    return fleet_config_filename(ctx, "old");
-}
+#define new_fleet_config_filename(a) fleet_config_filename((a), "new")
+#define cur_fleet_config_filename(a) fleet_config_filename((a), "cur")
+#define old_fleet_config_filename(a) fleet_config_filename((a), "old")
 
 static flb_sds_t time_fleet_config_filename(struct flb_in_calyptia_fleet_config *ctx, time_t t)
 {
@@ -1259,7 +1252,7 @@ static int calyptia_config_delete_old_dir(const char *cfgpath)
 static int calyptia_config_delete_old(struct flb_in_calyptia_fleet_config *ctx)
 {
     struct cfl_array *inis;
-    flb_sds_t glob_ini;
+    flb_sds_t glob_ini = NULL;
     int idx;
 
     if (generate_base_fleet_directory(ctx, &glob_ini) == NULL) {
@@ -1474,7 +1467,7 @@ conn_error:
 
 static int create_fleet_directory(struct flb_in_calyptia_fleet_config *ctx)
 {
-    flb_sds_t myfleetdir;
+    flb_sds_t myfleetdir = NULL;
 
     if (access(ctx->config_dir, F_OK) != 0) {
         if (__mkdir(ctx->config_dir, 0700) != 0) {
@@ -1499,7 +1492,7 @@ static int create_fleet_directory(struct flb_in_calyptia_fleet_config *ctx)
 
 static flb_sds_t fleet_gendir(struct flb_in_calyptia_fleet_config *ctx, time_t timestamp)
 {
-    flb_sds_t fleetdir;
+    flb_sds_t fleetdir = NULL;
     flb_sds_t fleetcurdir;
 
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -92,7 +92,6 @@ struct flb_in_calyptia_fleet_config {
     flb_sds_t fleet_files_url;
 
     struct flb_input_instance *ins;       /* plugin instance */
-    struct flb_config *config;            /* Fluent Bit context */
 
     /* Networking */
     struct flb_upstream *u;
@@ -2116,7 +2115,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
         return 0;
     }
 
-    if (exists_new_fleet_config(ctx) == FLB_TRUE || is_fleet_config(ctx, ctx->config)) {
+    if (exists_new_fleet_config(ctx) == FLB_TRUE || is_fleet_config(ctx, config)) {
         calyptia_config_commit(ctx);
     }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -2115,7 +2115,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
         return 0;
     }
 
-    if (exists_new_fleet_config(ctx) == FLB_TRUE || is_fleet_config(ctx, config)) {
+    if (is_fleet_config(ctx, config)) {
         calyptia_config_commit(ctx);
     }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1687,9 +1687,8 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
             return -1;
         }
 
-        flb_sds_destroy(cfgname);
-
 #ifndef FLB_SYSTEM_WINDOWS
+        flb_sds_destroy(cfgname);
         cfgnewname = new_fleet_config_filename(ctx);
         if (execute_reload(ctx, cfgnewname) == FLB_FALSE) {
             calyptia_config_rollback(ctx, cfgname);

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -953,7 +953,7 @@ static int calyptia_config_add(struct flb_in_calyptia_fleet_config *ctx,
         flb_sds_destroy(cfgoldname);
     }
 
-    link(cfgname, cfgnewname);
+    symlink(cfgname, cfgnewname);
     flb_sds_destroy(cfgnewname);
 
     return 0;
@@ -965,10 +965,12 @@ static int calyptia_config_commit(struct flb_in_calyptia_fleet_config *ctx,
     flb_sds_t cfgnewname;
     flb_sds_t cfgcurname;
     flb_sds_t cfgoldname;
+    flb_sds_t cfgtimename;
 
     cfgnewname = new_fleet_config_filename(ctx);
     cfgcurname = cur_fleet_config_filename(ctx);
     cfgoldname = old_fleet_config_filename(ctx);
+    cfgtimename = time_fleet_config_filename(ctx, ctx->config_timestamp);
 
     if (exists_new_fleet_config(ctx) == FLB_TRUE) {
         unlink(cfgnewname);
@@ -982,11 +984,12 @@ static int calyptia_config_commit(struct flb_in_calyptia_fleet_config *ctx,
         unlink(cfgcurname);
     }
 
-    link(cfgname, cfgcurname);
+    symlink(cfgtimename, cfgcurname);
 
     flb_sds_destroy(cfgnewname);
     flb_sds_destroy(cfgcurname);
     flb_sds_destroy(cfgoldname);
+    flb_sds_destroy(cfgtimename);
 
     return 0;
 }

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -129,7 +129,7 @@ static char *find_case_header(struct flb_http_client *cli, const char *header)
         if (strncasecmp(ptr, header, strlen(header)) == 0) {
 
             if (ptr[strlen(header)] == ':' && ptr[strlen(header)+1] == ' ') {
-                return ptr;                
+                return ptr;
             }
         }
     }
@@ -417,7 +417,7 @@ static void *do_reload(void *data)
 #ifndef FLB_SYSTEM_WINDOWS
     kill(getpid(), SIGHUP);
 #else
-	GenerateConsoleCtrlEvent(1 /* CTRL_BREAK_EVENT_1 */, 0);
+    GenerateConsoleCtrlEvent(1 /* CTRL_BREAK_EVENT_1 */, 0);
 #endif
     return NULL;
 }
@@ -438,7 +438,7 @@ static int test_config_is_valid(flb_sds_t cfgpath)
 
     if (conf == NULL) {
         goto cf_create_from_file_error;
-    } 
+    }
 
     ret = FLB_TRUE;
 
@@ -692,7 +692,7 @@ static flb_sds_t get_project_id_from_api_key(struct flb_in_calyptia_fleet_config
     memcpy(encoded, ctx->api_key, api_token_sep-ctx->api_key);
 
     ret = flb_base64_decode(token, sizeof(token)-1, &tlen,
-                            encoded, elen); 
+                            encoded, elen);
 
     if (ret != 0) {
         return NULL;
@@ -764,7 +764,7 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
     }
 
     url = flb_sds_create_size(4096);
-    flb_sds_printf(&url, "/v1/search?project_id=%s&resource=fleet&term=%s", 
+    flb_sds_printf(&url, "/v1/search?project_id=%s&resource=fleet&term=%s",
                    project_id, ctx->fleet_name);
 
     client = fleet_http_do(ctx, u_conn, url);
@@ -872,7 +872,7 @@ static int get_calyptia_file(struct flb_in_calyptia_fleet_config *ctx,
                              const char *hdr,
                              const char *dst,
                              time_t *time_last_modified)
- {
+{
     struct flb_http_client *client;
     size_t len;
     FILE *fp;
@@ -1303,7 +1303,7 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
     }
 
     /* create the base file. */
-    ret = get_calyptia_file(ctx, u_conn, ctx->fleet_url, header, 
+    ret = get_calyptia_file(ctx, u_conn, ctx->fleet_url, header,
                             ".ini", &time_last_modified);
 
     /* new file created! */
@@ -1325,7 +1325,7 @@ static int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx,
 
 /* cb_collect callback */
 static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
-                                     struct flb_config *config, 
+                                     struct flb_config *config,
                                      void *in_context)
 {
     struct flb_in_calyptia_fleet_config *ctx = in_context;

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -936,14 +936,14 @@ static int get_calyptia_file(struct flb_in_calyptia_fleet_config *ctx,
 
     if (hdr != NULL) {
         len = fwrite(hdr, strlen(hdr), 1, fp);
-        if (len < strlen(hdr)) {
+        if (len < 1) {
             flb_plg_error(ctx->ins, "truncated write: %s", dst);
             goto file_error;
         }
     }
 
     len = fwrite(client->resp.payload, client->resp.payload_size, 1, fp);
-    if (len < client->resp.payload_size) {
+    if (len < 1) {
         flb_plg_error(ctx->ins, "truncated write: %s", dst);
         goto file_error;
     }

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1331,24 +1331,22 @@ static int calyptia_config_delete_old_dir(const char *cfgpath)
     }
 
     files = read_glob(cfg_glob);
-    if (files == NULL) {
-        flb_sds_destroy(cfg_glob);
-        return FLB_FALSE;
-    }
 
-    for (idx = 0; idx < ((ssize_t)files->entry_count); idx++) {
-        unlink(files->entries[idx]->data.as_string);
+    if (files != NULL) {
+        for (idx = 0; idx < ((ssize_t)files->entry_count); idx++) {
+                unlink(files->entries[idx]->data.as_string);
+        }
+        cfl_array_destroy(files); 
     }
 
     /* attempt to delete the main directory */
-    ext = strrchr(cfg_glob, '/');
+    ext = strrchr(cfg_glob, PATH_SEPARATOR[0]);
     if (ext) {
         *ext = '\0';
         rmdir(cfg_glob);
     }
 
     flb_sds_destroy(cfg_glob);
-    cfl_array_destroy(files);
 
     return FLB_TRUE;
 }


### PR DESCRIPTION
# Summary

Add support for extra fleet files. These go along with the main configuration and can be referred to using relative paths. The intention is to use them for:

- Parsers
- Includes
- Lua Scripts

But they are not restricted to just those uses. They can also be used as general files for plugins.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
