### PR TITLE
core: in memory filtering implementation

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -133,6 +133,7 @@ void flb_filter_instance_exit(struct flb_filter_instance *ins,
 void flb_filter_exit(struct flb_config *config);
 void flb_filter_do(struct flb_input_chunk *ic,
                    const void *data, size_t bytes,
+                   void **out_data, size_t *out_bytes,
                    const char *tag, int tag_len,
                    struct flb_config *config);
 const char *flb_filter_name(struct flb_filter_instance *ins);


### PR DESCRIPTION
This PR replaces the order of the filtering and writing operations in order to perform any filtering necessary in memory which in turn allows fluent-bit to minimize the overhead that comes with overwriting chunk sections (ie. IO and having to recalculate the file checksum each time).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205838432919112