### PR TITLE
lib: lua: fix LUA_VERSION_NUM check

### DIFF
--- a/include/fluent-bit/flb_lua.h
+++ b/include/fluent-bit/flb_lua.h
@@ -75,7 +75,7 @@ static inline int flb_lua_metadata_init(struct flb_lua_metadata *meta)
 /* convert from negative index to positive index */
 static inline int flb_lua_absindex(lua_State *l , int index)
 {
-#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM < 520
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM < 502
     if (index < 0) {
         index = lua_gettop(l) + index + 1;
     }

--- a/src/flb_lua.c
+++ b/src/flb_lua.c
@@ -269,7 +269,7 @@ static int lua_isinteger(lua_State *L, int index)
 */
 static int lua_table_maxn(lua_State *l, int index)
 {
-#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM < 520
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM < 502
     int ret = -1;
     if (lua_type(l, index) != LUA_TTABLE) {
         return -1;


### PR DESCRIPTION
The `LUA_VERSION_NUM` macro definition for Lua 5.2 is 502 and not 520.

Reference:
https://github.com/lua/lua/blob/e2fc2ce8dfe107d1e2742b459c2aaf137227bbc1/lua.h#L21

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
