### PR TITLE
flb_input_chunk: skip overlimit check in mem mode

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -475,20 +475,12 @@ int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
     int overlimit = 0;
     struct mk_list *head;
     struct flb_output_instance *o_ins;
-    struct flb_input_instance *i_ins = ic->in;
-
 
     mk_list_foreach(head, &ic->in->config->outputs) {
         o_ins = mk_list_entry(head, struct flb_output_instance, _head);
 
         if ((o_ins->total_limit_size == -1) ||
             (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) == 0)) {
-            continue;
-        }
-
-        if (i_ins->storage_type == CIO_STORE_MEM) {
-            flb_plg_debug(i_ins, "plugin is in memory storage mode, storage.total_limit_size "
-                                "from output %s has no effect", o_ins->name);
             continue;
         }
 
@@ -516,12 +508,14 @@ int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
 int flb_input_chunk_place_new_chunk(struct flb_input_chunk *ic, size_t chunk_size)
 {
 	int overlimit;
+    struct flb_input_instance *i_ins = ic->in;
 
-    overlimit = flb_input_chunk_has_overlimit_routes(ic, chunk_size);
-    if (overlimit != 0) {
-        flb_input_chunk_find_space_new_data(ic, chunk_size, overlimit);
+    if (i_ins->storage_type == CIO_STORE_FS) {
+        overlimit = flb_input_chunk_has_overlimit_routes(ic, chunk_size);
+        if (overlimit != 0) {
+            flb_input_chunk_find_space_new_data(ic, chunk_size, overlimit);
+        }
     }
-
     return !flb_routes_mask_is_empty(ic->routes_mask);
 }
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -475,12 +475,20 @@ int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
     int overlimit = 0;
     struct mk_list *head;
     struct flb_output_instance *o_ins;
+    struct flb_input_instance *i_ins = ic->in;
+
 
     mk_list_foreach(head, &ic->in->config->outputs) {
         o_ins = mk_list_entry(head, struct flb_output_instance, _head);
 
         if ((o_ins->total_limit_size == -1) ||
             (flb_routes_mask_get_bit(ic->routes_mask, o_ins->id) == 0)) {
+            continue;
+        }
+
+        if (i_ins->storage_type == CIO_STORE_MEM) {
+            flb_plg_debug(i_ins, "plugin is in memory storage mode, storage.total_limit_size "
+                                "from output %s has no effect", o_ins->name);
             continue;
         }
 
@@ -508,6 +516,7 @@ int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
 int flb_input_chunk_place_new_chunk(struct flb_input_chunk *ic, size_t chunk_size)
 {
 	int overlimit;
+
     overlimit = flb_input_chunk_has_overlimit_routes(ic, chunk_size);
     if (overlimit != 0) {
         flb_input_chunk_find_space_new_data(ic, chunk_size, overlimit);


### PR DESCRIPTION
<!-- Provide summary of changes -->
When an output plugin is configured to use `storage.total_limit_size` while the input plugin uses memory storage mode, it would previously
continue calculating and eventually pass an empty pointer to the
storage context in the function that releases space. This PR adds a
validationg in the overlimit route check that will cause the check to
be skipped, ensuring that the rest of the space freeing routines are
never executed.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
Any input plugin with memory storage type, any output plugin with `storage.total_limit_size` set. I tested it with this:

```
[SERVICE]
    Flush            10
    Daemon           off
    Log_Level        debug
    scheduler.base   10
    scheduler.cap    60

[INPUT]
    Name tcp
    Tag firelens-healthcheck
    Listen 127.0.0.1
    Port 8877

[FILTER]
    Name stdout
    Match *

[OUTPUT]
    Name            http
    Match           *
    Log_Level       debug
    Format          json_lines
    Host            127.0.0.1
    Port            8080
    Retry_Limit     5
    storage.total_limit_size        1k

[OUTPUT]
    Name            http
    Match           *
    Log_Level       debug
    Format          json_lines
    Host            127.0.0.1
    Port            8081
    Retry_Limit     5
    storage.total_limit_size        1k
```

- [x] Debug log output from testing the change
```
braydonk@braydonk:~/Git/fluent-bit$ ./build/bin/fluent-bit --config x.conf
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/17 16:03:21] [ info] Configuration:
[2023/11/17 16:03:21] [ info]  flush time     | 10.000000 seconds
[2023/11/17 16:03:21] [ info]  grace          | 5 seconds
[2023/11/17 16:03:21] [ info]  daemon         | 0
[2023/11/17 16:03:21] [ info] ___________
[2023/11/17 16:03:21] [ info]  inputs:
[2023/11/17 16:03:21] [ info]      tcp
[2023/11/17 16:03:21] [ info] ___________
[2023/11/17 16:03:21] [ info]  filters:
[2023/11/17 16:03:21] [ info]      stdout.0
[2023/11/17 16:03:21] [ info] ___________
[2023/11/17 16:03:21] [ info]  outputs:
[2023/11/17 16:03:21] [ info]      http.0
[2023/11/17 16:03:21] [ info]      http.1
[2023/11/17 16:03:21] [ info] ___________
[2023/11/17 16:03:21] [ info]  collectors:
[2023/11/17 16:03:21] [ info] [fluent bit] version=2.2.1, commit=281aea0a10, pid=1220646
[2023/11/17 16:03:21] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/11/17 16:03:21] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/17 16:03:21] [ info] [cmetrics] version=0.6.4
[2023/11/17 16:03:21] [ info] [ctraces ] version=0.3.1
[2023/11/17 16:03:21] [ info] [input:tcp:tcp.0] initializing
[2023/11/17 16:03:21] [ info] [input:tcp:tcp.0] storage_strategy='memory' (memory only)
[2023/11/17 16:03:21] [debug] [tcp:tcp.0] created event channels: read=21 write=22
[2023/11/17 16:03:21] [debug] [downstream] listening on 127.0.0.1:8877
[2023/11/17 16:03:21] [debug] [http:http.0] created event channels: read=24 write=25
[2023/11/17 16:03:21] [debug] [http:http.1] created event channels: read=40 write=44
[2023/11/17 16:03:21] [ info] [output:http:http.0] worker #0 started
[2023/11/17 16:03:21] [ info] [output:http:http.0] worker #1 started
[2023/11/17 16:03:21] [ info] [output:http:http.1] worker #0 started
[2023/11/17 16:03:21] [debug] [router] match rule tcp.0:http.0
[2023/11/17 16:03:21] [debug] [router] match rule tcp.0:http.1
[2023/11/17 16:03:21] [ info] [sp] stream processor started
[2023/11/17 16:03:21] [ info] [output:http:http.1] worker #1 started
[0] firelens-healthcheck: [1700255005.828797729, {}, {"health"=>"checkcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheck"}]
[2023/11/17 16:03:25] [debug] [input chunk] update output instances with new chunk size diff=516, records=1, input=tcp.0
[2023/11/17 16:03:25] [debug] [input chunk] chunk 1220646-1700255005.828817124.flb update plugin http.0 fs_chunks_size by 516 bytes, the current fs_chunks_size is 516 bytes
[2023/11/17 16:03:25] [debug] [input chunk] chunk 1220646-1700255005.828817124.flb update plugin http.1 fs_chunks_size by 516 bytes, the current fs_chunks_size is 516 bytes
[2023/11/17 16:03:29] [ warn] [input:tcp:tcp.0] plugin is in memory storage mode, storage.total_limit_size from output http.0 has no effect
[0] firelens-healthcheck: [1700255009.843047916, {}, {"health"=>"checkcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheck"}]
[2023/11/17 16:03:29] [ warn] [input:tcp:tcp.0] plugin is in memory storage mode, storage.total_limit_size from output http.1 has no effect
[2023/11/17 16:03:29] [debug] [input chunk] update output instances with new chunk size diff=516, records=1, input=tcp.0
[2023/11/17 16:03:30] [debug] [output:http:http.0] task_id=0 assigned to thread #0
[2023/11/17 16:03:30] [debug] [output:http:http.1] task_id=0 assigned to thread #0
[2023/11/17 16:03:30] [debug] [upstream] KA connection #77 to 127.0.0.1:8080 is connected
[2023/11/17 16:03:30] [debug] [http_client] not using http_proxy for header
[2023/11/17 16:03:30] [debug] [upstream] KA connection #78 to 127.0.0.1:8081 is connected
[2023/11/17 16:03:30] [debug] [http_client] not using http_proxy for header
[2023/11/17 16:03:30] [ info] [output:http:http.0] 127.0.0.1:8080, HTTP status=200
[2023/11/17 16:03:30] [debug] [upstream] KA connection #77 to 127.0.0.1:8080 is now available
[2023/11/17 16:03:30] [debug] [out flush] cb_destroy coro_id=0
[2023/11/17 16:03:30] [ info] [output:http:http.1] 127.0.0.1:8081, HTTP status=200
[2023/11/17 16:03:30] [debug] [upstream] KA connection #78 to 127.0.0.1:8081 is now available
[2023/11/17 16:03:30] [debug] [out flush] cb_destroy coro_id=0
[2023/11/17 16:03:30] [debug] [task] destroy task=0x7f3a5003a020 (task_id=0)
[2023/11/17 16:03:30] [debug] [input chunk] remove chunk 1220646-1700255005.828817124.flb with 1032 bytes from plugin http.0, the updated fs_chunks_size is 0 bytes
[2023/11/17 16:03:30] [debug] [input chunk] remove chunk 1220646-1700255005.828817124.flb with 1032 bytes from plugin http.1, the updated fs_chunks_size is 0 bytes
[0] firelens-healthcheck: [1700255011.325668448, {}, {"health"=>"checkcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheck"}]
[2023/11/17 16:03:31] [debug] [input:tcp:tcp.0] plugin is in memory storage mode, storage.total_limit_size from output http.0 has no effect
[2023/11/17 16:03:31] [debug] [input:tcp:tcp.0] plugin is in memory storage mode, storage.total_limit_size from output http.1 has no effect
[2023/11/17 16:03:31] [debug] [input chunk] update output instances with new chunk size diff=516, records=1, input=tcp.0
[2023/11/17 16:03:31] [debug] [input chunk] chunk 1220646-1700255011.325678978.flb update plugin http.0 fs_chunks_size by 516 bytes, the current fs_chunks_size is 516 bytes
[2023/11/17 16:03:31] [debug] [input chunk] chunk 1220646-1700255011.325678978.flb update plugin http.1 fs_chunks_size by 516 bytes, the current fs_chunks_size is 516 bytes
[2023/11/17 16:03:40] [debug] [task] created task=0x7f3a50037090 id=0 OK
[2023/11/17 16:03:40] [debug] [output:http:http.0] task_id=0 assigned to thread #1
[2023/11/17 16:03:40] [debug] [output:http:http.1] task_id=0 assigned to thread #1
[2023/11/17 16:03:40] [debug] [upstream] KA connection #79 to 127.0.0.1:8081 is connected
[2023/11/17 16:03:40] [debug] [upstream] KA connection #76 to 127.0.0.1:8080 is connected
[2023/11/17 16:03:40] [debug] [http_client] not using http_proxy for header
[2023/11/17 16:03:40] [debug] [http_client] not using http_proxy for header
[2023/11/17 16:03:40] [ info] [output:http:http.0] 127.0.0.1:8080, HTTP status=200
[2023/11/17 16:03:40] [ info] [output:http:http.1] 127.0.0.1:8081, HTTP status=200
[2023/11/17 16:03:40] [debug] [upstream] KA connection #76 to 127.0.0.1:8080 is now available
[2023/11/17 16:03:40] [debug] [upstream] KA connection #79 to 127.0.0.1:8081 is now available
[2023/11/17 16:03:40] [debug] [task] destroy task=0x7f3a50037090 (task_id=0)
[2023/11/17 16:03:40] [debug] [out flush] cb_destroy coro_id=0
[2023/11/17 16:03:40] [debug] [out flush] cb_destroy coro_id=0
[2023/11/17 16:03:40] [debug] [input chunk] remove chunk 1220646-1700255011.325678978.flb with 516 bytes from plugin http.0, the updated fs_chunks_size is 0 bytes
[2023/11/17 16:03:40] [debug] [input chunk] remove chunk 1220646-1700255011.325678978.flb with 516 bytes from plugin http.1, the updated fs_chunks_size is 0 bytes
[2023/11/17 16:04:00] [debug] [upstream] drop keepalive connection #-1 to 127.0.0.1:8080 (keepalive idle timeout)
[2023/11/17 16:04:00] [debug] [upstream] drop keepalive connection #-1 to 127.0.0.1:8081 (keepalive idle timeout)
^C[2023/11/17 16:04:04] [engine] caught signal (SIGINT)
[2023/11/17 16:04:04] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/17 16:04:04] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/17 16:04:04] [ info] [output:http:http.0] thread worker #0 stopping...
[2023/11/17 16:04:04] [ info] [output:http:http.0] thread worker #0 stopped
[2023/11/17 16:04:04] [ info] [output:http:http.0] thread worker #1 stopping...
[2023/11/17 16:04:04] [ info] [output:http:http.0] thread worker #1 stopped
[2023/11/17 16:04:04] [ info] [output:http:http.1] thread worker #0 stopping...
[2023/11/17 16:04:04] [ info] [output:http:http.1] thread worker #0 stopped
[2023/11/17 16:04:04] [ info] [output:http:http.1] thread worker #1 stopping...
[2023/11/17 16:04:04] [ info] [output:http:http.1] thread worker #1 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
braydonk@braydonk:~/Git/fluent-bit$ valgrind --leak-check=full ./buildvalgrind/bin/fluent-bit --config x.conf
==1241488== Memcheck, a memory error detector
==1241488== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==1241488== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==1241488== Command: ./buildvalgrind/bin/fluent-bit --config x.conf
==1241488== 
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/17 17:33:21] [ info] Configuration:
[2023/11/17 17:33:21] [ info]  flush time     | 10.000000 seconds
[2023/11/17 17:33:21] [ info]  grace          | 5 seconds
[2023/11/17 17:33:21] [ info]  daemon         | 0
[2023/11/17 17:33:21] [ info] ___________
[2023/11/17 17:33:21] [ info]  inputs:
[2023/11/17 17:33:21] [ info]      tcp
[2023/11/17 17:33:21] [ info] ___________
[2023/11/17 17:33:21] [ info]  filters:
[2023/11/17 17:33:21] [ info]      stdout.0
[2023/11/17 17:33:21] [ info] ___________
[2023/11/17 17:33:21] [ info]  outputs:
[2023/11/17 17:33:21] [ info]      http.0
[2023/11/17 17:33:21] [ info]      http.1
[2023/11/17 17:33:21] [ info] ___________
[2023/11/17 17:33:21] [ info]  collectors:
[2023/11/17 17:33:21] [ info] [fluent bit] version=2.2.1, commit=fe062da4d8, pid=1241488
[2023/11/17 17:33:21] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/11/17 17:33:21] [ info] [output:http:http.0] worker #1 started
[2023/11/17 17:33:21] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/17 17:33:21] [ info] [cmetrics] version=0.6.4
[2023/11/17 17:33:21] [ info] [output:http:http.0] worker #0 started
[2023/11/17 17:33:21] [ info] [output:http:http.1] worker #1 started
[2023/11/17 17:33:21] [ info] [output:http:http.1] worker #0 started
[2023/11/17 17:33:21] [ info] [ctraces ] version=0.3.1
[2023/11/17 17:33:21] [ info] [input:tcp:tcp.0] initializing
[2023/11/17 17:33:21] [ info] [input:tcp:tcp.0] storage_strategy='memory' (memory only)
[2023/11/17 17:33:21] [debug] [tcp:tcp.0] created event channels: read=21 write=22
[2023/11/17 17:33:21] [debug] [downstream] listening on 127.0.0.1:8877
[2023/11/17 17:33:21] [debug] [http:http.0] created event channels: read=24 write=25
[2023/11/17 17:33:21] [debug] [http:http.1] created event channels: read=40 write=44
[2023/11/17 17:33:21] [debug] [router] match rule tcp.0:http.0
[2023/11/17 17:33:21] [debug] [router] match rule tcp.0:http.1
[2023/11/17 17:33:21] [ info] [sp] stream processor started
[0] firelens-healthcheck: [1700260402.026222454, {}, {"health"=>"checkcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheck"}]
[2023/11/17 17:33:22] [debug] [input chunk] update output instances with new chunk size diff=516, records=1, input=tcp.0
[2023/11/17 17:33:22] [debug] [input chunk] chunk 1241488-1700260402.64840985.flb update plugin http.0 fs_chunks_size by 516 bytes, the current fs_chunks_size is 516 bytes
[2023/11/17 17:33:22] [debug] [input chunk] chunk 1241488-1700260402.64840985.flb update plugin http.1 fs_chunks_size by 516 bytes, the current fs_chunks_size is 516 bytes
[0] firelens-healthcheck: [1700260403.753142943, {}, {"health"=>"checkcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheck"}]
[2023/11/17 17:33:23] [debug] [input chunk] update output instances with new chunk size diff=516, records=1, input=tcp.0
[2023/11/17 17:33:23] [debug] [input chunk] chunk 1241488-1700260402.64840985.flb update plugin http.0 fs_chunks_size by 516 bytes, the current fs_chunks_size is 1032 bytes
[2023/11/17 17:33:23] [debug] [input chunk] chunk 1241488-1700260402.64840985.flb update plugin http.1 fs_chunks_size by 516 bytes, the current fs_chunks_size is 1032 bytes
[0] firelens-healthcheck: [1700260405.643373133, {}, {"health"=>"checkcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheckcheck"}]
[2023/11/17 17:33:25] [debug] [input chunk] update output instances with new chunk size diff=516, records=1, input=tcp.0
[2023/11/17 17:33:25] [debug] [input chunk] chunk 1241488-1700260402.64840985.flb update plugin http.0 fs_chunks_size by 516 bytes, the current fs_chunks_size is 1548 bytes
[2023/11/17 17:33:25] [debug] [input chunk] chunk 1241488-1700260402.64840985.flb update plugin http.1 fs_chunks_size by 516 bytes, the current fs_chunks_size is 1548 bytes
[2023/11/17 17:33:31] [debug] [task] created task=0x6048150 id=0 OK
[2023/11/17 17:33:31] [debug] [output:http:http.0] task_id=0 assigned to thread #0
[2023/11/17 17:33:31] [debug] [output:http:http.1] task_id=0 assigned to thread #0
[2023/11/17 17:33:31] [debug] [upstream] KA connection #77 to 127.0.0.1:8081 is connected
[2023/11/17 17:33:31] [debug] [http_client] not using http_proxy for header
[2023/11/17 17:33:31] [debug] [upstream] KA connection #76 to 127.0.0.1:8080 is connected
[2023/11/17 17:33:31] [debug] [http_client] not using http_proxy for header
[2023/11/17 17:33:31] [ info] [output:http:http.0] 127.0.0.1:8080, HTTP status=200
[2023/11/17 17:33:31] [ info] [output:http:http.1] 127.0.0.1:8081, HTTP status=200
[2023/11/17 17:33:31] [debug] [upstream] KA connection #76 to 127.0.0.1:8080 is now available
[2023/11/17 17:33:31] [debug] [out flush] cb_destroy coro_id=0
[2023/11/17 17:33:31] [debug] [upstream] KA connection #77 to 127.0.0.1:8081 is now available
[2023/11/17 17:33:31] [debug] [task] destroy task=0x6048150 (task_id=0)
[2023/11/17 17:33:31] [debug] [out flush] cb_destroy coro_id=0
[2023/11/17 17:33:31] [debug] [input chunk] remove chunk 1241488-1700260402.64840985.flb with 1548 bytes from plugin http.0, the updated fs_chunks_size is 0 bytes
[2023/11/17 17:33:31] [debug] [input chunk] remove chunk 1241488-1700260402.64840985.flb with 1548 bytes from plugin http.1, the updated fs_chunks_size is 0 bytes
^C[2023/11/17 17:33:35] [engine] caught signal (SIGINT)
[2023/11/17 17:33:35] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/17 17:33:36] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/17 17:33:36] [ info] [output:http:http.0] thread worker #0 stopping...
[2023/11/17 17:33:36] [ info] [output:http:http.0] thread worker #0 stopped
[2023/11/17 17:33:36] [ info] [output:http:http.0] thread worker #1 stopping...
[2023/11/17 17:33:36] [ info] [output:http:http.0] thread worker #1 stopped
[2023/11/17 17:33:36] [ info] [output:http:http.1] thread worker #0 stopping...
[2023/11/17 17:33:36] [ info] [output:http:http.1] thread worker #0 stopped
[2023/11/17 17:33:36] [ info] [output:http:http.1] thread worker #1 stopping...
[2023/11/17 17:33:36] [ info] [output:http:http.1] thread worker #1 stopped
==1241488== 
==1241488== HEAP SUMMARY:
==1241488==     in use at exit: 0 bytes in 0 blocks
==1241488==   total heap usage: 3,823 allocs, 3,823 frees, 1,988,292 bytes allocated
==1241488== 
==1241488== All heap blocks were freed -- no leaks are possible
==1241488== 
==1241488== For lists of detected and suppressed errors, rerun with: -s
==1241488== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N?A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.
Maybe, I did not look into when this bug was introduced. May have been nascent for a long time.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
