### PR TITLE
workflows: ensure we do non-interactive set up

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -159,6 +159,7 @@ jobs:
 
       - name: Retrieve target info for repo creation
         id: get-target-info
+        timeout-minutes: 5
         # Remove any .arm648 suffix
         # For ubuntu map to codename using the disto-info list (CSV)
         run: |
@@ -178,6 +179,7 @@ jobs:
           echo "target=$TARGET" >> $GITHUB_OUTPUT
         env:
           DISTRO: ${{ matrix.distro }}
+          DEBIAN_FRONTEND: noninteractive
         shell: bash
 
       - name: Verify output target


### PR DESCRIPTION
Actuated builds are failing due to `awscli` installation which also installs `tzdata` on the runner and then wants an interactive set up of timezone info.



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Failing example:

```shell
$ docker run --rm -t ubuntu:22.04 sh -c 'apt-get update && apt-get install -y awscli'
...
Setting up tzdata (2023c-0ubuntu0.22.04.2) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration questions will narrow this down by presenting a list of cities, representing the time zones in which they are located.

  1. Africa  2. America  3. Antarctica  4. Australia  5. Arctic  6. Asia  7. Atlantic  8. Europe  9. Indian  10. Pacific  11. US  12. Etc
Geographic area: 
... <waits here>
```

Works when we ensure we have non-interactive setup:

```shell
$ docker run --rm -e DEBIAN_FRONTEND=noninteractive -t ubuntu:22.04 sh -c 'apt-get update && apt-get install -y awscli'
...
Setting up awscli (1.22.34-1) ...
Processing triggers for ca-certificates (20230311ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
