### PR TITLE
out_splunk: reduce noise and fix hec_token handling (fix #8859)

### DIFF
--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -120,6 +120,8 @@ struct flb_splunk {
 
     /* Plugin instance */
     struct flb_output_instance *ins;
+
+    pthread_mutex_t mutex_hec_token;
 };
 
 #endif

--- a/plugins/out_splunk/splunk_conf.c
+++ b/plugins/out_splunk/splunk_conf.c
@@ -262,6 +262,8 @@ struct flb_splunk *flb_splunk_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    pthread_mutex_init(&ctx->mutex_hec_token, NULL);
+
     /* Currently, Splunk HEC token is stored in a fixed key, hec_token. */
     ctx->metadata_auth_key = "$hec_token";
     if (ctx->metadata_auth_key) {
@@ -323,6 +325,10 @@ int flb_splunk_conf_destroy(struct flb_splunk *ctx)
 
     if (ctx->ra_metadata_auth_key) {
         flb_ra_destroy(ctx->ra_metadata_auth_key);
+    }
+
+    if (ctx->metadata_auth_header) {
+        flb_sds_destroy(ctx->metadata_auth_header);
     }
 
     event_fields_destroy(ctx);


### PR DESCRIPTION
The following patch perform 2 changes in the code that helps to fix the problems found with Splunk hec token handling:

1. In the recent PR #8793, when using the record accessor API flb_ra_translate_check() to validate if the hec_token field exists, leads to noisy log messages since that function warns the issue if the field is not found. Most of users are not using hec_token set by Splunk input plugin, so their logging gets noisy.

   This patch replaces that call with flb_ra_translate() which fixes the problem.

2. If hec_token was set in the record metadata, it was being store in the main context of the plugin, however the flush callbacks that formats and deliver the data runs in separate/parallel threads that could lead to a race condition if more than onen thread tries to manipulate the value.

   This patch adds protection to the context value so it becomes thread safe.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
