### PR TITLE
out_cloudwatch_logs: support log_group_class option

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -50,6 +50,33 @@ static struct flb_aws_header content_type_header = {
     .val_len = 26,
 };
 
+static int validate_log_group_class(struct flb_cloudwatch *ctx)
+{   
+    if (ctx->create_group == FLB_FALSE) {
+        flb_plg_error(ctx->ins, "Configuring log_group_class requires `auto_create_group On`.");
+        return -1;
+    }
+
+    if (ctx->log_group_class == NULL || strlen(ctx->log_group_class) == 0) {
+        ctx->log_group_class_type = LOG_CLASS_DEFAULT_TYPE;
+        ctx->log_group_class = LOG_CLASS_STANDARD;
+        return 0;
+    } else if (strncmp(ctx->log_group_class, LOG_CLASS_STANDARD, LOG_CLASS_STANDARD_LEN) == 0) {
+        flb_plg_debug(ctx->ins, "Using explicitly configured `log_group_class %s`, which is the default log class.", ctx->log_group_class);
+        ctx->log_group_class_type = LOG_CLASS_STANDARD_TYPE;
+        return 0;
+    } else if (strncmp(ctx->log_group_class, LOG_CLASS_INFREQUENT_ACCESS, LOG_CLASS_INFREQUENT_ACCESS_LEN) == 0) {
+        flb_plg_warn(ctx->ins, "Configured `log_group_class %s` will only apply to log groups created by Fluent Bit. "
+                     "Look for the `Created log group` info level message emitted when a group does not already exist and is created.", ctx->log_group_class);
+        ctx->log_group_class_type = LOG_CLASS_INFREQUENT_ACCESS_TYPE;
+        return 0;
+    }
+
+    flb_plg_error(ctx->ins, "The valid values for log_group_class are {%s, %s}. Invalid input was %s", LOG_CLASS_STANDARD, LOG_CLASS_INFREQUENT_ACCESS, ctx->log_group_class);
+
+    return -1;
+}
+
 static int cb_cloudwatch_init(struct flb_output_instance *ins,
                               struct flb_config *config, void *data)
 {
@@ -209,6 +236,11 @@ static int cb_cloudwatch_init(struct flb_output_instance *ins,
     tmp = flb_output_get_property("sts_endpoint", ins);
     if (tmp) {
         ctx->sts_endpoint = (char *) tmp;
+    }
+
+    ret = validate_log_group_class(ctx);
+    if (ret < 0) {
+        goto error;
     }
 
     /* one tls instance for provider, one for cw client */
@@ -650,6 +682,12 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_cloudwatch, profile),
      "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in "
      "$HOME/.aws/ directory."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "log_group_class", "",
+     0, FLB_TRUE, offsetof(struct flb_cloudwatch, log_group_class),
+     "Specify the log storage class. Valid values are STANDARD (default) and INFREQUENT_ACCESS."
     },
 
     /* EOF */

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -30,6 +30,16 @@
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/record_accessor/flb_ra_parser.h>
 
+#define LOG_CLASS_STANDARD                  "STANDARD"
+#define LOG_CLASS_STANDARD_LEN              8
+#define LOG_CLASS_INFREQUENT_ACCESS         "INFREQUENT_ACCESS"
+#define LOG_CLASS_INFREQUENT_ACCESS_LEN     17
+/* log_group_class not configured; do not send the logGroupClass field in request */
+#define LOG_CLASS_DEFAULT_TYPE              0
+/* send configured & validated string in request */
+#define LOG_CLASS_STANDARD_TYPE             1
+#define LOG_CLASS_INFREQUENT_ACCESS_TYPE    2
+
 /* buffers used for each flush */
 struct cw_flush {
     /* temporary buffer for storing the serialized event messages */
@@ -113,6 +123,8 @@ struct flb_cloudwatch {
     const char *extra_user_agent;
     const char *external_id;
     const char *profile;
+    const char *log_group_class;
+    int log_group_class_type;
     int custom_endpoint;
     /* Should the plugin create the log group */
     int create_group;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
