### PR TITLE
out_forward: fix memory leak during connection loss

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1574,9 +1574,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
         if (!u_conn) {
             flb_plg_error(ctx->ins, "no upstream connections available");
             msgpack_sbuffer_destroy(&mp_sbuf);
-            if (fc->time_as_integer == FLB_TRUE) {
-                flb_free(out_buf);
-            }
+            flb_free(out_buf);
             flb_free(flush_ctx);
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
@@ -1590,9 +1588,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
             flb_plg_error(ctx->ins, "no unix socket connection available");
 
             msgpack_sbuffer_destroy(&mp_sbuf);
-            if (fc->time_as_integer == FLB_TRUE) {
-                flb_free(out_buf);
-            }
+            flb_free(out_buf);
             flb_free(flush_ctx);
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
@@ -1622,9 +1618,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
             }
 
             msgpack_sbuffer_destroy(&mp_sbuf);
-            if (fc->time_as_integer == FLB_TRUE) {
-                flb_free(out_buf);
-            }
+            flb_free(out_buf);
             flb_free(flush_ctx);
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->
I observed that memory consumption was constantly growing while the data sink of the forward plugin was unavailable. Using valgrind, it could be confirmed that there is a leak in the forward output plugin:
```
==8== 385,024 bytes in 47 blocks are definitely lost in loss record 126 of 126
==8==    at 0x4E055B4: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8==    by 0x4E0A81C: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8==    by 0x739B7B: msgpack_sbuffer_write (sbuffer.h:81)
==8==    by 0x5D5262: msgpack_pack_map (pack_template.h:753)
==8==    by 0x5D8F8A: flb_mp_map_header_init (flb_mp.c:321)
==8==    by 0x73A026: append_options (forward_format.c:103)
==8==    by 0x73AE2F: flb_forward_format_forward_mode (forward_format.c:442)
==8==    by 0x73B3A4: flb_forward_format (forward_format.c:633)
==8==    by 0x73566E: cb_forward_flush (forward.c:1559)
==8==    by 0x51F033: output_pre_cb_flush (flb_output.h:597)
==8==    by 0xA45126: co_init (amd64.c:117)
```
Further analysis showed that during connection loss `out_buf` is only freed if `time_as_integer` is set to `true`:
```c
        if (!u_conn) {
            flb_plg_error(ctx->ins, "no upstream connections available");
            msgpack_sbuffer_destroy(&mp_sbuf);
            if (fc->time_as_integer == FLB_TRUE) {
                flb_free(out_buf);
            }
```
Source: https://github.com/fluent/fluent-bit/blob/master/plugins/out_forward/forward.c#L1574-L1579

However, from the code it looks like `out_buf` is also used to write metadata in `append_options` (https://github.com/fluent/fluent-bit/blob/master/plugins/out_forward/forward_format.c#L85). To verify this assumption, I enabled `Time_as_Integer` in the forward configuration. Afterwards, valgrind did no longer find a leak. Therefore, I removed the conditional, which is save because this is also done in other places (e.g. https://github.com/fluent/fluent-bit/blob/master/plugins/out_forward/forward.c#L1644) and even if `out_buf` is not used, it would be `NULL` and freeing `NULL` is valid.

I ran the patched version for 12 hours and the memory consumption was perfectly constant.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change -> Can be reproduced with any forward configuration which doesn't set `Time_as_Integer` to `true`
- [N/A] Debug log output from testing the change -> Change not visible in log
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found -> Nothing to attach, since valgrind found only known issues

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
