### PR TITLE
tests: in_dummy: try and wait for the first record before doing checks.

### DIFF
--- a/tests/runtime/in_simple_systems.c
+++ b/tests/runtime/in_simple_systems.c
@@ -104,6 +104,7 @@ void do_test(char *system, ...)
     va_list va;
     char *key;
     char *value;
+    int trys;
     struct flb_lib_out_cb cb;
 
     cb.cb   = callback_test;
@@ -150,17 +151,20 @@ void do_test(char *system, ...)
     /* Start test */
     TEST_CHECK(flb_start(ctx) == 0);
 
-    /* 2 sec passed. It must have flushed */
-    sleep(2);
+    for (trys = 0; trys < 5 && get_result() == 0; trys++) {
+        sleep(1);
+    }
+
     flb_info("[test] check status 1");
     ret = get_result();
     TEST_CHECK(ret > 0);
 
-    /* 4 sec passed. It must have flushed */
-    sleep(2);
+    for (trys = 0; trys < 5 && get_result() == ret; trys++) {
+        sleep(1);
+    }
+
     flb_info("[test] check status 2");
-    ret = get_result();
-    TEST_CHECK(ret > 0);
+    TEST_CHECK(get_result() > ret);
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -174,7 +178,8 @@ void do_test_records(char *system, void (*records_cb)(struct callback_records *)
     va_list va;
     char *key;
     char *value;
-    int i;
+    int idx;
+    int trys;
     struct flb_lib_out_cb cb;
     struct callback_records *records;
 
@@ -212,15 +217,16 @@ void do_test_records(char *system, void (*records_cb)(struct callback_records *)
     /* Start test */
     TEST_CHECK(flb_start(ctx) == 0);
 
-    /* 4 sec passed. It must have flushed */
-    sleep(5);
+    for (trys = 0; trys < 5 && records->num_records <= 0; trys++) {
+        sleep(1);
+    }
 
     records_cb(records);
 
     flb_stop(ctx);
 
-    for (i = 0; i < records->num_records; i++) {
-        flb_lib_free(records->records[i].data);
+    for (idx = 0; idx < records->num_records; idx++) {
+        flb_lib_free(records->records[idx].data);
     }
     flb_free(records->records);
     flb_free(records);
@@ -525,16 +531,31 @@ void flb_test_dummy_records_message_copies_1(struct callback_records *records)
 
 void flb_test_dummy_records_message_copies_5(struct callback_records *records)
 {
+    int trys;
+
+    for (trys = 0; trys < 5 && records->num_records < 5; trys++) {
+        sleep(1);
+    }
     TEST_CHECK(records->num_records >= 5);
 }
 
 void flb_test_dummy_records_message_copies_100(struct callback_records *records)
 {
+    int trys;
+
+    for (trys = 0; trys < 100 && records->num_records < 100; trys++) {
+        sleep(1);
+    }
     TEST_CHECK(records->num_records >= 100);
 }
 
 void flb_test_dummy_records_message_rate(struct callback_records *records)
 {
+    int trys;
+
+    for (trys = 0; trys < 20 && records->num_records < 20; trys++) {
+        sleep(1);
+    }
     TEST_CHECK(records->num_records >= 20);
 }
 


### PR DESCRIPTION
# Summary

Add a busy wait loop for in_dummy checks that wait around 5 seconds or for the first record before tests check record count. This should make tests less flaky when running on hosted multi-tenant environments.

I ran the test several times while running sysbench, similar to my previous log test fix.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
