### PR TITLE
in_forward: Handle multiply concatenated gzip payloads

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1544,11 +1544,11 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                         const size_t original_len = len;
 
                         gzip_payloads_count = gzip_concatenated_count(data, len);
-                        flb_plg_info(ctx->ins, "concatenated gzip payload count is %zd",
+                        flb_plg_debug(ctx->ins, "concatenated gzip payload count is %zd",
                                      gzip_payloads_count);
                         if (gzip_payloads_count > 0) {
                             if (gzip_concatenated_borders(data, len, &gzip_borders, gzip_payloads_count) < 0) {
-                                flb_plg_info(ctx->ins,
+                                flb_plg_error(ctx->ins,
                                              "failed to traverse boundaries of concatenated gzip payloads");
                                 return -1;
                             }
@@ -1566,13 +1566,7 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                                 len = gzip_borders[loop] - gzip_borders[loop - 1];
                             }
                         }
-                        if (gzip_payloads_count > 0) {
-                            for (int i = 0; i <= gzip_payloads_count; i++) {
-                                flb_plg_debug(ctx->ins,
-                                              "gzip_borders[%d] = %zd", i, gzip_borders[i]);
-                            }
-                        }
-                        flb_plg_debug(ctx->ins,
+                        flb_plg_trace(ctx->ins,
                                       "[gzip decompression] loop = %zd, len = %zd, original_len = %zd",
                                       loop, len, original_len);
 

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1208,10 +1208,10 @@ static size_t gzip_concatenated_count(const char *data, size_t len)
 
     p = (const uint8_t *) data;
 
-    /* search other gzip starting bits. */
+    /* search other gzip starting bits and method. */
     for (i = 2; i < len &&
-                 i + 1 <= len; i++) {
-        if (p[i] == 0x1F && p[i+1] == 0x8B) {
+                 i + 2 <= len; i++) {
+        if (p[i] == 0x1F && p[i+1] == 0x8B && p[i+2] == 8) {
             count++;
         }
     }
@@ -1233,10 +1233,10 @@ static size_t gzip_concatenated_borders(const char *data, size_t len, size_t **o
         return -1;
     }
 
-    /* search other gzip starting bits. */
+    /* search other gzip starting bits and method. */
     for (i = 2; i < len &&
-                 i + 1 <= len; i++) {
-        if (p[i] == 0x1F && p[i+1] == 0x8B) {
+                 i + 2 <= len; i++) {
+        if (p[i] == 0x1F && p[i+1] == 0x8B && p[i+2] == 8) {
             borders[count] = i;
             count++;
         }
@@ -1631,9 +1631,9 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                                 loop++;
                                 goto retry_uncompress;
                             }
-                            else if ((original_len - gzip_borders[loop]) > 18) {
+                            else {
                                 flb_plg_debug(ctx->ins, "left unconsumed %zd byte(s)",
-                                              len - (original_len - gzip_borders[loop]));
+                                              original_len - gzip_borders[loop]);
                             }
                             if (loop == gzip_payloads_count) {
                                 if (gzip_borders != NULL) {

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1200,6 +1200,55 @@ error:
     return -1;
 }
 
+static size_t gzip_concatenated_count(const char *data, size_t len)
+{
+    int i;
+    size_t count = 0;
+    const uint8_t *p;
+
+    p = (const uint8_t *) data;
+
+    /* search other gzip starting bits. */
+    for (i = 2; i < len &&
+                 i + 1 <= len; i++) {
+        if (p[i] == 0x1F && p[i+1] == 0x8B) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+static size_t gzip_concatenated_borders(const char *data, size_t len, size_t **out_borders, size_t border_count)
+{
+    int i;
+    size_t count = 0;
+    const uint8_t *p;
+    size_t *borders = NULL;
+
+    p = (const uint8_t *) data;
+    borders = (size_t *) flb_calloc(1, sizeof(size_t) * (border_count + 1));
+    if (borders == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    /* search other gzip starting bits. */
+    for (i = 2; i < len &&
+                 i + 1 <= len; i++) {
+        if (p[i] == 0x1F && p[i+1] == 0x8B) {
+            borders[count] = i;
+            count++;
+        }
+    }
+    /* The length of the last border refers to the original length. */
+    borders[border_count] = len;
+
+    *out_borders = borders;
+
+    return count;
+}
+
 int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
 {
     int ret;
@@ -1488,13 +1537,55 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                     }
 
                     if (ret == FLB_TRUE) {
-                        ret = flb_gzip_uncompress((void *) data, len,
+                        size_t prev_pos = 0;
+                        size_t gzip_payloads_count = 0;
+                        size_t loop = 0;
+                        size_t *gzip_borders = NULL;
+                        const size_t original_len = len;
+
+                        gzip_payloads_count = gzip_concatenated_count(data, len);
+                        flb_plg_info(ctx->ins, "concatenated gzip payload count is %zd",
+                                     gzip_payloads_count);
+                        if (gzip_payloads_count > 0) {
+                            if (gzip_concatenated_borders(data, len, &gzip_borders, gzip_payloads_count) < 0) {
+                                flb_plg_info(ctx->ins,
+                                             "failed to traverse boundaries of concatenated gzip payloads");
+                                return -1;
+                            }
+                        }
+
+                    retry_uncompress:
+                        if (gzip_payloads_count > 0) {
+                            if (loop == 0) {
+                                len = gzip_borders[loop];
+                            }
+                            else if (gzip_borders[loop] == original_len) {
+                                len = original_len - gzip_borders[loop - 1];
+                            }
+                            else if (loop >= 1) {
+                                len = gzip_borders[loop] - gzip_borders[loop - 1];
+                            }
+                        }
+                        if (gzip_payloads_count > 0) {
+                            for (int i = 0; i <= gzip_payloads_count; i++) {
+                                flb_plg_debug(ctx->ins,
+                                              "gzip_borders[%d] = %zd", i, gzip_borders[i]);
+                            }
+                        }
+                        flb_plg_debug(ctx->ins,
+                                      "[gzip decompression] loop = %zd, len = %zd, original_len = %zd",
+                                      loop, len, original_len);
+
+                        ret = flb_gzip_uncompress((void *) (data + prev_pos), len,
                                                   &gz_data, &gz_size);
                         if (ret == -1) {
                             flb_plg_error(ctx->ins, "gzip uncompress failure");
                             msgpack_unpacked_destroy(&result);
                             msgpack_unpacker_free(unp);
                             flb_sds_destroy(out_tag);
+                            if (gzip_borders != NULL) {
+                                flb_free(gzip_borders);
+                            }
                             return -1;
                         }
 
@@ -1506,6 +1597,9 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                                 msgpack_unpacker_free(unp);
                                 flb_sds_destroy(out_tag);
                                 flb_free(gz_data);
+                                if (gzip_borders != NULL) {
+                                    flb_free(gzip_borders);
+                                }
                                 return -1;
                             }
                             event_type = ret;
@@ -1519,9 +1613,34 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                             msgpack_unpacker_free(unp);
                             flb_sds_destroy(out_tag);
                             flb_free(gz_data);
+                            if (gzip_borders != NULL) {
+                                flb_free(gzip_borders);
+                            }
+
                             return -1;
                         }
                         flb_free(gz_data);
+
+                        /* a valid payload of gzip is larger than 18 bytes. */
+                        if (gzip_payloads_count > 0) {
+                            if ((gzip_payloads_count - loop) > 0 &&
+                                (original_len - gzip_borders[loop]) > 18) {
+                                len = original_len - gzip_borders[loop];
+                                flb_plg_debug(ctx->ins, "left unconsumed %zd byte(s)", len);
+                                prev_pos = gzip_borders[loop];
+                                loop++;
+                                goto retry_uncompress;
+                            }
+                            else if ((original_len - gzip_borders[loop]) > 18) {
+                                flb_plg_debug(ctx->ins, "left unconsumed %zd byte(s)",
+                                              len - (original_len - gzip_borders[loop]));
+                            }
+                            if (loop == gzip_payloads_count) {
+                                if (gzip_borders != NULL) {
+                                    flb_free(gzip_borders);
+                                }
+                            }
+                        }
                     }
                     else {
                         event_type = FLB_EVENT_TYPE_LOGS;


### PR DESCRIPTION
<!-- Provide summary of changes -->
On out_forward in Fluentd payloads, sometimes gzip compressed payloads are concatenated because Fluentd has a capability to compress its buffers with gzip compression.
With this circumstance, Fluentd sometimes concatenates its payloads on forward protocol.
This causes that Fluent Bit gives up to uncompress for the concatenated ones.
In this PR, I implemented for decoding way to distinguish whether the ingested forwarded payloads is concatenated or not.

This is not mandatory specification and not well-documented behavior on Ruby's zlib gem. 
But, in fact, Fluentd is heavily relying on this behavior for saving the CPU usage to avoid unnecessary compressions/decompressions. 

This is why I found that the reason Fluentd is actually relying on the concatenated gzipped payloads:
https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/compressable.rb#L57-L93

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```yaml
service:
    flush: 1
    log_level: debug
pipeline:
    inputs:
        - listen: 0.0.0.0
          port: "24224"
          buffer_max_size: "300mb"
          buffer_chunk_size: "32mb"
          Name: forward
    outputs:
        - Name: stdout
          match: "*"
```

- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.1
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/04/04 11:18:31] [ info] Configuration:
[2024/04/04 11:18:31] [ info]  flush time     | 1.000000 seconds
[2024/04/04 11:18:31] [ info]  grace          | 5 seconds
[2024/04/04 11:18:31] [ info]  daemon         | 0
[2024/04/04 11:18:31] [ info] ___________
[2024/04/04 11:18:31] [ info]  inputs:
[2024/04/04 11:18:31] [ info]      forward
[2024/04/04 11:18:31] [ info] ___________
[2024/04/04 11:18:31] [ info]  filters:
[2024/04/04 11:18:31] [ info] ___________
[2024/04/04 11:18:31] [ info]  outputs:
[2024/04/04 11:18:31] [ info]      stdout.0
[2024/04/04 11:18:31] [ info] ___________
[2024/04/04 11:18:31] [ info]  collectors:
[2024/04/04 11:18:31] [ info] [fluent bit] version=3.0.1, commit=dc5089bf8f, pid=1608824
[2024/04/04 11:18:31] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/04/04 11:18:31] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/04/04 11:18:31] [ info] [cmetrics] version=0.7.1
[2024/04/04 11:18:31] [ info] [ctraces ] version=0.4.0
[2024/04/04 11:18:31] [ info] [input:forward:forward.0] initializing
[2024/04/04 11:18:31] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2024/04/04 11:18:31] [debug] [forward:forward.0] created event channels: read=21 write=22
[2024/04/04 11:18:31] [ info] [output:stdout:stdout.0] worker #0 started
[2024/04/04 11:18:31] [debug] [in_fw] Listen='0.0.0.0' TCP_Port=24224
[2024/04/04 11:18:31] [debug] [downstream] listening on 0.0.0.0:24224
[2024/04/04 11:18:31] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
[2024/04/04 11:18:31] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/04/04 11:18:31] [ info] [sp] stream processor started
[2024/04/04 11:18:44] [debug] [input:forward:forward.0] concatenated gzip payload count is 2
[2024/04/04 11:18:44] [debug] [input chunk] update output instances with new chunk size diff=201922, records=1166, input=forward.0
[2024/04/04 11:18:44] [debug] [input:forward:forward.0] left unconsumed 21861 byte(s)
[2024/04/04 11:18:44] [debug] [input chunk] update output instances with new chunk size diff=185247, records=1229, input=forward.0
[2024/04/04 11:18:44] [debug] [input:forward:forward.0] left unconsumed 6368 byte(s)
[2024/04/04 11:18:44] [debug] [input chunk] update output instances with new chunk size diff=66720, records=472, input=forward.0
[2024/04/04 11:18:44] [debug] [input:forward:forward.0] left unconsumed 0 byte(s)
[2024/04/04 11:18:45] [debug] [task] created task=0x60df810 id=0 OK
[2024/04/04 11:18:45] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
<snip>
[2024/04/04 11:18:45] [debug] [out flush] cb_destroy coro_id=0
[2024/04/04 11:18:45] [debug] [task] destroy task=0x60df810 (task_id=0)
^C[2024/04/04 11:18:48] [engine] caught signal (SIGINT)
[2024/04/04 11:18:48] [ warn] [engine] service will shutdown in max 5 seconds
[2024/04/04 11:18:48] [ info] [input] pausing forward.0
[2024/04/04 11:18:48] [ info] [engine] service has stopped (0 pending tasks)
[2024/04/04 11:18:48] [ info] [input] pausing forward.0
[2024/04/04 11:18:48] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/04/04 11:18:48] [ info] [output:stdout:stdout.0] thread worker #0 stopped

```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==1608824== 
==1608824== HEAP SUMMARY:
==1608824==     in use at exit: 0 bytes in 0 blocks
==1608824==   total heap usage: 8,924 allocs, 8,924 frees, 58,435,290 bytes allocated
==1608824== 
==1608824== All heap blocks were freed -- no leaks are possible
==1608824== 
==1608824== For lists of detected and suppressed errors, rerun with: -s
==1608824== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
