### PR TITLE
Added debug message for systemd journal

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -139,10 +139,12 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
                             FLB_SYSTEMD_UNKNOWN, sizeof(FLB_SYSTEMD_UNKNOWN) - 1,
                             &tag, &tag_len);
             }
+            flb_debug("[in_systemd] dynamic tag: %s length: %i", tag, length);          
         }
         else {
             tag = ctx->i_ins->tag;
             tag_len = ctx->i_ins->tag_len;
+            flb_debug("[in_systemd] entry tag: %s length: %i", tag, tag_len);
         }
 
         if (last_tag_len == 0) {
@@ -161,7 +163,8 @@ static int in_systemd_collect(struct flb_input_instance *i_ins,
         sec = usec / 1000000;
         nsec = (usec % 1000000) * 1000;
         flb_time_set(&tm, sec, nsec);
-
+        flb_debug("[in_systemd] entry time set: %i secs and %i nsec", sec, nsec);
+      
         /*
          * The new incoming record can have a different tag than previous one,
          * so a new msgpack buffer is required. We ingest the data and prepare


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
