### PR TITLE
input_chunk: ensure returning/compairing FLB_BOOL(#8184)

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1289,7 +1289,14 @@ int flb_input_chunk_set_up_down(struct flb_input_chunk *ic)
 
 int flb_input_chunk_is_up(struct flb_input_chunk *ic)
 {
-    return cio_chunk_is_up(ic->chunk);
+    int ret = FLB_FALSE;
+
+    ret = cio_chunk_is_up(ic->chunk);
+    if (ret == CIO_TRUE) {
+        ret = FLB_TRUE;
+    }
+
+    return ret;
 }
 
 int flb_input_chunk_down(struct flb_input_chunk *ic)
@@ -1501,7 +1508,7 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
 
     /* Update 'input' metrics */
 #ifdef FLB_HAVE_METRICS
-    if (ret == CIO_OK) {
+    if (ret == FLB_TRUE) {
         ic->added_records =  n_records;
         ic->total_records += n_records;
     }


### PR DESCRIPTION
This patch is to 
- ensure flb_input_chunk_is_up returns FLB_TRUE/FLB_FALSE
  - It returned CIO_TRUE/FALSE and it is compared to FLB_TRUE/FALSE e.g. [Link](https://github.com/fluent/fluent-bit/blame/v2.2.0/src/flb_input_chunk.c#L940)
- fix wrong value comparing and it causes `ic->total_records` is always zero
  - It can cause issue #8184  because of `ic->total_records` and `event_chunk->total_events` are zero.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i dummy -p samples=1 -o loki
==89377== Memcheck, a memory error detector
==89377== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==89377== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==89377== Command: bin/fluent-bit -i dummy -p samples=1 -o loki
==89377== 
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/18 17:40:35] [ info] [fluent bit] version=2.2.1, commit=281aea0a10, pid=89377
[2023/11/18 17:40:35] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/18 17:40:35] [ info] [cmetrics] version=0.6.4
[2023/11/18 17:40:35] [ info] [ctraces ] version=0.3.1
[2023/11/18 17:40:35] [ info] [input:dummy:dummy.0] initializing
[2023/11/18 17:40:35] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/11/18 17:40:36] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2023/11/18 17:40:36] [ info] [sp] stream processor started
^C[2023/11/18 17:40:40] [engine] caught signal (SIGINT)
[2023/11/18 17:40:40] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/18 17:40:40] [ info] [input] pausing dummy.0
[2023/11/18 17:40:41] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/18 17:40:41] [ info] [input] pausing dummy.0
==89377== 
==89377== HEAP SUMMARY:
==89377==     in use at exit: 0 bytes in 0 blocks
==89377==   total heap usage: 1,686 allocs, 1,686 frees, 887,889 bytes allocated
==89377== 
==89377== All heap blocks were freed -- no leaks are possible
==89377== 
==89377== For lists of detected and suppressed errors, rerun with: -s
==89377== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Output of `nc- l 3100`
In issue #8184, `values` is blank array.
```
$ nc -l 3100
POST /loki/api/v1/push HTTP/1.1
Host: 127.0.0.1:3100
Content-Length: 106
User-Agent: Fluent-Bit
Content-Type: application/json
Connection: keep-alive

{"streams":[{"stream":{"job":"fluent-bit"},"values":[["1700297119512551798","{\"message\":\"dummy\"}"]]}]}
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
