### PR TITLE
config_format: flb_cf_yaml: change log level in processing. Backport #8131

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -877,7 +877,7 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
             break;
         case YAML_SCALAR_EVENT:
             value = (char *) event->data.scalar.value;
-            flb_error("[config yaml] including: %s", value);
+            flb_debug("[config yaml] including: %s", value);
 
             if (strchr(value, '*') != NULL) {
                 ret = read_glob(conf, ctx, state, value);


### PR DESCRIPTION
Backports #8131


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
