### PR TITLE
config: add default logfmt parser

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -39,6 +39,10 @@
     Time_Format %d/%b/%Y:%H:%M:%S %z
 
 [PARSER]
+    Name   logfmt
+    Format logfmt
+
+[PARSER]
     Name         docker
     Format       json
     Time_Key     time


### PR DESCRIPTION
This PR simply adds a reasonable default `logfmt` parser configuration, to allow filters to specify only `parser: logfmt` without needing a full-blown `parsers.conf`.