### PR TITLE
http_server: Fix keep-alive for HTTP/1.1 requests

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -139,7 +139,7 @@ static int in_elasticsearch_bulk_init(struct flb_input_instance *ins,
     if (ctx->enable_http2) {
         ret = flb_http_server_init(&ctx->http_server, 
                                     HTTP_PROTOCOL_AUTODETECT,
-                                    FLB_HTTP_SERVER_FLAG_AUTO_INFLATE,
+                                    (FLB_HTTP_SERVER_FLAG_KEEPALIVE | FLB_HTTP_SERVER_FLAG_AUTO_INFLATE),
                                     NULL,
                                     ins->host.listen,
                                     ins->host.port,

--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -96,7 +96,7 @@ static int in_http_init(struct flb_input_instance *ins,
     if (ctx->enable_http2) {
         ret = flb_http_server_init(&ctx->http_server, 
                                     HTTP_PROTOCOL_AUTODETECT,
-                                    FLB_HTTP_SERVER_FLAG_AUTO_INFLATE,
+                                    (FLB_HTTP_SERVER_FLAG_KEEPALIVE | FLB_HTTP_SERVER_FLAG_AUTO_INFLATE),
                                     NULL,
                                     ins->host.listen,
                                     ins->host.port,

--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -93,7 +93,7 @@ static int in_opentelemetry_init(struct flb_input_instance *ins,
     if (ctx->enable_http2) {
         ret = flb_http_server_init(&ctx->http_server, 
                                     HTTP_PROTOCOL_AUTODETECT,
-                                    FLB_HTTP_SERVER_FLAG_AUTO_INFLATE,
+                                    (FLB_HTTP_SERVER_FLAG_KEEPALIVE | FLB_HTTP_SERVER_FLAG_AUTO_INFLATE),
                                     NULL,
                                     ins->host.listen,
                                     ins->host.port,

--- a/plugins/in_splunk/splunk.c
+++ b/plugins/in_splunk/splunk.c
@@ -97,7 +97,7 @@ static int in_splunk_init(struct flb_input_instance *ins,
     if (ctx->enable_http2) {
         ret = flb_http_server_init(&ctx->http_server, 
                                     HTTP_PROTOCOL_AUTODETECT,
-                                    FLB_HTTP_SERVER_FLAG_AUTO_INFLATE,
+                                    (FLB_HTTP_SERVER_FLAG_KEEPALIVE | FLB_HTTP_SERVER_FLAG_AUTO_INFLATE),
                                     NULL,
                                     ins->host.listen,
                                     ins->host.port,

--- a/src/flb_http_common.c
+++ b/src/flb_http_common.c
@@ -437,6 +437,11 @@ void flb_http_stream_destroy(struct flb_http_stream *stream)
             cfl_list_del(&stream->_head);
         }
 
-        flb_free(stream);
+        flb_http_request_destroy(&stream->request);
+        flb_http_response_destroy(&stream->response);
+
+        if (stream->releasable) {
+          flb_free(stream);
+        }
     }
 }

--- a/src/http_server/flb_http_server_http1.c
+++ b/src/http_server/flb_http_server_http1.c
@@ -445,7 +445,8 @@ int flb_http1_server_session_init(struct flb_http1_server_session *session,
 
     if (parent != NULL && parent->parent != NULL) {
         user_data = parent->parent->user_data;
-    } else {
+    }
+    else {
         user_data = NULL;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch moves the initialisation of a HTTP/1.1 stream from the session initialisation to the session ingestion step.

Previously, using keep-alive on HTTP/1.1 would panic on the second request, as it would attempt to use components like the header map that are destroyed after each stream, but only initialised at the start of the session, when the HTTP protocol autodetection was run.

With this fix, HTTP/1.1 keep-alive is now enabled for the HTTP, OpenTelemetry, Elasticsearch and Splunk inputs

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8758

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
