### PR TITLE
engine_dispatch: remove chunks from memory if the task fails to be created

### DIFF
--- a/include/fluent-bit/flb_task.h
+++ b/include/fluent-bit/flb_task.h
@@ -125,6 +125,7 @@ struct flb_task_enqueued {
 
 int flb_task_running_count(struct flb_config *config);
 int flb_task_running_print(struct flb_config *config);
+int flb_task_map_get_task_id(struct flb_config *config);
 
 struct flb_task *flb_task_create(uint64_t ref_id,
                                  const char *buf,

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -331,6 +331,10 @@ int flb_task_running_print(struct flb_config *config)
     return 0;
 }
 
+int flb_task_map_get_task_id(struct flb_config *config) {
+    return map_get_task_id(config);
+}
+
 /* Create an engine task to handle the output plugin flushing work */
 struct flb_task *flb_task_create(uint64_t ref_id,
                                  const char *buf,


### PR DESCRIPTION
<!-- Provide summary of changes -->

When a task is not created and the filesystem storage is used, then set the chunk down

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #8395 #7329 #5485 #5217

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
