### PR TITLE
centos7: disable SQL processor to resolve build failures

### DIFF
--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -23,6 +23,7 @@ RUN cmake3 -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/e
     -DFLB_OUT_KAFKA=On \
     -DFLB_JEMALLOC=On \
     -DFLB_CHUNK_TRACE=On \
+    -DFLB_PROCESSOR_SQL=Off \
     -DFLB_OUT_PGSQL=On ../
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -77,7 +77,8 @@ RUN yum -y update && \
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
-ARG FLB_PROCESSOR_SQL=On
+# Fails on CentOS 8: https://github.com/fluent/fluent-bit/issues/8606
+ARG FLB_PROCESSOR_SQL=Off
 ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # centos/8.arm64v8 base image
@@ -103,7 +104,8 @@ RUN yum -y update && \
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
-ARG FLB_PROCESSOR_SQL=On
+# Fails on CentOS 8: https://github.com/fluent/fluent-bit/issues/8606
+ARG FLB_PROCESSOR_SQL=Off
 ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # Need larger page size

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -25,6 +25,9 @@ RUN yum -y update && \
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+# Fails on CentOS 7: https://github.com/fluent/fluent-bit/issues/8606
+ARG FLB_PROCESSOR_SQL=Off
+ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # centos/7.arm64v8 base image
 FROM arm64v8/centos:7 as centos-7.arm64v8-base
@@ -45,6 +48,9 @@ RUN yum -y update && \
 # There are no postgresql libraries available for this target
 ARG FLB_OUT_PGSQL=Off
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+# Fails on CentOS 7: https://github.com/fluent/fluent-bit/issues/8606
+ARG FLB_PROCESSOR_SQL=Off
+ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # Need larger page size
 ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
@@ -71,6 +77,8 @@ RUN yum -y update && \
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+ARG FLB_PROCESSOR_SQL=On
+ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # centos/8.arm64v8 base image
 FROM arm64v8/centos:8 as centos-8.arm64v8-base
@@ -95,6 +103,8 @@ RUN yum -y update && \
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+ARG FLB_PROCESSOR_SQL=On
+ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # Need larger page size
 ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
@@ -114,6 +124,8 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+ARG FLB_PROCESSOR_SQL=On
+ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # hadolint ignore=DL3029
 FROM --platform=arm64 quay.io/centos/centos:stream9 as centos-9.arm64v8-base
@@ -132,6 +144,8 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
 
 ARG FLB_OUT_PGSQL=On
 ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+ARG FLB_PROCESSOR_SQL=On
+ENV FLB_PROCESSOR_SQL=$FLB_PROCESSOR_SQL
 
 # Need larger page size
 ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
@@ -175,6 +189,7 @@ RUN cmake3 -DCMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" \
     -DFLB_JEMALLOC_OPTIONS="$FLB_JEMALLOC_OPTIONS" \
     -DFLB_JEMALLOC="${FLB_JEMALLOC}" \
     -DFLB_CHUNK_TRACE="${FLB_CHUNK_TRACE}" \
+    -DFLB_PROCESSOR_SQL="${FLB_PROCESSOR_SQL}" \
     ../
 
 VOLUME [ "/output" ]


### PR DESCRIPTION
Resolves #8606 by disabling SQL processor support for CentOS 7 targets.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

Tested in CI and locally: see the `ok-package-test` label to trigger builds of all supported targets.

Locally ran `./packaging/build.sh -d centos/7` and `./packaging/build.sh -d centos/8`.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
