### PR TITLE
http_server: api: v1: traces: fix finding inputs by alias.

### DIFF
--- a/src/http_server/api/v1/trace.c
+++ b/src/http_server/api/v1/trace.c
@@ -59,14 +59,11 @@ static struct flb_input_instance *find_input(struct flb_hs *hs, const char *name
 
     mk_list_foreach(head, &hs->config->inputs) {
         in = mk_list_entry(head, struct flb_input_instance, _head);
-        if (strlen(in->name) != nlen) {
-            continue;
-        }
-        if (strncmp(name, in->name, nlen) == 0) {
+        if ((strlen(in->name) == nlen) && (strncmp(name, in->name, nlen) == 0)) {
             return in;
         }
         if (in->alias) {
-            if (strcmp(name, in->alias) == 0) {
+            if ((strlen(in->alias) == nlen) && (strncmp(name, in->alias, nlen) == 0)) {
                 return in;
             }
         }
@@ -113,7 +110,7 @@ static int disable_trace_input(struct flb_hs *hs, const char *name, size_t nlen)
 
 static flb_sds_t get_input_name(mk_request_t *request)
 {
-    const char *base = "/api/v1/trace/";
+    const char base[] = "/api/v1/trace/";
 
 
     if (request->real_path.data == NULL) {
@@ -124,7 +121,7 @@ static flb_sds_t get_input_name(mk_request_t *request)
     }
 
     return flb_sds_create_len(&request->real_path.data[sizeof(base)-1],
-                              request->real_path.len - sizeof(base)-1);
+                              request->real_path.len - (sizeof(base)-1));
 }
 
 static int http_disable_trace(mk_request_t *request, void *data,


### PR DESCRIPTION
# Summary

Fix two bugs with name matching for inputs when enabling chunk traces via the http_server API:

- false positive with short names.
- matching for plugin aliases.

This fixes https://github.com/fluent/fluent-bit/issues/8885.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
