### PR TITLE
out_exit: add time_count (seconds) and record_count parameters for out_exit.

### DIFF
--- a/plugins/out_exit/exit.c
+++ b/plugins/out_exit/exit.c
@@ -67,9 +67,8 @@ static int cb_exit_init(struct flb_output_instance *ins, struct flb_config *conf
     if (ctx->flush_count == -1 &&
         ctx->record_count == -1 &&
         ctx->time_count == -1) {
-        flb_plg_error(ctx->ins, "no count set for flush, record or time, set at least one");
-        flb_free(ctx);
-        return -1;
+        // emulate legacy behaviour by setting to a single flush.
+        ctx->flush_count = 1;
     }
 
     flb_output_set_context(ins, ctx);

--- a/plugins/out_exit/exit.c
+++ b/plugins/out_exit/exit.c
@@ -19,15 +19,22 @@
 
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_log_event_decoder.h>
 
-#define FLB_EXIT_FLUSH_COUNT  "1"
+#define FLB_EXIT_FLUSH_COUNT  "-1"
+#define FLB_EXIT_RECORD_COUNT "-1"
+#define FLB_EXIT_TIME_COUNT   "-1"
 
 struct flb_exit {
     int is_running;
-    int count;
+    struct flb_time start_time;
 
     /* config */
     int flush_count;
+    int record_count;
+    int time_count;
+    struct flb_output_instance *ins;
 };
 
 static int cb_exit_init(struct flb_output_instance *ins, struct flb_config *config,
@@ -43,11 +50,24 @@ static int cb_exit_init(struct flb_output_instance *ins, struct flb_config *conf
         flb_errno();
         return -1;
     }
-    ctx->count = 0;
+    ctx->ins = ins;
     ctx->is_running = FLB_TRUE;
+    flb_time_get(&ctx->start_time);
+
+    ctx->flush_count = -1;
+    ctx->record_count = -1;
+    ctx->time_count = -1;
 
     ret = flb_output_config_map_set(ins, (void *) ctx);
     if (ret == -1) {
+        flb_free(ctx);
+        return -1;
+    }
+
+    if (ctx->flush_count == -1 &&
+        ctx->record_count == -1 &&
+        ctx->time_count == -1) {
+        flb_plg_error(ctx->ins, "no count set for flush, record or time, set at least one");
         flb_free(ctx);
         return -1;
     }
@@ -66,11 +86,57 @@ static void cb_exit_flush(struct flb_event_chunk *event_chunk,
     (void) i_ins;
     (void) out_context;
     struct flb_exit *ctx = out_context;
+    struct flb_log_event_decoder log_decoder;
+    struct flb_log_event         log_event;
+    struct flb_time now;
+    struct flb_time run;
+    int result;
 
-    ctx->count++;
-    if (ctx->is_running == FLB_TRUE && ctx->count >= ctx->flush_count) {
-        flb_engine_exit(config);
-        ctx->is_running = FLB_FALSE;
+    if (ctx->is_running == FLB_TRUE) {
+        if (ctx->flush_count > 0) {
+            ctx->flush_count--;
+        }
+
+        if (ctx->record_count > 0 && event_chunk->type == FLB_EVENT_TYPE_LOGS) {
+            result = flb_log_event_decoder_init(&log_decoder,
+                                               (char *) event_chunk->data,
+                                               event_chunk->size);
+            if (result != FLB_EVENT_DECODER_SUCCESS) {
+                flb_plg_error(ctx->ins,
+                              "Log event decoder initialization error : %d", result);
+
+                FLB_OUTPUT_RETURN(FLB_RETRY);
+            }
+
+            while (flb_log_event_decoder_next(&log_decoder,
+                                              &log_event) == FLB_EVENT_DECODER_SUCCESS) {
+                if (ctx->record_count > 0) {
+                    ctx->record_count--;
+                }
+            }
+
+            result = flb_log_event_decoder_get_last_result(&log_decoder);
+            flb_log_event_decoder_destroy(&log_decoder);
+
+            if (result != FLB_EVENT_DECODER_SUCCESS) {
+                flb_plg_error(ctx->ins, "Log event decoder error : %d", result);
+                FLB_OUTPUT_RETURN(FLB_ERROR);
+            }
+
+            FLB_OUTPUT_RETURN(FLB_OK);
+        }
+
+        if (ctx->time_count > 0) {
+            flb_time_get(&now);
+            flb_time_diff(&now, &ctx->start_time, &run);
+        }
+
+        if (ctx->flush_count == 0 ||
+            ctx->record_count == 0 ||
+            (ctx->time_count && flb_time_to_millisec(&run) > (ctx->time_count*1000))) {
+            flb_engine_exit(config);
+            ctx->is_running = FLB_FALSE;
+        }
     }
 
     FLB_OUTPUT_RETURN(FLB_OK);
@@ -90,7 +156,17 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_INT, "flush_count", FLB_EXIT_FLUSH_COUNT,
      0, FLB_TRUE, offsetof(struct flb_exit, flush_count),
-     NULL
+     "number of flushes before exiting"
+    },
+    {
+     FLB_CONFIG_MAP_INT, "record_count", FLB_EXIT_RECORD_COUNT,
+     0, FLB_TRUE, offsetof(struct flb_exit, record_count),
+     "number of records received before exiting"
+    },
+    {
+     FLB_CONFIG_MAP_INT, "time_count", FLB_EXIT_TIME_COUNT,
+     0, FLB_TRUE, offsetof(struct flb_exit, time_count),
+     "number of seconds before exiting (will trigger upon receiving a flush)"
     },
 
     /* EOF */

--- a/plugins/out_exit/exit.c
+++ b/plugins/out_exit/exit.c
@@ -132,7 +132,7 @@ static void cb_exit_flush(struct flb_event_chunk *event_chunk,
 
         if (ctx->flush_count == 0 ||
             ctx->record_count == 0 ||
-            (ctx->time_count && flb_time_to_millisec(&run) > (ctx->time_count*1000))) {
+            (ctx->time_count > 0 && flb_time_to_millisec(&run) > (ctx->time_count*1000))) {
             flb_engine_exit(config);
             ctx->is_running = FLB_FALSE;
         }


### PR DESCRIPTION
# Summary

This PR adds two new parameters to the `out_exit` plugin:

- record_count: exit after a set number of records.
- time_count: exit after a set number of seconds have elapsed (within a flush).

Here is a run for each different mode:

fush_count:

```
$ valgrind ./bin/fluent-bit -i dummy -o exit -p flush_count=5 -f 1
==225327== Memcheck, a memory error detector
==225327== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==225327== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==225327== Command: ./bin/fluent-bit -i dummy -o exit -p flush_count=5 -f 1
==225327==
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  <
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/

[2024/03/21 18:55:14] [ info] [fluent bit] version=3.0.0, commit=efa1e89fac, pid=225327
[2024/03/21 18:55:14] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/21 18:55:14] [ info] [cmetrics] version=0.7.0
[2024/03/21 18:55:14] [ info] [ctraces ] version=0.4.0
[2024/03/21 18:55:15] [ info] [input:dummy:dummy.0] initializing
[2024/03/21 18:55:15] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/03/21 18:55:15] [ info] [sp] stream processor started
[2024/03/21 18:55:20] [ warn] [engine] service will shutdown in max 5 seconds
[2024/03/21 18:55:20] [ info] [input] pausing dummy.0
[2024/03/21 18:55:21] [ info] [engine] service has stopped (0 pending tasks)
[2024/03/21 18:55:21] [ info] [input] pausing dummy.0
==225327==
==225327== HEAP SUMMARY:
==225327==     in use at exit: 0 bytes in 0 blocks
==225327==   total heap usage: 1,720 allocs, 1,720 frees, 2,247,178 bytes allocated
==225327==
==225327== All heap blocks were freed -- no leaks are possible
==225327==
==225327== For lists of detected and suppressed errors, rerun with: -s
==225327== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

record_count:

```
$ valgrind ./bin/fluent-bit -i dummy -p copies=2 -o exit -p record_count=6 -f 1
==225485== Memcheck, a memory error detector
==225485== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==225485== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==225485== Command: ./bin/fluent-bit -i dummy -p copies=2 -o exit -p record_count=6 -f 1
==225485==
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  <
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/

[2024/03/21 18:56:38] [ info] [fluent bit] version=3.0.0, commit=efa1e89fac, pid=225485
[2024/03/21 18:56:38] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/21 18:56:38] [ info] [cmetrics] version=0.7.0
[2024/03/21 18:56:38] [ info] [ctraces ] version=0.4.0
[2024/03/21 18:56:38] [ info] [input:dummy:dummy.0] initializing
[2024/03/21 18:56:38] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/03/21 18:56:38] [ info] [sp] stream processor started
[2024/03/21 18:56:43] [ warn] [engine] service will shutdown in max 5 seconds
[2024/03/21 18:56:43] [ info] [input] pausing dummy.0
[2024/03/21 18:56:44] [ info] [engine] service has stopped (0 pending tasks)
[2024/03/21 18:56:44] [ info] [input] pausing dummy.0
==225485==
==225485== HEAP SUMMARY:
==225485==     in use at exit: 0 bytes in 0 blocks
==225485==   total heap usage: 1,763 allocs, 1,763 frees, 2,067,814 bytes allocated
==225485==
==225485== All heap blocks were freed -- no leaks are possible
==225485==
==225485== For lists of detected and suppressed errors, rerun with: -s
==225485== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

time_count:
```
$ valgrind ./bin/fluent-bit -i dummy -p copies=5 -o exit -p time_count=3 -f 1
==225570== Memcheck, a memory error detector
==225570== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==225570== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==225570== Command: ./bin/fluent-bit -i dummy -p copies=5 -o exit -p time_count=3 -f 1
==225570==
Fluent Bit v3.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  <
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/

[2024/03/21 18:57:18] [ info] [fluent bit] version=3.0.0, commit=efa1e89fac, pid=225570
[2024/03/21 18:57:18] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/21 18:57:18] [ info] [cmetrics] version=0.7.0
[2024/03/21 18:57:18] [ info] [ctraces ] version=0.4.0
[2024/03/21 18:57:18] [ info] [input:dummy:dummy.0] initializing
[2024/03/21 18:57:18] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/03/21 18:57:18] [ info] [sp] stream processor started
[2024/03/21 18:57:22] [ warn] [engine] service will shutdown in max 5 seconds
[2024/03/21 18:57:22] [ info] [input] pausing dummy.0
[2024/03/21 18:57:23] [ info] [engine] service has stopped (0 pending tasks)
[2024/03/21 18:57:23] [ info] [input] pausing dummy.0
==225570==
==225570== HEAP SUMMARY:
==225570==     in use at exit: 0 bytes in 0 blocks
==225570==   total heap usage: 1,784 allocs, 1,784 frees, 1,741,196 bytes allocated
==225570==
==225570== All heap blocks were freed -- no leaks are possible
==225570==
==225570== For lists of detected and suppressed errors, rerun with: -s
==225570== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

It might be a good idea to start the timer for `time_count` from the first flush, but I don't know if that is worth the effort. It would be easy enough to implement if it is deemed worthwhile.

---
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
