### PR TITLE
in_emitter: Fix single record chunks and respect mem_buf_limit pause

### DIFF
--- a/plugins/filter_multiline/ml.h
+++ b/plugins/filter_multiline/ml.h
@@ -73,6 +73,7 @@ struct ml_ctx {
     size_t emitter_mem_buf_limit;           /* Emitter buffer limit */
     struct flb_input_instance *ins_emitter; /* emitter input plugin instance */
     struct flb_config *config;              /* Fluent Bit context */
+    struct flb_input_instance *i_ins;       /* Fluent Bit input instance (last used)*/
 
 #ifdef FLB_HAVE_METRICS
     struct cmt_counter *cmt_emitted;
@@ -82,6 +83,7 @@ struct ml_ctx {
 /* Register external function to emit records, check 'plugins/in_emitter' */
 int in_emitter_add_record(const char *tag, int tag_len,
                           const char *buf_data, size_t buf_size,
-                          struct flb_input_instance *in);
+                          struct flb_input_instance *in,
+                          struct flb_input_instance *i_ins);
 
 #endif

--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -355,7 +355,8 @@ static int ingest_inline(struct flb_rewrite_tag *ctx,
  */
 static int process_record(const char *tag, int tag_len, msgpack_object map,
                           const void *buf, size_t buf_size, int *keep,
-                          struct flb_rewrite_tag *ctx, int *matched)
+                          struct flb_rewrite_tag *ctx, int *matched,
+                          struct flb_input_instance *i_ins)
 {
     int ret;
     flb_sds_t out_tag;
@@ -404,7 +405,7 @@ static int process_record(const char *tag, int tag_len, msgpack_object map,
     if (!ret) {
         /* Emit record with new tag */
         ret = in_emitter_add_record(out_tag, flb_sds_len(out_tag), buf, buf_size,
-                                    ctx->ins_emitter);
+                                    ctx->ins_emitter, i_ins);
     }
     else {
         ret = 0;
@@ -489,7 +490,7 @@ static int cb_rewrite_tag_filter(const void *data, size_t bytes,
          * If a record was emitted, the variable 'keep' will define if the record must
          * be preserved or not.
          */
-        is_emitted = process_record(tag, tag_len, map, (char *) data + pre, off - pre, &keep, ctx, &is_matched);
+        is_emitted = process_record(tag, tag_len, map, (char *) data + pre, off - pre, &keep, ctx, &is_matched, i_ins);
         if (is_emitted == FLB_TRUE) {
             /* A record with the new tag was emitted */
             emitted_num++;

--- a/plugins/filter_rewrite_tag/rewrite_tag.h
+++ b/plugins/filter_rewrite_tag/rewrite_tag.h
@@ -57,7 +57,8 @@ struct flb_rewrite_tag {
 /* Register external function to emit records, check 'plugins/in_emitter' */
 int in_emitter_add_record(const char *tag, int tag_len,
                           const char *buf_data, size_t buf_size,
-                          struct flb_input_instance *in);
+                          struct flb_input_instance *in,
+                          struct flb_input_instance *i_ins);
 int in_emitter_get_collector_id(struct flb_input_instance *in);
 
 

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -31,6 +31,9 @@
 
 #define DEFAULT_EMITTER_RING_BUFFER_FLUSH_FREQUENCY 2000
 
+/* return values */
+#define FLB_EMITTER_BUSY     3
+
 struct em_chunk {
     flb_sds_t tag;
     struct msgpack_sbuffer mp_sbuf;  /* msgpack sbuffer        */
@@ -39,6 +42,7 @@ struct em_chunk {
 };
 
 struct flb_emitter {
+    int coll_fd;                        /* collector id */
     struct mk_list chunks;              /* list of all pending chunks */
     struct flb_input_instance *ins;     /* input instance */
     struct flb_ring_buffer *msgs;       /* ring buffer for cross-thread messages */
@@ -97,7 +101,6 @@ int static do_in_emitter_add_record(struct em_chunk *ec,
         em_chunk_destroy(ec);
         return -1;
     }
-    /* Release the echunk */
     em_chunk_destroy(ec);
     return 0;
 }
@@ -117,6 +120,12 @@ int in_emitter_add_record(const char *tag, int tag_len,
 
     ctx = (struct flb_emitter *) in->context;
     ec = NULL;
+
+    /* Restricted by mem_buf_limit */
+    if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
+        flb_plg_debug(ctx->ins, "emitter memory buffer limit reached. Not accepting record.");
+        return FLB_EMITTER_BUSY;
+    }
 
     /* Use the ring buffer first if it exists */
     if (ctx->msgs) {
@@ -161,8 +170,7 @@ int in_emitter_add_record(const char *tag, int tag_len,
 
     /* Append raw msgpack data */
     msgpack_sbuffer_write(&ec->mp_sbuf, buf_data, buf_size);
-
-    return do_in_emitter_add_record(ec, in);
+    return 0;
 }
 
 /*
@@ -189,6 +197,34 @@ static int in_emitter_ingest_ring_buffer(struct flb_input_instance *in,
         msgpack_sbuffer_destroy(&ec.mp_sbuf);
     }
     return ret;
+}
+
+static int cb_queue_chunks(struct flb_input_instance *in,
+                           struct flb_config *config, void *data)
+{
+    int ret;
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct em_chunk *echunk;
+    struct flb_emitter *ctx;
+
+    /* Get context */
+    ctx = (struct flb_emitter *) data;
+
+    /* Try to enqueue chunks under our limits */
+    mk_list_foreach_safe(head, tmp, &ctx->chunks) {
+        echunk = mk_list_entry(head, struct em_chunk, _head);
+
+        /* Associate this backlog chunk to this instance into the engine */
+        ret = do_in_emitter_add_record(echunk, in);
+        if (ret == -1) {
+            flb_error("[in_emitter] error registering chunk with tag: %s",
+                      echunk->tag);
+            continue;
+        }
+    }
+
+    return 0;
 }
 
 static int in_emitter_start_ring_buffer(struct flb_input_instance *in, struct flb_emitter *ctx)
@@ -257,11 +293,32 @@ static int cb_emitter_init(struct flb_input_instance *in,
             return -1;
         }
     }
+    else{
+        ret = flb_input_set_collector_time(in, cb_queue_chunks, 0, 50000000, config);
+        if (ret < 0) {
+            flb_error("[in_emitter] could not create collector");
+            flb_free(ctx);
+            return -1;
+        }
+        ctx->coll_fd = ret;
+    }
 
     /* export plugin context */
     flb_input_set_context(in, ctx);
 
     return 0;
+}
+
+static void cb_emitter_pause(void *data, struct flb_config *config)
+{
+    struct flb_emitter *ctx = data;
+    flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+}
+
+static void cb_emitter_resume(void *data, struct flb_config *config)
+{
+    struct flb_emitter *ctx = data;
+    flb_input_collector_resume(ctx->coll_fd, ctx->ins);
 }
 
 static int cb_emitter_exit(void *data, struct flb_config *config)
@@ -312,8 +369,8 @@ struct flb_input_plugin in_emitter_plugin = {
     .cb_ingest    = NULL,
     .cb_flush_buf = NULL,
     .config_map   = config_map,
-    .cb_pause     = NULL,
-    .cb_resume    = NULL,
+    .cb_pause     = cb_emitter_pause,
+    .cb_resume    = cb_emitter_resume,
     .cb_exit      = cb_emitter_exit,
 
     /* This plugin can only be configured and invoked by the Engine only */

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1729,6 +1729,7 @@ int flb_input_resume(struct flb_input_instance *ins)
             flb_input_thread_instance_resume(ins);
         }
         else {
+            flb_info("[input] resume %s", flb_input_name(ins));
             ins->p->cb_resume(ins->context, ins->config);
         }
     }


### PR DESCRIPTION
This PR covers two issues:
1) This PR corrects the behavior of a reached mem_buf_limit. The plugin used to accept further records even after being paused which leads to https://github.com/fluent/fluent-bit/issues/8198

2) The current `in_emitter` implementation results in ***only one record per chunk*** being created, which is suboptimal. This PR fixes the collector handling: 

Please refer to line:
https://github.com/fluent/fluent-bit/blob/9652b0dc6fd9e59ef87c3bdc59c89da9abed995b/plugins/in_emitter/emitter.c#L165

To validate this observation, please use:
- fluent-bit.conf https://gist.github.com/drbugfinder-work/e5b28ed2c2247c741695eca7c3add110
- multiline_parsers.conf https://gist.github.com/drbugfinder-work/a9979a730fef75242d5cb4058dc93757
- in_emitter_debug_output.diff https://gist.github.com/drbugfinder-work/f5eb5bf175e9a164cf27b954ba41b188

Check the output:

```
[2024/02/09 15:58:22] [trace] [filter:multiline:multiline.0 at /Users/root/Development/fluent-bit-in_emitter/fluent-bit/plugins/filter_multiline/ml.c:177] emitting from dummy.0 to dummy.0
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] did not use ring-buffer
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] Number of existing chunks: 0
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] no candidate chunk found, create a new one for tag: dummy.0
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] new chunk created for tag: dummy.0
[2024/02/09 15:58:22] [trace] [filter:multiline:multiline.0 at /Users/root/Development/fluent-bit-in_emitter/fluent-bit/plugins/filter_multiline/ml.c:740] not processing records from the emitter
[2024/02/09 15:58:22] [debug] [input chunk] update output instances with new chunk size diff=205, records=1, input=emitter_for_multiline.0
[2024/02/09 15:58:22] [trace] [filter:multiline:multiline.0 at /Users/root/Development/fluent-bit-in_emitter/fluent-bit/plugins/filter_multiline/ml.c:177] emitting from dummy.0 to dummy.0
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] did not use ring-buffer
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] Number of existing chunks: 0
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] no candidate chunk found, create a new one for tag: dummy.0
[2024/02/09 15:58:22] [debug] [input:emitter:emitter_for_multiline.0] new chunk created for tag: dummy.0
[2024/02/09 15:58:22] [trace] [filter:multiline:multiline.0 at /Users/root/Development/fluent-bit-in_emitter/fluent-bit/plugins/filter_multiline/ml.c:740] not processing records from the emitter

```
Full logs here: 
- output before PR change: https://gist.github.com/drbugfinder-work/d1e216dd89fee32fe6e8239993b3e390
- output after PR change: https://gist.github.com/drbugfinder-work/0c90824d2a947315d3cef5ce4f1f4360



I'm uncertain if this modification is the correct approach to resolve this issue, as it appears that the ring buffer is unused. This PR is partially reverting some parts to older code version.
However, implementing this does address the behavior of only one record being generated per chunk.

Please also see the valgrind output:
https://gist.github.com/drbugfinder-work/83352c59799659db9741f33a22083eaa



---------------------------------------
### _**Other comments, not directly related to this PR:**_



_Additionally, the entire file appears to require restructuring, as some comments are inaccurate, and the `DEFAULT_EMITTER_RING_BUFFER_FLUSH_FREQUENCY`, which I think should represent a time duration, is instead utilized as a 'buffer size'._

 https://github.com/fluent/fluent-bit/blob/9652b0dc6fd9e59ef87c3bdc59c89da9abed995b/plugins/in_emitter/emitter.c#L245


_The scheduler seems to be empty here, so the ring buffer will never be started (proved by another debug output):_

 https://github.com/fluent/fluent-bit/blob/9652b0dc6fd9e59ef87c3bdc59c89da9abed995b/plugins/in_emitter/emitter.c#L241-L259

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
