### PR TITLE
in_storage_backlog: if a chunk tag cannot be read, delete it

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -256,7 +256,6 @@ static int sb_append_chunk_to_segregated_backlog(struct cio_chunk    *target_chu
     struct sb_out_chunk *chunk;
 
     chunk = sb_allocate_chunk(target_chunk, stream, target_chunk_size);
-
     if (chunk == NULL) {
         flb_errno();
         return -1;
@@ -378,7 +377,16 @@ int sb_segregate_chunks(struct flb_config *config)
             if (ret) {
                 /*
                  * if the chunk could not be segregated, just remove it from the
-                 * queue and continue.
+                 * queue, delete it and continue.
+                 */
+
+                /* If the tag cannot be read it cannot be routed, let's remove it */
+                if (ret == -2) {
+                    cio_chunk_close(chunk, CIO_TRUE);
+                    continue;
+                }
+
+                /* 
                  *
                  * if content size is zero, it's safe to 'delete it'.
                  */


### PR DESCRIPTION
If a backlog chunk has corruptions and the Tag cannot be read, just completely remove it since it cannot be routed.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
