### PR TITLE
Add support to set otel fields from the event body based on keys. Sig…

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -1138,7 +1138,8 @@ static int append_v1_logs_message(struct opentelemetry_context *ctx,
                 if (log_record->span_id.data) {
                     // Convert to a byte array
                     uint8_t val[8];
-                    for(size_t count = 0; count < sizeof val/sizeof *val; count++ ){
+                    size_t count;
+                    for(count = 0; count < sizeof val/sizeof *val; count++ ){
                         sscanf(ra_val->o.via.str.ptr, "%2hhx", &val[count]);
                         ra_val->o.via.str.ptr+=2;
                     }
@@ -1167,7 +1168,8 @@ static int append_v1_logs_message(struct opentelemetry_context *ctx,
                 if (log_record->trace_id.data) {
                     // Convert from hexdec string to a 16 byte array
                     uint8_t val[16];
-                    for(size_t count = 0; count < sizeof val/sizeof *val; count++ ){
+                    size_t count;
+                    for(count = 0; count < sizeof val/sizeof *val; count++ ){
                         sscanf(ra_val->o.via.str.ptr, "%2hhx", &val[count]);
                         ra_val->o.via.str.ptr+=2;
                     }

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -1080,6 +1080,110 @@ static int append_v1_logs_metadata(struct opentelemetry_context *ctx,
     return 0;
 }
 
+static int append_v1_logs_message(struct opentelemetry_context *ctx,
+                                   struct flb_log_event *event,
+                                   Opentelemetry__Proto__Logs__V1__LogRecord  *log_record)
+{
+    struct flb_ra_value *ra_val;
+
+    if (ctx == NULL || event == NULL || log_record == NULL) {
+        return -1;
+    }
+
+        /* SeverityText */
+    if (ctx->ra_severity_text_message) {
+        ra_val = flb_ra_get_value_object(ctx->ra_severity_text_message, *event->body);
+        if (ra_val != NULL && ra_val->o.type == MSGPACK_OBJECT_STR) {
+            if(is_valid_severity_text(ra_val->o.via.str.ptr, ra_val->o.via.str.size) == FLB_TRUE){
+                log_record->severity_text = flb_calloc(1, ra_val->o.via.str.size+1);
+                if (log_record->severity_text) {
+                    strncpy(log_record->severity_text, ra_val->o.via.str.ptr, ra_val->o.via.str.size);
+                }
+                flb_ra_key_value_destroy(ra_val);
+            }else{
+                flb_plg_warn(ctx->ins, "Unable to process %s. Invalid Severity Text.\n", ctx->ra_severity_text_message->pattern);
+                log_record->severity_text = NULL;
+            }
+        }
+        else {
+            /* To prevent invalid free */
+            log_record->severity_text = NULL;
+        }
+    }
+
+    /* SeverityNumber */
+    if (ctx->ra_severity_number_message) {
+        ra_val = flb_ra_get_value_object(ctx->ra_severity_number_metadata, *event->body);
+        if (ra_val != NULL && ra_val->o.type == MSGPACK_OBJECT_POSITIVE_INTEGER &&
+            is_valid_severity_number(ra_val->o.via.u64) == FLB_TRUE) {
+            log_record->severity_number = ra_val->o.via.u64;
+            flb_ra_key_value_destroy(ra_val);
+        }
+    }else if(ctx->ra_severity_text_message){
+        //TODO get sev number based off sev text
+    }
+
+    /* SpanId */
+    if (ctx->ra_span_id_message) {
+        ra_val = flb_ra_get_value_object(ctx->ra_span_id_message, *event->body);
+        if (ra_val != NULL) {
+            if(ra_val->o.type == MSGPACK_OBJECT_BIN){
+                log_record->span_id.data = flb_calloc(1, ra_val->o.via.bin.size);
+                if (log_record->span_id.data) {
+                    memcpy(log_record->span_id.data, ra_val->o.via.bin.ptr, ra_val->o.via.bin.size);
+                    log_record->span_id.len = ra_val->o.via.bin.size;
+                }
+            }else if(ra_val->o.type == MSGPACK_OBJECT_STR){
+                log_record->span_id.data = flb_calloc(8, sizeof(uint8_t));
+                if (log_record->span_id.data) {
+                    // Convert to a byte array
+                    uint8_t val[8];
+                    for(size_t count = 0; count < sizeof val/sizeof *val; count++ ){
+                        sscanf(ra_val->o.via.str.ptr, "%2hhx", &val[count]);
+                        ra_val->o.via.str.ptr+=2;
+                    }
+                    memcpy(log_record->span_id.data, val, sizeof(val));
+                    log_record->span_id.len = sizeof(val);
+                }
+            }else{
+                flb_plg_warn(ctx->ins, "Unable to process %s. Unsupported data type.\n", ctx->ra_span_id_message->pattern);
+            }
+            flb_ra_key_value_destroy(ra_val);
+        }
+    }
+
+    /* TraceId */
+    if (ctx->ra_trace_id_message) {
+        ra_val = flb_ra_get_value_object(ctx->ra_trace_id_message, *event->body);
+        if (ra_val != NULL) {
+            if(ra_val->o.type == MSGPACK_OBJECT_BIN){
+                log_record->trace_id.data = flb_calloc(1, ra_val->o.via.bin.size);
+                if (log_record->trace_id.data) {
+                    memcpy(log_record->trace_id.data, ra_val->o.via.bin.ptr, ra_val->o.via.bin.size);
+                    log_record->trace_id.len = ra_val->o.via.bin.size;
+                }
+            }else if(ra_val->o.type == MSGPACK_OBJECT_STR){
+                log_record->trace_id.data = flb_calloc(16, sizeof(uint8_t));
+                if (log_record->trace_id.data) {
+                    // Convert from hexdec string to a 16 byte array
+                    uint8_t val[16];
+                    for(size_t count = 0; count < sizeof val/sizeof *val; count++ ){
+                        sscanf(ra_val->o.via.str.ptr, "%2hhx", &val[count]);
+                        ra_val->o.via.str.ptr+=2;
+                    }
+                    memcpy(log_record->trace_id.data, val, sizeof(val));
+                    log_record->trace_id.len = sizeof(val);
+                }
+            }else{
+                flb_plg_warn(ctx->ins, "Unable to process %s. Unsupported data type.\n", ctx->ra_trace_id_message->pattern);
+            }
+            flb_ra_key_value_destroy(ra_val);
+        }
+    }
+
+    return 0;
+}
+
 static int process_logs(struct flb_event_chunk *event_chunk,
                         struct flb_output_flush *out_flush,
                         struct flb_input_instance *ins, void *out_context,
@@ -1157,6 +1261,8 @@ static int process_logs(struct flb_event_chunk *event_chunk,
         }
 
         append_v1_logs_metadata(ctx, &event, &log_records[log_record_count]);
+
+        append_v1_logs_message(ctx, &event, &log_records[log_record_count]);
 
         ret = FLB_OK;
 
@@ -1543,6 +1649,26 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "logs_resource_metadata_key", "Resource",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_resource_metadata_key),
      "Specify a Resource key"
+    },
+        {
+     FLB_CONFIG_MAP_STR, "logs_span_id_message_key", "$SpanId",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_span_id_message_key),
+     "Specify a SpanId key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_trace_id_message_key", "$TraceId",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_trace_id_message_key),
+     "Specify a TraceId key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_severity_text_message_key", "$SeverityText",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_text_message_key),
+     "Specify a Severity Text key"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "logs_severity_number_message_key", "$SeverityNumber",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_severity_number_message_key),
+     "Specify a Severity Number key"
     },
 
     /* EOF */

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -87,6 +87,19 @@ struct opentelemetry_context {
     flb_sds_t logs_instrumentation_scope_metadata_key;
     flb_sds_t logs_resource_metadata_key;
 
+    /* otel body keys */
+    flb_sds_t logs_span_id_message_key;
+    struct flb_record_accessor *ra_span_id_message;
+
+    flb_sds_t logs_trace_id_message_key;
+    struct flb_record_accessor *ra_trace_id_message;
+
+    flb_sds_t logs_severity_text_message_key;
+    struct flb_record_accessor *ra_severity_text_message;
+
+    flb_sds_t logs_severity_number_message_key;
+    struct flb_record_accessor *ra_severity_number_message;
+
     /* Number of logs to flush at a time */
     int batch_size;
 

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -420,6 +420,26 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
     if (ctx->ra_attributes_metadata == NULL) {
         flb_plg_error(ins, "failed to create ra for attributes");
     }
+    ctx->ra_span_id_message = flb_ra_create((char*)ctx->logs_span_id_message_key,
+                                             FLB_FALSE);
+    if (ctx->ra_span_id_message == NULL) {
+        flb_plg_error(ins, "failed to create ra for message span id");
+    }
+    ctx->ra_trace_id_message = flb_ra_create((char*)ctx->logs_trace_id_message_key,
+                                              FLB_FALSE);
+    if (ctx->ra_trace_id_message == NULL) {
+        flb_plg_error(ins, "failed to create ra for message trace id");
+    }
+    ctx->ra_severity_text_message = flb_ra_create((char*)ctx->logs_severity_text_message_key,
+                                              FLB_FALSE);
+    if (ctx->ra_severity_text_message == NULL) {
+        flb_plg_error(ins, "failed to create ra for message severity text");
+    }
+    ctx->ra_severity_number_message = flb_ra_create((char*)ctx->logs_severity_number_message_key,
+                                              FLB_FALSE);
+    if (ctx->ra_severity_number_message == NULL) {
+        flb_plg_error(ins, "failed to create ra for message severity number");
+    }
 
     return ctx;
 }
@@ -465,6 +485,18 @@ void flb_opentelemetry_context_destroy(struct opentelemetry_context *ctx)
     }
     if (ctx->ra_attributes_metadata) {
         flb_ra_destroy(ctx->ra_attributes_metadata);
+    }
+    if (ctx->ra_span_id_message) {
+        flb_ra_destroy(ctx->ra_span_id_message);
+    }
+    if (ctx->ra_trace_id_message) {
+        flb_ra_destroy(ctx->ra_trace_id_message);
+    }
+    if (ctx->ra_severity_text_message) {
+        flb_ra_destroy(ctx->ra_severity_text_message);
+    }
+    if (ctx->ra_severity_number_message) {
+        flb_ra_destroy(ctx->ra_severity_number_message);
     }
 
     flb_free(ctx->proxy_host);


### PR DESCRIPTION
…ned-off-by: Cory Boslet <cb645j@att.com>

This is to support sending additional otlp properties derived from log events body/message properties based on keys. 
This is related to https://github.com/fluent/fluent-bit/issues/8359 and https://github.com/fluent/fluent-bit/issues/8552


Testing
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- N/A Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- N/A Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- N/A Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----
### Debug log ouput
stdout:
[0] kubernetes.local: [[1711471800.517000000, {}], {"timestamp"=>"2024-03-26 11:50:00.517", "loglevel"=>"INFO", "trace_id"=>"95e1d11ece6460e7d00c61d45cc195ff", "span_id"=>"11aafe22712ca02c", "message"=>"A log message"}]

outgoing opentelemetry message
see @sudomateo comment below

### Example Configuration

```
    [INPUT]
      Name   dummy
      Dummy {"message": "A log message", "span_id": "11aafe22712ca02c", "trace_id": "95e1d11ece6460e7d00c61d45cc195ff", "loglevel": "INFO"}

    [OUTPUT]
        Name stdout
        Log_Level trace
        Match *

    [OUTPUT]
        Name opentelemetry
        Match *
        Log_Level trace
        Host ingest.frontend.com
        Port 443
        Log_response_payload True
        logs_body_key $message
        logs_span_id_message_key span_id
        logs_trace_id_message_key trace_id
        logs_severity_text_message_key loglevel
        Tls                  On
        Tls.verify           Off
```

### Documentation

| Key  | Description | Default |
| ------------- | ------------- | ------------- |
| logs_span_id_message_key  | Specify a Span Id key to look up in the log events body/message  | SpanId |
| logs_trace_id_message_key  | Specify a Trace Id key to look up in the log events body/message  | TraceId |
| logs_severity_text_message_key   | Specify a Severity Text key to look up in the log events body/message  | SeverityText |
| logs_severity_number_message_key   | Specify a Severity Number key to look up in the log events body/message  | SeverityNumber|

Otel Log Data Model fields now supported:
- [x] Timestamp (already supported)
- [ ] ObserveredTimestamp
- [x] TraceId
- [x] SpanId
- [ ] TraceFlags
- [x] SeverityText
- [x] SeverityNumber
- [ ] Resource
- [ ] InstrumentationScope
- [ ] Attributes (plan to add on separate pr)

### Valgrind

valgrind --leak-check=yes fluent-bit --config fluent-bit-config.yaml
==16653== Memcheck, a memory error detector
==16653== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16653== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==16653== Command: ./projects/scratch/fluent-bit/build/bin/fluent-bit --config fluent-bit-config.yaml
==16653==

[2024/03/28 17:39:51] [ info] [fluent bit] version=3.0.1, commit=02b1a89090, pid=16653
[2024/03/28 17:39:51] [ info] [storage] ver=1.5.1, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/03/28 17:39:51] [ info] [cmetrics] version=0.7.0
[2024/03/28 17:39:51] [ info] [output:stdout:stdout.0] worker #0 started
[2024/03/28 17:39:51] [ info] [ctraces ] version=0.4.0
[2024/03/28 17:39:51] [ info] [input:dummy:dummy.0] initializing
[2024/03/28 17:39:51] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/03/28 17:39:51] [ info] [sp] stream processor started
[{"date":1711647592.169228,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647593.161132,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647594.156564,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647595.153959,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647596.163722,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647597.154836,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647598.153678,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[{"date":1711647599.152517,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
^C[2024/03/28 17:40:01] [engine] caught signal (SIGINT)
[2024/03/28 17:40:01] [ warn] [engine] service will shutdown in max 5 seconds
[{"date":1711647600.155777,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[2024/03/28 17:40:01] [ info] [input] pausing dummy.0
[{"date":1711647601.156709,"severityNumber":9,"severityText":"Info","name":"logA","message":"This is a log message","app":"server","instance_num":1,"traceId":"08040201000000000000000000000000","spanId":"0102040800000000"}]
[2024/03/28 17:40:02] [ info] [engine] service has stopped (0 pending tasks)
[2024/03/28 17:40:02] [ info] [input] pausing dummy.0
[2024/03/28 17:40:02] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/03/28 17:40:02] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==16653==
==16653== HEAP SUMMARY:
==16653==     in use at exit: 0 bytes in 0 blocks
==16653==   total heap usage: 2,053 allocs, 2,053 frees, 5,611,479 bytes allocated
==16653==
==16653== All heap blocks were freed -- no leaks are possible
==16653==
==16653== For lists of detected and suppressed errors, rerun with: -s
==16653== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
