### PR TITLE
out_azure_kusto: added default kusto endpoints connection timeout interval configs

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -132,11 +132,6 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
 
-    if (!u_conn) {
-        flb_plg_error(ctx->ins, "[out_azure_kusto] cannot create upstream connection while connecting to kusto endpoint");
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
-
     if (u_conn) {
         token = get_azure_kusto_token(ctx);
 

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -126,8 +126,8 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
     struct flb_http_client *c;
     flb_sds_t resp = NULL;
 
-    ctx->u->base.net.connect_timeout = ctx->ingestion_endpoint_connect_timeout;
-    ctx->u->base.net.keepalive_max_recycle = ctx->keep_alive_max_connection_recycle;
+    /* setting default connection timeout to kusto ingest endpoint */
+    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connect_timeout;
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -227,11 +227,11 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         return -1;
     }
 
-    const char *tmp = flb_output_get_property("ingestion_endpoint_connect_timeout", ins);
+    const char *tmp = flb_output_get_property("kusto_endpoint_connect_timeout", ins);
     if (tmp != NULL) {
-        ctx->ingestion_endpoint_connect_timeout = strtol(tmp, NULL, 0);
+        ctx->kusto_endpoint_connect_timeout = strtol(tmp, NULL, 0);
     } else {
-        ctx->ingestion_endpoint_connect_timeout = FLB_AZURE_KUSTO_INGEST_ENDPOINT_CONNECTION_TIMEOUT;
+        ctx->kusto_endpoint_connect_timeout = FLB_AZURE_KUSTO_ENDPOINT_CONNECTION_TIMEOUT;
     }
 
     flb_output_set_context(ins, ctx);
@@ -477,12 +477,9 @@ static struct flb_config_map config_map[] = {
      offsetof(struct flb_azure_kusto, time_key),
      "The key name of the time. If 'include_time_key' is false, "
      "This property is ignored"},
-    {FLB_CONFIG_MAP_TIME, "ingestion_endpoint_connect_timeout", FLB_AZURE_KUSTO_INGEST_ENDPOINT_CONNECTION_TIMEOUT, 0, FLB_TRUE,
-     offsetof(struct flb_azure_kusto, ingestion_endpoint_connect_timeout),
+    {FLB_CONFIG_MAP_TIME, "kusto_endpoint_connect_timeout", FLB_AZURE_KUSTO_ENDPOINT_CONNECTION_TIMEOUT, 0, FLB_TRUE,
+     offsetof(struct flb_azure_kusto, kusto_endpoint_connect_timeout),
              "Set the ingestion endpoint connection timeout in seconds"},
-    {FLB_CONFIG_MAP_INT, "keep_alive_max_connection_recycle", FLB_AZURE_KUSTO_KEEP_ALIVE_MAX_RECYCLE, 0, FLB_TRUE,
-            offsetof(struct flb_azure_kusto, keep_alive_max_connection_recycle),
-    "Set the ingestion endpoint connection timeout in seconds"},
     /* EOF */
     {0}};
 

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -127,7 +127,7 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
     flb_sds_t resp = NULL;
 
     /* setting default connection timeout to kusto ingest endpoint */
-    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connect_timeout;
+    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connection_timeout;
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -220,13 +220,6 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
     if (!ctx) {
         flb_plg_error(ins, "configuration failed");
         return -1;
-    }
-
-    const char *tmp = flb_output_get_property("kusto_endpoint_connect_timeout", ins);
-    if (tmp != NULL) {
-        ctx->kusto_endpoint_connect_timeout = strtol(tmp, NULL, 0);
-    } else {
-        ctx->kusto_endpoint_connect_timeout = FLB_AZURE_KUSTO_ENDPOINT_CONNECTION_TIMEOUT;
     }
 
     flb_output_set_context(ins, ctx);
@@ -472,8 +465,8 @@ static struct flb_config_map config_map[] = {
      offsetof(struct flb_azure_kusto, time_key),
      "The key name of the time. If 'include_time_key' is false, "
      "This property is ignored"},
-    {FLB_CONFIG_MAP_TIME, "kusto_endpoint_connect_timeout", FLB_AZURE_KUSTO_ENDPOINT_CONNECTION_TIMEOUT, 0, FLB_TRUE,
-     offsetof(struct flb_azure_kusto, kusto_endpoint_connect_timeout),
+    {FLB_CONFIG_MAP_TIME, "kusto_endpoint_connection_timeout", FLB_AZURE_KUSTO_INGEST_ENDPOINT_CONNECTION_TIMEOUT, 0, FLB_TRUE,
+     offsetof(struct flb_azure_kusto, kusto_endpoint_connection_timeout),
              "Set the connection timeout of various kusto endpoints (kusto ingest endpoint, kusto ingestion blob endpoint, kusto ingestion blob endpoint) in seconds"},
     /* EOF */
     {0}};

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -474,7 +474,7 @@ static struct flb_config_map config_map[] = {
      "This property is ignored"},
     {FLB_CONFIG_MAP_TIME, "kusto_endpoint_connect_timeout", FLB_AZURE_KUSTO_ENDPOINT_CONNECTION_TIMEOUT, 0, FLB_TRUE,
      offsetof(struct flb_azure_kusto, kusto_endpoint_connect_timeout),
-             "Set the ingestion endpoint connection timeout in seconds"},
+             "Set the connection timeout of various kusto endpoints (kusto ingest endpoint, kusto ingestion blob endpoint, kusto ingestion blob endpoint) in seconds"},
     /* EOF */
     {0}};
 

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -51,8 +51,7 @@
 
 #define FLB_AZURE_KUSTO_RESOURCES_LOAD_INTERVAL_SEC 3600
 
-#define FLB_AZURE_KUSTO_INGEST_ENDPOINT_CONNECTION_TIMEOUT "60"
-#define FLB_AZURE_KUSTO_KEEP_ALIVE_MAX_RECYCLE "20"
+#define FLB_AZURE_KUSTO_CONNECTION_ENDPOINT_CONNECTION_TIMEOUT "60"
 
 struct flb_azure_kusto_resources {
     struct flb_upstream_ha *blob_ha;
@@ -74,8 +73,7 @@ struct flb_azure_kusto {
     flb_sds_t ingestion_mapping_reference;
 
     /* connection configuration */
-    int ingestion_endpoint_connect_timeout;
-    int keep_alive_max_connection_recycle;
+    int kusto_endpoint_connect_timeout;
 
     /* records configuration */
     flb_sds_t log_key;

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -51,7 +51,7 @@
 
 #define FLB_AZURE_KUSTO_RESOURCES_LOAD_INTERVAL_SEC 3600
 
-#define FLB_AZURE_KUSTO_CONNECTION_ENDPOINT_CONNECTION_TIMEOUT "60"
+#define FLB_AZURE_KUSTO_INGEST_ENDPOINT_CONNECTION_TIMEOUT "60"
 
 struct flb_azure_kusto_resources {
     struct flb_upstream_ha *blob_ha;
@@ -73,7 +73,7 @@ struct flb_azure_kusto {
     flb_sds_t ingestion_mapping_reference;
 
     /* connection configuration */
-    int kusto_endpoint_connect_timeout;
+    int kusto_endpoint_connection_timeout;
 
     /* records configuration */
     flb_sds_t log_key;

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -51,6 +51,9 @@
 
 #define FLB_AZURE_KUSTO_RESOURCES_LOAD_INTERVAL_SEC 3600
 
+#define FLB_AZURE_KUSTO_INGEST_ENDPOINT_CONNECTION_TIMEOUT "60"
+#define FLB_AZURE_KUSTO_KEEP_ALIVE_MAX_RECYCLE "20"
+
 struct flb_azure_kusto_resources {
     struct flb_upstream_ha *blob_ha;
     struct flb_upstream_ha *queue_ha;
@@ -69,6 +72,10 @@ struct flb_azure_kusto {
     flb_sds_t database_name;
     flb_sds_t table_name;
     flb_sds_t ingestion_mapping_reference;
+
+    /* connection configuration */
+    int ingestion_endpoint_connect_timeout;
+    int keep_alive_max_connection_recycle;
 
     /* records configuration */
     flb_sds_t log_key;

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -149,6 +149,11 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
 
     u_conn = flb_upstream_conn_get(u_node->u);
 
+    if (!u_conn) {
+        flb_plg_error(ctx->ins, "[out_azure_kusto] cannot create upstream connection while connecting to blob endpoint");
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
     if (u_conn) {
         uri = azure_kusto_create_blob_uri(ctx, u_node, blob_id);
 

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -148,7 +148,7 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
     }
 
     /* setting default connection timeout to kusto azure blob endpoint */
-    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connect_timeout;
+    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connection_timeout;
 
     u_conn = flb_upstream_conn_get(u_node->u);
 
@@ -352,7 +352,7 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
     }
 
     /* setting default connection timeout to kusto azure queue endpoint */
-    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connect_timeout;
+    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connection_timeout;
 
     u_conn = flb_upstream_conn_get(u_node->u);
 

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -152,11 +152,6 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
 
     u_conn = flb_upstream_conn_get(u_node->u);
 
-    if (!u_conn) {
-        flb_plg_error(ctx->ins, "[out_azure_kusto] cannot create upstream connection while connecting to blob endpoint");
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
-
     if (u_conn) {
         uri = azure_kusto_create_blob_uri(ctx, u_node, blob_id);
 

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -147,6 +147,9 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
         return NULL;
     }
 
+    /* setting default connection timeout to kusto azure blob endpoint */
+    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connect_timeout;
+
     u_conn = flb_upstream_conn_get(u_node->u);
 
     if (!u_conn) {
@@ -352,6 +355,9 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
         flb_plg_error(ctx->ins, "error getting queue upstream");
         return -1;
     }
+
+    /* setting default connection timeout to kusto azure queue endpoint */
+    ctx->u->base.net.connect_timeout = ctx->kusto_endpoint_connect_timeout;
 
     u_conn = flb_upstream_conn_get(u_node->u);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
