### PR TITLE
dockerfile: update to bookworm base image

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -120,7 +120,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     libzstd1 \
     liblz4-1 \
     libgssapi-krb5-2 \
-    libldap-2.4-2 \
+    libldap-2.4 \
     libgpg-error0 \
     libkrb5-3 \
     libk5crypto3 \
@@ -135,7 +135,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     libnettle8 \
     libhogweed6 \
     libgmp10 \
-    libffi7 \
+    libffi8 \
     liblzma5 \
     libyaml-0-2 && \
     mkdir -p /dpkg/var/lib/dpkg/status.d/ && \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -108,7 +108,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get download \
-    libssl1.1 \
+    libssl3 \
     libsasl2-2 \
     pkg-config \
     libpq5 \
@@ -207,7 +207,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    libssl1.1 \
+    libssl3 \
     libsasl2-2 \
     pkg-config \
     libpq5 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -137,7 +137,9 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     libgmp10 \
     libffi8 \
     liblzma5 \
-    libyaml-0-2 && \
+    libyaml-0-2 \
+    libcap2 \
+    && \
     mkdir -p /dpkg/var/lib/dpkg/status.d/ && \
     for deb in *.deb; do \
     package_name=$(dpkg-deb -I "${deb}" | awk '/^ Package: .*$/ {print $2}'); \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -120,7 +120,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     libzstd1 \
     liblz4-1 \
     libgssapi-krb5-2 \
-    libldap-2.4 \
+    libldap-2.5 \
     libgpg-error0 \
     libkrb5-3 \
     libk5crypto3 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -17,7 +17,7 @@ ARG RELEASE_VERSION=3.0.7
 FROM multiarch/qemu-user-static:x86_64-arm as qemu-arm32
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu-arm64
 
-FROM debian:bullseye-slim as builder-base
+FROM debian:bookworm-slim as builder-base
 
 COPY --from=qemu-arm32 /usr/bin/qemu-arm-static /usr/bin/
 COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
@@ -33,7 +33,7 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
 ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
@@ -46,7 +46,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev/bullseye-backports \
+    libsystemd-dev/bookworm-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -97,7 +97,7 @@ RUN /fluent-bit/bin/fluent-bit -J > /fluent-bit/etc/schema.json
 
 # Simple example of how to properly extract packages for reuse in distroless
 # Taken from: https://github.com/GoogleContainerTools/distroless/issues/863
-FROM debian:bullseye-slim as deb-extractor
+FROM debian:bookworm-slim as deb-extractor
 COPY --from=qemu-arm32 /usr/bin/qemu-arm-static /usr/bin/
 COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 
@@ -105,14 +105,14 @@ COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 # We also include some extra handling for the status files that some tooling uses for scanning, etc.
 WORKDIR /tmp
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get download \
     libssl1.1 \
     libsasl2-2 \
     pkg-config \
     libpq5 \
-    libsystemd0/bullseye-backports \
+    libsystemd0/bookworm-backports \
     zlib1g \
     ca-certificates \
     libatomic1 \
@@ -152,7 +152,7 @@ RUN find /dpkg/ -type d -empty -delete && \
 
 # We want latest at time of build
 # hadolint ignore=DL3006
-FROM gcr.io/distroless/cc-debian11 as production
+FROM gcr.io/distroless/cc-debian12 as production
 ARG RELEASE_VERSION
 ENV FLUENT_BIT_VERSION=${RELEASE_VERSION}
 LABEL description="Fluent Bit multi-architecture container image" \
@@ -183,7 +183,7 @@ EXPOSE 2020
 ENTRYPOINT [ "/fluent-bit/bin/fluent-bit" ]
 CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
 
-FROM debian:bullseye-slim as debug
+FROM debian:bookworm-slim as debug
 ARG RELEASE_VERSION
 ENV FLUENT_BIT_VERSION=${RELEASE_VERSION}
 LABEL description="Fluent Bit multi-architecture debug container image" \
@@ -204,14 +204,14 @@ COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     libssl1.1 \
     libsasl2-2 \
     pkg-config \
     libpq5 \
-    libsystemd0/bullseye-backports \
+    libsystemd0/bookworm-backports \
     zlib1g \
     ca-certificates \
     libatomic1 \
@@ -225,7 +225,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/
     openssl \
     htop atop strace iotop sysstat ncdu logrotate hdparm pciutils psmisc tree pv \
     cmake make tar flex bison \
-    libssl-dev libsasl2-dev libsystemd-dev/bullseye-backports zlib1g-dev libpq-dev libyaml-dev postgresql-server-dev-all \
+    libssl-dev libsasl2-dev libsystemd-dev/bookworm-backports zlib1g-dev libpq-dev libyaml-dev postgresql-server-dev-all \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Update to Debian `bookworm` as the base for the container images.
Increments to `libssl3`, `libldap-2.5` and `libffi8` as part of this. Also added `libcap2` to prevent runtime linkage problems.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

CI covers build and run sanity check.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
