### PR TITLE
in_prometheus_scrape: add User-Agent HTTP header (#8880)

### DIFF
--- a/plugins/in_prometheus_scrape/prom_scrape.c
+++ b/plugins/in_prometheus_scrape/prom_scrape.c
@@ -107,6 +107,9 @@ static int collect_metrics(struct prom_scrape *ctx)
         flb_http_bearer_auth(c, ctx->bearer_token);
     }
 
+    /* Add User-Agent */
+    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "http do error");


### PR DESCRIPTION
This PR will add a `User-Agent: Fluent-Bit` to the `in_prometheus_scrape` HTTP requests.

Fixes #8880

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change

- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

[valgrind.txt](https://github.com/fluent/fluent-bit/files/15456328/valgrind.txt)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
