### PR TITLE
in_calyptia_fleet: create configuration directory before the fleet header.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1938,11 +1938,6 @@ static int load_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
     flb_ctx_t *flb_ctx = flb_context_get();
     flb_sds_t cfgnewname = NULL;
 
-    if (create_fleet_directory(ctx) != 0) {
-        flb_plg_error(ctx->ins, "unable to create fleet directories");
-        return -1;
-    }
-
     /* check if we are already using the fleet configuration file. */
     if (is_fleet_config(ctx, flb_ctx->config) == FLB_FALSE) {
         flb_plg_debug(ctx->ins, "loading configuration file");
@@ -2226,6 +2221,12 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
 
     /* Set the context */
     flb_input_set_context(in, ctx);
+
+    /* create fleet directory before creating the fleet header. */
+    if (create_fleet_directory(ctx) != 0) {
+        flb_plg_error(ctx->ins, "unable to create fleet directories");
+        return -1;
+    }
 
     /* refresh calyptia settings before attempting to load the fleet
      * configuration file.


### PR DESCRIPTION
# Summary

Upon first run of the calyptia fleet plugin there will be no fleet directory but the plugin will attempt to create it's base configuration header. Fix that by creating the fleet directory first.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
