### PR TITLE
test: internal: log: fix failures caused by timing issue.

### DIFF
--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -81,14 +81,17 @@ static void cache_basic_timeout()
     cache = flb_log_cache_create(timeout, 4);
     TEST_CHECK(cache != NULL);
 
+    clock1 = time(NULL);
     ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);
+
+    clock2 = time(NULL);
     ret_2 = flb_log_cache_check_suppress(cache, TEST_RECORD_02, TEST_RECORD_02_SIZE);
+
     TEST_CHECK(ret_1 == FLB_FALSE);
     TEST_CHECK(ret_2 == FLB_FALSE);
+
     sleep(1);
 
-    clock1 = time(NULL);
-    clock2 = time(NULL);
 
     for (i = 1, start = time(NULL); i < 10 && start+(timeout*20) >  time(NULL); i++) {
         ret_1 = flb_log_cache_check_suppress(cache, TEST_RECORD_01, TEST_RECORD_01_SIZE);


### PR DESCRIPTION
# Summary

The `flb-it-log` is failing sporadically. I believe this is because initially time is counted from 1 second before the message is first cached for both messages being test, TEST_RECORD_1 and TEST_RECORD_2.

```
[ FAILED ]
  log.c:18: Check (start + timeout) >= now... failed
    clock error, unsuppresed log: now=1712179281, timeout=1712179280, diff=1
  log.c:110: Check ret == 0... failed
  log.c:18: Check (start + timeout) >= now... failed
    clock error, unsuppresed log: now=1712179281, timeout=1712179280, diff=1
  log.c:114: Check ret == 0... failed
Test cache_one_slot...                          
[ OK ]
FAILED: 1 of 2 unit tests has failed.
```

Only a single failure is registered even though the loop occurs twice. This lines up with the idea that it is an off-by-one caused by starting the clocks one second after initially sending the message(s) to be suppressed by the log cache.

This fix simply starts counting time for each record right before emitting each one.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
