### PR TITLE
core: Fix crash when running dry

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1344,6 +1344,7 @@ int flb_main(int argc, char **argv)
 
     if (config->dry_run == FLB_TRUE) {
         fprintf(stderr, "configuration test is successful\n");
+        flb_init_env();
         flb_cf_destroy(cf_opts);
         flb_destroy(ctx);
         exit(EXIT_SUCCESS);


### PR DESCRIPTION
The tls variable for out_flush_params is not initialized as the flb_start function is not called during the dry run. Call flb_init directly and then shutdown the engine.


```
configuration test is successful
================================================================= ==63633==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x0001f71b3ac0 in thread T0
    #0 0x103c9f260 in wrap_free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x53260)
    #1 0x100179d9c in flb_free flb_mem.h:127
    #2 0x10017f4a0 in flb_output_exit flb_output.c:481
    #3 0x1001cb038 in flb_engine_shutdown flb_engine.c:1119
    #4 0x10010d45c in flb_destroy flb_lib.c:240
    #5 0x100008c40 in flb_main fluent-bit.c:1348
    #6 0x10000c644 in main fluent-bit.c:1456
    #7 0x18f11e0dc  (<unknown module>)

frame #6: 0x000000010017f4a4 fluent-bit`flb_output_exit(config=0x0000000102b00200) at flb_output.c:481:9
   478
   479 	    params = FLB_TLS_GET(out_flush_params);
   480 	    if (params) {
-> 481 	        flb_free(params);
   482 	    }
   483 	}
```

<!-- Provide summary of changes -->

Executing `fluent-bit -D` crashes on macos.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A] Example configuration file for the change
- [ x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
