### PR TITLE
out_http: Use x-ndjson content type for json_lines

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -178,13 +178,19 @@ static int http_post(struct flb_out_http *ctx,
     }
     else if ((ctx->out_format == FLB_PACK_JSON_FORMAT_JSON) ||
         (ctx->out_format == FLB_PACK_JSON_FORMAT_STREAM) ||
-        (ctx->out_format == FLB_PACK_JSON_FORMAT_LINES) ||
         (ctx->out_format == FLB_HTTP_OUT_GELF)) {
         flb_http_add_header(c,
                             FLB_HTTP_CONTENT_TYPE,
                             sizeof(FLB_HTTP_CONTENT_TYPE) - 1,
                             FLB_HTTP_MIME_JSON,
                             sizeof(FLB_HTTP_MIME_JSON) - 1);
+    }
+    else if ((ctx->out_format == FLB_PACK_JSON_FORMAT_LINES)) {
+        flb_http_add_header(c,
+                            FLB_HTTP_CONTENT_TYPE,
+                            sizeof(FLB_HTTP_CONTENT_TYPE) - 1,
+                            FLB_HTTP_MIME_NDJSON,
+                            sizeof(FLB_HTTP_MIME_NDJSON) - 1);
     }
     else if ((ctx->out_format == FLB_HTTP_OUT_MSGPACK)) {
         flb_http_add_header(c,

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -26,6 +26,7 @@
 #define FLB_HTTP_CONTENT_TYPE   "Content-Type"
 #define FLB_HTTP_MIME_MSGPACK   "application/msgpack"
 #define FLB_HTTP_MIME_JSON      "application/json"
+#define FLB_HTTP_MIME_NDJSON    "application/x-ndjson"
 
 #ifdef FLB_HAVE_SIGNV4
 #ifdef FLB_HAVE_AWS


### PR DESCRIPTION
json_lines currently results in Content-Type `application/json`, but it should be `application/x-ndjson`.

Fluentd uses `application/x-ndjson`
https://github.com/fluent/fluentd/blob/284bf4064a9831f5262330a94e3505e09ef6a068/lib/fluent/plugin/out_http.rb#L192

This spec here suggests the same: https://github.com/ndjson/ndjson-spec?tab=readme-ov-file#33-mediatype-and-file-extensions

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
