### PR TITLE
in_kubernetes_events: make timestamp from incoming record configurable

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -889,6 +889,11 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct k8s_events, namespace),
       "kubernetes namespace to get events from, gets event from all namespaces by default."
     },
+    {
+       FLB_CONFIG_MAP_STR, "timestamp_key", K8S_EVENTS_RA_TIMESTAMP,
+       0, FLB_TRUE, offsetof(struct k8s_events, timestamp_key),
+       "Record accessor for the timestamp from the event. Default is $metadata['creationTimestamp']."
+    },
 
 #ifdef FLB_HAVE_SQLDB
     {

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -892,7 +892,7 @@ static struct flb_config_map config_map[] = {
     {
        FLB_CONFIG_MAP_STR, "timestamp_key", K8S_EVENTS_RA_TIMESTAMP,
        0, FLB_TRUE, offsetof(struct k8s_events, timestamp_key),
-       "Record accessor for the timestamp from the event. Default is $metadata['creationTimestamp']."
+       "Record accessor for the timestamp from the event. Default is $lastTimestamp."
     },
 
 #ifdef FLB_HAVE_SQLDB

--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -74,6 +74,9 @@ struct k8s_events {
 
     struct flb_log_event_encoder *encoder;
 
+    /* timestamp key */
+    flb_sds_t timestamp_key;
+
     /* record accessor */
     struct flb_record_accessor *ra_timestamp;
     struct flb_record_accessor *ra_resource_version;

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -135,6 +135,7 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     int ret;
     const char *p;
     const char *url;
+    const char *timestampKey;
     const char *tmp;
     struct k8s_events *ctx = NULL;
     pthread_mutexattr_t attr;
@@ -165,10 +166,14 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     }
 
     /* Record accessor pattern */
-    ctx->ra_timestamp = flb_ra_create(K8S_EVENTS_RA_TIMESTAMP, FLB_TRUE);
+    timestampKey = flb_input_get_property("timestamp_key", ins);
+    if (!timestampKey ) {
+        timestampKey = K8S_EVENTS_RA_TIMESTAMP;
+    }
+    ctx->ra_timestamp = flb_ra_create(timestampKey, FLB_TRUE);
     if (!ctx->ra_timestamp) {
         flb_plg_error(ctx->ins,
-                      "could not create record accessor for metadata items");
+                      "could not create record accessor for record timestamp");
         k8s_events_conf_destroy(ctx);
         return NULL;
     }

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.h
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.h
@@ -38,7 +38,7 @@
 #define K8S_EVENTS_KUBE_TOKEN          "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #define K8S_EVENTS_KUBE_CA             "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
-#define K8S_EVENTS_RA_TIMESTAMP        "$metadata['creationTimestamp']"
+#define K8S_EVENTS_RA_TIMESTAMP        "$lastTimestamp"
 #define K8S_EVENTS_RA_RESOURCE_VERSION "$metadata['resourceVersion']"
 
 struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins);


### PR DESCRIPTION
<!-- Provide summary of changes -->
input kubernetes_events currently uses a record accessor that is hard coded to `$metadata['creationTimestamp']`. This patch allows it to be configurable so that you can use other timestamp fields as the record timestamp such as `lastTimestamp` which will have the most recent event's timestamp and not the time the of the first matching kubernetes event (which could be hours/days prior) which is what the `$metadata['creationTimestamp']` is set to.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ X] Example configuration file for the change
```
[INPUT]
    Name kubernetes_events
    Tag k8s_events
    timestamp_key lastTimestamp
```

- [ ] Debug log output from testing the change

- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

Docs PR: https://github.com/fluent/fluent-bit-docs/pull/1274

**Backporting**
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
