### PR TITLE
out_cloudwatch_logs: enhance api error response readability

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -582,7 +582,7 @@ void flb_aws_print_error(char *response, size_t response_len,
     error = flb_json_get_val(response, response_len, "__type");
     if (!error) {
         /* error can not be parsed, print raw response */
-        flb_plg_warn(ins, "Raw response: %s", response);
+        flb_plg_warn(ins, "%s: Raw response: %s", api, response);
         return;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Tested by adding a fake error:
```
[2023/11/02 20:43:59] [ warn] [output:cloudwatch_logs:cloudwatch_logs.1] PutLogEvents: Raw response: {"nextSequenceToken":"49645959017322090641208425572396895883538558252795036370"}
```
It works.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
