### PR TITLE
in_process_exporter_metrics: release str in error cases

### DIFF
--- a/plugins/in_process_exporter_metrics/pe_process.c
+++ b/plugins/in_process_exporter_metrics/pe_process.c
@@ -309,6 +309,7 @@ static int get_name(const char *entry, char **out_name, char *id_entry)
     tmp = strdup(entry);
     tmp_name = strtok(tmp, ")");
     if (tmp_name == NULL) {
+        flb_free(tmp);
         return -1;
     }
 
@@ -538,12 +539,14 @@ static int process_thread_update(struct flb_pe *ctx, uint64_t ts, flb_sds_t pid,
              * The entry of processes stat will start after that. */
             tmp = strstr(entry->str, ")");
             if (tmp == NULL) {
+                flb_free(thread_name);
                 continue;
             }
 
             mk_list_init(&split_list);
             ret = flb_slist_split_string(&split_list, tmp+2, ' ', -1);
             if (ret == -1) {
+                flb_free(thread_name);
                 continue;
             }
 


### PR DESCRIPTION
This function is to release string in error cases.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
