### PR TITLE
Fix GCC 14.1 build issues

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -487,7 +487,7 @@ static int process_events(struct k8s_events *ctx, char *in_data, size_t in_size,
             goto msg_error;
         }
 
-        if (check_event_is_filtered(ctx, item, &ts) == FLB_TRUE) {
+        if (check_event_is_filtered(ctx, item, (time_t *) &ts) == FLB_TRUE) {
             continue;
         }
 

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -217,7 +217,7 @@ static int tls_context_server_alpn_select_callback(SSL *ssl,
     result = SSL_TLSEXT_ERR_NOACK;
 
     if (ctx->alpn != NULL) {
-        result = SSL_select_next_proto(out, 
+        result = SSL_select_next_proto((unsigned char **) out,
                                        outlen,
                                        &ctx->alpn[1], 
                                        (unsigned int) ctx->alpn[0], 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fix two instances where the build fails with GCC 14.1 by adding explicit type casting.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #8858

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
