### PR TITLE
in_node_exporter_metrics: collect metrics at startup(#8368)

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -156,6 +156,10 @@ static int activate_collector(struct flb_ne *ctx, struct flb_config *config,
     }
     coll->activated = FLB_TRUE;
 
+    if (coll->cb_update) {
+        coll->cb_update(ctx->ins, config, ctx);
+    }
+
     return 0;
 }
 
@@ -206,18 +210,6 @@ static int in_ne_init(struct flb_input_instance *in,
     /* Associate context with the instance */
     flb_input_set_context(in, ctx);
 
-    /* Create the collector */
-    ret = flb_input_set_collector_time(in,
-                                       cb_ne_collect,
-                                       ctx->scrape_interval, 0,
-                                       config);
-    if (ret == -1) {
-        flb_plg_error(ctx->ins,
-                      "could not set collector for Node Exporter Metrics plugin");
-        return -1;
-    }
-    ctx->coll_fd = ret;
-
     /* Check and initialize enabled metrics */
     if (ctx->metrics) {
         mk_list_foreach(head, ctx->metrics) {
@@ -246,6 +238,18 @@ static int in_ne_init(struct flb_input_instance *in,
 
         return -1;
     }
+
+    /* Create the collector */
+    ret = flb_input_set_collector_time(in,
+                                       cb_ne_collect,
+                                       ctx->scrape_interval, 0,
+                                       config);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins,
+                      "could not set collector for Node Exporter Metrics plugin");
+        return -1;
+    }
+    ctx->coll_fd = ret;
 
     return 0;
 }


### PR DESCRIPTION
Fixes #8368 

The issue #8368 is caused by flushing metrics before updating it.
This patch is to update metrics at startup to prevent flushing empty metrics.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -i node_exporter_metrics -o stdout -f 1 
==17236== Memcheck, a memory error detector
==17236== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17236== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==17236== Command: bin/fluent-bit -i node_exporter_metrics -o stdout -f 1
==17236== 
Fluent Bit v2.2.2
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

____________________
< Fluent Bit v2.2.2 >
 -------------------
(snip)
[2024/01/13 09:01:00] [ info] [fluent bit] version=2.2.2, commit=6f2c553ebc, pid=17236
[2024/01/13 09:01:00] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/01/13 09:01:00] [ info] [cmetrics] version=0.6.6
[2024/01/13 09:01:00] [ info] [ctraces ] version=0.4.0
[2024/01/13 09:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2024/01/13 09:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2024/01/13 09:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2024/01/13 09:01:00] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2024/01/13 09:01:01] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2024/01/13 09:01:01] [ info] [output:stdout:stdout.0] worker #0 started
[2024/01/13 09:01:01] [ info] [sp] stream processor started
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="idle"} = 3534.29
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="iowait"} = 13.41
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="irq"} = 0
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="nice"} = 9.1899999999999995
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="softirq"} = 0.040000000000000001
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="steal"} = 0
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="system"} = 179.81999999999999
2024-01-13T00:01:05.988566934Z node_cpu_seconds_total{cpu="0",mode="user"} = 263.85000000000002
(snip)
2024-01-13T00:01:06.031529249Z node_systemd_version{version="249.11-0ubuntu3.11"} = 249.11000000000001
^C[2024/01/13 09:01:10] [engine] caught signal (SIGINT)
[2024/01/13 09:01:10] [ warn] [engine] service will shutdown in max 5 seconds
[2024/01/13 09:01:10] [ info] [engine] service has stopped (0 pending tasks)
[2024/01/13 09:01:10] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/01/13 09:01:11] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==17236== 
==17236== HEAP SUMMARY:
==17236==     in use at exit: 0 bytes in 0 blocks
==17236==   total heap usage: 75,311 allocs, 75,311 frees, 2,083,706,014 bytes allocated
==17236== 
==17236== All heap blocks were freed -- no leaks are possible
==17236== 
==17236== For lists of detected and suppressed errors, rerun with: -s
==17236== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
