### PR TITLE
out_stackdriver: add project_id_key override to allow specifying gcp project id from the record

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1509,6 +1509,7 @@ static int pack_json_payload(int insert_id_extracted,
     {
         monitored_resource_key,
         local_resource_id_key,
+        ctx->project_id_key,
         ctx->labels_key,
         ctx->severity_key,
         ctx->trace_key,
@@ -1679,6 +1680,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     msgpack_packer mp_pck;
     flb_sds_t out_buf;
     struct flb_mp_map_header mh;
+
+    /* Parameters for project_id_key */
+    int project_id_extracted = FLB_FALSE;
+    flb_sds_t project_id_key;
 
     /* Parameters for severity */
     int severity_extracted = FLB_FALSE;
@@ -2204,6 +2209,13 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             entry_size += 1;
         }
 
+        /* Extract project id */
+        project_id_extracted = FLB_FALSE;
+        if (ctx->project_id_key
+            && get_string(&project_id_key, obj, ctx->project_id_key) == 0) {
+            project_id_extracted = FLB_TRUE;
+        }
+
         /* Extract log name */
         log_name_extracted = FLB_FALSE;
         if (ctx->log_name_key
@@ -2409,10 +2421,16 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             new_log_name = log_name;
         }
 
-        /* logName */
-        len = snprintf(path, sizeof(path) - 1,
+        if (project_id_extracted == FLB_TRUE) {
+            len = snprintf(path, sizeof(path) - 1,
+                       "projects/%s/logs/%s", project_id_key, new_log_name);
+            flb_sds_destroy(project_id_key);
+        } else {
+            len = snprintf(path, sizeof(path) - 1,
                        "projects/%s/logs/%s", ctx->export_to_project_id, new_log_name);
+        }
 
+        /* logName */
         if (log_name_extracted == FLB_TRUE) {
             flb_sds_destroy(log_name);
         }
@@ -2967,6 +2985,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "export_to_project_id", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_stackdriver, export_to_project_id),
       "Export to project id"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "project_id_key", DEFAULT_PROJECT_ID_KEY,
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, project_id_key),
+      "Set the gcp project id key"
     },
     {
       FLB_CONFIG_MAP_STR, "resource", FLB_SDS_RESOURCE_TYPE,

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -49,6 +49,7 @@
 #define MONITORED_RESOURCE_KEY "logging.googleapis.com/monitored_resource"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
+#define DEFAULT_PROJECT_ID_KEY "logging.googleapis.com/projectId"
 #define DEFAULT_SEVERITY_KEY "logging.googleapis.com/severity"
 #define DEFAULT_TRACE_KEY "logging.googleapis.com/trace"
 #define DEFAULT_SPAN_ID_KEY "logging.googleapis.com/spanId"
@@ -170,6 +171,7 @@ struct flb_stackdriver {
 
     /* other */
     flb_sds_t export_to_project_id;
+    flb_sds_t project_id_key;
     flb_sds_t resource;
     flb_sds_t severity_key;
     flb_sds_t trace_key;

--- a/tests/runtime/data/stackdriver/stackdriver_test_log_name.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_log_name.h
@@ -8,3 +8,15 @@
 	"1591111124," \
 	"{"	\
 	"}]"
+
+#define LOG_NAME_PROJECT_ID_OVERRIDE "[" \
+	"1591111124," \
+	"{"	\
+		"\"test_project_key\": \"fluent-bit-test-project-2\"" \
+	"}]"
+
+#define LOG_NAME_PROJECT_ID_NO_OVERRIDE	"[" \
+	"1591111124," \
+	"{"	\
+	    "\"logging.googleapis.com/projectId\": \"fluent-bit-test-project-2\"" \
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -841,6 +841,24 @@ static void cb_check_log_name_no_override(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_project_key_override(void *ctx, int ffd,
+                                          int res_ret, void *res_data, size_t res_size,
+                                          void *data)
+{
+    int ret;
+
+    /* logName in the entries is created using the value under log_name_key */
+    ret = mp_kv_cmp(
+        res_data, res_size, "$entries[0]['logName']", "projects/fluent-bit-test-project-2/logs/test");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* log_name_key has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['test_project_key']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_k8s_node_resource(void *ctx, int ffd,
                                        int res_ret, void *res_data, size_t res_size,
                                        void *data)
@@ -2650,6 +2668,87 @@ void flb_test_set_metadata_server()
 
     /* Ingest data sample */
     flb_lib_push(ctx, in_ffd, (char *) JSON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_project_id_override()
+{
+    int ret;
+    int size = sizeof(LOG_NAME_PROJECT_ID_OVERRIDE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",                   
+                   "project_id_key", "test_project_key",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_project_key_override,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) LOG_NAME_PROJECT_ID_OVERRIDE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_project_id_no_override()
+{
+    int ret;
+    int size = sizeof(LOG_NAME_PROJECT_ID_NO_OVERRIDE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",                   
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_project_key_override,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) LOG_NAME_PROJECT_ID_NO_OVERRIDE, size);
 
     sleep(2);
     flb_stop(ctx);
@@ -6149,6 +6248,10 @@ TEST_LIST = {
 
     /* test metadata server */
     {"set_metadata_server", flb_test_set_metadata_server},
+
+    /* test project key */
+    {"project_key_override", flb_test_project_id_override},
+    {"project_key_no_override", flb_test_project_id_no_override},
 
     /* test log name */
     {"log_name_override", flb_test_log_name_override},


### PR DESCRIPTION
<!-- Provide summary of changes -->
A new configuration option for the out_stackdriver plugin `project_id_key` allows you to specify a key within the jsonPayload that will be used to set the GCP Project ID to export to. This allows a stackdriver out plugin that has logWriter permissions in multiple projects to write to different gcp projects based on a jsonPayload (record) key. This also introduces a default `logging.googleapis.com/projectId` key that will be used if present in the record. The key that is used from the record is removed similar to how `severity_key` and `label_key` work.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #8195

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
```
[FILTER]
    Name modify
    Match k8s_*project1*
    Add logging_project_id prj-fluent-bit-test1

[FILTER]
    Name modify
    Match k8s_*project2*
    Add logging_project_id prj-fluent-bit-test2

[OUTPUT]
    Name stackdriver
    Match k8s_*
    export_to_project_key logging_project_id
    resource k8s_container
    k8s_cluster_name my-test-cluster
    k8s_cluster_location us-central1
```

- [ ] Debug log output from testing the change


<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==97479== 
==97479== HEAP SUMMARY:
==97479==     in use at exit: 0 bytes in 0 blocks
==97479==   total heap usage: 995 allocs, 995 frees, 238,168 bytes allocated
==97479== 
==97479== All heap blocks were freed -- no leaks are possible
==97479== 
==97479== For lists of detected and suppressed errors, rerun with: -s
==97479== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
Docs PR: https://github.com/fluent/fluent-bit-docs/pull/1267

Configuration Parameters
|Key|Description|default|
| --- | ----------| ---|
|project_id_key| The value of this field is used by the Stackdriver output plugin to find the gcp project id from jsonPayload and then extract the value of it to set the `PROJECT_ID` within LogEntry `logName`, which controls the gcp project that should receive these logs. |logging.googleapis.com/projectId, if not present within the jsonPayload the value of export_to_project_id is used as the gcp project id. |

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
