### PR TITLE
reload: bin: filter: handle invalid values of configuration correctly on hot reloading

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -64,6 +64,7 @@ struct flb_filter_plugin {
     struct flb_config_map *config_map;
 
     /* Callbacks */
+    int (*cb_pre_run) (struct flb_filter_instance *, struct flb_config *, void *);
     int (*cb_init) (struct flb_filter_instance *, struct flb_config *, void *);
     int (*cb_filter) (const void *, size_t,
                       const char *, int,

--- a/include/fluent-bit/flb_reload.h
+++ b/include/fluent-bit/flb_reload.h
@@ -27,6 +27,7 @@
 
 #define FLB_RELOAD_IDLE 0
 #define FLB_RELOAD_IN_PROGRESS 1
+#define FLB_RELOAD_ABORTED     2
 
 int flb_reload_property_check_all(struct flb_config *config);
 int flb_reload_reconstruct_cf(struct flb_cf *src_cf, struct flb_cf *dest_cf);

--- a/include/fluent-bit/flb_reload.h
+++ b/include/fluent-bit/flb_reload.h
@@ -25,9 +25,12 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_config_format.h>
 
-#define FLB_RELOAD_IDLE 0
-#define FLB_RELOAD_IN_PROGRESS 1
-#define FLB_RELOAD_ABORTED     2
+#define FLB_RELOAD_IDLE             0
+#define FLB_RELOAD_IN_PROGRESS      1
+#define FLB_RELOAD_ABORTED         -1
+#define FLB_RELOAD_HALTED          -2
+#define FLB_RELOAD_NOT_ENABLED     -3
+#define FLB_RELOAD_INVALID_CONTEXT -4
 
 int flb_reload_property_check_all(struct flb_config *config);
 int flb_reload_reconstruct_cf(struct flb_cf *src_cf, struct flb_cf *dest_cf);

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -77,6 +77,7 @@ static int cb_lua_init(struct flb_filter_instance *f_ins,
     }
 
     if (ret == -1) {
+        flb_luajit_destroy(ctx->lua);
         lua_config_destroy(ctx);
         return -1;
     }

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -36,6 +36,46 @@
 #include "lua_config.h"
 #include "mpack/mpack.h"
 
+static int cb_lua_pre_run(struct flb_filter_instance *f_ins,
+                          struct flb_config *config, void *data)
+{
+    int ret;
+    (void) data;
+    struct lua_filter *ctx;
+    struct flb_luajit *lj;
+
+    /* Create context */
+    ctx = lua_config_create(f_ins, config);
+    if (!ctx) {
+        flb_error("[filter_lua] filter cannot be loaded");
+        return -1;
+    }
+
+    /* Create LuaJIT state/vm */
+    lj = flb_luajit_create(config);
+    if (!lj) {
+        lua_config_destroy(ctx);
+        return -1;
+    }
+    ctx->lua = lj;
+
+    /* Lua script source code */
+    if (ctx->code) {
+        ret = flb_luajit_load_buffer(ctx->lua,
+                                     ctx->code, flb_sds_len(ctx->code),
+                                     "fluentbit.lua");
+    }
+    else {
+        /* Load Script / file path*/
+        ret = flb_luajit_load_script(ctx->lua, ctx->script);
+    }
+
+    flb_luajit_destroy(ctx->lua);
+    lua_config_destroy(ctx);
+
+    return ret;
+}
+
 static int cb_lua_init(struct flb_filter_instance *f_ins,
                        struct flb_config *config,
                        void *data)
@@ -702,6 +742,7 @@ static struct flb_config_map config_map[] = {
 struct flb_filter_plugin filter_lua_plugin = {
     .name         = "lua",
     .description  = "Lua Scripting Filter",
+    .cb_pre_run   = cb_lua_pre_run,
     .cb_init      = cb_lua_init,
 #ifdef FLB_FILTER_LUA_USE_MPACK
     .cb_filter    = cb_lua_filter_mpack,

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -588,6 +588,15 @@ int flb_filter_init(struct flb_config *config, struct flb_filter_instance *ins)
         return 0;
     }
 
+    /* Run pre_run callback for the filter */
+    if (p->cb_pre_run) {
+        ret = p->cb_pre_run(ins, config, ins->data);
+        if (ret != 0) {
+            flb_error("Failed pre_run callback on filter %s", ins->name);
+            return -1;
+        }
+    }
+
     /* Initialize the input */
     if (p->cb_init) {
         ret = p->cb_init(ins, config, ins->data);

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -512,12 +512,19 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
     ret = flb_start(new_ctx);
 
-    /* Store the new value of hot reloading times into the new context */
-    if (ret == 0) {
-        new_config->hot_reloaded_count = reloaded_count;
-        flb_debug("[reload] hot reloaded %d time(s)", reloaded_count);
-        new_config->hot_reloading = FLB_FALSE;
+    if (ret != 0) {
+        flb_stop(new_ctx);
+        flb_destroy(new_ctx);
+
+        flb_error("[reload] loaded configuration contains error(s). Reloading is aborted");
+
+        return -1;
     }
+
+    /* Store the new value of hot reloading times into the new context */
+    new_config->hot_reloaded_count = reloaded_count;
+    flb_debug("[reload] hot reloaded %d time(s)", reloaded_count);
+    new_config->hot_reloading = FLB_FALSE;
 
     return 0;
 }

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -31,6 +31,7 @@
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_plugin.h>
+#include <fluent-bit/flb_reload.h>
 
 #include <cfl/cfl.h>
 #include <cfl/cfl_sds.h>
@@ -128,6 +129,7 @@ static int flb_filter_propery_check_all(struct flb_config *config)
     struct mk_list *tmp;
     struct mk_list *head;
     struct flb_filter_instance *ins;
+    struct flb_filter_plugin *p;
 
     /* Iterate all active input instance plugins */
     mk_list_foreach_safe(head, tmp, &config->filters) {
@@ -143,6 +145,17 @@ static int flb_filter_propery_check_all(struct flb_config *config)
         ret = flb_filter_plugin_property_check(ins, config);
         if (ret == -1) {
             return -1;
+        }
+
+        /* Check actual values with additional validator */
+        p = ins->p;
+        /* Run pre_run callback for the filter */
+        if (p->cb_pre_run) {
+            ret = p->cb_pre_run(ins, config, ins->data);
+            if (ret != 0) {
+                flb_error("Failed pre_run callback on filter %s", ins->name);
+                return -1;
+            }
         }
 
         /* destroy config map (will be recreated at flb_start) */
@@ -205,7 +218,7 @@ int flb_reload_property_check_all(struct flb_config *config)
     /* Check properties of filter plugins */
     ret = flb_filter_propery_check_all(config);
     if (ret == -1) {
-        flb_error("[reload] check properties for filter plugins is failed");
+        flb_error("[reload] check properties and additonal vaildations for filter plugins is failed");
 
         return -1;
     }
@@ -371,13 +384,13 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
     if (ctx == NULL) {
         flb_error("[reload] given flb context is NULL");
-        return -2;
+        return FLB_RELOAD_INVALID_CONTEXT;
     }
 
     old_config = ctx->config;
     if (old_config->enable_hot_reload != FLB_TRUE) {
         flb_warn("[reload] hot reloading is not enabled");
-        return -3;
+        return FLB_RELOAD_NOT_ENABLED;
     }
 
     if (old_config->ensure_thread_safety_on_hot_reloading) {
@@ -391,7 +404,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
      */
     new_cf = flb_cf_create();
     if (!new_cf) {
-        return -1;
+        return FLB_RELOAD_HALTED;
     }
 
     flb_info("reloading instance pid=%lu tid=%p", (long unsigned) getpid(), pthread_self());
@@ -406,7 +419,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
             }
             flb_cf_destroy(new_cf);
             flb_error("[reload] reconstruct cf failed");
-            return -1;
+            return FLB_RELOAD_HALTED;
         }
     }
 
@@ -419,7 +432,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
         flb_cf_destroy(new_cf);
         flb_error("[reload] creating flb context is failed. Reloading is halted");
 
-        return -1;
+        return FLB_RELOAD_HALTED;
     }
 
     new_config = new_ctx->config;
@@ -446,7 +459,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
         if (!new_cf) {
             flb_sds_destroy(file);
 
-            return -1;
+            return FLB_RELOAD_HALTED;
         }
     }
 
@@ -462,7 +475,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
             flb_destroy(new_ctx);
             flb_error("[reload] reloaded config is invalid. Reloading is halted");
 
-            return -1;
+            return FLB_RELOAD_HALTED;
         }
     }
 
@@ -476,7 +489,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
         flb_error("[reload] reloaded config format is invalid. Reloading is halted");
 
-        return -1;
+        return FLB_RELOAD_HALTED;
     }
 
     /* Validate plugin properites before fluent-bit stops the old context. */
@@ -489,7 +502,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
         flb_error("[reload] reloaded config is invalid. Reloading is halted");
 
-        return -1;
+        return FLB_RELOAD_HALTED;
     }
 
     /* Delete the original context of config format before replacing
@@ -518,7 +531,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
         flb_error("[reload] loaded configuration contains error(s). Reloading is aborted");
 
-        return -1;
+        return FLB_RELOAD_ABORTED;
     }
 
     /* Store the new value of hot reloading times into the new context */

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1400,8 +1400,13 @@ int flb_main(int argc, char **argv)
                 flb_bin_restarting = FLB_RELOAD_IDLE;
             }
             else {
-                flb_bin_restarting = FLB_RELOAD_ABORTED;
+                flb_bin_restarting = ret;
             }
+        }
+
+        if (flb_bin_restarting == FLB_RELOAD_HALTED) {
+            sleep(1);
+            flb_bin_restarting = FLB_RELOAD_IDLE;
         }
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
On hot-reloading, we intended to keep fluent-bit process as much as possible when an error is included in the loaded configuration file. 
However, the current behavior is not ideal for containing invalid values for provided valid parameters in the configuration file during hot-reloading. This PR is mainly for filter_lua case which is loaded invalid lua script as described in #8067.
In this situation, we should validate malformed values especially for Lua script.
In filter_lua, fluent-bit isn't able to process events when loading an invalid Lua script. This should be halted for hot-reloading process.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Related to #8067 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
