### PR TITLE
in_splunk: Add switch for storing in metadata or records and handle multiple tokens on in splunk

### DIFF
--- a/plugins/in_splunk/splunk.c
+++ b/plugins/in_splunk/splunk.c
@@ -237,9 +237,9 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "store_token_to_metadata", "true",
+     FLB_CONFIG_MAP_BOOL, "store_token_in_metadata", "true",
      0, FLB_TRUE, offsetof(struct flb_splunk, store_token_to_metadata),
-     "Store Splunk HEC tokens to matadata. If set as false, they will be stored into records."
+     "Store Splunk HEC tokens in matadata. If set as false, they will be stored into records."
     },
 
     {

--- a/plugins/in_splunk/splunk.c
+++ b/plugins/in_splunk/splunk.c
@@ -237,6 +237,18 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "store_token_to_metadata", "true",
+     0, FLB_TRUE, offsetof(struct flb_splunk, store_token_to_metadata),
+     "Store Splunk HEC tokens to matadata. If set as false, they will be stored into records."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "splunk_token_key", "@splunk_token",
+     0, FLB_TRUE, offsetof(struct flb_splunk, store_token_key),
+     "Set a record key for storing Splunk HEC token for the request"
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "tag_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_splunk, tag_key),
      ""

--- a/plugins/in_splunk/splunk.c
+++ b/plugins/in_splunk/splunk.c
@@ -238,7 +238,7 @@ static struct flb_config_map config_map[] = {
 
     {
      FLB_CONFIG_MAP_BOOL, "store_token_in_metadata", "true",
-     0, FLB_TRUE, offsetof(struct flb_splunk, store_token_to_metadata),
+     0, FLB_TRUE, offsetof(struct flb_splunk, store_token_in_metadata),
      "Store Splunk HEC tokens in matadata. If set as false, they will be stored into records."
     },
 

--- a/plugins/in_splunk/splunk.h
+++ b/plugins/in_splunk/splunk.h
@@ -43,6 +43,8 @@ struct flb_splunk {
     /* Token Auth */
     flb_sds_t auth_header;
     flb_sds_t ingested_auth_header;
+    int store_token_to_metadata;
+    flb_sds_t store_token_key;
 
     struct flb_log_event_encoder log_encoder;
 

--- a/plugins/in_splunk/splunk.h
+++ b/plugins/in_splunk/splunk.h
@@ -32,6 +32,11 @@
 #define HTTP_BUFFER_MAX_SIZE    "4M"
 #define HTTP_BUFFER_CHUNK_SIZE  "512K"
 
+struct flb_splunk_tokens {
+    flb_sds_t header;
+    struct mk_list _head;
+};
+
 struct flb_splunk {
     flb_sds_t listen;
     flb_sds_t tcp_port;
@@ -41,7 +46,7 @@ struct flb_splunk {
     struct mk_list *success_headers;
 
     /* Token Auth */
-    flb_sds_t auth_header;
+    struct mk_list auth_tokens;
     flb_sds_t ingested_auth_header;
     int store_token_to_metadata;
     flb_sds_t store_token_key;

--- a/plugins/in_splunk/splunk.h
+++ b/plugins/in_splunk/splunk.h
@@ -48,7 +48,7 @@ struct flb_splunk {
     /* Token Auth */
     struct mk_list auth_tokens;
     flb_sds_t ingested_auth_header;
-    int store_token_to_metadata;
+    int store_token_in_metadata;
     flb_sds_t store_token_key;
 
     struct flb_log_event_encoder log_encoder;

--- a/plugins/in_splunk/splunk_config.c
+++ b/plugins/in_splunk/splunk_config.c
@@ -34,7 +34,7 @@ static void delete_hec_tokens(struct flb_splunk *ctx)
         splunk_token = mk_list_entry(head, struct flb_splunk_tokens, _head);
         flb_sds_destroy(splunk_token->header);
         mk_list_del(&splunk_token->_head);
-        flb_free(&splunk_token);
+        flb_free(splunk_token);
     }
 }
 

--- a/plugins/in_splunk/splunk_config.c
+++ b/plugins/in_splunk/splunk_config.c
@@ -24,6 +24,66 @@
 #include "splunk_conn.h"
 #include "splunk_config.h"
 
+static void delete_hec_tokens(struct flb_splunk *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_splunk_tokens *splunk_token;
+
+    mk_list_foreach_safe(head, tmp, &ctx->auth_tokens) {
+        splunk_token = mk_list_entry(head, struct flb_splunk_tokens, _head);
+        flb_sds_destroy(splunk_token->header);
+        mk_list_del(&splunk_token->_head);
+        flb_free(&splunk_token);
+    }
+}
+
+static int setup_hec_tokens(struct flb_splunk *ctx)
+{
+    int         ret;
+    const char *tmp;
+    char       *tmp_tokens;
+    char       *token;
+    flb_sds_t   auth_header;
+    struct flb_splunk_tokens *splunk_token;
+
+    tmp = flb_input_get_property("splunk_token", ctx->ins);
+    if (tmp) {
+        tmp_tokens = flb_strdup(tmp);
+
+        token = strtok(tmp_tokens, ",");
+        while (token) {
+            auth_header = flb_sds_create("Splunk ");
+            if (auth_header == NULL) {
+                flb_plg_error(ctx->ins, "error on prefix of auth_header generation");
+                return -1;
+            }
+
+            ret = flb_sds_cat_safe(&auth_header, tmp, strlen(tmp));
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "error on token generation");
+                return -1;
+            }
+
+            /* Create a new token */
+            splunk_token = flb_malloc(sizeof(struct flb_splunk_tokens));
+            if (!splunk_token) {
+                flb_errno();
+                return -1;
+            }
+
+            splunk_token->header = auth_header;
+
+            /* Link to parent list */
+            mk_list_add(&splunk_token->_head, &ctx->auth_tokens);
+
+            token = strtok(NULL, ",");
+        }
+    }
+
+    return 0;
+}
+
 struct flb_splunk *splunk_config_create(struct flb_input_instance *ins)
 {
     struct mk_list            *header_iterator;
@@ -33,7 +93,6 @@ struct flb_splunk *splunk_config_create(struct flb_input_instance *ins)
     char                       port[8];
     int                        ret;
     struct flb_splunk         *ctx;
-    const char                *tmp;
 
     ctx = flb_calloc(1, sizeof(struct flb_splunk));
     if (!ctx) {
@@ -42,6 +101,7 @@ struct flb_splunk *splunk_config_create(struct flb_input_instance *ins)
     }
     ctx->ins = ins;
     mk_list_init(&ctx->connections);
+    mk_list_init(&ctx->auth_tokens);
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *) ctx);
@@ -50,22 +110,12 @@ struct flb_splunk *splunk_config_create(struct flb_input_instance *ins)
         return NULL;
     }
 
-    ctx->auth_header = NULL;
     ctx->ingested_auth_header = NULL;
-    tmp = flb_input_get_property("splunk_token", ins);
-    if (tmp) {
-        ctx->auth_header = flb_sds_create("Splunk ");
-        if (ctx->auth_header == NULL) {
-            flb_plg_error(ctx->ins, "error on prefix of auth_header generation");
-            splunk_config_destroy(ctx);
-            return NULL;
-        }
-        ret = flb_sds_cat_safe(&ctx->auth_header, tmp, strlen(tmp));
-        if (ret < 0) {
-            flb_plg_error(ctx->ins, "error on token generation");
-            splunk_config_destroy(ctx);
-            return NULL;
-        }
+
+    ret = setup_hec_tokens(ctx);
+    if (ret != 0) {
+        splunk_config_destroy(ctx);
+        return NULL;
     }
 
     /* Listen interface (if not set, defaults to 0.0.0.0:8088) */
@@ -161,10 +211,6 @@ int splunk_config_destroy(struct flb_splunk *ctx)
         ctx->collector_id = -1;
     }
 
-    if (ctx->auth_header != NULL) {
-        flb_sds_destroy(ctx->auth_header);
-    }
-
     if (ctx->downstream != NULL) {
         flb_downstream_destroy(ctx->downstream);
     }
@@ -181,6 +227,7 @@ int splunk_config_destroy(struct flb_splunk *ctx)
         flb_sds_destroy(ctx->success_headers_str);
     }
 
+    delete_hec_tokens(ctx);
 
     flb_free(ctx->listen);
     flb_free(ctx->tcp_port);

--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -481,7 +481,6 @@ static ssize_t parse_hec_payload_json(struct flb_splunk *ctx, flb_sds_t tag,
 
 static int validate_auth_header(struct flb_splunk *ctx, struct mk_http_request *request)
 {
-    struct mk_list *tmp;
     struct mk_list *head;
     struct mk_http_header *auth_header = NULL;
     struct flb_splunk_tokens *splunk_token;
@@ -497,7 +496,7 @@ static int validate_auth_header(struct flb_splunk *ctx, struct mk_http_request *
     }
 
     if (auth_header != NULL && auth_header->val.len > 0) {
-        mk_list_foreach_safe(head, tmp, &ctx->auth_tokens) {
+        mk_list_foreach(head, &ctx->auth_tokens) {
             splunk_token = mk_list_entry(head, struct flb_splunk_tokens, _head);
             if (strncmp(splunk_token->header,
                         auth_header->val.data,

--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -999,8 +999,10 @@ static int process_hec_payload_ng(struct flb_http_request *request,
     }
 
     ret = flb_hash_table_get(request->headers, "authorization", 13, (void **)&auth_header, &size);
-    if (ret != 0) {
-        ctx->ingested_auth_header = auth_header;
+    if (ret != 0 && size > 0) {
+        if (strncasecmp(auth_header, "Splunk ", 7) == 0) {
+            ctx->ingested_auth_header = auth_header;
+        }
     }
 
     if (request->body == NULL || cfl_sds_len(request->body) <= 0) {
@@ -1032,8 +1034,10 @@ static int process_hec_raw_payload_ng(struct flb_http_request *request,
     }
 
     ret = flb_hash_table_get(request->headers, "authorization", 13, (void **)&auth_header, &size);
-    if (ret != 0) {
-        ctx->ingested_auth_header = auth_header;
+    if (ret != 0 && size > 0) {
+        if (strncasecmp(auth_header, "Splunk ", 7) == 0) {
+            ctx->ingested_auth_header = auth_header;
+        }
     }
 
     if (request->body == NULL || cfl_sds_len(request->body) == 0) {

--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -226,7 +226,7 @@ static int process_raw_payload_pack(struct flb_splunk *ctx, flb_sds_t tag, char 
         ret = flb_log_event_encoder_set_current_timestamp(&ctx->log_encoder);
     }
 
-    if (ctx->store_token_to_metadata == FLB_TRUE) {
+    if (ctx->store_token_in_metadata == FLB_TRUE) {
         if (ret == FLB_EVENT_ENCODER_SUCCESS) {
             ret = flb_log_event_encoder_append_body_values(
                     &ctx->log_encoder,
@@ -235,7 +235,7 @@ static int process_raw_payload_pack(struct flb_splunk *ctx, flb_sds_t tag, char 
         }
     }
 
-    if (ctx->store_token_to_metadata == FLB_TRUE) {
+    if (ctx->store_token_in_metadata == FLB_TRUE) {
         if (ctx->ingested_auth_header != NULL) {
             if (ret == FLB_EVENT_ENCODER_SUCCESS) {
                 ret = flb_log_event_encoder_append_metadata_values(
@@ -303,7 +303,7 @@ static void process_flb_log_append(struct flb_splunk *ctx, msgpack_object *recor
                 &tm);
     }
 
-    if (ctx->store_token_to_metadata == FLB_TRUE) {
+    if (ctx->store_token_in_metadata == FLB_TRUE) {
         if (ret == FLB_EVENT_ENCODER_SUCCESS) {
             ret = flb_log_event_encoder_set_body_from_msgpack_object(
                     &ctx->log_encoder,

--- a/tests/runtime/in_splunk.c
+++ b/tests/runtime/in_splunk.c
@@ -846,7 +846,7 @@ void flb_test_splunk_auth_header(int port, char *endpoint)
                         NULL);
     TEST_CHECK(ret == 0);
     ret = flb_input_set(ctx->flb, ctx->i_ffd,
-                        "store_token_to_metadata", "false",
+                        "store_token_in_metadata", "false",
                         NULL);
     TEST_CHECK(ret == 0);
 

--- a/tests/runtime/in_splunk.c
+++ b/tests/runtime/in_splunk.c
@@ -810,6 +810,106 @@ void flb_test_splunk_collector_raw_multilines_gzip()
     flb_test_splunk_raw_multilines_gzip(8815);
 }
 
+#define SPLUNK_HEC_TOKEN "Splunk b386261b-d949-411a-b4e8-0103211aa7ae"
+
+void flb_test_splunk_auth_header(int port, char *endpoint)
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+    char *buf = "{\"event\": \"Pony 1 has left the barn\"}{\"event\": \"Pony 2 has left the barn\"}{\"event\": \"Pony 3 has left the barn\", \"nested\": {\"key1\": \"value1\"}}";
+    char *expected = "\"@splunk_token\":";
+    char sport[16];
+    flb_sds_t target;
+
+    target = flb_sds_create_size(64);
+    flb_sds_cat(target, endpoint, strlen(endpoint));
+
+    snprintf(sport, 16, "%d", port);
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = expected;
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "port", sport,
+                        NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "store_token_to_metadata", "false",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = splunk_client_ctx_create(port);
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, target, buf, strlen(buf),
+                        "127.0.0.1", port, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_AUTH, strlen(FLB_HTTP_HEADER_AUTH),
+                              SPLUNK_HEC_TOKEN, strlen(SPLUNK_HEC_TOKEN));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("splunk_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 200)) {
+        TEST_MSG("http response code error. expect: 200, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_sds_destroy(target);
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_splunk_collector_event_hec_token_key()
+{
+    flb_test_splunk_auth_header(8816, "/services/collector/event");
+}
+
+void flb_test_splunk_collector_raw_hec_token_key()
+{
+    flb_test_splunk_auth_header(8817, "/services/collector/raw");
+}
+
 TEST_LIST = {
     {"health", flb_test_splunk_health},
     {"collector", flb_test_splunk_collector},
@@ -820,5 +920,7 @@ TEST_LIST = {
     {"collector_event_gzip", flb_test_splunk_collector_event_gzip},
     {"collector_raw_multilines_gzip", flb_test_splunk_collector_raw_multilines_gzip},
     {"tag_key", flb_test_splunk_tag_key},
+    {"collector_event_with_auth_key", flb_test_splunk_collector_event_hec_token_key},
+    {"collector_raw_with_auth_key", flb_test_splunk_collector_raw_hec_token_key},
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
In this enhancement, I implemented capabilities for storing metadata into records and handle multiple HEC tokens in configuration.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

### For injecting HEC tokens into records case

```ini
[INPUT]
    Name splunk
    Tag splunk.test.ingest
    HTTP2 off
    store_token_in_metadata off
    Splunk_Token 7bba8847-4aee-4e62-ba7b-08c6139e42b9,4e63c0c9-c3b5-4a0a-bf4d-bfd5bc0d0070
[OUTPUT]
    Name stdout
    Match *
```

### For injecting HEC tokens into metadata case (default behavior)

```ini
[INPUT]
    Name splunk
    Tag splunk.test.ingest
    HTTP2 off
    store_token_in_metadata on
    Splunk_Token 7bba8847-4aee-4e62-ba7b-08c6139e42b9,4e63c0c9-c3b5-4a0a-bf4d-bfd5bc0d0070
[OUTPUT]
    Name stdout
    Match *
```

- [x] Debug log output from testing the change

### For injecting HEC tokens into records case

```log
Fluent Bit v3.0.7
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/06/05 15:16:58] [ info] Configuration:
[2024/06/05 15:16:58] [ info]  flush time     | 1.000000 seconds
[2024/06/05 15:16:58] [ info]  grace          | 5 seconds
[2024/06/05 15:16:58] [ info]  daemon         | 0
[2024/06/05 15:16:58] [ info] ___________
[2024/06/05 15:16:58] [ info]  inputs:
[2024/06/05 15:16:58] [ info]      splunk
[2024/06/05 15:16:58] [ info] ___________
[2024/06/05 15:16:58] [ info]  filters:
[2024/06/05 15:16:58] [ info] ___________
[2024/06/05 15:16:58] [ info]  outputs:
[2024/06/05 15:16:58] [ info]      stdout.0
[2024/06/05 15:16:58] [ info] ___________
[2024/06/05 15:16:58] [ info]  collectors:
[2024/06/05 15:16:58] [ info] [fluent bit] version=3.0.7, commit=8e004d495b, pid=230460
[2024/06/05 15:16:58] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/06/05 15:16:58] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/06/05 15:16:58] [ info] [cmetrics] version=0.9.0
[2024/06/05 15:16:58] [ info] [ctraces ] version=0.5.1
[2024/06/05 15:16:58] [ info] [input:splunk:splunk.0] initializing
[2024/06/05 15:16:58] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/06/05 15:16:58] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/06/05 15:16:58] [ info] [output:stdout:stdout.0] worker #0 started
[2024/06/05 15:16:58] [debug] [downstream] listening on 0.0.0.0:8088
[2024/06/05 15:16:58] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/06/05 15:16:58] [ info] [sp] stream processor started
[2024/06/05 15:17:00] [debug] [input:splunk:splunk.0] Mark as unknown type for ingested payloads
[2024/06/05 15:17:00] [debug] [task] created task=0x5f1d1d0 id=0 OK
[2024/06/05 15:17:00] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.test.ingest: [[1717568220.883936807, {}], {"event"=>"Pony 1 has left the barn", "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[1] splunk.test.ingest: [[1717568220.883936807, {}], {"event"=>"Pony 2 has left the barn", "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[2] splunk.test.ingest: [[1717568220.883936807, {}], {"event"=>"Pony 3 has left the barn", "nested"=>{"key1"=>"value1"}, "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[2024/06/05 15:17:00] [debug] [out flush] cb_destroy coro_id=0
[2024/06/05 15:17:00] [debug] [task] destroy task=0x5f1d1d0 (task_id=0)
^C[2024/06/05 15:17:02] [engine] caught signal (SIGINT)
[2024/06/05 15:17:02] [ warn] [engine] service will shutdown in max 5 seconds
[2024/06/05 15:17:02] [ info] [input] pausing splunk.0
[2024/06/05 15:17:02] [ info] [engine] service has stopped (0 pending tasks)
[2024/06/05 15:17:02] [ info] [input] pausing splunk.0
[2024/06/05 15:17:02] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/06/05 15:17:02] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

### For injecting HEC tokens into metadata case (default behavior)

```log
Fluent Bit v3.0.7
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/06/05 15:15:49] [ info] Configuration:
[2024/06/05 15:15:49] [ info]  flush time     | 1.000000 seconds
[2024/06/05 15:15:49] [ info]  grace          | 5 seconds
[2024/06/05 15:15:49] [ info]  daemon         | 0
[2024/06/05 15:15:49] [ info] ___________
[2024/06/05 15:15:49] [ info]  inputs:
[2024/06/05 15:15:49] [ info]      splunk
[2024/06/05 15:15:49] [ info] ___________
[2024/06/05 15:15:49] [ info]  filters:
[2024/06/05 15:15:49] [ info] ___________
[2024/06/05 15:15:49] [ info]  outputs:
[2024/06/05 15:15:49] [ info]      stdout.0
[2024/06/05 15:15:49] [ info] ___________
[2024/06/05 15:15:49] [ info]  collectors:
[2024/06/05 15:15:49] [ info] [fluent bit] version=3.0.7, commit=8e004d495b, pid=230194
[2024/06/05 15:15:49] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/06/05 15:15:49] [ info] [output:stdout:stdout.0] worker #0 started
[2024/06/05 15:15:49] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/06/05 15:15:49] [ info] [cmetrics] version=0.9.0
[2024/06/05 15:15:49] [ info] [ctraces ] version=0.5.1
[2024/06/05 15:15:49] [ info] [input:splunk:splunk.0] initializing
[2024/06/05 15:15:49] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/06/05 15:15:49] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/06/05 15:15:49] [debug] [downstream] listening on 0.0.0.0:8088
[2024/06/05 15:15:49] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/06/05 15:15:49] [ info] [sp] stream processor started
[2024/06/05 15:15:53] [ warn] [input:splunk:splunk.0] wrong credentials in request headers
[2024/06/05 15:16:04] [debug] [input:splunk:splunk.0] Mark as unknown type for ingested payloads
[2024/06/05 15:16:04] [debug] [task] created task=0x5f7cea0 id=0 OK
[2024/06/05 15:16:04] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.test.ingest: [[1717568164.904838207, {"hec_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}], {"event"=>"Pony 1 has left the barn"}]
[1] splunk.test.ingest: [[1717568164.904838207, {"hec_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}], {"event"=>"Pony 2 has left the barn"}]
[2] splunk.test.ingest: [[1717568164.904838207, {"hec_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}], {"event"=>"Pony 3 has left the barn", "nested"=>{"key1"=>"value1"}}]
[2024/06/05 15:16:04] [debug] [out flush] cb_destroy coro_id=0
[2024/06/05 15:16:04] [debug] [task] destroy task=0x5f7cea0 (task_id=0)
^C[2024/06/05 15:16:08] [engine] caught signal (SIGINT)
[2024/06/05 15:16:08] [ warn] [engine] service will shutdown in max 5 seconds
[2024/06/05 15:16:08] [ info] [input] pausing splunk.0
[2024/06/05 15:16:08] [ info] [engine] service has stopped (0 pending tasks)
[2024/06/05 15:16:08] [ info] [input] pausing splunk.0
[2024/06/05 15:16:08] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/06/05 15:16:08] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

### For injecting HEC tokens into records case

```log
==230460== 
==230460== HEAP SUMMARY:
==230460==     in use at exit: 0 bytes in 0 blocks
==230460==   total heap usage: 3,057 allocs, 3,057 frees, 933,540 bytes allocated
==230460== 
==230460== All heap blocks were freed -- no leaks are possible
==230460== 
==230460== For lists of detected and suppressed errors, rerun with: -s
==230460== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### For injecting HEC tokens into metadata case (default behavior)

```log
==230194== 
==230194== HEAP SUMMARY:
==230194==     in use at exit: 0 bytes in 0 blocks
==230194==   total heap usage: 3,154 allocs, 3,154 frees, 1,360,792 bytes allocated
==230194== 
==230194== All heap blocks were freed -- no leaks are possible
==230194== 
==230194== For lists of detected and suppressed errors, rerun with: -s
==230194== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1387

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
