### PR TITLE
processor_metrics_selector: Implement delete by label value operation

### DIFF
--- a/plugins/processor_metrics_selector/selector.h
+++ b/plugins/processor_metrics_selector/selector.h
@@ -39,14 +39,16 @@
 #define SELECTOR_NOTOUCH   1
 #define SELECTOR_FAILURE   2
 
-#define SELECTOR_OPERATION_REGEX     0
-#define SELECTOR_OPERATION_PREFIX    1
-#define SELECTOR_OPERATION_SUBSTRING 2
+#define SELECTOR_OPERATION_REGEX          0
+#define SELECTOR_OPERATION_PREFIX         1
+#define SELECTOR_OPERATION_SUBSTRING      2
+#define SELECTOR_OPERATION_LABEL_DELETION 3
 
 /* context */
-#define SELECTOR_CONTEXT_FQNAME 0
-#define SELECTOR_CONTEXT_LABELS 1
-#define SELECTOR_CONTEXT_DESC   2
+#define SELECTOR_CONTEXT_FQNAME             0
+#define SELECTOR_CONTEXT_LABELS             1
+#define SELECTOR_CONTEXT_DESC               2
+#define SELECTOR_CONTEXT_DELETE_LABEL_VALUE 3
 
 struct selector_ctx {
     struct mk_list metrics_rules;
@@ -55,6 +57,8 @@ struct selector_ctx {
     int op_type;
     int context_type;
     char *selector_pattern;
+    flb_sds_t label_key;
+    flb_sds_t label_value;
     struct flb_regex *name_regex;
     struct flb_processor_instance *ins;
     struct flb_config *config;

--- a/tests/runtime/processor_metrics_selector.c
+++ b/tests/runtime/processor_metrics_selector.c
@@ -613,6 +613,82 @@ void flb_test_selector_can_modify_output(void)
     flb_stop(ctx);
     flb_destroy(ctx);
 }
+
+
+void flb_test_selector_context_delete_label_value(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct cfl_variant var = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "delete_label_value",
+    };
+    struct cfl_variant label_pair = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "name lib.0",
+    };
+    int got;
+    int n_metrics = 20;
+    int not_used = 0;
+    struct flb_lib_out_cb cb_data;
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_metrics_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "metrics_selector");
+    TEST_CHECK(pu != NULL);
+    ret = flb_processor_unit_set_property(pu, "context", &var);
+    TEST_CHECK(ret == 0);
+    ret = flb_processor_unit_set_property(pu, "label", &label_pair);
+    TEST_CHECK(ret == 0);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "fluentbit_metrics", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_on_start", "true", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "scrape_interval", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+    clear_output_num();
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    got = get_output_num();
+    if (!TEST_CHECK(got >= n_metrics)) {
+        TEST_MSG("expect: %d >= %d, got: %d < %d", got, n_metrics, got, n_metrics);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
 #endif
 
 /* Test list */
@@ -625,6 +701,7 @@ TEST_LIST = {
     {"substring_include", flb_test_selector_substring_include},
     {"substring_exclude", flb_test_selector_substring_exclude},
     {"can_modify_output", flb_test_selector_can_modify_output},
+    {"context_delete_label_value", flb_test_selector_context_delete_label_value},
 #endif
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

In this PR, I implemented a context of delete_label_value operation.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```yaml
service:
  flush: 2
  daemon: off
  log_level:  debug

pipeline:
  inputs:
    - name: fluentbit_metrics
      tag: fluentbit.metrics
      scrape_interval: 2

      processors:
        metrics:
          - name: metrics_selector
            context: delete_label_value
            label: name stdout.0

  outputs:
    - name: stdout
      match: '*'
```

- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.4
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/05/10 15:55:59] [ info] Configuration:
[2024/05/10 15:55:59] [ info]  flush time     | 2.000000 seconds
[2024/05/10 15:55:59] [ info]  grace          | 5 seconds
[2024/05/10 15:55:59] [ info]  daemon         | 0
[2024/05/10 15:55:59] [ info] ___________
[2024/05/10 15:55:59] [ info]  inputs:
[2024/05/10 15:55:59] [ info]      fluentbit_metrics
[2024/05/10 15:55:59] [ info] ___________
[2024/05/10 15:55:59] [ info]  filters:
[2024/05/10 15:55:59] [ info] ___________
[2024/05/10 15:55:59] [ info]  outputs:
[2024/05/10 15:55:59] [ info]      stdout.0
[2024/05/10 15:55:59] [ info] ___________
[2024/05/10 15:55:59] [ info]  collectors:
[2024/05/10 15:55:59] [ info] [fluent bit] version=3.0.4, commit=41ef155add, pid=138532
[2024/05/10 15:55:59] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/05/10 15:55:59] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/05/10 15:55:59] [ info] [cmetrics] version=0.9.0
[2024/05/10 15:55:59] [ info] [ctraces ] version=0.5.1
[2024/05/10 15:55:59] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2024/05/10 15:55:59] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2024/05/10 15:55:59] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2024/05/10 15:55:59] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/05/10 15:55:59] [ info] [output:stdout:stdout.0] worker #0 started
[2024/05/10 15:55:59] [ info] [sp] stream processor started
[2024/05/10 15:56:03] [debug] [task] created task=0x5f52390 id=0 OK
[2024/05/10 15:56:03] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-05-10T06:56:01.036525578Z fluentbit_uptime{hostname="cosmo-desktop2"} = 2
2024-05-10T06:55:59.414406238Z fluentbit_input_bytes_total{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_records_total{name="fluentbit_metrics.0"} = 0
2024-05-10T06:56:01.032061668Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0"} = 1
2024-05-10T06:56:01.036525578Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2"} = 1715324159
2024-05-10T06:56:01.036525578Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.0.4",os="linux"} = 1715324159
2024-05-10T06:56:01.036525578Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2"} = 0
2024-05-10T06:56:01.045084677Z fluentbit_storage_chunks = 0
2024-05-10T06:56:01.045084677Z fluentbit_storage_mem_chunks = 0
2024-05-10T06:56:01.045084677Z fluentbit_storage_fs_chunks = 0
2024-05-10T06:56:01.045084677Z fluentbit_storage_fs_chunks_up = 0
2024-05-10T06:56:01.045084677Z fluentbit_storage_fs_chunks_down = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_ingestion_paused{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_overlimit{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_memory_bytes{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_up{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_down{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_busy{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_busy_bytes{name="fluentbit_metrics.0"} = 0
[2024/05/10 15:56:03] [debug] [out flush] cb_destroy coro_id=0
[2024/05/10 15:56:03] [debug] [task] destroy task=0x5f52390 (task_id=0)
^C[2024/05/10 15:56:03] [engine] caught signal (SIGINT)
[2024/05/10 15:56:03] [debug] [task] created task=0x60040e0 id=0 OK
[2024/05/10 15:56:03] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-05-10T06:56:03.049517846Z fluentbit_uptime{hostname="cosmo-desktop2"} = 4
2024-05-10T06:55:59.414406238Z fluentbit_input_bytes_total{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_records_total{name="fluentbit_metrics.0"} = 0
2024-05-10T06:56:03.049340936Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0"} = 2
2024-05-10T06:56:03.049517846Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2"} = 1715324159
2024-05-10T06:56:03.049517846Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.0.4",os="linux"} = 1715324159
2024-05-10T06:56:03.049517846Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2"} = 0
2024-05-10T06:56:03.049862719Z fluentbit_storage_chunks = 1
2024-05-10T06:56:03.049862719Z fluentbit_storage_mem_chunks = 1
2024-05-10T06:56:03.049862719Z fluentbit_storage_fs_chunks = 0
2024-05-10T06:56:03.049862719Z fluentbit_storage_fs_chunks_up = 0
2024-05-10T06:56:03.049862719Z fluentbit_storage_fs_chunks_down = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_ingestion_paused{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_overlimit{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_memory_bytes{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_up{name="fluentbit_metrics.0"} = 0
[2024/05/10 15:56:03] [ warn] [engine] service will shutdown in max 5 seconds
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_down{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_busy{name="fluentbit_metrics.0"} = 0
2024-05-10T06:55:59.414406238Z fluentbit_input_storage_chunks_busy_bytes{name="fluentbit_metrics.0"} = 0
[2024/05/10 15:56:03] [debug] [out flush] cb_destroy coro_id=1
[2024/05/10 15:56:03] [ info] [input] pausing fluentbit_metrics.0
[2024/05/10 15:56:03] [debug] [task] destroy task=0x60040e0 (task_id=0)
[2024/05/10 15:56:04] [ info] [engine] service has stopped (0 pending tasks)
[2024/05/10 15:56:04] [ info] [input] pausing fluentbit_metrics.0
[2024/05/10 15:56:04] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/05/10 15:56:04] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==138532== 
==138532== HEAP SUMMARY:
==138532==     in use at exit: 0 bytes in 0 blocks
==138532==   total heap usage: 8,187 allocs, 8,187 frees, 1,616,398 bytes allocated
==138532== 
==138532== All heap blocks were freed -- no leaks are possible
==138532== 
==138532== For lists of detected and suppressed errors, rerun with: -s
==138532== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1367

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
