### PR TITLE
filter_type_converter: support map_key

### DIFF
--- a/include/fluent-bit/flb_typecast.h
+++ b/include/fluent-bit/flb_typecast.h
@@ -33,6 +33,8 @@ typedef enum {
     FLB_TYPECAST_TYPE_BOOL,
     FLB_TYPECAST_TYPE_STR,
     FLB_TYPECAST_TYPE_HEX,
+    FLB_TYPECAST_TYPE_JSON_STR,
+    FLB_TYPECAST_TYPE_MAP,
     FLB_TYPECAST_TYPE_ERROR,
 } flb_typecast_type_t;
 
@@ -48,7 +50,7 @@ struct flb_typecast_value {
         int64_t   i_num;   /* int  */
         uint64_t  ui_num;  /* uint, hex */
         double    d_num;   /* float */
-        flb_sds_t str;     /* string */
+        flb_sds_t str;     /* string, json_str */
     } val;
 };
 

--- a/plugins/filter_type_converter/type_converter.c
+++ b/plugins/filter_type_converter/type_converter.c
@@ -130,6 +130,9 @@ static int configure(struct type_converter_ctx *ctx,
     flb_config_map_foreach(head, mv, ctx->float_keys) {
         config_rule(ctx, "float", mv);
     }
+    flb_config_map_foreach(head, mv, ctx->map_keys) {
+        config_rule(ctx, "map", mv);
+    }
 
     if (mk_list_size(&ctx->conv_entries) == 0) {
         flb_plg_error(ctx->ins, "no rules");
@@ -384,6 +387,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct type_converter_ctx, str_keys),
      "Convert string to other type. e.g. str_key id id_val integer"
     },
+    {
+     FLB_CONFIG_MAP_SLIST_3, "map_key", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct type_converter_ctx, map_keys),
+     "Convert map to other type. e.g. map_key obj obj_str json_string"
+    },
+
     {0}
 };
   

--- a/plugins/filter_type_converter/type_converter.h
+++ b/plugins/filter_type_converter/type_converter.h
@@ -41,6 +41,7 @@ struct type_converter_ctx {
     struct mk_list *uint_keys;
     struct mk_list *float_keys;
     struct mk_list *str_keys;
+    struct mk_list *map_keys;
 };
 
 #endif


### PR DESCRIPTION
Fixes #8193 

This patch is to support `map_key` for filter_type_converter.
It is to convert from map to json string.
e.g. 
```json
"map_data":{"key":"value", "id":123}
```
to
```json
"map_str": "{"key":"value","id":123}"
```

| Key | Description |
| :--- | :--- |
| map_key | This parameter is for string source. `json_string` is allowed as `dst_data_type`.|

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"map_data":{"key":"value", "id":123}}

[FILTER]
    Name type_converter
    Match *
    Map_key map_data map_str json_string

[OUTPUT]
    name stdout
    match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.conf 
==69763== Memcheck, a memory error detector
==69763== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==69763== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==69763== Command: bin/fluent-bit -c a.conf
==69763== 
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/18 10:45:29] [ info] [fluent bit] version=2.2.1, commit=281aea0a10, pid=69763
[2023/11/18 10:45:29] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/18 10:45:29] [ info] [cmetrics] version=0.6.4
[2023/11/18 10:45:29] [ info] [ctraces ] version=0.3.1
[2023/11/18 10:45:29] [ info] [input:dummy:dummy.0] initializing
[2023/11/18 10:45:29] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/11/18 10:45:29] [ info] [output:stdout:stdout.0] worker #0 started
[2023/11/18 10:45:29] [ info] [sp] stream processor started
[0] dummy.0: [[1700271930.009027474, {}], {"map_data"=>{"key"=>"value", "id"=>123}, "map_str"=>"{"key":"value","id":123}"}]
^C[2023/11/18 10:45:31] [engine] caught signal (SIGINT)
[2023/11/18 10:45:31] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [[1700271931.015915198, {}], {"map_data"=>{"key"=>"value", "id"=>123}, "map_str"=>"{"key":"value","id":123}"}]
[2023/11/18 10:45:31] [ info] [input] pausing dummy.0
[2023/11/18 10:45:31] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/18 10:45:31] [ info] [input] pausing dummy.0
[2023/11/18 10:45:32] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/18 10:45:32] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==69763== 
==69763== HEAP SUMMARY:
==69763==     in use at exit: 0 bytes in 0 blocks
==69763==   total heap usage: 1,797 allocs, 1,797 frees, 1,191,670 bytes allocated
==69763== 
==69763== All heap blocks were freed -- no leaks are possible
==69763== 
==69763== For lists of detected and suppressed errors, rerun with: -s
==69763== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
