### PR TITLE
in_winevtlog: pass correct value

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -83,7 +83,7 @@ static int pack_binary(struct winevtlog_config *ctx, PBYTE bin, size_t length)
     unsigned int idx = 0;
 
     if (length == 0) {
-        pack_nullstr(ctx->log_encoder);
+        pack_nullstr(ctx);
         return 0;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This function needs the `winevtlog_config*` not the log encoder. This was causing a crash on any event log with `<Binary \>` in it.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#7832 