### PR TITLE
in_winevtlog: Fix threshold condition to avoid unnecessary warning

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -74,7 +74,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
 
     /* Set up total reading size threshold */
     if (ctx->total_size_threshold >= MINIMUM_THRESHOLD_SIZE &&
-        ctx->total_size_threshold < MAXIMUM_THRESHOLD_SIZE) {
+        ctx->total_size_threshold <= MAXIMUM_THRESHOLD_SIZE) {
         flb_utils_bytes_to_human_readable_size((size_t) ctx->total_size_threshold,
                                                human_readable_size,
                                                sizeof(human_readable_size) - 1);
@@ -82,7 +82,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
                       "read limit per cycle is set up as %s",
                       human_readable_size);
     }
-    else if (ctx->total_size_threshold >= MAXIMUM_THRESHOLD_SIZE) {
+    else if (ctx->total_size_threshold > MAXIMUM_THRESHOLD_SIZE) {
         flb_utils_bytes_to_human_readable_size((size_t) MAXIMUM_THRESHOLD_SIZE,
                                                human_readable_size,
                                                sizeof(human_readable_size) - 1);


### PR DESCRIPTION
This pull request addresses a **conditioning error** in the **in_winevtlog.c** file. 

Currently, even if the **highest allowed value (1843200)** is set for the **read_limit_per_cycle** parameter in the configuration file, an unnecessary warning **(read limit per cycle cannot exceed)** message is still shown **without exceeding the maximum threshold size.**

**MAXIMUM_THRESHOLD_SIZE =1843200**.

issue (#8783)

- Warning log

`[2024/04/23 19:33:02] [ warn] [input:winevtlog:winevtlog.0] read limit per cycle cannot exceed 1.8M. Set up to 1.8M`

 This fix ensures that when the maximum value is set, the warning message is skipped, making the behavior more consistent and clear.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
