### PR TITLE
[out_azure_kusto] azure kusto ingestion resources dynamic parsing

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -160,8 +160,7 @@ static int parse_storage_resources(struct flb_azure_kusto *ctx, struct flb_confi
 {
     jsmn_parser parser;
     jsmntok_t *t;
-    jsmntok_t *tokens;
-    int tok_size = 100;
+    jsmntok_t *tokens = NULL;
     int ret = -1;
     int i;
     int blob_count = 0;
@@ -172,6 +171,7 @@ static int parse_storage_resources(struct flb_azure_kusto *ctx, struct flb_confi
     struct flb_upstream_node *node;
     struct flb_upstream_ha *ha;
     flb_sds_t resource_uri;
+    int token_size = flb_sds_len(response);
 
     /* Response is a json in the form of
      * {
@@ -199,10 +199,12 @@ static int parse_storage_resources(struct flb_azure_kusto *ctx, struct flb_confi
     }
 
     jsmn_init(&parser);
-    tokens = flb_calloc(1, sizeof(jsmntok_t) * tok_size);
+
+    /* Dynamically allocate memory for tokens based on response length */
+    tokens = flb_calloc(1, sizeof(jsmntok_t) * token_size);
 
     if (tokens) {
-        ret = jsmn_parse(&parser, response, flb_sds_len(response), tokens, tok_size);
+        ret = jsmn_parse(&parser, response, flb_sds_len(response), tokens, token_size);
 
         if (ret > 0) {
             /* skip all tokens until we reach "Rows" */


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
