### PR TITLE
tests/runtime/in_podman_metrics: refactor iteration of counters to use cfl_list from #8844.

### DIFF
--- a/tests/runtime/in_podman_metrics.c
+++ b/tests/runtime/in_podman_metrics.c
@@ -30,11 +30,11 @@
 #define DPATH_PODMAN_CGROUP_V2      FLB_TESTS_DATA_PATH "/data/podman/cgroupv2"
 
 
-int check_metric(flb_ctx_t *ctx, flb_sds_t *name) {
+int check_metric(flb_ctx_t *ctx, char *name) {
     struct mk_list *tmp;
     struct mk_list *head;
-    struct mk_list *inner_tmp;
-    struct mk_list *inner_head;
+    struct cfl_list *inner_tmp;
+    struct cfl_list *inner_head;
 
     struct flb_input_instance *i_ins;
     struct cmt_counter *counter;
@@ -43,8 +43,8 @@ int check_metric(flb_ctx_t *ctx, flb_sds_t *name) {
 
     mk_list_foreach_safe(head, tmp, &ctx->config->inputs) {
         i_ins = mk_list_entry(head, struct flb_input_instance, _head);
-        mk_list_foreach_safe(inner_head, inner_tmp, &i_ins->cmt->counters) {
-            counter = mk_list_entry(inner_head, struct cmt_counter, _head);
+        cfl_list_foreach_safe(inner_head, inner_tmp, &i_ins->cmt->counters) {
+            counter = cfl_list_entry(inner_head, struct cmt_counter, _head);
 
             if (strlen(name) != 0 && strcmp(name, counter->opts.name) == 0)
             {


### PR DESCRIPTION
# Summary

re-apply #8844 to master.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
