### PR TITLE
workflows: macos: Use matrix for building Apple Silicon artefacts

### DIFF
--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -64,12 +64,21 @@ jobs:
 
   call-build-macos-package:
     if: needs.call-build-macos-legacy-check.outputs.build-type == 'modern'
-    runs-on: macos-latest
+    runs-on: ${{ matrix.config.runner }}
     environment: ${{ inputs.environment }}
     needs:
       - call-build-macos-legacy-check
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Normal macOS-latest runner (Intel)"
+            runner: macos-12
+          - name: "Apple Silicon macOS runner"
+            runner: macos-14
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -92,7 +101,7 @@ jobs:
       - name: Upload build packages
         uses: actions/upload-artifact@v4
         with:
-          name: macos-packages
+          name: macos-packages on ${{ matrix.config.runner }}
           path: |
             build/fluent-bit-*-apple*
             build/fluent-bit-*-intel*
@@ -108,6 +117,15 @@ jobs:
       - call-build-macos-package
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Normal macOS-latest package (Intel)"
+            os: macos-12
+          - name: "Apple Silicon macOS package"
+            os: macos-14
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -118,7 +136,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: macos-packages
+          name: macos-packages on ${{ matrix.config.os }}
           path: artifacts/
 
       - name: Push MacOS packages to S3


### PR DESCRIPTION
<!-- Provide summary of changes -->

GitHub now published hosted runners which are based on M1 macOS: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

To use them and continue to use Intel mac runners, we need to specify them with build matrix and set up with `macos-12` and `macos-14`. Now, macos-latest is pointed in macos-14. So, we need to specify macos-12 or macos-13 explicitly to create Intel Mac artefacts.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
