### PR TITLE
pal: platform abstraction layer and strerror_r(3) wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1102,6 +1102,28 @@ if(HAVE_GETENTROPY_SYS_RANDOM)
   FLB_DEFINITION(FLB_HAVE_GETENTROPY_SYS_RANDOM)
 endif()
 
+#
+# strerror_r(3) definition type.
+#
+# Do not depend on the _POSIX_C_SOURCE and _GNU_SOURCE macros; the latter
+# depends on glibc.
+#
+check_symbol_exists(strerror_r "string.h" HAVE_STRERROR_R)
+if(HAVE_STRERROR_R)
+  FLB_DEFINITION(FLB_HAVE_STRERROR_R)
+  check_c_source_compiles("
+    #include <errno.h>
+    #include <string.h>
+    int main() {
+      char buf[256], *p;
+      p = strerror_r(EINVAL, buf, sizeof(buf));
+      return 0;
+    }" HAVE_STRERROR_R_CHAR_P)
+  if(HAVE_STRERROR_R_CHAR_P)
+    FLB_DEFINITION(FLB_HAVE_STRERROR_R_CHAR_P)
+  endif()
+endif()
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_info.h.in"
   "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_info.h"

--- a/include/fluent-bit/flb_pal.h
+++ b/include/fluent-bit/flb_pal.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PAL_H
+#define FLB_PAL_H
+
+#include <fluent-bit/flb_macros.h>
+
+#ifdef FLB_HAVE_STRERROR_R
+FLB_EXPORT int flb_strerror_r(int errnum, char *buf, size_t buflen);
+#endif
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(src
   flb_log_event_encoder_dynamic_field.c
   flb_processor.c
   flb_reload.c
+  flb_pal.c
   )
 
 # Config format

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -62,6 +62,7 @@
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_pal.h>
 
 int flb_io_net_accept(struct flb_connection *connection,
                        struct flb_coro *coro)
@@ -422,7 +423,7 @@ retry:
 
                 if (error != 0) {
                     /* Connection is broken, not much to do here */
-                    strerror_r(error, so_error_buf, sizeof(so_error_buf) - 1);
+                    flb_strerror_r(error, so_error_buf, sizeof(so_error_buf));
 
                     flb_error("[io fd=%i] error sending data to: %s (%s)",
                               connection->fd,

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -32,6 +32,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_worker.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_pal.h>
 
 #ifdef FLB_HAVE_AWS_ERROR_REPORTER
 #include <fluent-bit/aws/flb_aws_error_reporter.h>
@@ -670,7 +671,7 @@ int flb_errno_print(int errnum, const char *file, int line)
 {
     char buf[256];
 
-    strerror_r(errnum, buf, sizeof(buf) - 1);
+    flb_strerror_r(errnum, buf, sizeof(buf));
     flb_error("[%s:%i errno=%i] %s", file, line, errnum, buf);
     return 0;
 }

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -45,6 +45,7 @@
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_scheduler.h>
+#include <fluent-bit/flb_pal.h>
 
 #include <monkey/mk_core.h>
 #include <ares.h>
@@ -401,7 +402,6 @@ static int net_connect_async(int fd,
     int socket_errno;
     uint32_t mask;
     char so_error_buf[256];
-    char *str;
     struct flb_upstream *u;
 
     u = u_conn->upstream;
@@ -523,9 +523,9 @@ static int net_connect_async(int fd,
             }
 
             /* Connection is broken, not much to do here */
-            str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
+            flb_strerror_r(error, so_error_buf, sizeof(so_error_buf));
             flb_error("[net] TCP connection failed: %s:%i (%s)",
-                      u->tcp_host, u->tcp_port, str);
+                      u->tcp_host, u->tcp_port, so_error_buf);
             return -1;
         }
     }

--- a/src/flb_pal.c
+++ b/src/flb_pal.c
@@ -1,0 +1,65 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#include <fluent-bit/flb_pal.h>
+
+#include <errno.h>
+#include <string.h>
+
+/*
+ * The pal component encapsulates the platform dependency of the common
+ * platform features used by the rest of the Fluent Bit implementation.
+ */
+
+/*
+ * The wrapper of strerror_r(3).
+ *
+ * The signature follows that of POSIX.1-2001.
+ *
+ * Under glibc, copy the returned string to buf if the returned pointer is not
+ * equal to buf.
+ */
+#ifdef FLB_HAVE_STRERROR_R
+int flb_strerror_r(int errnum, char *buf, size_t buflen)
+{
+#ifdef FLB_HAVE_STRERROR_R_CHAR_P
+    int ret;
+    char *p;
+
+    ret = 0;
+
+    p = strerror_r(errnum, buf, buflen);
+    if (NULL == p) {
+        return errno;
+    }
+    if (p != buf) {
+        if (strlen(p) > buflen - 1) {
+            ret = ERANGE;
+        }
+        strncpy(buf, p, buflen - 1);
+        buf[buflen - 1] = '\0';
+    }
+
+    return ret;
+#else
+	return strerror_r(errnum, buf, buflen);
+#endif
+}
+#endif

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -42,6 +42,7 @@ set(UNIT_TESTS_FILES
   log_event_encoder.c
   processor.c
   uri.c
+  pal.c
   )
 
 # Config format

--- a/tests/internal/pal.c
+++ b/tests/internal/pal.c
@@ -51,10 +51,9 @@ static void test_pal_strerror_r_smallbuf()
 
 static void test_pal_strerror_r_error_unknown()
 {
-    int ret;
     char buf[BUFSIZE];
 
-    ret = flb_strerror_r(INT_MAX, buf, sizeof(buf));
+    flb_strerror_r(INT_MAX, buf, sizeof(buf));
 
     /*
      * The return value upon an unknown errno is not covered by

--- a/tests/internal/pal.c
+++ b/tests/internal/pal.c
@@ -1,0 +1,77 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_pal.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+#include "flb_tests_internal.h"
+
+#define BUFSIZE (256)
+#define BUFSIZE_SMALL (1)
+
+#ifdef FLB_HAVE_STRERROR_R
+static void test_pal_strerror_r_noerror()
+{
+    int ret;
+    char buf[BUFSIZE];
+
+    ret = flb_strerror_r(0, buf, sizeof(buf));
+
+    TEST_CHECK(0 == ret);
+    TEST_CHECK(NULL != memchr(buf, '\0', sizeof(buf)));
+    TEST_CHECK(0 < strlen(buf));
+}
+
+static void test_pal_strerror_r_error_einval()
+{
+    int ret;
+    char buf[BUFSIZE];
+
+    ret = flb_strerror_r(EINVAL, buf, sizeof(buf));
+
+    TEST_CHECK(0 == ret);
+    TEST_CHECK(NULL != memchr(buf, '\0', sizeof(buf)));
+    TEST_CHECK(0 < strlen(buf));
+}
+
+static void test_pal_strerror_r_smallbuf()
+{
+    int ret;
+    char buf[BUFSIZE_SMALL];
+
+    ret = flb_strerror_r(EINVAL, buf, sizeof(buf));
+
+    TEST_CHECK(ERANGE == ret);
+    TEST_CHECK(NULL != memchr(buf, '\0', sizeof(buf)));
+    TEST_CHECK(0 == strlen(buf));
+}
+
+static void test_pal_strerror_r_error_unknown()
+{
+    int ret;
+    char buf[BUFSIZE];
+
+    ret = flb_strerror_r(INT_MAX, buf, sizeof(buf));
+
+    /*
+     * The return value upon an unknown errno is not covered by
+     * flb_strerror_r(); it is difficult to find the max supported errno value.
+     * Just assure that flb_strerror_r() returns a string error message.
+     */
+    TEST_CHECK(NULL != memchr(buf, '\0', sizeof(buf)));
+    TEST_CHECK(0 < strlen(buf));
+}
+#endif
+
+TEST_LIST = {
+#ifdef FLB_HAVE_STRERROR_R
+    { "pal_strerror_r_noerror" , test_pal_strerror_r_noerror},
+    { "pal_strerror_r_error_einval" , test_pal_strerror_r_error_einval},
+    { "pal_strerror_r_smallbuf" , test_pal_strerror_r_smallbuf},
+    { "pal_strerror_r_error_unknown" , test_pal_strerror_r_error_unknown},
+#endif
+    { 0 }
+};


### PR DESCRIPTION
This PR is for the following changes:
- Introduce the `pal` module, the platform abstraction layer.
- Add `flb_strerror_r()`, the wrapper of `strerror_r(3)`.

## Fixed Issue

#8379

## Background

The `strerror_r(3)` implementations of glibc and POSIX.1-2001 have the different signatures and usages, which causes a build error and/or an unexpected behaviour.

Please refer to Issue #8379 for the detailed analysis.

## Changes

This fix implements `flb_strerror_r()`, the POSIX.1-2001-compliant wrapper of `strerror_r(3)` into `pal`, the new core module dedicated to encapsulate the platform dependency found on the common external features.  The goal of `pal` is similar to [the `AC_LIBOBJ()` macro of GNU Autoconf](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Generic-Functions.html#index-AC_005fLIBOBJ-1), except that `pal` holds all wrapper functions in a single source.

The wrapper functions in `pal` are intended for the Fluent Bit core and plugins only.  The third-party libraries under `lib` must not call them, in order to keep their independency.

### `pal` Source Files

- `src/flb_pal.c`
- `include/fluent-bit/flb_pal.h`

### `pal` Internal Test Files

- `tests/internal/pal.c`

### New `pal` Function

- `int flb_strerror_r(int errnum, char *buf, size_t buflen);`
  The wrapper of `strerror_r(3)` with the signature and semantics of POSIX.1-2001.  Available if `strerror_r(3)` exists in the platform, regardless from its implementation.

### `flb_strerror_r()` Callers

The `strerror_r(3)` calls in the following files have been converted to `flb_strerror_r()`:

- `src/flb_io.c`
- `src/flb_log.c`
- `src/flb_network.c`

## Tested Environments

- Debian x86_64 12.2 (`strerror_r(3)` standard: glibc)
- FreeBSD/amd64 14.0-RELEASE (`strerror_r(3)` standard: POSIX.1-2001)
  - fluent/fluent-bit/pull/8376 included for the coverage report.

----

## Testing

- `N/A` Example configuration file for the change
  The issue does not depend on a specific configuration.

- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Test Results**

- Debian x86_64 12.2: [logs-fluent-bit-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.zip](https://github.com/fluent/fluent-bit/files/13978470/logs-fluent-bit-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.zip)
  - `fluent-bit-cmake-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.log`
    The `cmake` log.
  - `fluent-bit-make-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.log`
    The `make` log.
  - `fluent-bit-ctest-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.log`
    The `ctest` log.
  - `fluent-bit-ctest-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2-LastTest.log`
    The `LastTest.log`  file out of `ctest`.
  - `fluent-bit-valgrind-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.log`
    The `valgrind --leak-check=full` log.
	No memory leak happened.
  - `gcov-tests-topic-pal-strerror_r-wrapper-github-pr-debian_x86_64_12_2.tar.xz`
    The `lcov` coverage report.
    - The new code has been covered except for one.
	  - Can we depend on the glibc `strerror_r(3)` never returning `NULL`?
- FreeBSD/amd64 14.0-RELEASE: [logs-fluent-bit-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.zip](https://github.com/fluent/fluent-bit/files/13978481/logs-fluent-bit-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.zip)
  - `fluent-bit-cmake-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.log`
    The `cmake` log.
  - `fluent-bit-make-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.log`
    The `make` log.
  - `fluent-bit-ctest-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.log`
    The `ctest` log.
  - `fluent-bit-ctest-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release-LastTest.log`
    The `LastTest.log`  file out of `ctest`.
  - `fluent-bit-valgrind-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.log`
    The `valgrind --leak-check=full` log.
	- The coverage is disabled because of the Valgrind problem that makes an assertion failure.
	- Many conditional jumps or moves on uninitialised value.
	  - These are the false errors; no conditional instructions have been found out of the codewalk.
	- 3 blocks are still reachable with flb_strerror_r().
	  - These are for the NLS message catalogue, read only once and staying until the process exits.
	- The rest of the leaks do not involve the Fluent Bit implementation.
  - `llvm-cov-tests-topic-pal-strerror_r-wrapper-freebsd_amd64_14_0_release.tar.xz`
    The LLVM coverage report.
    - The new code has been covered.

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- `N/A` Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- `N/A` Set `ok-package-test` label to test for all targets (requires maintainer to do).
  Packaging is not affected.

## Documentation

- `?` Documentation required for this feature
  The `pal` paragraph in `DEVELOPER_GUIDE.md`?

## Backporting

- [x] Backport to latest stable release.
  This PR is the fix to a build breakage.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
