### PR TITLE
in_kafka: Make back pressure workable and add a mechanism of polling threshold

### DIFF
--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -241,13 +241,8 @@ static int in_kafka_init(struct flb_input_instance *ins,
         goto init_error;
     }
 
-    if (ctx->ins->mem_buf_limit > 0 || ctx->buffer_max_size > 0) {
-        if (ctx->ins->mem_buf_limit) {
-            ctx->polling_threshold = ctx->ins->mem_buf_limit;
-        }
-        else if (ctx->buffer_max_size > 0) {
-            ctx->polling_threshold = ctx->buffer_max_size;
-        }
+    if (ctx->buffer_max_size > 0) {
+        ctx->polling_threshold = ctx->buffer_max_size;
 
         snprintf(conf_val, sizeof(conf_val), "%zu", ctx->polling_threshold - 512);
         res = rd_kafka_conf_set(kafka_conf, "fetch.max.bytes", conf_val,

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -281,6 +281,8 @@ static int in_kafka_init(struct flb_input_instance *ins,
         goto init_error;
     }
 
+    ctx->coll_fd = ret;
+
     ctx->log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
 
     if (ctx->log_encoder == NULL) {
@@ -304,6 +306,20 @@ init_error:
     flb_free(ctx);
 
     return -1;
+}
+
+static void in_kafka_pause(void *data, struct flb_config *config)
+{
+    struct flb_in_kafka_config *ctx = data;
+
+    flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+}
+
+static void in_kafka_resume(void *data, struct flb_config *config)
+{
+    struct flb_in_kafka_config *ctx = data;
+
+    flb_input_collector_resume(ctx->coll_fd, ctx->ins);
 }
 
 /* Cleanup serial input */
@@ -377,6 +393,8 @@ struct flb_input_plugin in_kafka_plugin = {
     .cb_pre_run   = NULL,
     .cb_collect   = in_kafka_collect,
     .cb_flush_buf = NULL,
+    .cb_pause     = in_kafka_pause,
+    .cb_resume    = in_kafka_resume,
     .cb_exit      = in_kafka_exit,
     .config_map   = config_map
 };

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -241,20 +241,20 @@ static int in_kafka_init(struct flb_input_instance *ins,
         goto init_error;
     }
 
-    if (ctx->ins->mem_buf_limit > 0 || ctx->buffer_chunk_size > 0) {
+    if (ctx->ins->mem_buf_limit > 0 || ctx->buffer_max_size > 0) {
         if (ctx->ins->mem_buf_limit) {
             ctx->polling_threshold = ctx->ins->mem_buf_limit;
         }
-        else if (ctx->buffer_chunk_size > 0) {
-            ctx->polling_threshold = ctx->buffer_chunk_size;
+        else if (ctx->buffer_max_size > 0) {
+            ctx->polling_threshold = ctx->buffer_max_size;
         }
 
         snprintf(conf_val, sizeof(conf_val), "%zu", ctx->polling_threshold - 512);
         res = rd_kafka_conf_set(kafka_conf, "fetch.max.bytes", conf_val,
                                 errstr, sizeof(errstr));
         if (res != RD_KAFKA_CONF_OK) {
-            flb_plg_error(ins, "Failed to set up fetch.max.bytes: %s",
-                          rd_kafka_err2str(err));
+            flb_plg_error(ins, "Failed to set up fetch.max.bytes: %s, val = %s",
+                          rd_kafka_err2str(err), conf_val);
             goto init_error;
         }
 
@@ -262,8 +262,8 @@ static int in_kafka_init(struct flb_input_instance *ins,
         res = rd_kafka_conf_set(kafka_conf, "receive.message.max.bytes", conf_val,
                                 errstr, sizeof(errstr));
         if (res != RD_KAFKA_CONF_OK) {
-            flb_plg_error(ins, "Failed to set up receive.message.max.bytes: %s",
-                          rd_kafka_err2str(err));
+            flb_plg_error(ins, "Failed to set up receive.message.max.bytes: %s, val = %s",
+                          rd_kafka_err2str(err), conf_val);
             goto init_error;
         }
     }
@@ -427,9 +427,9 @@ static struct flb_config_map config_map[] = {
     "Set the librdkafka options"
    },
    {
-    FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", (char *)NULL,
-    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, buffer_chunk_size),
-    "Set the chunk size"
+    FLB_CONFIG_MAP_SIZE, "buffer_max_size", FLB_IN_KAFKA_BUFFER_MAX_SIZE,
+    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, buffer_max_size),
+    "Set the maximum size of chunk"
    },
    /* EOF */
    {0}

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -191,9 +191,11 @@ static int in_kafka_collect(struct flb_input_instance *ins,
     }
 
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-        flb_input_log_append(ins, NULL, 0,
-                             ctx->log_encoder->output_buffer,
-                             ctx->log_encoder->output_length);
+        if (ctx->log_encoder->output_length > 0) {
+            flb_input_log_append(ins, NULL, 0,
+                                 ctx->log_encoder->output_buffer,
+                                 ctx->log_encoder->output_length);
+        }
         ret = 0;
     }
     else {

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -43,6 +43,7 @@ struct flb_in_kafka_config {
     int poll_ms;
     int format;
     char *format_str;
+    int coll_fd;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -30,6 +30,7 @@
 
 #define FLB_IN_KAFKA_DEFAULT_POLL_MS       "500"
 #define FLB_IN_KAFKA_DEFAULT_FORMAT        "none"
+#define FLB_IN_KAFKA_UNLIMITED             (size_t)-1
 
 enum {
     FLB_IN_KAFKA_FORMAT_NONE,
@@ -44,6 +45,8 @@ struct flb_in_kafka_config {
     int format;
     char *format_str;
     int coll_fd;
+    size_t buffer_chunk_size;          /* Chunk allocation size */
+    size_t polling_threshold;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -31,6 +31,7 @@
 #define FLB_IN_KAFKA_DEFAULT_POLL_MS       "500"
 #define FLB_IN_KAFKA_DEFAULT_FORMAT        "none"
 #define FLB_IN_KAFKA_UNLIMITED             (size_t)-1
+#define FLB_IN_KAFKA_BUFFER_MAX_SIZE       "4M"
 
 enum {
     FLB_IN_KAFKA_FORMAT_NONE,
@@ -45,7 +46,7 @@ struct flb_in_kafka_config {
     int format;
     char *format_str;
     int coll_fd;
-    size_t buffer_chunk_size;          /* Chunk allocation size */
+    size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
 };
 


### PR DESCRIPTION
We need to register pause/resume callback for correct handling of back pressure in in_kafka.
Back pressure implementation of Fluent Bit is relying on pause/resume callback which is registered in the each of plugins.
~~Also, the current implementation of in_kafka does not consider the threshold to halt polling after reaching the limit of chunks.~~
~~It causes always over limit status of chunks. This shouldn't happen if the parameters are correctly set up.~~
I implemented restrictive polling in in_kafka. This shouldn't cause spikes of memory consumption.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```ini
[INPUT]
        Name        kafka
        Brokers     127.0.0.1:9092
        Topics      test
        rdkafka.auto.offset.reset earliest
        # To increase flow rate, specify larger value into buffer_max_size
        # buffer_max_size 5M
```
- [x] Debug log output from testing the change
The above config is effective to restrict polling records at once:
```log
<snip>
[2023/11/15 19:01:56] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:01:56] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:01:56] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:01:56] [debug] [input chunk] update output instances with new chunk size diff=5000544, records=2328, input=kafka.0
[2023/11/15 19:01:56] [ warn] [input] kafka.0 paused (mem buf overlimit)
[2023/11/15 19:01:56] [ info] [input] pausing kafka.0
[2023/11/15 19:01:57] [debug] [task] created task=0x7f5db8071fc0 id=0 OK
[2023/11/15 19:01:57] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #1
[2023/11/15 19:01:57] [debug] [upstream] KA connection #73 to 127.0.0.1:8443 has been assigned (recycled)
[2023/11/15 19:01:57] [debug] [http_client] not using http_proxy for header
[2023/11/15 19:01:57] [debug] [upstream] KA connection #73 to 127.0.0.1:8443 is now available
[2023/11/15 19:01:57] [debug] [out flush] cb_destroy coro_id=20
[2023/11/15 19:01:57] [debug] [task] destroy task=0x7f5db8071fc0 (task_id=0)
[2023/11/15 19:01:57] [ info] [input] kafka.0 resume (mem buf overlimit)
<snip>
```

Also, when specifying **buffer_chunk_size**, this parameter is effective to restrict polling events at once:
```
<snip>
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input:kafka:kafka.0] kafka message received
[2023/11/15 19:05:05] [debug] [input chunk] update output instances with new chunk size diff=5017600, records=2328, input=kafka.0
[2023/11/15 19:05:05] [debug] [task] destroy task=0x7faa6407f2e0 (task_id=0)
<snip>
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1257

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
