### PR TITLE
out_bigquery: Add debug log for response payload when HTTP 200 OK

### DIFF
--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -1033,6 +1033,10 @@ static void cb_bigquery_flush(struct flb_event_chunk *event_chunk,
         /* The request was issued successfully, validate the 'error' field */
         flb_plg_debug(ctx->ins, "HTTP Status=%i", c->resp.status);
         if (c->resp.status == 200) {
+            /* Even with HTTP 200, the resp payload could contain errors, e.g. insetErrors */
+            if (c->resp.payload && c->resp.payload_size > 0) {
+                flb_plg_debug(ctx->ins, "response\n%s", c->resp.payload);
+            }
             ret_code = FLB_OK;
         }
         else {


### PR DESCRIPTION
This commit adds debug logging of the response payload. Even with HTTP 200 OK status response, BigQuery may return an error message in the payload. This can lead to data not being inserted into BigQuery silently.

See https://cloud.google.com/bigquery/docs/streaming-data-into-bigquery#streaming-success for reference:

```
Success HTTP response codes
Even if you receive a success HTTP response, you'll need to check the insertErrors property of the response to determine whether the row insertions were successful because it's possible that BigQuery was only partially successful at inserting the rows. You might encounter one of the following scenarios:
    
- All rows inserted successfully.
  If the insertErrors property is an empty list, all of the rows were inserted successfully.
- Some rows inserted successfully.
  Except in cases where there is a schema mismatch in any of the rows, rows indicated in the insertErrors property are not inserted, and all other rows are inserted successfully. The errors property contains detailed information about why each unsuccessful row failed. The index property indicates the 0-based row index of the request that the error applies to.
- None of the rows inserted successfully.
  If BigQuery encounters a schema mismatch on individual rows in the request, none of the rows are inserted and an insertErrors entry is returned for each row, even the rows that did not have a schema mismatch. Rows that did not have a schema mismatch have an error with the reason property set to stopped, and can be re-sent as-is. Rows that failed include detailed information about the schema mismatch. To learn about the supported protocol buffer types for each BigQuery data type, see [Data type conversions](https://cloud.google.com/bigquery/docs/write-api#data_type_conversions).
```

Now it is easier to detect such cases with debug logging:

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
```
[2024/04/19 07:59:05] [debug] [output:bigquery:bigquery.1] HTTP Status=200
[2024/04/19 07:59:05] [debug] [output:bigquery:bigquery.1] response
{
  "kind": "bigquery#tableDataInsertAllResponse",
  "insertErrors": [
    {
      "index": 0,
      "errors": [
        {
          "reason": "invalid",
          "location": "verticaluncertainty",
          "debugInfo": "",
          "message": "Invalid NUMERIC value: 5233.56298828125"
        }
      ]
    }
  ]
}
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
