### PR TITLE
processor_attributes: fix warnings

### DIFF
--- a/plugins/processor_attributes/attributes.c
+++ b/plugins/processor_attributes/attributes.c
@@ -826,11 +826,11 @@ static void attribute_match_cb(const char *name,
     if (temporary_value != NULL) {
         span = (struct ctrace_span *) context;
 
-        if (span_contains_attribute(span, name) == FLB_TRUE) {
-            span_remove_attribute(span, name);
+        if (span_contains_attribute(span, (char*)name) == FLB_TRUE) {
+            span_remove_attribute(span, (char*)name);
         }
 
-        ctr_span_set_attribute_string(span, name, temporary_value);
+        ctr_span_set_attribute_string(span, (char*)name, temporary_value);
 
         cfl_sds_destroy(temporary_value);
     }


### PR DESCRIPTION
This patch is to fix following warnings.

```
 [ 57%] Building C object plugins/processor_attributes/CMakeFiles/flb-plugin-processor_attributes.dir/attributes.c.o
/home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c: In function ‘attribute_match_cb’:
/home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c:829:43: warning: passing argument 2 of ‘span_contains_attribute’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  829 |         if (span_contains_attribute(span, name) == FLB_TRUE) {
      |                                           ^~~~
/home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c:676:42: note: expected ‘char *’ but argument is of type ‘const char *’
  676 |                                    char *name)
      |                                    ~~~~~~^~~~
/home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c:830:41: warning: passing argument 2 of ‘span_remove_attribute’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  830 |             span_remove_attribute(span, name);
      |                                         ^~~~
/home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c:686:40: note: expected ‘char *’ but argument is of type ‘const char *’
  686 |                                  char *name)
      |                                  ~~~~~~^~~~
/home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c:833:45: warning: passing argument 2 of ‘ctr_span_set_attribute_string’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  833 |         ctr_span_set_attribute_string(span, name, temporary_value);
      |                                             ^~~~
In file included from /home/taka/git/fluent-bit/lib/ctraces/include/ctraces/ctraces.h:84,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_processor.h:29,
                 from /home/taka/git/fluent-bit/include/fluent-bit/flb_processor_plugin.h:24,
                 from /home/taka/git/fluent-bit/plugins/processor_attributes/attributes.c:25:
/home/taka/git/fluent-bit/lib/ctraces/include/ctraces/ctr_span.h:120:67: note: expected ‘char *’ but argument is of type ‘const char *’
  120 | int ctr_span_set_attribute_string(struct ctrace_span *span, char *key, char *value);
      |                                                             ~~~~~~^~~
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
