### PR TITLE
engine: free after log worker thread has been stopped

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -390,12 +390,12 @@ void flb_config_exit(struct flb_config *config)
     struct mk_list *head;
     struct flb_cf *cf;
 
-    if (config->log_file) {
-        flb_free(config->log_file);
-    }
-
     if (config->log) {
         flb_log_destroy(config->log, config);
+    }
+
+    if (config->log_file) {
+        flb_free(config->log_file);
     }
 
     if (config->parsers_file) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the current code, `config->log_file` may be referenced in the `log_push` function after it is freed. This fix frees `log_file` after calling `flb_log_destroy` function so that it waits for `log_worker_collector` function to exit.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8429 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[valgrind.log](https://github.com/fluent/fluent-bit/files/14294441/valgrind.log)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
