### PR TITLE
tests: runtime: processor_content_modifier: add test code

### DIFF
--- a/plugins/processor_content_modifier/cm_logs.c
+++ b/plugins/processor_content_modifier/cm_logs.c
@@ -113,10 +113,8 @@ static int hash_transformer(void *context, struct cfl_variant *value)
     }
 
     encoded_hash = cfl_sds_create(converted_value->data.as_string);
-
+    cfl_variant_destroy(converted_value);
     if (encoded_hash == NULL) {
-        cfl_variant_destroy(converted_value);
-
         return FLB_FALSE;
     }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -134,6 +134,10 @@ if (FLB_PROCESSOR_METRICS_SELECTOR)
   FLB_RT_TEST(FLB_PROCESSOR_METRICS_SELECTOR "processor_metrics_selector.c")
 endif()
 
+if (FLB_PROCESSOR_CONTENT_MODIFIER)
+  FLB_RT_TEST(FLB_PROCESSOR_CONTENT_MODIFIER "processor_content_modifier.c")
+endif()
+
 # HTTP Client Debug (requires -DFLB_HTTP_CLIENT_DEBUG=On)
 if(FLB_HTTP_CLIENT_DEBUG)
   FLB_RT_TEST(FLB_OUT_TD           "http_callbacks.c")

--- a/tests/runtime/processor_content_modifier.c
+++ b/tests/runtime/processor_content_modifier.c
@@ -1,0 +1,957 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2024 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include <msgpack.h>
+#include "flb_tests_runtime.h"
+
+struct processor_test {
+    flb_ctx_t *flb;    /* Fluent Bit library context */
+    int i_ffd;         /* Input fd  */
+    int f_ffd;         /* Filter fd */
+    int o_ffd;         /* Output fd */
+    int type; /* logs/metrics/traces */
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+};
+
+struct expect_str {
+    char *str;
+    int  found;
+};
+
+
+/* Callback to check expected results */
+static int cb_check_result(void *record, size_t size, void *data)
+{
+    char *p;
+    char *result;
+    struct expect_str *expected;
+
+    expected = (struct expect_str*)data;
+    result = (char *) record;
+
+    if (!TEST_CHECK(expected != NULL)) {
+        flb_error("expected is NULL");
+    }
+    if (!TEST_CHECK(result != NULL)) {
+        flb_error("result is NULL");
+    }
+
+    while(expected != NULL && expected->str != NULL) {
+        if (expected->found == FLB_TRUE) {
+            p = strstr(result, expected->str);
+            if(!TEST_CHECK(p != NULL)) {
+                flb_error("Expected to find: '%s' in result '%s'",
+                          expected->str, result);
+            }
+        }
+        else {
+            p = strstr(result, expected->str);
+            if(!TEST_CHECK(p == NULL)) {
+                flb_error("'%s' should be removed in result '%s'",
+                          expected->str, result);
+            }
+        }
+
+        /*
+         * If you want to debug your test
+         *
+         * printf("Expect: '%s' in result '%s'", expected, result);
+         */
+
+        expected++;
+    }
+
+    flb_free(record);
+    return 0;
+}
+
+static int init_logs(struct processor_test *ctx, struct flb_lib_out_cb *data)
+{
+    int i_ffd;
+    int o_ffd;
+    int ret;
+
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "lib", NULL);
+    if(!TEST_CHECK(i_ffd >= 0)) {
+        TEST_MSG("flb_input failed");
+        return -1;
+    }
+    flb_input_set(ctx->flb, i_ffd, "tag", "test", NULL);
+    ctx->i_ffd = i_ffd;
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", (void *) data);
+    if(!TEST_CHECK(o_ffd >= 0)) {
+        TEST_MSG("flb_output failed");
+        return -1;
+    }
+    flb_output_set(ctx->flb, o_ffd,
+                   "match", "test",
+                   NULL);
+    ctx->o_ffd = o_ffd;
+
+    ctx->pu = flb_processor_unit_create(ctx->proc, ctx->type, "content_modifier");
+    if(!TEST_CHECK(ctx->pu != NULL)) {
+        TEST_MSG("flb_processor_unit_create failed");
+        return -1;
+    }
+
+    ret = flb_input_set_processor(ctx->flb, i_ffd, ctx->proc);
+    if(!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_input_set_processor faild");
+        return -1;
+    }
+
+    return 0;
+}
+
+static struct processor_test *processor_test_create(int type, struct flb_lib_out_cb *data)
+{
+    struct processor_test *ctx;
+    int ret = -1;
+
+    ctx = flb_malloc(sizeof(struct processor_test));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->proc = NULL;
+    ctx->i_ffd = -1;
+    ctx->f_ffd = -1;
+
+    /* Service config */
+    ctx->flb = flb_create();
+    flb_service_set(ctx->flb,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    ctx->proc = flb_processor_create(ctx->flb->config, "unit_test", NULL, 0);
+    if (!TEST_CHECK(ctx->proc != NULL)) {
+        TEST_MSG("flb_processor_create failed");
+        flb_destroy(ctx->flb);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->type = type;
+    switch (type) {
+    case FLB_PROCESSOR_LOGS:
+        ret = init_logs(ctx, data);
+        break;
+    default:
+        flb_error("not implemented");
+    }
+
+
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("init failed");
+        flb_destroy(ctx->flb);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+static void processor_test_destroy(struct processor_test *ctx)
+{
+    sleep(1);
+    flb_stop(ctx->flb);
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+static void flb_logs_action_insert()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"new_key\":\"new_value\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "insert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "new_key",
+    };
+    struct cfl_variant value = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "new_value",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "value", &value);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_delete()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"key\":\"value\"", FLB_FALSE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "delete",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "key",
+    };
+    struct cfl_variant value = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "value",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "value", &value);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"key\":\"value\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_rename()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"key\":\"value\"", FLB_FALSE},
+      {"\"new_key\":\"value\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "rename",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "key",
+    };
+    struct cfl_variant value = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "new_key",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "value", &value);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"key\":\"value\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_upsert()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"key\":\"new_value\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "upsert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "key",
+    };
+    struct cfl_variant value = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "new_value",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "value", &value);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"key\":\"value\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_hash()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"key\":\"value\"", FLB_FALSE},
+      {"\"key\":\"cd42404d52ad55ccfa9aca4adc828aa5800ad9d385a0671fbcbf724118320619\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "hash",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "key",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"key\":\"value\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_extract()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {"\"log\":\"exception occurred\"", FLB_TRUE},
+      {"\"date\":\"2024/03/15\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "extract",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "key",
+    };
+    struct cfl_variant pattern = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "/(?<date>\\d{4}\\/\\d{2}\\/\\d{2}) (?<log>.+)/",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "pattern", &pattern);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"key\":\"2024/03/15 exception occurred\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_string_to_int()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"str\":100", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "str",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "int",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"str\":\"100\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_int_to_string()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"i_key\":\"-100\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "i_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "string",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"i_key\":-100}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_string_to_double()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"str\":123.456", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "str",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "double",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"str\":\"123.456\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_double_to_string()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"d_key\":\"123.456\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "d_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "string",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"d_key\":123.456}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_string_to_boolean()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"str\":false", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "str",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "boolean",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"str\":\"false\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+TEST_LIST = {
+    {"logs.action.insert"           , flb_logs_action_insert },
+    {"logs.action.delete"           , flb_logs_action_delete },
+    {"logs.action.rename"           , flb_logs_action_rename },
+    {"logs.action.upsert"           , flb_logs_action_upsert },
+    {"logs.action.hash"             , flb_logs_action_hash },
+    {"logs.action.extract"          , flb_logs_action_extract },
+    {"logs.action.convert_from_string_to_int" , flb_logs_action_convert_from_string_to_int },
+    {"logs.action.convert_from_int_to_string" , flb_logs_action_convert_from_int_to_string },
+    {"logs.action.convert_from_string_to_double" , flb_logs_action_convert_from_string_to_double },
+    {"logs.action.convert_from_double_to_string" , flb_logs_action_convert_from_double_to_string },
+    {"logs.action.convert_from_string_to_boolean" , flb_logs_action_convert_from_string_to_boolean },
+    {NULL, NULL}
+};


### PR DESCRIPTION
This patch is to
- Add test code for "logs" using processor_content_modifier
- Fix not freed memory issue for processor_content_modifier

Note: Test code for `metrics` and `traces` are not implemented.

Memory issue is 
```
==66962== HEAP SUMMARY:
==66962==     in use at exit: 105 bytes in 2 blocks
==66962==   total heap usage: 12,619 allocs, 12,617 frees, 4,267,696 bytes allocated
==66962== 
==66962== 105 (24 direct, 81 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 2
==66962==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==66962==    by 0x96CE2F: cfl_variant_create (cfl_variant.c:242)
==66962==    by 0x96CB1A: cfl_variant_create_from_string_s (cfl_variant.c:94)
==66962==    by 0x53D9A7: cfl_variant_convert (cm_logs.c:182)
==66962==    by 0x53D6AB: hash_transformer (cm_logs.c:79)
==66962==    by 0x53E234: run_action_hash (cm_logs.c:449)
==66962==    by 0x53E6A9: cm_logs_process (cm_logs.c:584)
==66962==    by 0x534BE2: cb_process_logs (cm.c:78)
==66962==    by 0x214BC4: flb_processor_run (flb_processor.c:570)
==66962==    by 0x28F7EC: input_log_append (flb_input_log.c:51)
==66962==    by 0x28F909: flb_input_log_append (flb_input_log.c:90)
==66962==    by 0x51511D: in_lib_collect (in_lib.c:162)
==66962== 
==66962== LEAK SUMMARY:
==66962==    definitely lost: 24 bytes in 1 blocks
==66962==    indirectly lost: 81 bytes in 1 blocks
==66962==      possibly lost: 0 bytes in 0 blocks
==66962==    still reachable: 0 bytes in 0 blocks
==66962==         suppressed: 0 bytes in 0 blocks
==66962== 
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-rt-processor_content_modifier 
==32959== Memcheck, a memory error detector
==32959== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32959== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==32959== Command: bin/flb-rt-processor_content_modifier
==32959== 
Test logs.action.insert...                      [ OK ]
Test logs.action.delete...                      [ OK ]
Test logs.action.rename...                      [ OK ]
Test logs.action.upsert...                      [ OK ]
Test logs.action.hash...                        [ OK ]
Test logs.action.extract...                     [ OK ]
Test logs.action.convert_from_string_to_int...  [ OK ]
Test logs.action.convert_from_int_to_string...  [ OK ]
Test logs.action.convert_from_string_to_double... [ OK ]
Test logs.action.convert_from_double_to_string... [ OK ]
Test logs.action.convert_from_string_to_boolean... [ OK ]
SUCCESS: All unit tests have passed.
==32959== 
==32959== HEAP SUMMARY:
==32959==     in use at exit: 0 bytes in 0 blocks
==32959==   total heap usage: 21,979 allocs, 21,979 frees, 8,949,295 bytes allocated
==32959== 
==32959== All heap blocks were freed -- no leaks are possible
==32959== 
==32959== For lists of detected and suppressed errors, rerun with: -s
==32959== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
