### PR TITLE
tls: input: output: Provide restoring way for tls.verify hebavior

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -359,6 +359,7 @@ struct flb_input_instance {
     /* TLS settings */
     int use_tls;                         /* bool, try to use TLS for I/O */
     int tls_verify;                      /* Verify certs (default: true) */
+    int tls_verify_hostname;             /* Verify hostname (default: false) */
     int tls_debug;                       /* mbedtls debug level          */
     char *tls_vhost;                     /* Virtual hostname for SNI     */
     char *tls_ca_path;                   /* Path to certificates         */

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -284,6 +284,7 @@ struct flb_output_instance {
 
 #ifdef FLB_HAVE_TLS
     int tls_verify;                      /* Verify certs (default: true) */
+    int tls_verify_hostname;             /* Verify hostname (default: false) */
     int tls_debug;                       /* mbedtls debug level          */
     char *tls_vhost;                     /* Virtual hostname for SNI     */
     char *tls_ca_path;                   /* Path to certificates         */

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -92,6 +92,7 @@ struct flb_tls {
     int debug;                        /* Debug level               */
     char *vhost;                      /* Virtual hostname for SNI  */
     int mode;                         /* Client or Server          */
+    int verify_hostname;              /* Verify hostname           */
 
     /* Bakend library for TLS */
     void *ctx;                        /* TLS context created */
@@ -111,6 +112,8 @@ struct flb_tls *flb_tls_create(int mode,
 int flb_tls_destroy(struct flb_tls *tls);
 
 int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn);
+
+int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname);
 
 int flb_tls_load_system_certificates(struct flb_tls *tls);
 

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -80,6 +80,7 @@ struct flb_kube {
     int dummy_meta;
     int tls_debug;
     int tls_verify;
+    int tls_verify_hostname;
     int kube_token_ttl;
     flb_sds_t meta_preload_cache_dir;
 

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -1681,6 +1681,7 @@ static int wait_for_dns(struct flb_kube *ctx)
 
 static int flb_kubelet_network_init(struct flb_kube *ctx, struct flb_config *config)
 {
+    int ret;
     int io_type = FLB_IO_TCP;
     int api_https = FLB_TRUE;
     ctx->kubelet_upstream = NULL;    
@@ -1709,6 +1710,14 @@ static int flb_kubelet_network_init(struct flb_kube *ctx, struct flb_config *con
             return -1;
         }
 
+        if (ctx->tls_verify_hostname == FLB_TRUE) {
+            ret = flb_tls_set_verify_hostname(ctx->kubelet_tls, ctx->tls_verify_hostname);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "kubelet network tls set up failed for hostname verification");
+                return -1;
+            }
+        }
+
         io_type = FLB_IO_TLS;
     }
 
@@ -1726,12 +1735,13 @@ static int flb_kubelet_network_init(struct flb_kube *ctx, struct flb_config *con
 
     /* Remove async flag from upstream */
     flb_stream_disable_async_mode(&ctx->kubelet_upstream->base);
-    
+
     return 0;
 }
 
 static int flb_kube_network_init(struct flb_kube *ctx, struct flb_config *config)
 {
+    int ret;
     int io_type = FLB_IO_TCP;
     int kubelet_network_init_ret = 0;
 
@@ -1751,6 +1761,14 @@ static int flb_kube_network_init(struct flb_kube *ctx, struct flb_config *config
                                   NULL, NULL, NULL);
         if (!ctx->tls) {
             return -1;
+        }
+
+        if (ctx->tls_verify_hostname == FLB_TRUE) {
+            ret = flb_tls_set_verify_hostname(ctx->tls, ctx->tls_verify_hostname);
+            if (ret == -1) {
+                flb_plg_debug(ctx->ins, "network tls set up failed for hostname verification");
+                return -1;
+            }
         }
 
         io_type = FLB_IO_TLS;

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -800,6 +800,13 @@ static struct flb_config_map config_map[] = {
      "set optional TLS virtual host"
     },
 
+    /* TLS: set tls.hostame_verification feature */
+    {
+     FLB_CONFIG_MAP_BOOL, "tls.verify_hostname", "off",
+     0, FLB_TRUE, offsetof(struct flb_kube, tls_verify_hostname),
+     "enable or disable to verify hostname"
+    },
+
     /* Merge structured record as independent keys */
     {
      FLB_CONFIG_MAP_BOOL, "merge_log", "false",

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -308,6 +308,7 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         instance->tls                   = NULL;
         instance->tls_debug             = -1;
         instance->tls_verify            = FLB_TRUE;
+        instance->tls_verify_hostname   = FLB_FALSE;
         instance->tls_vhost             = NULL;
         instance->tls_ca_path           = NULL;
         instance->tls_ca_file           = NULL;
@@ -551,6 +552,10 @@ int flb_input_set_property(struct flb_input_instance *ins,
     }
     else if (prop_key_check("tls.verify", k, len) == 0 && tmp) {
         ins->tls_verify = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
+    }
+    else if (prop_key_check("tls.verify_hostname", k, len) == 0 && tmp) {
+        ins->tls_verify_hostname = flb_utils_bool(tmp);
         flb_sds_destroy(tmp);
     }
     else if (prop_key_check("tls.debug", k, len) == 0 && tmp) {
@@ -1120,6 +1125,16 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                       ins->name);
 
             return -1;
+        }
+
+        if (ins->tls_verify_hostname == FLB_TRUE) {
+            ret = flb_tls_set_verify_hostname(ins->tls, ins->tls_verify_hostname);
+            if (ret == -1) {
+                flb_error("[input %s] error set up to verify hostname in TLS context",
+                          ins->name);
+
+                return -1;
+            }
         }
     }
 

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -678,6 +678,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->tls                   = NULL;
     instance->tls_debug             = -1;
     instance->tls_verify            = FLB_TRUE;
+    instance->tls_verify_hostname   = FLB_FALSE;
     instance->tls_vhost             = NULL;
     instance->tls_ca_path           = NULL;
     instance->tls_ca_file           = NULL;
@@ -870,6 +871,10 @@ int flb_output_set_property(struct flb_output_instance *ins,
     }
     else if (prop_key_check("tls.verify", k, len) == 0 && tmp) {
         ins->tls_verify = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
+    }
+    else if (prop_key_check("tls.verify_hostname", k, len) == 0 && tmp) {
+        ins->tls_verify_hostname = flb_utils_bool(tmp);
         flb_sds_destroy(tmp);
     }
     else if (prop_key_check("tls.debug", k, len) == 0 && tmp) {
@@ -1248,6 +1253,16 @@ int flb_output_init_all(struct flb_config *config)
                           ins->name);
                 flb_output_instance_destroy(ins);
                 return -1;
+            }
+
+            if (ins->tls_verify_hostname == FLB_TRUE) {
+                ret = flb_tls_set_verify_hostname(ins->tls, ins->tls_verify_hostname);
+                if (ret == -1) {
+                    flb_error("[output %s] error set up to verify hostname in TLS context",
+                              ins->name);
+
+                    return -1;
+                }
             }
         }
 #endif

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -74,6 +74,12 @@ struct flb_config_map tls_configmap[] = {
      "Hostname to be used for TLS SNI extension"
     },
 
+    {
+     FLB_CONFIG_MAP_BOOL, "tls.verify_hostname", "off",
+     0, FLB_FALSE, 0,
+     "Enable or disable to verify hostname"
+    },
+
     /* EOF */
     {0}
 };
@@ -191,6 +197,7 @@ struct flb_tls *flb_tls_create(int mode,
     tls->verify = verify;
     tls->debug = debug;
     tls->mode = mode;
+    tls->verify_hostname = FLB_FALSE;
 
     if (vhost != NULL) {
         tls->vhost = flb_strdup(vhost);
@@ -231,6 +238,16 @@ int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn)
     return 0;
 }
 
+int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname)
+{
+    if (!tls) {
+        return -1;
+    }
+
+    tls->verify_hostname = !!verify_hostname;
+
+    return 0;
+}
 
 int flb_tls_net_read(struct flb_tls_session *session, void *buf, size_t len)
 {

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -692,7 +692,8 @@ static int tls_net_handshake(struct flb_tls *tls,
         }
     }
 
-    if (tls->verify == FLB_TRUE) {
+    if (tls->verify == FLB_TRUE &&
+        tls->verify_hostname == FLB_TRUE) {
         if (vhost != NULL) {
             ret = setup_hostname_validation(session, vhost);
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Closes https://github.com/fluent/fluent-bit/issues/8959.

The previous enforced hostname verification with tls.verify breaks some of the certificates
 for kubelet. We should restore functionality and make opt-in feature for hostname verification in TLS.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
Same as in https://github.com/fluent/fluent-bit/issues/8072. But it needs to add `tls.verify_hostname on` for hostname verification.

- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1393

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
