### PR TITLE
in_dummy: Add flush_on_startup config.

### DIFF
--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -351,6 +351,10 @@ static int in_dummy_init(struct flb_input_instance *in,
 
     flb_input_set_context(in, ctx);
 
+    if (ctx->flush_on_startup) {
+        in_dummy_collect(in, config, ctx);
+    }
+
     ret = flb_input_set_collector_time(in,
                                        in_dummy_collect,
                                        tm.tv_sec,
@@ -443,6 +447,11 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_BOOL, "fixed_timestamp", "off",
     0, FLB_TRUE, offsetof(struct flb_dummy, fixed_timestamp),
     "used a fixed timestamp, allows the message to pre-generated once."
+   },
+   {
+    FLB_CONFIG_MAP_BOOL, "flush_on_startup", "false",
+    0, FLB_TRUE, offsetof(struct flb_dummy, flush_on_startup),
+    "generate the first event on startup"
    },
    {0}
 };

--- a/plugins/in_dummy/in_dummy.h
+++ b/plugins/in_dummy/in_dummy.h
@@ -48,6 +48,7 @@ struct flb_dummy {
     int  start_time_nsec;
 
     bool fixed_timestamp;
+    bool flush_on_startup;
 
     char *ref_metadata_msgpack;
     size_t ref_metadata_msgpack_size;

--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -548,6 +548,11 @@ void flb_test_dummy_records_message_interval_nsec(struct callback_records *recor
     TEST_CHECK(records->num_records >= 1);
 }
 
+void flb_test_dummy_records_message_flush_on_startup(struct callback_records *records)
+{
+    TEST_CHECK(records->num_records >= 2);
+}
+
 void flb_test_in_dummy_flush()
 {
     do_test("dummy", NULL);
@@ -588,6 +593,11 @@ void flb_test_in_dummy_flush()
     do_test_records_wait_time("dummy", 1, flb_test_dummy_records_message_interval_nsec,
                     "interval_sec", "0",
                     "interval_nsec", "700000000",
+                    NULL);
+    do_test_records_wait_time("dummy", 5, flb_test_dummy_records_message_flush_on_startup,
+                    "interval_sec", "5",
+                    "interval_nsec", "0",
+                    "flush_on_startup", "true",
                     NULL);
 }
 


### PR DESCRIPTION
This PR adds new `flush_on_startup` setting to the in_dummy input plugin. When `interval_sec/nsec` is set for a long time, its helpful to be able to verify the first event is generated at startup to avoid waiting.

Documentation update in https://github.com/fluent/fluent-bit-docs/pull/1264.

### Configuration
```
[INPUT]
    Dummy            {"message": "Dummy", "severity": "INFO"}
    Interval_NSec    0
    Interval_Sec     10
    Name             dummy
    Start_time_sec   0
    Flush_on_startup True

[OUTPUT]
    Name            stdout
    Match           *
```

### Output Log
With this config a log message is generated at startup and then every 10 seconds.
```
./fluent-bit -c fluent-bit.conf
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/27 21:22:50] [ info] [fluent bit] version=2.2.1, commit=8733b25df1, pid=1790739
[2023/11/27 21:22:50] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/27 21:22:50] [ info] [cmetrics] version=0.6.5
[2023/11/27 21:22:50] [ info] [ctraces ] version=0.3.1
[2023/11/27 21:22:50] [ info] [input:dummy:dummy.0] initializing
[2023/11/27 21:22:50] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/11/27 21:22:50] [ info] [sp] stream processor started
[2023/11/27 21:22:50] [ info] [output:stdout:stdout.0] worker #0 started
[0] dummy.0: [[0.000070090, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
[0] dummy.0: [[9.447917175, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
[0] dummy.0: [[19.447787506, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
[0] dummy.0: [[29.447908652, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
^C[2023/11/27 21:23:24] [engine] caught signal (SIGINT)
[2023/11/27 21:23:24] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/27 21:23:24] [ info] [input] pausing dummy.0
[2023/11/27 21:23:24] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/27 21:23:24] [ info] [input] pausing dummy.0
[2023/11/27 21:23:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/27 21:23:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

### Valgrind Output
```
valgrind --leak-check=yes ./fluent-bit   --config ./fluent-bit.conf
==1790816== Memcheck, a memory error detector
==1790816== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==1790816== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==1790816== Command: ./fluent-bit --config ./fluent-bit.conf
==1790816==
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/11/27 21:23:46] [ info] [fluent bit] version=2.2.1, commit=8733b25df1, pid=1790816
[2023/11/27 21:23:46] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/11/27 21:23:46] [ info] [cmetrics] version=0.6.5
[2023/11/27 21:23:46] [ info] [ctraces ] version=0.3.1
[2023/11/27 21:23:46] [ info] [input:dummy:dummy.0] initializing
[2023/11/27 21:23:46] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2023/11/27 21:23:46] [ info] [sp] stream processor started
[2023/11/27 21:23:46] [ info] [output:stdout:stdout.0] worker #0 started
==1790816== Warning: client switching stacks?  SP change: 0x6cbae58 --> 0x517e0a0
==1790816==          to suppress, use: --max-stackframe=28560824 or greater
==1790816== Warning: client switching stacks?  SP change: 0x517df88 --> 0x6cbae58
==1790816==          to suppress, use: --max-stackframe=28561104 or greater
==1790816== Warning: client switching stacks?  SP change: 0x6cbae58 --> 0x517df88
==1790816==          to suppress, use: --max-stackframe=28561104 or greater
==1790816==          further instances of this message will not be shown.
[0] dummy.0: [[0.014987779, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
[0] dummy.0: [[9.137168279, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
[0] dummy.0: [[19.135748536, {}], {"message"=>"Dummy", "severity"=>"INFO"}]
^C[2023/11/27 21:24:07] [engine] caught signal (SIGINT)
[2023/11/27 21:24:07] [ warn] [engine] service will shutdown in max 5 seconds
[2023/11/27 21:24:07] [ info] [input] pausing dummy.0
[2023/11/27 21:24:08] [ info] [engine] service has stopped (0 pending tasks)
[2023/11/27 21:24:08] [ info] [input] pausing dummy.0
[2023/11/27 21:24:08] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/11/27 21:24:08] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==1790816==
==1790816== HEAP SUMMARY:
==1790816==     in use at exit: 0 bytes in 0 blocks
==1790816==   total heap usage: 1,755 allocs, 1,755 frees, 1,875,538 bytes allocated
==1790816==
==1790816== All heap blocks were freed -- no leaks are possible
==1790816==
==1790816== For lists of detected and suppressed errors, rerun with: -s
==1790816== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
