### PR TITLE
in_calyptia_fleet: fix memory leaks during hot-reload of current and new configurations.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -938,9 +938,6 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
             flb_sds_destroy(cfgoldname);
             goto reload_error;
         }
-        else {
-            FLB_INPUT_RETURN(0);
-        }
     }
 
     ret = 0;

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -686,27 +686,34 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
 
     if (ret != 0) {
         flb_plg_error(ctx->ins, "http do error");
+        flb_http_client_destroy(client);
         return -1;
     }
 
     if (client->resp.status != 200) {
         flb_plg_error(ctx->ins, "search http status code error: %d", client->resp.status);
+        flb_http_client_destroy(client);
         return -1;
     }
 
     if (client->resp.payload_size <= 0) {
         flb_plg_error(ctx->ins, "empty response");
+        flb_http_client_destroy(client);
         return -1;
     }
 
     if (parse_fleet_search_json(ctx, client->resp.payload, client->resp.payload_size) == -1) {
         flb_plg_error(ctx->ins, "unable to find fleet: %s", ctx->fleet_name);
+        flb_http_client_destroy(client);
         return -1;
     }
 
     if (ctx->fleet_id == NULL) {
+        flb_http_client_destroy(client);
         return -1;
     }
+
+    flb_http_client_destroy(client);
     return 0;
 }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -67,7 +67,11 @@ struct flb_in_calyptia_fleet_config {
     long config_timestamp;
 
     flb_sds_t api_key;
+
     flb_sds_t fleet_id;
+    /* flag used to mark fleet_id for release when found automatically. */
+    int fleet_id_found;
+
     flb_sds_t fleet_name;
     flb_sds_t machine_id;
     flb_sds_t config_dir;
@@ -593,6 +597,7 @@ static ssize_t parse_fleet_search_json(struct flb_in_calyptia_fleet_config *ctx,
                             return -1;
                         }
 
+                        ctx->fleet_id_found = 1;
                         ctx->fleet_id = flb_sds_create_len(cur->val.via.str.ptr,
                                                            cur->val.via.str.size);
                         break;
@@ -1222,6 +1227,14 @@ static int in_calyptia_fleet_exit(void *data, struct flb_config *config)
 {
     (void) *config;
     struct flb_in_calyptia_fleet_config *ctx = (struct flb_in_calyptia_fleet_config *)data;
+
+    if (ctx->fleet_url) {
+        flb_sds_destroy(ctx->fleet_url);
+    }
+
+    if (ctx->fleet_id && ctx->fleet_id_found) {
+        flb_sds_destroy(ctx->fleet_id);
+    }
 
     flb_input_collector_delete(ctx->collect_fd, ctx->ins);
     flb_upstream_destroy(ctx->u);


### PR DESCRIPTION
# Summary

I have identified and fixed several memory leaks in fleet that happen during the reloading of the current configuration (when it exists from a previous run) or any new configurations loaded from the calyptia API.

- Initialization of plugin instances when testing the new configuration in `test_config_is_valid`.
- Memory leaked due to premature return (FLB_OUTPUT_RETURN) in the collect callback.
- File paths (flb_sds_t) leaked during error handling.

The function `test_config_is_valid` was attempting to be far too intelligent by instantiating the configured plugins. Attempting to free the memory instantiated by the initialization is problematic since `flb_output_exit` also frees the TLS variables it uses to store co-routine parameters, making it not thread-safe.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
