### PR TITLE
parser: add Time_System_Timezone

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -48,6 +48,7 @@ struct flb_parser {
     char *time_fmt_full;  /* original given time format */
     char *time_key;       /* field name that contains the time */
     int time_offset;      /* fixed UTC offset */
+    int time_system_timezone; /* use the system timezone as a fallback */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
     int logfmt_no_bare_keys; /* in logfmt parsers, require all keys to have values */
@@ -74,13 +75,18 @@ enum {
     FLB_PARSER_TYPE_HEX,
 };
 
-static inline time_t flb_parser_tm2time(const struct flb_tm *src)
+static inline time_t flb_parser_tm2time(const struct flb_tm *src, 
+                                        int use_system_timezone)
 {
     struct tm tmp;
     time_t res;
 
     tmp = src->tm;
-    res = timegm(&tmp) - flb_tm_gmtoff(src);
+    if (use_system_timezone) {
+        res = mktime(&tmp);
+    } else {
+        res = timegm(&tmp) - flb_tm_gmtoff(src);
+    }
     return res;
 }
 
@@ -92,6 +98,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *time_offset,
                                      int time_keep,
                                      int time_strict,
+                                     int time_system_timezone,
                                      int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -225,7 +225,7 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
         return -2;
     }
 
-    val->tm.tv_sec = flb_parser_tm2time(&tm);
+    val->tm.tv_sec = flb_parser_tm2time(&tm, FLB_FALSE);
     val->tm.tv_nsec = 0;
 
     return 0;

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -207,7 +207,7 @@ int flb_parser_json_do(struct flb_parser *parser,
         skip = map_size;
     }
     else {
-        time_lookup = flb_parser_tm2time(&tm);
+        time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
     }
 
     /* Compose a new map without the time_key field */

--- a/src/flb_parser_logfmt.c
+++ b/src/flb_parser_logfmt.c
@@ -166,7 +166,7 @@ static int logfmt_parser(struct flb_parser *parser,
                                   parser->name, parser->time_fmt_full);
                         return -1;
                     }
-                    *time_lookup = flb_parser_tm2time(&tm);
+                    *time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
                 }
                 time_found = FLB_TRUE;
             }

--- a/src/flb_parser_ltsv.c
+++ b/src/flb_parser_ltsv.c
@@ -139,7 +139,7 @@ static int ltsv_parser(struct flb_parser *parser,
                                  parser->name, parser->time_fmt_full);
                        return -1;
                     }
-                    *time_lookup = flb_parser_tm2time(&tm);
+                    *time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
                 }
                 time_found = FLB_TRUE;
             }

--- a/src/flb_parser_regex.c
+++ b/src/flb_parser_regex.c
@@ -87,7 +87,7 @@ static void cb_results(const char *name, const char *value,
             }
 
             pcb->time_frac = frac;
-            pcb->time_lookup = flb_parser_tm2time(&tm);
+            pcb->time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
 
             if (parser->time_keep == FLB_FALSE) {
                 pcb->num_skipped++;

--- a/src/multiline/flb_ml_parser_cri.c
+++ b/src/multiline/flb_ml_parser_cri.c
@@ -40,6 +40,7 @@ static struct flb_parser *cri_parser_create(struct flb_config *config)
                           NULL,                    /* time offset */
                           FLB_TRUE,                /* time keep */
                           FLB_FALSE,               /* time strict */
+                          FLB_FALSE,               /* time system timezone */
                           FLB_FALSE,               /* no bare keys */
                           NULL,                    /* parser types */
                           0,                       /* types len */

--- a/src/multiline/flb_ml_parser_docker.c
+++ b/src/multiline/flb_ml_parser_docker.c
@@ -35,6 +35,7 @@ static struct flb_parser *docker_parser_create(struct flb_config *config)
                           NULL,                   /* time offset */
                           FLB_TRUE,               /* time keep */
                           FLB_FALSE,              /* time strict */
+                          FLB_FALSE,              /* time system timezone */
                           FLB_FALSE,              /* no bare keys */
                           NULL,                   /* parser types */
                           0,                      /* types len */

--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -143,7 +143,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
 
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
                                 "%s.%L", "time", NULL, MK_FALSE, 0, FLB_FALSE,
-                               NULL, 0, NULL, ctx->config);
+                               FLB_FALSE, NULL, 0, NULL, ctx->config);
     filter_ffd = flb_filter(ctx, (char *) "parser", NULL);
     int ret;
     ret = flb_filter_set(ctx, filter_ffd, "Match", "test",

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -51,7 +51,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     }
 
     fuzz_parser = flb_parser_create("fuzzer", "json", NULL, FLB_TRUE, NULL,
-                                    NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE,
+                                    NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
                                     NULL, 0, NULL, fuzz_config);
     if (fuzz_parser) {
         flb_parser_do(fuzz_parser, (char*)data, size,

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -32,8 +32,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     }
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, FLB_TRUE,
                                     NULL, NULL, NULL, MK_FALSE,
-                                    MK_TRUE, FLB_FALSE, NULL, 0, NULL,
-                                    fuzz_config);
+                                    MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                                    NULL, fuzz_config);
     if (fuzz_parser) {
         flb_parser_do(fuzz_parser, (char*)data, size,
                       &out_buf, &out_size, &out_time);

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -19,8 +19,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, FLB_TRUE,
                                     NULL, NULL, NULL, MK_FALSE, 
-                                    MK_TRUE, FLB_FALSE, NULL, 0, NULL,
-                                    fuzz_config);
+                                    MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                                    NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);
 

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -154,7 +154,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     /* now call into the parser */
     fuzz_parser = flb_parser_create("fuzzer", format, pregex, FLB_TRUE,
             time_fmt, time_key, time_offset, time_keep, 0, FLB_FALSE,
-            types, types_len, list, fuzz_config);
+            FLB_FALSE, types, types_len, list, fuzz_config);
 
     /* Second step is to use the random parser to parse random input */
     if (fuzz_parser != NULL) {

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -231,7 +231,7 @@ void test_parser_time_lookup()
             continue;
         }
 
-        epoch = flb_parser_tm2time(&tm);
+        epoch = flb_parser_tm2time(&tm, FLB_FALSE);
         epoch -= year_diff;
         TEST_CHECK(t->epoch == epoch);
         TEST_CHECK(t->frac_seconds == ns);

--- a/tests/internal/parser_json.c
+++ b/tests/internal/parser_json.c
@@ -171,7 +171,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -223,7 +223,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -284,7 +284,7 @@ void test_time_keep()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE,
+                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -365,7 +365,7 @@ void test_types_is_not_supported()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -450,7 +450,7 @@ void test_decode_field_json()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, decoder, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -505,7 +505,7 @@ void test_time_key_kept_if_parse_fails()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, time_format, "time", NULL,
-                               FLB_FALSE, FLB_TRUE, FLB_FALSE,
+                               FLB_FALSE, FLB_TRUE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/internal/parser_logfmt.c
+++ b/tests/internal/parser_logfmt.c
@@ -171,7 +171,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -223,7 +223,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -284,7 +284,7 @@ void test_time_keep()
     }
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE,
+                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -361,7 +361,7 @@ void test_types()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/internal/parser_ltsv.c
+++ b/tests/internal/parser_ltsv.c
@@ -171,7 +171,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -223,7 +223,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -284,7 +284,7 @@ void test_time_keep()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE,
+                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -361,7 +361,7 @@ void test_types()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -446,7 +446,7 @@ void test_decode_field_json()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, decoder, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/internal/parser_regex.c
+++ b/tests/internal/parser_regex.c
@@ -172,7 +172,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -225,7 +225,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -287,7 +287,7 @@ void test_time_keep()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE,
+                               FLB_TRUE /*time_keep */, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -365,7 +365,7 @@ void test_types()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -451,7 +451,7 @@ void test_decode_field_json()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
                                NULL, 0, decoder, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");


### PR DESCRIPTION
Added a new config option for parsers called `time_system_timezone` which will fall back to `mktime` for tm to time conversion which will force the usage of the system timezone.

Fixes #593 

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
### a.txt
```
{"message": "test", "time": "2023-11-11:13:00:00"}
{"message": "test2", "time": "2023-10-17:00:00:00"}
```
### parser.conf
```
[PARSER]
    Name        no_timezone
    Format      json
    Time_Key    time
    Time_Format %Y-%m-%d:%H:%M:%S
    Time_System_Timezone true
```
### config.conf
```
[SERVICE]
  Log_Level debug

[INPUT]
    Name           tail
    Tag            test
    Exit_On_Eof    true
    Read_From_Head true
    Path           a.txt
    Key            log

[FILTER]
    Name     parser
    Match    *
    Parser   no_timezone 
    Key_Name log

[OUTPUT]
    Name   stdout
    Match  *
```
- [x] Debug log output from testing the change
## Linux
```
braydonk@braydonk:~/Git/fluent-bit$ ./build/bin/fluent-bit --conf ~/Documents/fluent-bit-configs/config.conf --parser ~/Documents/fluent-bit-configs/parser.conf 
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/12 19:30:17] [ info] Configuration:
[2023/11/12 19:30:17] [ info]  flush time     | 1.000000 seconds
[2023/11/12 19:30:17] [ info]  grace          | 5 seconds
[2023/11/12 19:30:17] [ info]  daemon         | 0
[2023/11/12 19:30:17] [ info] ___________
[2023/11/12 19:30:17] [ info]  inputs:
[2023/11/12 19:30:17] [ info]      tail
[2023/11/12 19:30:17] [ info] ___________
[2023/11/12 19:30:17] [ info]  filters:
[2023/11/12 19:30:17] [ info]      parser.0
[2023/11/12 19:30:17] [ info] ___________
[2023/11/12 19:30:17] [ info]  outputs:
[2023/11/12 19:30:17] [ info]      stdout.0
[2023/11/12 19:30:17] [ info] ___________
[2023/11/12 19:30:17] [ info]  collectors:
[2023/11/12 19:30:17] [ info] [fluent bit] version=2.2.0, commit=1c4c9ec2e3, pid=385488
[2023/11/12 19:30:17] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/11/12 19:30:17] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/12 19:30:17] [ info] [cmetrics] version=0.6.3
[2023/11/12 19:30:17] [ info] [ctraces ] version=0.3.1
[2023/11/12 19:30:17] [ info] [input:tail:tail.0] initializing
[2023/11/12 19:30:17] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/11/12 19:30:17] [debug] [tail:tail.0] created event channels: read=21 write=22
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] inotify watch fd=27
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] scanning path a.txt
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] inode=5906182 with offset=0 appended as a.txt
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] scan_glob add(): a.txt, inode 5906182
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] 1 new files found on path 'a.txt'
[2023/11/12 19:30:17] [debug] [stdout:stdout.0] created event channels: read=29 write=30
[2023/11/12 19:30:17] [ info] [sp] stream processor started
[2023/11/12 19:30:17] [ info] [output:stdout:stdout.0] worker #0 started
[2023/11/12 19:30:17] [debug] [input chunk] update output instances with new chunk size diff=71, records=2, input=tail.0
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] [static files] processed 103b
[2023/11/12 19:30:17] [ info] [input:tail:tail.0] inode=5906182 file=a.txt ended, stop
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] inode=5906182 file=a.txt promote to TAIL_EVENT
[2023/11/12 19:30:17] [ info] [input:tail:tail.0] inotify_fs_add(): inode=5906182 watch_fd=1 name=a.txt
[2023/11/12 19:30:17] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2023/11/12 19:30:17] [debug] [task] created task=0x7f0664038ea0 id=0 OK
[2023/11/12 19:30:17] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/11/12 19:30:17] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/12 19:30:17] [ info] [input] pausing tail.0
[0] test: [[1699725600.000000000, {}], {"message"=>"test"}]
[1] test: [[1697515200.000000000, {}], {"message"=>"test2"}]
[2023/11/12 19:30:17] [debug] [out flush] cb_destroy coro_id=0
[2023/11/12 19:30:17] [debug] [task] destroy task=0x7f0664038ea0 (task_id=0)
[2023/11/12 19:30:18] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/12 19:30:18] [ info] [input] pausing tail.0
[2023/11/12 19:30:18] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/12 19:30:18] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2023/11/12 19:30:18] [debug] [input:tail:tail.0] inode=5906182 removing file name a.txt
[2023/11/12 19:30:18] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=5906182 watch_fd=1
braydonk@braydonk:~/Git/fluent-bit$ date -d @1699725600
Sat Nov 11 01:00:00 PM EST 2023
braydonk@braydonk:~/Git/fluent-bit$ date -d @1697515200
Tue Oct 17 12:00:00 AM EDT 2023
```
Note that the timestamps printed from `date -d` can be compared with the log lines from `a.txt` above. They are both correctly interpreted as being the time in the timestamp at my system timezone, which is Eastern Time. Daylight savings is correctly determined for Oct 17, which occurs before the clocks go back on Nov 5.
If your system is in a different timezone, running `TZ=EST5EDT ./fluent-bit ... etc` should produce the same result as what I got.

## Windows
```
PS C:\Users\braydonk\Documents> C:\Users\braydonk\Git\fluent-bit\build\bin\Debug\fluent-bit.exe --config config.conf --parser parser.conf
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/12 19:55:28] [ info] Configuration:
[2023/11/12 19:55:28] [ info]  flush time     | 1.000000 seconds
[2023/11/12 19:55:28] [ info]  grace          | 5 seconds
[2023/11/12 19:55:28] [ info]  daemon         | 0
[2023/11/12 19:55:28] [ info] ___________
[2023/11/12 19:55:28] [ info]  inputs:
[2023/11/12 19:55:28] [ info]      tail
[2023/11/12 19:55:28] [ info] ___________
[2023/11/12 19:55:28] [ info]  filters:
[2023/11/12 19:55:28] [ info]      parser.0
[2023/11/12 19:55:28] [ info] ___________
[2023/11/12 19:55:28] [ info]  outputs:
[2023/11/12 19:55:28] [ info]      stdout.0
[2023/11/12 19:55:28] [ info] ___________
[2023/11/12 19:55:28] [ info]  collectors:
[2023/11/12 19:55:28] [ info] [fluent bit] version=2.2.0, commit=640762fb33, pid=4328
[2023/11/12 19:55:28] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2023/11/12 19:55:28] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/12 19:55:28] [ info] [cmetrics] version=0.6.3
[2023/11/12 19:55:28] [ info] [ctraces ] version=0.3.1
[2023/11/12 19:55:28] [ info] [input:tail:tail.0] initializing
[2023/11/12 19:55:28] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/11/12 19:55:28] [debug] [tail:tail.0] created event channels: read=820 write=824
[2023/11/12 19:55:28] [debug] [input:tail:tail.0] flb_tail_fs_stat_init() initializing stat tail input
[2023/11/12 19:55:28] [debug] [input:tail:tail.0] inode=53198770598527222 with offset=0 appended as C:\Users\braydonk\Documents\a.txt
[2023/11/12 19:55:28] [debug] [input:tail:tail.0] 1 new files found on path 'a.txt'
[2023/11/12 19:55:28] [debug] [stdout:stdout.0] created event channels: read=848 write=852
[2023/11/12 19:55:28] [ info] [sp] stream processor started
[2023/11/12 19:55:28] [debug] [input chunk] update output instances with new chunk size diff=71, records=2, input=tail.0
[2023/11/12 19:55:28] [ info] [output:stdout:stdout.0] worker #0 started
[2023/11/12 19:55:28] [debug] [input:tail:tail.0] [static files] processed 105b
[0] test: [[1699725600.000000000, [2023/11/12 19:55:28] [ info] [input:tail:tail.0] inode=53198770598527222 file=C:\Users\braydonk\Documents\a.txt ended, stop
{}], [2023/11/12 19:55:28] [debug] [input:tail:tail.0] inode=53198770598527222 file=C:\Users\braydonk\Documents\a.txt promote to TAIL_EVENT
{[2023/11/12 19:55:28] [debug] [input:tail:tail.0] [static files] processed 0b, done
"[2023/11/12 19:55:28] [debug] [task] created task=000002A3795D4AA0 id=0 OK
message[2023/11/12 19:55:28] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
"[2023/11/12 19:55:28] [ warn] [engine] service will shutdown in max 5 seconds
=>"[2023/11/12 19:55:28] [ info] [input] pausing tail.0
test"}]
[1] test: [[1697515200.000000000, {}], {"message"=>"test2"}]
[2023/11/12 19:55:28] [debug] [out flush] cb_destroy coro_id=0
[2023/11/12 19:55:28] [debug] [task] destroy task=000002A3795D4AA0 (task_id=0)
[2023/11/12 19:55:29] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/12 19:55:29] [ info] [input] pausing tail.0
[2023/11/12 19:55:29] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/12 19:55:29] [debug] [input:tail:tail.0] inode=53198770598527222 removing file name C:\Users\braydonk\Documents\a.txt
[2023/11/12 19:55:29] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
With my Windows machine set to the same timezone as my Linux machine, I got the same timestamp results.
(I couldn't tell you why the output from stdout is mangled like that, but it's the same on master :shrug: )

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
braydonk@braydonk:~/Git/fluent-bit$ valgrind --leak-check=full ./buildvalgrind/bin/fluent-bit --conf ~/Documents/fluent-bit-configs/config.conf --parser ~/Documents/fluent-bit-configs/parser.conf 
==399441== Memcheck, a memory error detector
==399441== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==399441== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==399441== Command: ./buildvalgrind/bin/fluent-bit --conf /home/braydonk/Documents/fluent-bit-configs/config.conf --parser /home/braydonk/Documents/fluent-bit-configs/parser.conf
==399441== 
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/12 20:04:53] [ info] Configuration:
[2023/11/12 20:04:53] [ info]  flush time     | 1.000000 seconds
[2023/11/12 20:04:53] [ info]  grace          | 5 seconds
[2023/11/12 20:04:53] [ info]  daemon         | 0
[2023/11/12 20:04:53] [ info] ___________
[2023/11/12 20:04:53] [ info]  inputs:
[2023/11/12 20:04:53] [ info]      tail
[2023/11/12 20:04:53] [ info] ___________
[2023/11/12 20:04:53] [ info]  filters:
[2023/11/12 20:04:53] [ info]      parser.0
[2023/11/12 20:04:53] [ info] ___________
[2023/11/12 20:04:53] [ info]  outputs:
[2023/11/12 20:04:53] [ info]      stdout.0
[2023/11/12 20:04:53] [ info] ___________
[2023/11/12 20:04:53] [ info]  collectors:
[2023/11/12 20:04:53] [ info] [fluent bit] version=2.2.0, commit=6af61749af, pid=399441
[2023/11/12 20:04:53] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/11/12 20:04:53] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/12 20:04:53] [ info] [cmetrics] version=0.6.3
[2023/11/12 20:04:53] [ info] [ctraces ] version=0.3.1
[2023/11/12 20:04:53] [ info] [input:tail:tail.0] initializing
[2023/11/12 20:04:53] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/11/12 20:04:53] [debug] [tail:tail.0] created event channels: read=21 write=22
[2023/11/12 20:04:53] [ info] [output:stdout:stdout.0] worker #0 started
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] inotify watch fd=27
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] scanning path a.txt
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] inode=5906182 with offset=0 appended as a.txt
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] scan_glob add(): a.txt, inode 5906182
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] 1 new files found on path 'a.txt'
[2023/11/12 20:04:53] [debug] [stdout:stdout.0] created event channels: read=29 write=30
[0] test: [[1699725600.000000000, {}], {"message"=>"test"}]
[1] test: [[1697515200.000000000, {}], {"message"=>"test2"}]
[2023/11/12 20:04:53] [ info] [sp] stream processor started
[2023/11/12 20:04:53] [debug] [out flush] cb_destroy coro_id=0
[2023/11/12 20:04:53] [debug] [input chunk] update output instances with new chunk size diff=71, records=2, input=tail.0
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] [static files] processed 103b
[2023/11/12 20:04:53] [ info] [input:tail:tail.0] inode=5906182 file=a.txt ended, stop
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] inode=5906182 file=a.txt promote to TAIL_EVENT
[2023/11/12 20:04:53] [ info] [input:tail:tail.0] inotify_fs_add(): inode=5906182 watch_fd=1 name=a.txt
[2023/11/12 20:04:53] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2023/11/12 20:04:53] [debug] [task] created task=0x5fd5e30 id=0 OK
[2023/11/12 20:04:53] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/11/12 20:04:53] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/12 20:04:53] [ info] [input] pausing tail.0
[2023/11/12 20:04:53] [debug] [task] destroy task=0x5fd5e30 (task_id=0)
[2023/11/12 20:04:54] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/12 20:04:54] [ info] [input] pausing tail.0
[2023/11/12 20:04:54] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/12 20:04:54] [debug] [input:tail:tail.0] inode=5906182 removing file name a.txt
[2023/11/12 20:04:54] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2023/11/12 20:04:54] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=5906182 watch_fd=1
==399441== 
==399441== HEAP SUMMARY:
==399441==     in use at exit: 0 bytes in 0 blocks
==399441==   total heap usage: 3,313 allocs, 3,313 frees, 983,448 bytes allocated
==399441== 
==399441== All heap blocks were freed -- no leaks are possible
==399441== 
==399441== For lists of detected and suppressed errors, rerun with: -s
==399441== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/1388

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
