### PR TITLE
network: prefer ipv6 DNS results option

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -213,6 +213,7 @@ struct flb_config {
     char *dns_mode;
     char *dns_resolver;
     int   dns_prefer_ipv4;
+    int   dns_prefer_ipv6;
 
     /* Chunk I/O Buffering */
     void *cio;
@@ -350,6 +351,7 @@ enum conf_type {
 #define FLB_CONF_DNS_MODE              "dns.mode"
 #define FLB_CONF_DNS_RESOLVER          "dns.resolver"
 #define FLB_CONF_DNS_PREFER_IPV4       "dns.prefer_ipv4"
+#define FLB_CONF_DNS_PREFER_IPV6       "dns.prefer_ipv6"
 
 /* Storage / Chunk I/O */
 #define FLB_CONF_STORAGE_PATH          "storage.path"

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -77,6 +77,9 @@ struct flb_net_setup {
     /* prioritize ipv4 results when trying to establish a connection*/
     int   dns_prefer_ipv4;
 
+    /* prioritize ipv6 results when trying to establish a connection*/
+    int   dns_prefer_ipv6;
+
     /* maximum number of allowed active TCP connections */
     int max_worker_connections;
 };

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -125,6 +125,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, dns_prefer_ipv4)},
 
+    {FLB_CONF_DNS_PREFER_IPV6,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, dns_prefer_ipv6)},
+
     /* Storage */
     {FLB_CONF_STORAGE_PATH,
      FLB_CONF_TYPE_STR,

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -104,6 +104,7 @@ void flb_net_setup_init(struct flb_net_setup *net)
     net->dns_mode = NULL;
     net->dns_resolver = NULL;
     net->dns_prefer_ipv4 = FLB_FALSE;
+    net->dns_prefer_ipv6 = FLB_FALSE;
     net->keepalive = FLB_TRUE;
     net->keepalive_idle_timeout = 30;
     net->keepalive_max_recycle = 0;
@@ -1268,7 +1269,23 @@ flb_sockfd_t flb_net_tcp_connect(const char *host, unsigned long port,
         sorted_res = flb_net_sort_addrinfo_list(res, AF_INET);
 
         if (sorted_res == NULL) {
-            flb_debug("[net] error sorting getaddrinfo results");
+            flb_debug("[net] error sorting ipv4 getaddrinfo results");
+
+            if (use_async_dns) {
+                flb_net_free_translated_addrinfo(res);
+            }
+            else {
+                freeaddrinfo(res);
+            }
+
+            return -1;
+        }
+    }
+    else if (u_conn->net->dns_prefer_ipv6) {
+        sorted_res = flb_net_sort_addrinfo_list(res, AF_INET6);
+
+        if (sorted_res == NULL) {
+            flb_debug("[net] error sorting ipv6 getaddrinfo results");
 
             if (use_async_dns) {
                 flb_net_free_translated_addrinfo(res);

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -54,6 +54,12 @@ struct flb_config_map upstream_net[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "net.dns.prefer_ipv6", "false",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, dns_prefer_ipv6),
+     "Prioritize IPv6 DNS results when trying to establish a connection"
+    },
+
+    {
      FLB_CONFIG_MAP_BOOL, "net.keepalive", "true",
      0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive),
      "Enable or disable Keepalive support"
@@ -162,6 +168,12 @@ struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
         if (config->dns_prefer_ipv4) {
             if (strcmp(upstream_net[config_index].name,
                        "net.dns.prefer_ipv4") == 0) {
+                upstream_net[config_index].def_value = "true";
+            }
+        }
+        if (config->dns_prefer_ipv6) {
+            if (strcmp(upstream_net[config_index].name,
+                       "net.dns.prefer_ipv6") == 0) {
                 upstream_net[config_index].def_value = "true";
             }
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8214 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
[SERVICE]
    flush     1
    log_level debug

[INPUT]
    name      dummy
    Tag       dummy.tag

[OUTPUT]
    name                   loki
    match                  *
    host                   listener
    port                   8080
    tls                    Off
    net.dns.prefer_ipv6    true
```

```
version: '3.7'

services:
  listener:
    image: mendhak/http-https-echo
    ports:
      - "8080:8080"
    environment:
      - LOG_WITHOUT_NEWLINE=true
      - ECHO_BACK_TO_CLIENT=false
    networks:
      app_net:
        ipv6_address: 2001:db8:1::40

  fluent-bit:
    build:
      context: .
      dockerfile: dockerfiles/Dockerfile
    image: fluent/fluent-bit
    volumes:
      - ./conf/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
    networks:
      app_net:
        ipv6_address: 2001:db8:1::10

networks:
  app_net:
    driver: bridge
    enable_ipv6: true
    ipam:
      driver: default
      config:
        - subnet: "2001:db8:1::/64"

```

- [x] Debug log output from testing the change

Ipv6 prefer option:
```
fluent-bit-fluent-bit-1  | Fluent Bit v2.2.1
fluent-bit-fluent-bit-1  | * Copyright (C) 2015-2023 The Fluent Bit Authors
fluent-bit-fluent-bit-1  | * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
fluent-bit-fluent-bit-1  | * https://fluentbit.io
fluent-bit-fluent-bit-1  |
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] Configuration:
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  flush time     | 1.000000 seconds
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  grace          | 5 seconds
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  daemon         | 0
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] ___________
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  inputs:
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]      dummy
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] ___________
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  filters:
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] ___________
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  outputs:
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]      loki.0
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] ___________
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info]  collectors:
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [fluent bit] version=2.2.1, commit=8733b25df1, pid=1
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [cmetrics] version=0.6.5
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [ctraces ] version=0.3.1
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [input:dummy:dummy.0] initializing
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [debug] [dummy:dummy.0] created event channels: read=21 write=22
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [debug] [loki:loki.0] created event channels: read=23 write=24
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [output:loki:loki.0] configured, hostname=listener:8080
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [ info] [sp] stream processor started
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:17] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
fluent-bit-listener-1    | Listening on ports 8080 for http, and 8443 for https.
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [task] created task=0x7fcadde36640 id=0 OK
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [upstream] KA connection #31 to listener:8080 is connected
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [http_client] not using http_proxy for header
fluent-bit-listener-1    | {"path":"/loki/api/v1/push","headers":{"host":"listener:8080","content-length":"57","user-agent":"Fluent-Bit","content-type":"application/json","connection":"keep-alive"},"method":"POST","body":"{\"streams\":[{\"stream\":{\"job\":\"fluent-bit\"},\"values\":[]}]}","fresh":false,"hostname":"listener","ip":"2001:db8:1::10","ips":[],"protocol":"http","query":{},"subdomains":[],"xhr":false,"os":{"hostname":"ddb98d22bf71"},"connection":{},"json":{"streams":[{"stream":{"job":"fluent-bit"},"values":[]}]}}
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [output:loki:loki.0] listener:8080, HTTP status=200
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [upstream] KA connection #31 to listener:8080 is now available
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [out flush] cb_destroy coro_id=0
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:18] [debug] [task] destroy task=0x7fcadde36640 (task_id=0)
fluent-bit-listener-1    | 2001:db8:1::10 - - [26/Nov/2023:18:11:18 +0000] "POST /loki/api/v1/push HTTP/1.1" 200 - "-" "Fluent-Bit"
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [task] created task=0x7fcadde36640 id=0 OK
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [upstream] KA connection #31 to listener:8080 has been assigned (recycled)
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [http_client] not using http_proxy for header
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [output:loki:loki.0] listener:8080, HTTP status=200
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [upstream] KA connection #31 to listener:8080 is now available
fluent-bit-listener-1    | {"path":"/loki/api/v1/push","headers":{"host":"listener:8080","content-length":"57","user-agent":"Fluent-Bit","content-type":"application/json","connection":"keep-alive"},"method":"POST","body":"{\"streams\":[{\"stream\":{\"job\":\"fluent-bit\"},\"values\":[]}]}","fresh":false,"hostname":"listener","ip":"2001:db8:1::10","ips":[],"protocol":"http","query":{},"subdomains":[],"xhr":false,"os":{"hostname":"ddb98d22bf71"},"connection":{},"json":{"streams":[{"stream":{"job":"fluent-bit"},"values":[]}]}}
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [out flush] cb_destroy coro_id=1
fluent-bit-fluent-bit-1  | [2023/11/26 18:11:19] [debug] [task] destroy task=0x7fcadde36640 (task_id=0)
fluent-bit-listener-1    | 2001:db8:1::10 - - [26/Nov/2023:18:11:19 +0000] "POST /loki/api/v1/push HTTP/1.1" 200 - "-" "Fluent-Bit"
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==1082533== Memcheck, a memory error detector
==1082533== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1082533== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==1082533== Command: ./bin/fluent-bit -c ./conf/fluent-bit.conf
==1082533==
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/26 20:17:01] [ info] Configuration:
[2023/11/26 20:17:01] [ info]  flush time     | 1.000000 seconds
[2023/11/26 20:17:01] [ info]  grace          | 5 seconds
[2023/11/26 20:17:01] [ info]  daemon         | 0
[2023/11/26 20:17:01] [ info] ___________
[2023/11/26 20:17:01] [ info]  inputs:
[2023/11/26 20:17:01] [ info]      dummy
[2023/11/26 20:17:01] [ info] ___________
[2023/11/26 20:17:01] [ info]  filters:
[2023/11/26 20:17:01] [ info] ___________
[2023/11/26 20:17:01] [ info]  outputs:
[2023/11/26 20:17:01] [ info]      loki.0
[2023/11/26 20:17:01] [ info] ___________
[2023/11/26 20:17:01] [ info]  collectors:
[2023/11/26 20:17:01] [ info] [fluent bit] version=2.2.1, commit=6ec7b61c90, pid=1082533
[2023/11/26 20:17:01] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/11/26 20:17:01] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/26 20:17:01] [ info] [cmetrics] version=0.6.5
[2023/11/26 20:17:01] [ info] [ctraces ] version=0.3.1
[2023/11/26 20:17:01] [ info] [input:dummy:dummy.0] initializing
[2023/11/26 20:17:01] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/11/26 20:17:01] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2023/11/26 20:17:01] [debug] [loki:loki.0] created event channels: read=23 write=24
[2023/11/26 20:17:01] [ info] [output:loki:loki.0] configured, hostname=localhost:8080
[2023/11/26 20:17:01] [ info] [sp] stream processor started
[2023/11/26 20:17:01] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:02] [debug] [task] created task=0x54d61d0 id=0 OK
[2023/11/26 20:17:02] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:02] [debug] [upstream] KA connection #32 to localhost:8080 is connected
[2023/11/26 20:17:02] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:02] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:02] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:02] [debug] [out flush] cb_destroy coro_id=0
[2023/11/26 20:17:02] [debug] [task] destroy task=0x54d61d0 (task_id=0)
[2023/11/26 20:17:03] [debug] [task] created task=0x5552a50 id=0 OK
[2023/11/26 20:17:03] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:03] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:03] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:03] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:03] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:03] [debug] [out flush] cb_destroy coro_id=1
[2023/11/26 20:17:03] [debug] [task] destroy task=0x5552a50 (task_id=0)
[2023/11/26 20:17:04] [debug] [task] created task=0x55ae000 id=0 OK
[2023/11/26 20:17:04] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:04] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:04] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:04] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:04] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:04] [debug] [out flush] cb_destroy coro_id=2
[2023/11/26 20:17:04] [debug] [task] destroy task=0x55ae000 (task_id=0)
[2023/11/26 20:17:05] [debug] [task] created task=0x560b5f0 id=0 OK
[2023/11/26 20:17:05] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:05] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:05] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:05] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:05] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:05] [debug] [out flush] cb_destroy coro_id=3
[2023/11/26 20:17:05] [debug] [task] destroy task=0x560b5f0 (task_id=0)
[2023/11/26 20:17:06] [debug] [task] created task=0x5666ba0 id=0 OK
[2023/11/26 20:17:06] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:06] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:06] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:06] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:06] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:06] [debug] [out flush] cb_destroy coro_id=4
[2023/11/26 20:17:06] [debug] [task] destroy task=0x5666ba0 (task_id=0)
[2023/11/26 20:17:07] [debug] [task] created task=0x56c2150 id=0 OK
[2023/11/26 20:17:07] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:07] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:07] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:07] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:07] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:07] [debug] [out flush] cb_destroy coro_id=5
[2023/11/26 20:17:07] [debug] [task] destroy task=0x56c2150 (task_id=0)
[2023/11/26 20:17:08] [debug] [task] created task=0x571d700 id=0 OK
[2023/11/26 20:17:08] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:08] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:08] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:08] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:08] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:08] [debug] [out flush] cb_destroy coro_id=6
[2023/11/26 20:17:08] [debug] [task] destroy task=0x571d700 (task_id=0)
[2023/11/26 20:17:09] [debug] [task] created task=0x5778cb0 id=0 OK
[2023/11/26 20:17:09] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:09] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:09] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:09] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:09] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:09] [debug] [out flush] cb_destroy coro_id=7
[2023/11/26 20:17:09] [debug] [task] destroy task=0x5778cb0 (task_id=0)
[2023/11/26 20:17:10] [debug] [task] created task=0x57d62a0 id=0 OK
[2023/11/26 20:17:10] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:10] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:10] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:10] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:10] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:10] [debug] [out flush] cb_destroy coro_id=8
[2023/11/26 20:17:10] [debug] [task] destroy task=0x57d62a0 (task_id=0)
[2023/11/26 20:17:11] [debug] [task] created task=0x57ea010 id=0 OK
[2023/11/26 20:17:11] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:11] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:11] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:11] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:11] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:11] [debug] [out flush] cb_destroy coro_id=9
[2023/11/26 20:17:11] [debug] [task] destroy task=0x57ea010 (task_id=0)
[2023/11/26 20:17:12] [debug] [task] created task=0x57f7a10 id=0 OK
[2023/11/26 20:17:12] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:12] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:12] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:12] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:12] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:12] [debug] [out flush] cb_destroy coro_id=10
[2023/11/26 20:17:12] [debug] [task] destroy task=0x57f7a10 (task_id=0)
[2023/11/26 20:17:13] [debug] [task] created task=0x5812e50 id=0 OK
[2023/11/26 20:17:13] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:13] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:13] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:13] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:13] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:13] [debug] [out flush] cb_destroy coro_id=11
[2023/11/26 20:17:13] [debug] [task] destroy task=0x5812e50 (task_id=0)
[2023/11/26 20:17:14] [debug] [task] created task=0x69529b0 id=0 OK
[2023/11/26 20:17:14] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:14] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:14] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:14] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:14] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:14] [debug] [out flush] cb_destroy coro_id=12
[2023/11/26 20:17:14] [debug] [task] destroy task=0x69529b0 (task_id=0)
[2023/11/26 20:17:15] [debug] [task] created task=0x69affa0 id=0 OK
[2023/11/26 20:17:15] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:15] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:15] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:15] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:15] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:15] [debug] [out flush] cb_destroy coro_id=13
[2023/11/26 20:17:15] [debug] [task] destroy task=0x69affa0 (task_id=0)
[2023/11/26 20:17:16] [debug] [task] created task=0x6a0b550 id=0 OK
[2023/11/26 20:17:16] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:16] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:16] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:16] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:16] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:16] [debug] [out flush] cb_destroy coro_id=14
[2023/11/26 20:17:16] [debug] [task] destroy task=0x6a0b550 (task_id=0)
[2023/11/26 20:17:17] [debug] [task] created task=0x6a66b00 id=0 OK
[2023/11/26 20:17:17] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:17] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:17] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:17] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:17] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:17] [debug] [out flush] cb_destroy coro_id=15
[2023/11/26 20:17:17] [debug] [task] destroy task=0x6a66b00 (task_id=0)
[2023/11/26 20:17:18] [debug] [task] created task=0x6ac20b0 id=0 OK
[2023/11/26 20:17:18] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:18] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:18] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:18] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:18] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:18] [debug] [out flush] cb_destroy coro_id=16
[2023/11/26 20:17:18] [debug] [task] destroy task=0x6ac20b0 (task_id=0)
[2023/11/26 20:17:19] [debug] [task] created task=0x6b1d660 id=0 OK
[2023/11/26 20:17:19] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:19] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:19] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:19] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:19] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:19] [debug] [out flush] cb_destroy coro_id=17
[2023/11/26 20:17:19] [debug] [task] destroy task=0x6b1d660 (task_id=0)
[2023/11/26 20:17:20] [debug] [task] created task=0x6b7ac50 id=0 OK
[2023/11/26 20:17:20] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:20] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:20] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:20] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:20] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:20] [debug] [out flush] cb_destroy coro_id=18
[2023/11/26 20:17:20] [debug] [task] destroy task=0x6b7ac50 (task_id=0)
[2023/11/26 20:17:21] [debug] [task] created task=0x6bd6200 id=0 OK
[2023/11/26 20:17:21] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:21] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:21] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:21] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:21] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:21] [debug] [out flush] cb_destroy coro_id=19
[2023/11/26 20:17:21] [debug] [task] destroy task=0x6bd6200 (task_id=0)
[2023/11/26 20:17:22] [debug] [task] created task=0x6c317b0 id=0 OK
[2023/11/26 20:17:22] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:22] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:22] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:22] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:22] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:22] [debug] [out flush] cb_destroy coro_id=20
[2023/11/26 20:17:22] [debug] [task] destroy task=0x6c317b0 (task_id=0)
[2023/11/26 20:17:23] [debug] [task] created task=0x6c8cda0 id=0 OK
[2023/11/26 20:17:23] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:23] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:23] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:23] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:23] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:23] [debug] [out flush] cb_destroy coro_id=21
[2023/11/26 20:17:23] [debug] [task] destroy task=0x6c8cda0 (task_id=0)
[2023/11/26 20:17:24] [debug] [task] created task=0x6ce8350 id=0 OK
[2023/11/26 20:17:24] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:24] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:24] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:24] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:24] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:24] [debug] [out flush] cb_destroy coro_id=22
[2023/11/26 20:17:24] [debug] [task] destroy task=0x6ce8350 (task_id=0)
[2023/11/26 20:17:25] [debug] [task] created task=0x6d45940 id=0 OK
[2023/11/26 20:17:25] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:25] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:25] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:25] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:25] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:25] [debug] [out flush] cb_destroy coro_id=23
[2023/11/26 20:17:25] [debug] [task] destroy task=0x6d45940 (task_id=0)
[2023/11/26 20:17:26] [debug] [task] created task=0x6da0ef0 id=0 OK
[2023/11/26 20:17:26] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:26] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:26] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:26] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:26] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:26] [debug] [out flush] cb_destroy coro_id=24
[2023/11/26 20:17:26] [debug] [task] destroy task=0x6da0ef0 (task_id=0)
[2023/11/26 20:17:27] [debug] [task] created task=0x6dfc4a0 id=0 OK
[2023/11/26 20:17:27] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:27] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:27] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:27] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:27] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:27] [debug] [out flush] cb_destroy coro_id=25
[2023/11/26 20:17:27] [debug] [task] destroy task=0x6dfc4a0 (task_id=0)
[2023/11/26 20:17:28] [debug] [task] created task=0x6e57a50 id=0 OK
[2023/11/26 20:17:28] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:28] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:28] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:28] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:28] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:28] [debug] [out flush] cb_destroy coro_id=26
[2023/11/26 20:17:28] [debug] [task] destroy task=0x6e57a50 (task_id=0)
[2023/11/26 20:17:29] [debug] [task] created task=0x6eb3000 id=0 OK
[2023/11/26 20:17:29] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:29] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:29] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:29] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:29] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:29] [debug] [out flush] cb_destroy coro_id=27
[2023/11/26 20:17:29] [debug] [task] destroy task=0x6eb3000 (task_id=0)
[2023/11/26 20:17:30] [debug] [task] created task=0x6f105f0 id=0 OK
[2023/11/26 20:17:30] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:30] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:30] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:30] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:30] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:30] [debug] [out flush] cb_destroy coro_id=28
[2023/11/26 20:17:30] [debug] [task] destroy task=0x6f105f0 (task_id=0)
[2023/11/26 20:17:31] [debug] [task] created task=0x6f6bba0 id=0 OK
[2023/11/26 20:17:31] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:31] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:31] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:31] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:31] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:31] [debug] [out flush] cb_destroy coro_id=29
[2023/11/26 20:17:31] [debug] [task] destroy task=0x6f6bba0 (task_id=0)
[2023/11/26 20:17:32] [debug] [task] created task=0x6fc7150 id=0 OK
[2023/11/26 20:17:32] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:32] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:32] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:32] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:32] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:32] [debug] [out flush] cb_destroy coro_id=30
[2023/11/26 20:17:32] [debug] [task] destroy task=0x6fc7150 (task_id=0)
[2023/11/26 20:17:33] [debug] [task] created task=0x7022700 id=0 OK
[2023/11/26 20:17:33] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:33] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:33] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:33] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:33] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:33] [debug] [out flush] cb_destroy coro_id=31
[2023/11/26 20:17:33] [debug] [task] destroy task=0x7022700 (task_id=0)
[2023/11/26 20:17:34] [debug] [task] created task=0x7032ac0 id=0 OK
[2023/11/26 20:17:34] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:34] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:34] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:34] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:34] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:34] [debug] [out flush] cb_destroy coro_id=32
[2023/11/26 20:17:34] [debug] [task] destroy task=0x7032ac0 (task_id=0)
[2023/11/26 20:17:35] [debug] [task] created task=0x70db2d0 id=0 OK
[2023/11/26 20:17:35] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:35] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:35] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:35] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:35] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:35] [debug] [out flush] cb_destroy coro_id=33
[2023/11/26 20:17:35] [debug] [task] destroy task=0x70db2d0 (task_id=0)
[2023/11/26 20:17:36] [debug] [task] created task=0x7136880 id=0 OK
[2023/11/26 20:17:36] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:36] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:36] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:36] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:36] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:36] [debug] [out flush] cb_destroy coro_id=34
[2023/11/26 20:17:36] [debug] [task] destroy task=0x7136880 (task_id=0)
[2023/11/26 20:17:37] [debug] [task] created task=0x7191e30 id=0 OK
[2023/11/26 20:17:37] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:37] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:37] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:37] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:37] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:37] [debug] [out flush] cb_destroy coro_id=35
[2023/11/26 20:17:37] [debug] [task] destroy task=0x7191e30 (task_id=0)
[2023/11/26 20:17:38] [debug] [task] created task=0x71ed3e0 id=0 OK
[2023/11/26 20:17:38] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:38] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:38] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:38] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:38] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:38] [debug] [out flush] cb_destroy coro_id=36
[2023/11/26 20:17:38] [debug] [task] destroy task=0x71ed3e0 (task_id=0)
[2023/11/26 20:17:39] [debug] [task] created task=0x7248990 id=0 OK
[2023/11/26 20:17:39] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:39] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:39] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:39] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:39] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:39] [debug] [out flush] cb_destroy coro_id=37
[2023/11/26 20:17:39] [debug] [task] destroy task=0x7248990 (task_id=0)
[2023/11/26 20:17:40] [debug] [task] created task=0x72a5f80 id=0 OK
[2023/11/26 20:17:40] [debug] [input chunk] update output instances with new chunk size diff=36, records=1, input=dummy.0
[2023/11/26 20:17:40] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:40] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:40] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:40] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:40] [debug] [out flush] cb_destroy coro_id=38
[2023/11/26 20:17:40] [debug] [task] destroy task=0x72a5f80 (task_id=0)
^C[2023/11/26 20:17:41] [engine] caught signal (SIGINT)
[2023/11/26 20:17:41] [debug] [task] created task=0x7301580 id=0 OK
[2023/11/26 20:17:41] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/26 20:17:41] [ info] [input] pausing dummy.0
[2023/11/26 20:17:41] [debug] [upstream] KA connection #32 to localhost:8080 has been assigned (recycled)
[2023/11/26 20:17:41] [debug] [http_client] not using http_proxy for header
[2023/11/26 20:17:41] [debug] [output:loki:loki.0] localhost:8080, HTTP status=200
[2023/11/26 20:17:41] [debug] [upstream] KA connection #32 to localhost:8080 is now available
[2023/11/26 20:17:41] [debug] [out flush] cb_destroy coro_id=39
[2023/11/26 20:17:41] [debug] [task] destroy task=0x7301580 (task_id=0)
[2023/11/26 20:17:41] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/26 20:17:41] [ info] [input] pausing dummy.0
==1082533==
==1082533== HEAP SUMMARY:
==1082533==     in use at exit: 0 bytes in 0 blocks
==1082533==   total heap usage: 4,078 allocs, 4,078 frees, 15,321,706 bytes allocated
==1082533==
==1082533== All heap blocks were freed -- no leaks are possible
==1082533==
==1082533== For lists of detected and suppressed errors, rerun with: -s
==1082533== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
