### PR TITLE
aws_util: fix leading zeros in time_key

### DIFF
--- a/tests/internal/aws_util.c
+++ b/tests/internal/aws_util.c
@@ -376,6 +376,24 @@ static void test_flb_get_s3_key_mixed_timestamp()
     flb_sds_destroy(s3_key_format);
 }
 
+/*
+ * https://github.com/fluent/fluent-bit/issues/7538
+ */
+static void test_flb_aws_strftime_precision_leading_zeros()
+{
+    char *out_buf;
+    struct flb_time tms;
+    char *time_format = "ms=%3N, ns=%9N, ns=%L";
+    tms.tm.tv_sec = 1698784683;
+    tms.tm.tv_nsec = 1000009;
+
+    out_buf = flb_malloc(1024);
+    TEST_CHECK(out_buf != NULL);
+    flb_aws_strftime_precision(&out_buf, time_format, &tms);
+
+    TEST_CHECK(strcmp(out_buf, "ms=001, ns=001000009, ns=001000009") == 0);
+}
+
 TEST_LIST = {
     { "parse_api_error" , test_flb_aws_error},
     { "flb_aws_endpoint" , test_flb_aws_endpoint},
@@ -391,5 +409,6 @@ TEST_LIST = {
     {"flb_get_s3_key_increment_index", test_flb_get_s3_key_increment_index},
     {"flb_get_s3_key_index_overflow", test_flb_get_s3_key_index_overflow},
     {"flb_get_s3_key_mixed_timestamp", test_flb_get_s3_key_mixed_timestamp},
+    {"test_flb_aws_strftime_precision_leading_zeros", test_flb_aws_strftime_precision_leading_zeros},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #7538

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
