### PR TITLE
workflows: handle v4 upload-artifact usage

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -181,7 +181,7 @@ jobs:
         shell: bash
 
       - name: Upload the schema
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./fluent-bit-schema*.json
           name: fluent-bit-schema-${{ inputs.version }}

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -78,7 +78,7 @@ jobs:
           SOURCE_FILENAME_PREFIX: source-${{ inputs.version }}
 
       - name: Upload the source artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source-${{ inputs.version }}
           path: source-packages/*
@@ -132,7 +132,7 @@ jobs:
 
       - name: Replace all special characters with dashes
         id: formatted_distro
-        run:
+        run: |
           output=${INPUT//[\/]/-}
           echo "$INPUT --> $output"
           echo "replaced=$output" >> "$GITHUB_OUTPUT"
@@ -151,7 +151,7 @@ jobs:
         working-directory: packaging
 
       - name: Upload the ${{ steps.formatted_distro.outputs.replaced }} artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packages-${{ inputs.version }}-${{ steps.formatted_distro.outputs.replaced }}
           path: packaging/packages/

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -90,7 +90,7 @@ jobs:
         working-directory: build
 
       - name: Upload build packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-packages
           path: |

--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -168,9 +168,9 @@ jobs:
       - name: Upload build packages
         # Skip upload if we skipped build.
         if: ${{ matrix.config.arch != 'amd64_arm64' || needs.call-build-windows-get-meta.outputs.armSupported == 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: windows-packages
+          name: windows-packages-${{ matrix.config.arch }}
           path: |
             build/*-bit-*.exe
             build/*-bit-*.msi
@@ -198,7 +198,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: windows-packages
+          pattern: windows-packages-*
           path: artifacts/
 
       - name: Set up Windows checksums

--- a/.github/workflows/call-integration-image-build.yaml
+++ b/.github/workflows/call-integration-image-build.yaml
@@ -74,21 +74,6 @@ jobs:
           push: true
           load: false
 
-      - name: Upload the image just in case as an artefact
-        run: |
-          docker pull $IMAGE
-          docker save --output /tmp/pr-image.tar $IMAGE
-        env:
-          IMAGE: ${{ steps.meta.outputs.tags }}
-        shell: bash
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: pr-${{ github.event.pull_request.number }}-image
-          path: /tmp/pr-image.tar
-          if-no-files-found: error
-
       - name: Extract metadata from Github
         id: meta-debug
         uses: docker/metadata-action@v5

--- a/.github/workflows/cron-scorecards-analysis.yaml
+++ b/.github/workflows/cron-scorecards-analysis.yaml
@@ -45,7 +45,7 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: scorecard-results.sarif

--- a/.github/workflows/cron-trivy.yaml
+++ b/.github/workflows/cron-trivy.yaml
@@ -80,7 +80,7 @@ jobs:
 
       # In case we need to analyse the uploaded files for some reason.
       - name: Detain results for debug if needed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-results-${{ matrix.local_tag }}.sarif
           path: trivy-results-${{ matrix.local_tag }}.sarif

--- a/.github/workflows/pr-fuzz.yaml
+++ b/.github/workflows/pr-fuzz.yaml
@@ -26,7 +26,7 @@ jobs:
         language: c
         output-sarif: true
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
Resolves #8298 by ensuring we use uploads immutably.
Note v4 is a matching upgrade for upload and download artifact.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
