### PR TITLE
in_splunk: out_splunk: Propagate ingested splunk_token authentication header

### DIFF
--- a/plugins/in_splunk/splunk.h
+++ b/plugins/in_splunk/splunk.h
@@ -42,6 +42,7 @@ struct flb_splunk {
 
     /* Token Auth */
     flb_sds_t auth_header;
+    flb_sds_t ingested_auth_header;
 
     struct flb_log_event_encoder log_encoder;
 

--- a/plugins/in_splunk/splunk_config.c
+++ b/plugins/in_splunk/splunk_config.c
@@ -51,6 +51,7 @@ struct flb_splunk *splunk_config_create(struct flb_input_instance *ins)
     }
 
     ctx->auth_header = NULL;
+    ctx->ingested_auth_header = NULL;
     tmp = flb_input_get_property("splunk_token", ins);
     if (tmp) {
         ctx->auth_header = flb_sds_create("Splunk ");

--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -95,6 +95,8 @@ struct flb_splunk {
 
     /* Token Auth */
     flb_sds_t auth_header;
+    /* Token Auth (via metadata) */
+    flb_sds_t metadata_auth_header;
 
     /* Channel identifier */
     flb_sds_t channel;

--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -98,6 +98,10 @@ struct flb_splunk {
     /* Token Auth (via metadata) */
     flb_sds_t metadata_auth_header;
 
+    /* Metadata of Splunk Authentication */
+    flb_sds_t metadata_auth_key;
+    struct flb_record_accessor *ra_metadata_auth_key;
+
     /* Channel identifier */
     flb_sds_t channel;
     size_t channel_len;

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -240,6 +240,7 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
         return NULL;
     }
 
+    ctx->metadata_auth_header = NULL;
     /* No http_user is set, fallback to splunk_token, if splunk_token is unset, fail. */
     if (!ctx->http_user) {
         /* Splunk Auth Token */

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -262,6 +262,21 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    /* Currently, Splunk HEC token is stored in a fixed key, hec_token. */
+    ctx->metadata_auth_key = "hec_token";
+    if (ctx->metadata_auth_key) {
+        ctx->ra_metadata_auth_key = flb_ra_create(ctx->metadata_auth_key, FLB_TRUE);
+        if (!ctx->ra_metadata_auth_key) {
+            flb_plg_error(ctx->ins,
+                          "cannot create record accessor for "
+                          "metadata_auth_key pattern: '%s'",
+                          ctx->event_host);
+            flb_splunk_conf_destroy(ctx);
+            return NULL;
+        }
+    }
+
+
     /* channel */
     if (ctx->channel != NULL) {
         ctx->channel_len = flb_sds_len(ctx->channel);
@@ -304,6 +319,10 @@ int flb_splunk_conf_destroy(struct flb_splunk *ctx)
 
     if (ctx->ra_event_index_key) {
         flb_ra_destroy(ctx->ra_event_index_key);
+    }
+
+    if (ctx->ra_metadata_auth_key) {
+        flb_ra_destroy(ctx->ra_metadata_auth_key);
     }
 
     event_fields_destroy(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, in_splunk does not have a capability to store and propagate the ingested Splunk token.
This could be needed to handle for simplifying logs pipeline for ingesting payloads of Splunk HEC format.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

On terminal:

```console
$ bin/fluent-bit -i splunk -p port=8088 -o splunk -p port=8081 -psplunk_token=db496524-e7e6-4ae9-b3f0-2287d8e65cd4 -p "event_key=\$event" -f 1 -v
```

And another terminal:

```console
$ bin/fluent-bit -i splunk -p port=8081 -o stdout 
```

- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.3
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/04/22 14:03:51] [ info] Configuration:
[2024/04/22 14:03:51] [ info]  flush time     | 1.000000 seconds
[2024/04/22 14:03:51] [ info]  grace          | 5 seconds
[2024/04/22 14:03:51] [ info]  daemon         | 0
[2024/04/22 14:03:51] [ info] ___________
[2024/04/22 14:03:51] [ info]  inputs:
[2024/04/22 14:03:51] [ info]      splunk
[2024/04/22 14:03:51] [ info] ___________
[2024/04/22 14:03:51] [ info]  filters:
[2024/04/22 14:03:51] [ info] ___________
[2024/04/22 14:03:51] [ info]  outputs:
[2024/04/22 14:03:51] [ info]      splunk.0
[2024/04/22 14:03:51] [ info] ___________
[2024/04/22 14:03:51] [ info]  collectors:
[2024/04/22 14:03:51] [ info] [fluent bit] version=3.0.3, commit=b134bf3bed, pid=199949
[2024/04/22 14:03:51] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/04/22 14:03:51] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/04/22 14:03:51] [ info] [cmetrics] version=0.8.0
[2024/04/22 14:03:51] [ info] [ctraces ] version=0.5.0
[2024/04/22 14:03:51] [ info] [input:splunk:splunk.0] initializing
[2024/04/22 14:03:51] [ info] [output:splunk:splunk.0] worker #1 started
[2024/04/22 14:03:51] [ info] [output:splunk:splunk.0] worker #0 started
[2024/04/22 14:03:51] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/04/22 14:03:51] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/04/22 14:03:51] [debug] [downstream] listening on 0.0.0.0:8088
[2024/04/22 14:03:51] [debug] [splunk:splunk.0] created event channels: read=24 write=25
[2024/04/22 14:03:51] [ info] [sp] stream processor started
[2024/04/22 14:04:10] [debug] [task] created task=0x5f8e3b0 id=0 OK
[2024/04/22 14:04:10] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #0
[2024/04/22 14:04:10] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 is connected
[2024/04/22 14:04:10] [debug] [output:splunk:splunk.0] Could not find a record accessor definition of hec_token
[2024/04/22 14:04:10] [debug] [http_client] not using http_proxy for header
[2024/04/22 14:04:10] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 is now available
[2024/04/22 14:04:10] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 has been disconnected by the remote service
[2024/04/22 14:04:10] [debug] [task] destroy task=0x5f8e3b0 (task_id=0)
[2024/04/22 14:04:10] [debug] [out flush] cb_destroy coro_id=0
[2024/04/22 14:04:11] [debug] [task] created task=0x6002a40 id=0 OK
[2024/04/22 14:04:11] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #1
[2024/04/22 14:04:11] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 is connected
[2024/04/22 14:04:11] [debug] [output:splunk:splunk.0] Could not find a record accessor definition of hec_token
[2024/04/22 14:04:11] [debug] [http_client] not using http_proxy for header
[2024/04/22 14:04:11] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 is now available
[2024/04/22 14:04:11] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 has been disconnected by the remote service
[2024/04/22 14:04:11] [debug] [out flush] cb_destroy coro_id=0
[2024/04/22 14:04:11] [debug] [task] destroy task=0x6002a40 (task_id=0)
[2024/04/22 14:04:12] [debug] [task] created task=0x60859d0 id=0 OK
[2024/04/22 14:04:12] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #0
[2024/04/22 14:04:12] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 is connected
[2024/04/22 14:04:12] [debug] [output:splunk:splunk.0] Could not find a record accessor definition of hec_token
[2024/04/22 14:04:12] [debug] [output:splunk:splunk.0] Could not find a record accessor definition of hec_token
[2024/04/22 14:04:12] [debug] [http_client] not using http_proxy for header
[2024/04/22 14:04:12] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 is now available
[2024/04/22 14:04:12] [debug] [upstream] KA connection #49 to 127.0.0.1:8081 has been disconnected by the remote service
[2024/04/22 14:04:12] [debug] [out flush] cb_destroy coro_id=1
[2024/04/22 14:04:12] [debug] [task] destroy task=0x60859d0 (task_id=0)
^C[2024/04/22 14:04:14] [engine] caught signal (SIGINT)
[2024/04/22 14:04:14] [ warn] [engine] service will shutdown in max 5 seconds
[2024/04/22 14:04:14] [ info] [input] pausing splunk.0
[2024/04/22 14:04:15] [ info] [engine] service has stopped (0 pending tasks)
[2024/04/22 14:04:15] [ info] [input] pausing splunk.0
[2024/04/22 14:04:15] [ info] [output:splunk:splunk.0] thread worker #0 stopping...
[2024/04/22 14:04:15] [ info] [output:splunk:splunk.0] thread worker #0 stopped
[2024/04/22 14:04:15] [ info] [output:splunk:splunk.0] thread worker #1 stopping...
[2024/04/22 14:04:15] [ info] [output:splunk:splunk.0] thread worker #1 stopped
```

```log
Fluent Bit v3.0.3
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/04/22 14:04:05] [ info] Configuration:
[2024/04/22 14:04:05] [ info]  flush time     | 1.000000 seconds
[2024/04/22 14:04:05] [ info]  grace          | 5 seconds
[2024/04/22 14:04:05] [ info]  daemon         | 0
[2024/04/22 14:04:05] [ info] ___________
[2024/04/22 14:04:05] [ info]  inputs:
[2024/04/22 14:04:05] [ info]      splunk
[2024/04/22 14:04:05] [ info] ___________
[2024/04/22 14:04:05] [ info]  filters:
[2024/04/22 14:04:05] [ info] ___________
[2024/04/22 14:04:05] [ info]  outputs:
[2024/04/22 14:04:05] [ info]      stdout.0
[2024/04/22 14:04:05] [ info] ___________
[2024/04/22 14:04:05] [ info]  collectors:
[2024/04/22 14:04:05] [ info] [fluent bit] version=3.0.3, commit=b134bf3bed, pid=199984
[2024/04/22 14:04:05] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/04/22 14:04:05] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/04/22 14:04:05] [ info] [cmetrics] version=0.8.0
[2024/04/22 14:04:05] [ info] [ctraces ] version=0.5.0
[2024/04/22 14:04:05] [ info] [input:splunk:splunk.0] initializing
[2024/04/22 14:04:05] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/04/22 14:04:05] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/04/22 14:04:05] [debug] [downstream] listening on 0.0.0.0:8081
[2024/04/22 14:04:05] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/04/22 14:04:05] [ info] [sp] stream processor started
[2024/04/22 14:04:05] [ info] [output:stdout:stdout.0] worker #0 started
[2024/04/22 14:04:11] [debug] [task] created task=0x5f303d0 id=0 OK
[2024/04/22 14:04:11] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.0: [[1713762250.731699688, {"hec_token"=>"Splunk db496524-e7e6-4ae9-b3f0-2287d8e65cd4"}], {"time"=>1713762249.733121, "event"=>"{"message":"dummy"}"}]
[2024/04/22 14:04:11] [debug] [out flush] cb_destroy coro_id=0
[2024/04/22 14:04:11] [debug] [task] destroy task=0x5f303d0 (task_id=0)
[0] splunk.0: [[1713762251.613924063, {"hec_token"=>"Splunk db496524-e7e6-4ae9-b3f0-2287d8e65cd4"}], {"time"=>1713762250.637001, "event"=>"{"message":"dummy"}"}]
[2024/04/22 14:04:12] [debug] [task] created task=0x5f94f40 id=0 OK
[2024/04/22 14:04:12] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2024/04/22 14:04:12] [debug] [out flush] cb_destroy coro_id=1
[2024/04/22 14:04:12] [debug] [task] destroy task=0x5f94f40 (task_id=0)
[2024/04/22 14:04:13] [debug] [task] created task=0x5ffba40 id=0 OK
[2024/04/22 14:04:13] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.0: [[1713762252.610231383, {"hec_token"=>"Splunk db496524-e7e6-4ae9-b3f0-2287d8e65cd4"}], {"time"=>1713762251.610019, "event"=>"{"message":"dummy"}"}]
[1] splunk.0: [[1713762252.610231383, {"hec_token"=>"Splunk db496524-e7e6-4ae9-b3f0-2287d8e65cd4"}], {"time"=>1713762252.038443, "event"=>"{"message":"dummy"}"}]
[2024/04/22 14:04:13] [debug] [out flush] cb_destroy coro_id=2
[2024/04/22 14:04:13] [debug] [task] destroy task=0x5ffba40 (task_id=0)
^C[2024/04/22 14:04:18] [engine] caught signal (SIGINT)
[2024/04/22 14:04:18] [ warn] [engine] service will shutdown in max 5 seconds
[2024/04/22 14:04:18] [ info] [input] pausing splunk.0
[2024/04/22 14:04:18] [ info] [engine] service has stopped (0 pending tasks)
[2024/04/22 14:04:18] [ info] [input] pausing splunk.0
[2024/04/22 14:04:18] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/04/22 14:04:18] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==199949== 
==199949== HEAP SUMMARY:
==199949==     in use at exit: 0 bytes in 0 blocks
==199949==   total heap usage: 3,699 allocs, 3,699 frees, 2,448,482 bytes allocated
==199949== 
==199949== All heap blocks were freed -- no leaks are possible
==199949== 
==199949== For lists of detected and suppressed errors, rerun with: -s
==199949== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```log
==199984== 
==199984== HEAP SUMMARY:
==199984==     in use at exit: 0 bytes in 0 blocks
==199984==   total heap usage: 3,174 allocs, 3,174 frees, 1,897,854 bytes allocated
==199984== 
==199984== All heap blocks were freed -- no leaks are possible
==199984== 
==199984== For lists of detected and suppressed errors, rerun with: -s
==199984== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
