### PR TITLE
winevtlog: change total_size_threshold to size_t

### DIFF
--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -27,7 +27,7 @@
 struct winevtlog_config {
     unsigned int interval_sec;
     unsigned int interval_nsec;
-    unsigned int total_size_threshold;
+    size_t total_size_threshold;
     int string_inserts;
     int read_existing_events;
     int render_event_as_xml;


### PR DESCRIPTION
<!-- Provide summary of changes -->
The `total_size_threshold` field was originally an unsigned int. The field in the config map uses `FLB_CONFIG_MAP_SIZE`, which reads the value as a `size_t` and then writes it to the offset of the field in the struct. On a 64-bit machine, this is 8 bytes. This means the 8 byte value would be written at this offset, as a result overriding the value of the next struct field. This would cause `string_inserts` with default values to end up being `false` when it should be `true`.

This PR changes `total_size_threshold` to a `size_t`. This seems consistent with other usages of `FLB_CONFIG_MAP_SIZE` that I was able to find.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#8854

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
