### PR TITLE
out_azure_blob: add support for Azure Blob SAS authentication

### DIFF
--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -200,6 +200,12 @@ static int send_blob(struct flb_config *config,
         return FLB_OK;
     }
     else if (c->resp.status == 404) {
+        /* delete "&sig=..." in the c->uri for security */
+        char *p = strstr(c->uri, "&sig=");
+        if (p) {
+            *p = '\0';
+        }
+
         flb_plg_info(ctx->ins, "blob not found: %s", c->uri);
         flb_http_client_destroy(c);
         return CREATE_BLOB;
@@ -269,6 +275,11 @@ static int create_blob(struct flb_azure_blob *ctx, char *name)
     }
 
     if (c->resp.status == 201) {
+        /* delete "&sig=..." in the c->uri for security */
+        char *p = strstr(c->uri, "&sig=");
+        if (p) {
+            *p = '\0';
+        }
         flb_plg_info(ctx->ins, "blob created successfully: %s", c->uri);
     }
     else {
@@ -570,6 +581,18 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "date_key", "@timestamp",
      0, FLB_TRUE, offsetof(struct flb_azure_blob, date_key),
      "Name of the key that will have the record timestamp"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "auth_type", "key",
+     0, FLB_TRUE, offsetof(struct flb_azure_blob, auth_type),
+     "Set the auth type: key or sas"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "sas_token", NULL,
+     0, FLB_TRUE, offsetof(struct flb_azure_blob, sas_token),
+     "Azure Blob SAS token"
     },
 
     /* EOF */

--- a/plugins/out_azure_blob/azure_blob.h
+++ b/plugins/out_azure_blob/azure_blob.h
@@ -41,6 +41,9 @@
 #define AZURE_BLOB_APPENDBLOB 0
 #define AZURE_BLOB_BLOCKBLOB  1
 
+#define AZURE_BLOB_AUTH_KEY 0
+#define AZURE_BLOB_AUTH_SAS 1
+
 struct flb_azure_blob {
     int auto_create_container;
     int emulator_mode;
@@ -53,11 +56,14 @@ struct flb_azure_blob {
     flb_sds_t endpoint;
     flb_sds_t path;
     flb_sds_t date_key;
+    flb_sds_t auth_type;
+    flb_sds_t sas_token;
 
     /*
      * Internal use
      */
     int  btype;                  /* blob type */
+    int  atype;                  /* auth type */
     flb_sds_t real_endpoint;
     flb_sds_t base_uri;
     flb_sds_t shared_key_prefix;

--- a/plugins/out_azure_blob/azure_blob_appendblob.c
+++ b/plugins/out_azure_blob/azure_blob_appendblob.c
@@ -40,5 +40,9 @@ flb_sds_t azb_append_blob_uri(struct flb_azure_blob *ctx, char *tag)
         flb_sds_printf(&uri, "/%s?comp=appendblock", tag);
     }
 
+    if (ctx->atype == AZURE_BLOB_AUTH_SAS && ctx->sas_token) {
+        flb_sds_printf(&uri, "&%s", ctx->sas_token);
+    }
+
     return uri;
 }

--- a/plugins/out_azure_blob/azure_blob_http.c
+++ b/plugins/out_azure_blob/azure_blob_http.c
@@ -339,20 +339,22 @@ int azb_http_client_setup(struct flb_azure_blob *ctx, struct flb_http_client *c,
     /* Azure header: x-ms-version */
     flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
 
-    can_req = azb_http_canonical_request(ctx, c, content_length, content_type,
-                                         content_encoding);
+    if (ctx->atype == AZURE_BLOB_AUTH_KEY) {
+        can_req = azb_http_canonical_request(ctx, c, content_length, content_type,
+                                             content_encoding);
 
-    auth = flb_sds_create_size(64 + flb_sds_len(can_req));
+        auth = flb_sds_create_size(64 + flb_sds_len(can_req));
 
-    flb_sds_cat(auth, ctx->shared_key_prefix, flb_sds_len(ctx->shared_key_prefix));
-    flb_sds_cat(auth, can_req, flb_sds_len(can_req));
+        flb_sds_cat(auth, ctx->shared_key_prefix, flb_sds_len(ctx->shared_key_prefix));
+        flb_sds_cat(auth, can_req, flb_sds_len(can_req));
 
-    /* Azure header: authorization */
-    flb_http_add_header(c, "Authorization", 13, auth, flb_sds_len(auth));
+        /* Azure header: authorization */
+        flb_http_add_header(c, "Authorization", 13, auth, flb_sds_len(auth));
 
-    /* Release buffers */
-    flb_sds_destroy(can_req);
-    flb_sds_destroy(auth);
+        /* Release buffers */
+        flb_sds_destroy(can_req);
+        flb_sds_destroy(auth);
+    }
 
     /* Set callback context to the HTTP client context */
     flb_http_set_callback_context(c, ctx->ins->callback);

--- a/plugins/out_azure_blob/azure_blob_uri.c
+++ b/plugins/out_azure_blob/azure_blob_uri.c
@@ -127,6 +127,10 @@ flb_sds_t azb_uri_ensure_or_create_container(struct flb_azure_blob *ctx)
     }
 
     flb_sds_printf(&uri, "?restype=container");
+    if (ctx->atype == AZURE_BLOB_AUTH_SAS && ctx->sas_token) {
+        flb_sds_printf(&uri, "&%s", ctx->sas_token);
+    }
+
     return uri;
 }
 
@@ -144,6 +148,10 @@ flb_sds_t azb_uri_create_blob(struct flb_azure_blob *ctx, char *tag)
     }
     else {
         flb_sds_printf(&uri, "/%s", tag);
+    }
+
+    if (ctx->atype == AZURE_BLOB_AUTH_SAS && ctx->sas_token) {
+        flb_sds_printf(&uri, "?%s", ctx->sas_token);
     }
 
     return uri;


### PR DESCRIPTION
Sometimes user cannot use shared key authentication. So, this patch support authenticate Azure Blob Storage with shared access signatures. 

Here is the document about shared access signatures: https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview

This patch add two configuration parameters for out_azure_blob plugin: auth_type and sas_token.

    - auth_type, default value is "key", it can be "key" or "sas".
    - sas_token, default value is NULL, it is the SAS token, it is required when auth_type is "sas".

Fixes #8230 

------
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
[INPUT]
    name tail
    path /workspaces/fluent-bit/build/test.log
    tag test.txt

[OUTPUT]
    name                  azure_blob
    match                 *
    account_name         my_account
    auth_type             sas
    sas_token             sv=2022-11-02&ss=bfqt&srt=sco&sp=rwdlacupyx&se=2023-12-04T15:08:48Z&st=2023-12-03T07:08:48Z&spr=https&sig=xxxxxx
    path                  test_fs/test_fluent_bit
    container_name        my_container
    auto_create_container on
    tls                   on
```

- [x] Debug log output from testing the change

```
[2023/12/03 13:02:01] [debug] [input:tail:tail.0] inode=15033, /workspaces/fluent-bit/build/test.log, events: IN_ATTRIB
[2023/12/03 13:02:01] [debug] [input chunk] update output instances with new chunk size diff=108, records=3, input=tail.0
[2023/12/03 13:02:01] [debug] [input:tail:tail.0] inode=15033, /workspaces/fluent-bit/build/test.log, events: IN_MODIFY
[2023/12/03 13:02:01] [debug] [task] created task=0xffff7c051b30 id=0 OK
[2023/12/03 13:02:02] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is connected
[2023/12/03 13:02:02] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 has been assigned (recycled)
[2023/12/03 13:02:03] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:02:03] [ info] [output:azure_blob:azure_blob.0] blob not found: /my_container/test_fs/test_fluent_bit/test.txt?comp=appendblock&sv=2022-11-02&ss=bfqt&srt=sco&sp=rwdlacupyx&se=2023-12-13T15:08:48Z&st=2023-12-03T07:08:48Z&spr=https
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 has been assigned (recycled)
[2023/12/03 13:02:03] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:02:03] [ info] [output:azure_blob:azure_blob.0] blob created successfully: /my_container/test_fs/test_fluent_bit/test.txt?sv=2022-11-02&ss=bfqt&srt=sco&sp=rwdlacupyx&se=2023-12-13T15:08:48Z&st=2023-12-03T07:08:48Z&spr=https
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 has been assigned (recycled)
[2023/12/03 13:02:03] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:02:03] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:02:03] [ info] [output:azure_blob:azure_blob.0] content appended to blob successfully
[2023/12/03 13:02:03] [debug] [out flush] cb_destroy coro_id=0
[2023/12/03 13:02:03] [debug] [task] destroy task=0xffff7c051b30 (task_id=0)
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
fluent-bit@008906c25bf5:/workspaces/fluent-bit/build$ valgrind ./bin/fluent-bit -c fluent-bit.conf
==50903== Memcheck, a memory error detector
==50903== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==50903== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==50903== Command: ./bin/fluent-bit -c fluent-bit.conf
==50903==
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/03 13:33:34] [ info] Configuration:
[2023/12/03 13:33:34] [ info]  flush time     | 1.000000 seconds
[2023/12/03 13:33:34] [ info]  grace          | 5 seconds
[2023/12/03 13:33:34] [ info]  daemon         | 0
[2023/12/03 13:33:34] [ info] ___________
[2023/12/03 13:33:34] [ info]  inputs:
[2023/12/03 13:33:34] [ info]      tail
[2023/12/03 13:33:34] [ info] ___________
[2023/12/03 13:33:34] [ info]  filters:
[2023/12/03 13:33:34] [ info] ___________
[2023/12/03 13:33:34] [ info]  outputs:
[2023/12/03 13:33:34] [ info]      azure_blob.0
[2023/12/03 13:33:34] [ info] ___________
[2023/12/03 13:33:34] [ info]  collectors:
[2023/12/03 13:33:34] [ info] [fluent bit] version=2.2.1, commit=fad58c93b9, pid=50903
[2023/12/03 13:33:34] [debug] [engine] coroutine stack size: 196608 bytes (192.0K)
[2023/12/03 13:33:34] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/03 13:33:34] [ info] [cmetrics] version=0.6.5
[2023/12/03 13:33:34] [ info] [ctraces ] version=0.3.1
[2023/12/03 13:33:34] [ info] [input:tail:tail.0] initializing
[2023/12/03 13:33:34] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2023/12/03 13:33:34] [debug] [tail:tail.0] created event channels: read=21 write=22
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] flb_tail_fs_inotify_init() initializing inotify tail input
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] inotify watch fd=27
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] scanning path /workspaces/fluent-bit/build/test.log
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] inode=15033 with offset=815 appended as /workspaces/fluent-bit/build/test.log
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] scan_glob add(): /workspaces/fluent-bit/build/test.log, inode 15033
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] 1 new files found on path '/workspaces/fluent-bit/build/test.log'
[2023/12/03 13:33:34] [debug] [azure_blob:azure_blob.0] created event channels: read=29 write=30
[2023/12/03 13:33:34] [ info] [output:azure_blob:azure_blob.0] account_name=my_account, container_name=my_container, blob_type=blockblob, emulator_mode=no, endpoint=my_account.blob.core.windows.net, auth_type=sas
[2023/12/03 13:33:34] [ info] [sp] stream processor started
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] inode=15033 file=/workspaces/fluent-bit/build/test.log promote to TAIL_EVENT
[2023/12/03 13:33:34] [ info] [input:tail:tail.0] inotify_fs_add(): inode=15033 watch_fd=1 name=/workspaces/fluent-bit/build/test.log
[2023/12/03 13:33:34] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2023/12/03 13:33:42] [debug] [input:tail:tail.0] inode=15033, /workspaces/fluent-bit/build/test.log, events: IN_ATTRIB
[2023/12/03 13:33:42] [debug] [input chunk] update output instances with new chunk size diff=72, records=2, input=tail.0
[2023/12/03 13:33:42] [debug] [input:tail:tail.0] inode=15033, /workspaces/fluent-bit/build/test.log, events: IN_MODIFY
[2023/12/03 13:33:42] [debug] [task] created task=0x5363fe0 id=0 OK
[2023/12/03 13:33:44] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is connected
[2023/12/03 13:33:44] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:33:44] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:33:44] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 has been assigned (recycled)
[2023/12/03 13:33:44] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:33:44] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:33:44] [ info] [output:azure_blob:azure_blob.0] content appended to blob successfully
[2023/12/03 13:33:44] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 has been assigned (recycled)
[2023/12/03 13:33:44] [debug] [http_client] not using http_proxy for header
[2023/12/03 13:33:45] [ info] [output:azure_blob:azure_blob.0] blob id ZmxiLTE3MDE2MTA0MjQuNTI3My5pZA== committed successfully
[2023/12/03 13:33:45] [debug] [upstream] KA connection #40 to my_account.blob.core.windows.net:443 is now available
[2023/12/03 13:33:45] [debug] [out flush] cb_destroy coro_id=0
[2023/12/03 13:33:45] [debug] [task] destroy task=0x5363fe0 (task_id=0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/1265

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
