### PR TITLE
tls: Verify vhost when tls.verify is enabled

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -25,6 +25,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
+#include <openssl/x509v3.h>
 
 #ifdef FLB_SYSTEM_WINDOWS
     #define strtok_r(str, delimiter, context) \
@@ -636,11 +637,33 @@ static int tls_net_write(struct flb_tls_session *session,
     return ret;
 }
 
+int setup_hostname_validation(struct tls_session *session, const char *hostname)
+{
+    X509_VERIFY_PARAM *param;
+
+    param = SSL_get0_param(session->ssl);
+
+    if (!param) {
+        flb_error("[tls] error: ssl context is invalid");
+        return -1;
+    }
+
+    X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    if (!X509_VERIFY_PARAM_set1_host(param, hostname, 0)) {
+        flb_error("[tls] error: hostname parameter vailidation is failed : %s",
+                  hostname);
+        return -1;
+    }
+
+    return 0;
+}
+
 static int tls_net_handshake(struct flb_tls *tls,
                              char *vhost,
                              void *ptr_session)
 {
     int ret = 0;
+    long ssl_code = 0;
     char err_buf[256];
     struct tls_session *session = ptr_session;
     struct tls_context *ctx;
@@ -669,6 +692,20 @@ static int tls_net_handshake(struct flb_tls *tls,
         }
     }
 
+    if (tls->verify == FLB_TRUE) {
+        if (vhost != NULL) {
+            ret = setup_hostname_validation(session, vhost);
+        }
+        else if (tls->vhost) {
+            ret = setup_hostname_validation(session, tls->vhost);
+        }
+
+        if (ret != 0) {
+            pthread_mutex_unlock(&ctx->mutex);
+            return -1;
+        }
+    }
+
     ERR_clear_error();
 
     if (tls->mode == FLB_TLS_CLIENT_MODE) {
@@ -686,7 +723,14 @@ static int tls_net_handshake(struct flb_tls *tls,
             // The SSL_ERROR_SYSCALL with errno value of 0 indicates unexpected
             //  EOF from the peer. This is fixed in OpenSSL 3.0.
             if (ret == 0) {
-            	flb_error("[tls] error: unexpected EOF");
+                ssl_code = SSL_get_verify_result(session->ssl);
+                if (ssl_code != X509_V_OK) {
+                    flb_error("[tls] error: unexpected EOF with reason: %s",
+                              ERR_reason_error_string(ERR_get_error()));
+                }
+                else {
+                    flb_error("[tls] error: unexpected EOF");
+                }
             } else {
                 ERR_error_string_n(ret, err_buf, sizeof(err_buf)-1);
                 flb_error("[tls] error: %s", err_buf);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Closes #8072

As mentioned in the TLS hostname issue ticket, this issue will be reproduced easily.
After applied this patch, Fluent Bit will deny to connect inappropriate server name against for the certificates' data.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

As mentioned in https://github.com/fluent/fluent-bit/issues/8072

- [x] Debug log output from testing the change

After applied this patch, Fluent Bit does safely disconnect from the not matched vhost.


```log
Fluent Bit v3.1.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/06/10 18:41:32] [ info] Configuration:
[2024/06/10 18:41:32] [ info]  flush time     | 1.000000 seconds
[2024/06/10 18:41:32] [ info]  grace          | 5 seconds
[2024/06/10 18:41:32] [ info]  daemon         | 0
[2024/06/10 18:41:32] [ info] ___________
[2024/06/10 18:41:32] [ info]  inputs:
[2024/06/10 18:41:32] [ info]      dummy
[2024/06/10 18:41:32] [ info] ___________
[2024/06/10 18:41:32] [ info]  filters:
[2024/06/10 18:41:32] [ info] ___________
[2024/06/10 18:41:32] [ info]  outputs:
[2024/06/10 18:41:32] [ info]      forward.0
[2024/06/10 18:41:32] [ info] ___________
[2024/06/10 18:41:32] [ info]  collectors:
[2024/06/10 18:41:33] [ info] [fluent bit] version=3.1.0, commit=40935fabd7, pid=103380
[2024/06/10 18:41:33] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/06/10 18:41:33] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/06/10 18:41:33] [ info] [cmetrics] version=0.9.1
[2024/06/10 18:41:33] [ info] [ctraces ] version=0.5.1
[2024/06/10 18:41:33] [ info] [input:dummy:dummy.0] initializing
[2024/06/10 18:41:33] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/06/10 18:41:33] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/06/10 18:41:33] [debug] [forward:forward.0] created event channels: read=23 write=24
[2024/06/10 18:41:33] [ info] [sp] stream processor started
[2024/06/10 18:41:33] [ info] [output:forward:forward.0] worker #1 started
[2024/06/10 18:41:33] [ info] [output:forward:forward.0] worker #0 started
[2024/06/10 18:41:34] [debug] [task] created task=0x617db40 id=0 OK
[2024/06/10 18:41:34] [debug] [output:forward:forward.0] task_id=0 assigned to thread #0
[2024/06/10 18:41:34] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/06/10 18:41:35] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/06/10 18:41:35] [debug] [upstream] connection #49 failed to other.fluent-backoffice.de:24224
[2024/06/10 18:41:35] [debug] [retry] new retry created for task_id=0 attempts=1
[2024/06/10 18:41:35] [error] [output:forward:forward.0] no upstream connections available
[2024/06/10 18:41:35] [ warn] [engine] failed to flush chunk '103380-1718012493.702233148.flb', retry in 8 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2024/06/10 18:41:35] [debug] [out flush] cb_destroy coro_id=0
[2024/06/10 18:41:35] [debug] [task] created task=0x8243cd0 id=1 OK
[2024/06/10 18:41:35] [debug] [output:forward:forward.0] task_id=1 assigned to thread #1
[2024/06/10 18:41:35] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/06/10 18:41:35] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/06/10 18:41:35] [debug] [upstream] connection #50 failed to other.fluent-backoffice.de:24224
[2024/06/10 18:41:35] [error] [output:forward:forward.0] no upstream connections available
[2024/06/10 18:41:35] [debug] [out flush] cb_destroy coro_id=0
[2024/06/10 18:41:35] [debug] [retry] new retry created for task_id=1 attempts=1
[2024/06/10 18:41:35] [ warn] [engine] failed to flush chunk '103380-1718012494.740826531.flb', retry in 9 seconds: task_id=1, input=dummy.0 > output=forward.0 (out_id=0)
^C[2024/06/10 18:41:36] [engine] caught signal (SIGINT)
[2024/06/10 18:41:36] [debug] [task] created task=0x82f02c0 id=2 OK
[2024/06/10 18:41:36] [debug] [output:forward:forward.0] task_id=2 assigned to thread #0
[2024/06/10 18:41:36] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/06/10 18:41:36] [ warn] [engine] service will shutdown in max 5 seconds
[2024/06/10 18:41:36] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/06/10 18:41:36] [debug] [engine] re-scheduled retry=0x8243b10 for task 0
[2024/06/10 18:41:36] [debug] [engine] re-scheduled retry=0x82f00b0 for task 1
[2024/06/10 18:41:36] [ info] [input] pausing dummy.0
[2024/06/10 18:41:36] [debug] [output:forward:forward.0] task_id=0 assigned to thread #1
[2024/06/10 18:41:36] [debug] [output:forward:forward.0] task_id=1 assigned to thread #0
[2024/06/10 18:41:36] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/06/10 18:41:36] [ info] [task] dummy/dummy.0 has 3 pending task(s):
[2024/06/10 18:41:36] [ info] [task]   task_id=0 still running on route(s): forward/forward.0 
[2024/06/10 18:41:36] [ info] [task]   task_id=1 still running on route(s): forward/forward.0 
[2024/06/10 18:41:36] [ info] [task]   task_id=2 still running on route(s): forward/forward.0 
[2024/06/10 18:41:36] [ info] [input] pausing dummy.0
[2024/06/10 18:41:37] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/06/10 18:41:37] [debug] [upstream] connection #50 failed to other.fluent-backoffice.de:24224
[2024/06/10 18:41:37] [error] [output:forward:forward.0] no upstream connections available
[2024/06/10 18:41:37] [debug] [task] task_id=0 reached retry-attempts limit 1/1
[2024/06/10 18:41:37] [debug] [out flush] cb_destroy coro_id=1
[2024/06/10 18:41:37] [error] [engine] chunk '103380-1718012493.702233148.flb' cannot be retried: task_id=0, input=dummy.0 > output=forward.0
[2024/06/10 18:41:37] [debug] [task] destroy task=0x617db40 (task_id=0)
[2024/06/10 18:41:37] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/06/10 18:41:37] [debug] [upstream] connection #51 failed to other.fluent-backoffice.de:24224
[2024/06/10 18:41:37] [error] [output:forward:forward.0] no upstream connections available
[2024/06/10 18:41:37] [debug] [out flush] cb_destroy coro_id=2
[2024/06/10 18:41:37] [debug] [task] task_id=1 reached retry-attempts limit 1/1
[2024/06/10 18:41:37] [error] [engine] chunk '103380-1718012494.740826531.flb' cannot be retried: task_id=1, input=dummy.0 > output=forward.0
[2024/06/10 18:41:37] [debug] [task] destroy task=0x8243cd0 (task_id=1)
[2024/06/10 18:41:37] [ info] [input] pausing dummy.0
[2024/06/10 18:41:38] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/06/10 18:41:38] [debug] [upstream] connection #49 failed to other.fluent-backoffice.de:24224
[2024/06/10 18:41:38] [error] [output:forward:forward.0] no upstream connections available
[2024/06/10 18:41:38] [debug] [out flush] cb_destroy coro_id=1
[2024/06/10 18:41:38] [debug] [retry] new retry created for task_id=2 attempts=1
[2024/06/10 18:41:38] [ warn] [engine] failed to flush chunk '103380-1718012495.669380090.flb', retry in 1 seconds: task_id=2, input=dummy.0 > output=forward.0 (out_id=0)
[2024/06/10 18:41:38] [debug] [output:forward:forward.0] task_id=2 assigned to thread #1
[2024/06/10 18:41:38] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/06/10 18:41:38] [ info] [input] pausing dummy.0
[2024/06/10 18:41:39] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/06/10 18:41:39] [debug] [upstream] connection #38 failed to other.fluent-backoffice.de:24224
[2024/06/10 18:41:39] [error] [output:forward:forward.0] no upstream connections available
[2024/06/10 18:41:39] [debug] [out flush] cb_destroy coro_id=2
[2024/06/10 18:41:39] [debug] [task] task_id=2 reached retry-attempts limit 1/1
[2024/06/10 18:41:39] [error] [engine] chunk '103380-1718012495.669380090.flb' cannot be retried: task_id=2, input=dummy.0 > output=forward.0
[2024/06/10 18:41:39] [debug] [task] destroy task=0x82f02c0 (task_id=2)
[2024/06/10 18:41:39] [ info] [engine] service has stopped (0 pending tasks)
[2024/06/10 18:41:39] [ info] [input] pausing dummy.0
[2024/06/10 18:41:39] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2024/06/10 18:41:39] [ info] [output:forward:forward.0] thread worker #0 stopped
[2024/06/10 18:41:39] [ info] [output:forward:forward.0] thread worker #1 stopping...
[2024/06/10 18:41:39] [ info] [output:forward:forward.0] thread worker #1 stopped
````
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==103380== 
==103380== HEAP SUMMARY:
==103380==     in use at exit: 0 bytes in 0 blocks
==103380==   total heap usage: 31,700 allocs, 31,700 frees, 4,425,117 bytes allocated
==103380== 
==103380== All heap blocks were freed -- no leaks are possible
==103380== 
==103380== For lists of detected and suppressed errors, rerun with: -s
==103380== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
