### PR TITLE
better handling for the es-like services, such as manticore search.

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -675,7 +675,7 @@ static int elasticsearch_error_check(struct flb_elasticsearch *ctx,
         }
 
         /* Lookup error field */
-        if (strstr(c->resp.payload, "\"errors\":false,\"items\":[")) {
+        if (strstr(c->resp.payload, "\"errors\":false")) {
             return FLB_FALSE;
         }
 


### PR DESCRIPTION
update es response condition

elasticsearch action response struct as follow:
{"error":false,"items":[.....]}

but es-like services, such as manticore search response struct as follow:
{"items":[....],"error":false}

🤔 they have a similar json structure,  just not in the same order, and this condition that used too much content is not a good choice,  maybe this update can make compatibility  better.
excuse my poor english 😊 and hope this can help your team.

