### PR TITLE
in_winevtlog: Make configurable for the size of collecting threshold per a cycle

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -95,7 +95,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
         flb_utils_bytes_to_human_readable_size((size_t) MINIMUM_THRESHOLD_SIZE,
                                                human_readable_size,
                                                sizeof(human_readable_size) - 1);
-        flb_plg_error(ctx->ins,
+        flb_plg_warn(ctx->ins,
                      "read limit per cycle cannot under 1KiB. Set up to %s",
                      human_readable_size);
         ctx->total_size_threshold = (unsigned int) MINIMUM_THRESHOLD_SIZE;

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -83,15 +83,21 @@ static int in_winevtlog_init(struct flb_input_instance *in,
                       human_readable_size);
     }
     else if (ctx->total_size_threshold >= MAXIMUM_THRESHOLD_SIZE) {
+        flb_utils_bytes_to_human_readable_size((size_t) MAXIMUM_THRESHOLD_SIZE,
+                                               human_readable_size,
+                                               sizeof(human_readable_size) - 1);
         flb_plg_warn(ctx->ins,
-                     "read limit per cycle cannot exceed 1.8MiB. Set up to %d",
-                     MAXIMUM_THRESHOLD_SIZE);
+                     "read limit per cycle cannot exceed 1.8MiB. Set up to %s",
+                     human_readable_size);
         ctx->total_size_threshold = (unsigned int) MAXIMUM_THRESHOLD_SIZE;
     }
     else if (ctx->total_size_threshold < MINIMUM_THRESHOLD_SIZE){
+        flb_utils_bytes_to_human_readable_size((size_t) MINIMUM_THRESHOLD_SIZE,
+                                               human_readable_size,
+                                               sizeof(human_readable_size) - 1);
         flb_plg_error(ctx->ins,
-                     "read limit per cycle cannot under 1KiB. Set up to %d",
-                     MINIMUM_THRESHOLD_SIZE);
+                     "read limit per cycle cannot under 1KiB. Set up to %s",
+                     human_readable_size);
         ctx->total_size_threshold = (unsigned int) MINIMUM_THRESHOLD_SIZE;
     }
 

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -31,7 +31,7 @@
 #define DEFAULT_THRESHOLD_SIZE 0x7ffff /* Default reading buffer size */
                                        /* (512kib = 524287bytes) */
 #define MINIMUM_THRESHOLD_SIZE 0x0400   /* 1024 bytes */
-#define MAXIMUM_THRESHOLD_SIZE 0x1ccccd /* 1887437 bytes (about 1.8 MiB) */
+#define MAXIMUM_THRESHOLD_SIZE (FLB_INPUT_CHUNK_FS_MAX_SIZE - (1024 * 200))
 
 static int in_winevtlog_collect(struct flb_input_instance *ins,
                                 struct flb_config *config, void *in_context);

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -37,6 +37,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
                              struct flb_config *config, void *data)
 {
     int ret;
+    int64_t threshold_size;
     const char *tmp;
     int read_existing_events = FLB_FALSE;
     struct mk_list *head;
@@ -70,6 +71,16 @@ static int in_winevtlog_init(struct flb_input_instance *in,
 
     /* Set up total reading size threshold */
     ctx->total_size_threshold = DEFAULT_THRESHOLD_SIZE;
+    tmp = flb_input_get_property("threshold_size", in);
+    if (tmp != NULL) {
+        threshold_size = flb_utils_size_to_bytes(tmp);
+        if (threshold_size > DEFAULT_THRESHOLD_SIZE) {
+            ctx->total_size_threshold = (unsigned int) threshold_size;
+            flb_plg_debug(ctx->ins,
+                          "threshold size is changed to %" PRId64 "KB",
+                          threshold_size / 1000);
+        }
+    }
 
     /* Open channels */
     tmp = flb_input_get_property("channels", in);
@@ -260,6 +271,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "event_query", "*",
       0, FLB_TRUE, offsetof(struct winevtlog_config, event_query),
       "Specify XML query for filtering events"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "threshold_size", NULL,
+      0, FLB_TRUE, 0,
+      "Specify threshold size for collecting Windows EventLog per a cycle"
     },
     /* EOF */
     {0}

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -87,8 +87,8 @@ static int in_winevtlog_init(struct flb_input_instance *in,
                                                human_readable_size,
                                                sizeof(human_readable_size) - 1);
         flb_plg_warn(ctx->ins,
-                     "read limit per cycle cannot exceed 1.8MiB. Set up to %s",
-                     human_readable_size);
+                     "read limit per cycle cannot exceed %s. Set up to %s",
+                     human_readable_size, human_readable_size);
         ctx->total_size_threshold = (unsigned int) MAXIMUM_THRESHOLD_SIZE;
     }
     else if (ctx->total_size_threshold < MINIMUM_THRESHOLD_SIZE){


### PR DESCRIPTION
Previously, I had chosen to restrict with the threshold to prevent unlimited subscribing per a cycle.
This should cause flood of memory comsumptions but it depends on the amound of the channels of Windows EventLog.
Nowadays, this plugin is getting widely used.
Also, in the fluent community slack, there is a request to make to be able to configure for this threshold per a cycle.

To prevent slowing down for the subscribe the channels, it won't de able to set up below 512KiB with the newly introduced parameter.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```powershell
PS> bin/fluent-bit -i winevtlog -p channels=application -p threshold_size=1MB -p USE_ANSI=On -p read_existing_events=On -o stdout -v
```
- [x] Debug log output from testing the change

After introduced `threshold_size` parameter, the number of collected logs per a cycle is increased around 2000. This could increase events per second.

```
[1734] winevtlog.0: [[1712303476.639718600, {}], {"ProviderName"=>"Microsoft-Windows-RestartManager", "ProviderGuid"=>"{0888E5EF-9B98-4695-979D-E92CE4247224}", "Qualifiers"=>"", "EventID"=>10005, "Version"=>0, "Level"=>4, "Task"=>0, "Opcode"=>0, "Keywords"=>"0x8000000000000000", "TimeCreated"=>"2024-04-05 16:49:26 +0900", "EventRecordID"=>21470, "ActivityID"=>"", "RelatedActivityID"=>"", "ProcessID"=>162420, "ThreadID"=>161096, "Channel"=>"Application", "Computer"=>"hiroshi-14-eu", "UserID"=>"S-1-5-18", "Message"=>"コンピューターの再起動が必要です。", "StringInserts"=>[0, 1, 2]}]
[1735] winevtlog.0: [[1712303476.640162200, {}], {"ProviderName"=>"Microsoft-Windows-Security-SPP", "ProviderGuid"=>"{E23B33B0-C8C9-472C-A5F9-F2BDFEA0F156}", "Qualifiers"=>16384, "EventID"=>16384, "Version"=>0, "Level"=>4, "Task"=>0, "Opcode"=>0, "Keywords"=>"0x80000000000000", "TimeCreated"=>"2024-04-05 16:49:46 +0900", "EventRecordID"=>21471, "ActivityID"=>"", "RelatedActivityID"=>"", "ProcessID"=>161772, "ThreadID"=>0, "Channel"=>"Application", "Computer"=>"hiroshi-14-eu", "UserID"=>"", "Message"=>"ソフトウェア保護サービスの 2124-03-12T07:49:46Z の再起動をスケジュールしました。理由: RulesEngine。", "StringInserts"=>["2124-03-12T07:49:46Z", "RulesEngine"]}]
[2024/04/05 16:51:24] [debug] [out flush] cb_destroy coro_id=10
[2024/04/05 16:51:24] [debug] [task] destroy task=0000020BE6A34550 (task_id=0)
[2024/04/05 16:51:37] [debug] [input:winevtlog:winevtlog.0] read 920 bytes from 'application'
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1350

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
