### PR TITLE
in_tail: Add option file_cache_advise to reduce file cache usage

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -696,7 +696,13 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_tail_config, skip_empty_lines),
      "Allows to skip empty lines."
     },
-
+#ifdef __linux__
+    {
+     FLB_CONFIG_MAP_BOOL, "file_cache_advise", "true",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, file_cache_advise),
+     "Use posix_fadvise for file access. Advise not to use kernel file cache."
+    },
+#endif
 #ifdef FLB_HAVE_INOTIFY
     {
      FLB_CONFIG_MAP_BOOL, "inotify_watcher", "true",

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -93,6 +93,9 @@ struct flb_tail_config {
     int   skip_long_lines;     /* skip long lines              */
     int   skip_empty_lines;    /* skip empty lines (off)       */
     int   exit_on_eof;         /* exit fluent-bit on EOF, test */
+#ifdef __linux__
+    int   file_cache_advise;   /* Use posix_fadvise for file access */
+#endif
 
     int progress_check_interval;      /* watcher interval             */
     int progress_check_interval_nsec; /* watcher interval             */

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -940,7 +940,13 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     if (flb_tail_file_exists(st, ctx) == FLB_TRUE) {
         return -1;
     }
-
+   
+    #ifdef __linux__
+    if (ctx->file_cache_advise) {
+        flb_plg_debug(ctx->ins, "file will be read in POSIX_FADV_DONTNEED mode %s", path);
+    }
+    #endif
+    
     fd = open(path, O_RDONLY);
     if (fd == -1) {
         flb_errno();
@@ -1429,6 +1435,15 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         file_buffer_capacity = (file->buf_size - file->buf_len) - 1;
     }
 
+    #ifdef __linux__
+    if (ctx->file_cache_advise) {
+        if (posix_fadvise(file->fd, 0, 0, POSIX_FADV_DONTNEED) == -1) {
+            flb_errno();
+            flb_plg_error(ctx->ins, "error during posix_fadvise");
+        }
+    }
+    #endif
+    
     read_size = file_buffer_capacity;
 
     if (file->decompression_context != NULL) {


### PR DESCRIPTION
This PR will add option file_cache_advise to the tail plugin. It allows to set the posix_fadvise in POSIX_FADV_DONTNEED mode. This will drastically reduce the usage of the kernel file cache.
 
This can be necessary when running in K8s environments, where the file cache is accounted to the total memory usage of the pod (see: https://github.com/kubernetes/kubernetes/issues/43916). I/O intensive loads (like Fluent Bit) might run into OOM-kills because of filling the file cache with reads of the tail plugin.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1291


**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
