### PR TITLE
out_calyptia: move debug payload to debug level.

### DIFF
--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -779,7 +779,7 @@ static void debug_payload(struct flb_calyptia *ctx, void *data, size_t bytes)
     }
 
     out = cmt_encode_text_create(cmt);
-    flb_plg_info(ctx->ins, "debug payload:\n%s", out);
+    flb_plg_debug(ctx->ins, "debug payload:\n%s", out);
     cmt_encode_text_destroy(out);
     cmt_destroy(cmt);
 }


### PR DESCRIPTION
Moving the debug payload from info to debug level.

The output of this can result in half-way lines, which confuses the user.

<details><summary>Example 1</summary>

```text
[2024/05/07 21:11:41] [ warn] [output:calyptia:calyptia.2] http_status=422:
{"error":"zero metric values"}
[2024/05/07 21:11:41] [error] [output:calyptia:calyptia.2] could not deliver metrics
[2024/05/07 21:11:41] [ info] [output:calyptia:calyptia.2] debug payload:
2024-05-07T21:11:40.221389762Z fluentbit_uptime{pipeline_id="xxx",hostname="yyy"} = 5
...
2024-05-07T21:11:35.674983168Z fluentbit_output_retries_failed_total{pipeline_id="xxx",name="stdout.1"} = 0
2024-05-07T21:11:35.674983168Z fluentbit_output_dropped_records_total{pipeline_id="xxx",name="stdout.1"} = 0
2024-05-07T21:11:35.674983168Z fluentbit_output_retried_records_total{pipeline_id="xxx",name="stdout.1"} = 0
2024-05-07T21:11:35.675263704Z fluentbit_output_proc_records_total{pipeline_id="xxx",name="calyptia.2"} = 0
2024-05-07T21:11:35.675263704Z fluentbit_output_proc_bytes_total{pipeline_id="xxx",name="calyptia.2"} = 0
2024-05-07T21:11:35.675263704Z fluentbit_output_errors_total{pipeline_id="xxx",name="calyptia
```

</details> 

<details><summary>Example 2</summary>

```text
[2024/05/04 15:40:23] [ warn] [output:calyptia:calyptia.1] http_status=422:
{"error":"zero metric values"}
[2024/05/04 15:40:23] [error] [output:calyptia:calyptia.1] could not deliver metrics
[2024/05/04 15:40:23] [ info] [output:calyptia:calyptia.1] debug payload:
...
2024-05-04T15:40:17.432402887Z fluentbit_output_retried_records_total{pipeline_id="yyy",name="calyptia.1"} = 0
2024-05-04T15:40:22.217258412Z fluentbit_process_start_time_seconds{pipeline_id="yyy",hostname="xxx"} = 1714837217
2024-05-04T15:40:22.217258412Z fluentbit_build_info{pipeline_id="yyy",hostname="xxx",,os="linux"} = 1714837217
2024-05-04T15:40:22.217258412Z fluent
```

</details> 


This should only be printed if debug is enabled.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
