### PR TITLE
packaging: add build support for ubuntu 24.04 noble numbat

### DIFF
--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -93,6 +93,14 @@
           "type": "deb"
         },
         {
+          "target": "ubuntu/24.04",
+          "type": "deb"
+        },
+        {
+          "target": "ubuntu/24.04.arm64v8",
+          "type": "deb"
+        },
+        {
           "target": "raspbian/buster",
           "type": "deb"
         },

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -122,6 +122,32 @@ RUN apt-get update && \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
+    # ubuntu/24.04 base image
+FROM ubuntu:24.04 as ubuntu-24.04-base
+ENV DEBIAN_FRONTEND noninteractive
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates build-essential libsystemd-dev \
+    cmake make bash wget unzip nano vim valgrind dh-make flex bison \
+    libpq-dev postgresql-server-dev-all libpq5 \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
+    apt-get install -y --reinstall lsb-base lsb-release
+
+# ubuntu/24.04.arm64v8 base image
+FROM arm64v8/ubuntu:24.04 as ubuntu-24.04.arm64v8-base
+ENV DEBIAN_FRONTEND noninteractive
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates build-essential libsystemd-dev \
+    cmake make bash wget unzip nano vim valgrind dh-make flex bison \
+    libpq-dev postgresql-server-dev-all libpq5 \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
+    apt-get install -y --reinstall lsb-base lsb-release
+
 # Common build for all distributions now
 # hadolint ignore=DL3006
 FROM $BASE_BUILDER as builder

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -54,6 +54,7 @@ DEB_REPO_PATHS=( "debian/bookworm"
                  "ubuntu/bionic"
                  "ubuntu/focal"
                  "ubuntu/jammy"
+                 "ubuntu/noble"
                  "raspbian/buster"
                  "raspbian/bullseye" )
 


### PR DESCRIPTION
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

Closes: #8775
