### PR TITLE
in_systemd: Move one record back after skipping to the end

### DIFF
--- a/plugins/in_systemd/systemd_config.c
+++ b/plugins/in_systemd/systemd_config.c
@@ -212,6 +212,7 @@ struct flb_systemd_config *flb_systemd_config_create(struct flb_input_instance *
 
     if (ctx->read_from_tail == FLB_TRUE) {
         sd_journal_seek_tail(ctx->j);
+        sd_journal_previous(ctx->j);
         /*
         * Skip up to 350 records until the end of journal is found.
         * Workaround for bug https://github.com/systemd/systemd/issues/9934


### PR DESCRIPTION
On recent versions of systemd, `read_from_tail()` doesn't work as expected unless followed with a call to `sd_journal_previous()`.

This can be tested with: `fluent-bit -i systemd -p read_from_tail=On -o stdout`
The command works on:
  - Ubuntu 22.10 with systemd 251 (251.4-1ubuntu7.3)
  - Yocto mickledore with systemd 253 (253.1)

But it doesn't work on:
  - Ubuntu 24.04 with systemd 255 (255.4-1ubuntu8.1)
  - Yocto nanbield with systemd 254 (254.4)

The following short program can also be used to test this (uncomment the line that calls sd_journal_previous() to see the difference):
```C
#include <stdio.h>
#include <stdlib.h>
#include <systemd/sd-journal.h>

int main(void) {
    sd_journal *j;
    int ret;

    sd_journal_open(&j, SD_JOURNAL_LOCAL_ONLY);
    sd_journal_seek_tail(j);
    //sd_journal_previous(j);

    for (;;) {
        sd_journal_wait(j, (uint64_t) -1);
        while (sd_journal_next(j) > 0) {
            const char *d;
            size_t l;

            if (sd_journal_get_data(j, "MESSAGE", (const void **)&d, &l) >= 0) {
                printf("%.*s\n", (int)l, d);
            }
        }
    }

    sd_journal_close(j);

    return 0;
}
```
