### PR TITLE
in_http: http realloc fus fix, http_server: same fix

### DIFF
--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -57,22 +57,22 @@ static int http_conn_realloc(struct flb_http *ctx,
     flb_plg_trace(ctx->ins, "buffer realloc %i -> %zu",
                     conn->buf_size, size);
 
-    check_and_reassign_ptr(&conn->method_p.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->uri.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->uri_processed.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->protocol_p.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->body.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->_content_length.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->content_type.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->connection.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->host.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->host_port.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->if_modified_since.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->last_modified_since.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->range.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->data.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->real_path.data, conn->buf_data tmp);
-    check_and_reassign_ptr(&conn->query_string.data, conn->buf_data tmp);
+    check_and_reassign_ptr(&conn->request.method_p.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.uri.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.uri_processed.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.protocol_p.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.body.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request._content_length.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.content_type.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.connection.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.host.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.host_port.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.if_modified_since.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.last_modified_since.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.range.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.data.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.real_path.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.query_string.data, conn->buf_data, tmp);
 
     for (idx = conn->session.parser.header_min; idx <= conn->session.parser.header_max && idx >= 0; idx++) {
         header = &conn->session.parser.headers[idx];


### PR DESCRIPTION
# Summary

These patches provide equivalent fixes for both `in_http` and the new `http_server` when it is ingesting http1/.x protocol requests.

When large requests are sent with HTTP/1.0 the buffer gets reallocated when reaching or exceeding the initial buffer size. The request (a `struct mk_http_request`) uses several `mk_ptr_t` to point to values for certain headers and parts of the request and points directly at the buffer.

This patch seeks to recalculate those pointers when this happens so they remain valid and point to valid content.

Without this patch `in_http` will fail, either crashing when using `http2=off` or returning a 400 "invalid request" error.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
