### PR TITLE
dockerfiles: reduce debug information from the production container image.

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -28,8 +28,7 @@ ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
 ARG FLB_CHUNK_TRACE=On
 ENV FLB_CHUNK_TRACE=${FLB_CHUNK_TRACE}
 
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
-RUN mkdir -p /usr/lib/debug/fluent-bit/bin
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /usr/lib/debug/fluent-bit/bin
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -81,10 +80,9 @@ RUN cmake -DFLB_RELEASE=On \
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/
-
-RUN objcopy --only-keep-debug /fluent-bit/bin/fluent-bit /usr/lib/debug/fluent-bit/bin/fluent-bit.debug
-RUN objcopy --strip-debug /fluent-bit/bin/fluent-bit
-RUN objcopy --add-gnu-debuglink=/usr/lib/debug/fluent-bit/bin/fluent-bit.debug /fluent-bit/bin/fluent-bit
+RUN objcopy --only-keep-debug /fluent-bit/bin/fluent-bit /usr/lib/debug/fluent-bit/bin/fluent-bit.debug && \
+    objcopy --strip-debug /fluent-bit/bin/fluent-bit && \
+    objcopy --add-gnu-debuglink=/usr/lib/debug/fluent-bit/bin/fluent-bit.debug /fluent-bit/bin/fluent-bit
 
 # Configuration files
 COPY conf/fluent-bit.conf \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -29,6 +29,7 @@ ARG FLB_CHUNK_TRACE=On
 ENV FLB_CHUNK_TRACE=${FLB_CHUNK_TRACE}
 
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
+RUN mkdir -p /usr/lib/debug/fluent-bit/bin
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -80,6 +81,10 @@ RUN cmake -DFLB_RELEASE=On \
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/
+
+RUN objcopy --only-keep-debug /fluent-bit/bin/fluent-bit /usr/lib/debug/fluent-bit/bin/fluent-bit.debug
+RUN objcopy --strip-debug /fluent-bit/bin/fluent-bit
+RUN objcopy --add-gnu-debuglink=/usr/lib/debug/fluent-bit/bin/fluent-bit.debug /fluent-bit/bin/fluent-bit
 
 # Configuration files
 COPY conf/fluent-bit.conf \
@@ -231,6 +236,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/
 
 RUN rm -f /usr/bin/qemu-*-static
 COPY --from=builder /fluent-bit /fluent-bit
+COPY --from=builder /usr/lib/debug/fluent-bit /usr/lib/debug/fluent-bit
 
 EXPOSE 2020
 


### PR DESCRIPTION
follow-up for https://github.com/fluent/fluent-bit/discussions/8807

By reducing debug information from the production container image, we aim to achieve a lightweight container image and enhance security.
I considered using the same fluent-bit binary for both production and debug containers, while including the debug information file only in the debug container, allowing for the continued use of debuggers such as gdb as before.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
