### PR TITLE
tests: runtime: processor_content_modifier: add test cases for convert

### DIFF
--- a/tests/runtime/processor_content_modifier.c
+++ b/tests/runtime/processor_content_modifier.c
@@ -941,6 +941,490 @@ static void flb_logs_action_convert_from_string_to_boolean()
     processor_test_destroy(ctx);
 }
 
+static void flb_logs_action_convert_from_int_to_boolean()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"i_key\":true", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "i_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "boolean",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"i_key\":-100}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_int_to_double()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"i_key\":-100.0", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "i_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "double",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"i_key\":-100}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_double_to_int()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"d_key\":123", FLB_TRUE},
+      {"\"d_key\":123.", FLB_FALSE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "d_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "int",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"d_key\":123.456}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_double_to_boolean()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"d_key\":true", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "d_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "boolean",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"d_key\":123.456}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_null_to_string()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"n_key\":\"null\"", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "n_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "string",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"n_key\":null}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_null_to_int()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"n_key\":0", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "n_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "int",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"n_key\":null}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
+static void flb_logs_action_convert_from_null_to_double()
+{
+    struct processor_test *ctx;
+    struct flb_lib_out_cb cb_data;
+    int ret;
+    char *p;
+    int bytes;
+    size_t len;
+    struct expect_str expect[] = {
+      {"\"n_key\":0.0", FLB_TRUE},
+      {"\"k\":\"sample\"", FLB_TRUE},
+      {NULL, FLB_TRUE}
+    };
+
+    struct cfl_variant action = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "convert",
+    };
+    struct cfl_variant context = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "message",
+    };
+    struct cfl_variant key = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "n_key",
+    };
+    struct cfl_variant converted_type = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "double",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_check_result;
+    cb_data.data = &expect;
+
+    ctx = processor_test_create(FLB_PROCESSOR_LOGS, &cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("failed to create ctx");
+        return;
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(ctx->pu, "action", &action);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "context", &context);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "key", &key);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(ctx->pu, "converted_type", &converted_type);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed");
+        return;
+    }
+
+    p = "[0, {\"k\":\"sample\", \"n_key\":null}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    processor_test_destroy(ctx);
+}
+
 TEST_LIST = {
     {"logs.action.insert"           , flb_logs_action_insert },
     {"logs.action.delete"           , flb_logs_action_delete },
@@ -953,5 +1437,12 @@ TEST_LIST = {
     {"logs.action.convert_from_string_to_double" , flb_logs_action_convert_from_string_to_double },
     {"logs.action.convert_from_double_to_string" , flb_logs_action_convert_from_double_to_string },
     {"logs.action.convert_from_string_to_boolean" , flb_logs_action_convert_from_string_to_boolean },
+    {"logs.action.convert_from_int_to_boolean" , flb_logs_action_convert_from_int_to_boolean },
+    {"logs.action.convert_from_int_to_double" , flb_logs_action_convert_from_int_to_double },
+    {"logs.action.convert_from_double_to_int" , flb_logs_action_convert_from_double_to_int },
+    {"logs.action.convert_from_double_to_boolean" , flb_logs_action_convert_from_double_to_boolean },
+    {"logs.action.convert_from_null_to_string" , flb_logs_action_convert_from_null_to_string },
+    {"logs.action.convert_from_null_to_int" , flb_logs_action_convert_from_null_to_int },
+    {"logs.action.convert_from_null_to_double" , flb_logs_action_convert_from_null_to_double },
     {NULL, NULL}
 };


### PR DESCRIPTION
This patch is to enrich test cases for convert of processor_content_modifier.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
d$ valgrind --leak-check=full bin/flb-rt-processor_content_modifier 
==48356== Memcheck, a memory error detector
==48356== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==48356== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==48356== Command: bin/flb-rt-processor_content_modifier
==48356== 
Test logs.action.insert...                      [ OK ]
Test logs.action.delete...                      [ OK ]
Test logs.action.rename...                      [ OK ]
Test logs.action.upsert...                      [ OK ]
Test logs.action.hash...                        [ OK ]
Test logs.action.extract...                     [ OK ]
Test logs.action.convert_from_string_to_int...  [ OK ]
Test logs.action.convert_from_int_to_string...  [ OK ]
Test logs.action.convert_from_string_to_double... [ OK ]
Test logs.action.convert_from_double_to_string... [ OK ]
Test logs.action.convert_from_string_to_boolean... [ OK ]
Test logs.action.convert_from_int_to_boolean... [ OK ]
Test logs.action.convert_from_int_to_double...  [ OK ]
Test logs.action.convert_from_double_to_int...  [ OK ]
Test logs.action.convert_from_double_to_boolean... [ OK ]
Test logs.action.convert_from_null_to_string... [ OK ]
Test logs.action.convert_from_null_to_int...    [ OK ]
Test logs.action.convert_from_null_to_double... [ OK ]
SUCCESS: All unit tests have passed.
==48356== 
==48356== HEAP SUMMARY:
==48356==     in use at exit: 0 bytes in 0 blocks
==48356==   total heap usage: 32,830 allocs, 32,830 frees, 14,408,994 bytes allocated
==48356== 
==48356== All heap blocks were freed -- no leaks are possible
==48356== 
==48356== For lists of detected and suppressed errors, rerun with: -s
==48356== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
