### PR TITLE
output: Fix handling of metrics in output processor

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -627,6 +627,7 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
     struct cmt *metrics_context;
     struct ctrace *trace_context;
     size_t chunk_offset;
+    struct cmt *cmt_out_context = NULL;
 
     /* Custom output coroutine info */
     out_flush = (struct flb_output_flush *) flb_calloc(1, sizeof(struct flb_output_flush));
@@ -715,13 +716,25 @@ struct flb_output_flush *flb_output_flush_create(struct flb_task *task,
                                         flb_sds_len(evc->tag),
                                         (char *) metrics_context,
                                         0,
-                                        NULL,
+                                        (void **)&cmt_out_context,
                                         NULL);
 
                 if (ret == 0) {
-                    ret = cmt_encode_msgpack_create(metrics_context,
-                                                    &serialized_context_buffer,
-                                                    &serialized_context_size);
+                    if (cmt_out_context != NULL) {
+                        ret = cmt_encode_msgpack_create(cmt_out_context,
+                                                        &serialized_context_buffer,
+                                                        &serialized_context_size);
+
+                        if (cmt_out_context != metrics_context) {
+                            cmt_destroy(cmt_out_context);
+                        }
+
+                    }
+                    else {
+                        ret = cmt_encode_msgpack_create(metrics_context,
+                                                        &serialized_context_buffer,
+                                                        &serialized_context_size);
+                    }
 
                     cmt_destroy(metrics_context);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This patch passes an cmt_out_context pointer so that output processors can modify metrics.

Without this change, it is not possible to modify metrics in an output processor. Example config which reproduces:

```yaml
service:
    flush: 1
    log_level: info

pipeline:
    inputs:
        - name: event_type
          tag: event
          type: metrics

    outputs:
        - name: stdout
          match: event
          processors:
            metrics:
              - name: metrics_selector
                metric_name: /kubernetes/
                action: include
```  

Without the patch, we observe unmodified metrics:


```
2024-05-21T17:51:30.526411118Z kubernetes_network_load_counter = 3
2024-05-21T17:51:30.526411118Z kubernetes_network_load_counter{hostname="localhost",app="cmetrics"} = 1
2024-05-21T17:51:30.526411118Z kubernetes_network_load_counter{hostname="localhost",app="test"} = 12.15
2024-05-21T17:51:30.526411118Z kubernetes_network_load_gauge = 1
2024-05-21T17:51:30.526411118Z k8s_disk_load_summary = { quantiles = { 0.1=1.1, 0.2=2.2, 0.3=3.3, 0.4=4.4, 0.5=5.5 }, sum=51.6129, count=10 }
2024-05-21T17:51:30.526411118Z k8s_disk_load_summary{my_label="my_val"} = { quantiles = { 0.1=11.11, 0.2=0, 0.3=33.33, 0.4=44.44, 0.5=55.55 }, sum=51.6129, count=10 }
2024-05-21T17:51:30.526411118Z k8s_network_load_histogram = { buckets = { 0.05=2, 5=3, 10=4, +Inf=5 }, sum=1013.02, count=5 }
2024-05-21T17:51:30.526411118Z k8s_network_load_histogram{my_label="my_val"} = { buckets = { 0.05=2, 5=3, 10=4, +Inf=5 }, sum=1013.02, count=5 }
```

With the patch, we see the filtered metrics:

```
2024-05-21T17:52:29.525856283Z kubernetes_network_load_counter = 3
2024-05-21T17:52:29.525856283Z kubernetes_network_load_counter{hostname="localhost",app="cmetrics"} = 1
2024-05-21T17:52:29.525856283Z kubernetes_network_load_counter{hostname="localhost",app="test"} = 12.15
2024-05-21T17:52:29.525856283Z kubernetes_network_load_gauge = 1
```

valgrind output:

```
==117643== Memcheck, a memory error detector
==117643== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==117643== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==117643== Command: ./build/bin/fluent-bit -c metrics-processor.yaml
==117643== Parent PID: 12681
==117643== 
==117643== 
==117643== HEAP SUMMARY:
==117643==     in use at exit: 0 bytes in 0 blocks
==117643==   total heap usage: 4,189 allocs, 4,189 frees, 2,700,236 bytes allocated
==117643== 
==117643== All heap blocks were freed -- no leaks are possible
==117643== 
==117643== For lists of detected and suppressed errors, rerun with: -s
==117643== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
