### PR TITLE
out_kafka: increase max kafka dynamic topic length to 249 characters

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -227,9 +227,9 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
                             flb_warn("',' not allowed in dynamic_kafka topic names");
                             continue;
                         }
-                        if (val.via.str.size > 64) {
-                            /* Don't allow length of dynamic kafka topics > 64 */
-                            flb_warn(" dynamic kafka topic length > 64 not allowed");
+                        if (val.via.str.size > 249) {
+                            /* Don't allow length of dynamic kafka topics > 249 */
+                            flb_warn(" dynamic kafka topic length > 249 not allowed");
                             continue;
                         }
                         dynamic_topic = flb_malloc(val.via.str.size + 1);


### PR DESCRIPTION
This commit increases the max length of kafka dynamic topics.

As the limit previously set (64) seemed arbitrary, and kafka allows for a maximum of 249 characters per topic, I think fluentbit should reflect that limit.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #4337 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
