### PR TITLE
cmt_math: fix metric conversions

### DIFF
--- a/lib/cmetrics/include/cmetrics/cmt_math.h
+++ b/lib/cmetrics/include/cmetrics/cmt_math.h
@@ -38,7 +38,7 @@ static inline uint64_t cmt_math_d64_to_uint64(double val)
     union val_union u;
 
     u.d = val;
-    return u.u;
+    return u.d;
 }
 
 static inline double cmt_math_uint64_to_d64(uint64_t val)
@@ -46,7 +46,7 @@ static inline double cmt_math_uint64_to_d64(uint64_t val)
     union val_union u;
 
     u.u = val;
-    return u.d;
+    return u.u;
 }
 
 #endif


### PR DESCRIPTION
Fixed issue with metric conversions where garbage values were being returned from a union. This method now implicitly does a cast as seemed to be intended by the original method. This issue was found because I was having an issue where fluent bit was spitting out garbage values for my metric counters when using the opentelemetry_input function.

Fixes #8083 

- [x] Example configuration file for the change
- [x] Debug log output from testing the change

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.