### PR TITLE
custom_calyptia: fix using after freed memory(#8530)

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -245,7 +245,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
 
     if (!cloud) {
         flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
-        flb_free(ctx);
         return NULL;
     }
 
@@ -254,7 +253,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
 
     if (ret != 0) {
         flb_plg_error(ctx->ins, "could not load Calyptia Cloud connector");
-        flb_free(ctx);
         return NULL;
     }
 
@@ -268,7 +266,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
             label = flb_sds_create_size(strlen(key->str) + strlen(val->str) + 1);
 
             if (!label) {
-                flb_free(ctx);
                 return NULL;
             }
 
@@ -316,7 +313,6 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
         label = flb_sds_create_size(strlen("fleet_id") + strlen(ctx->fleet_id) + 1);
 
         if (!label) {
-            flb_free(ctx);
             return NULL;
         }
 
@@ -455,6 +451,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
         ctx->o = setup_cloud_output(config, ctx);
 
         if (ctx->o == NULL) {
+            flb_free(ctx);
             return -1;
         }
     }

--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -420,6 +420,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
 
         if (ctx->machine_id == NULL) {
             flb_plg_error(ctx->ins, "unable to retrieve machine_id");
+            flb_free(ctx);
             return -1;
         }
 
@@ -431,6 +432,7 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
 
     if (!ctx->i) {
         flb_plg_error(ctx->ins, "could not load metrics collector");
+        flb_free(ctx);
         return -1;
     }
 


### PR DESCRIPTION
This patch is to fix #8530 and release ctx when initialization failed.

#8530 points following code is vulnerable.
Because `setup_cloud_output` can release ctx and it means `ctx->o` can be freed memory.
```c
        ctx->o = setup_cloud_output(config, ctx);

        if (ctx->o == NULL) {
            return -1;
        }
```



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
