### PR TITLE
cmake: link missing framework CoreFoundation and IOKit for machine_id on macOS.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -554,6 +554,22 @@ if(FLB_BINARY)
       DESTINATION ${FLB_INSTALL_CONFDIR}
       COMPONENT binary
       RENAME "${FLB_OUT_NAME}.conf")
+
+    # link in CoreFoundation and IOKit for machine_id code on macOS
+    find_library(CORE_FOUNDATION CoreFoundation)
+    if (NOT CORE_FOUNDATION)
+      message(FATAL_ERROR "CoreFoundation framework missing on macOS")
+    endif()
+
+    find_library(IOKITLIB IOKit)
+    if (NOT IOKITLIB)
+      message(FATAL_ERROR "IOKitLib framework missing on macOS")
+    endif()
+
+    target_link_libraries(fluent-bit-static "-framework CoreFoundation")
+    target_link_libraries(fluent-bit-static "-framework IOKit")
+    set_target_properties(fluent-bit-static PROPERTIES LINK_FLAGS "-Wl,-F/Library/Frameworks")
+
   else()
     install(FILES
       "${PROJECT_SOURCE_DIR}/conf/fluent-bit.conf"


### PR DESCRIPTION
# Summary

The previous PR #8096 added support for using IOKit to retrieve the serial of the macOS machine to use as a machineID. Somehow the lack of linking instructions to the CoreFoundation and IOKit frameworks snuck past CI.

This PR aims to fix that.

Why did it compile earlier?

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
