### PR TITLE
out_azure_kusto: added-kusto-specific-headers

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -156,7 +156,6 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
 
                     /* added kusto specific headers for debugging requests */
                     flb_http_add_header(c, "x-ms-user", 9, "Kusto.Fluent-Bit", 16);
-                    flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
                     flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
                     flb_http_add_header(c, "x-ms-app", 8, "Kusto.Fluent-Bit", 16);
 

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_signv4.h>
 #include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_version.h>
 
 #include "azure_kusto.h"
 #include "azure_kusto_conf.h"
@@ -152,6 +153,13 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
                     flb_http_add_header(c, "Accept", 6, "application/json", 16);
                     flb_http_add_header(c, "Authorization", 13, token,
                                         flb_sds_len(token));
+
+                    /* added kusto specific headers for debugging requests */
+                    flb_http_add_header(c, "x-ms-user", 9, "Kusto.Fluent-Bit", 16);
+                    flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
+                    flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
+                    flb_http_add_header(c, "x-ms-app", 8, "Kusto.Fluent-Bit", 16);
+
                     flb_http_buffer_size(c, FLB_HTTP_DATA_SIZE_MAX * 10);
 
                     /* Send HTTP request */

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -166,7 +166,7 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
                 flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
 
                 /* added kusto specific headers for debugging requests */
-                flb_http_add_header(c, "x-ms-user", 9, "Fluent-Bit", 10);
+                flb_http_add_header(c, "x-ms-user", 9, "Kusto.Fluent-Bit", 16);
                 flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
                 flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
                 flb_http_add_header(c, "x-ms-app", 8, "Kusto.Fluent-Bit", 16);
@@ -375,7 +375,7 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
                     flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
 
                     /* added kusto specific headers for debugging requests */
-                    flb_http_add_header(c, "x-ms-user", 9, "Fluent-Bit", 10);
+                    flb_http_add_header(c, "x-ms-user", 9, "Kusto.Fluent-Bit", 16);
                     flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
                     flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
                     flb_http_add_header(c, "x-ms-app", 8, "Kusto.Fluent-Bit", 16);

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_random.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_version.h>
 
 #include <math.h>
 #include <msgpack.h>
@@ -163,6 +164,12 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
                 flb_http_add_header(c, "x-ms-blob-type", 14, "BlockBlob", 9);
                 flb_http_add_header(c, "x-ms-date", 9, tmp, len);
                 flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
+
+                //added kusto specific headers for debugging requests
+                flb_http_add_header(c, "x-ms-user", 9, "Fluent-Bit", 10);
+                flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
+                flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
+                flb_http_add_header(c, "x-ms-app", 8, "Kusto.Fluent-Bit", 16);
 
                 ret = flb_http_do(c, &resp_size);
                 flb_plg_debug(ctx->ins,
@@ -366,6 +373,12 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
                                         20);
                     flb_http_add_header(c, "x-ms-date", 9, tmp, len);
                     flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
+
+                    //added kusto specific headers for debugging requests
+                    flb_http_add_header(c, "x-ms-user", 9, "Fluent-Bit", 10);
+                    flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
+                    flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
+                    flb_http_add_header(c, "x-ms-app", 8, "Kusto.Fluent-Bit", 16);
 
                     ret = flb_http_do(c, &resp_size);
                     flb_plg_debug(ctx->ins,

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -165,7 +165,7 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
                 flb_http_add_header(c, "x-ms-date", 9, tmp, len);
                 flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
 
-                //added kusto specific headers for debugging requests
+                /* added kusto specific headers for debugging requests */
                 flb_http_add_header(c, "x-ms-user", 9, "Fluent-Bit", 10);
                 flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
                 flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));
@@ -374,7 +374,7 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
                     flb_http_add_header(c, "x-ms-date", 9, tmp, len);
                     flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
 
-                    //added kusto specific headers for debugging requests
+                    /* added kusto specific headers for debugging requests */
                     flb_http_add_header(c, "x-ms-user", 9, "Fluent-Bit", 10);
                     flb_http_add_header(c, "x-ms-client-request-id", 22, generate_uuid(), 36);
                     flb_http_add_header(c, "x-ms-client-version", 10, FLB_VERSION_STR, strlen(FLB_VERSION_STR));


### PR DESCRIPTION
Signed-off-by: Tanmaya Panda <tanmayapanda@microsoft.com>
(cherry picked from commit ccfc8ee8bb261107b14c442b8687966ede4fd1bd)

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
