### PR TITLE
chunk_trace: use a threaded pipeline.

### DIFF
--- a/include/fluent-bit/flb_chunk_trace.h
+++ b/include/fluent-bit/flb_chunk_trace.h
@@ -67,22 +67,27 @@ struct flb_chunk_trace_limit {
     int count;
 };
 
-struct flb_chunk_trace_context {
+struct flb_chunk_pipeline_context {
+    flb_ctx_t *flb;
+    flb_sds_t output_name;
+    pthread_t thread;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    struct mk_list *props;
+    void *data;
     void *input;
     void *output;
+};
+
+struct flb_chunk_trace_context {
+    void *input;
     int trace_count;
     struct flb_chunk_trace_limit limit;
     flb_sds_t trace_prefix;
     int to_destroy;
     int chunks;
-    flb_ctx_t *flb;
-    struct cio_ctx *cio;
-    pthread_t thread;
-    pthread_cond_t wait;
-    pthread_mutex_t lock;
-    flb_sds_t output_name;
-    struct mk_list *props;
-    void *data;
+
+    struct flb_chunk_pipeline_context pipeline;
 };
 
 struct flb_chunk_trace {

--- a/include/fluent-bit/flb_chunk_trace.h
+++ b/include/fluent-bit/flb_chunk_trace.h
@@ -77,6 +77,12 @@ struct flb_chunk_trace_context {
     int chunks;
     flb_ctx_t *flb;
     struct cio_ctx *cio;
+    pthread_t thread;
+    pthread_cond_t wait;
+    pthread_mutex_t lock;
+    flb_sds_t output_name;
+    struct mk_list *props;
+    void *data;
 };
 
 struct flb_chunk_trace {

--- a/include/fluent-bit/flb_chunk_trace.h
+++ b/include/fluent-bit/flb_chunk_trace.h
@@ -100,6 +100,7 @@ int flb_chunk_trace_input(struct flb_chunk_trace *trace);
 void flb_chunk_trace_do_input(struct flb_input_chunk *trace);
 int flb_chunk_trace_pre_output(struct flb_chunk_trace *trace);
 int flb_chunk_trace_filter(struct flb_chunk_trace *trace, void *pfilter, struct flb_time *, struct flb_time *, char *buf, size_t buf_size);
+int flb_chunk_trace_output(struct flb_chunk_trace *trace, struct flb_output_instance *output, int ret);
 void flb_chunk_trace_free(struct flb_chunk_trace *trace);
 int flb_chunk_trace_context_set_limit(void *input, int, int);
 int flb_chunk_trace_context_hit_limit(void *input);

--- a/include/fluent-bit/flb_event.h
+++ b/include/fluent-bit/flb_event.h
@@ -42,6 +42,9 @@ struct flb_event_chunk {
     void *data;             /* event content */
     size_t size;            /* size of event */
     size_t total_events;    /* total number of serialized events */
+#ifdef FLB_HAVE_CHUNK_TRACE
+    struct flb_chunk_trace *trace;
+#endif
 };
 
 struct flb_event_chunk *flb_event_chunk_create(int type,

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -945,15 +945,15 @@ static inline void flb_output_return(int ret, struct flb_coro *co) {
 
     flb_task_release_lock(task);
 
-    flb_error("chunk process event chunk: %p", out_flush->processed_event_chunk);
-    if (out_flush->processed_event_chunk) {
-
 #ifdef FLB_HAVE_CHUNK_TRACE
-        flb_error("chunk tracing for output");
-        if (out_flush->processed_event_chunk->trace) {
-             flb_chunk_trace_output(out_flush->processed_event_chunk->trace, o_ins, ret);
+    if (task->event_chunk) {
+        if (task->event_chunk->trace) {
+             flb_chunk_trace_output(task->event_chunk->trace, o_ins, ret);
         }
+    }
 #endif
+
+    if (out_flush->processed_event_chunk) {
 
         if (task->event_chunk->data != out_flush->processed_event_chunk->data) {
             flb_free(out_flush->processed_event_chunk->data);

--- a/src/flb_event.c
+++ b/src/flb_event.c
@@ -45,6 +45,10 @@ struct flb_event_chunk *flb_event_chunk_create(int type,
         return NULL;
     }
 
+#ifdef FLB_HAVE_CHUNK_TRACE
+    evc->trace = NULL;
+#endif
+
     evc->type = type;
     evc->data = buf_data;
     evc->size = buf_size;

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -376,6 +376,14 @@ struct flb_task *flb_task_create(uint64_t ref_id,
         *err = FLB_TRUE;
         return NULL;
     }
+
+#ifdef FLB_HAVE_CHUNK_TRACE
+    if (ic->trace) {
+        flb_debug("add trace to task");
+        evc->trace = ic->trace;
+    }
+#endif
+
     task->event_chunk = evc;
     task_ic = (struct flb_input_chunk *) ic;
     task_ic->task = task;


### PR DESCRIPTION
# Summary

Create a separate thread to run the pipeline for chunk traces.

With this pull request traces now use a threaded input so traces can be logged using a ring buffer. This bypasses the need to call in_emitter_add_record from the in_emitter plugin as well.

This should fix the occasional crash ocurring during the flb-rt-core_chunk_trace test as well as making traces more stable.

As an extra bonus, the use of a threaded input with ring buffers now allows for logging the output return value from outputs.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
