### PR TITLE
help: input: Handle listen to be a parameter for setting up listen address

### DIFF
--- a/src/flb_help.c
+++ b/src/flb_help.c
@@ -201,9 +201,15 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
     struct mk_list *tls_config;
     struct flb_config_map m_input_net_listen = {
         .type =      FLB_CONFIG_MAP_STR,
-        .name =      "host",
+        .name =      "listen",
         .def_value = "0.0.0.0",
         .desc =      "Listen Address",
+    };
+    struct flb_config_map m_input_net_host = {
+        .type =      FLB_CONFIG_MAP_STR,
+        .name =      "host",
+        .def_value = "localhost",
+        .desc =      "Hostname",
     };
     struct flb_config_map m_input_net_port = {
         .type =      FLB_CONFIG_MAP_INT,
@@ -243,7 +249,7 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
         options_size = mk_list_size(config_map);
 
         if ((ins->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) != 0) {
-            options_size += 2;
+            options_size += 3;
         }
         if (ins->flags & FLB_IO_OPT_TLS) {
             tls_config = flb_tls_get_config_map(ins->config);
@@ -254,6 +260,7 @@ int flb_help_input(struct flb_input_instance *ins, void **out_buf, size_t *out_s
 
         if ((ins->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) != 0) {
             pack_config_map_entry(&mp_pck, &m_input_net_listen);
+            pack_config_map_entry(&mp_pck, &m_input_net_host);
             pack_config_map_entry(&mp_pck, &m_input_net_port);
         }
         if (ins->flags & FLB_IO_OPT_TLS) {


### PR DESCRIPTION
Before this commit, fluent-bit -J produces the incorrect schema for listen address for ip.
host should be used for specifing to hostname.
And, listen parameter should be used for setting up for listen address.

This is because the following lines in flb_input.c:
```c
    else if (prop_key_check("listen", k, len) == 0) {
        flb_utils_set_plugin_string_property("listen", &ins->host.listen, tmp);
    }
    else if (prop_key_check("host", k, len) == 0) {
        flb_utils_set_plugin_string_property("host", &ins->host.name, tmp);
    }
```

Set up for listen address and hostname respectively. And the host member is typed as struct flb_net_host whose definition is:
```c
struct flb_input_instance {
/* snip */
    /*
     * Input network info:
     *
     * An input plugin can be specified just using it shortname or using the
     * complete network address format, e.g:
     *
     *  $ fluent-bit -i cpu -o plugin://hostname:port/uri
     *
     * where:
     *
     *   plugin   = the output plugin shortname
     *   name     = IP address or hostname of the target
     *   port     = target TCP port
     *   uri      = extra information that may be used by the plugin
     */
    struct flb_net_host host;
/* snip */
};
```

Then, the type of struct flb_net_host should be:
```c
/* Defines a host service and it properties */
struct flb_net_host {
    int ipv6;              /* IPv6 required ?        */
    flb_sds_t address;     /* Original address       */
    int port;              /* TCP port               */
    flb_sds_t name;        /* Hostname               */
    flb_sds_t listen;      /* Listen interface       */
    struct flb_uri *uri;   /* Extra URI parameters   */
};
```

So, the usage and generating for host and listen parameters are inverted
and I have to add a host config_map for DNS resolutions.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
