### PR TITLE
in_kubernetes_events: consolidate record timestamp logic

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -74,11 +74,10 @@ struct k8s_events {
 
     struct flb_log_event_encoder *encoder;
 
-    /* timestamp key */
+    /* timestamp key - deprecated, to be removed in v3.0 */
     flb_sds_t timestamp_key;
 
     /* record accessor */
-    struct flb_record_accessor *ra_timestamp;
     struct flb_record_accessor *ra_resource_version;
 
     /* others */

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -135,7 +135,6 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     int ret;
     const char *p;
     const char *url;
-    const char *timestampKey;
     const char *tmp;
     struct k8s_events *ctx = NULL;
     pthread_mutexattr_t attr;
@@ -161,19 +160,6 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
     ctx->encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
     if (!ctx->encoder) {
         flb_plg_error(ins, "could not initialize event encoder");
-        k8s_events_conf_destroy(ctx);
-        return NULL;
-    }
-
-    /* Record accessor pattern */
-    timestampKey = flb_input_get_property("timestamp_key", ins);
-    if (!timestampKey ) {
-        timestampKey = K8S_EVENTS_RA_TIMESTAMP;
-    }
-    ctx->ra_timestamp = flb_ra_create(timestampKey, FLB_TRUE);
-    if (!ctx->ra_timestamp) {
-        flb_plg_error(ctx->ins,
-                      "could not create record accessor for record timestamp");
         k8s_events_conf_destroy(ctx);
         return NULL;
     }
@@ -289,9 +275,6 @@ struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins)
 
 void k8s_events_conf_destroy(struct k8s_events *ctx)
 {
-    if (ctx->ra_timestamp) {
-        flb_ra_destroy(ctx->ra_timestamp);
-    }
 
     if (ctx->ra_resource_version) {
         flb_ra_destroy(ctx->ra_resource_version);

--- a/plugins/in_kubernetes_events/kubernetes_events_conf.h
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.h
@@ -38,7 +38,6 @@
 #define K8S_EVENTS_KUBE_TOKEN          "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #define K8S_EVENTS_KUBE_CA             "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
-#define K8S_EVENTS_RA_TIMESTAMP        "$lastTimestamp"
 #define K8S_EVENTS_RA_RESOURCE_VERSION "$metadata['resourceVersion']"
 
 struct k8s_events *k8s_events_conf_create(struct flb_input_instance *ins);


### PR DESCRIPTION
----
This consolidates timestamp lookup logic in the kubernetes_events input and removes record accessor timestamp key logic entirely as it's not needed.

Currently during events processing logic we are fetching the timestamp from the record twice in 2 different ways.
We first use `item_get_timestamp()` that cleanly fetches the timestamp from any of the following record values in order of precedence: lastTimestamp, firstTimestamp, metadata.creationTimestamp, this is then used to look up if the current event is older than the set retention time and if so the event is discarded (via `check_event_is_filtered`). We then immediately fetch the timestamp again to set it in the event, but only look at a single field from the resource accessor (`K8S_EVENTS_RA_TIMESTAMP`). 

This diff removes the record accessor, and it's config, because the safest option is to just check in order of preference for a proper timestamp which `item_get_timestamp()` already does. It also fetches the timestamp from the incoming record only once, then just passes the time to `check_event_is_filtered` instead of having 2 different ways of finding the event time.


**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
```
[SERVICE]
    flush        1
    daemon       Off
    log_level    debug
    http_server  On
    http_listen  0.0.0.0
    http_port    2020

[INPUT]
    name          kubernetes_events
    alias         k8s_events
    tag           k8s_events
```

- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
(on a mac so it was easier to use leaks)
```
Process:         fluent-bit [89628]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x10b25e000
Identifier:      fluent-bit
Version:         0
Code Type:       X86-64
Platform:        macOS
Parent Process:  leaks [89627]

Date/Time:       2023-12-22 09:08:00.303 -0600
Launch Time:     2023-12-22 09:07:34.867 -0600
OS Version:      macOS 14.2.1 (23C71)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         7444K
Physical footprint (peak):  7600K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 89628: 596 nodes malloced for 92 KB
Process 89628: 0 leaks for 0 total leaked bytes.

[2023/12/22 09:08:00] [engine] caught signal (SIGCONT)
[2023/12/22 09:08:00] Fluent Bit Dump
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1277
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
