### PR TITLE
in_head: fix buffer length for split_line

### DIFF
--- a/plugins/in_head/in_head.c
+++ b/plugins/in_head/in_head.c
@@ -223,7 +223,7 @@ static int split_lines_per_record(struct flb_input_instance *i_ins,
             ret = flb_log_event_encoder_append_body_values(
                     &ctx->log_encoder,
                     FLB_LOG_EVENT_CSTRING_VALUE(key_str),
-                    FLB_LOG_EVENT_STRING_VALUE(ctx->buf, ctx->buf_len));
+                    FLB_LOG_EVENT_STRING_VALUE(ctx->buf, str_len));
         }
     }
 


### PR DESCRIPTION
"split_line" of in_head doesn't work at least v2.1.2.
in_head outputs blank value.

This patch is  to fix this issue.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
pipeline:
    inputs:
        - name: head
          tag: head.cpu
          file: /proc/cpuinfo
          lines: 8
          split_line: true
    filters:
        - name: record_modifier
          match: '*'
          whitelist_key: line7
    outputs:
        - name: stdout
          match: '*'
```

## Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c a.yaml 
==17085== Memcheck, a memory error detector
==17085== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17085== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==17085== Command: bin/fluent-bit -c a.yaml
==17085== 
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/02/25 10:37:52] [ info] [fluent bit] version=3.0.0, commit=f1bbae6084, pid=17085
[2024/02/25 10:37:52] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/02/25 10:37:52] [ info] [cmetrics] version=0.6.6
[2024/02/25 10:37:52] [ info] [ctraces ] version=0.4.0
[2024/02/25 10:37:52] [ info] [input:head:head.0] initializing
[2024/02/25 10:37:52] [ info] [input:head:head.0] storage_strategy='memory' (memory only)
[2024/02/25 10:37:52] [ info] [output:stdout:stdout.0] worker #0 started
[2024/02/25 10:37:52] [ info] [sp] stream processor started
[0] head.cpu: [[1708825073.008924105, {}], {"line7"=>"cache size	: 512 KB"}]
^C[2024/02/25 10:37:54] [engine] caught signal (SIGINT)
[2024/02/25 10:37:54] [ warn] [engine] service will shutdown in max 5 seconds
[0] head.cpu: [[1708825074.015178729, {}], {"line7"=>"cache size	: 512 KB"}]
[2024/02/25 10:37:54] [ info] [input] pausing head.0
[2024/02/25 10:37:54] [ info] [engine] service has stopped (0 pending tasks)
[2024/02/25 10:37:54] [ info] [input] pausing head.0
[2024/02/25 10:37:55] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/02/25 10:37:55] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==17085== 
==17085== HEAP SUMMARY:
==17085==     in use at exit: 0 bytes in 0 blocks
==17085==   total heap usage: 1,992 allocs, 1,992 frees, 1,186,739 bytes allocated
==17085== 
==17085== All heap blocks were freed -- no leaks are possible
==17085== 
==17085== For lists of detected and suppressed errors, rerun with: -s
==17085== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
