### PR TITLE
out_cloudwatch_logs: Support EMF format for metrics type of events

### DIFF
--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -38,6 +38,7 @@
 #include <cmetrics/cmt_encode_prometheus_remote_write.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_encode_splunk_hec.h>
+#include <cmetrics/cmt_encode_cloudwatch_emf.h>
 
 /* Metrics IDs for general purpose (used by core and Plugins */
 #define FLB_METRIC_N_RECORDS   0

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -42,9 +42,9 @@
 
 void cw_flush_destroy(struct cw_flush *buf);
 
-int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin, 
+int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                      struct cw_flush *buf, flb_sds_t tag,
-                     const char *data, size_t bytes);
+                     const char *data, size_t bytes, int event_type);
 int create_log_stream(struct flb_cloudwatch *ctx, struct log_stream *stream, int can_retry);
 struct log_stream *get_log_stream(struct flb_cloudwatch *ctx, flb_sds_t tag,
                                   const msgpack_object map);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -414,7 +414,8 @@ static void cb_cloudwatch_flush(struct flb_event_chunk *event_chunk,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    event_count = process_and_send(ctx, i_ins->p->name, buf, event_chunk->tag, event_chunk->data, event_chunk->size);
+    event_count = process_and_send(ctx, i_ins->p->name, buf, event_chunk->tag, event_chunk->data, event_chunk->size,
+                                   event_chunk->type);
     if (event_count < 0) {
         flb_plg_error(ctx->ins, "Failed to send events");
         cw_flush_destroy(buf);
@@ -660,6 +661,7 @@ struct flb_output_plugin out_cloudwatch_logs_plugin = {
     .cb_exit      = cb_cloudwatch_exit,
     .flags        = 0,
     .workers      = 1,
+    .event_type   = FLB_OUTPUT_LOGS | FLB_OUTPUT_METRICS,
 
     /* Configuration */
     .config_map     = config_map,

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -478,6 +478,10 @@ void flb_cloudwatch_ctx_destroy(struct flb_cloudwatch *ctx)
             flb_sds_destroy(ctx->stream_name);
         }
 
+        if (ctx->metric_namespace) {
+            flb_sds_destroy(ctx->metric_namespace);
+        }
+
         mk_list_foreach_safe(head, tmp, &ctx->streams) {
             stream = mk_list_entry(head, struct log_stream, _head);
             mk_list_del(&stream->_head);

--- a/tests/runtime/out_cloudwatch.c
+++ b/tests/runtime/out_cloudwatch.c
@@ -46,6 +46,52 @@ void flb_test_cloudwatch_success(void)
     flb_destroy(ctx);
 }
 
+/* It writes a json/emf formatted metrics */
+void flb_test_cloudwatch_success_with_metrics(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "cloudwatch_logs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
+    flb_output_set(ctx, out_ffd,"region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd,"log_format", "json_emf", NULL);
+    flb_output_set(ctx, out_ffd,"log_group_name", "fluent-health", NULL);
+    flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-cmetrics-", NULL);
+    flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
+    flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_cloudwatch_already_exists_create_group(void)
 {
     int ret;
@@ -350,6 +396,7 @@ void flb_test_cloudwatch_error_put_retention_policy(void)
 /* Test list */
 TEST_LIST = {
     {"success", flb_test_cloudwatch_success },
+    {"success_with_metrics", flb_test_cloudwatch_success_with_metrics},
     {"group_already_exists", flb_test_cloudwatch_already_exists_create_group },
     {"stream_already_exists", flb_test_cloudwatch_already_exists_create_stream },
     {"create_group_error", flb_test_cloudwatch_error_create_group },


### PR DESCRIPTION
<!-- Provide summary of changes -->
~~This PR depends on [EMF encoder support on cmetrics](https://github.com/fluent/cmetrics/pull/192). So, the current PR status is _canary_.~~

This PR supports metrics type of plugins handling on out_cloudwatch_logs plugin.
On ingested the metrics type of events, cmetrics will encode JSON/EMF format to prepare ingesting to the Cloudwatch Logs' metrics.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```python
[SERVICE]
    Flush        10
    Daemon       Off
    Log_Level    debug
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020
    Hot_Reload   On
    Grace 5

[INPUT]
    Name fluentbit_metrics

[FILTER]
    Name stdout
    Match *

[OUTPUT]
    Name cloudwatch_logs
    Match *
    log_stream_name fluent-bit-cloudwatch
    log_group_name fluent-bit-cloudwatch
    region us-west-1
    log_format json/emf
    metric_namespace fluent-bit-metrics
    auto_create_group true

```
- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/02/24 22:30:24] [ info] Configuration:
[2024/02/24 22:30:24] [ info]  flush time     | 10.000000 seconds
[2024/02/24 22:30:24] [ info]  grace          | 5 seconds
[2024/02/24 22:30:24] [ info]  daemon         | 0
[2024/02/24 22:30:24] [ info] ___________
[2024/02/24 22:30:24] [ info]  inputs:
[2024/02/24 22:30:24] [ info]      fluentbit_metrics
[2024/02/24 22:30:24] [ info] ___________
[2024/02/24 22:30:24] [ info]  filters:
[2024/02/24 22:30:24] [ info]      stdout.0
[2024/02/24 22:30:24] [ info] ___________
[2024/02/24 22:30:24] [ info]  outputs:
[2024/02/24 22:30:24] [ info]      cloudwatch_logs.0
[2024/02/24 22:30:24] [ info] ___________
[2024/02/24 22:30:24] [ info]  collectors:
[2024/02/24 22:30:24] [ info] [fluent bit] version=3.0.0, commit=a2e0438e0d, pid=535697
[2024/02/24 22:30:24] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/02/24 22:30:24] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/02/24 22:30:24] [ info] [cmetrics] version=0.7.0
[2024/02/24 22:30:24] [ info] [ctraces ] version=0.4.0
[2024/02/24 22:30:24] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2024/02/24 22:30:24] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2024/02/24 22:30:24] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2024/02/24 22:30:24] [debug] [cloudwatch_logs:cloudwatch_logs.0] created event channels: read=23 write=24
[2024/02/24 22:30:24] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Metric Namespace=fluent-bit-metrics
[2024/02/24 22:30:24] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2024/02/24 22:30:24] [debug] [aws_credentials] creating profile (null) provider
[2024/02/24 22:30:24] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2024/02/24 22:30:24] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2024/02/24 22:30:24] [debug] [aws_credentials] Not initializing ECS Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set
[2024/02/24 22:30:24] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2024/02/24 22:30:24] [debug] [aws_credentials] Sync called on the EC2 provider
[2024/02/24 22:30:24] [debug] [aws_credentials] Init called on the env provider
[2024/02/24 22:30:24] [debug] [aws_credentials] Init called on the profile provider
[2024/02/24 22:30:24] [debug] [aws_credentials] Reading shared config file.
[2024/02/24 22:30:24] [debug] [aws_credentials] Reading shared credentials file.
[2024/02/24 22:30:24] [debug] [aws_credentials] upstream_set called on the EC2 provider
[2024/02/24 22:30:24] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] worker #0 started
[2024/02/24 22:30:24] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2024/02/24 22:30:24] [ info] [sp] stream processor started
[2024/02/24 22:30:26] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
[2024/02/24 22:30:28] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
[2024/02/24 22:30:30] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
[2024/02/24 22:30:32] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
[2024/02/24 22:30:34] [debug] [task] created task=0x63cfa80 id=0 OK
[2024/02/24 22:30:34] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] task_id=0 assigned to thread #0
[2024/02/24 22:30:34] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:34] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
[2024/02/24 22:30:34] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log stream fluent-bit-cloudwatch in log group fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [upstream] KA connection #52 to logs.us-west-1.amazonaws.com:443 is connected
[2024/02/24 22:30:35] [debug] [http_client] not using http_proxy for header
[2024/02/24 22:30:35] [debug] [http_client] server logs.us-west-1.amazonaws.com:443 will close connection #52
[2024/02/24 22:30:35] [debug] [aws_client] logs.us-west-1.amazonaws.com: http_do=0, HTTP Status: 400
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] CreateLogStream http status=400
[2024/02/24 22:30:35] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Log Stream fluent-bit-cloudwatch already exists
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] cloudwatch:PutLogEvents: events=34, payload=12374 bytes
[2024/02/24 22:30:35] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream fluent-bit-cloudwatch
[2024/02/24 22:30:36] [debug] [upstream] KA connection #52 to logs.us-west-1.amazonaws.com:443 is connected
[2024/02/24 22:30:36] [debug] [http_client] not using http_proxy for header
[2024/02/24 22:30:36] [debug] [upstream] KA connection #52 to logs.us-west-1.amazonaws.com:443 is now available
[2024/02/24 22:30:36] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200
[2024/02/24 22:30:36] [debug] [task] destroy task=0x63cfa80 (task_id=0)
[2024/02/24 22:30:36] [debug] [out flush] cb_destroy coro_id=0
[2024/02/24 22:30:36] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
[2024/02/24 22:30:38] [debug] [input chunk] update output instances with new chunk size diff=6926, records=0, input=fluentbit_metrics.0
^C[2024/02/24 22:30:39] [engine] caught signal (SIGINT)
[2024/02/24 22:30:39] [debug] [task] created task=0x9977d90 id=0 OK
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] task_id=0 assigned to thread #0
[2024/02/24 22:30:39] [ warn] [engine] service will shutdown in max 5 seconds
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [ info] [input] pausing fluentbit_metrics.0
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Using stream=fluent-bit-cloudwatch, group=fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] cloudwatch:PutLogEvents: events=34, payload=12379 bytes
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream fluent-bit-cloudwatch
[2024/02/24 22:30:39] [debug] [upstream] KA connection #52 to logs.us-west-1.amazonaws.com:443 has been assigned (recycled)
[2024/02/24 22:30:39] [debug] [http_client] not using http_proxy for header
[2024/02/24 22:30:39] [debug] [upstream] KA connection #52 to logs.us-west-1.amazonaws.com:443 is now available
[2024/02/24 22:30:39] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200
[2024/02/24 22:30:39] [debug] [task] destroy task=0x9977d90 (task_id=0)
[2024/02/24 22:30:39] [debug] [out flush] cb_destroy coro_id=1
[2024/02/24 22:30:40] [ info] [engine] service has stopped (0 pending tasks)
[2024/02/24 22:30:40] [ info] [input] pausing fluentbit_metrics.0
[2024/02/24 22:30:40] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] thread worker #0 stopping...
[2024/02/24 22:30:40] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==535697== 
==535697== HEAP SUMMARY:
==535697==     in use at exit: 0 bytes in 0 blocks
==535697==   total heap usage: 46,140 allocs, 46,140 frees, 9,702,482 bytes allocated
==535697== 
==535697== All heap blocks were freed -- no leaks are possible
==535697== 
==535697== For lists of detected and suppressed errors, rerun with: -s
==535697== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
