### PR TITLE
out_http: don't retry non retryable 4xx status codes

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -276,7 +276,15 @@ static int http_post(struct flb_out_http *ctx,
                 flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i",
                               ctx->host, ctx->port, c->resp.status);
             }
-            out_ret = FLB_RETRY;
+            if (c->resp.status >= 400 && c->resp.status < 500 && c->resp.status != 429) {
+                flb_plg_warn(ctx->ins, "could not flush records to %s:%i (http_do=%i), "
+                                "chunk will not be retried",
+                                ctx->host, ctx->port, ret);
+                out_ret = FLB_ERROR;
+            }
+            else {
+                out_ret = FLB_RETRY;
+            }
         }
         else {
             if (ctx->log_response_payload &&


### PR DESCRIPTION
Fix a problem that http output plugin retries all requests that respond with an 4xx status code excepting 429 status code

<!-- Provide summary of changes -->

Fixes #8860

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
