### PR TITLE
dockerfiles: Add support for s390x to 2.1

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -120,7 +120,7 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/s390x
           target: production
           # Must be disabled to provide legacy format images from the registry
           provenance: false
@@ -147,7 +147,7 @@ jobs:
           context: .
           tags: ${{ steps.debug-meta.outputs.tags }}
           labels: ${{ steps.debug-meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/s390x
           # Must be disabled to provide legacy format images from the registry
           provenance: false
           target: debug

--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ linux/amd64, linux/arm64, linux/arm/v7 ]
+        arch: [ linux/amd64, linux/arm64, linux/arm/v7, linux/s390x ]
         include:
           # Rather than extract the specific central arch we just provide it
           - arch: linux/amd64
@@ -85,6 +85,8 @@ jobs:
             expected: arm64
           - arch: linux/arm/v7
             expected: arm
+          - arch: linux/s390x
+            expected: s390x
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -128,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false # verify all
       matrix:
-        arch: [ linux/amd64, linux/arm64, linux/arm/v7 ]
+        arch: [ linux/amd64, linux/arm64, linux/arm/v7, linux/s390x ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,11 @@ if (FLB_SYSTEM_MACOS)
   include(cmake/macos-setup.cmake)
 endif()
 
+# Build for SystemZ - s390x arch
+if (FLB_SYSTEM_LINUX)
+  include(cmake/s390x.cmake)
+endif ()
+
 # Extract Git commit information for debug output.
 # Note that this is only set when cmake is run, the intent here is to use in CI for verification of releases so is acceptable.
 # For a better solution see https://jonathanhamberg.com/post/cmake-embedding-git-hash/ but this is simple and easy.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Fluent Bit is fully supported on Windows environments, get started with [these i
 
 [Fluent Bit](http://fluentbit.io) is based in a pluggable architecture where different plugins plays a major role in the data pipeline:
 
+#### Running on s390x
+
+Fluent Bit is supported on Linux on IBM Z(s390x), but the WASM and LUA filter plugins are not.
+
 #### Input Plugins
 
 | name | title | description |

--- a/cmake/s390x.cmake
+++ b/cmake/s390x.cmake
@@ -1,0 +1,8 @@
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(SystemZ|s390x)")
+  message(STATUS "Forcing characters to be signed, as on x86_64.")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")
+  message(STATUS "Cannot build WAMR on this platform, so WASM support is disabled.")
+  set(FLB_WASM OFF)
+  message(STATUS "This platform does not support LuaJIT, so it's disabled.")
+  set(FLB_LUAJIT OFF)
+endif ()

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -8,7 +8,7 @@
 # docker buildx rm builder
 # docker buildx create --name builder --use
 # docker buildx inspect --bootstrap
-# docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz ./dockerfiles/
+# docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7,linux/s390x" -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz ./dockerfiles/
 
 # Set this to the current release version: it gets done so as part of the release.
 ARG RELEASE_VERSION=2.1.11

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -40,7 +40,7 @@ docker buildx inspect --bootstrap
 ```
 4. Build Fluent Bit from the **root of the Git repo (not from this directory)**:
 ```
-docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" --target=production -f dockerfiles/Dockerfile .
+docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7,linux/s390x" --target=production -f dockerfiles/Dockerfile .
 ```
 
 ## Build and test


### PR DESCRIPTION
<!-- Provide summary of changes -->
- Adding support for linux-s390x in CI
- Added s390x specific cmake target to disable WASM and LuaJIT

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Backporting s390x enablement via https://github.com/fluent/fluent-bit/pull/8095

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--  
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support: 
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature -- https://github.com/fluent/fluent-bit-docs/pull/1245

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
