### PR TITLE
go: plugin_proxy: Handle FLBPluginInit(cb_init) error correctly and plug a SEGV case

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -525,6 +525,12 @@ int flb_proxy_output_cb_init(struct flb_output_instance *o_ins,
                   pc->proxy->def->proxy);
     }
 
+    if (ret == -1) {
+        flb_error("[output] could not initialize '%s' plugin",
+                  o_ins->p->name);
+        return -1;
+    }
+
     /* Multi-threading enabled if configured */
     ret = flb_output_enable_multi_threading(o_ins, config);
     if (ret == -1) {

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -110,7 +110,6 @@ int proxy_go_output_init(struct flb_plugin_proxy *proxy)
     if (ret <= 0) {
         flb_error("[go proxy]: plugin '%s' failed to initialize",
                   plugin->name);
-        flb_free(plugin);
         return -1;
     }
 


### PR DESCRIPTION
As described in #8253, we should handle an error on initialization from Golang output plugin.
Currently, this should be discarded and not handled correctly. We should handle it properly.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush        5
    Daemon       Off
    Log_Level    info
    Plugins_File plugins.conf
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020
    storage.metrics On

[INPUT]
    Name gdummy
    Tag  dummy.local.ins1
    Dummy {"compact": true, "schema": 1, "message": "ok"}
    # threaded on

[OUTPUT]
    Name  gstdout
    Match *
```

```ini
[PLUGINS]
  Path /path/to/fluent-bit/build/in_gdummy.so
  Path /path/to/fluent-bit/build/out_gstdout.so
```

- [x] Debug log output from testing the change
If an error occurred on Golang plugin side, we can obtain the following log instead of SEGV:

```log
% bin/fluent-bit -c fluent-bit.conf -Y -v -H -P 2020 -vv
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/12 13:39:18] [ info] [fluent bit] version=2.2.1, commit=40978390b6, pid=2799088
[2023/12/12 13:39:18] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/12 13:39:18] [ info] [cmetrics] version=0.6.5
[2023/12/12 13:39:18] [ info] [ctraces ] version=0.3.1
[2023/12/12 13:39:18] [ info] [input:gdummy:gdummy.0] initializing
[2023/12/12 13:39:18] [ info] [input:gdummy:gdummy.0] storage_strategy='memory' (memory only)
[2023/12/12 13:39:18] [ info] [gdummy] plugin initialized
[2023/12/12 13:39:18] [ info] [input:gdummy:gdummy.0] thread instance initialized
[flb-go] plugin parameter = ''
[2023/12/12 13:39:18] [error] [go proxy]: plugin 'gstdout' failed to initialize
[2023/12/12 13:39:18] [error] [output] could not initialize 'gstdout' plugin
[2023/12/12 13:39:18] [error] [output] failed to initialize 'gstdout' plugin
[2023/12/12 13:39:18] [error] [engine] output initialization failed
[2023/12/12 13:39:18] [error] [lib] backend failed
[2023/12/12 13:39:19] [error] [input:gdummy:gdummy.0] wrong event, type=2 op=1

[2023/12/12 13:39:19] [error] could not retrieve collectors signal from parent thread on 'gdummy.0'

```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
