### PR TITLE
time: support Msgpack timestamp extension type

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -54,6 +54,7 @@ enum flb_time_eventtime_fmt {
     FLB_TIME_ETFMT_V0,        /* EventTime (v0) */
     FLB_TIME_ETFMT_V1_EXT,    /* EventTime (v1 ext) */
     FLB_TIME_ETFMT_V1_FIXEXT, /* EventTime (v1 fixext) */
+    FLB_TIME_ETFMT_MSGPACK_TIME_EXT, /* Msgpack Timestamp extension type */
     FLB_TIME_ETFMT_OTHER,
 };
 

--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -153,24 +153,12 @@ void flb_log_event_decoder_destroy(struct flb_log_event_decoder *context)
 int flb_log_event_decoder_decode_timestamp(msgpack_object *input,
                                            struct flb_time *output)
 {
+    int ret;
+
     flb_time_zero(output);
 
-    if (input->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
-        output->tm.tv_sec  = input->via.u64;
-    }
-    else if(input->type == MSGPACK_OBJECT_FLOAT) {
-        output->tm.tv_sec  = input->via.f64;
-        output->tm.tv_nsec = ((input->via.f64 - output->tm.tv_sec) * 1000000000);
-    }
-    else if(input->type == MSGPACK_OBJECT_EXT) {
-        if (input->via.ext.type != 0 || input->via.ext.size != 8) {
-            return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
-        }
-
-        output->tm.tv_sec  = FLB_BSWAP_32(*((uint32_t *) &input->via.ext.ptr[0]));
-        output->tm.tv_nsec = FLB_BSWAP_32(*((uint32_t *) &input->via.ext.ptr[4]));
-    }
-    else {
+    ret = flb_time_msgpack_to_time(output, input);
+    if (ret == -1) {
         return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
     }
 


### PR DESCRIPTION
This patch is to support MessagePack timestamp extension type. See also https://github.com/fluent/fluent-bit/issues/8641.
https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type

- Use flb_time API to support Msgpack timestamp extension type for flb_log_decoder
- Add test code

Note: This patch is to support decoding only. Time will not be encoded as MessagePack timestamp extension type.
Note: mpack API doesn't support MessagePack timestamp extension type. It needs another PR.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

## Debug/Valgrind output

```
$ valgrind --leak-check=full bin/flb-it-flb_time 
==25509== Memcheck, a memory error detector
==25509== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25509== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==25509== Command: bin/flb-it-flb_time
==25509== 
Test flb_time_to_nanosec...                     [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test flb_time_append_to_mpack_v1...             [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test msgpack_to_time_int...                     [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test msgpack_to_time_double...                  [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test msgpack_to_time_eventtime...               [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test msgpack_to_time_invalid...                 [2024/03/30 09:11:23] [ warn] [time] unknown ext type. type=0 size=5
[2024/03/30 09:11:23] [ warn] [time] unknown ext type. type=10 size=8
[ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test msgpack_to_time_eventtime...               [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test append_to_msgpack_eventtime...             [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
Test append_to_msgpack_extension_time...        [ OK ]
==25509== Warning: invalid file descriptor -1 in syscall close()
SUCCESS: All unit tests have passed.
==25509== 
==25509== HEAP SUMMARY:
==25509==     in use at exit: 0 bytes in 0 blocks
==25509==   total heap usage: 7,647 allocs, 7,647 frees, 907,902 bytes allocated
==25509== 
==25509== All heap blocks were freed -- no leaks are possible
==25509== 
==25509== For lists of detected and suppressed errors, rerun with: -s
==25509== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
