### PR TITLE
processor: Implement native processor metrics_selector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ option(FLB_FILTER_GEOIP2               "Enable geoip2 filter"                   
 option(FLB_FILTER_NIGHTFALL            "Enable Nightfall filter"                      Yes)
 option(FLB_FILTER_WASM                 "Enable WASM filter"                           Yes)
 option(FLB_PROCESSOR_LABELS            "Enable metrics label manipulation processor"  Yes)
-option(FLB_PROCESSOR_ATTRIBUTES        "Enable atributes manipulation processor"      Yes)
+option(FLB_PROCESSOR_METRICS_SELECTOR  "Enable metrics selector processor"            Yes)
 option(FLB_PROCESSOR_CONTENT_MODIFIER  "Enable content modifier processor"            Yes)
 
 if(DEFINED FLB_NIGHTLY_BUILD AND NOT "${FLB_NIGHTLY_BUILD}" STREQUAL "")

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -46,11 +46,15 @@ struct flb_lib_out_cb {
 /* For Fluent Bit library callers, we only export the following symbols */
 typedef struct flb_lib_ctx         flb_ctx_t;
 
+struct flb_processor;
+
 FLB_EXPORT void flb_init_env();
 FLB_EXPORT flb_ctx_t *flb_create();
 FLB_EXPORT void flb_destroy(flb_ctx_t *ctx);
 FLB_EXPORT int flb_input(flb_ctx_t *ctx, const char *input, void *data);
+FLB_EXPORT int flb_input_set_processor(flb_ctx_t *ctx, int ffd, struct flb_processor *proc);
 FLB_EXPORT int flb_output(flb_ctx_t *ctx, const char *output, struct flb_lib_out_cb *cb);
+FLB_EXPORT int flb_output_set_processor(flb_ctx_t *ctx, int ffd, struct flb_processor *proc);
 FLB_EXPORT int flb_filter(flb_ctx_t *ctx, const char *filter, void *data);
 FLB_EXPORT int flb_input_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_input_property_check(flb_ctx_t *ctx, int ffd, char *key, char *val);

--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -39,6 +39,7 @@
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_encode_splunk_hec.h>
 #include <cmetrics/cmt_encode_cloudwatch_emf.h>
+#include <cmetrics/cmt_filter.h>
 
 /* Metrics IDs for general purpose (used by core and Plugins */
 #define FLB_METRIC_N_RECORDS   0

--- a/include/fluent-bit/flb_processor.h
+++ b/include/fluent-bit/flb_processor.h
@@ -143,7 +143,8 @@ struct flb_processor_plugin {
                             int);
 
     int (*cb_process_metrics) (struct flb_processor_instance *,
-                               struct cmt *,
+                               struct cmt *, /* in */
+                               struct cmt **, /* out */
                                const char *,
                                int);
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -282,6 +282,7 @@ REGISTER_IN_PLUGIN("in_random")
 # PROCESSORS
 # ==========
 REGISTER_PROCESSOR_PLUGIN("processor_labels")
+REGISTER_PROCESSOR_PLUGIN("processor_metrics_selector")
 REGISTER_PROCESSOR_PLUGIN("processor_content_modifier")
 
 # OUTPUTS

--- a/plugins/processor_labels/labels.c
+++ b/plugins/processor_labels/labels.c
@@ -1696,14 +1696,22 @@ static int hash_labels(struct cmt *metrics_context,
 
 static int cb_process_metrics(struct flb_processor_instance *processor_instance,
                               struct cmt *metrics_context,
+                              struct cmt **out_context,
                               const char *tag,
                               int tag_len)
 {
+    struct cmt                        *out_cmt;
     struct internal_processor_context *processor_context;
     int                                result;
 
     processor_context =
         (struct internal_processor_context *) processor_instance->context;
+
+    out_cmt = cmt_create();
+    if (out_cmt == NULL) {
+        flb_plg_error(processor_instance, "could not create out_cmt context");
+        return FLB_PROCESSOR_FAILURE;
+    }
 
     result = delete_labels(metrics_context,
                            &processor_context->delete_labels);
@@ -1726,6 +1734,17 @@ static int cb_process_metrics(struct flb_processor_instance *processor_instance,
     if (result == FLB_PROCESSOR_SUCCESS) {
         result = hash_labels(metrics_context,
                              &processor_context->hash_labels);
+    }
+
+    if (result == FLB_PROCESSOR_SUCCESS) {
+        result = cmt_cat(out_cmt, metrics_context);
+        if (result != 0) {
+            cmt_destroy(out_cmt);
+
+            return FLB_PROCESSOR_FAILURE;
+        }
+
+        *out_context = out_cmt;
     }
 
     if (result != FLB_PROCESSOR_SUCCESS) {

--- a/plugins/processor_metrics_selector/CMakeLists.txt
+++ b/plugins/processor_metrics_selector/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src
+  selector.c)
+
+FLB_PLUGIN(processor_metrics_selector "${src}" "")

--- a/plugins/processor_metrics_selector/selector.c
+++ b/plugins/processor_metrics_selector/selector.c
@@ -1,0 +1,394 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+#include <sys/types.h>
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_processor_plugin.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_metrics.h>
+#include <msgpack.h>
+
+#include "selector.h"
+
+static void delete_metrics_rules(struct selector_ctx *ctx)
+{
+    if (ctx->name_regex != NULL) {
+        flb_regex_destroy(ctx->name_regex);
+    }
+}
+
+static void destroy_context(struct selector_ctx *context)
+{
+    if (context != NULL) {
+        delete_metrics_rules(context);
+        flb_free(context->selector_pattern);
+        flb_free(context);
+    }
+}
+
+static int set_metrics_rules(struct selector_ctx *ctx, struct flb_processor_instance *p_ins)
+{
+    const char *action;
+    const char *metric_name;
+    const char *op_type;
+    const char *context;
+    size_t name_len = 0;
+
+    action = flb_processor_instance_get_property("action", p_ins);
+    if (action == NULL) {
+        ctx->action_type = SELECTOR_INCLUDE;
+    }
+    else if (strncasecmp(action, "include", 7) == 0) {
+        flb_plg_debug(ctx->ins, "action type INCLUDE");
+        ctx->action_type = SELECTOR_INCLUDE;
+    }
+    else if (strncasecmp(action, "exclude", 7) == 0) {
+        flb_plg_debug(ctx->ins, "action type EXCLUDE");
+        ctx->action_type = SELECTOR_EXCLUDE;
+    }
+    else {
+        flb_plg_error(ctx->ins, "unknown action type '%s'", action);
+        return -1;
+    }
+
+    metric_name = flb_processor_instance_get_property("metric_name", p_ins);
+    if (metric_name == NULL) {
+        flb_plg_error(ctx->ins, "metric_name is needed for selector");
+        return -1;
+    }
+    ctx->selector_pattern = flb_strdup(metric_name);
+    name_len = strlen(metric_name);
+
+    op_type = flb_processor_instance_get_property("operation_type", p_ins);
+    if (op_type == NULL) {
+        ctx->op_type = SELECTOR_OPERATION_PREFIX;
+    }
+    else if (strncasecmp(op_type, "prefix", 6) == 0) {
+        flb_plg_debug(ctx->ins, "operation type PREFIX");
+        ctx->op_type = SELECTOR_OPERATION_PREFIX;
+    }
+    else if (strncasecmp(op_type, "substring", 9) == 0) {
+        flb_plg_debug(ctx->ins, "operation type SUBSTRING");
+        ctx->op_type = SELECTOR_OPERATION_SUBSTRING;
+    }
+    else {
+        flb_plg_error(ctx->ins, "unknown action type '%s'", op_type);
+        return -1;
+    }
+
+    if (ctx->selector_pattern[0] == '/' && ctx->selector_pattern[name_len-1] == '/') {
+        /* Convert string to regex pattern for metrics */
+        ctx->name_regex = flb_regex_create(ctx->selector_pattern);
+        if (!ctx->name_regex) {
+            flb_plg_error(ctx->ins, "could not compile regex pattern '%s'",
+                          ctx->selector_pattern);
+            return -1;
+        }
+        ctx->op_type = SELECTOR_OPERATION_REGEX;
+    }
+
+    context = flb_processor_instance_get_property("context", p_ins);
+    if (context == NULL) {
+        ctx->context_type = SELECTOR_CONTEXT_FQNAME;
+    }
+    else if (strncasecmp(context, "metric_name", 11) == 0) {
+        ctx->context_type = SELECTOR_CONTEXT_FQNAME;
+    }
+    else {
+        flb_plg_error(ctx->ins, "unknown context '%s'", context);
+        delete_metrics_rules(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+static struct selector_ctx *
+        create_context(struct flb_processor_instance *processor_instance,
+                       struct flb_config *config)
+{
+    int result;
+    struct selector_ctx *ctx;
+
+    ctx = flb_malloc(sizeof(struct selector_ctx));
+    if (ctx != NULL) {
+        ctx->ins = processor_instance;
+        ctx->config = config;
+        ctx->name_regex = NULL;
+
+        result = flb_processor_instance_config_map_set(processor_instance, (void *) ctx);
+
+        if (result == 0) {
+            /* Load rules */
+            result= set_metrics_rules(ctx, processor_instance);
+            if (result == -1) {
+                destroy_context(ctx);
+                ctx = NULL;
+
+                return ctx;
+            }
+        }
+
+        if (result != 0) {
+            destroy_context(ctx);
+
+            ctx = NULL;
+        }
+    }
+    else {
+        flb_errno();
+    }
+
+    return ctx;
+}
+
+
+static int cb_selector_init(struct flb_processor_instance *processor_instance,
+                            void *source_plugin_instance,
+                            int source_plugin_type,
+                            struct flb_config *config)
+{
+    /* Create context */
+    processor_instance->context = (void *) create_context(
+                                            processor_instance, config);
+
+    if (processor_instance->context == NULL) {
+        return FLB_PROCESSOR_FAILURE;
+    }
+
+    return FLB_PROCESSOR_SUCCESS;
+}
+
+#ifdef FLB_HAVE_METRICS
+static int cmt_regex_match(void *ctx, const char *str, size_t slen)
+{
+    int ret;
+    struct flb_regex *r = (struct flb_regex *)ctx;
+    unsigned char *s = (unsigned char *)str;
+    ret = flb_regex_match(r, s, slen);
+
+    if (ret == 1) {
+        ret = CMT_TRUE;
+    }
+    else {
+        ret = CMT_FALSE;
+    }
+
+    return ret;
+}
+
+static int cmt_regex_exclude(void *ctx, const char *str, size_t slen)
+{
+    int ret;
+    struct flb_regex *r = (struct flb_regex *)ctx;
+    unsigned char *s = (unsigned char *)str;
+    ret = flb_regex_match(r, s, slen);
+
+    if (ret == 1) {
+        ret = CMT_FALSE;
+    }
+    else {
+        ret = CMT_TRUE;
+    }
+
+    return ret;
+}
+
+static inline int selector_metrics_process_fqname(struct cmt *cmt, struct cmt *out_cmt,
+                                                  struct selector_ctx *ctx)
+{
+    int ret;
+    int found = FLB_FALSE;
+    struct cmt *filtered = NULL;
+    int flags = 0;
+
+    /* On processor_selector, we only process one rule in each of contexts */
+
+    filtered = cmt_create();
+    if (filtered == NULL) {
+        flb_plg_error(ctx->ins, "could not create filtered context");
+
+        return SELECTOR_FAILURE;
+    }
+
+    if (ctx->op_type == SELECTOR_OPERATION_REGEX) {
+        if (ctx->action_type == SELECTOR_INCLUDE) {
+            ret = cmt_filter(filtered, cmt, NULL, NULL, ctx->name_regex, cmt_regex_match, 0);
+        }
+        else if (ctx->action_type == SELECTOR_EXCLUDE) {
+            ret = cmt_filter(filtered, cmt, NULL, NULL, ctx->name_regex, cmt_regex_exclude, 0);
+        }
+    }
+    else if (ctx->selector_pattern != NULL) {
+        if (ctx->action_type == SELECTOR_EXCLUDE) {
+            flags |= CMT_FILTER_EXCLUDE;
+        }
+
+        if (ctx->op_type == SELECTOR_OPERATION_PREFIX) {
+            flags |= CMT_FILTER_PREFIX;
+        }
+        else if (ctx->op_type == SELECTOR_OPERATION_SUBSTRING) {
+            flags |= CMT_FILTER_SUBSTRING;
+        }
+
+        ret = cmt_filter(filtered, cmt, ctx->selector_pattern, NULL, NULL, NULL, flags);
+    }
+
+    if (ret == 0) {
+        found = FLB_TRUE;
+    }
+    else if (ret != 0) {
+        flb_plg_debug(ctx->ins, "not matched for rule = \"%s\"", ctx->selector_pattern);
+    }
+
+    cmt_cat(out_cmt, filtered);
+    cmt_destroy(filtered);
+
+    if (ctx->action_type == SELECTOR_INCLUDE) {
+        return found ? SELECTOR_RET_KEEP : SELECTOR_RET_EXCLUDE;
+    }
+
+    /* The last rule is exclude */
+    return found ? SELECTOR_RET_EXCLUDE : SELECTOR_RET_KEEP;
+}
+
+/* Given a metrics context, do some select action based on the defined rules */
+static inline int selector_metrics(struct cmt *cmt, struct cmt *out_cmt,
+                                   struct selector_ctx *ctx)
+{
+    if (ctx->context_type == SELECTOR_CONTEXT_FQNAME) {
+        return selector_metrics_process_fqname(cmt, out_cmt, ctx);
+    }
+
+    return 0;
+}
+
+static int process_metrics(struct flb_processor_instance *processor_instance,
+                           struct cmt *metrics_context,
+                           struct cmt **out_context,
+                           const char *tag,
+                           int tag_len)
+{
+    int ret;
+    struct selector_ctx *ctx;
+    struct cmt *out_cmt;
+
+    ctx = (struct selector_ctx *) processor_instance->context;
+
+    out_cmt = cmt_create();
+    if (out_cmt == NULL) {
+        flb_plg_error(processor_instance, "could not create out_cmt context");
+        return SELECTOR_FAILURE;
+    }
+
+    ret = selector_metrics(metrics_context, out_cmt, ctx);
+
+    if (ret == SELECTOR_RET_KEEP || ret == SELECTOR_RET_EXCLUDE) {
+        ret = SELECTOR_SUCCESS;
+        *out_context = out_cmt;
+    }
+    else {
+        /* destroy out_context contexts */
+        cmt_destroy(out_cmt);
+
+        ret = SELECTOR_FAILURE;
+    }
+
+    return ret;
+}
+#endif
+
+static int cb_selector_process_metrics(struct flb_processor_instance *processor_instance,
+                                       struct cmt *metrics_context,
+                                       struct cmt **out_context,
+                                       const char *tag,
+                                       int tag_len)
+{
+    int result = SELECTOR_SUCCESS;
+
+#ifdef FLB_HAVE_METRICS
+    result = process_metrics(processor_instance,
+                             metrics_context,
+                             out_context,
+                             tag, tag_len);
+#endif
+
+    if (result != SELECTOR_SUCCESS) {
+        return FLB_PROCESSOR_FAILURE;
+    }
+
+    return FLB_PROCESSOR_SUCCESS;
+}
+
+static int cb_selector_exit(struct flb_processor_instance *processor_instance)
+{
+    if (processor_instance != NULL &&
+        processor_instance->context != NULL) {
+        destroy_context(processor_instance->context);
+    }
+
+    return FLB_PROCESSOR_SUCCESS;
+}
+
+static struct flb_config_map config_map[] = {
+    {
+     FLB_CONFIG_MAP_STR, "metric_name", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Keep metrics in which the metric of name matches with the actual name or the regular expression."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "context", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Specify matching context. Currently, metric_name is only supported."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "action", NULL,
+     0, FLB_FALSE, 0,
+     "Specify the action for specified metrics. INCLUDE and EXCLUDE are allowed."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "operation_type", NULL,
+     0, FLB_FALSE, 0,
+     "Specify the operation type of action for metrics payloads. PREFIX and SUBSTRING are allowed."
+    },    /* EOF */
+    {0}
+};
+
+struct flb_processor_plugin processor_metrics_selector_plugin = {
+    .name               = "metrics_selector",
+    .description        = "select metrics by specified name",
+    .cb_init            = cb_selector_init,
+    .cb_process_logs    = NULL,
+    .cb_process_metrics = cb_selector_process_metrics,
+    .cb_process_traces  = NULL,
+    .cb_exit            = cb_selector_exit,
+    .config_map         = config_map,
+    .flags              = 0
+};

--- a/plugins/processor_metrics_selector/selector.h
+++ b/plugins/processor_metrics_selector/selector.h
@@ -1,0 +1,63 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PROCESSOR_SELECTOR_H
+#define FLB_PROCESSOR_SELECTOR_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_processor_plugin.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_record_accessor.h>
+
+/* rule types */
+#define SELECTOR_NO_RULE  0
+#define SELECTOR_INCLUDE  1
+#define SELECTOR_EXCLUDE  2
+
+/* actions */
+#define SELECTOR_RET_KEEP     0
+#define SELECTOR_RET_EXCLUDE  1
+
+#define SELECTOR_SUCCESS   0
+#define SELECTOR_NOTOUCH   1
+#define SELECTOR_FAILURE   2
+
+#define SELECTOR_OPERATION_REGEX     0
+#define SELECTOR_OPERATION_PREFIX    1
+#define SELECTOR_OPERATION_SUBSTRING 2
+
+/* context */
+#define SELECTOR_CONTEXT_FQNAME 0
+#define SELECTOR_CONTEXT_LABELS 1
+#define SELECTOR_CONTEXT_DESC   2
+
+struct selector_ctx {
+    struct mk_list metrics_rules;
+    flb_sds_t action;
+    int action_type;
+    int op_type;
+    int context_type;
+    char *selector_pattern;
+    struct flb_regex *name_regex;
+    struct flb_processor_instance *ins;
+    struct flb_config *config;
+};
+
+#endif

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -329,6 +329,24 @@ int flb_input_set(flb_ctx_t *ctx, int ffd, ...)
     return 0;
 }
 
+int flb_input_set_processor(flb_ctx_t *ctx, int ffd, struct flb_processor *proc)
+{
+    struct flb_input_instance *i_ins;
+
+    i_ins = in_instance_get(ctx, ffd);
+    if (!i_ins) {
+        return -1;
+    }
+
+    if (i_ins->processor) {
+        flb_processor_destroy(i_ins->processor);
+    }
+
+    i_ins->processor = proc;
+
+    return 0;
+}
+
 static inline int flb_config_map_property_check(char *plugin_name, struct mk_list *config_map, char *key, char *val)
 {
     struct flb_kv *kv;
@@ -462,6 +480,24 @@ int flb_output_set(flb_ctx_t *ctx, int ffd, ...)
     }
 
     va_end(va);
+    return 0;
+}
+
+int flb_output_set_processor(flb_ctx_t *ctx, int ffd, struct flb_processor *proc)
+{
+    struct flb_output_instance *o_ins;
+
+    o_ins = out_instance_get(ctx, ffd);
+    if (!o_ins) {
+        return -1;
+    }
+
+    if (o_ins->processor) {
+        flb_processor_destroy(o_ins->processor);
+    }
+
+    o_ins->processor = proc;
+
     return 0;
 }
 

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -430,9 +430,9 @@ int flb_processor_run(struct flb_processor *proc,
 {
     int ret;
     int finalize;
-    void *cur_buf;
+    void *cur_buf = NULL;
     size_t cur_size;
-    void *tmp_buf;
+    void *tmp_buf = NULL;
     size_t tmp_size;
     struct mk_list *head;
     struct mk_list *list = NULL;
@@ -640,6 +640,7 @@ int flb_processor_run(struct flb_processor *proc,
                 if (p_ins->p->cb_process_metrics != NULL) {
                     ret = p_ins->p->cb_process_metrics(p_ins,
                                                        (struct cmt *) cur_buf,
+                                                       (struct cmt **) &tmp_buf,
                                                        tag,
                                                        tag_len);
 
@@ -648,8 +649,16 @@ int flb_processor_run(struct flb_processor *proc,
                                      FLB_PROCESSOR_LOCK_RETRY_LIMIT,
                                      FLB_PROCESSOR_LOCK_RETRY_DELAY);
 
+                        out_buf = NULL;
+
                         return -1;
                     }
+
+                    if (cur_buf != data) {
+                        cmt_destroy(cur_buf);
+                    }
+
+                    cur_buf = (void *)tmp_buf;
                 }
             }
             else if (type == FLB_PROCESSOR_TRACES) {

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -130,6 +130,9 @@ if (FLB_CUSTOM_CALYPTIA)
   FLB_RT_TEST(FLB_CUSTOM_CALYPTIA "custom_calyptia_test.c")
 endif()
 
+if (FLB_PROCESSOR_METRICS_SELECTOR)
+  FLB_RT_TEST(FLB_PROCESSOR_METRICS_SELECTOR "processor_metrics_selector.c")
+endif()
 
 # HTTP Client Debug (requires -DFLB_HTTP_CLIENT_DEBUG=On)
 if(FLB_HTTP_CLIENT_DEBUG)

--- a/tests/runtime/processor_metrics_selector.c
+++ b/tests/runtime/processor_metrics_selector.c
@@ -1,0 +1,565 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_runtime.h"
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int  num_output = 0;
+
+static int cb_count_metrics_msgpack(void *record, size_t size, void *data)
+{
+    int i;
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text = NULL;
+    struct cmt *cmt = NULL;
+    char *p;
+
+    if (!TEST_CHECK(data != NULL)) {
+        flb_error("data is NULL");
+    }
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return -1;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+    /* To inspect the metrics from the callback, just comment out below: */
+    /* flb_info("[filter_grep][test] text = %s", text); */
+    for (i = 0; i < strlen(text); i++) {
+        p = (char *)(text + i);
+        if (*p == '\n') {
+            num_output++;
+        }
+    }
+
+    if (record) {
+        flb_free(record);
+    }
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+
+    cmt_encode_text_destroy(text);
+
+    return 0;
+}
+
+
+static void clear_output_num()
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = 0;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+#ifdef FLB_HAVE_METRICS
+void flb_test_selector_regex_include(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "/storage/",
+    };
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "include",
+    };
+    int got;
+    int n_metrics = 12;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "metric_name", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "action", &action);
+    TEST_CHECK(ret == 0);
+
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_selector_regex_exclude(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "/input/",
+    };
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "exclude",
+    };
+    int got;
+    int n_metrics = 19;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "metric_name", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "action", &action);
+    TEST_CHECK(ret == 0);
+
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_selector_prefix_include(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "fluentbit_input",
+    };
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "include",
+    };
+    struct cfl_variant op_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "prefix",
+    };
+    int got;
+    int n_metrics = 11;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "metric_name", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "operation_type", &op_type);
+    TEST_CHECK(ret == 0);
+
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_selector_prefix_exclude(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "fluentbit_storage",
+    };
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "exclude",
+    };
+    struct cfl_variant op_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "prefix",
+    };
+    int got;
+    int n_metrics = 25;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "metric_name", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "operation_type", &op_type);
+    TEST_CHECK(ret == 0);
+
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_selector_substring_include(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "dropped",
+    };
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "include",
+    };
+    struct cfl_variant op_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "substring",
+    };
+    int got;
+    int n_metrics = 1;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "metric_name", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "operation_type", &op_type);
+    TEST_CHECK(ret == 0);
+
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_selector_substring_exclude(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "connections",
+    };
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "exclude",
+    };
+    struct cfl_variant op_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "substring",
+    };
+    int got;
+    int n_metrics = 28;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "metric_name", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "operation_type", &op_type);
+    TEST_CHECK(ret == 0);
+
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+#endif
+
+/* Test list */
+TEST_LIST = {
+#ifdef FLB_HAVE_METRICS
+    {"regex_include", flb_test_selector_regex_include},
+    {"regex_exclude", flb_test_selector_regex_exclude},
+    {"prefix_include", flb_test_selector_prefix_include},
+    {"prefix_exclude", flb_test_selector_prefix_exclude},
+    {"substring_include", flb_test_selector_substring_include},
+    {"substring_exclude", flb_test_selector_substring_exclude},
+#endif
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
For processing metrics, we need to move using processors because there is less motivations in the current implementation to use processors based pipeline.
If we provide filtering feature on this mechanism, users want to use processors from the classic configuration.

Also, ordinary filters are intended to use non-processor world due to msgpack based ingestion on ingesting filters. This is really hard to distinguish which types of events: logs, metrics, and traces.
Instead, the interface of processor provides easily to be able to distinguish three types of events.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
  flush: 5
  daemon: off
  log_level:  debug

pipeline:
  inputs:
    - name: fluentbit_metrics
      tag: fluentbit.metrics
      scrape_interval: 10

      processors:
        metrics:
          - name: metrics_selector
            metric_name: /storage/
            action: include
          - name: metrics_selector
            metric_name: /fs/
            action: exclude

          - name: labels
            delete: name


  outputs:
    - name: stdout
      match: '*'
```
- [x] Debug log output from testing the change
```log
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/02/27 14:49:56] [ info] Configuration:
[2024/02/27 14:49:56] [ info]  flush time     | 5.000000 seconds
[2024/02/27 14:49:56] [ info]  grace          | 5 seconds
[2024/02/27 14:49:56] [ info]  daemon         | 0
[2024/02/27 14:49:56] [ info] ___________
[2024/02/27 14:49:56] [ info]  inputs:
[2024/02/27 14:49:56] [ info]      fluentbit_metrics
[2024/02/27 14:49:56] [ info] ___________
[2024/02/27 14:49:56] [ info]  filters:
[2024/02/27 14:49:56] [ info] ___________
[2024/02/27 14:49:56] [ info]  outputs:
[2024/02/27 14:49:56] [ info]      stdout.0
[2024/02/27 14:49:56] [ info] ___________
[2024/02/27 14:49:56] [ info]  collectors:
[2024/02/27 14:49:56] [ info] [fluent bit] version=3.0.0, commit=f9ed76af1b, pid=997805
[2024/02/27 14:49:56] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/02/27 14:49:56] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/02/27 14:49:56] [ info] [cmetrics] version=0.7.0
[2024/02/27 14:49:56] [ info] [ctraces ] version=0.4.0
[2024/02/27 14:49:56] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2024/02/27 14:49:56] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2024/02/27 14:49:56] [ info] [output:stdout:stdout.0] worker #0 started
[2024/02/27 14:49:56] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2024/02/27 14:49:56] [ info] [processor:selector:selector.0] OR mode
[2024/02/27 14:49:56] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/02/27 14:49:56] [ info] [sp] stream processor started
[2024/02/27 14:50:06] [debug] [input chunk] update output instances with new chunk size diff=3314, records=0, input=fluentbit_metrics.0
[2024/02/27 14:50:11] [debug] [task] created task=0x6195f70 id=0 OK
2024-02-27T05:50:06.314435517Z fluentbit_uptime{hostname="cosmo-desktop2"} = 10
2024-02-27T05:49:56.491818462Z fluentbit_input_bytes_total = 0
2024-02-27T05:49:56.491818462Z fluentbit_input_records_total = 0
2024-02-27T05:50:06.310958339Z fluentbit_input_metrics_scrapes_total = 1
2024-02-27T05:49:56.516306480Z fluentbit_output_proc_records_total = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_proc_bytes_total = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_errors_total = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_retries_total = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_retries_failed_total = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_dropped_records_total = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_retried_records_total = 0
2024-02-27T05:50:06.314435517Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2"} = 1709012996
2024-02-27T05:50:06.314435517Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.0.0",os="linux"} = 1709012996
2024-02-27T05:50:06.314435517Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2"} = 0
2024-02-27T05:49:56.491818462Z fluentbit_input_ingestion_paused = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_upstream_total_connections = 0
[2024/02/27 14:50:11] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-02-27T05:49:56.516306480Z fluentbit_output_upstream_busy_connections = 0
2024-02-27T05:49:56.516306480Z fluentbit_output_chunk_available_capacity_percent = 100
[2024/02/27 14:50:11] [debug] [out flush] cb_destroy coro_id=0
[2024/02/27 14:50:11] [debug] [task] destroy task=0x6195f70 (task_id=0)
^C[2024/02/27 14:50:12] [engine] caught signal (SIGINT)
[2024/02/27 14:50:12] [ warn] [engine] service will shutdown in max 5 seconds
[2024/02/27 14:50:12] [ info] [input] pausing fluentbit_metrics.0
[2024/02/27 14:50:12] [ info] [engine] service has stopped (0 pending tasks)
[2024/02/27 14:50:12] [ info] [input] pausing fluentbit_metrics.0
[2024/02/27 14:50:12] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/02/27 14:50:12] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==997805== 
==997805== HEAP SUMMARY:
==997805==     in use at exit: 0 bytes in 0 blocks
==997805==   total heap usage: 6,236 allocs, 6,236 frees, 1,330,806 bytes allocated
==997805== 
==997805== All heap blocks were freed -- no leaks are possible
==997805== 
==997805== For lists of detected and suppressed errors, rerun with: -s
==997805== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
