### PR TITLE
in_forward: Implement handshake protocol

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -18,10 +18,12 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_downstream.h>
 #include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 #include <msgpack.h>
 
@@ -153,6 +155,92 @@ static int in_fw_collect(struct flb_input_instance *ins,
     return 0;
 }
 
+static void delete_users(struct flb_in_fw_config *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_in_fw_user *user;
+
+    mk_list_foreach_safe(head, tmp, &ctx->users) {
+        user = mk_list_entry(head, struct flb_in_fw_user, _head);
+        flb_sds_destroy(user->name);
+        flb_sds_destroy(user->password);
+        mk_list_del(&user->_head);
+        flb_free(user);
+    }
+}
+
+static int setup_users(struct flb_in_fw_config *ctx,
+                       struct flb_input_instance *ins)
+{
+    flb_sds_t tmp;
+    struct mk_list *head;
+    struct mk_list *split;
+    struct flb_split_entry *sentry;
+    struct flb_kv *kv;
+    struct flb_in_fw_user *user;
+
+    /* Iterate all input properties */
+    mk_list_foreach(head, &ins->properties) {
+        kv = mk_list_entry(head, struct flb_kv, _head);
+
+        /* Create a new user */
+        user = flb_malloc(sizeof(struct flb_in_fw_user));
+        if (!user) {
+            flb_errno();
+            return -1;
+        }
+
+        /* Get the type */
+        if (strcasecmp(kv->key, "security.users") != 0) {
+            /* Other property. Skip */
+            flb_free(user);
+            continue;
+        }
+
+        /* As a value we expect a pair of a username and a passowrd */
+        split = flb_utils_split(kv->val, ' ', 1);
+        if (mk_list_size(split) != 2) {
+            flb_plg_error(ctx->ins,
+                          "invalid value, expected username and password");
+            delete_users(ctx);
+            flb_free(user);
+            flb_utils_split_free(split);
+            return -1;
+        }
+
+        /* Get first value (user's name) */
+        sentry = mk_list_entry_first(split, struct flb_split_entry, _head);
+        tmp = flb_sds_create_len(sentry->value, sentry->len + 1);
+        if (tmp == NULL) {
+            delete_users(ctx);
+            flb_free(user);
+            flb_utils_split_free(split);
+            return -1;
+        }
+        user->name = tmp;
+
+        /* Get remaining content (password) */
+        sentry = mk_list_entry_last(split, struct flb_split_entry, _head);
+        tmp = flb_sds_create_len(sentry->value, sentry->len);
+        if (tmp == NULL) {
+            delete_users(ctx);
+            flb_free(user);
+            flb_utils_split_free(split);
+            return -1;
+        }
+        user->password = tmp;
+
+        /* Release split */
+        flb_utils_split_free(split);
+
+        /* Link to parent list */
+        mk_list_add(&user->_head, &ctx->users);
+    }
+
+    return 0;
+}
+
 /* Initialize plugin */
 static int in_fw_init(struct flb_input_instance *ins,
                       struct flb_config *config, void *data)
@@ -172,6 +260,7 @@ static int in_fw_init(struct flb_input_instance *ins,
     ctx->coll_fd = -1;
     ctx->ins = ins;
     mk_list_init(&ctx->connections);
+    mk_list_init(&ctx->users);
 
     /* Set the context */
     flb_input_set_context(ins, ctx);
@@ -229,6 +318,13 @@ static int in_fw_init(struct flb_input_instance *ins,
         }
     }
 
+    /* Load users */
+    ret = setup_users(ctx, ins);
+    if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
     flb_input_downstream_set(ctx->downstream, ctx->ins);
 
     flb_net_socket_nonblocking(ctx->downstream->server_fd);
@@ -275,6 +371,7 @@ static int in_fw_exit(void *data, struct flb_config *config)
         return 0;
     }
 
+    delete_users(ctx);
     fw_conn_del_all(ctx);
     fw_config_destroy(ctx);
     return 0;
@@ -296,6 +393,11 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_STR, "self_hostname", NULL,
     0, FLB_FALSE, 0,
     "Hostname"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "security.users", NULL,
+    FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+    "Specify username and password pairs."
    },
    {
     FLB_CONFIG_MAP_STR, "unix_path", NULL,

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -288,6 +288,16 @@ static struct flb_config_map config_map[] = {
     "Prefix incoming tag with the defined value."
    },
    {
+    FLB_CONFIG_MAP_STR, "shared_key", NULL,
+    0, FLB_FALSE, 0,
+    "Shared key for authentication"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "self_hostname", NULL,
+    0, FLB_FALSE, 0,
+    "Hostname"
+   },
+   {
     FLB_CONFIG_MAP_STR, "unix_path", NULL,
     0, FLB_TRUE, offsetof(struct flb_in_fw_config, unix_path),
     "The path to unix socket to receive a Forward message."

--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -25,6 +25,19 @@
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
+enum {
+    FW_HANDSHAKE_HELO        = 1,
+    FW_HANDSHAKE_PINGPONG    = 2,
+    FW_HANDSHAKE_ESTABLISHED = 3,
+};
+
+struct flb_in_fw_helo {
+    flb_sds_t nonce;
+    int nonce_len;
+    flb_sds_t salt;
+    int salt_len;
+};
+
 struct flb_in_fw_config {
     size_t buffer_max_size;         /* Max Buffer size             */
     size_t buffer_chunk_size;       /* Chunk allocation size       */
@@ -39,6 +52,10 @@ struct flb_in_fw_config {
     char *unix_path;                /* Unix path for socket        */
     unsigned int unix_perm;         /* Permission for socket       */
     flb_sds_t unix_perm_str;        /* Permission (config map)     */
+
+    /* secure forward */
+    flb_sds_t shared_key;        /* shared key                   */
+    flb_sds_t self_hostname;     /* hostname used in certificate  */
 
     int coll_fd;
     struct flb_downstream *downstream; /* Client manager          */

--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -38,6 +38,12 @@ struct flb_in_fw_helo {
     int salt_len;
 };
 
+struct flb_in_fw_user {
+    flb_sds_t name;
+    flb_sds_t password;
+    struct mk_list _head;
+};
+
 struct flb_in_fw_config {
     size_t buffer_max_size;         /* Max Buffer size             */
     size_t buffer_chunk_size;       /* Chunk allocation size       */
@@ -56,6 +62,7 @@ struct flb_in_fw_config {
     /* secure forward */
     flb_sds_t shared_key;        /* shared key                   */
     flb_sds_t self_hostname;     /* hostname used in certificate  */
+    struct mk_list users;        /* username and password pairs  */
 
     int coll_fd;
     struct flb_downstream *downstream; /* Client manager          */

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -84,6 +84,24 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
         flb_debug("[in_fw] Listen='%s' TCP_Port=%s",
                   config->listen, config->tcp_port);
     }
+
+    /* Shared Key */
+    p = flb_input_get_property("shared_key", i_ins);
+    if (p) {
+        config->shared_key = flb_sds_create(p);
+    }
+    else {
+        config->shared_key = NULL;
+    }
+
+    /* Self Hostname */
+    p = flb_input_get_property("self_hostname", i_ins);
+    if (p) {
+        config->self_hostname = flb_sds_create(p);
+    }
+    else {
+        config->self_hostname = flb_sds_create("localhost");
+    }
     return config;
 }
 
@@ -113,6 +131,9 @@ int fw_config_destroy(struct flb_in_fw_config *config)
     else {
         flb_free(config->tcp_port);
     }
+
+    flb_sds_destroy(config->shared_key);
+    flb_sds_destroy(config->self_hostname);
 
     flb_free(config);
 

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -51,13 +51,18 @@ int fw_conn_event(void *data)
 
     if (event->mask & MK_EVENT_READ) {
         if (conn->handshake_status == FW_HANDSHAKE_PINGPONG) {
+            flb_plg_trace(ctx->ins, "handshake status = %d", conn->handshake_status);
 
             ret = fw_prot_secure_forward_handshake(ctx->ins, conn);
             if (ret == -1) {
                 return -1;
             }
+
             conn->handshake_status = FW_HANDSHAKE_ESTABLISHED;
+            return 0;
         }
+
+        flb_plg_trace(ctx->ins, "handshake status = %d", conn->handshake_status);
 
         available = (conn->buf_size - conn->buf_len);
         if (available < 1) {

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -49,14 +49,8 @@ int fw_conn_event(void *data)
 
     event = &connection->event;
 
-    flb_plg_info(ctx->ins, "ctx->handshake_status = %d", conn->handshake_status);
-    flb_plg_debug(ctx->ins, "[conn_event] conn->helo->nonce = %s", conn->helo->nonce);
-    flb_plg_debug(ctx->ins, "[conn_event] conn->helo->salt = %s", conn->helo->salt);
-
     if (event->mask & MK_EVENT_READ) {
         if (conn->handshake_status == FW_HANDSHAKE_PINGPONG) {
-            flb_plg_debug(ctx->ins, "[conn_event] conn->helo = %p", conn->helo);
-            flb_plg_debug(ctx->ins, "[conn_event] conn->helo->nonce = %s", conn->helo->nonce);
 
             ret = fw_prot_secure_forward_handshake(ctx->ins, conn);
             if (ret == -1) {
@@ -64,8 +58,6 @@ int fw_conn_event(void *data)
             }
             conn->handshake_status = FW_HANDSHAKE_ESTABLISHED;
         }
-
-        flb_plg_info(ctx->ins, "[event->mask] ctx->status = %d", conn->handshake_status);
 
         available = (conn->buf_size - conn->buf_len);
         if (available < 1) {
@@ -155,13 +147,8 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
             return NULL;
         }
 
-        flb_plg_debug(ctx->ins, "helo->nonce = %s", helo->nonce);
-        flb_plg_debug(ctx->ins, "helo->salt = %s", helo->salt);
         conn->handshake_status = FW_HANDSHAKE_PINGPONG;
     }
-
-    flb_plg_debug(ctx->ins, "helo: helo->nonce = %s", helo->nonce);
-    flb_plg_debug(ctx->ins, "helo: helo->salt = %s", helo->salt);
 
     conn->connection = connection;
     conn->helo       = helo;
@@ -187,10 +174,6 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     }
     conn->buf_size = ctx->buffer_chunk_size;
     conn->in       = ctx->ins;
-
-    flb_plg_debug(ctx->ins, "helo: conn->helo = %p", conn->helo);
-    flb_plg_debug(ctx->ins, "helo: conn->helo->nonce = %s", conn->helo->nonce);
-    flb_plg_debug(ctx->ins, "helo: conn->helo->salt = %s", conn->helo->salt);
 
     /* Register instance into the event loop */
     ret = mk_event_add(flb_engine_evl_get(),

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -142,7 +142,7 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     }
 
     conn->handshake_status = FW_HANDSHAKE_ESTABLISHED;
-    if (ctx->ins->use_tls == FLB_TRUE || ctx->shared_key != NULL) {
+    if (ctx->shared_key != NULL) {
         conn->handshake_status = FW_HANDSHAKE_HELO;
         helo = flb_malloc(sizeof(struct flb_in_fw_helo));
         if (!helo) {

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -55,6 +55,9 @@ int fw_conn_event(void *data)
 
             ret = fw_prot_secure_forward_handshake(ctx->ins, conn);
             if (ret == -1) {
+                flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);
+                fw_conn_del(conn);
+
                 return -1;
             }
 

--- a/plugins/in_forward/fw_conn.h
+++ b/plugins/in_forward/fw_conn.h
@@ -22,6 +22,8 @@
 
 #define FLB_IN_FW_CHUNK_SIZE      "1024000" /* 1MB */
 #define FLB_IN_FW_CHUNK_MAX_SIZE  "6144000" /* =FLB_IN_FW_CHUNK_SIZE * 6.  6MB */
+#define FLB_IN_FW_NONCE_SIZE      16
+#define FLB_IN_FW_SALT_SIZE       16
 
 enum {
     FW_NEW        = 1,  /* it's a new connection                */
@@ -33,15 +35,20 @@ struct fw_conn_stream {
     size_t tag_len;
 };
 
+struct flb_in_fw_helo;
+
 /* Respresents a connection */
 struct fw_conn {
     int status;                      /* Connection status                 */
+    int handshake_status;            /* handshake status                 */
 
     /* Buffer */
     char *buf;                       /* Buffer data                       */
     int  buf_len;                    /* Data length                       */
     int  buf_size;                   /* Buffer size                       */
     size_t rest;                     /* Unpacking offset                  */
+
+    struct flb_in_fw_helo *helo;     /* secure forward HELO phase */
 
     struct flb_input_instance *in;   /* Parent plugin instance            */
     struct flb_in_fw_config *ctx;    /* Plugin configuration context      */

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -24,6 +24,9 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_gzip.h>
+#include <fluent-bit/flb_random.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_crypto.h>
 
 #include <fluent-bit/flb_input_metric.h>
 #include <fluent-bit/flb_input_trace.h>
@@ -131,6 +134,523 @@ static int is_gzip_compressed(msgpack_object options)
     }
 
     return FLB_FALSE;
+}
+
+static inline void print_msgpack_error_code(struct flb_input_instance *in,
+                                            int ret, char *context)
+{
+    switch (ret) {
+    case MSGPACK_UNPACK_EXTRA_BYTES:
+        flb_plg_error(in, "%s MSGPACK_UNPACK_EXTRA_BYTES", context);
+        break;
+    case MSGPACK_UNPACK_CONTINUE:
+        flb_plg_trace(in, "%s MSGPACK_UNPACK_CONTINUE", context);
+        break;
+    case MSGPACK_UNPACK_PARSE_ERROR:
+        flb_plg_error(in, "%s MSGPACK_UNPACK_PARSE_ERROR", context);
+        break;
+    case MSGPACK_UNPACK_NOMEM_ERROR:
+        flb_plg_error(in, "%s MSGPACK_UNPACK_NOMEM_ERROR", context);
+        break;
+    }
+}
+
+/* Read a secure forward msgpack message for handshake */
+static int secure_forward_read(struct flb_input_instance *in,
+                               struct flb_connection *connection,
+                               char *buf, size_t size, size_t *out_len)
+{
+    int ret;
+    size_t off;
+    size_t avail;
+    size_t buf_off = 0;
+    msgpack_unpacked result;
+
+    msgpack_unpacked_init(&result);
+    while (1) {
+        avail = size - buf_off;
+        if (avail < 1) {
+            goto error;
+        }
+
+        /* Read the message */
+        ret = flb_io_net_read(connection, buf + buf_off, size - buf_off);
+        if (ret <= 0) {
+            flb_plg_debug(in, "read %d byte(s)", ret);
+            goto error;
+        }
+        buf_off += ret;
+
+        /* Validate */
+        off = 0;
+        ret = msgpack_unpack_next(&result, buf, buf_off, &off);
+        switch (ret) {
+        case MSGPACK_UNPACK_SUCCESS:
+            msgpack_unpacked_destroy(&result);
+            *out_len = buf_off;
+            return 0;
+        default:
+            print_msgpack_error_code(in, ret, "handshake");
+            goto error;
+        };
+    }
+
+ error:
+    msgpack_unpacked_destroy(&result);
+    return -1;
+}
+
+int flb_secure_forward_set_helo(struct flb_input_instance *in,
+                                struct flb_in_fw_helo *helo,
+                                unsigned char *nonce, unsigned char *salt)
+{
+    int ret;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object o;
+    size_t off = 0;
+    flb_sds_t tmp;
+
+    memset(helo, 0, sizeof(struct flb_in_fw_helo));
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_str(&mp_pck, FLB_IN_FW_NONCE_SIZE);
+    msgpack_pack_str_body(&mp_pck, nonce, FLB_IN_FW_NONCE_SIZE);
+    msgpack_pack_str(&mp_pck, FLB_IN_FW_SALT_SIZE);
+    msgpack_pack_str_body(&mp_pck, salt, FLB_IN_FW_SALT_SIZE);
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        msgpack_unpacked_destroy(&result);
+
+        return -1;
+    }
+
+    root = result.data;
+    o = root.via.array.ptr[0];
+
+    tmp = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
+    if (tmp == NULL) {
+        flb_plg_warn(in, "cannot create nonce string");
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        msgpack_unpacked_destroy(&result);
+
+        return -1;
+    }
+    helo->nonce = tmp;
+    helo->nonce_len = FLB_IN_FW_NONCE_SIZE;
+    flb_plg_debug(in, "set_helo: nonce = %s", helo->nonce);
+    flb_plg_debug(in, "set_helo: nonce_size = %d", o.via.str.size);
+    o = root.via.array.ptr[1];
+
+    tmp = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
+    if (tmp == NULL) {
+        flb_plg_warn(in, "cannot create salt string");
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        msgpack_unpacked_destroy(&result);
+
+        return -1;
+    }
+    helo->salt = tmp;
+    helo->salt_len = FLB_IN_FW_SALT_SIZE;
+    flb_plg_debug(in, "set_helo: salt = %s", helo->salt);
+    flb_plg_debug(in, "set_helo: salt_size = %d", o.via.str.size);
+
+    msgpack_unpacked_destroy(&result);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    return 0;
+}
+
+/* Don't include this function for secure_forward_handshake. This
+ * should be needed to send HELO packet at first before the handler
+ * for reading is registered. */
+static int send_helo(struct flb_input_instance *in, struct flb_connection *connection,
+                     struct flb_in_fw_helo *helo)
+{
+    int result;
+    size_t sent;
+    ssize_t bytes;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    unsigned char nonce[FLB_IN_FW_NONCE_SIZE] = {0};
+    unsigned char user_auth_salt[FLB_IN_FW_SALT_SIZE] = {0};
+
+    /* Generate nonce */
+    if (flb_random_bytes(nonce, FLB_IN_FW_NONCE_SIZE)) {
+        flb_plg_error(in, "cannot generate nonce");
+        return -1;
+    }
+
+    /* Generate the shared key salt */
+    if (flb_random_bytes(user_auth_salt, FLB_IN_FW_SALT_SIZE)) {
+        flb_plg_error(in, "cannot generate shared key salt");
+        return -1;
+    }
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "HELO", 4);
+    /* option: {nonce, auth} */
+    msgpack_pack_map(&mp_pck, 2);
+    /* nonce */
+    msgpack_pack_str(&mp_pck, 5);
+    msgpack_pack_str_body(&mp_pck, "nonce", 5);
+    msgpack_pack_str(&mp_pck, FLB_IN_FW_NONCE_SIZE);
+    msgpack_pack_str_body(&mp_pck, nonce, FLB_IN_FW_NONCE_SIZE);
+    /* auth */
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "auth", 4);
+    msgpack_pack_str(&mp_pck, FLB_IN_FW_SALT_SIZE);
+    msgpack_pack_str_body(&mp_pck, user_auth_salt, FLB_IN_FW_SALT_SIZE);
+
+    bytes = flb_io_net_write(connection,
+                             (void *) mp_sbuf.data,
+                             mp_sbuf.size,
+                             &sent);
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    if (bytes == -1) {
+        flb_plg_error(in, "cannot send HELO");
+
+        result = -1;
+    }
+    else {
+        result = 0;
+    }
+
+    flb_plg_debug(in, "send_helo: nonce = %s", nonce);
+    flb_plg_debug(in, "send_helo: salt = %s", user_auth_salt);
+
+    result = flb_secure_forward_set_helo(in, helo, nonce, user_auth_salt);
+
+    flb_plg_debug(in, "send_helo: helo = %p", helo);
+
+    return result;
+}
+
+static void flb_secure_forward_format_bin_to_hex(uint8_t *buf, size_t len, char *out)
+{
+    int i;
+    static char map[] = "0123456789abcdef";
+
+    for (i = 0; i < len; i++) {
+        out[i * 2]     = map[buf[i] >> 4];
+        out[i * 2 + 1] = map[buf[i] & 0x0f];
+    }
+}
+
+static int flb_secure_forward_hash_shared_key(struct flb_input_instance *ins,
+                                              struct fw_conn *conn,
+                                              flb_sds_t shared_key_salt,
+                                              flb_sds_t hostname,
+                                              int hostname_len,
+                                              char *buf, int buflen)
+{
+    int ret;
+    size_t length_entries[4];
+    unsigned char *data_entries[4];
+    uint8_t hash[64];
+    struct flb_in_fw_config *ctx = conn->ctx;
+
+    if (buflen < 128) {
+        return -1;
+    }
+
+    /* NOTE: shared_key_salt is handled as string type. We should
+     * calculate the length of it with strlen here instead of using
+     * fixed 16 bytes. */
+    data_entries[0]   = (unsigned char *) shared_key_salt;
+    length_entries[0] = flb_sds_len(shared_key_salt);
+
+    flb_plg_info(ins, "[hash_digest] shared_key_salt = %s", shared_key_salt);
+    flb_plg_info(ins, "[hash_digest] shared_key_salt_len = %zd", flb_sds_len(shared_key_salt));
+
+    data_entries[1]   = (unsigned char *) hostname;
+    length_entries[1] = hostname_len;
+
+    data_entries[2]   = (unsigned char *) conn->helo->nonce;
+    length_entries[2] = FLB_IN_FW_NONCE_SIZE; /* always 16 bytes. */
+
+    data_entries[3]   = (unsigned char *) ctx->shared_key;
+    length_entries[3] = strlen(ctx->shared_key);
+
+    ret = flb_hash_simple_batch(FLB_HASH_SHA512,
+                                4,
+                                data_entries,
+                                length_entries,
+                                hash,
+                                sizeof(hash));
+
+    if (ret != FLB_CRYPTO_SUCCESS) {
+        return -1;
+    }
+
+    flb_secure_forward_format_bin_to_hex(hash, 64, buf);
+
+    return 0;
+}
+
+static int flb_secure_forward_hash_digest(struct flb_input_instance *ins,
+                                          struct fw_conn *conn,
+                                          flb_sds_t shared_key_salt,
+                                          char *buf, int buflen)
+{
+    int result;
+    size_t length_entries[4];
+    unsigned char *data_entries[4];
+    uint8_t hash[64];
+    struct flb_in_fw_config *ctx = conn->ctx;
+
+    if (buflen < 128) {
+        return -1;
+    }
+
+    /* NOTE: shared_key_salt is handled as string type. We should
+     * calculate the length of it with strlen here instead of using
+     * fixed 16 bytes. */
+    data_entries[0]   = (unsigned char *) shared_key_salt;
+    length_entries[0] = flb_sds_len(shared_key_salt);
+
+    flb_plg_info(ins, "[hash_digest] shared_key_salt = %s", shared_key_salt);
+    flb_plg_info(ins, "[hash_digest] shared_key_salt_len = %zd", flb_sds_len(shared_key_salt));
+
+    data_entries[1]   = (unsigned char *) ctx->self_hostname;
+    length_entries[1] = strlen(ctx->self_hostname);
+
+    flb_plg_info(ins, "[hash_digest] ctx->self_hostname = %s", ctx->self_hostname);
+
+    data_entries[2]   = (unsigned char *) conn->helo->nonce;
+    length_entries[2] = FLB_IN_FW_NONCE_SIZE; /* always 16 bytes. */
+
+    flb_plg_info(ins, "[hash_digest] conn->helo->nonce = %s", conn->helo->nonce);
+
+    data_entries[3]   = (unsigned char *) ctx->shared_key;
+    length_entries[3] = strlen(ctx->shared_key);
+    flb_plg_info(ins, "[hash_digest] ctx->shared_key = %s", ctx->shared_key);
+
+    result = flb_hash_simple_batch(FLB_HASH_SHA512,
+                                   4,
+                                   data_entries,
+                                   length_entries,
+                                   hash,
+                                   sizeof(hash));
+
+    if (result != FLB_CRYPTO_SUCCESS) {
+        return -1;
+    }
+
+    flb_secure_forward_format_bin_to_hex(hash, 64, buf);
+
+    return 0;
+}
+
+static int check_ping(struct flb_input_instance *ins,
+                      struct fw_conn *conn,
+                      flb_sds_t *out_shared_key_salt)
+{
+    int ret;
+    char buf[1024];
+    size_t out_len;
+    size_t off;
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object o;
+    flb_sds_t hostname = NULL;
+    flb_sds_t shared_key_salt = NULL;
+    flb_sds_t shared_key_digest = NULL;
+    size_t hostname_len = 0;
+    size_t shared_key_digest_len = 0;
+    char *serverside = NULL;
+    struct flb_in_fw_config *ctx = conn->ctx;
+
+    serverside = flb_calloc(128, sizeof(char));
+
+    /* Wait for client PING */
+    ret = secure_forward_read(ins, conn->connection, buf, sizeof(buf) - 1, &out_len);
+    if (ret == -1) {
+        flb_free(serverside);
+        flb_plg_error(ins, "handshake error expecting PING");
+        return -1;
+    }
+
+    /* Unpack message and validate */
+    off = 0;
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, buf, out_len, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        flb_free(serverside);
+        print_msgpack_error_code(ins, ret, "PING");
+        return -1;
+    }
+
+    /* Parse PING message */
+    root = result.data;
+    if (root.via.array.size < 6) {
+        flb_plg_error(ins, "Invalid PING message");
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    o = root.via.array.ptr[0];
+    if (o.type != MSGPACK_OBJECT_STR) {
+        flb_plg_error(ins, "Invalid PING type message");
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    if (strncmp(o.via.str.ptr, "PING", 4) != 0 || o.via.str.size != 4) {
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    flb_plg_debug(ins, "protocol: received PING");
+
+    /* hostname */
+    o = root.via.array.ptr[1];
+    if (o.type != MSGPACK_OBJECT_STR) {
+        flb_plg_error(ins, "Invalid hostname type message");
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+    hostname = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
+    hostname_len = o.via.str.size;
+
+    /* shared_key_salt */
+    o = root.via.array.ptr[2];
+    if (o.type != MSGPACK_OBJECT_STR) {
+        flb_plg_error(ins, "Invalid shared_key_salt type message");
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+    shared_key_salt = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
+
+    /* shared_key_digest */
+    o = root.via.array.ptr[3];
+    if (o.type != MSGPACK_OBJECT_STR) {
+        flb_plg_error(ins, "Invalid shared_key_digest type message");
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+    shared_key_digest = flb_sds_create_len(o.via.str.ptr, o.via.str.size);
+    shared_key_digest_len = o.via.str.size;
+
+    msgpack_unpacked_destroy(&result);
+
+    if (flb_secure_forward_hash_shared_key(ins, conn,
+                                           shared_key_salt, hostname, hostname_len,
+                                           serverside, 128)) {
+        flb_free(serverside);
+        flb_plg_error(ctx->ins, "failed to hash password");
+        return -1;
+    }
+
+    flb_plg_debug(ins, "[check_ping] conn->helo = %p", conn->helo);
+    flb_plg_debug(ins, "[check_ping] conn->helo->nonce = %s", conn->helo->nonce);
+    flb_plg_debug(ins, "[check_ping] hostname = %s\nshared_key_salt = %s\nshared_key_digest = %s",
+                  hostname, shared_key_salt, shared_key_digest);
+
+    flb_plg_debug(ins, "[check_ping] \nserverside        = %s\nshared_key_digest = %s", serverside, shared_key_digest);
+
+    if (strncmp(serverside, shared_key_digest, shared_key_digest_len) != 0) {
+        flb_plg_error(ins, "shared_key mismatch");
+        flb_free(serverside);
+
+        goto error;
+    }
+
+    flb_sds_destroy(hostname);
+    flb_sds_destroy(shared_key_digest);
+    flb_free(serverside);
+
+    *out_shared_key_salt = shared_key_salt;
+
+    return 0;
+
+error:
+    flb_sds_destroy(hostname);
+    flb_sds_destroy(shared_key_salt);
+    flb_sds_destroy(shared_key_digest);
+
+    return -1;
+}
+
+static int send_pong(struct flb_input_instance *in,
+                     struct fw_conn *conn,
+                     flb_sds_t shared_key_salt)
+{
+    int result;
+    size_t sent;
+    ssize_t bytes;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    size_t hostname_len;
+    char shared_key_digest_hex[128];
+    struct flb_in_fw_config *ctx = conn->ctx;
+
+    if (flb_secure_forward_hash_digest(in, conn,
+                                       shared_key_salt,
+                                       shared_key_digest_hex, 128)) {
+        return -1;
+    }
+
+    /* hostname len */
+    hostname_len = strlen(ctx->self_hostname);
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 5);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "PONG", 4);
+    /* auth result */
+    msgpack_pack_true(&mp_pck);
+    /* reason or salt */
+    msgpack_pack_str(&mp_pck, 0);
+    msgpack_pack_str_body(&mp_pck, "", 0);
+    /* hostname */
+    msgpack_pack_str(&mp_pck, hostname_len);
+    msgpack_pack_str_body(&mp_pck, ctx->self_hostname, hostname_len);
+    /* shared_key_digest */
+    msgpack_pack_str(&mp_pck, 128);
+    msgpack_pack_str_body(&mp_pck, shared_key_digest_hex, 128);
+
+    flb_plg_info(in, "[send_pong] shared_key_digest_hex = %s", shared_key_digest_hex);
+
+    bytes = flb_io_net_write(conn->connection,
+                             (void *) mp_sbuf.data,
+                             mp_sbuf.size,
+                             &sent);
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    if (bytes == -1) {
+        flb_plg_error(in, "cannot send PONG");
+
+        result = -1;
+    }
+    else {
+        result = 0;
+    }
+
+    return result;
 }
 
 static int send_ack(struct flb_input_instance *in, struct fw_conn *conn,
@@ -492,6 +1012,71 @@ static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
     return 0;
 }
 
+int fw_prot_secure_forward_handshake_start(struct flb_input_instance *ins,
+                                           struct flb_connection *connection,
+                                           struct flb_in_fw_helo *helo)
+{
+    int ret;
+
+    /* When using secure connection, we need to try communitating
+     * with HELO first. */
+    flb_plg_debug(ins, "protocol: sending HELO");
+    ret = send_helo(ins, connection, helo);
+    if (ret == -1) {
+        return -1;
+    }
+
+    flb_plg_debug(ins, "protocol: nonce = %s", helo->nonce);
+    flb_plg_debug(ins, "protocol: salt = %s", helo->salt);
+
+    return 0;
+}
+
+int fw_prot_secure_forward_handshake(struct flb_input_instance *ins,
+                                     struct fw_conn *conn)
+{
+    int ret;
+    char *shared_key_salt = NULL;
+
+    flb_plg_debug(ins, "protocol: checking PING");
+    ret = check_ping(ins, conn, &shared_key_salt);
+    if (ret == -1) {
+        flb_plg_error(ins, "handshake error checking PING");
+
+        goto error;
+    }
+
+    flb_plg_debug(ins, "protocol: sending PONG");
+    ret = send_pong(ins, conn, shared_key_salt);
+    if (ret == -1) {
+        flb_plg_error(ins, "handshake error sending PONG");
+
+        goto error;
+    }
+
+    /* if (conn->helo->nonce != NULL) { */
+    /*     flb_sds_destroy(conn->helo->nonce); */
+    /* } */
+    /* if (conn->helo->salt != NULL) { */
+    /*     flb_sds_destroy(conn->helo->salt); */
+    /* } */
+    flb_sds_destroy(shared_key_salt);
+
+    return 0;
+
+error:
+    if (conn->helo->nonce != NULL) {
+        flb_sds_destroy(conn->helo->nonce);
+    }
+    if (conn->helo->salt != NULL) {
+        flb_sds_destroy(conn->helo->salt);
+    }
+    if (shared_key_salt != NULL) {
+        flb_sds_destroy(shared_key_salt);
+    }
+
+    return -1;
+}
 
 int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
 {

--- a/plugins/in_forward/fw_prot.h
+++ b/plugins/in_forward/fw_prot.h
@@ -22,7 +22,16 @@
 
 #include "fw_conn.h"
 
+struct flb_in_fw_helo;
+
 int fw_prot_parser(struct fw_conn *conn);
 int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn);
-
+int flb_secure_forward_set_helo(struct flb_input_instance *ins,
+                                struct flb_in_fw_helo *helo,
+                                unsigned char *nonce, unsigned char *salt);
+int fw_prot_secure_forward_handshake_start(struct flb_input_instance *ins,
+                                           struct flb_connection *connection,
+                                           struct flb_in_fw_helo *helo);
+int fw_prot_secure_forward_handshake(struct flb_input_instance *ins,
+                                     struct fw_conn *conn);
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
In forward protocol, there is a definition for handshake.
When using out_forward on Fluentd with `<security>` directive(s), out_forward on Fluentd hangs due to Fluent Bit didn't implement handshake protocol on its in_forward.
This PR aims to implement handshake protocol. ~~but I didn't implement user authentication part yet.~~ User authentication is also implemented in this PR.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush        5
    Daemon       Off
    Log_Level    debug
    HTTP_Monitor Off
    HTTP_Port    2020

[INPUT]
    Name forward
    Listen 0.0.0.0
    Port 24224
    shared_key  FluentBit
    security.users fluentd changeme
    tls         On
    tls.verify  Off
    tls.crt_file self_signed.crt
    tls.key_file self_signed.key

[OUTPUT]
    Name  stdout
    Match **
```

The self signed certificate is created by the following:

```console
/path/to/fluent-bit/build$ openssl req -x509 \
            -newkey rsa:4096 \
            -sha256 \
            -nodes \
            -keyout self_signed.key \
            -out self_signed.crt \
            -subj "/CN=test.host.net"
```

And using Fluentd with its configuration:

```aconf
<source>
  @type sample
  tag test
  # rate 10
</source>

<match test>
  @type forward
  flush_interval 2
  transport tls
  tls_allow_self_signed_cert true
  tls_cert_path /path/to/fluent-bit/build/self_signed.crt
  tls_verify_hostname false
  <security>
    self_hostname output.testing.local
    shared_key FluentBit
  </security>
  <server>
    host 127.0.0.1
    port 24224
    username fluentd
    password changeme
  </server>
</match>
```


- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/03/11 19:29:49] [ info] Configuration:
[2024/03/11 19:29:49] [ info]  flush time     | 5.000000 seconds
[2024/03/11 19:29:49] [ info]  grace          | 5 seconds
[2024/03/11 19:29:49] [ info]  daemon         | 0
[2024/03/11 19:29:49] [ info] ___________
[2024/03/11 19:29:49] [ info]  inputs:
[2024/03/11 19:29:49] [ info]      forward
[2024/03/11 19:29:49] [ info] ___________
[2024/03/11 19:29:49] [ info]  filters:
[2024/03/11 19:29:49] [ info] ___________
[2024/03/11 19:29:49] [ info]  outputs:
[2024/03/11 19:29:49] [ info]      stdout.0
[2024/03/11 19:29:49] [ info] ___________
[2024/03/11 19:29:49] [ info]  collectors:
[2024/03/11 19:29:49] [ info] [fluent bit] version=3.0.0, commit=df5ea6a818, pid=193377
[2024/03/11 19:29:49] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/03/11 19:29:49] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/11 19:29:49] [ info] [cmetrics] version=0.7.0
[2024/03/11 19:29:49] [ info] [ctraces ] version=0.4.0
[2024/03/11 19:29:49] [ info] [input:forward:forward.0] initializing
[2024/03/11 19:29:49] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2024/03/11 19:29:49] [debug] [forward:forward.0] created event channels: read=21 write=22
[2024/03/11 19:29:49] [debug] [in_fw] Listen='0.0.0.0' TCP_Port=24224
[2024/03/11 19:29:49] [debug] [downstream] listening on 0.0.0.0:24224
[2024/03/11 19:29:49] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2024/03/11 19:29:49] [ info] [output:stdout:stdout.0] worker #0 started
[2024/03/11 19:29:49] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/03/11 19:29:49] [ info] [sp] stream processor started
[2024/03/11 19:29:53] [debug] [input:forward:forward.0] protocol: sending HELO
[2024/03/11 19:29:53] [debug] [input:forward:forward.0] protocol: checking PING
[2024/03/11 19:29:53] [debug] [input:forward:forward.0] protocol: received PING
[2024/03/11 19:29:53] [debug] [input:forward:forward.0] protocol: sending PONG
[2024/03/11 19:29:53] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/03/11 19:29:54] [debug] [input:forward:forward.0] protocol: sending HELO
[2024/03/11 19:29:54] [debug] [input:forward:forward.0] protocol: checking PING
[2024/03/11 19:29:54] [debug] [input:forward:forward.0] protocol: received PING
[2024/03/11 19:29:54] [debug] [input:forward:forward.0] protocol: sending PONG
[2024/03/11 19:29:54] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/03/11 19:29:56] [debug] [input:forward:forward.0] protocol: sending HELO
[2024/03/11 19:29:56] [debug] [input:forward:forward.0] protocol: sending HELO
[2024/03/11 19:29:56] [debug] [input:forward:forward.0] protocol: checking PING
[2024/03/11 19:29:56] [debug] [input:forward:forward.0] protocol: received PING
[2024/03/11 19:29:56] [debug] [input:forward:forward.0] protocol: sending PONG
[2024/03/11 19:29:56] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: sending HELO
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: checking PING
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: received PING
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: sending PONG
[2024/03/11 19:29:57] [debug] [input chunk] update output instances with new chunk size diff=81, records=3, input=forward.0
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: checking PING
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: received PING
[2024/03/11 19:29:57] [debug] [input:forward:forward.0] protocol: sending PONG
[2024/03/11 19:29:57] [debug] [socket] could not validate socket status for #41 (don't worry)
[2024/03/11 19:29:57] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/03/11 19:29:58] [debug] [input:forward:forward.0] protocol: sending HELO
[2024/03/11 19:29:58] [debug] [input:forward:forward.0] protocol: checking PING
[2024/03/11 19:29:58] [debug] [input:forward:forward.0] protocol: received PING
[2024/03/11 19:29:58] [debug] [input:forward:forward.0] protocol: sending PONG
[2024/03/11 19:29:58] [debug] [input chunk] update output instances with new chunk size diff=27, records=1, input=forward.0
[2024/03/11 19:29:58] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/03/11 19:29:59] [debug] [task] created task=0x8119730 id=0 OK
[2024/03/11 19:29:59] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] test: [[1710152993.026812836, {}], {"message"=>"sample"}]
[1] test: [[1710152994.028428225, {}], {"message"=>"sample"}]
[2] test: [[1710152995.030168613, {}], {"message"=>"sample"}]
[3] test: [[1710152996.032160194, {}], {"message"=>"sample"}]
[2024/03/11 19:29:59] [debug] [out flush] cb_destroy coro_id=0
[2024/03/11 19:29:59] [debug] [task] destroy task=0x8119730 (task_id=0)
^C[2024/03/11 19:30:01] [engine] caught signal (SIGINT)
[2024/03/11 19:30:01] [ warn] [engine] service will shutdown in max 5 seconds
[2024/03/11 19:30:01] [ info] [input] pausing forward.0
[2024/03/11 19:30:01] [ info] [engine] service has stopped (0 pending tasks)
[2024/03/11 19:30:01] [ info] [input] pausing forward.0
[2024/03/11 19:30:01] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/03/11 19:30:01] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==193377== 
==193377== HEAP SUMMARY:
==193377==     in use at exit: 0 bytes in 0 blocks
==193377==   total heap usage: 12,496 allocs, 12,496 frees, 8,767,279 bytes allocated
==193377== 
==193377== All heap blocks were freed -- no leaks are possible
==193377== 
==193377== For lists of detected and suppressed errors, rerun with: -s
==193377== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
