### PR TITLE
out_http: default the output format to JSON.

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -186,7 +186,7 @@ static int http_post(struct flb_out_http *ctx,
                             FLB_HTTP_MIME_JSON,
                             sizeof(FLB_HTTP_MIME_JSON) - 1);
     }
-    else {
+    else if ((ctx->out_format == FLB_HTTP_OUT_MSGPACK)) {
         flb_http_add_header(c,
                             FLB_HTTP_CONTENT_TYPE,
                             sizeof(FLB_HTTP_CONTENT_TYPE) - 1,
@@ -665,8 +665,8 @@ static struct flb_config_map config_map[] = {
      "Set a HTTP header which value is the Tag"
     },
     {
-     FLB_CONFIG_MAP_STR, "format", NULL,
-     0, FLB_FALSE, 0,
+     FLB_CONFIG_MAP_STR, "format", "json",
+     0, FLB_TRUE, offsetof(struct flb_out_http, format),
      "Set desired payload format: json, json_stream, json_lines, gelf or msgpack"
     },
     {

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -55,6 +55,7 @@ struct flb_out_http {
 
     /* Output format */
     int out_format;
+    flb_sds_t format;
 
     int json_date_format;
     flb_sds_t json_date_key;

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -208,13 +208,15 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
 
     /* Output format */
     ctx->out_format = FLB_PACK_JSON_FORMAT_NONE;
-    tmp = flb_output_get_property("format", ins);
-    if (tmp) {
-        if (strcasecmp(tmp, "gelf") == 0) {
+    if (ctx->format) {
+        if (strcasecmp(ctx->format, "gelf") == 0) {
             ctx->out_format = FLB_HTTP_OUT_GELF;
         }
+        else if (strcasecmp(ctx->format, "msgpack") == 0) {
+            ctx->out_format = FLB_HTTP_OUT_MSGPACK;
+        }
         else {
-            ret = flb_pack_to_json_format_type(tmp);
+            ret = flb_pack_to_json_format_type(ctx->format);
             if (ret == -1) {
                 flb_plg_error(ctx->ins, "unrecognized 'format' option. "
                               "Using 'msgpack'");


### PR DESCRIPTION
# Summary

Default `out_http` to JSON format so it works with in_http. Setting the output format to msgpack is still possible by setting it manually.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
