### PR TITLE
lib: nghttp2: Disable auto-detection for OpenSSL

### DIFF
--- a/lib/nghttp2/CMakeLists.txt
+++ b/lib/nghttp2/CMakeLists.txt
@@ -60,7 +60,8 @@ set(OPENSSL_MSVC_STATIC_RT  ON)
 find_package(Python3 COMPONENTS Interpreter)
 
 # Auto-detection of features that can be toggled
-find_package(OpenSSL 1.0.1)
+## This auto detection causes weird linker errors. So, it's disabled for now.
+# find_package(OpenSSL 1.0.1)
 find_package(Libev 4.11)
 find_package(Libcares 1.7.5)
 find_package(ZLIB 1.2.3)


### PR DESCRIPTION
<!-- Provide summary of changes -->

Even if dusabling the auto-detection for OpenSSL in nghttp2, 
I got the following result:

```python
[INPUT]
    Name        http
    Port        8080
    tls         On
    tls.verify  Off
    tls.crt_file self_signed.crt
    tls.key_file self_signed.key

[OUTPUT]
    Name stdout
    Match *
```

```
% bin/fluent-bit -c in_http.conf
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/03/21 19:32:27] [ info] [fluent bit] version=3.0.0, commit=79c05d92fd, pid=9487
[2024/03/21 19:32:27] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/21 19:32:27] [ info] [cmetrics] version=0.7.0
[2024/03/21 19:32:27] [ info] [ctraces ] version=0.4.0
[2024/03/21 19:32:27] [ info] [input:http:http.0] initializing
[2024/03/21 19:32:27] [ info] [input:http:http.0] storage_strategy='memory' (memory only)
[2024/03/21 19:32:27] [ info] [output:stdout:stdout.0] worker #0 started
[2024/03/21 19:32:27] [ info] [sp] stream processor started
[0] http.0: [[1711017151.387275000, {}], {"protocol"=>"http2?"}]
^C[2024/03/21 19:32:33] [engine] caught signal (SIGINT)
[2024/03/21 19:32:33] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/03/21 19:32:33] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

```
% curl --verbose -XPOST -H 'Content-Type: application/json' -d '{"protocol":"http2?"}' -k https://localhost:8080
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying [::1]:8080...
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=test.host.net
*  start date: Mar 21 08:54:55 2024 GMT
*  expire date: Apr 20 08:54:55 2024 GMT
*  issuer: CN=test.host.net
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://localhost:8080/
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: localhost:8080]
* [HTTP/2] [1] [:path: /]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [content-type: application/json]
* [HTTP/2] [1] [content-length: 21]
> POST / HTTP/2
> Host: localhost:8080
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 21
> 
< HTTP/2 201 
< content-length: 0
< 
* Connection #0 to host localhost left intact
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
