### PR TITLE
out_stackdriver: Support writing to textPayload field of Cloud Logging LogEntry.

### DIFF
--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -208,6 +208,9 @@ struct flb_stackdriver {
     /* upstream context for metadata end-point */
     struct flb_upstream *metadata_u;
 
+    /* the key to extract unstructured text payload from */
+    flb_sds_t text_payload_key;
+
 #ifdef FLB_HAVE_METRICS
     /* metrics */
     struct cmt_counter *cmt_successful_requests;

--- a/tests/runtime/data/stackdriver/stackdriver_test_payload.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_payload.h
@@ -1,0 +1,26 @@
+#define STRING_TEXT_PAYLOAD "[" \
+        "1595349600," \
+        "{" \
+        "\"message\": \"The application errored out\"," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"" \
+        "}]"
+
+#define STRING_TEXT_PAYLOAD_WITH_RESIDUAL_FIELDS "[" \
+        "1595349600," \
+        "{" \
+        "\"message\": \"The application errored out\"," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"," \
+        "\"errorCode\": \"400\"" \
+        "}]"
+
+#define NON_SCALAR_PAYLOAD_WITH_RESIDUAL_FIELDS "[" \
+        "1595349600," \
+        "{" \
+        "\"message\": " \
+        "{"            \
+            "\"application_name\": \"my_application\"," \
+            "\"error_message\": \"The application errored out\"," \
+        "}," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"," \
+        "\"errorCode\": \"400\"" \
+        "}]"


### PR DESCRIPTION
Write payload to textPayload field of LogEntry if the text_payload_key is string format and the only field after stripping special fields.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[OUTPUT]
    Name                      stackdriver
    Match                     etcd
    Resource                  gke_container
    severity_key              severity
    text_payload_key          message
    test_log_entry_format     true
    k8s_cluster_name          test-cluster
    k8s_cluster_location      us-central1-c
    export_to_project_id      customer-project
```
- [x] Debug log output from testing the change
       Change is unit tested.
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
cmake -DFLB_DEV=On -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On -DFLB_VALGRIND=On ../ && make -j 8

valgrind ./bin/flb-rt-out_stackdriver

SUCCESS: All unit tests have passed.
==1058340==
==1058340== HEAP SUMMARY:
==1058340==     in use at exit: 56 bytes in 1 blocks
==1058340==   total heap usage: 307,811 allocs, 307,810 frees, 122,902,958 bytes allocated
==1058340==
==1058340== LEAK SUMMARY:
==1058340==    definitely lost: 0 bytes in 0 blocks
==1058340==    indirectly lost: 0 bytes in 0 blocks
==1058340==      possibly lost: 0 bytes in 0 blocks
==1058340==    still reachable: 56 bytes in 1 blocks
==1058340==         suppressed: 0 bytes in 0 blocks
==1058340== Rerun with --leak-check=full to see details of leaked memory
==1058340==
==1058340== For lists of detected and suppressed errors, rerun with: -s
==1058340== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
