### PR TITLE
lib: ctraces: Fix a crash in fluent-bit when in_opentelemetry plugin handles a trace message from opentelemetry-cpp/example_otlp_http sample app

### DIFF
--- a/lib/ctraces/src/ctr_decode_opentelemetry.c
+++ b/lib/ctraces/src/ctr_decode_opentelemetry.c
@@ -571,7 +571,9 @@ int ctr_decode_opentelemetry_create(struct ctrace **out_ctr,
                 ctr_span_kind_set(span, otel_span->kind);
                 ctr_span_start_ts(ctr, span, otel_span->start_time_unix_nano);
                 ctr_span_end_ts(ctr, span, otel_span->end_time_unix_nano);
-                ctr_span_set_status(span, otel_span->status->code, otel_span->status->message);
+                if (otel_span->status) {
+                    ctr_span_set_status(span, otel_span->status->code, otel_span->status->message);
+                }
                 ctr_span_set_attributes(span, otel_span->n_attributes, otel_span->attributes);
                 ctr_span_set_events(span, otel_span->n_events, otel_span->events);
                 ctr_span_set_dropped_attributes_count(span, otel_span->dropped_attributes_count);


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch fixes a crash in fluent-bit when ctr_decode_opentelemetry_create() tries to access the span status and when span status is not present.

the patch has been tested with opentelemetry-cpp-1.12.0/example_otlp_http http://localhost:4318/v1/traces DEBUG=yes bin and fluent-bit 2.2.0
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
[INPUT]
        name opentelemetry
        listen 127.0.0.1
        port 4318
        successful_response_code 200

[OUTPUT]
        name stdout
        match *
- [ ] Debug log output from testing the change
Before fix:
root@b4aa3e5d75b5:/source/opentelemetry-cpp-1.12.0/build/examples/otlp# ./example_otlp_http http://localhost:4318/v1/traces DEBUG=yes bin

[2023/12/02 11:25:16] [engine] caught signal (SIGSEGV)
[2023/12/02 11:25:16] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/opentelemetry.c:52] new TCP connection arrived FD=40
[2023/12/02 11:25:16] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=402 pre_len=0 now_len=402
#0  0x559e36b6196c      in  ctr_decode_opentelemetry_create() at lib/ctraces/src/ctr_decode_opentelemetry.c:574
#1  0x559e36841d39      in  process_payload_traces_proto() at plugins/in_opentelemetry/opentelemetry_prot.c:166
#2  0x559e36841fa8      in  process_payload_traces() at plugins/in_opentelemetry/opentelemetry_prot.c:234
#3  0x559e3684543c      in  opentelemetry_prot_handle() at plugins/in_opentelemetry/opentelemetry_prot.c:1644
#4  0x559e3683c73c      in  opentelemetry_conn_event() at plugins/in_opentelemetry/http_conn.c:99
#5  0x559e3661e79f      in  flb_engine_start() at src/flb_engine.c:1009
#6  0x559e365bccf2      in  flb_lib_worker() at src/flb_lib.c:638
#7  0x7f1a092a2ad9      in  ???() at ???:0
#8  0x7f1a093332e3      in  ???() at ???:0
#9  0xffffffffffffffff  in  ???() at ???:0
Aborted (core dumped)

Post fix:

[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/opentelemetry.c:52] new TCP connection arrived FD=40
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=402 pre_len=0 now_len=402
[2023/12/02 14:50:23] [debug] [input chunk] update output instances with new chunk size diff=567, records=0, input=opentelemetry.0
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=402 pre_len=0 now_len=402
[2023/12/02 14:50:23] [debug] [input chunk] update output instances with new chunk size diff=567, records=0, input=opentelemetry.0
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=165 pre_len=0 now_len=165
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=237 pre_len=165 now_len=402
[2023/12/02 14:50:23] [debug] [input chunk] update output instances with new chunk size diff=567, records=0, input=opentelemetry.0
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=165 pre_len=0 now_len=165
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:89] read()=232 pre_len=165 now_len=397
[2023/12/02 14:50:23] [debug] [input chunk] update output instances with new chunk size diff=556, records=0, input=opentelemetry.0
[2023/12/02 14:50:23] [trace] [input:opentelemetry:opentelemetry.0 at /source/fluent-bit-2.2.0/plugins/in_opentelemetry/http_conn.c:84] fd=40 closed connection
[2023/12/02 14:50:24] [debug] [task] created task=0x7fabf8018480 id=0 OK
[2023/12/02 14:50:24] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f1']
             - trace_id                : e86248c61e028f03fde5e462bcae3fb1
             - span_id                 : 5593e2db2dd9c035
             - parent_span_id          : 9e1b28eb1506ce3c
             - kind                    : 1 (internal)
             - start_time              : 1701517823379482754
             - end_time                : 1701517823379486350
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
[2023/12/02 14:50:24] [debug] [out flush] cb_destroy coro_id=0
[2023/12/02 14:50:24] [debug] [task] destroy task=0x7fabf8018480 (task_id=0)

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
