### PR TITLE
in_http: reassign mk_http_request values on realloc.

### DIFF
--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -27,13 +27,72 @@
 static void http_conn_request_init(struct mk_http_session *session,
                                    struct mk_http_request *request);
 
+static void check_and_reassign_ptr(char **ptr, const char *old, char *new)
+{
+    if (ptr == NULL) {
+        return;
+    }
+
+    if (*ptr == NULL) {
+        return;
+    }
+
+    *ptr = new + (*ptr - old);
+}
+
+static int http_conn_realloc(struct flb_http *ctx,
+                               struct http_conn *conn,
+                               size_t size)
+{
+    char *tmp;
+    int idx;
+    struct mk_http_header *header;
+
+
+    tmp = flb_realloc(conn->buf_data, size);
+    if (!tmp) {
+        flb_errno();
+        return -1;
+    }
+    flb_plg_trace(ctx->ins, "buffer realloc %i -> %zu",
+                    conn->buf_size, size);
+
+    check_and_reassign_ptr(&conn->request.method_p.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.uri.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.uri_processed.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.protocol_p.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.body.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request._content_length.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.content_type.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.connection.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.host.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.host_port.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.if_modified_since.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.last_modified_since.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.range.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.data.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.real_path.data, conn->buf_data, tmp);
+    check_and_reassign_ptr(&conn->request.query_string.data, conn->buf_data, tmp);
+
+    for (idx = conn->session.parser.header_min; idx <= conn->session.parser.header_max && idx >= 0; idx++) {
+        header = &conn->session.parser.headers[idx];
+
+        check_and_reassign_ptr(&header->key.data, conn->buf_data, tmp);
+        check_and_reassign_ptr(&header->val.data, conn->buf_data, tmp);
+    }
+
+    conn->buf_data = tmp;
+    conn->buf_size = size;
+
+    return 0;
+}
+
 static int http_conn_event(void *data)
 {
     int status;
     size_t size;
     ssize_t available;
     ssize_t bytes;
-    char *tmp;
     char *request_end;
     size_t request_len;
     struct flb_connection *connection;
@@ -61,16 +120,13 @@ static int http_conn_event(void *data)
             }
 
             size = conn->buf_size + ctx->buffer_chunk_size;
-            tmp = flb_realloc(conn->buf_data, size);
-            if (!tmp) {
+            if (http_conn_realloc(ctx, conn, size) == -1) {
                 flb_errno();
                 return -1;
             }
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
-            conn->buf_data = tmp;
-            conn->buf_size = size;
             available = (conn->buf_size - conn->buf_len) - 1;
         }
 


### PR DESCRIPTION
# Summary

Reassign pointers in mk_http_request when the request buffer is reallocated. If this is not done a crash occurs when in_http attempts to check header values or the uri.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
