### PR TITLE
Improved OpenTelemetry OTLP error handling

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -2205,6 +2205,9 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
 
         cmt_decode_opentelemetry_destroy(&decoded_contexts);
     }
+    else {
+        flb_plg_warn(ctx->ins, "non-success cmetrics opentelemetry decode result %d", result);
+    }
 
     return 0;
 }
@@ -2241,6 +2244,9 @@ static int process_payload_traces_proto_ng(struct flb_opentelemetry *ctx,
     if (result == 0) {
         result = flb_input_trace_append(ctx->ins, NULL, 0, decoded_context);
         ctr_decode_opentelemetry_destroy(decoded_context);
+    }
+    else {
+        flb_plg_warn(ctx->ins, "non-success ctraces opentelemetry decode result %d", result);
     }
 
     return result;

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -2207,6 +2207,7 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
     }
     else {
         flb_plg_warn(ctx->ins, "non-success cmetrics opentelemetry decode result %d", result);
+        return -1;
     }
 
     return 0;

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -2461,7 +2461,12 @@ int opentelemetry_prot_handle_ng(struct flb_http_request *request,
         send_export_service_response_ng(response, result, payload_type);
     }
     else {
-        send_response_ng(response, context->successful_response_code, NULL);
+        if (result == 0) {
+            send_response_ng(response, context->successful_response_code, NULL);
+        }
+        else {
+            send_response_ng(response, 400, "invalid request: deserialisation error\n");
+        }
     }
 
     return result;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Updates to the OpenTelemetry input plugin's HTTP/2 server code to handle/report error cases better.

These were changes I made as part of other work trying to fix #8734 - but I have split them out into a separate PR as I can imagine they may need to be reviewed separately. 

----

**Testing requirements**
- [x] Example configuration file for the change:
```
service:
    log_level: debug
pipeline:
    inputs:
        - name: opentelemetry
          tag_from_uri: true
          http2: true
    outputs:
        - name: 'stdout'
          match: '*'
```
- [ ] Debug log output from testing the change (will add in update)
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature - don't think so? Although the new HTTP 400 case might warrant documenting.

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
