### PR TITLE
in_splunk: ensure releasing tag_from_record

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -292,8 +292,6 @@ static void process_flb_log_append(struct flb_splunk *ctx, msgpack_object *recor
                                  flb_sds_len(tag_from_record),
                                  ctx->log_encoder.output_buffer,
                                  ctx->log_encoder.output_length);
-
-            flb_sds_destroy(tag_from_record);
         }
         else if (tag) {
             flb_input_log_append(ctx->ins, tag, flb_sds_len(tag),
@@ -309,6 +307,10 @@ static void process_flb_log_append(struct flb_splunk *ctx, msgpack_object *recor
     }
     else {
         flb_plg_error(ctx->ins, "Error encoding record : %d", ret);
+    }
+
+    if (tag_from_record) {
+        flb_sds_destroy(tag_from_record);
     }
 }
 


### PR DESCRIPTION
`tag_from_record` is allocated at `tag_key`.
https://github.com/fluent/fluent-bit/blob/v2.1.10/plugins/in_splunk/splunk_prot.c#L202

It will be only released upon success at `process_flb_log_append`
https://github.com/fluent/fluent-bit/blob/v2.1.10/plugins/in_splunk/splunk_prot.c#L296

This patch is to ensure releasing `tag_from_record`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
