### PR TITLE
filter: extend filter capabilities to start handling metrics and traces type of events

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -71,7 +71,8 @@ struct flb_filter_plugin {
                       void **, size_t *,
                       struct flb_filter_instance *,
                       struct flb_input_instance *,
-                      void *, struct flb_config *);
+                      void *, struct flb_config *,
+                      int);
     int (*cb_exit) (void *, struct flb_config *);
 
     struct mk_list _head;  /* Link to parent list (config->filters) */
@@ -136,7 +137,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
                    const void *data, size_t bytes,
                    void **out_data, size_t *out_bytes,
                    const char *tag, int tag_len,
-                   struct flb_config *config);
+                   struct flb_config *config,
+                   int event_type);
 const char *flb_filter_name(struct flb_filter_instance *ins);
 
 int flb_filter_match_property_existence(struct flb_filter_instance *ins);

--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -21,6 +21,7 @@
 #define FLB_FILTER_H
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input.h>
 
 #ifdef FLB_HAVE_REGEX
 #include <fluent-bit/flb_regex.h>

--- a/plugins/filter_alter_size/alter_size.c
+++ b/plugins/filter_alter_size/alter_size.c
@@ -89,7 +89,8 @@ static int cb_alter_size_filter(const void *data, size_t bytes,
                                 struct flb_filter_instance *ins,
                                 struct flb_input_instance *i_ins,
                                 void *filter_context,
-                                struct flb_config *config)
+                                struct flb_config *config,
+                                int event_type)
 {
     int i;
     int len;

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -724,7 +724,8 @@ static int cb_aws_filter(const void *data, size_t bytes,
                          struct flb_filter_instance *f_ins,
                          struct flb_input_instance *i_ins,
                          void *context,
-                         struct flb_config *config)
+                         struct flb_config *config,
+                         int event_type)
 {
     struct flb_filter_aws *ctx = context;
     int i = 0;

--- a/plugins/filter_checklist/checklist.c
+++ b/plugins/filter_checklist/checklist.c
@@ -419,7 +419,8 @@ static int cb_checklist_filter(const void *data, size_t bytes,
                                struct flb_filter_instance *ins,
                                struct flb_input_instance *i_ins,
                                void *filter_context,
-                               struct flb_config *config)
+                               struct flb_config *config,
+                               int event_type)
 {
     int i;
     int id;

--- a/plugins/filter_ecs/ecs.c
+++ b/plugins/filter_ecs/ecs.c
@@ -1440,7 +1440,8 @@ static int cb_ecs_filter(const void *data, size_t bytes,
                          struct flb_filter_instance *f_ins,
                          struct flb_input_instance *i_ins,
                          void *context,
-                         struct flb_config *config)
+                         struct flb_config *config,
+                         int event_type)
 {
     struct flb_filter_ecs *ctx = context;
     int i = 0;

--- a/plugins/filter_expect/expect.c
+++ b/plugins/filter_expect/expect.c
@@ -401,7 +401,8 @@ static int cb_expect_filter(const void *data, size_t bytes,
                             struct flb_filter_instance *f_ins,
                             struct flb_input_instance *i_ins,
                             void *filter_context,
-                            struct flb_config *config)
+                            struct flb_config *config,
+                            int event_type)
 {
     int ret;
     int i;

--- a/plugins/filter_geoip2/geoip2.c
+++ b/plugins/filter_geoip2/geoip2.c
@@ -383,7 +383,8 @@ static int cb_geoip2_filter(const void *data, size_t bytes,
                             struct flb_filter_instance *f_ins,
                             struct flb_input_instance *i_ins,
                             void *context,
-                            struct flb_config *config)
+                            struct flb_config *config,
+                            int event_type)
 {
     struct geoip2_ctx *ctx = context;
     msgpack_object_kv *kv;

--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -289,7 +289,8 @@ static int cb_grep_filter(const void *data, size_t bytes,
                           struct flb_filter_instance *f_ins,
                           struct flb_input_instance *i_ins,
                           void *context,
-                          struct flb_config *config)
+                          struct flb_config *config,
+                          int event_type)
 {
     int ret;
     int old_size = 0;

--- a/plugins/filter_grep/grep.c
+++ b/plugins/filter_grep/grep.c
@@ -283,14 +283,13 @@ static inline int grep_filter_data_and_or(msgpack_object map, struct grep_ctx *c
     return found ? GREP_RET_EXCLUDE : GREP_RET_KEEP;
 }
 
-static int cb_grep_filter(const void *data, size_t bytes,
+static int process_log(const void *data, size_t bytes,
                           const char *tag, int tag_len,
                           void **out_buf, size_t *out_size,
                           struct flb_filter_instance *f_ins,
                           struct flb_input_instance *i_ins,
                           void *context,
-                          struct flb_config *config,
-                          int event_type)
+                          struct flb_config *config)
 {
     int ret;
     int old_size = 0;
@@ -388,6 +387,28 @@ static int cb_grep_filter(const void *data, size_t bytes,
 
     flb_log_event_decoder_destroy(&log_decoder);
     flb_log_event_encoder_destroy(&log_encoder);
+
+    return ret;
+}
+
+static int cb_grep_filter(const void *data, size_t bytes,
+                          const char *tag, int tag_len,
+                          void **out_buf, size_t *out_size,
+                          struct flb_filter_instance *f_ins,
+                          struct flb_input_instance *i_ins,
+                          void *context,
+                          struct flb_config *config,
+                          int event_type)
+{
+    int ret;
+
+    if (event_type == FLB_INPUT_LOGS) {
+        ret = process_log(data, bytes,
+                          tag, tag_len,
+                          out_buf, out_size,
+                          f_ins, i_ins,
+                          context, config);
+    }
 
     return ret;
 }

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -521,7 +521,8 @@ static int cb_kube_filter(const void *data, size_t bytes,
                           struct flb_filter_instance *f_ins,
                           struct flb_input_instance *i_ins,
                           void *filter_context,
-                          struct flb_config *config)
+                          struct flb_config *config,
+                          int event_type)
 {
     int ret;
     size_t pre = 0;

--- a/plugins/filter_log_to_metrics/log_to_metrics.c
+++ b/plugins/filter_log_to_metrics/log_to_metrics.c
@@ -663,7 +663,8 @@ static int cb_log_to_metrics_filter(const void *data, size_t bytes,
                             void **out_buf, size_t *out_size,
                             struct flb_filter_instance *f_ins,
                             struct flb_input_instance *i_ins, void *context,
-                            struct flb_config *config)
+                            struct flb_config *config,
+                            int event_type)
 {
     int ret;
     msgpack_unpacked result;

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -214,7 +214,8 @@ static int cb_lua_filter_mpack(const void *data, size_t bytes,
                                struct flb_filter_instance *f_ins,
                                struct flb_input_instance *i_ins,
                                void *filter_context,
-                               struct flb_config *config)
+                               struct flb_config *config,
+                               int event_type)
 {
     (void) i_ins;
     int ret;
@@ -484,7 +485,8 @@ static int cb_lua_filter(const void *data, size_t bytes,
                          struct flb_filter_instance *f_ins,
                          struct flb_input_instance *i_ins,
                          void *filter_context,
-                         struct flb_config *config)
+                         struct flb_config *config,
+                         int event_type)
 {
     int ret;
     double ts = 0;

--- a/plugins/filter_modify/modify.c
+++ b/plugins/filter_modify/modify.c
@@ -1484,7 +1484,8 @@ static int cb_modify_filter(const void *data, size_t bytes,
                             void **out_buf, size_t * out_size,
                             struct flb_filter_instance *f_ins,
                             struct flb_input_instance *i_ins,
-                            void *context, struct flb_config *config)
+                            void *context, struct flb_config *config,
+                            int event_type)
 {
     struct flb_log_event_encoder log_encoder;
     struct flb_log_event_decoder log_decoder;

--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -721,7 +721,8 @@ static int cb_ml_filter(const void *data, size_t bytes,
                         struct flb_filter_instance *f_ins,
                         struct flb_input_instance *i_ins,
                         void *filter_context,
-                        struct flb_config *config)
+                        struct flb_config *config,
+                        int event_type)
 {
     size_t                       tmp_size;
     char                        *tmp_buf;

--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -623,7 +623,8 @@ static int cb_nest_filter(const void *data, size_t bytes,
                           void **out_buf, size_t * out_size,
                           struct flb_filter_instance *f_ins,
                           struct flb_input_instance *i_ins,
-                          void *context, struct flb_config *config)
+                          void *context, struct flb_config *config,
+                          int event_type)
 {
     struct flb_log_event_encoder log_encoder;
     struct flb_log_event_decoder log_decoder;

--- a/plugins/filter_nightfall/nightfall.c
+++ b/plugins/filter_nightfall/nightfall.c
@@ -459,7 +459,8 @@ static int cb_nightfall_filter(const void *data, size_t bytes,
                                struct flb_filter_instance *f_ins,
                                struct flb_input_instance *i_ins,
                                void *context,
-                               struct flb_config *config)
+                               struct flb_config *config,
+                               int event_type)
 {
     struct flb_filter_nightfall *ctx = context;
     int ret;

--- a/plugins/filter_parser/filter_parser.c
+++ b/plugins/filter_parser/filter_parser.c
@@ -172,7 +172,8 @@ static int cb_parser_filter(const void *data, size_t bytes,
                             struct flb_filter_instance *f_ins,
                             struct flb_input_instance *i_ins,
                             void *context,
-                            struct flb_config *config)
+                            struct flb_config *config,
+                            int event_type)
 {
     int continue_parsing;
     struct filter_parser_ctx *ctx = context;

--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -301,7 +301,8 @@ static int cb_modifier_filter(const void *data, size_t bytes,
                               struct flb_filter_instance *f_ins,
                               struct flb_input_instance *i_ins,
                               void *context,
-                              struct flb_config *config)
+                              struct flb_config *config,
+                              int event_type)
 {
     struct record_modifier_ctx *ctx = context;
     char is_modified = FLB_FALSE;

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -426,7 +426,8 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
                                  struct flb_filter_instance *f_ins,
                                  struct flb_input_instance *i_ins,
                                  void *filter_context,
-                                 struct flb_config *config)
+                                 struct flb_config *config,
+                                 int event_type)
 {
     int keep;
     int emitted_num = 0;

--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -25,6 +25,11 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_metrics.h>
+
+#include <ctraces/ctraces.h>
+#include <ctraces/ctr_decode_msgpack.h>
+
 #include <msgpack.h>
 
 static int cb_stdout_init(struct flb_filter_instance *f_ins,
@@ -40,6 +45,64 @@ static int cb_stdout_init(struct flb_filter_instance *f_ins,
         return -1;
     }
     return 0;
+}
+
+#ifdef FLB_HAVE_METRICS
+static void print_metrics_text(struct flb_filter_instance *f_ins,
+                               const void *data, size_t bytes)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) data, bytes, &off);
+    if (ret != 0) {
+        flb_plg_error(f_ins, "could not process metrics payload");
+        return;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+
+    printf("%s", text);
+    fflush(stdout);
+
+    cmt_encode_text_destroy(text);
+}
+#endif
+
+static void print_traces_text(struct flb_filter_instance *f_ins,
+                              const void *data, size_t bytes)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text;
+    struct ctrace *ctr = NULL;
+    int ok = CTR_DECODE_MSGPACK_SUCCESS;
+
+    /* Decode each ctrace context */
+    while ((ret = ctr_decode_msgpack_create(&ctr,
+                                            (char *) data,
+                                            bytes, &off)) == ok) {
+        /* convert to text representation */
+        text = ctr_encode_text_create(ctr);
+
+        /* destroy ctr context */
+        ctr_destroy(ctr);
+
+        printf("%s", text);
+        fflush(stdout);
+
+        ctr_encode_text_destroy(text);
+    }
+    if (ret != ok) {
+        flb_plg_debug(f_ins, "ctr decode msgpack returned : %d", ret);
+    }
 }
 
 static int cb_stdout_filter(const void *data, size_t bytes,
@@ -62,6 +125,19 @@ static int cb_stdout_filter(const void *data, size_t bytes,
     (void) i_ins;
     (void) filter_context;
     (void) config;
+
+#ifdef FLB_HAVE_METRICS
+    /* Check if the event type is metrics, handle the payload differently */
+    if (event_type == FLB_INPUT_METRICS) {
+        print_metrics_text(f_ins, (char *) data, bytes);
+        return FLB_FILTER_NOTOUCH;
+    }
+#endif
+
+    if (event_type == FLB_INPUT_TRACES) {
+        print_traces_text(f_ins, (char *) data, bytes);
+        return FLB_FILTER_NOTOUCH;
+    }
 
     ret = flb_log_event_decoder_init(&log_decoder, (char *) data, bytes);
 
@@ -104,5 +180,6 @@ struct flb_filter_plugin filter_stdout_plugin = {
     .cb_filter    = cb_stdout_filter,
     .cb_exit      = NULL,
     .config_map   = config_map,
+    .event_type   = FLB_FILTER_LOGS | FLB_FILTER_METRICS | FLB_FILTER_TRACES,
     .flags        = 0
 };

--- a/plugins/filter_stdout/stdout.c
+++ b/plugins/filter_stdout/stdout.c
@@ -48,7 +48,8 @@ static int cb_stdout_filter(const void *data, size_t bytes,
                             struct flb_filter_instance *f_ins,
                             struct flb_input_instance *i_ins,
                             void *filter_context,
-                            struct flb_config *config)
+                            struct flb_config *config,
+                            int event_type)
 {
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;

--- a/plugins/filter_sysinfo/sysinfo.c
+++ b/plugins/filter_sysinfo/sysinfo.c
@@ -178,7 +178,8 @@ static int cb_sysinfo_filter(const void *data, size_t bytes,
                              struct flb_filter_instance *f_ins,
                              struct flb_input_instance *i_ins,
                              void *filter_context,
-                             struct flb_config *config)
+                             struct flb_config *config,
+                             int event_type)
 {
     struct filter_sysinfo_ctx *ctx = filter_context;
     struct flb_log_event_decoder log_decoder;

--- a/plugins/filter_tensorflow/tensorflow.c
+++ b/plugins/filter_tensorflow/tensorflow.c
@@ -249,7 +249,8 @@ static int cb_tensorflow_filter(const void *data, size_t bytes,
                                 struct flb_filter_instance *f_ins,
                                 struct flb_input_instance *i_ins,
                                 void *filter_context,
-                                struct flb_config *config)
+                                struct flb_config *config,
+                                int event_type)
 {
     int i;
     int j;

--- a/plugins/filter_throttle/throttle.c
+++ b/plugins/filter_throttle/throttle.c
@@ -192,7 +192,8 @@ static int cb_throttle_filter(const void *data, size_t bytes,
                               struct flb_filter_instance *f_ins,
                               struct flb_input_instance *i_ins,
                               void *context,
-                              struct flb_config *config)
+                              struct flb_config *config,
+                              int event_type)
 {
     int ret;
     int old_size = 0;

--- a/plugins/filter_throttle_size/throttle_size.c
+++ b/plugins/filter_throttle_size/throttle_size.c
@@ -661,7 +661,8 @@ static int cb_throttle_size_filter(const void *data, size_t bytes,
                                    void **out_buf, size_t * out_size,
                                    struct flb_filter_instance *ins,
                                    struct flb_input_instance *i_ins,
-                                   void *context, struct flb_config *config)
+                                   void *context, struct flb_config *config,
+                                   int event_type)
 {
     int ret;
     int old_size = 0;

--- a/plugins/filter_type_converter/type_converter.c
+++ b/plugins/filter_type_converter/type_converter.c
@@ -185,7 +185,8 @@ static int cb_type_converter_filter(const void *data, size_t bytes,
                                     struct flb_filter_instance *f_ins,
                                     struct flb_input_instance *i_ins,
                                     void *filter_context,
-                                    struct flb_config *config)
+                                    struct flb_config *config,
+                                    int event_type)
 {
     struct type_converter_ctx *ctx = filter_context;
     struct flb_time tm;

--- a/plugins/filter_wasm/filter_wasm.c
+++ b/plugins/filter_wasm/filter_wasm.c
@@ -43,7 +43,8 @@ static int cb_wasm_filter(const void *data, size_t bytes,
                           struct flb_filter_instance *f_ins,
                           struct flb_input_instance *i_ins,
                           void *filter_context,
-                          struct flb_config *config)
+                          struct flb_config *config,
+                          int event_type)
 {
     int ret;
     char *ret_val = NULL;

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -79,7 +79,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
                    const void *data, size_t bytes,
                    void **out_data, size_t *out_bytes,
                    const char *tag, int tag_len,
-                   struct flb_config *config)
+                   struct flb_config *config,
+                   int event_type)
 {
     int ret;
 #ifdef FLB_HAVE_METRICS
@@ -163,7 +164,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
                                       f_ins,          /* filter instance  */
                                       i_ins,          /* input instance   */
                                       f_ins->context, /* filter priv data */
-                                      config);
+                                      config,
+                                      event_type);
 
 #ifdef FLB_HAVE_CHUNK_TRACE
             if (ic->trace) {

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -75,6 +75,25 @@ static inline int prop_key_check(const char *key, const char *kv, int k_len)
     return -1;
 }
 
+static inline int flb_filter_match_type(int in_event_type,
+                                        struct flb_filter_instance *f_ins)
+{
+    if (in_event_type == FLB_INPUT_LOGS &&
+        !(f_ins->event_type & FLB_FILTER_LOGS)) {
+        return FLB_FALSE;
+    }
+    else if (in_event_type == FLB_INPUT_METRICS &&
+             !(f_ins->event_type & FLB_FILTER_METRICS)) {
+        return FLB_FALSE;
+    }
+    else if (in_event_type == FLB_INPUT_TRACES &&
+             !(f_ins->event_type & FLB_FILTER_TRACES)) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+}
+
 void flb_filter_do(struct flb_input_chunk *ic,
                    const void *data, size_t bytes,
                    void **out_data, size_t *out_bytes,
@@ -135,6 +154,10 @@ void flb_filter_do(struct flb_input_chunk *ic,
         f_ins = mk_list_entry(head, struct flb_filter_instance, _head);
 
         if (is_active(&f_ins->properties) == FLB_FALSE) {
+            continue;
+        }
+
+        if (!flb_filter_match_type(event_type, f_ins)) {
             continue;
         }
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1516,13 +1516,16 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     final_data_size = buf_size;
 
     /* Apply filters */
-    if (event_type == FLB_INPUT_LOGS) {
+    if (event_type == FLB_INPUT_LOGS ||
+        event_type == FLB_INPUT_METRICS ||
+        event_type == FLB_INPUT_TRACES) {
         flb_filter_do(ic,
                       buf, buf_size,
                       &filtered_data_buffer,
                       &filtered_data_size,
                       tag, tag_len,
-                      in->config);
+                      in->config,
+                      event_type);
 
         final_data_buffer = filtered_data_buffer;
         final_data_size = filtered_data_size;

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -437,15 +437,19 @@ int flb_processor_run(struct flb_processor *proc,
     struct flb_processor_unit *pu;
     struct flb_filter_instance *f_ins;
     struct flb_processor_instance *p_ins;
+    int event_type;
 
     if (type == FLB_PROCESSOR_LOGS) {
         list = &proc->logs;
+        event_type = FLB_INPUT_LOGS;
     }
     else if (type == FLB_PROCESSOR_METRICS) {
         list = &proc->metrics;
+        event_type = FLB_INPUT_METRICS;
     }
     else if (type == FLB_PROCESSOR_TRACES) {
         list = &proc->traces;
+        event_type = FLB_INPUT_TRACES;
     }
 
     /* set current data buffer */
@@ -487,7 +491,8 @@ int flb_processor_run(struct flb_processor *proc,
                                       f_ins,                /* filter instance */
                                       proc->data,           /* (input/output) instance context */
                                       f_ins->context,       /* filter context */
-                                      proc->config);
+                                      proc->config,
+                                      event_type);
 
             /*
              * The cb_filter() function return status tells us if something changed


### PR DESCRIPTION
<!-- Provide summary of changes -->
For EMF enhancement, we need to enrich information for metrics type of events in filter plugins.
To implement this, I added for the three filter plugins to add capabilities for handling metrics and traces type of events.
filter_aws and filter_ecs starts to handle metrics type of events and the enrichment should be effective for adding static labels with cmt_label_add API on cmetrics.
Also, I added another example to handle three types of events in filter_stdout.

For future enhancement, we need to filter feature on cmetrics side to filter / remove metrics by the matched labels or static labels.
This will be effective on filter_grep but I didn't implement such feature for now.
filter_modify and filter_grep are tweaked for future enhancement but I just adjusted to handle log type of events only.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

https://github.com/fluent/fluent-bit-docs/pull/1294

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
