### PR TITLE
filter_lua: Add chunk mode for processing multiple records

### DIFF
--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -100,5 +100,5 @@ void flb_lua_tompack(lua_State *l,
                      struct flb_lua_l2c_config *l2cc);
 void flb_lua_dump_stack(FILE *out, lua_State *l);
 int flb_lua_enable_flb_null(lua_State *l);
-
+void flb_lua_bulk_process(lua_State *l, struct flb_time *t, msgpack_object *o, int table_index);
 #endif

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -34,6 +34,7 @@ struct lua_filter {
     flb_sds_t call;                   /* function name   */
     flb_sds_t buffer;                 /* json dec buffer */
     int    protected_mode;            /* exec lua function in protected mode */
+    int    chunk_mode;                /* pass whole chunk to lua script */
     int    time_as_table;             /* timestamp as a Lua table */
     int    enable_flb_null;           /* Use flb_null in Lua */
     struct flb_lua_l2c_config l2cc;   /* lua -> C config */

--- a/src/flb_lua.c
+++ b/src/flb_lua.c
@@ -173,7 +173,6 @@ void flb_lua_pushmsgpack(lua_State *l, msgpack_object *o)
     struct flb_lua_metadata meta;
 
     lua_checkstack(l, 3);
-
     switch(o->type) {
         case MSGPACK_OBJECT_NIL:
             lua_getglobal(l, FLB_LUA_VAR_FLB_NULL);
@@ -838,4 +837,24 @@ void flb_lua_dump_stack(FILE *out, lua_State *l)
         print_lua_value(out, l, i, 2);
     }
     fprintf(out, "======\n");
+}
+
+void flb_lua_bulk_process(lua_State *l, struct flb_time *t, msgpack_object *o, int table_index) {
+    int i;
+    struct flb_lua_metadata meta;
+
+    lua_checkstack(l, 3);
+
+    lua_createtable(l, 0, 2);
+
+    lua_pushstring(l, "timestamp");
+    flb_lua_pushtimetable(l, t);
+    lua_rawset(l, -3);
+
+    lua_pushstring(l, "record");
+    flb_lua_pushmsgpack(l, o);
+    lua_rawset(l, -3);
+
+    /* Now, append this table to the global Lua table at the given index */
+    lua_rawseti(l, table_index, lua_objlen(l, table_index) + 1);
 }


### PR DESCRIPTION
This PR will introduce a chunk_mode for lua filter. It can be needed for use cases like parallelization (see lua lanes).

Please note that the lua functions will take only two arguments:

```
function process_records(tag, records)
  if records and type(records) == "table" then
    for i, record_row in ipairs(records) do
        local timestamp = record_row.timestamp
        local record = record_row.record

        print("Timestamp entry:", timestamp.sec, timestamp.nsec)
        print("Record entry:", record.message)
    end
  else
    print("Error: Invalid 'records' table or nil")
  end
  return records
end
```

It's configuration looks like this:
```
[FILTER]
    Name          lua
    Match         my_logs
    script        lanes_example.lua
    call          process_records
    chunk_mode    On
    time_as_table On
```

The returned table must be in the same format (table of timestamp and record pairs).

This mode currently only supports time_as_table by default and does always emit the returned records. There is no return code to be set.


A use case for this can be the parallel execution of lua filters by using the lua lanes library. 
Please see example here (remember to install lua lanes first e.g. `apt install luarocks && luarocks install lanes` and check the path in the lanes_example.lua)

- fluent-bit.conf: https://gist.github.com/drbugfinder-work/63b6992247cfc3f865ee08f01c3d4b64
- lanes_example.lua: https://gist.github.com/drbugfinder-work/252bc103cd8efe6b0153242df8494978

Please see valgrind output:

- https://gist.github.com/drbugfinder-work/54eab5d992c902cc067a07e29d03839e

Documentation PR:
https://github.com/fluent/fluent-bit-docs/pull/1310

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
