### PR TITLE
out_loki: allow sending unquoted strings

### DIFF
--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -41,6 +41,11 @@
 #define FLB_LOKI_FMT_JSON  0
 #define FLB_LOKI_FMT_KV    1
 
+/* Drop single key */
+#define FLB_LOKI_DROP_SINGLE_KEY_OFF (((uint64_t) 1) << 0)
+#define FLB_LOKI_DROP_SINGLE_KEY_ON  (((uint64_t) 1) << 1)
+#define FLB_LOKI_DROP_SINGLE_KEY_RAW (((uint64_t) 1) << 2)
+
 struct flb_loki_kv {
     int val_type;                       /* FLB_LOKI_KV_STR or FLB_LOKI_KV_RA */
     flb_sds_t key;                      /* string key */
@@ -54,8 +59,8 @@ struct flb_loki_kv {
 struct flb_loki {
     /* Public configuration properties */
     int auto_kubernetes_labels;
-    int drop_single_key;
 
+    flb_sds_t drop_single_key;
     flb_sds_t uri;
     flb_sds_t line_format;
     flb_sds_t tenant_id;
@@ -80,6 +85,7 @@ struct flb_loki {
     int tcp_port;
     char *tcp_host;
     int out_line_format;
+    int out_drop_single_key;
     int ra_used;                        /* number of record accessor label keys */
     struct flb_record_accessor *ra_k8s; /* kubernetes record accessor */
     struct mk_list labels_list;         /* list of flb_loki_kv nodes */

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -285,6 +285,182 @@ void flb_test_line_format()
     flb_destroy(ctx);
 }
 
+static void cb_check_drop_single_key_off(void *ctx, int ffd,
+                                         int res_ret, void *res_data, size_t res_size,
+                                         void *data)
+{
+    char *p;
+    flb_sds_t out_js = res_data;
+    char *index_line = "{\\\"key\\\":\\\"value\\\"}";
+
+    p = strstr(out_js, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out_js);
+    }
+
+    flb_sds_destroy(out_js);
+}
+
+void flb_test_drop_single_key_off()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Loki output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "drop_single_key", "off",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_drop_single_key_off,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+static void cb_check_drop_single_key_on(void *ctx, int ffd,
+                                         int res_ret, void *res_data, size_t res_size,
+                                         void *data)
+{
+    char *p;
+    flb_sds_t out_js = res_data;
+    char *index_line = "\\\"value\\\"";
+
+    p = strstr(out_js, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out_js);
+    }
+
+    flb_sds_destroy(out_js);
+}
+
+void flb_test_drop_single_key_on()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Loki output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "drop_single_key", "on",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_drop_single_key_on,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+static void cb_check_drop_single_key_raw(void *ctx, int ffd,
+                                         int res_ret, void *res_data, size_t res_size,
+                                         void *data)
+{
+    char *p;
+    flb_sds_t out_js = res_data;
+    char *index_line = "\"value\"";
+
+    p = strstr(out_js, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out_js);
+    }
+
+    flb_sds_destroy(out_js);
+}
+
+void flb_test_drop_single_key_raw()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Loki output */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "drop_single_key", "raw",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_drop_single_key_raw,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
 
 static void cb_check_line_format_remove_keys(void *ctx, int ffd,
                                              int res_ret, void *res_data,
@@ -611,13 +787,16 @@ void flb_test_float_value()
 /* Test list */
 TEST_LIST = {
     {"remove_keys_remove_map" , flb_test_remove_map},
-    {"labels_ra"        , flb_test_labels_ra },
-    {"remove_keys"      , flb_test_remove_keys },
-    {"basic"            , flb_test_basic },
-    {"labels"           , flb_test_labels },
-    {"label_keys"       , flb_test_label_keys },
-    {"line_format"      , flb_test_line_format },
-    {"label_map_path"   , flb_test_label_map_path},
-    {"float_value"      , flb_test_float_value},
+    {"labels_ra"              , flb_test_labels_ra },
+    {"remove_keys"            , flb_test_remove_keys },
+    {"basic"                  , flb_test_basic },
+    {"labels"                 , flb_test_labels },
+    {"label_keys"             , flb_test_label_keys },
+    {"line_format"            , flb_test_line_format },
+    {"drop_single_key_off"    , flb_test_drop_single_key_off },
+    {"drop_single_key_on"     , flb_test_drop_single_key_on },
+    {"drop_single_key_raw"    , flb_test_drop_single_key_raw },
+    {"label_map_path"         , flb_test_label_map_path},
+    {"float_value"            , flb_test_float_value},
     {NULL, NULL}
 };


### PR DESCRIPTION
This patch adds a third value to `drop_single_key` - `raw`, which allows sending unquoted strings to Loki when using JSON as the `line_format`.

While yes, for the output to be valid JSON, quotes would be expected, Loki does not support reading a plain quoted string with its JSON parser, complaining that it cannot find a `}` character. Instead, you need to use a combination of regexp and line_format expressions to unquote the log before running any other parsers over it.

By adding a third value of `raw`, this ensures backwards compatibility for anyone that is already relying on the existing behaviour.

An example query before this change for plaintext logs, to remove the quotes:

```
{"job"="fluent-bit"} | regexp `^"?(?S<log>.*?)"?$` | line_format "{{.log}}"
```

This is necessary to add before any other parsing for non-JSON logs, such as using Loki's `logfmt` parser, as it will otherwise drop the first and last key/value pair due to the extraneous quotes. Given Loki by design does not care about the input format (there's a reason JSON parsing is optional in the first place!), I do think this should be the default behavior some day, but given the breaking nature of the change, having it as an option for now should be fine.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #4353, #3005

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[SERVICE]
    flush     1
    log_level trace

[INPUT]
    name      dummy
    dummy     {"key": "value"}

[OUTPUT]
    name                   loki
    match                  *
    host                   127.0.0.1
    port                   3100
    drop_single_key        raw
```
- [x] Debug log output from testing the change
Note that I sent this to a fake http server instead of a Loki instance for testing, hence the 200 response. The HTTP body my server received was this:
```json
{"streams":[{"stream":{"job":"fluent-bit"},"values":[["1715344552991602966","value"]]}]}
```
```
Fluent Bit v3.0.4
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/05/10 22:35:52] [ info] Configuration:
[2024/05/10 22:35:52] [ info]  flush time     | 1.000000 seconds
[2024/05/10 22:35:52] [ info]  grace          | 5 seconds
[2024/05/10 22:35:52] [ info]  daemon         | 0
[2024/05/10 22:35:52] [ info] ___________
[2024/05/10 22:35:52] [ info]  inputs:
[2024/05/10 22:35:52] [ info]      dummy
[2024/05/10 22:35:52] [ info] ___________
[2024/05/10 22:35:52] [ info]  filters:
[2024/05/10 22:35:52] [ info] ___________
[2024/05/10 22:35:52] [ info]  outputs:
[2024/05/10 22:35:52] [ info]      loki.0
[2024/05/10 22:35:52] [ info] ___________
[2024/05/10 22:35:52] [ info]  collectors:
[2024/05/10 22:35:52] [ info] [fluent bit] version=3.0.4, commit=41ef155add, pid=140071
[2024/05/10 22:35:52] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/05/10 22:35:52] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/05/10 22:35:52] [ info] [cmetrics] version=0.9.0
[2024/05/10 22:35:52] [ info] [ctraces ] version=0.5.1
[2024/05/10 22:35:52] [ info] [input:dummy:dummy.0] initializing
[2024/05/10 22:35:52] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/05/10 22:35:52] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/05/10 22:35:52] [debug] [loki:loki.0] created event channels: read=23 write=24
[2024/05/10 22:35:52] [ info] [output:loki:loki.0] configured, hostname=127.0.0.1:3100
[2024/05/10 22:35:52] [ info] [sp] stream processor started
[2024/05/10 22:35:52] [trace] [input chunk] update output instances with new chunk size diff=32, records=1, input=dummy.0
[2024/05/10 22:35:53] [trace] [task 0x7dae40019030] created (id=0)
[2024/05/10 22:35:53] [debug] [task] created task=0x7dae40019030 id=0 OK
[2024/05/10 22:35:53] [trace] [upstream] get new connection for 127.0.0.1:3100, net setup:
net.connect_timeout        = 10 seconds
net.source_address         = any
net.keepalive              = enabled
net.keepalive_idle_timeout = 30 seconds
net.max_worker_connections = 0
[2024/05/10 22:35:53] [trace] [net] connection #31 in process to 127.0.0.1:3100
[2024/05/10 22:35:53] [trace] [engine] resuming coroutine=0x7dae40019150
[2024/05/10 22:35:53] [trace] [io] connection OK
[2024/05/10 22:35:53] [debug] [upstream] KA connection #31 to 127.0.0.1:3100 is connected
[2024/05/10 22:35:53] [debug] [http_client] not using http_proxy for header
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [net_write] trying 157 bytes
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [fd 31] write_async(2)=157 (157/157)
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [net_write] ret=157 total=157/157
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [net_write] trying 88 bytes
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [fd 31] write_async(2)=88 (88/88)
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [net_write] ret=88 total=88/88
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [net_read] try up to 4095 bytes
[2024/05/10 22:35:53] [trace] [engine] resuming coroutine=0x7dae40019150
[2024/05/10 22:35:53] [trace] [io coro=0x7dae40019150] [net_read] ret=124
[2024/05/10 22:35:53] [debug] [output:loki:loki.0] 127.0.0.1:3100, HTTP status=200
accepted
[2024/05/10 22:35:53] [debug] [upstream] KA connection #31 to 127.0.0.1:3100 is now available
[2024/05/10 22:35:53] [trace] [engine] [task event] task_id=0 out_id=0 return=OK
[2024/05/10 22:35:53] [debug] [out flush] cb_destroy coro_id=0
[2024/05/10 22:35:53] [trace] [coro] destroy coroutine=0x7dae40019150 data=0x7dae40019170
[2024/05/10 22:35:53] [debug] [task] destroy task=0x7dae40019030 (task_id=0)
^C[2024/05/10 22:35:56] [engine] caught signal (SIGINT)
[2024/05/10 22:35:56] [trace] [engine] flush enqueued data
[2024/05/10 22:35:56] [ warn] [engine] service will shutdown in max 5 seconds
[2024/05/10 22:35:56] [ info] [input] pausing dummy.0
[2024/05/10 22:35:56] [ info] [engine] service has stopped (0 pending tasks)
[2024/05/10 22:35:56] [ info] [input] pausing dummy.0
[2024/05/10 22:35:56] [trace] [upstream] destroy connection #31 to 127.0.0.1:3100
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
==140694== Memcheck, a memory error detector
==140694== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==140694== Using Valgrind-3.23.0 and LibVEX; rerun with -h for copyright info
==140694== Command: ./bin/fluent-bit -c fluent-bit.conf
==140694== 
...
==140694== 
==140694== HEAP SUMMARY:
==140694==     in use at exit: 0 bytes in 0 blocks
==140694==   total heap usage: 1,769 allocs, 1,769 frees, 806,933 bytes allocated
==140694== 
==140694== All heap blocks were freed -- no leaks are possible
==140694== 
==140694== For lists of detected and suppressed errors, rerun with: -s
==140694== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
fluent/fluent-bit-docs#1368

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
