### PR TITLE
in_systemd: fix no journal data when reading from tail

### DIFF
--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -220,6 +220,7 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
         * up to 4096/25*2 ~= 350 old log messages. See also fluent-bit PR #1565.
         */
         ret = sd_journal_next_skip(ctx->j, 350);
+        sd_journal_previous(ctx->j);
         flb_plg_debug(ctx->ins,
                       "jump to the end of journal and skip %d last entries", ret);
     }


### PR DESCRIPTION
Adds a journal cursor step-back after seeking to journal tail. This is necessary in order for subsequent journal reads to return data. Fixes issue #8394.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
