### PR TITLE
in_kubernetes_filter: add namespace_metadata_only option to fix regression from #8279

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -76,6 +76,7 @@ struct flb_kube {
     int annotations;
     int namespace_labels;
     int namespace_annotations;
+    int namespace_metadata_only;
     int dummy_meta;
     int tls_debug;
     int tls_verify;

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -2053,7 +2053,7 @@ int flb_kube_meta_get(struct flb_kube *ctx,
                         data_size, namespace_out_buf, namespace_out_size, namespace_meta);
     }
 
-    if(ctx->labels == FLB_TRUE || ctx->annotations == FLB_TRUE) {
+    if(ctx->namespace_metadata_only == FLB_FALSE) {
         ret_pod_meta = flb_kube_pod_meta_get(ctx, tag, tag_len, data, data_size,
                                              out_buf, out_size, meta, props);
     }

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -914,6 +914,12 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_kube, namespace_annotations),
      "include Kubernetes namespace annotations on every record"
     },
+    /* Ignore pod metadata entirely, useful for fetching only namespace meta */
+    {
+     FLB_CONFIG_MAP_BOOL, "namespace_metadata_only", "false",
+     0, FLB_TRUE, offsetof(struct flb_kube, namespace_metadata_only),
+     "ignore pod metadata entirely and only fetch namespace metadata"
+    },
 
     /*
      * The Application may 'propose' special configuration keys


### PR DESCRIPTION
fix regression in 3.0 from #8279

fixes #8642

Adds a new namespace_metadata_only config option that is off by default. When this option is enabled it allows you to fetch only namespace metadata without also having to fetch pod metadata.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1352

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
