### PR TITLE
in_opentelemetry: fix memory leak

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -410,13 +410,15 @@ static int binary_payload_to_msgpack(struct flb_log_event_encoder *encoder,
     input_logs = opentelemetry__proto__collector__logs__v1__export_logs_service_request__unpack(NULL, in_size, in_buf);
     if (input_logs == NULL) {
         flb_error("[otel] Failed to unpack input logs");
-        return -1;
+        ret = -1;
+        goto binary_payload_to_msgpack_end;
     }
 
     resource_logs = input_logs->resource_logs;
     if (resource_logs == NULL) {
         flb_error("[otel] No resource logs found");
-        return -1;
+        ret = -1;
+        goto binary_payload_to_msgpack_end;
     }
 
     for (resource_logs_index = 0; resource_logs_index < input_logs->n_resource_logs; resource_logs_index++) {
@@ -425,7 +427,8 @@ static int binary_payload_to_msgpack(struct flb_log_event_encoder *encoder,
 
         if (resource_log->n_scope_logs > 0 && scope_logs == NULL) {
             flb_error("[otel] No scope logs found");
-            return -1;
+            ret = -1;
+            goto binary_payload_to_msgpack_end;
         }
 
         for (scope_log_index = 0; scope_log_index < resource_log->n_scope_logs; scope_log_index++) {
@@ -434,7 +437,8 @@ static int binary_payload_to_msgpack(struct flb_log_event_encoder *encoder,
 
             if (log_records == NULL) {
                 flb_error("[otel] No log records found");
-                return -1;
+                ret = -1;
+                goto binary_payload_to_msgpack_end;
             }
 
             for (log_record_index=0; log_record_index < scope_log->n_log_records; log_record_index++) {
@@ -499,16 +503,22 @@ static int binary_payload_to_msgpack(struct flb_log_event_encoder *encoder,
                 }
                 else {
                     flb_error("[otel] marshalling error");
-
-                    msgpack_sbuffer_destroy(&buffer);
-
-                    return -1;
+                    goto binary_payload_to_msgpack_end;
                 }
             }
         }
     }
 
+ binary_payload_to_msgpack_end:
     msgpack_sbuffer_destroy(&buffer);
+    if (input_logs) {
+        opentelemetry__proto__collector__logs__v1__export_logs_service_request__free_unpacked(
+                                            input_logs, NULL);
+    }
+
+    if (ret != 0) {
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
This patch is to fix following valgrind error.
The resource should be freed by `opentelemetry__proto__collector__logs__v1__export_logs_service_request__free_unpacked`.
```
==149281== 
==149281== HEAP SUMMARY:
==149281==     in use at exit: 688 bytes in 21 blocks
==149281==   total heap usage: 1,611 allocs, 1,590 frees, 1,258,568 bytes allocated
==149281== 
==149281== 688 (40 direct, 648 indirect) bytes in 1 blocks are definitely lost in loss record 9 of 9
==149281==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==149281==    by 0x9893BC: system_alloc (protobuf-c.c:154)
==149281==    by 0x98940C: do_alloc (protobuf-c.c:167)
==149281==    by 0x98E30C: protobuf_c_message_unpack (protobuf-c.c:3063)
==149281==    by 0x9926B3: opentelemetry__proto__collector__logs__v1__export_logs_service_request__unpack (logs_service.pb-c.c:43)
==149281==    by 0x4BF436: binary_payload_to_msgpack (opentelemetry_prot.c:410)
==149281==    by 0x4C1922: process_payload_logs (opentelemetry_prot.c:1339)
==149281==    by 0x4C2406: opentelemetry_prot_handle (opentelemetry_prot.c:1647)
==149281==    by 0x4B942E: opentelemetry_conn_event (http_conn.c:99)
==149281==    by 0x244C82: flb_engine_start (flb_engine.c:1009)
==149281==    by 0x1DE9F4: flb_lib_worker (flb_lib.c:638)
==149281==    by 0x4FF4AC2: start_thread (pthread_create.c:442)
==149281== 
==149281== LEAK SUMMARY:
==149281==    definitely lost: 40 bytes in 1 blocks
==149281==    indirectly lost: 648 bytes in 20 blocks
==149281==      possibly lost: 0 bytes in 0 blocks
==149281==    still reachable: 0 bytes in 0 blocks
==149281==         suppressed: 0 bytes in 0 blocks
==149281== 
==149281== For lists of detected and suppressed errors, rerun with: -s
==149281== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name opentelemetry
    Port 4318

[OUTPUT]
    Name stdout
```

## Debug/Valgrind output

1. Run fluent-bit
2. Send logs using `telemetrygen logs --otlp-http --otlp-insecure  --telemetry-attributes "key=\"value\""`

Note: I installed telemetrygen using following command.
```
go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest
```

```
$ valgrind --leak-check=full bin/fluent-bit -c otel.cfg 
==146487== Memcheck, a memory error detector
==146487== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==146487== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==146487== Command: bin/fluent-bit -c otel.cfg
==146487== 
Fluent Bit v2.2.1
* Copyright (C) 2015-2023 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2023/12/17 11:51:01] [ info] [fluent bit] version=2.2.1, commit=2389f44ee4, pid=146487
[2023/12/17 11:51:02] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2023/12/17 11:51:02] [ info] [cmetrics] version=0.6.5
[2023/12/17 11:51:02] [ info] [ctraces ] version=0.3.1
[2023/12/17 11:51:02] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2023/12/17 11:51:02] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2023/12/17 11:51:02] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:4318
[2023/12/17 11:51:02] [ info] [output:stdout:stdout.0] worker #0 started
[2023/12/17 11:51:02] [ info] [sp] stream processor started
[0] v1_logs: [[1702781469.874892154, {"app"=>"server", "value"=>"value"}], {"message"=>"the message"}]
^C[2023/12/17 11:51:11] [engine] caught signal (SIGINT)
[2023/12/17 11:51:11] [ warn] [engine] service will shutdown in max 5 seconds
[2023/12/17 11:51:12] [ info] [engine] service has stopped (0 pending tasks)
[2023/12/17 11:51:12] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2023/12/17 11:51:12] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==146487== 
==146487== HEAP SUMMARY:
==146487==     in use at exit: 0 bytes in 0 blocks
==146487==   total heap usage: 1,630 allocs, 1,630 frees, 1,414,216 bytes allocated
==146487== 
==146487== All heap blocks were freed -- no leaks are possible
==146487== 
==146487== For lists of detected and suppressed errors, rerun with: -s
==146487== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
