### PR TITLE
out_prometheus_exporter: respond with 200 even with no metrics

### DIFF
--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -163,17 +163,17 @@ static void cb_metrics(mk_request_t *request, void *data)
     struct prom_http_buf *buf;
     (void) data;
 
+    mk_http_status(request, 200);
+    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_PROMETHEUS);
+
     buf = metrics_get_latest();
     if (!buf) {
-        mk_http_status(request, 404);
         mk_http_done(request);
         return;
     }
 
     buf->users++;
 
-    mk_http_status(request, 200);
-    flb_hs_add_content_type_to_req(request, FLB_HS_CONTENT_TYPE_PROMETHEUS);
     mk_http_send(request, buf->buf_data, buf->buf_size, NULL);
     mk_http_done(request);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Prometheus scrapers consider non-200 responses errors. It's not necessarily an error that no filter has yet caused a metric to be exported (consider eg. a filter that exposes the number of error log messages as a prometheus metric, where there does not happen to have been error log messages in the inputs so far)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
