### PR TITLE
in_elasticsearch: include file to fix warnings

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.h
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.h
@@ -20,6 +20,8 @@
 #ifndef FLB_IN_ELASTICSEARCH_BULK_PROT
 #define FLB_IN_ELASTICSEARCH_BULK_PROT
 
+#include "in_elasticsearch_bulk_conn.h"
+
 #define ES_VERSION_RESPONSE_TEMPLATE \
     "{\"version\":{\"number\":\"%s\",\"build_flavor\":\"Fluent Bit OSS\"},\"tagline\":\"Fluent Bit's Bulk API compatible endpoint\"}"
 


### PR DESCRIPTION
This patch is to fix following warnings.

```
[ 57%] Building C object plugins/in_elasticsearch/CMakeFiles/flb-plugin-in_elasticsearch.dir/in_elasticsearch.c.o
In file included from /home/taka/git/fluent-bit/plugins/in_elasticsearch/in_elasticsearch.c:28:
/home/taka/git/fluent-bit/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.h:31:46: warning: ‘struct in_elasticsearch_bulk_conn’ declared inside parameter list will not be visible outside of this definition or declaration
   31 |                                       struct in_elasticsearch_bulk_conn *conn,
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/taka/git/fluent-bit/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.h:36:52: warning: ‘struct in_elasticsearch_bulk_conn’ declared inside parameter list will not be visible outside of this definition or declaration
   36 |                                             struct in_elasticsearch_bulk_conn *conn,
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-in_elasticsearch 
==23660== Memcheck, a memory error detector
==23660== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==23660== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==23660== Command: bin/flb-rt-in_elasticsearch
==23660== 
Test version...                                 ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test configured_version...                      ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test index_op...                                ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test create_op...                               ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test update_op...                               ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test delete_op...                               ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test nonexistent_op...                          ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test multi_ops...                               ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test multi_ops_gzip...                          ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test index_op_with_plugin_tag...                ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test node_info...                               ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test tag_key...                                 ==23660== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==23660== 
==23660== HEAP SUMMARY:
==23660==     in use at exit: 0 bytes in 0 blocks
==23660==   total heap usage: 29,067 allocs, 29,067 frees, 80,142,440 bytes allocated
==23660== 
==23660== All heap blocks were freed -- no leaks are possible
==23660== 
==23660== For lists of detected and suppressed errors, rerun with: -s
==23660== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
