### PR TITLE
tests: event_loop: increase eplison on linux.

### DIFF
--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -23,7 +23,7 @@
 #elif FLB_SYSTEM_MACOS
     #define TIME_EPSILON_MS 200
 #else
-    #define TIME_EPSILON_MS 10
+    #define TIME_EPSILON_MS 50
 #endif
 
 #define TIMER_COARSE_EPSION_MS 300


### PR DESCRIPTION
# Summary

The event loop has multiple time epsilons defined, one for each operating system, which defines the longest time delta that is acceptable for a wait or timeout when running timers in the event loop. This delta can easily be exceeded when either running on over-provisioned machines, running other tasks on the same hardware, etc...

This pull request increases this epsilon from 20ms to 50ms for linux. I arrived at this number by running the tests in 1024 parallel instances using GNU parallel while running sysbench on the same AMD Ryzen 9 5900X 12-Core Processor.

The script I used to run the parallel instances of the test:

```bash
#!/bin/bash

NUM=1024
parallel --joblog job.log -j 1024 ./test.sh {1} ::: {1..1024}
if cat job.log | awk -F ' ' '{print $7}' | grep -v "0\|Exitval"; then
	exit 1
fi
```

```bash
#!/bin/bash

./bin/flb-it-flb_event_loop test_non_blocking_and_blocking_timeout
```

I used two scripts simply to mask the fact that GNU parallel needs to pass different arguments to each instance.

I ran tests.sh in a while loop while running sysbench in another terminal:

```bash
sysbench cpu run --cpu-max-prime=100000000 --threads=24
```

I was able to successfully run the test script multiple times for the entire duration of the sysbench test without any failures. My machine might be overpowered compared to the actual runners at github which might justify raising the epsilon even more.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
