### PR TITLE
processor_labels: Remove a needless existence check for insert operation

### DIFF
--- a/plugins/processor_labels/labels.c
+++ b/plugins/processor_labels/labels.c
@@ -1524,26 +1524,27 @@ static int insert_labels(struct cmt *metrics_context,
                                                         pair->key);
 
         if (result == FLB_TRUE) {
-            result = metrics_context_insert_dynamic_label(metrics_context,
-                                                          pair->key,
-                                                          pair->val);
+            continue;
+        }
+
+        result = metrics_context_insert_dynamic_label(metrics_context,
+                                                      pair->key,
+                                                      pair->val);
+
+        if (result == FLB_FALSE) {
+            return FLB_FALSE;
+        }
+
+        result = metrics_context_contains_static_label(metrics_context,
+                                                       pair->key);
+
+        if (result == FLB_TRUE) {
+            result = metrics_context_insert_static_label(metrics_context,
+                                                         pair->key,
+                                                         pair->val);
 
             if (result == FLB_FALSE) {
                 return FLB_FALSE;
-            }
-        }
-        else {
-            result = metrics_context_contains_static_label(metrics_context,
-                                                           pair->key);
-
-            if (result == FLB_FALSE) {
-                result = metrics_context_insert_static_label(metrics_context,
-                                                             pair->key,
-                                                             pair->val);
-
-                if (result == FLB_FALSE) {
-                    return FLB_FALSE;
-                }
             }
         }
     }


### PR DESCRIPTION
Insert implies that adding new key-value pairs of labels. However, we did put the existence check for the keys of labels. This shouldn't be effective for such operation

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
  flush: 2
  daemon: off
  log_level:  debug

pipeline:
  inputs:
    - name: fluentbit_metrics
      tag: fluentbit.metrics
      scrape_interval: 2

      processors:
        metrics:
          - name: labels
            insert: agent fluentbit


  outputs:
    - name: stdout
      match: '*'
```
- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.4
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/05/14 22:11:43] [ info] Configuration:
[2024/05/14 22:11:43] [ info]  flush time     | 2.000000 seconds
[2024/05/14 22:11:43] [ info]  grace          | 5 seconds
[2024/05/14 22:11:43] [ info]  daemon         | 0
[2024/05/14 22:11:43] [ info] ___________
[2024/05/14 22:11:43] [ info]  inputs:
[2024/05/14 22:11:43] [ info]      fluentbit_metrics
[2024/05/14 22:11:43] [ info] ___________
[2024/05/14 22:11:43] [ info]  filters:
[2024/05/14 22:11:43] [ info] ___________
[2024/05/14 22:11:43] [ info]  outputs:
[2024/05/14 22:11:43] [ info]      stdout.0
[2024/05/14 22:11:43] [ info] ___________
[2024/05/14 22:11:43] [ info]  collectors:
[2024/05/14 22:11:43] [ info] [fluent bit] version=3.0.4, commit=549e7fbfc4, pid=337215
[2024/05/14 22:11:43] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/05/14 22:11:43] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/05/14 22:11:43] [ info] [cmetrics] version=0.9.0
[2024/05/14 22:11:43] [ info] [ctraces ] version=0.5.1
[2024/05/14 22:11:43] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2024/05/14 22:11:43] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2024/05/14 22:11:43] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2024/05/14 22:11:43] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/05/14 22:11:43] [ info] [sp] stream processor started
[2024/05/14 22:11:43] [ info] [output:stdout:stdout.0] worker #0 started
[2024/05/14 22:11:46] [debug] [task] created task=0x5f454e0 id=0 OK
[2024/05/14 22:11:46] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-05-14T13:11:44.402905181Z fluentbit_uptime{hostname="cosmo-desktop2",agent="fluentbit"} = 2
2024-05-14T13:11:43.119393661Z fluentbit_input_bytes_total{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_records_total{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:44.400500038Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0",agent="fluentbit"} = 1
2024-05-14T13:11:43.148140351Z fluentbit_output_proc_records_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_proc_bytes_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_errors_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_retries_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_retries_failed_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_dropped_records_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_retried_records_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:44.402905181Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2",agent="fluentbit"} = 1715692302
2024-05-14T13:11:44.402905181Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.0.4",os="linux",agent="fluentbit"} = 1715692302
2024-05-14T13:11:44.402905181Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2",agent="fluentbit"} = 0
2024-05-14T13:11:44.405137050Z fluentbit_storage_chunks{agent="fluentbit"} = 0
2024-05-14T13:11:44.405137050Z fluentbit_storage_mem_chunks{agent="fluentbit"} = 0
2024-05-14T13:11:44.405137050Z fluentbit_storage_fs_chunks{agent="fluentbit"} = 0
2024-05-14T13:11:44.405137050Z fluentbit_storage_fs_chunks_up{agent="fluentbit"} = 0
2024-05-14T13:11:44.405137050Z fluentbit_storage_fs_chunks_down{agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_ingestion_paused{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_overlimit{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_memory_bytes{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_up{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_down{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_busy{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_busy_bytes{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_upstream_total_connections{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_upstream_busy_connections{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_chunk_available_capacity_percent{name="stdout.0",agent="fluentbit"} = 100
[2024/05/14 22:11:46] [debug] [out flush] cb_destroy coro_id=0
[2024/05/14 22:11:46] [debug] [task] destroy task=0x5f454e0 (task_id=0)
^C[2024/05/14 22:11:47] [engine] caught signal (SIGINT)
[2024/05/14 22:11:47] [debug] [task] created task=0x6068210 id=0 OK
[2024/05/14 22:11:47] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-05-14T13:11:46.418079697Z fluentbit_uptime{hostname="cosmo-desktop2",agent="fluentbit"} = 4
2024-05-14T13:11:43.119393661Z fluentbit_input_bytes_total{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_records_total{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:46.417894880Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0",agent="fluentbit"} = 2
2024-05-14T13:11:43.148140351Z fluentbit_output_proc_records_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_proc_bytes_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_errors_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_retries_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_retries_failed_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_dropped_records_total[2024/05/14 22:11:47] [ warn] [engine] service will shutdown in max 5 seconds
[2024/05/14 22:11:47] [ info] [input] pausing fluentbit_metrics.0
{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_retried_records_total{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:46.418079697Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2",agent="fluentbit"} = 1715692302
2024-05-14T13:11:46.418079697Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.0.4",os="linux",agent="fluentbit"} = 1715692302
2024-05-14T13:11:46.418079697Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2",agent="fluentbit"} = 0
2024-05-14T13:11:46.418434940Z fluentbit_storage_chunks{agent="fluentbit"} = 1
2024-05-14T13:11:46.418434940Z fluentbit_storage_mem_chunks{agent="fluentbit"} = 1
2024-05-14T13:11:46.418434940Z fluentbit_storage_fs_chunks{agent="fluentbit"} = 0
2024-05-14T13:11:46.418434940Z fluentbit_storage_fs_chunks_up{agent="fluentbit"} = 0
2024-05-14T13:11:46.418434940Z fluentbit_storage_fs_chunks_down{agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_ingestion_paused{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_overlimit{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_memory_bytes{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_up{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_down{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_busy{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.119393661Z fluentbit_input_storage_chunks_busy_bytes{name="fluentbit_metrics.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_upstream_total_connections{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_upstream_busy_connections{name="stdout.0",agent="fluentbit"} = 0
2024-05-14T13:11:43.148140351Z fluentbit_output_chunk_available_capacity_percent{name="stdout.0",agent="fluentbit"} = 100
[2024/05/14 22:11:47] [debug] [out flush] cb_destroy coro_id=1
[2024/05/14 22:11:47] [debug] [task] destroy task=0x6068210 (task_id=0)
[2024/05/14 22:11:48] [ info] [engine] service has stopped (0 pending tasks)
[2024/05/14 22:11:48] [ info] [input] pausing fluentbit_metrics.0
[2024/05/14 22:11:48] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/05/14 22:11:48] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==337215== 
==337215== HEAP SUMMARY:
==337215==     in use at exit: 0 bytes in 0 blocks
==337215==   total heap usage: 8,210 allocs, 8,210 frees, 2,566,010 bytes allocated
==337215== 
==337215== All heap blocks were freed -- no leaks are possible
==337215== 
==337215== For lists of detected and suppressed errors, rerun with: -s
==337215== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1371

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
