### PR TITLE
[out_azure_kusto] fixed deadlock and added granular locks

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -231,6 +231,7 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
      */
     pthread_mutex_init(&ctx->token_mutex, NULL);
     pthread_mutex_init(&ctx->resources_mutex, NULL);
+    pthread_mutex_init(&ctx->blob_mutex, NULL);
 
     /*
      * Create upstream context for Kusto Ingestion endpoint
@@ -416,6 +417,10 @@ static int cb_azure_kusto_exit(void *data, struct flb_config *config)
         flb_upstream_destroy(ctx->u);
         ctx->u = NULL;
     }
+
+    pthread_mutex_destroy(&ctx->resources_mutex);
+    pthread_mutex_destroy(&ctx->token_mutex);
+    pthread_mutex_destroy(&ctx->blob_mutex);
 
     flb_azure_kusto_conf_destroy(ctx);
 

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -94,6 +94,9 @@ struct flb_azure_kusto {
     /* mutex for loading reosurces */
     pthread_mutex_t resources_mutex;
 
+    /* mutex for kusto blob operations */
+    pthread_mutex_t blob_mutex;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
