### PR TITLE
Update cmetrics_decode_fuzz.c: Add missing include

### DIFF
--- a/tests/internal/fuzzers/cmetrics_decode_fuzz.c
+++ b/tests/internal/fuzzers/cmetrics_decode_fuzz.c
@@ -17,6 +17,7 @@
  *  limitations under the License.
  */
 
+#include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_decode_opentelemetry.h>
 #include <cmetrics/cmt_decode_prometheus.h>
 


### PR DESCRIPTION
Add missing include to fix clang-18 error:

```
2 warnings and 1 error generated.
/src/fluent-bit/tests/internal/fuzzers/cmetrics_decode_fuzz.c:53:18: error: call to undeclared function 'cmt_decode_msgpack_create'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   53 |         result = cmt_decode_msgpack_create(&cmt, (char *) data, size, &off);
      |                  ^
```

----

**Testing**

I've only tested this via oss-fuzz, after bumping the oss-fuzz clang version to clang-18.

I've used this command in the oss-fuzz project to test:

```
oss-fuzz# python3 infra/helper.py build_fuzzers --sanitizer address    --engine libfuzzer fluent-bit
```

Docs, Backport, or other testing should not be needed, I think.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
