### PR TITLE
output: do not add net.* properties to the main properties list.

### DIFF
--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -837,7 +837,7 @@ int flb_output_set_property(struct flb_output_instance *ins,
             ins->retry_limit = 1;
         }
     }
-    else if (strncasecmp("net.", k, 4) == 0 && tmp) {
+    else if (strncasecmp("net.", k, 4) == 0) {
         kv = flb_kv_item_create(&ins->net_properties, (char *) k, NULL);
         if (!kv) {
             if (tmp) {


### PR DESCRIPTION
# Summary

This fixes an error where empty net.* properties throw a false negative 'unknown property' error.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
