### PR TITLE
config: yaml: add support for cfl_arrays when a property is declared as a list.

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -669,7 +669,8 @@ static enum status state_copy_into_config_group(struct parser_state *state, stru
                     return YAML_FAILURE;
                 }
 
-                if (cfl_array_append(arr, var) < 0) {
+                if (cfl_array_append(carr, var) < 0) {
+                    cfl_array_destroy(arr);
                     flb_error("unable to append value to array");
                     return YAML_FAILURE;
                 }

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -708,6 +708,7 @@ static enum status state_copy_into_properties(struct parser_state *state, struct
     struct cfl_kvpair *kvp;
     struct cfl_variant *var;
     struct cfl_array *arr;
+    int idx;
 
     cfl_list_foreach(head, &state->keyvals->list) {
         kvp = cfl_list_entry(head, struct cfl_kvpair, _head);
@@ -735,7 +736,8 @@ static enum status state_copy_into_properties(struct parser_state *state, struct
             }
 
             while(kvp->val->data.as_array->entry_count > 0) {
-                var = cfl_array_fetch_by_index(kvp->val->data.as_array, 0);
+                idx = kvp->val->data.as_array->entry_count-1;
+                var = cfl_array_fetch_by_index(kvp->val->data.as_array, idx);
 
                 if (var == NULL) {
                     cfl_array_destroy(arr);
@@ -749,8 +751,8 @@ static enum status state_copy_into_properties(struct parser_state *state, struct
                 }
                 // NULLify the entry since there is no way to otherwise
                 // takeover the memory from the cfl_array.
-                kvp->val->data.as_array->entries[0] = NULL;
-                cfl_array_remove_by_index(kvp->val->data.as_array, 0);
+                kvp->val->data.as_array->entries[idx] = NULL;
+                cfl_array_remove_by_index(kvp->val->data.as_array, idx);
             }
             break;
         default:

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -801,40 +801,56 @@ static int configure_plugins_type(struct flb_config *config, struct flb_cf *cf, 
             if (type == FLB_CF_CUSTOM) {
                 if (kv->val->type == CFL_VARIANT_STRING) {
                     ret = flb_custom_set_property(ins, kv->key, kv->val->data.as_string);
-                } else if (kv->val->type == CFL_VARIANT_ARRAY) {
+                }
+                else if (kv->val->type == CFL_VARIANT_ARRAY) {
                     for (i = 0; i < kv->val->data.as_array->entry_count; i++) {
                         val = kv->val->data.as_array->entries[i];
-                        ret = flb_custom_set_property(ins, kv->key, val->data.as_string);
+
+                        if (val->type == CFL_VARIANT_STRING) {
+                            ret = flb_custom_set_property(ins, kv->key, val->data.as_string);
+                        }
                     }
                 }
             }
             else if (type == FLB_CF_INPUT) {
                  if (kv->val->type == CFL_VARIANT_STRING) {
                     ret = flb_input_set_property(ins, kv->key, kv->val->data.as_string);
-                } else if (kv->val->type == CFL_VARIANT_ARRAY) {
+                }
+                else if (kv->val->type == CFL_VARIANT_ARRAY) {
                     for (i = 0; i < kv->val->data.as_array->entry_count; i++) {
                         val = kv->val->data.as_array->entries[i];
-                        ret = flb_input_set_property(ins, kv->key, val->data.as_string);
+
+                        if (val->type == CFL_VARIANT_STRING) {
+                            ret = flb_input_set_property(ins, kv->key, val->data.as_string);
+                        }
                     }
                 }
             }
             else if (type == FLB_CF_FILTER) {
                  if (kv->val->type == CFL_VARIANT_STRING) {
                     ret = flb_filter_set_property(ins, kv->key, kv->val->data.as_string);
-                } else if (kv->val->type == CFL_VARIANT_ARRAY) {
+                }
+                else if (kv->val->type == CFL_VARIANT_ARRAY) {
                     for (i = 0; i < kv->val->data.as_array->entry_count; i++) {
                         val = kv->val->data.as_array->entries[i];
-                        ret = flb_filter_set_property(ins, kv->key, val->data.as_string);
+
+                        if (val->type == CFL_VARIANT_STRING) {
+                            ret = flb_filter_set_property(ins, kv->key, val->data.as_string);
+                        }
                     }
                 }
             }
             else if (type == FLB_CF_OUTPUT) {
                  if (kv->val->type == CFL_VARIANT_STRING) {
                     ret = flb_output_set_property(ins, kv->key, kv->val->data.as_string);
-                } else if (kv->val->type == CFL_VARIANT_ARRAY) {
+                }
+                else if (kv->val->type == CFL_VARIANT_ARRAY) {
                     for (i = 0; i < kv->val->data.as_array->entry_count; i++) {
                         val = kv->val->data.as_array->entries[i];
-                        ret = flb_output_set_property(ins, kv->key, val->data.as_string);
+
+                        if (val->type == CFL_VARIANT_STRING) {
+                            ret = flb_output_set_property(ins, kv->key, val->data.as_string);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Summary

When a property is declared as a list with variant values it will be parsed using cfl_array with variants inside.

An example is this:

```yaml
pipeline:
  inputs:
    - name: test
      hosts:
        - foo
        - bar
```

This should also work with arrays that have key/vales, ie:

```yaml
pipeline:
  inputs:
    - name: test
      hosts:
        - ip: 127.0.0.1
          port: 4444
```

This also works with processors and will be key for an upcoming feature for the `content_modifier` processor:

```yaml
pipeline:
  inputs:
    - name: dummy
      dummy: '{"message": "foobar", "foobar": "barfoo"}'
      processors:
        logs:
          - name: content_modifier
            actions:
              - action: insert
                key: foo
                value: bar
              - action: delete
                key: foo
              - action: delete
                key: foobar
              - action: insert
                key: bar
                value: foo
```

This pull request does not attempt to actually allow passing these properties to a plugin. Changes to the config and config_map layer are required for these values to actually be passed to a plugin instance.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
