### PR TITLE
flb_utils: add code for getting the machineID on macOS.

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -46,6 +46,11 @@ extern struct flb_aws_error_reporter *error_reporter;
 #include <openssl/rand.h>
 #endif
 
+#ifdef FLB_SYSTEM_MACOS
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#endif
+
 /*
  * The following block descriptor describes the private use unicode character range
  * used for denoting invalid utf-8 fragments. Invalid fragment 0xCE would become
@@ -1416,6 +1421,46 @@ int flb_utils_get_machine_id(char **out_id, size_t *out_size)
         }
 
         *out_size = dwBufSize;
+        return 0;
+    }
+#elif defined (FLB_SYSTEM_MACOS)
+    bool bret;
+    CFStringRef serialNumber;
+    io_service_t platformExpert = IOServiceGetMatchingService(kIOMainPortDefault,
+        IOServiceMatching("IOPlatformExpertDevice"));
+
+    if (platformExpert) {
+        CFTypeRef serialNumberAsCFString =
+            IORegistryEntryCreateCFProperty(platformExpert,
+                                        CFSTR(kIOPlatformSerialNumberKey),
+                                        kCFAllocatorDefault, 0);
+        if (serialNumberAsCFString) {
+            serialNumber = (CFStringRef)serialNumberAsCFString;
+        }
+        else {
+            IOObjectRelease(platformExpert);
+            return -1;
+        }
+        IOObjectRelease(platformExpert);
+
+        *out_size = CFStringGetLength(serialNumber);
+        *out_id = flb_malloc(CFStringGetLength(serialNumber)+1);
+
+        if (*out_id == NULL) {
+            return -1;
+        }
+
+        bret = CFStringGetCString(serialNumber, *out_id,
+                                  CFStringGetLength(serialNumber)+1,
+                                  kCFStringEncodingUTF8);
+        CFRelease(serialNumber);
+
+        if (bret == false) {
+            flb_free(*out_size);
+            *out_size = 0;
+            return -1;
+        }
+
         return 0;
     }
 #endif


### PR DESCRIPTION
# Summary

Add code to get the machineID (serial number) on macOS machines.

This value is used after hashing it to identify agents in a fleet that does not have a machineID already assigned manually with the `MachineID` configuration property.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
