### PR TITLE
out_stdout: Fix incomplete printing of traces

### DIFF
--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -135,24 +135,26 @@ static void print_traces_text(struct flb_output_instance *ins,
     size_t off = 0;
     cfl_sds_t text;
     struct ctrace *ctr = NULL;
+    int ok = CTR_DECODE_MSGPACK_SUCCESS;
 
-    /* get cmetrics context */
-    ret = ctr_decode_msgpack_create(&ctr, (char *) data, bytes, &off);
-    if (ret != 0) {
-        flb_plg_error(ins, "could not process traces payload (ret=%i)", ret);
-        return;
+    /* Decode each ctrace context */
+    while ((ret = ctr_decode_msgpack_create(&ctr,
+                                            (char *) data,
+                                            bytes, &off)) == ok) {
+        /* convert to text representation */
+        text = ctr_encode_text_create(ctr);
+
+        /* destroy ctr context */
+        ctr_destroy(ctr);
+
+        printf("%s", text);
+        fflush(stdout);
+
+        ctr_encode_text_destroy(text);
     }
-
-    /* convert to text representation */
-    text = ctr_encode_text_create(ctr);
-
-    /* destroy cmt context */
-    ctr_destroy(ctr);
-
-    printf("%s", text);
-    fflush(stdout);
-
-    ctr_encode_text_destroy(text);
+    if (ret != ok) {
+        flb_plg_debug(ins, "ctr decode msgpack returned : %d", ret);
+    }
 }
 
 static void cb_stdout_flush(struct flb_event_chunk *event_chunk,


### PR DESCRIPTION
This patch fixes print_traces_text() function to print all ctrace contexts

the patch has been tested with opentelemetry-cpp-1.12.0/example_otlp_http http://localhost:4318/v1/traces DEBUG=yes bin, fluent-bit 2.2.0 and ctrace fix (https://github.com/fluent/ctraces/pull/46)

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[INPUT]
        name opentelemetry
        listen 127.0.0.1
        port 4318
        successful_response_code 200

[OUTPUT]
        name stdout
        match *
```
- [x] Debug log output from testing the change
```
Before fix

root@40eda9de5e56:/source/fluent-bit-2.2.0/build/bin# ./fluent-bit -c ./flb.conf
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/10 09:18:45] [ info] [fluent bit] version=2.2.0, commit=, pid=18212
[2023/12/10 09:18:45] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/10 09:18:45] [ info] [cmetrics] version=0.6.4
[2023/12/10 09:18:45] [ info] [ctraces ] version=0.3.1
[2023/12/10 09:18:45] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/12/10 09:18:45] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/12/10 09:18:45] [ info] [input:opentelemetry:opentelemetry.0] listening on 127.0.0.1:4318
[2023/12/10 09:18:45] [ info] [sp] stream processor started
[2023/12/10 09:18:45] [ info] [output:stdout:stdout.0] worker #0 started
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f1']
             - trace_id                : 47ddf5e2818c25e21e83c40049b38aab
             - span_id                 : c4951f03b38c5478
             - parent_span_id          : a474145d46ae5a08
             - kind                    : 1 (internal)
             - start_time              : 1702181985523690793
             - end_time                : 1702181985523694550
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
```
Post Fix

```
root@40eda9de5e56:/source/opentelemetry-cpp-1.12.0/build/examples/otlp# ./example_otlp_http http://localhost:4318/v1/traces DEBUG=yes bin
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:899 [OTLP HTTP Client] Request body(Binary): resource_spans {
  resource {
    attributes {
      key: "service.name"
      value {
        string_value: "unknown_service"
      }
    }
    attributes {
      key: "telemetry.sdk.version"
      value {
        string_value: "1.12.0"
      }
    }
    attributes {
      key: "telemetry.sdk.name"
      value {
        string_value: "opentelemetry"
      }
    }
    attributes {
      key: "telemetry.sdk.language"
      value {
        string_value: "cpp"
      }
    }
  }
  scope_spans {
    scope {
      name: "foo_library"
      version: "1.12.0"
    }
    spans {
      trace_id: "\205p\036M\202lw:\007\021i?\t.\352\377"
      span_id: "\034\241\274\036\005O\016\212"
      parent_span_id: "\363^b6\266\347\227\206"
      name: "f1"
      kind: SPAN_KIND_INTERNAL
      start_time_unix_nano: 1702183260032772795
      end_time_unix_nano: 1702183260032776171
    }
  }
}

[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:175 [OTLP HTTP Client] Session state: session created
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:189 [OTLP HTTP Client] Session state: connecting to peer
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:746 [OTLP HTTP Client] Waiting for response from http://localhost:4318/v1/traces (timeout = 10000 milliseconds)
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:207 [OTLP HTTP Client] Session state: connected
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:214 [OTLP HTTP Client] Session state: sending request
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:232 [OTLP HTTP Client] Session state: response received
,Body:] Server: Fluent Bit v2.2.0ry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:112 [OTLP HTTP Client] Export success, Status:200, Header:        Content-Length: 0
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_exporter.cc:127 [OTLP HTTP Client] Export 1 trace span(s) success
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:899 [OTLP HTTP Client] Request body(Binary): resource_spans {
  resource {
    attributes {
      key: "service.name"
      value {
        string_value: "unknown_service"
      }
    }
    attributes {
      key: "telemetry.sdk.version"
      value {
        string_value: "1.12.0"
      }
    }
    attributes {
      key: "telemetry.sdk.name"
      value {
        string_value: "opentelemetry"
      }
    }
    attributes {
      key: "telemetry.sdk.language"
      value {
        string_value: "cpp"
      }
    }
  }
  scope_spans {
    scope {
      name: "foo_library"
      version: "1.12.0"
    }
    spans {
      trace_id: "\205p\036M\202lw:\007\021i?\t.\352\377"
      span_id: "\346!s\205\203_Q\030"
      parent_span_id: "\363^b6\266\347\227\206"
      name: "f1"
      kind: SPAN_KIND_INTERNAL
      start_time_unix_nano: 1702183260034963887
      end_time_unix_nano: 1702183260034969708
    }
  }
}

[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:175 [OTLP HTTP Client] Session state: session created
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:189 [OTLP HTTP Client] Session state: connecting to peer
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:746 [OTLP HTTP Client] Waiting for response from http://localhost:4318/v1/traces (timeout = 10000 milliseconds)
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:207 [OTLP HTTP Client] Session state: connected
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:214 [OTLP HTTP Client] Session state: sending request
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:232 [OTLP HTTP Client] Session state: response received
,Body:] Server: Fluent Bit v2.2.0ry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:112 [OTLP HTTP Client] Export success, Status:200, Header:        Content-Length: 0
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_exporter.cc:127 [OTLP HTTP Client] Export 1 trace span(s) success
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:899 [OTLP HTTP Client] Request body(Binary): resource_spans {
  resource {
    attributes {
      key: "service.name"
      value {
        string_value: "unknown_service"
      }
    }
    attributes {
      key: "telemetry.sdk.version"
      value {
        string_value: "1.12.0"
      }
    }
    attributes {
      key: "telemetry.sdk.name"
      value {
        string_value: "opentelemetry"
      }
    }
    attributes {
      key: "telemetry.sdk.language"
      value {
        string_value: "cpp"
      }
    }
  }
  scope_spans {
    scope {
      name: "foo_library"
      version: "1.12.0"
    }
    spans {
      trace_id: "\205p\036M\202lw:\007\021i?\t.\352\377"
      span_id: "\363^b6\266\347\227\206"
      parent_span_id: "\t\315O\177\023\356\336D"
      name: "f2"
      kind: SPAN_KIND_INTERNAL
      start_time_unix_nano: 1702183260032766383
      end_time_unix_nano: 1702183260035807413
    }
  }
}

[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:175 [OTLP HTTP Client] Session state: session created
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:189 [OTLP HTTP Client] Session state: connecting to peer
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:746 [OTLP HTTP Client] Waiting for response from http://localhost:4318/v1/traces (timeout = 10000 milliseconds)
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:207 [OTLP HTTP Client] Session state: connected
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:214 [OTLP HTTP Client] Session state: sending request
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:232 [OTLP HTTP Client] Session state: response received
,Body:] Server: Fluent Bit v2.2.0ry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:112 [OTLP HTTP Client] Export success, Status:200, Header:        Content-Length: 0
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_exporter.cc:127 [OTLP HTTP Client] Export 1 trace span(s) success
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:899 [OTLP HTTP Client] Request body(Binary): resource_spans {
  resource {
    attributes {
      key: "service.name"
      value {
        string_value: "unknown_service"
      }
    }
    attributes {
      key: "telemetry.sdk.version"
      value {
        string_value: "1.12.0"
      }
    }
    attributes {
      key: "telemetry.sdk.name"
      value {
        string_value: "opentelemetry"
      }
    }
    attributes {
      key: "telemetry.sdk.language"
      value {
        string_value: "cpp"
      }
    }
  }
  scope_spans {
    scope {
      name: "foo_library"
      version: "1.12.0"
    }
    spans {
      trace_id: "\205p\036M\202lw:\007\021i?\t.\352\377"
      span_id: "\t\315O\177\023\356\336D"
      name: "library"
      kind: SPAN_KIND_INTERNAL
      start_time_unix_nano: 1702183260032755503
      end_time_unix_nano: 1702183260036593833
    }
  }
}

[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:175 [OTLP HTTP Client] Session state: session created
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:189 [OTLP HTTP Client] Session state: connecting to peer
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:746 [OTLP HTTP Client] Waiting for response from http://localhost:4318/v1/traces (timeout = 10000 milliseconds)
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:207 [OTLP HTTP Client] Session state: connected
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:214 [OTLP HTTP Client] Session state: sending request
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:232 [OTLP HTTP Client] Session state: response received
,Body:] Server: Fluent Bit v2.2.0ry-cpp-1.12.0/exporters/otlp/src/otlp_http_client.cc:112 [OTLP HTTP Client] Export success, Status:200, Header:        Content-Length: 0
[Debug] File: /source/opentelemetry-cpp-1.12.0/exporters/otlp/src/otlp_http_exporter.cc:127 [OTLP HTTP Client] Export 1 trace span(s) success
root@40eda9de5e56:/source/opentelemetry-cpp-1.12.0/build/examples/otlp#


root@40eda9de5e56:/source/fluent-bit-2.2.0/build/bin# ./fluent-bit -c ./flb.conf
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/10 09:40:52] [ info] [fluent bit] version=2.2.0, commit=, pid=19836
[2023/12/10 09:40:52] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/10 09:40:52] [ info] [cmetrics] version=0.6.4
[2023/12/10 09:40:52] [ info] [ctraces ] version=0.3.1
[2023/12/10 09:40:52] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/12/10 09:40:52] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/12/10 09:40:52] [ info] [input:opentelemetry:opentelemetry.0] listening on 127.0.0.1:4318
[2023/12/10 09:40:52] [ info] [sp] stream processor started
[2023/12/10 09:40:52] [ info] [output:stdout:stdout.0] worker #0 started
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f1']
             - trace_id                : 85701e4d826c773a0711693f092eeaff
             - span_id                 : 1ca1bc1e054f0e8a
             - parent_span_id          : f35e6236b6e79786
             - kind                    : 1 (internal)
             - start_time              : 1702183260032772795
             - end_time                : 1702183260032776171
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f1']
             - trace_id                : 85701e4d826c773a0711693f092eeaff
             - span_id                 : e6217385835f5118
             - parent_span_id          : f35e6236b6e79786
             - kind                    : 1 (internal)
             - start_time              : 1702183260034963887
             - end_time                : 1702183260034969708
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f2']
             - trace_id                : 85701e4d826c773a0711693f092eeaff
             - span_id                 : f35e6236b6e79786
             - parent_span_id          : 09cd4f7f13eede44
             - kind                    : 1 (internal)
             - start_time              : 1702183260032766383
             - end_time                : 1702183260035807413
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'library']
             - trace_id                : 85701e4d826c773a0711693f092eeaff
             - span_id                 : 09cd4f7f13eede44
             - parent_span_id          : undefined
             - kind                    : 1 (internal)
             - start_time              : 1702183260032755503
             - end_time                : 1702183260036593833
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
^C[2023/12/10 09:41:08] [engine] caught signal (SIGINT)
[2023/12/10 09:41:08] [ warn] [engine] service will shutdown in max 5 seconds
[2023/12/10 09:41:09] [ info] [engine] service has stopped (0 pending tasks)
[2023/12/10 09:41:09] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/12/10 09:41:09] [ info] [output:stdout:stdout.0] thread worker #0 stopped

```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
root@40eda9de5e56:/source/fluent-bit-2.2.0/build/bin# valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all ./fluent-bit -v -c ./flb.conf
==20065== Memcheck, a memory error detector
==20065== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==20065== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==20065== Command: ./fluent-bit -v -c ./flb.conf
==20065==
Fluent Bit v2.2.0
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/10 09:45:04] [ info] Configuration:
[2023/12/10 09:45:04] [ info]  flush time     | 1.000000 seconds
[2023/12/10 09:45:04] [ info]  grace          | 5 seconds
[2023/12/10 09:45:04] [ info]  daemon         | 0
[2023/12/10 09:45:04] [ info] ___________
[2023/12/10 09:45:04] [ info]  inputs:
[2023/12/10 09:45:04] [ info]      opentelemetry
[2023/12/10 09:45:04] [ info] ___________
[2023/12/10 09:45:04] [ info]  filters:
[2023/12/10 09:45:04] [ info] ___________
[2023/12/10 09:45:04] [ info]  outputs:
[2023/12/10 09:45:04] [ info]      stdout.0
[2023/12/10 09:45:04] [ info] ___________
[2023/12/10 09:45:04] [ info]  collectors:
[2023/12/10 09:45:04] [ info] [fluent bit] version=2.2.0, commit=, pid=20065
[2023/12/10 09:45:04] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2023/12/10 09:45:04] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/10 09:45:04] [ info] [cmetrics] version=0.6.4
[2023/12/10 09:45:04] [ info] [ctraces ] version=0.3.1
[2023/12/10 09:45:04] [ info] [output:stdout:stdout.0] worker #0 started
[2023/12/10 09:45:04] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/12/10 09:45:04] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/12/10 09:45:04] [debug] [opentelemetry:opentelemetry.0] created event channels: read=21 write=22
[2023/12/10 09:45:04] [debug] [downstream] listening on 127.0.0.1:4318
[2023/12/10 09:45:04] [ info] [input:opentelemetry:opentelemetry.0] listening on 127.0.0.1:4318
[2023/12/10 09:45:04] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2023/12/10 09:45:04] [ info] [sp] stream processor started
[2023/12/10 09:45:12] [debug] [input chunk] update output instances with new chunk size diff=567, records=0, input=opentelemetry.0
[2023/12/10 09:45:12] [debug] [input chunk] update output instances with new chunk size diff=567, records=0, input=opentelemetry.0
[2023/12/10 09:45:12] [debug] [input chunk] update output instances with new chunk size diff=567, records=0, input=opentelemetry.0
[2023/12/10 09:45:12] [debug] [input chunk] update output instances with new chunk size diff=556, records=0, input=opentelemetry.0
[2023/12/10 09:45:12] [debug] [task] created task=0x5274990 id=0 OK
[2023/12/10 09:45:12] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
==20065== Warning: client switching stacks?  SP change: 0x6d227a8 --> 0x5280f40
==20065==          to suppress, use: --max-stackframe=27924584 or greater
==20065== Warning: client switching stacks?  SP change: 0x5280e28 --> 0x6d227a8
==20065==          to suppress, use: --max-stackframe=27924864 or greater
==20065== Warning: client switching stacks?  SP change: 0x6d227a8 --> 0x5280e28
==20065==          to suppress, use: --max-stackframe=27924864 or greater
==20065==          further instances of this message will not be shown.
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f1']
             - trace_id                : 3e3d1d615a7f7b1864e0fa2e31eab4c5
             - span_id                 : d2a13cb392a2de2b
             - parent_span_id          : 24bf379926f40a16
             - kind                    : 1 (internal)
             - start_time              : 1702183512262437964
             - end_time                : 1702183512262441431
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f1']
             - trace_id                : 3e3d1d615a7f7b1864e0fa2e31eab4c5
             - span_id                 : 0d839be5422f824a
             - parent_span_id          : 24bf379926f40a16
             - kind                    : 1 (internal)
             - start_time              : 1702183512416579139
             - end_time                : 1702183512416584709
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'f2']
             - trace_id                : 3e3d1d615a7f7b1864e0fa2e31eab4c5
             - span_id                 : 24bf379926f40a16
             - parent_span_id          : 1d7fbf7646dc7970
             - kind                    : 1 (internal)
             - start_time              : 1702183512262431432
             - end_time                : 1702183512424556348
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'unknown_service'
            - telemetry.sdk.version: '1.12.0'
            - telemetry.sdk.name: 'opentelemetry'
            - telemetry.sdk.language: 'cpp'
     - dropped_attributes_count: 0
  schema_url:
  [scope_span]
    instrumentation scope:
        - name                    : foo_library
        - version                 : 1.12.0
        - dropped_attributes_count: 0
        - attributes:

    schema_url:
    [spans]
         [span 'library']
             - trace_id                : 3e3d1d615a7f7b1864e0fa2e31eab4c5
             - span_id                 : 1d7fbf7646dc7970
             - parent_span_id          : undefined
             - kind                    : 1 (internal)
             - start_time              : 1702183512262420481
             - end_time                : 1702183512428093748
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
[2023/12/10 09:45:12] [debug] [output:stdout:stdout.0] ctr decode msgpack returned : 6
[2023/12/10 09:45:12] [debug] [out flush] cb_destroy coro_id=0
[2023/12/10 09:45:12] [debug] [task] destroy task=0x5274990 (task_id=0)
^C[2023/12/10 09:45:25] [engine] caught signal (SIGINT)
[2023/12/10 09:45:25] [ warn] [engine] service will shutdown in max 5 seconds
[2023/12/10 09:45:26] [ info] [engine] service has stopped (0 pending tasks)
[2023/12/10 09:45:26] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/12/10 09:45:26] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==20065==
==20065== HEAP SUMMARY:
==20065==     in use at exit: 0 bytes in 0 blocks
==20065==   total heap usage: 2,307 allocs, 2,307 frees, 1,692,315 bytes allocated
==20065==
==20065== All heap blocks were freed -- no leaks are possible
==20065==
==20065== For lists of detected and suppressed errors, rerun with: -s
==20065== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
