### PR TITLE
pack: increase buffer reallocation for higher performance (fix #8492)

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -807,10 +807,11 @@ flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
     while (1) {
         ret = flb_msgpack_to_json(out_buf, out_size, root);
         if (ret <= 0) {
+            realloc_size *= 2;
             tmp_buf = flb_sds_increase(out_buf, realloc_size);
             if (tmp_buf) {
                 out_buf = tmp_buf;
-                out_size += realloc_size;
+                out_size *= realloc_size;
             }
             else {
                 flb_errno();
@@ -1168,7 +1169,7 @@ char *flb_msgpack_to_json_str(size_t size, const msgpack_object *obj)
         ret = flb_msgpack_to_json(buf, size, obj);
         if (ret <= 0) {
             /* buffer is small. retry.*/
-            size += 128;
+            size *= 2;
             tmp = flb_realloc(buf, size);
             if (tmp) {
                 buf = tmp;


### PR DESCRIPTION
When converting from msgpack to raw JSON or sds-json, the reallocation strategy is very convervative to keep the memory usage very low, but in most of scenarios this lead to more fragmentation and high CPU usage.

This patch changes the memory reallocation with an exponential strategy for better performance.

Kudos to @LukasJerabek and @lecaros for helping to troubleshoot and indentify the root cause of this issue.

Here are some comparison before and after the changes:

**before**
note: the test could not finish, takes too long

![image](https://github.com/fluent/fluent-bit/assets/369718/76ab1540-ac7f-4e99-a774-c1029c0a288a)

**after**
note: it finished pretty quickly

![image](https://github.com/fluent/fluent-bit/assets/369718/b13bd24b-1cfb-4657-9975-bd02c0ec6dcc)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
