### PR TITLE
in_splunk: Store HEC token on enabled HTTP2 and raw endpoints

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -961,6 +961,10 @@ static int process_hec_raw_payload_ng(struct flb_http_request *request,
                                       flb_sds_t tag,
                                       struct flb_splunk *ctx)
 {
+    int ret = 0;
+    size_t size = 0;
+    char *auth_header;
+
     if (request->content_type == NULL) {
         send_response_ng(response, 400, "error: header 'Content-Type' is not set\n");
 
@@ -969,6 +973,11 @@ static int process_hec_raw_payload_ng(struct flb_http_request *request,
     else if (strcasecmp(request->content_type, "text/plain") != 0) {
         /* Not neccesary to specify content-type for Splunk HEC. */
         flb_plg_debug(ctx->ins, "Mark as unknown type for ingested payloads");
+    }
+
+    ret = flb_hash_table_get(request->headers, "authorization", 13, (void **)&auth_header, &size);
+    if (ret != 0) {
+        ctx->ingested_auth_header = auth_header;
     }
 
     if (request->body == NULL || cfl_sds_len(request->body) == 0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

When enabling HTTP2 and using raw HEC endpoint, I got a garbage character for Splunk HEC token.
This shouldn't be occurred and handled properly.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```console
$ bin/fluent-bit -i splunk -p port=8081 -o stdout -v
```

```console
$ bin/fluent-bit -i splunk -p port=8088 -o splunk -p port=8081 -psplunk_token=db496524-e7e6-4ae9-b3f0-2287d8e65cd4 -p "event_key=\$event" -f 1 -v
```

And sending a HEC event via curl:

```console
$ curl -k -XPOST "http://localhost:8088/services/collector/raw" \
    -H "Authorization: Splunk db496524-e7e6-4ae9-b3f0-2287d8e65cd4" \
    -d '{"event": "Hello, world!"}'
```


- [x] Debug log output from testing the change

```log
Fluent Bit v3.0.7
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/05/28 14:52:45] [ info] Configuration:
[2024/05/28 14:52:45] [ info]  flush time     | 1.000000 seconds
[2024/05/28 14:52:45] [ info]  grace          | 5 seconds
[2024/05/28 14:52:45] [ info]  daemon         | 0
[2024/05/28 14:52:45] [ info] ___________
[2024/05/28 14:52:45] [ info]  inputs:
[2024/05/28 14:52:45] [ info]      splunk
[2024/05/28 14:52:45] [ info] ___________
[2024/05/28 14:52:45] [ info]  filters:
[2024/05/28 14:52:45] [ info] ___________
[2024/05/28 14:52:45] [ info]  outputs:
[2024/05/28 14:52:45] [ info]      stdout.0
[2024/05/28 14:52:45] [ info] ___________
[2024/05/28 14:52:45] [ info]  collectors:
[2024/05/28 14:52:46] [ info] [fluent bit] version=3.0.7, commit=4b34956184, pid=1247334
[2024/05/28 14:52:46] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/05/28 14:52:46] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/05/28 14:52:46] [ info] [cmetrics] version=0.9.0
[2024/05/28 14:52:46] [ info] [ctraces ] version=0.5.1
[2024/05/28 14:52:46] [ info] [output:stdout:stdout.0] worker #0 started
[2024/05/28 14:52:46] [ info] [input:splunk:splunk.0] initializing
[2024/05/28 14:52:46] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/05/28 14:52:46] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/05/28 14:52:46] [debug] [downstream] listening on 0.0.0.0:8081
[2024/05/28 14:52:46] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/05/28 14:52:46] [ info] [sp] stream processor started
[2024/05/28 14:52:51] [debug] [task] created task=0x5f2a690 id=0 OK
[2024/05/28 14:52:51] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.0: [[1716875570.561814830, {"hec_token"=>"Splunk db496524-e7e6-4ae9-b3f0-2287d8e65cd4"}], {"time"=>1716875569.871028, "event"=>{"log"=>"{"event": "Hello, world!"}"}}]
[2024/05/28 14:52:51] [debug] [out flush] cb_destroy coro_id=0
[2024/05/28 14:52:51] [debug] [task] destroy task=0x5f2a690 (task_id=0)
^C[2024/05/28 14:52:54] [engine] caught signal (SIGINT)
[2024/05/28 14:52:54] [ warn] [engine] service will shutdown in max 5 seconds
[2024/05/28 14:52:54] [ info] [input] pausing splunk.0
[2024/05/28 14:52:54] [ info] [engine] service has stopped (0 pending tasks)
[2024/05/28 14:52:54] [ info] [input] pausing splunk.0
[2024/05/28 14:52:54] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/05/28 14:52:54] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==1247334== 
==1247334== HEAP SUMMARY:
==1247334==     in use at exit: 0 bytes in 0 blocks
==1247334==   total heap usage: 3,001 allocs, 3,001 frees, 987,658 bytes allocated
==1247334== 
==1247334== All heap blocks were freed -- no leaks are possible
==1247334== 
==1247334== For lists of detected and suppressed errors, rerun with: -s
==1247334== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
