### PR TITLE
tests: rutime: out_http: simplify and make the in_http test more robust.

### DIFF
--- a/tests/runtime/out_http.c
+++ b/tests/runtime/out_http.c
@@ -1040,39 +1040,6 @@ void flb_test_json_date_format_java_sql_timestamp()
     test_ctx_destroy(ctx);
 }
 
-static struct test_ctx *test_ctx_create_in_http(struct flb_lib_out_cb *cb)
-{
-    int i_ffd;
-    int o_ffd;
-    struct test_ctx *ctx = NULL;
-
-    ctx = flb_malloc(sizeof(struct test_ctx));
-    if (!TEST_CHECK(ctx != NULL)) {
-        TEST_MSG("malloc failed");
-        flb_errno();
-        return NULL;
-    }
-
-    /* Service config */
-    ctx->flb = flb_create();
-    flb_service_set(ctx->flb,
-                    "Flush", "0.200000000",
-                    "Grace", "1",
-                    "Log_Level", "error",
-                    NULL);
-
-    /* Input */
-    i_ffd = flb_input(ctx->flb, (char *) "http", NULL);
-    TEST_CHECK(i_ffd >= 0);
-    ctx->i_ffd = i_ffd;
-
-    /* Output */
-    o_ffd = flb_output(ctx->flb, (char *) "lib", cb);
-    ctx->o_ffd = o_ffd;
-
-    return ctx;
-}
-
 int callback_test(void* data, size_t size, void* cb_data)
 {
     int num;
@@ -1087,79 +1054,89 @@ int callback_test(void* data, size_t size, void* cb_data)
 /* test to make sure out_http is always able to work with in_http by default. */
 void flb_test_in_http()
 {
-    struct test_ctx *ctx_in_http;
-    struct test_ctx *ctx_out_http;
+    struct test_ctx *ctx;
     int ret;
     int num;
+    int i_ffd;
+    int o_ffd;
+    int trys;
     struct flb_lib_out_cb cb;
+    char *buf = "[1, {\"msg\":\"hello world\"}]";
+    size_t size = strlen(buf);
 
     cb.cb   = callback_test;
     cb.data = NULL;
     clear_output_num();
 
-    char *buf1 = "[1, {\"msg\":\"hello world\"}]";
-    size_t size1 = strlen(buf1);
-    char *buf2 = "[2, {\"msg\":\"hello world\"}]";
-    size_t size2 = strlen(buf2);
 
-    ctx_in_http = test_ctx_create_in_http(&cb);
-    if (!TEST_CHECK(ctx_in_http != NULL)) {
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
         TEST_MSG("test_ctx_create failed");
         exit(EXIT_FAILURE);
     }
 
-    ctx_out_http = test_ctx_create();
-    if (!TEST_CHECK(ctx_out_http != NULL)) {
-        TEST_MSG("test_ctx_create failed");
-        exit(EXIT_FAILURE);
-    }
+    ret = flb_input_set(ctx->flb,
+                        ctx->i_ffd,
+                        "tag", "lib",
+                        NULL);
+    TEST_CHECK(ret == 0);
 
-    ret = flb_input_set(ctx_in_http->flb,
-                        ctx_in_http->i_ffd,
+    /* Input */
+    i_ffd = flb_input(ctx->flb, (char *) "http", NULL);
+    TEST_CHECK(i_ffd >= 0);
+
+    ret = flb_input_set(ctx->flb,
+                        i_ffd,
                         "port", "8888",
+                        "tag", "http",
                         "host", "127.0.0.1",
                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Output */
+    o_ffd = flb_output(ctx->flb, (char *) "lib", &cb);
+    TEST_CHECK(o_ffd >= 0);
+    ret = flb_output_set(ctx->flb,
+                         o_ffd,
+                         "match", "http",
+                         NULL);
     TEST_CHECK(ret == 0);
 
     /* explicitly do not set anything beyond match, port and localhost
      * to be sure the default options work with in_http.
      */
-    ret = flb_output_set(ctx_out_http->flb,
-                         ctx_out_http->o_ffd,
-                         "match", "*",
+    ret = flb_output_set(ctx->flb,
+                         ctx->o_ffd,
+                         "match", "lib",
                          "host", "127.0.0.1",
                          "port", "8888",
                          NULL);
     TEST_CHECK(ret == 0);
 
     /* Start the engines */
-    ret = flb_start(ctx_in_http->flb);
-    TEST_CHECK(ret == 0);
-    ret = flb_start(ctx_out_http->flb);
+    ret = flb_start(ctx->flb);
     TEST_CHECK(ret == 0);
 
     /* Ingest data sample */
-    ret = flb_lib_push(ctx_out_http->flb,
-                       ctx_out_http->i_ffd,
-                       (char *) buf1,
-                       size1);
-    TEST_CHECK(ret >= 0);
-    ret = flb_lib_push(ctx_out_http->flb,
-                       ctx_out_http->i_ffd,
-                       (char *) buf2,
-                       size2);
+    ret = flb_lib_push(ctx->flb,
+                       ctx->i_ffd,
+                       (char *) buf,
+                       size);
     TEST_CHECK(ret >= 0);
 
-    /* waiting to flush */
-    flb_time_msleep(500);
+    /* try several times to detect the record being flushed. */
+    for (trys = 0, num = 0; trys < 20 && num <= 0; trys++) {
+        num = get_output_num();
+        if (num <= 0) {
+            flb_time_msleep(500);
+        }
+    }
 
-    num = get_output_num();
     if (!TEST_CHECK(num > 0))  {
         TEST_MSG("no outputs");
     }
 
-    test_ctx_destroy(ctx_out_http);
-    test_ctx_destroy(ctx_in_http);
+    test_ctx_destroy(ctx);
 }
 
 /* Test list */


### PR DESCRIPTION
# Summary

This PR simplifies the `in_http` test for `out_http`, designed to make sure the defaults work well together, to use a single fluent-bit context. This should hopefully make it work better on machines with higher occupancy.

This PR also improves the chances of success by using a try loop to detect when the output is finally flushed.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
