### PR TITLE
flb_input: Config parsing order fixed for storage.pause_on_chunks_overlimit

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -591,7 +591,15 @@ int flb_input_set_property(struct flb_input_instance *ins,
             flb_sds_destroy(tmp);
             return -1;
         }
+
+        if (ins->storage_type != FLB_STORAGE_FS && 
+            ins->storage_pause_on_chunks_overlimit == FLB_TRUE) {
+                flb_debug("[input] storage.pause_on_chunks_overlimit will be "
+                            "reset because storage.type is not filesystem");
+                ins->storage_pause_on_chunks_overlimit = FLB_FALSE;
+        }
         flb_sds_destroy(tmp);
+
     }
     else if (prop_key_check("threaded", k, len) == 0 && tmp) {
         enabled = flb_utils_bool(tmp);
@@ -604,14 +612,12 @@ int flb_input_set_property(struct flb_input_instance *ins,
         ins->is_threaded = enabled;
     }
     else if (prop_key_check("storage.pause_on_chunks_overlimit", k, len) == 0 && tmp) {
-        if (ins->storage_type == FLB_STORAGE_FS) {
-            ret = flb_utils_bool(tmp);
-            flb_sds_destroy(tmp);
-            if (ret == -1) {
-                return -1;
-            }
-            ins->storage_pause_on_chunks_overlimit = ret;
+        ret = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
+        if (ret == -1) {
+            return -1;
         }
+        ins->storage_pause_on_chunks_overlimit = ret;
     }
     else {
         /*


### PR DESCRIPTION
This PR fixes a dependency issue for the `storage.pause_on_chunks_overlimit` parameter.

In case the order in the config file was
```
  storage.pause_on_chunks_overlimit On
  storage.type Filesystem
```
then the `storage.pause_on_chunks_overlimit` was ignored.

This PR changes this behavior, so that the `storage.pause_on_chunks_overlimit` parameter will be parsed and set. It will be reset in case the `storage.type` is set to a different type than FS later.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
