### PR TITLE
out_opentelemetry: support metadata key properties

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -1502,32 +1502,32 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "logs_timestamp_metadata_key", "$Timestamp",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_timestamp_metadata_key),
-     "Specify an Timestamp key"
+     "Specify a Timestamp key"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_severity_text_metadata_key", "$SeverityText",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_text_metadata_key),
-     "Specify an SeverityText key"
+     "Specify a SeverityText key"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_severity_number_metadata_key", "$SeverityNumber",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_number_metadata_key),
-     "Specify an SeverityNumber key"
+     "Specify a SeverityNumber key"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_trace_flags_metadata_key", "$TraceFlags",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_trace_flags_metadata_key),
-     "Specify an TraceFlags key"
+     "Specify a TraceFlags key"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_span_id_metadata_key", "$SpanId",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_span_id_metadata_key),
-     "Specify an SpanId key"
+     "Specify a SpanId key"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_trace_id_metadata_key", "$TraceId",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_trace_id_metadata_key),
-     "Specify an TraceId key"
+     "Specify a TraceId key"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_attributes_metadata_key", "$Attributes",
@@ -1542,7 +1542,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "logs_resource_metadata_key", "Resource",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_resource_metadata_key),
-     "Specify an Resource key"
+     "Specify a Resource key"
     },
 
     /* EOF */

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -355,6 +355,15 @@ static void clear_array(Opentelemetry__Proto__Logs__V1__LogRecord **logs,
 
             logs[index]->attributes = NULL;
         }
+        if (logs[index]->severity_text != NULL) {
+            flb_free(logs[index]->severity_text);
+        }
+        if (logs[index]->span_id.data != NULL) {
+            flb_free(logs[index]->span_id.data);
+        }
+        if (logs[index]->trace_id.data != NULL) {
+            flb_free(logs[index]->trace_id.data);
+        }
     }
 }
 
@@ -934,6 +943,147 @@ static int flush_to_otel(struct opentelemetry_context *ctx,
     return ret;
 }
 
+static msgpack_object *get_msgpack_object_from_map(msgpack_object *obj, flb_sds_t key)
+{
+    msgpack_object *ret = NULL;
+    msgpack_object key_obj;
+    int i;
+
+    if (obj == NULL || obj->type != MSGPACK_OBJECT_MAP|| flb_sds_len(key) == 0) {
+        return NULL;
+    }
+    for (i=0; i< obj->via.map.size; i++) {
+        key_obj = obj->via.map.ptr[i].key;
+        if (key_obj.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+        if (flb_sds_len(key) != key_obj.via.str.size) {
+            continue;
+        }
+        if (memcmp(key_obj.via.str.ptr, key, flb_sds_len(key)) == 0) {
+            ret = &obj->via.map.ptr[i].val;
+            break;
+        }
+    }
+    return ret;
+}
+
+/* https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber */
+static int is_valid_severity_text(const char *str, size_t str_len)
+{
+    if (str_len == 5) {
+        if (strncmp("TRACE", str, 5) == 0 ||
+            strncmp("DEBUG", str, 5) == 0 ||
+            strncmp("ERROR", str, 5) == 0 ||
+            strncmp("FATAL", str, 5) == 0) {
+            return FLB_TRUE;
+        }
+    }
+    else if (str_len == 4) {
+        if (strncmp("INFO", str, 4) == 0||
+            strncmp("WARN", str, 4) == 0) {
+            return FLB_TRUE;
+        }
+    }
+    return FLB_FALSE;
+}
+/* https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber */
+static int is_valid_severity_number(uint64_t val)
+{
+    if (val >= 1 && val <= 24) {
+        return FLB_TRUE;
+    }
+    return FLB_FALSE;
+}
+
+static int append_v1_logs_metadata(struct opentelemetry_context *ctx,
+                                   struct flb_log_event *event,
+                                   Opentelemetry__Proto__Logs__V1__LogRecord  *log_record)
+{
+    msgpack_object *obj = NULL;
+
+    if (ctx == NULL || event == NULL || log_record == NULL) {
+        return -1;
+    }
+    /* ObservedTimestamp */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_observed_timestamp_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        log_record->observed_time_unix_nano = obj->via.u64;
+    }
+
+    /* Timestamp */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_timestamp_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        log_record->time_unix_nano = obj->via.u64;
+    }
+    else {
+        log_record->time_unix_nano = flb_time_to_nanosec(&event->timestamp);
+    }
+
+    /* SeverityText */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_severity_text_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_STR &&
+        is_valid_severity_text(obj->via.str.ptr, obj->via.str.size) == FLB_TRUE) {
+        log_record->severity_text = flb_calloc(1, obj->via.str.size+1);
+        if (log_record->severity_text) {
+            strncpy(log_record->severity_text, obj->via.str.ptr, obj->via.str.size);
+        }
+    }
+    else {
+        /* To prevent invalid free */
+        log_record->severity_text = NULL;
+    }
+
+    /* SeverityNumber */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_severity_number_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER &&
+        is_valid_severity_number(obj->via.u64) == FLB_TRUE) {
+        log_record->severity_number = obj->via.u64;
+    }
+
+    /* TraceFlags */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_trace_flags_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        log_record->flags = (uint32_t)obj->via.u64;
+    }
+
+    /* SpanId */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_span_id_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_BIN) {
+        log_record->span_id.data = flb_calloc(1, obj->via.bin.size);
+        if (log_record->span_id.data) {
+            memcpy(log_record->span_id.data, obj->via.bin.ptr, obj->via.bin.size);
+            log_record->span_id.len = obj->via.bin.size;
+        }
+    }
+
+    /* TraceId */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_trace_id_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_BIN) {
+        log_record->trace_id.data = flb_calloc(1, obj->via.bin.size);
+        if (log_record->trace_id.data) {
+            memcpy(log_record->trace_id.data, obj->via.bin.ptr, obj->via.bin.size);
+            log_record->trace_id.len = obj->via.bin.size;
+        }
+    }
+
+    /* Attributes */
+    obj = get_msgpack_object_from_map(event->metadata,
+                                      ctx->logs_attributes_metadata_key);
+    if (obj != NULL && obj->type == MSGPACK_OBJECT_MAP) {
+        log_record->attributes = msgpack_map_to_otlp_kvarray(obj, &log_record->n_attributes);
+    }
+
+    return 0;
+}
+
 static int process_logs(struct flb_event_chunk *event_chunk,
                         struct flb_output_flush *out_flush,
                         struct flb_input_instance *ins, void *out_context,
@@ -986,6 +1136,7 @@ static int process_logs(struct flb_event_chunk *event_chunk,
     while (flb_log_event_decoder_next(decoder, &event) == FLB_EVENT_DECODER_SUCCESS) {
         ra_match = NULL;
         opentelemetry__proto__logs__v1__log_record__init(&log_records[log_record_count]);
+        append_v1_logs_metadata(ctx, &event, &log_records[log_record_count]);
 
         /*
          * Set the record body by using the logic defined in the configuration by
@@ -1012,7 +1163,6 @@ static int process_logs(struct flb_event_chunk *event_chunk,
 
         ret = FLB_OK;
 
-        /* set timestamp */
         log_records[log_record_count].time_unix_nano = flb_time_to_nanosec(&event.timestamp);
         log_record_count++;
 
@@ -1314,7 +1464,6 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Set payload compression mechanism. Option available is 'gzip'"
     },
-
     /*
      * Logs Properties
      * ---------------
@@ -1348,6 +1497,57 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct opentelemetry_context, log_response_payload),
      "Specify if the response paylod should be logged or not"
     },
+    {
+     FLB_CONFIG_MAP_STR, "logs_observed_timestamp_metadata_key", "ObservedTimestamp",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_observed_timestamp_metadata_key),
+     "Specify an ObservedTimestamp key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_timestamp_metadata_key", "Timestamp",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_timestamp_metadata_key),
+     "Specify an Timestamp key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_severity_text_metadata_key", "SeverityText",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_text_metadata_key),
+     "Specify an SeverityText key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_severity_number_metadata_key", "SeverityNumber",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_number_metadata_key),
+     "Specify an SeverityNumber key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_trace_flags_metadata_key", "TraceFlags",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_trace_flags_metadata_key),
+     "Specify an TraceFlags key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_span_id_metadata_key", "SpanId",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_span_id_metadata_key),
+     "Specify an SpanId key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_trace_id_metadata_key", "TraceId",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_trace_id_metadata_key),
+     "Specify an TraceId key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_attributes_metadata_key", "Attributes",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_attributes_metadata_key),
+     "Specify an Attributes key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_instrumentation_scope_metadata_key", "InstrumentationScope",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_instrumentation_scope_metadata_key),
+     "Specify an InstrumentationScope key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_resource_metadata_key", "Resource",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_resource_metadata_key),
+     "Specify an Resource key"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -61,13 +61,29 @@ struct opentelemetry_context {
 
     /* metadata keys */
     flb_sds_t logs_observed_timestamp_metadata_key;
+    struct flb_record_accessor *ra_observed_timestamp_metadata;
+
     flb_sds_t logs_timestamp_metadata_key;
+    struct flb_record_accessor *ra_timestamp_metadata;
+
     flb_sds_t logs_severity_text_metadata_key;
+    struct flb_record_accessor *ra_severity_text_metadata;
+
     flb_sds_t logs_severity_number_metadata_key;
+    struct flb_record_accessor *ra_severity_number_metadata;
+
     flb_sds_t logs_trace_flags_metadata_key;
+    struct flb_record_accessor *ra_trace_flags_metadata;
+
     flb_sds_t logs_span_id_metadata_key;
+    struct flb_record_accessor *ra_span_id_metadata;
+
     flb_sds_t logs_trace_id_metadata_key;
+    struct flb_record_accessor *ra_trace_id_metadata;
+
     flb_sds_t logs_attributes_metadata_key;
+    struct flb_record_accessor *ra_attributes_metadata;
+
     flb_sds_t logs_instrumentation_scope_metadata_key;
     flb_sds_t logs_resource_metadata_key;
 

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -59,6 +59,18 @@ struct opentelemetry_context {
     char *host;
     int port;
 
+    /* metadata keys */
+    flb_sds_t logs_observed_timestamp_metadata_key;
+    flb_sds_t logs_timestamp_metadata_key;
+    flb_sds_t logs_severity_text_metadata_key;
+    flb_sds_t logs_severity_number_metadata_key;
+    flb_sds_t logs_trace_flags_metadata_key;
+    flb_sds_t logs_span_id_metadata_key;
+    flb_sds_t logs_trace_id_metadata_key;
+    flb_sds_t logs_attributes_metadata_key;
+    flb_sds_t logs_instrumentation_scope_metadata_key;
+    flb_sds_t logs_resource_metadata_key;
+
     /* Number of logs to flush at a time */
     int batch_size;
 

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -380,6 +380,47 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         }
     }
 
+    ctx->ra_observed_timestamp_metadata = flb_ra_create((char*)ctx->logs_observed_timestamp_metadata_key,
+                                                        FLB_FALSE);
+    if (ctx->ra_observed_timestamp_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for observed timestamp");
+    }
+    ctx->ra_timestamp_metadata = flb_ra_create((char*)ctx->logs_timestamp_metadata_key,
+                                               FLB_FALSE);
+    if (ctx->ra_timestamp_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for timestamp");
+    }
+    ctx->ra_severity_text_metadata = flb_ra_create((char*)ctx->logs_severity_text_metadata_key,
+                                                   FLB_FALSE);
+    if (ctx->ra_severity_text_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for severity text");
+    }
+    ctx->ra_severity_number_metadata = flb_ra_create((char*)ctx->logs_severity_number_metadata_key,
+                                                   FLB_FALSE);
+    if (ctx->ra_severity_number_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for severity number");
+    }
+    ctx->ra_trace_flags_metadata = flb_ra_create((char*)ctx->logs_trace_flags_metadata_key,
+                                                 FLB_FALSE);
+    if (ctx->ra_trace_flags_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for trace flags");
+    }
+    ctx->ra_span_id_metadata = flb_ra_create((char*)ctx->logs_span_id_metadata_key,
+                                             FLB_FALSE);
+    if (ctx->ra_span_id_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for span id");
+    }
+    ctx->ra_trace_id_metadata = flb_ra_create((char*)ctx->logs_trace_id_metadata_key,
+                                              FLB_FALSE);
+    if (ctx->ra_trace_id_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for trace id");
+    }
+    ctx->ra_attributes_metadata = flb_ra_create((char*)ctx->logs_attributes_metadata_key,
+                                                FLB_FALSE);
+    if (ctx->ra_attributes_metadata == NULL) {
+        flb_plg_error(ins, "failed to create ra for attributes");
+    }
+
     return ctx;
 }
 
@@ -400,6 +441,30 @@ void flb_opentelemetry_context_destroy(struct opentelemetry_context *ctx)
 
     if (ctx->mp_accessor) {
         flb_mp_accessor_destroy(ctx->mp_accessor);
+    }
+    if (ctx->ra_observed_timestamp_metadata) {
+        flb_ra_destroy(ctx->ra_observed_timestamp_metadata);
+    }
+    if (ctx->ra_timestamp_metadata) {
+        flb_ra_destroy(ctx->ra_timestamp_metadata);
+    }
+    if (ctx->ra_severity_text_metadata) {
+        flb_ra_destroy(ctx->ra_severity_text_metadata);
+    }
+    if (ctx->ra_severity_number_metadata) {
+        flb_ra_destroy(ctx->ra_severity_number_metadata);
+    }
+    if (ctx->ra_trace_flags_metadata) {
+        flb_ra_destroy(ctx->ra_trace_flags_metadata);
+    }
+    if (ctx->ra_span_id_metadata) {
+        flb_ra_destroy(ctx->ra_span_id_metadata);
+    }
+    if (ctx->ra_trace_id_metadata) {
+        flb_ra_destroy(ctx->ra_trace_id_metadata);
+    }
+    if (ctx->ra_attributes_metadata) {
+        flb_ra_destroy(ctx->ra_attributes_metadata);
     }
 
     flb_free(ctx->proxy_host);


### PR DESCRIPTION
This patch is to support several metadata key properties to get a OTLP values from metadata.
See also https://github.com/fluent/fluent-bit/pull/8294 and https://github.com/fluent/fluent-bit/issues/8205

|key|Description|Default|
|---|--|---|
|logs_observed_timestamp_metadata_key| Specify an ObservedTimestamp key to look up in the metadata. |ObservedKey|
|logs_timestamp_metadata_key|Specify an Timestamp key to look up in the metadata. |Timestamp|
|logs_severity_key_metadata_key|Specify an SeverityText key to look up in the metadata.|SeverityText|
|logs_severity_number_metadata_key| Specify an SeverityNumber key to look up in the metadata.|SeverityNumber|
|logs_trace_flags_metadata_key|Specify an Flags key to look up in the metadata.|Flags|
|logs_span_id_metadata_key|Specify an SpanId key to look up in the metadata.|SpanId|
|logs_trace_id_metadata_key|Specify an TraceId key to look up in the metadata.|TraceId|
|logs_attributes_metadata_key|Specify an Attributes key to look up in the metadata.|Attributes|

- [X] Timestamp
- [X] ObservedTimestamp
- [X] TraceId
- [X] SpanId
- [X] TraceFlags
- [X] SeverityText
- [X] SeverityNumber
- [ ] Resource
- [ ] InstrumentationScope
- [X] Attributes



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    NAME dummy
    samples 1
    Dummy {"log":"aaaa"}
    Metadata {"ObservedTimestamp":1234, "Timestamp":3456, "SeverityText":"WARN", "SeverityNumber":5, "TraceFlags":13, "Attributes":{"log.file.name":"a.log"}}

[OUTPUT]
    Name   stdout
    Match *

[OUTPUT]
    Name opentelemetry
    Host localhost
    Port 6969
    Match *
```

Config for otelcol-contrib:
```yaml
receivers:
  otlp:
    protocols:
      http:
        endpoint: localhost:6969

exporters:
  file:
    path: 2_out.json

service:
  telemetry:
    logs:
      level: debug
  pipelines:
    logs:
      receivers: [otlp]
      exporters: [file]
```

## Debug/Valgrind output

```
[2024/02/11 12:41:01] [ info] [fluent bit] version=3.0.0, commit=9652b0dc6f, pid=61472
[2024/02/11 12:41:01] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/02/11 12:41:01] [ info] [cmetrics] version=0.6.6
[2024/02/11 12:41:01] [ info] [ctraces ] version=0.4.0
[2024/02/11 12:41:01] [ info] [input:dummy:dummy.0] initializing
[2024/02/11 12:41:01] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/02/11 12:41:02] [ info] [output:stdout:stdout.0] worker #0 started
[2024/02/11 12:41:02] [ info] [sp] stream processor started
[0] dummy.0: [[1707622862.439011464, {"ObservedTimestamp"=>1234, "Timestamp"=>3456, "SeverityText"=>"WARN", "SeverityNumber"=>5, "TraceFlags"=>13, "Attributes"=>{"log.file.name"=>"a.log"}}], {"log"=>"aaaa"}]
[2024/02/11 12:41:03] [ info] [output:opentelemetry:opentelemetry.1] localhost:6969, HTTP status=200


^C[2024/02/11 12:41:05] [engine] caught signal (SIGINT)
[2024/02/11 12:41:05] [ warn] [engine] service will shutdown in max 5 seconds
[2024/02/11 12:41:05] [ info] [input] pausing dummy.0
[2024/02/11 12:41:05] [ info] [engine] service has stopped (0 pending tasks)
[2024/02/11 12:41:05] [ info] [input] pausing dummy.0
[2024/02/11 12:41:05] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/02/11 12:41:05] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==61472== 
==61472== HEAP SUMMARY:
==61472==     in use at exit: 0 bytes in 0 blocks
==61472==   total heap usage: 2,236 allocs, 2,236 frees, 1,002,111 bytes allocated
==61472== 
==61472== All heap blocks were freed -- no leaks are possible
==61472== 
==61472== For lists of detected and suppressed errors, rerun with: -s
```


Output of otelcol-contrib:
```json
{
  "resourceLogs": [
    {
      "resource": {},
      "scopeLogs": [
        {
          "scope": {},
          "logRecords": [
            {
              "timeUnixNano": "3456",
              "observedTimeUnixNano": "1234",
              "severityNumber": 5,
              "severityText": "WARN",
              "body": {
                "kvlistValue": {
                  "values": [
                    {
                      "key": "log",
                      "value": {
                        "stringValue": "aaaa"
                      }
                    }
                  ]
                }
              },
              "attributes": [
                {
                  "key": "log.file.name",
                  "value": {
                    "stringValue": "a.log"
                  }
                }
              ],
              "flags": 13,
              "traceId": "",
              "spanId": ""
            }
          ]
        }
      ]
    }
  ]
}
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
