### PR TITLE
utils: floating-point number support in size-to-bytes conversion

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -522,7 +522,7 @@ int64_t flb_utils_size_to_bytes(const char *size)
     int i;
     int len;
     int plen = 0;
-    int64_t val;
+    double_t val;
     char c;
     char tmp[3] = {0};
     int64_t KB = 1000;
@@ -538,7 +538,7 @@ int64_t flb_utils_size_to_bytes(const char *size)
     }
 
     len = strlen(size);
-    val = atoll(size);
+    val = atof(size);
 
     if (len == 0) {
         return -1;
@@ -554,7 +554,7 @@ int64_t flb_utils_size_to_bytes(const char *size)
     }
 
     if (plen == 0) {
-        return val;
+        return (int64_t)val;
     }
     else if (plen > 2) {
         return -1;
@@ -577,27 +577,27 @@ int64_t flb_utils_size_to_bytes(const char *size)
         {
             return -1;
         }
-        return (val * KB);
+        return (int64_t)(val * KB);
     }
     else if (tmp[0] == 'M') {
         /* set upper bound (2**64/MB)/2 to avoid overflows */
         if (val >= 9223372036854 || val <= -9223372036853) {
             return -1;
         }
-        return (val * MB);
+        return (int64_t)(val * MB);
     }
     else if (tmp[0] == 'G') {
         /* set upper bound (2**64/GB)/2 to avoid overflows */
         if (val >= 9223372036 || val <= -9223372035) {
             return -1;
         }
-        return (val * GB);
+        return (int64_t)(val * GB);
     }
     else {
         return -1;
     }
 
-    return val;
+    return (int64_t)val;
 }
 
 int64_t flb_utils_hex2int(char *hex, int len)

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -522,7 +522,7 @@ int64_t flb_utils_size_to_bytes(const char *size)
     int i;
     int len;
     int plen = 0;
-    double_t val;
+    double val;
     char c;
     char tmp[3] = {0};
     int64_t KB = 1000;

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -618,6 +618,42 @@ void test_flb_utils_get_machine_id()
     flb_free(id);
 }
 
+struct size_to_bytes_check {
+    char *size;      /* size in string    */
+    int64_t ret;     /* expected size     */
+};
+
+struct size_to_bytes_check size_to_bytes_checks[] = {
+    {"922337.63", 922337},
+    {"2K",2000},
+    {"5.7263K", 5726},
+    {"9223372036854775.23K", -1},
+    {"1M", 1000000},
+    {"1.1M", 1100000},
+    {"3.592M", 3592000},
+    {"52.752383M", 52752383},
+    {"9223372036854.42M", -1},
+    {"492.364G",492364000000},
+    {"1.2973G", 1297300000},
+    {"9223372036.78G", -1},
+};
+
+void test_size_to_bytes() 
+{
+    int i;
+    int size;
+    int64_t ret;
+    struct size_to_bytes_check *u;
+
+    size = sizeof(size_to_bytes_checks) / sizeof(struct size_to_bytes_check);
+    for (i = 0; i < size; i++) {
+        u = &size_to_bytes_checks[i];
+
+        ret = flb_utils_size_to_bytes(u->size);
+        TEST_CHECK(ret == u->ret);
+    }
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "url_split", test_url_split },
@@ -632,5 +668,6 @@ TEST_LIST = {
     { "test_flb_utils_split_quoted", test_flb_utils_split_quoted},
     { "test_flb_utils_split_quoted_errors", test_flb_utils_split_quoted_errors},
     { "test_flb_utils_get_machine_id", test_flb_utils_get_machine_id },
+    { "test_size_to_bytes", test_size_to_bytes },
     { 0 }
 };


### PR DESCRIPTION
This PR addresses an issue, which is that the **flb_utils_size_to_bytes** function is only processing non-floating numbers even after providing a floating-number in configuration.

It would address one aspect of the performance issues (Ref: https://github.com/fluent/fluent-bit/issues/8673)

----

- Consider a case where the **input plugin** is **winevtlog** and the **output plugin** is **stdout**.

1. If **read_limit_per_cycle** is set to **1.8 M**,

- Configuration file for the above scenario 
```
[SERVICE]
    flush        1
    daemon       Off
    log_level    debug
    parsers_file parsers.conf
    plugins_file plugins.con
    http_server  Off
    http_listen  0.0.0.0
    http_port    2020
    storage.metrics on

[INPUT]
    Name         winevtlog
    Channels     Setup,Windows PowerShell
    Interval_Sec 60
    read_existing_events true
    render_event_as_xml true
    read_limit_per_cycle 1.8M

[OUTPUT]
    name  stdout
    match *
```

- Output for the above configuration in debug mode to check, which value is set up for the **read_limit_per_cycle** parameter.

`[2024/04/23 18:34:22] [debug] [input:winevtlog:winevtlog.0] read limit per cycle is set up as 976.6K`

- It only sets **976.6k (human_readable_size)** as the **read_limit_per_cycle** parameter value, but **it should be 1.7M (human_readable_size)**.



2. If **read_limit_per_cycle** is set to **1.2M**

- Output for the above configuration in debug mode to check which value is set up for the **read_limit_per_cycle** parameter if **read_limit_per_cycle** is set to **1.2M**

`[2024/04/23 18:42:00] [debug] [input:winevtlog:winevtlog.0] read limit per cycle is set up as 976.6K`

- In this case also, the **read_limit_per_cycle** parameter value sets **976.6k (human_readable_size)**, but **it should be 1.1M (human_readable_size).**

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
