### PR TITLE
out_stackdriver: print tag with api error message

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2942,15 +2942,18 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
 #endif
           if (c->resp.status >= 400 && c->resp.status < 500) {
             ret_code = FLB_ERROR;
-            flb_plg_warn(ctx->ins, "error: %s", c->resp.payload);
+            flb_plg_warn(ctx->ins, "tag=%s error sending to Cloud Logging: %s", event_chunk->tag,
+                         c->resp.payload);
           }
           else {
             if (c->resp.payload_size > 0) {
               /* we got an error */
-              flb_plg_warn(ctx->ins, "error: %s", c->resp.payload);
+              flb_plg_warn(ctx->ins, "tag=%s error sending to Cloud Logging: %s", event_chunk->tag,
+                           c->resp.payload);
             }
             else {
-              flb_plg_debug(ctx->ins, "response: %s", c->resp.payload);
+              flb_plg_debug(ctx->ins, "tag=%s response from Cloud Logging: %s", event_chunk->tag,
+                            c->resp.payload);
             }
             ret_code = FLB_RETRY;
           }


### PR DESCRIPTION
When there is an api error (ie a permission denied, or other error) when submitting to the google logging api, we get a print out of the payload text, but that is not specific enough to debug the issue. Adding the chunk tag (which usually comes from an input plugin like tail) may assist in finding the root cause of the issue. 

Ideally I'd like the output success / failure metrics to include the logName as a tag, but this is much more involved as this would require looping through every entry in the logging request to get the entry number and logName and that would have to be compared to the response. Maybe this is less work that i initially assessed but it would possibly be a good idea and something that we can put into a feature request in the future.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
