### PR TITLE
in_node_exporter_metrics: Suppress error log when NVMe is not mounted

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_nvme_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_nvme_linux.c
@@ -137,6 +137,13 @@ static int nvme_update(struct flb_ne *ctx)
         .firmware_revision = ""
     };
 
+    if (access(nvme_class_path, F_OK) == -1 &&
+        errno == ENOENT) {
+        flb_plg_debug(ctx->ins, "NVMe storage is not mounted");
+
+        return 0;
+    }
+
     mk_list_init(&nvme_class_list);
 
     ts = cfl_time_now();


### PR DESCRIPTION
In NVMe not mounted node, the not found error is generated by ne_utils_path_scan.
However, not every node and Linux boxes have NVMe as their storage.
So, we have to suppress the error message and suppress logs for it.

Specifically, it will occurred on the visualized/containerized environments such as EC2 instances or ChromeOS's Linux containers.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [x] Debug log output from testing the change

```log
$ LANG=C ls /sys/class/nvme
ls: cannot access '/sys/class/nvme': No such file or directory
$ bin/fluent-bit -i node_exporter_metrics -p metrics=nvme -o stdout -v
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/05 16:45:01] [ info] Configuration:
[2023/12/05 16:45:01] [ info]  flush time     | 1.000000 seconds
[2023/12/05 16:45:01] [ info]  grace          | 5 seconds
[2023/12/05 16:45:01] [ info]  daemon         | 0
[2023/12/05 16:45:01] [ info] ___________
[2023/12/05 16:45:01] [ info]  inputs:
[2023/12/05 16:45:01] [ info]      node_exporter_metrics
[2023/12/05 16:45:01] [ info] ___________
[2023/12/05 16:45:01] [ info]  filters:
[2023/12/05 16:45:01] [ info] ___________
[2023/12/05 16:45:01] [ info]  outputs:
[2023/12/05 16:45:01] [ info]      stdout.0
[2023/12/05 16:45:01] [ info] ___________
[2023/12/05 16:45:01] [ info]  collectors:
[2023/12/05 16:45:01] [ info] [fluent bit] version=2.2.1, commit=5626757c8a, pid=12821
[2023/12/05 16:45:01] [debug] [engine] coroutine stack size: 196608 bytes (192.0K)
[2023/12/05 16:45:01] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/05 16:45:01] [ info] [cmetrics] version=0.6.5
[2023/12/05 16:45:01] [ info] [ctraces ] version=0.3.1
[2023/12/05 16:45:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2023/12/05 16:45:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2023/12/05 16:45:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2023/12/05 16:45:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2023/12/05 16:45:01] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics nvme
[2023/12/05 16:45:01] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2023/12/05 16:45:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2023/12/05 16:45:01] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=30 write=31
[2023/12/05 16:45:01] [debug] [stdout:stdout.0] created event channels: read=35 write=36
[2023/12/05 16:45:01] [ info] [sp] stream processor started
[2023/12/05 16:45:01] [ info] [output:stdout:stdout.0] worker #0 started
[2023/12/05 16:45:06] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] NVMe storage is not mounted
[2023/12/05 16:45:06] [debug] [input chunk] update output instances with new chunk size diff=226, records=0, input=node_exporter_metrics.0
[2023/12/05 16:45:06] [debug] [task] created task=0x7940022650 id=0 OK
[2023/12/05 16:45:06] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2023/12/05 16:45:06] [debug] [out flush] cb_destroy coro_id=0
[2023/12/05 16:45:06] [debug] [task] destroy task=0x7940022650 (task_id=0)
^C[2023/12/05 16:45:07] [engine] caught signal (SIGINT)
[2023/12/05 16:45:07] [ warn] [engine] service will shutdown in max 5 seconds
[2023/12/05 16:45:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/12/05 16:45:07] [ info] [engine] service has stopped (0 pending tasks)
[2023/12/05 16:45:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2023/12/05 16:45:07] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/12/05 16:45:07] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2023/12/05 16:45:07] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
