### PR TITLE
fix: ARES_OPT_TRIES must be set to update opt.tries

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -996,12 +996,9 @@ static struct flb_dns_lookup_context *flb_net_dns_lookup_context_create(
         return NULL;
     }
 
-    /* c-ares options: Set the transport layer to the desired protocol and
-     *                 the number of retries to 2
-     */
+    /* c-ares options: Set the transport layer to the desired protocol */
 
-    optmask = ARES_OPT_FLAGS | ARES_OPT_TRIES;
-    opts.tries = 2;
+    optmask = ARES_OPT_FLAGS;
 
     if (dns_mode == FLB_DNS_USE_TCP) {
         opts.flags = ARES_FLAG_USEVC;

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1000,7 +1000,7 @@ static struct flb_dns_lookup_context *flb_net_dns_lookup_context_create(
      *                 the number of retries to 2
      */
 
-    optmask = ARES_OPT_FLAGS;
+    optmask = ARES_OPT_FLAGS | ARES_OPT_TRIES;
     opts.tries = 2;
 
     if (dns_mode == FLB_DNS_USE_TCP) {


### PR DESCRIPTION
This is a typo I spotted in reviewing #5613 - the current code  appears to set opt.tries to 2 (from the default 3) but because the corresponding optflag is not set it will be ignored.

See the c-ares code that is being called:
https://github.com/c-ares/c-ares/blob/e4a4346596c62621704371270220b567b0ddd83d/src/lib/ares_options.c#L310-L316

I'm afraid this is a bit thrown over the wall and untested - I'm just doing it to highlight what's clearly a bug in the code.
An alternative approach would be to delete the line setting opt.tries, because that would leave the behaviour unchanged;
right now I'd _want_ the change I'm proposing tested, because that tries setting has never worked before.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
