### PR TITLE
typecast: fix strtoimax error(#8632)

### DIFF
--- a/src/flb_typecast.c
+++ b/src/flb_typecast.c
@@ -76,6 +76,7 @@ static int flb_typecast_conv_str(const char *input, int input_len,
 {
     flb_sds_t tmp_str;
     int ret = 0;
+    char *endp = NULL;
 
     if(input == NULL || rule == NULL || output == NULL) {
         return -1;
@@ -97,8 +98,8 @@ static int flb_typecast_conv_str(const char *input, int input_len,
 
     switch(rule->to_type) {
     case FLB_TYPECAST_TYPE_INT:
-      output->val.i_num = strtoimax(tmp_str, NULL, 10);
-      if (output->val.i_num == 0) {
+      output->val.i_num = strtoimax(tmp_str, &endp, 10);
+      if (output->val.i_num == 0 && (tmp_str == endp)) {
           flb_error("%s: convert error. input=%s", __FUNCTION__, tmp_str);
           ret = -1;
           goto typecast_conv_str_end;
@@ -108,8 +109,8 @@ static int flb_typecast_conv_str(const char *input, int input_len,
       }
       break;
     case FLB_TYPECAST_TYPE_UINT:
-      output->val.ui_num = strtoumax(tmp_str, NULL, 10);
-      if (output->val.ui_num == 0) {
+      output->val.ui_num = strtoumax(tmp_str, &endp, 10);
+      if (output->val.ui_num == 0 && (tmp_str == endp)) {
           flb_error("%s: convert error. input=%s", __FUNCTION__, tmp_str);
           ret = -1;
           goto typecast_conv_str_end;


### PR DESCRIPTION
This patch is to 
- Fix conversion error when string is "0"
- Add test case for "0" and invalid string

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Configuration

```
[INPUT]
    Name dummy
    Dummy {"teste": "0"}

[FILTER]
    Name type_converter
    Match *
    str_key teste teste_int uint

[OUTPUT]
    Name stdout
    Match *
```

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/fluent-bit -c 8632.conf 
==17270== Memcheck, a memory error detector
==17270== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17270== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==17270== Command: bin/fluent-bit -c 8632.conf
==17270== 
Fluent Bit v3.0.1
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/03/26 08:02:56] [ info] [fluent bit] version=3.0.1, commit=b99fc4dc7b, pid=17270
[2024/03/26 08:02:56] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/26 08:02:56] [ info] [cmetrics] version=0.7.0
[2024/03/26 08:02:56] [ info] [ctraces ] version=0.4.0
[2024/03/26 08:02:56] [ info] [input:dummy:dummy.0] initializing
[2024/03/26 08:02:56] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/03/26 08:02:56] [ info] [output:stdout:stdout.0] worker #0 started
[2024/03/26 08:02:56] [ info] [sp] stream processor started
[0] dummy.0: [[1711407776.990652015, {}], {"teste"=>"0", "teste_int"=>0}]
^C[2024/03/26 08:02:58] [engine] caught signal (SIGINT)
[2024/03/26 08:02:58] [ warn] [engine] service will shutdown in max 5 seconds
[0] dummy.0: [[1711407777.997907300, {}], {"teste"=>"0", "teste_int"=>0}]
[2024/03/26 08:02:58] [ info] [input] pausing dummy.0
[2024/03/26 08:02:58] [ info] [engine] service has stopped (0 pending tasks)
[2024/03/26 08:02:58] [ info] [input] pausing dummy.0
[2024/03/26 08:02:59] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/03/26 08:02:59] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==17270== 
==17270== HEAP SUMMARY:
==17270==     in use at exit: 0 bytes in 0 blocks
==17270==   total heap usage: 1,819 allocs, 1,819 frees, 1,184,698 bytes allocated
==17270== 
==17270== All heap blocks were freed -- no leaks are possible
==17270== 
==17270== For lists of detected and suppressed errors, rerun with: -s
==17270== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --leak-check=full bin/flb-it-typecast 
==17054== Memcheck, a memory error detector
==17054== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==17054== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==17054== Command: bin/flb-it-typecast
==17054== 
Test str_to_int...                              [ OK ]
==17055== Warning: invalid file descriptor -1 in syscall close()
==17055== 
==17055== HEAP SUMMARY:
==17055==     in use at exit: 0 bytes in 0 blocks
==17055==   total heap usage: 855 allocs, 855 frees, 104,555 bytes allocated
==17055== 
==17055== All heap blocks were freed -- no leaks are possible
==17055== 
==17055== For lists of detected and suppressed errors, rerun with: -s
==17055== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test int_to_str...                              [ OK ]
==17056== Warning: invalid file descriptor -1 in syscall close()
==17056== 
==17056== HEAP SUMMARY:
==17056==     in use at exit: 0 bytes in 0 blocks
==17056==   total heap usage: 853 allocs, 853 frees, 96,299 bytes allocated
==17056== 
==17056== All heap blocks were freed -- no leaks are possible
==17056== 
==17056== For lists of detected and suppressed errors, rerun with: -s
==17056== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test str_to_float...                            [ OK ]
==17057== Warning: invalid file descriptor -1 in syscall close()
==17057== 
==17057== HEAP SUMMARY:
==17057==     in use at exit: 0 bytes in 0 blocks
==17057==   total heap usage: 855 allocs, 855 frees, 104,559 bytes allocated
==17057== 
==17057== All heap blocks were freed -- no leaks are possible
==17057== 
==17057== For lists of detected and suppressed errors, rerun with: -s
==17057== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test float_to_str...                            [ OK ]
==17058== Warning: invalid file descriptor -1 in syscall close()
==17058== 
==17058== HEAP SUMMARY:
==17058==     in use at exit: 0 bytes in 0 blocks
==17058==   total heap usage: 853 allocs, 853 frees, 96,312 bytes allocated
==17058== 
==17058== All heap blocks were freed -- no leaks are possible
==17058== 
==17058== For lists of detected and suppressed errors, rerun with: -s
==17058== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test bool_to_str...                             [ OK ]
==17059== Warning: invalid file descriptor -1 in syscall close()
==17059== 
==17059== HEAP SUMMARY:
==17059==     in use at exit: 0 bytes in 0 blocks
==17059==   total heap usage: 853 allocs, 853 frees, 96,299 bytes allocated
==17059== 
==17059== All heap blocks were freed -- no leaks are possible
==17059== 
==17059== For lists of detected and suppressed errors, rerun with: -s
==17059== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test str_to_bool...                             [ OK ]
==17060== Warning: invalid file descriptor -1 in syscall close()
==17060== 
==17060== HEAP SUMMARY:
==17060==     in use at exit: 0 bytes in 0 blocks
==17060==   total heap usage: 855 allocs, 855 frees, 104,555 bytes allocated
==17060== 
==17060== All heap blocks were freed -- no leaks are possible
==17060== 
==17060== For lists of detected and suppressed errors, rerun with: -s
==17060== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test str_to_hex...                              [ OK ]
==17061== Warning: invalid file descriptor -1 in syscall close()
==17061== 
==17061== HEAP SUMMARY:
==17061==     in use at exit: 0 bytes in 0 blocks
==17061==   total heap usage: 855 allocs, 855 frees, 104,561 bytes allocated
==17061== 
==17061== All heap blocks were freed -- no leaks are possible
==17061== 
==17061== For lists of detected and suppressed errors, rerun with: -s
==17061== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test convert_string_0...                        [ OK ]
==17062== Warning: invalid file descriptor -1 in syscall close()
==17062== 
==17062== HEAP SUMMARY:
==17062==     in use at exit: 0 bytes in 0 blocks
==17062==   total heap usage: 855 allocs, 855 frees, 104,552 bytes allocated
==17062== 
==17062== All heap blocks were freed -- no leaks are possible
==17062== 
==17062== For lists of detected and suppressed errors, rerun with: -s
==17062== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Test convert_invalid_str...                     [2024/03/26 07:58:49] [error] flb_typecast_conv_str: convert error. input=invalid
[ OK ]
==17063== Warning: invalid file descriptor -1 in syscall close()
==17063== 
==17063== HEAP SUMMARY:
==17063==     in use at exit: 0 bytes in 0 blocks
==17063==   total heap usage: 862 allocs, 862 frees, 109,332 bytes allocated
==17063== 
==17063== All heap blocks were freed -- no leaks are possible
==17063== 
==17063== For lists of detected and suppressed errors, rerun with: -s
==17063== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==17054== 
==17054== HEAP SUMMARY:
==17054==     in use at exit: 0 bytes in 0 blocks
==17054==   total heap usage: 3 allocs, 3 frees, 1,205 bytes allocated
==17054== 
==17054== All heap blocks were freed -- no leaks are possible
==17054== 
==17054== For lists of detected and suppressed errors, rerun with: -s
==17054== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
