### PR TITLE
in_kubernetes_events: refactor time check to use struct flb_time.

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -291,7 +291,7 @@ static int item_get_timestamp(msgpack_object *obj, struct flb_time *event_time)
 }
 
 static bool check_event_is_filtered(struct k8s_events *ctx, msgpack_object *obj,
-                                    time_t* event_time)
+                                    struct flb_time *event_time)
 {
     int ret;
     time_t now;
@@ -300,7 +300,7 @@ static bool check_event_is_filtered(struct k8s_events *ctx, msgpack_object *obj,
     uint64_t resource_version;
 
     now = (time_t)(cfl_time_now() / 1000000000);
-    if (*event_time < (now - ctx->retention_time)) {
+    if (event_time->tm.tv_sec < (now - ctx->retention_time)) {
         flb_plg_debug(ctx->ins, "Item is older than retention_time: %ld < %ld",
                       *event_time,  (now - ctx->retention_time));
         return FLB_TRUE;


### PR DESCRIPTION
# Summary

Fixes a build error when building in_kubernetes_events caused by code that was not properly refactored. This is basically a reaplication of #8845 to master.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
