### PR TITLE
in_winevtlog: Display error on invalid subscription state

### DIFF
--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -56,7 +56,7 @@ struct winevtlog_channel *winevtlog_subscribe(const char *channel, int read_exis
     }
     ch->query = NULL;
 
-    signal_event = CreateEvent(NULL, FALSE, FALSE, NULL);
+    signal_event = CreateEvent(NULL, TRUE, TRUE, NULL);
 
     // channel : To wide char
     len = MultiByteToWideChar(CP_UTF8, 0, channel, -1, NULL, 0);
@@ -492,6 +492,7 @@ static int winevtlog_next(struct winevtlog_channel *ch, int hit_threshold)
     DWORD status = ERROR_SUCCESS;
     BOOL has_next = FALSE;
     int i;
+    DWORD wait = 0;
 
     /* If subscription handle is NULL, it should return false. */
     if (!ch->subscription) {
@@ -500,6 +501,15 @@ static int winevtlog_next(struct winevtlog_channel *ch, int hit_threshold)
     }
 
     if (hit_threshold) {
+        return FLB_FALSE;
+    }
+
+    wait = WaitForSingleObject(ch->signal_event, 0);
+    if (wait == WAIT_FAILED) {
+        flb_error("subscription is invalid");
+        return FLB_FALSE;
+    }
+    else if (wait != WAIT_OBJECT_0) {
         return FLB_FALSE;
     }
 
@@ -514,6 +524,8 @@ static int winevtlog_next(struct winevtlog_channel *ch, int hit_threshold)
         if (ERROR_NO_MORE_ITEMS != status) {
             return FLB_FALSE;
         }
+
+        ResetEvent(ch->signal_event);
     }
 
     if (status == ERROR_SUCCESS) {

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -506,7 +506,7 @@ static int winevtlog_next(struct winevtlog_channel *ch, int hit_threshold)
 
     wait = WaitForSingleObject(ch->signal_event, 0);
     if (wait == WAIT_FAILED) {
-        flb_error("subscription is invalid");
+        flb_error("subscription is invalid. err code = %d", GetLastError());
         return FLB_FALSE;
     }
     else if (wait != WAIT_OBJECT_0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fluent Bit is also using pull subscription model for collecting Windows EventLog. Through a registered signal, we're able to obtain the internal state of EvtSubscribe API.
Like as https://github.com/fluent-plugins-nursery/winevt_c/pull/44 fix, Fluent Bit can be made to detect the failure of the subscription.
We need to check it for more strict approach to handle subscription for EventLog.
When failed status is returned from a registered signal, we should recreate the subscription if possible.

This signal approach is inspired from the article: https://learn.microsoft.com/en-us/windows/win32/wes/subscribing-to-events#pull-subscriptions
This article describes that when using the pull type of subscription, EvtSubscribe can tell whether Windows EventLogs are collected or not via a registered signal.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
