### PR TITLE
config_format: yaml: windows: Handle directory separator for include directive on yaml config correctly on windows

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -1934,10 +1934,16 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
             return -1;
         }
 
-        if (flb_sds_printf(&include_dir, "%s/%s", parent->path, cfg_file) == NULL) {
+#ifdef _WIN32
+#define PATH_CONCAT_TEMPLATE "%s\\%s"
+#else
+#define PATH_CONCAT_TEMPLATE "%s/%s"
+#endif
+        if (flb_sds_printf(&include_dir, PATH_CONCAT_TEMPLATE, parent->path, cfg_file) == NULL) {
             flb_error("unable to create full filename");
             return -1;
         }
+#undef PATH_CONCAT_TEMPLATE
 
     }
     else {

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -11,10 +11,22 @@
 
 #include "flb_tests_internal.h"
 
+#ifdef _WIN32
+#define FLB_TESTS_CONF_PATH FLB_TESTS_DATA_PATH "\\data\\config_format\\yaml"
+#else
 #define FLB_TESTS_CONF_PATH FLB_TESTS_DATA_PATH "/data/config_format/yaml"
+#endif
+
 #define FLB_000 FLB_TESTS_CONF_PATH "/fluent-bit.yaml"
 #define FLB_001 FLB_TESTS_CONF_PATH "/issue_7559.yaml"
 #define FLB_002 FLB_TESTS_CONF_PATH "/processors.yaml"
+#define FLB_000_WIN FLB_TESTS_CONF_PATH "\\fluent-bit-windows.yaml"
+
+#ifdef _WIN32
+#define FLB_BASIC FLB_000_WIN
+#else
+#define FLB_BASIC FLB_000
+#endif
 
 /*
  * Configurations to test:
@@ -39,7 +51,7 @@ static void test_basic()
     struct cfl_variant *v;
     int idx = 0;
 
-    cf = flb_cf_yaml_create(NULL, FLB_000, NULL, 0);
+    cf = flb_cf_yaml_create(NULL, FLB_BASIC, NULL, 0);
     TEST_CHECK(cf != NULL);
     if (!cf) {
         exit(EXIT_FAILURE);

--- a/tests/internal/data/config_format/yaml/fluent-bit-windows.yaml
+++ b/tests/internal/data/config_format/yaml/fluent-bit-windows.yaml
@@ -1,0 +1,29 @@
+env:
+    flush_interval: 1
+
+includes:
+    - service-windows.yaml
+
+customs:
+    - name: ${observability}
+      api_key: zyJUb2tlbklEItoiY2ZlMTcx
+
+pipeline:
+    inputs:
+        - name: tail
+          path: ./test.log
+          parser: json
+          read_from_head: true
+        - name: tail
+          path: ./test.log
+          parser: json
+          read_from_head: true
+
+    filters:
+        - name: record_modifier
+          match: "*"
+          record: powered_by calyptia
+
+    outputs:
+        - name: stdout
+          match: "*"

--- a/tests/internal/data/config_format/yaml/service-windows.yaml
+++ b/tests/internal/data/config_format/yaml/service-windows.yaml
@@ -1,0 +1,5 @@
+env:
+    observability: calyptia
+
+includes:
+    - test\nested.yaml


### PR DESCRIPTION
<!-- Provide summary of changes -->
In Windows, flb-it-config_format_yaml unit test has been failed. However, the failed YAML config test is not enabled on AppVeyor. So, we didn't recognize this failure.
I'm not sure this should be the correct fix but this failure was introduced by stack based YAML parser.
This stack based parser for YAML config format is working correctly on non-Windows platforms.
Some of the functionalities of concatenating directories is not working correctly yet on Windows.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
