### PR TITLE
packaging: build: Make to be able to replace docker cli via environment variable

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -77,7 +77,7 @@ echo "CMAKE_INSTALL_PREFIX  => $CMAKE_INSTALL_PREFIX"
 echo "FLB_NIGHTLY_BUILD     => $FLB_NIGHTLY_BUILD"
 echo "FLB_JEMALLOC          => $FLB_JEMALLOC"
 
-if [ ${DOCKER} = "docker" ]; then
+if [ "${DOCKER}" = "docker" ]; then
     export DOCKER_BUILDKIT=1
 else
     export DOCKER_BUILDKIT=0

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -10,6 +10,7 @@ FLB_DISTRO=${FLB_DISTRO:-}
 FLB_OUT_DIR=${FLB_OUT_DIR:-}
 FLB_NIGHTLY_BUILD=${FLB_NIGHTLY_BUILD:-}
 FLB_JEMALLOC=${FLB_JEMALLOC:-On}
+DOCKER=${FLB_DOCKER_CLI:-docker}
 
 # Use this to pass special arguments to docker build
 FLB_ARG=${FLB_ARG:-}
@@ -76,11 +77,15 @@ echo "CMAKE_INSTALL_PREFIX  => $CMAKE_INSTALL_PREFIX"
 echo "FLB_NIGHTLY_BUILD     => $FLB_NIGHTLY_BUILD"
 echo "FLB_JEMALLOC          => $FLB_JEMALLOC"
 
-export DOCKER_BUILDKIT=1
+if [ ${DOCKER} = "docker" ]; then
+    export DOCKER_BUILDKIT=1
+else
+    export DOCKER_BUILDKIT=0
+fi
 
 # Build the main image - we do want word splitting
 # shellcheck disable=SC2086
-if ! docker build \
+if ! ${DOCKER} build \
     --build-arg CMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" \
     --build-arg FLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
     --build-arg FLB_JEMALLOC="$FLB_JEMALLOC" \
@@ -95,7 +100,7 @@ then
 fi
 
 # Compile and package
-if ! docker run \
+if ! ${DOCKER} run \
     -v "$volume":/output \
     "$MAIN_IMAGE"
 then


### PR DESCRIPTION
Theoretically, podman cli could be used for creating packages. The default command for container cli should be docker.
To use _podman_ instead of _docker_, define `FLB_DOCKER_CLI=podman`. Then podman is working with build and run commands.
 
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
