### PR TITLE
Add shared, buffer memory & Change unit to byte

### DIFF
--- a/plugins/in_mem/mem.h
+++ b/plugins/in_mem/mem.h
@@ -33,6 +33,8 @@ struct flb_in_mem_info {
     uint64_t mem_total;
     uint64_t mem_used;
     uint64_t mem_free;
+    uint64_t mem_shard;
+    uint64_t mem_buffer;
     uint64_t swap_total;
     uint64_t swap_used;
     uint64_t swap_free;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Shared, buffer memory information and unit changes.

```
[2024/03/18 21:10:15] [ info] [fluent bit] version=3.0.0, commit=2ff1365abc, pid=45683
[2024/03/18 21:10:15] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/18 21:10:15] [ info] [cmetrics] version=0.7.0
[2024/03/18 21:10:15] [ info] [ctraces ] version=0.4.0
[2024/03/18 21:10:15] [ info] [input:mem:mem.0] initializing
[2024/03/18 21:10:15] [ info] [input:mem:mem.0] storage_strategy='memory' (memory only)
[2024/03/18 21:10:15] [ info] [sp] stream processor started
[2024/03/18 21:10:15] [ info] [output:stdout:stdout.0] worker #0 started
[0] mem.0: [[1710763816.240879347, {}], {"Mem.total"=>33190821888, "Mem.used"=>4165926912, "Mem.free"=>29024894976, "Mem.shared"=>3170304, "Mem.buffer"=>123072512, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763817.240616841, {}], {"Mem.total"=>33190821888, "Mem.used"=>4165943296, "Mem.free"=>29024878592, "Mem.shared"=>3170304, "Mem.buffer"=>123072512, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763818.240591300, {}], {"Mem.total"=>33190821888, "Mem.used"=>4163796992, "Mem.free"=>29027024896, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763819.240603306, {}], {"Mem.total"=>33190821888, "Mem.used"=>4163796992, "Mem.free"=>29027024896, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763820.240604918, {}], {"Mem.total"=>33190821888, "Mem.used"=>4165890048, "Mem.free"=>29024931840, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763821.240602812, {}], {"Mem.total"=>33190821888, "Mem.used"=>4165890048, "Mem.free"=>29024931840, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763822.240597363, {}], {"Mem.total"=>33190821888, "Mem.used"=>4165890048, "Mem.free"=>29024931840, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763823.240595038, {}], {"Mem.total"=>33190821888, "Mem.used"=>4165890048, "Mem.free"=>29024931840, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763824.240610770, {}], {"Mem.total"=>33190821888, "Mem.used"=>4164018176, "Mem.free"=>29026803712, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
[0] mem.0: [[1710763825.240606888, {}], {"Mem.total"=>33190821888, "Mem.used"=>4164018176, "Mem.free"=>29026803712, "Mem.shared"=>3170304, "Mem.buffer"=>123080704, "Swap.total"=>8589934592, "Swap.used"=>0, "Swap.free"=>8589934592}]
```
A case for changing units kb to byte,
Many visualization tools define the default unit as bytes.
I suggest changing the unit to bytes for convenience in visualizations and to reduce unnecessary computations.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
