### PR TITLE
filter_nest: define a new var to prevent pointer arithmetic

### DIFF
--- a/plugins/filter_nest/nest.c
+++ b/plugins/filter_nest/nest.c
@@ -198,9 +198,19 @@ static void helper_pack_string_add_prefix(struct flb_log_event_encoder *log_enco
         const char *str,
         int len)
 {
+    size_t new_size;
+
+    /*
+       An arg of FLB_LOG_EVENT_STRING_LENGTH_VALUE is a flb_log_event_encoder_size_t.
+       flb_log_event_encoder_size_t is size_t* on Windows.
+       It can cause pointer arithmetic and the output can be larger value.
+       We use 'new_size' to prevent pointer arithmetic.
+     */
+    new_size = ctx->prefix_len + len;
+
     flb_log_event_encoder_append_body_values(
         log_encoder,
-        FLB_LOG_EVENT_STRING_LENGTH_VALUE(ctx->prefix_len + len),
+        FLB_LOG_EVENT_STRING_LENGTH_VALUE(new_size),
         FLB_LOG_EVENT_STRING_BODY_VALUE(ctx->prefix, ctx->prefix_len),
         FLB_LOG_EVENT_STRING_BODY_VALUE(str, len));
 }


### PR DESCRIPTION
https://github.com/fluent/fluent-bit/issues/8137

An arg of `FLB_LOG_EVENT_STRING_LENGTH_VALUE` is a `flb_log_event_encoder_size_t`. 
`flb_log_event_encoder_size_t` is `size_t*` on Windows. 
It can cause pointer arithmetic and the output can be larger value. 
e.g. `FLB_LOG_EVENT_STRING_LENGTH_VALUE(10+3)` can be 10 + sizeof(size_t*) * 3 = 34.

We use 'new_size' to prevent pointer arithmetic.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[SERVICE]
    Log_Level debug

[INPUT]
    Name dummy
    Dummy {"map_data":{"key":"value", "id":123}}
    samples 1

[FILTER]
    Name nest
    Match *
    Operation lift
    Nested_under map_data
    Add_prefix _map_data.

[OUTPUT]
    name stdout
    match *
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
