### PR TITLE
input: add support for upstream configuration for input client plugins.

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -25,6 +25,8 @@
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_downstream.h>
+#include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_str.h>
 #include <fluent-bit/flb_bits.h>

--- a/src/flb_help.c
+++ b/src/flb_help.c
@@ -198,7 +198,6 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
     int options_size = 0;
-    struct mk_list *tls_config;
     struct flb_config_map m_input_net_listen = {
         .type =      FLB_CONFIG_MAP_STR,
         .name =      "host",
@@ -245,23 +244,12 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
         if ((ins->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) != 0) {
             options_size += 2;
         }
-        if (ins->flags & FLB_IO_OPT_TLS) {
-            tls_config = flb_tls_get_config_map(ins->config);
-            options_size += mk_list_size(tls_config);
-        }
 
         msgpack_pack_array(&mp_pck, options_size);
 
         if ((ins->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) != 0) {
             pack_config_map_entry(&mp_pck, &m_input_net_listen);
             pack_config_map_entry(&mp_pck, &m_input_net_port);
-        }
-        if (ins->flags & FLB_IO_OPT_TLS) {
-            mk_list_foreach(head, tls_config) {
-                m = mk_list_entry(head, struct flb_config_map, _head);
-                pack_config_map_entry(&mp_pck, m);
-            }
-            flb_config_map_destroy(tls_config);
         }
 
         mk_list_foreach(head, config_map) {

--- a/src/flb_help.c
+++ b/src/flb_help.c
@@ -271,6 +271,53 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
         flb_config_map_destroy(config_map);
     }
 
+    if (ins->p->flags & FLB_INPUT_NET_SERVER) {
+        flb_mp_map_header_append(&mh);
+        pack_str(&mp_pck, "networking");
+
+        config_map = flb_downstream_get_config_map(ins->config);
+        msgpack_pack_array(&mp_pck, mk_list_size(config_map));
+        mk_list_foreach(head, config_map) {
+            m = mk_list_entry(head, struct flb_config_map, _head);
+            pack_config_map_entry(&mp_pck, m);
+        }
+        flb_config_map_destroy(config_map);
+    }
+    else if (ins->p->flags & FLB_INPUT_NET) {
+        flb_mp_map_header_append(&mh);
+        pack_str(&mp_pck, "networking");
+
+        config_map = flb_upstream_get_config_map(ins->config);
+        msgpack_pack_array(&mp_pck, mk_list_size(config_map));
+        mk_list_foreach(head, config_map) {
+            m = mk_list_entry(head, struct flb_config_map, _head);
+            pack_config_map_entry(&mp_pck, m);
+        }
+        flb_config_map_destroy(config_map);
+    }
+
+    if (ins->p->flags & (FLB_IO_TLS | FLB_IO_OPT_TLS)) {
+        flb_mp_map_header_append(&mh);
+        pack_str(&mp_pck, "network_tls");
+
+        config_map = flb_tls_get_config_map(ins->config);
+        msgpack_pack_array(&mp_pck, mk_list_size(config_map));
+
+        /* Adjust 'tls' default value based on plugin type" */
+        m = mk_list_entry_first(config_map, struct flb_config_map, _head);
+        if (ins->p->flags & FLB_IO_TLS) {
+            m->value.val.boolean = FLB_TRUE;
+        }
+        else if (ins->p->flags & FLB_IO_OPT_TLS) {
+            m->value.val.boolean = FLB_FALSE;
+        }
+        mk_list_foreach(head, config_map) {
+            m = mk_list_entry(head, struct flb_config_map, _head);
+            pack_config_map_entry(&mp_pck, m);
+        }
+        flb_config_map_destroy(config_map);
+    }
+
     flb_mp_map_header_end(&mh);
 
     *out_buf = mp_sbuf.data;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -35,6 +35,7 @@
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_downstream.h>
+#include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_plugin.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_hash_table.h>
@@ -853,11 +854,20 @@ int flb_input_net_property_check(struct flb_input_instance *ins,
 {
     int ret = 0;
 
-    /* Get Downstream net_setup configmap */
-    ins->net_config_map = flb_downstream_get_config_map(config);
-    if (!ins->net_config_map) {
-        flb_input_instance_destroy(ins);
-        return -1;
+    /* Get Downstream or Upstream net_setup configmap */
+    if (ins->p->flags & FLB_INPUT_NET_SERVER) {
+        ins->net_config_map = flb_downstream_get_config_map(config);
+        if (!ins->net_config_map) {
+            flb_input_instance_destroy(ins);
+            return -1;
+        }
+    }
+    else if (ins->p->flags & FLB_INPUT_NET) {
+        ins->net_config_map = flb_upstream_get_config_map(config);
+        if (!ins->net_config_map) {
+            flb_input_instance_destroy(ins);
+            return -1;
+        }
     }
 
     /*


### PR DESCRIPTION
# Summary

Add support for upstream configuration for client input plugins.

# Description

Client side input plugins like in_health and in_kubernetes_events use the upstream API but the property check for input plugins only applies downstream configuration checks. This pull request checks the plugin flags to see which one applies, either the downstream or upstream configuration map.

# Notes

I have not added a check to make sure that not both flags, FLB_INPUT and FLB_INPUT_SERVER, are set on a plugin. In this case the downstream configuration map would be used. There should probably be a check, earlier than `flb_input_net_property_check`, that actually checks that both flags are not set.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205870292835340