### PR TITLE
out_stackdriver: Don't overwrite ctx->client_email and ctx->private_key.

### DIFF
--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -394,12 +394,13 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             flb_stackdriver_conf_destroy(ctx);
             return NULL;
         }
-        
+
         /* Service Account Email */
         if (ctx->client_email == NULL) {
             tmp = getenv("SERVICE_ACCOUNT_EMAIL");
             if (tmp) {
                 ctx->creds->client_email = flb_sds_create(tmp);
+                ctx->client_email = ctx->creds->client_email;
             }
         }
 
@@ -408,11 +409,9 @@ struct flb_stackdriver *flb_stackdriver_conf_create(struct flb_output_instance *
             tmp = getenv("SERVICE_ACCOUNT_SECRET");
             if (tmp) {
                 ctx->creds->private_key = flb_sds_create(tmp);
+                ctx->private_key = ctx->creds->private_key;
             }
         }
-
-        ctx->private_key = ctx->creds->private_key;
-        ctx->client_email = ctx->creds->client_email;
     }
 
     /*


### PR DESCRIPTION
<!-- Provide summary of changes -->
This fixes the use case of specifying the `service_account_email` and `service_account_secret` options explicitly.

Fixes #6969 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
  ```
  [OUTPUT]
    Name        stackdriver
    Match       …
    service_account_email …
    service_account_secret …
  ```
- [N/A] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

#8094 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
