### PR TITLE
out_datadog: Update the descriptions of special field options

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -495,19 +495,24 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "dd_service", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_service),
-     "The human readable name for your service generating the logs "
-     "- the name of your application or database."
+     "The human readable name for your service generating the logs  "
+     "(e.g. the name of your application or database). If unset, Datadog "
+     "will look for the service using Service Remapper in Log Management "
+     "(by default it will look at the `service` and `syslog.appname` attributes)."
+     ""
     },
     {
      FLB_CONFIG_MAP_STR, "dd_source", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_source),
-     "A human readable name for the underlying technology of your service. "
-     "For example, 'postgres' or 'nginx'."
+     "A human readable name for the underlying technology of your service "
+     "(e.g. 'postgres' or 'nginx'). If unset, Datadog will expect the source "
+     "to be set as the `ddsource` attribute."
     },
     {
      FLB_CONFIG_MAP_STR, "dd_tags", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_tags),
-     "The tags you want to assign to your logs in Datadog."
+     "The tags you want to assign to your logs in Datadog. If unset, Datadog "
+     "will expect the tags in the `ddtags` attribute."
     },
 
     {


### PR DESCRIPTION
These options are useful when there is no attribute in the incoming log that indicates the field to use for the `source` or `service` attributes, but otherwise the backend will automatically look for both in the incoming log attributes.

Ref: #8687

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
