### PR TITLE
in_opentelemetry: support tag_from_uri

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -170,6 +170,11 @@ static struct flb_config_map config_map[] = {
      ""
     },
     {
+     FLB_CONFIG_MAP_BOOL, "tag_from_uri", "true",
+     0, FLB_TRUE, offsetof(struct flb_opentelemetry, tag_from_uri),
+     "If true, tag will be created from uri. e.g. v1_metrics from /v1/metrics ."
+    },
+    {
      FLB_CONFIG_MAP_INT, "successful_response_code", "201",
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, successful_response_code),
      "Set successful response code. 200, 201 and 204 are supported."

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -35,6 +35,7 @@ struct flb_opentelemetry {
     flb_sds_t tcp_port;
     const char *tag_key;
     bool raw_traces;
+    int  tag_from_uri;
 
     size_t buffer_max_size;            /* Maximum buffer size */
     size_t buffer_chunk_size;          /* Chunk allocation size */

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -1568,8 +1568,8 @@ int opentelemetry_prot_handle(struct flb_opentelemetry *ctx, struct http_conn *c
     /* Compose the query string using the URI */
     len = strlen(uri);
 
-    if (len == 1) {
-        tag = NULL; /* use default tag */
+    if (ctx->tag_from_uri != FLB_TRUE) {
+        tag = flb_sds_create(ctx->ins->tag);
     }
     else {
         tag = flb_sds_create_size(len);

--- a/tests/runtime/in_opentelemetry.c
+++ b/tests/runtime/in_opentelemetry.c
@@ -367,10 +367,85 @@ void flb_test_otel_successful_response_code_204()
     flb_test_otel_successful_response_code("204");    
 }
 
+void flb_test_otel_tag_from_uri_false()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+
+    char *buf = TEST_MSG_OTEL_LOGS;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = TEST_CB_MSG_OTEL_LOGS;
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "not_uri",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "tag_from_uri", "false",
+                        "tag", "not_uri",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, V1_ENDPOINT_LOGS, buf, strlen(buf),
+                        "127.0.0.1", PORT_OTEL, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 201)) {
+        TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
 TEST_LIST = {
     {"otel_logs", flb_test_otel_logs},
     {"successful_response_code_200", flb_test_otel_successful_response_code_200},
     {"successful_response_code_204", flb_test_otel_successful_response_code_204},
+    {"tag_from_uri_false", flb_test_otel_tag_from_uri_false},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
This patch is to support property `tag_from_uri`.

Currently, in_otel composes tag from uri.
e.g.  v1_metrics, v1_traces or v1_logs.

It may confuse user. https://github.com/fluent/fluent-bit/issues/7939

If user set `tag_from_uri=false`, tag will be the value of property `tag`.
Default is `true` to prevent breaking current behavior.

|Key|Description|Default|
|---|---|---|
|tag_from_uri|If true, tag will be created from uri. e.g. v1_metrics from /v1/metrics .| true |

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Configuration 

```
[INPUT]
    Name opentelemetry
    Tag not_uri
    Tag_from_uri false

[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind output

Use curl like 
```
curl --header "Content-Type: application/json" --request POST --data '{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1660296023390371588","body":{"stringValue":"{\"message\":\"dummy\"}"},"traceId":"","spanId":""}]}]}]}'   http://0.0.0.0:4318/v1/logs
```

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==10939== Memcheck, a memory error detector
==10939== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10939== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==10939== Command: bin/fluent-bit -c a.conf
==10939== 
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/04 09:15:32] [ info] [fluent bit] version=2.2.0, commit=99d568b7c1, pid=10939
[2023/11/04 09:15:32] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/04 09:15:32] [ info] [cmetrics] version=0.6.4
[2023/11/04 09:15:32] [ info] [ctraces ] version=0.3.1
[2023/11/04 09:15:32] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/11/04 09:15:32] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/11/04 09:15:32] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:4318
[2023/11/04 09:15:32] [ info] [output:stdout:stdout.0] worker #0 started
[2023/11/04 09:15:32] [ info] [sp] stream processor started
[0] not_uri: [[1660296023.1698112429, {}], {"log"=>"{"message":"dummy"}"}]
^C[2023/11/04 09:15:35] [engine] caught signal (SIGINT)
[2023/11/04 09:15:35] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/04 09:15:35] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/04 09:15:35] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/04 09:15:35] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==10939== 
==10939== HEAP SUMMARY:
==10939==     in use at exit: 0 bytes in 0 blocks
==10939==   total heap usage: 1,605 allocs, 1,605 frees, 1,243,678 bytes allocated
==10939== 
==10939== All heap blocks were freed -- no leaks are possible
==10939== 
==10939== For lists of detected and suppressed errors, rerun with: -s
==10939== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
