### PR TITLE
network: utils: Fix int conversion errors

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -49,6 +49,14 @@
 #include <monkey/mk_core.h>
 #include <ares.h>
 
+#ifdef FLB_SYSTEM_MACOS
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE
+#endif
+/* Use POSIX version of strerror_r forcibly on macOS. */
+#include <string.h>
+#endif
+
 #ifndef SOL_TCP
 #define SOL_TCP IPPROTO_TCP
 #endif
@@ -524,7 +532,20 @@ static int net_connect_async(int fd,
             }
 
             /* Connection is broken, not much to do here */
+#if ((defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) ||    \
+     (defined(_XOPEN_SOURCE) || _XOPEN_SOURCE - 0L >= 600L)) &&     \
+  (!defined(_GNU_SOURCE))
+            ret = strerror_r(error, so_error_buf, sizeof(so_error_buf));
+            if (ret == 0) {
+                str = so_error_buf;
+            }
+            else {
+                flb_errno();
+                return -1;
+            }
+#else
             str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
+#endif
             flb_error("[net] TCP connection failed: %s:%i (%s)",
                       u->tcp_host, u->tcp_port, str);
             return -1;

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1456,7 +1456,6 @@ int flb_utils_get_machine_id(char **out_id, size_t *out_size)
         CFRelease(serialNumber);
 
         if (bret == false) {
-            flb_free(*out_size);
             *out_size = 0;
             return -1;
         }

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -605,6 +605,19 @@ void test_flb_utils_split_quoted_errors()
     TEST_CHECK(split == NULL);
 }
 
+void test_flb_utils_get_machine_id()
+{
+    int ret;
+    char *id = NULL;
+    size_t size;
+
+    ret = flb_utils_get_machine_id(&id, &size);
+    TEST_CHECK(size != 0);
+    TEST_CHECK(id != NULL);
+
+    flb_free(id);
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "url_split", test_url_split },
@@ -618,5 +631,6 @@ TEST_LIST = {
     { "test_flb_utils_split", test_flb_utils_split },
     { "test_flb_utils_split_quoted", test_flb_utils_split_quoted},
     { "test_flb_utils_split_quoted_errors", test_flb_utils_split_quoted_errors},
+    { "test_flb_utils_get_machine_id", test_flb_utils_get_machine_id },
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
After updated the latest command line tools, I got int conversion errors.
These should be generated using POSIX version of strerror_r and needless flb_free calling.

The latter one is able to be confirmed with:

```
 % leaks -atExit -- bin/flb-it-utils test_flb_utils_get_machine_id
 flb-it-utils(34841) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be inc
luded in process footprint - (null)
 flb-it-utils(34841) MallocStackLogging: recording malloc and VM allocation stacks using lite mode
 Test test_flb_utils_get_machine_id...           [ OK ]
 SUCCESS: All unit tests have passed.
 Process 34841 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memo
ry of restricted processes.
    
 Process:         flb-it-utils [34841]
 Path:            /Users/USER/*/flb-it-utils
 Load Address:    0x1023cc000
 Identifier:      flb-it-utils
 Version:         0
 Code Type:       ARM64
 Platform:        macOS
 Parent Process:  leaks [34840]
    
 Date/Time:       2024-03-06 23:42:29.641 +0900
 Launch Time:     2024-03-06 23:42:29.596 +0900
 OS Version:      macOS 14.3.1 (23D60)
 Report Version:  7
 Analysis Tool:   /usr/bin/leaks
    
 Physical footprint:         4385K
 Physical footprint (peak):  4385K
 Idle exit:                  untracked
 ----
    
 leaks Report Version: 4.0, multi-line stacks
 Process 34841: 516 nodes malloced for 42 KB
 Process 34841: 0 leaks for 0 total leaked bytes.
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
