### PR TITLE
out_es: Allow Logstash_Prefix_Key with prefix

### DIFF
--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -326,7 +326,7 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     }
 
     if (ctx->logstash_prefix_key) {
-        if (ctx->logstash_prefix_key[0] != '$') {
+        if (strchr(ctx->logstash_prefix_key, '$') == NULL) {
             len = flb_sds_len(ctx->logstash_prefix_key);
             buf = flb_malloc(len + 2);
             if (!buf) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
The option Logstash_Prefix_Key should be a record accessor.

There is a convenience feature that automatically prefixes a $ when the value is just a static string (since that is expected to be set as Logstash_Prefix instead).

However, record accessor can contain the $ not just at the beginning. One example would be
  containers-$kubernetes['namespace_name']

This patch thus makes the autodetection look for a $ in the whole value, not just the first character.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8773

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
