### PR TITLE
metrics: Allocate metrics' titles dynamically

### DIFF
--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -56,17 +56,20 @@
 #define FLB_METRIC_OUT_DROPPED_RECORDS 15       /* dropped_records_total */
 #define FLB_METRIC_OUT_RETRIED_RECORDS 16       /* retried_records_total */
 
+/* The limitation of title name length */
+#define FLB_METRIC_LENGTH_LIMIT 1024
+
 struct flb_metric {
     int id;
     int title_len;
-    char title[64];
+    char *title;
     size_t val;
     struct mk_list _head;
 };
 
 struct flb_metrics {
     int title_len;         /* Title string length */
-    char title[64];        /* Title or id for this metrics context */
+    char *title;           /* Title or id for this metrics context */
     int count;             /* Total count of metrics registered */
     struct mk_list list;   /* Head of metrics list */
 };

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -78,7 +78,7 @@ struct flb_metrics *flb_metrics_create(const char *title)
 {
     int ret;
     struct flb_metrics *metrics;
-    size_t title_len = strlen(title);
+    size_t title_len = 0;
     char *allocated_title = NULL;
 
     /* Create a metrics parent context */
@@ -89,12 +89,14 @@ struct flb_metrics *flb_metrics_create(const char *title)
     }
     metrics->count = 0;
 
-    allocated_title = flb_calloc(title_len + 1, sizeof(char));
+    title_len = snprintf(NULL, 0, "%s\n", title);
+    allocated_title = flb_calloc(title_len, sizeof(char));
     if (allocated_title == NULL) {
         flb_free(metrics);
         return NULL;
     }
     metrics->title = allocated_title;
+    metrics->title[title_len] = '\0';
 
     /* Set metrics title */
     ret = flb_metrics_title(title, metrics);
@@ -112,14 +114,14 @@ struct flb_metrics *flb_metrics_create(const char *title)
 int flb_metrics_title(const char *title, struct flb_metrics *metrics)
 {
     int ret;
-    size_t size = sizeof(metrics->title) - 1;
+    size_t size = sizeof(metrics->title);
 
     ret = snprintf(metrics->title, size, "%s", title);
     if (ret == -1) {
         flb_errno();
         return -1;
     }
-    else if (ret >= size) {
+    else if (ret > size) {
         flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
     }
     metrics->title_len = strlen(metrics->title);

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -89,14 +89,13 @@ struct flb_metrics *flb_metrics_create(const char *title)
     }
     metrics->count = 0;
 
-    title_len = snprintf(NULL, 0, "%s\n", title);
-    allocated_title = flb_calloc(title_len, sizeof(char));
+    title_len = snprintf(NULL, 0, "%s", title);
+    allocated_title = flb_calloc(title_len + 1, sizeof(char));
     if (allocated_title == NULL) {
         flb_free(metrics);
         return NULL;
     }
     metrics->title = allocated_title;
-    metrics->title[title_len] = '\0';
 
     /* Set metrics title */
     ret = flb_metrics_title(title, metrics);
@@ -114,7 +113,7 @@ struct flb_metrics *flb_metrics_create(const char *title)
 int flb_metrics_title(const char *title, struct flb_metrics *metrics)
 {
     int ret;
-    size_t size = sizeof(metrics->title);
+    size_t size = snprintf(NULL, 0, "%s", title);
 
     ret = snprintf(metrics->title, size, "%s", title);
     if (ret == -1) {

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -80,6 +80,7 @@ struct flb_metrics *flb_metrics_create(const char *title)
     struct flb_metrics *metrics;
     size_t title_len = 0;
     char *allocated_title = NULL;
+    size_t threshold = FLB_METRIC_LENGTH_LIMIT;
 
     /* Create a metrics parent context */
     metrics = flb_malloc(sizeof(struct flb_metrics));
@@ -90,6 +91,12 @@ struct flb_metrics *flb_metrics_create(const char *title)
     metrics->count = 0;
 
     title_len = snprintf(NULL, 0, "%s", title);
+
+    if (title_len > threshold) {
+        title_len = threshold;
+        flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
+    }
+
     allocated_title = flb_calloc(title_len + 1, sizeof(char));
     if (allocated_title == NULL) {
         flb_free(metrics);
@@ -120,9 +127,7 @@ int flb_metrics_title(const char *title, struct flb_metrics *metrics)
         flb_errno();
         return -1;
     }
-    else if (ret > size) {
-        flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
-    }
+
     metrics->title_len = strlen(metrics->title);
     return 0;
 }


### PR DESCRIPTION
However, still aded limitations over 1024 characters to prevent a waste of memory consumptions for title names.

Closes https://github.com/fluent/fluent-bit/issues/8938

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```console
$ fluent-bit -i fluentbit_metrics -o stdout -v
```

- [x] Debug log output from testing the change

```log
Fluent Bit v3.1.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/06/17 22:23:12] [ info] Configuration:
[2024/06/17 22:23:12] [ info]  flush time     | 1.000000 seconds
[2024/06/17 22:23:12] [ info]  grace          | 5 seconds
[2024/06/17 22:23:12] [ info]  daemon         | 0
[2024/06/17 22:23:12] [ info] ___________
[2024/06/17 22:23:12] [ info]  inputs:
[2024/06/17 22:23:12] [ info]      fluentbit_metrics
[2024/06/17 22:23:12] [ info] ___________
[2024/06/17 22:23:12] [ info]  filters:
[2024/06/17 22:23:12] [ info] ___________
[2024/06/17 22:23:12] [ info]  outputs:
[2024/06/17 22:23:12] [ info]      stdout.0
[2024/06/17 22:23:12] [ info] ___________
[2024/06/17 22:23:12] [ info]  collectors:
[2024/06/17 22:23:12] [ info] [fluent bit] version=3.1.0, commit=01ec4a8ede, pid=525311
[2024/06/17 22:23:12] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/06/17 22:23:12] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/06/17 22:23:12] [ info] [cmetrics] version=0.9.1
[2024/06/17 22:23:12] [ info] [ctraces ] version=0.5.1
[2024/06/17 22:23:12] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2024/06/17 22:23:12] [ info] [output:stdout:stdout.0] worker #0 started
[2024/06/17 22:23:12] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2024/06/17 22:23:12] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2024/06/17 22:23:12] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/06/17 22:23:12] [ info] [sp] stream processor started
[2024/06/17 22:23:15] [debug] [task] created task=0x5f0c660 id=0 OK
[2024/06/17 22:23:15] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-06-17T13:23:14.045002300Z fluentbit_uptime{hostname="cosmo-desktop2"} = 2
2024-06-17T13:23:12.721627690Z fluentbit_input_bytes_total{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_records_total{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:14.040403399Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0"} = 1
2024-06-17T13:23:12.745225553Z fluentbit_output_proc_records_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_proc_bytes_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_errors_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_retries_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_retries_failed_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_dropped_records_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_retried_records_total{name="stdout.0"} = 0
2024-06-17T13:23:14.045002300Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2"} = 1718630592
2024-06-17T13:23:14.045002300Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.1.0",os="linux"} = 1718630592
2024-06-17T13:23:14.045002300Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2"} = 0
2024-06-17T13:23:14.054781235Z fluentbit_storage_chunks = 0
2024-06-17T13:23:14.054781235Z fluentbit_storage_mem_chunks = 0
2024-06-17T13:23:14.054781235Z fluentbit_storage_fs_chunks = 0
2024-06-17T13:23:14.054781235Z fluentbit_storage_fs_chunks_up = 0
2024-06-17T13:23:14.054781235Z fluentbit_storage_fs_chunks_down = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_ingestion_paused{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_overlimit{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_memory_bytes{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_up{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_down{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_busy{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_busy_bytes{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_upstream_total_connections{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_upstream_busy_connections{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_chunk_available_capacity_percent{name="stdout.0"} = 100
[2024/06/17 22:23:15] [debug] [out flush] cb_destroy coro_id=0
[2024/06/17 22:23:15] [debug] [task] destroy task=0x5f0c660 (task_id=0)
^C[2024/06/17 22:23:16] [engine] caught signal (SIGINT)
[2024/06/17 22:23:16] [debug] [task] created task=0x5fd4930 id=0 OK
[2024/06/17 22:23:16] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2024-06-17T13:23:16.038871114Z fluentbit_uptime{hostname="cosmo-desktop2"} = 4
2024-06-17T13:23:12.721627690Z fluentbit_input_bytes_total{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_records_total{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:16.038724569Z fluentbit_input_metrics_scrapes_total{name="fluentbit_metrics.0"} = 2
2024-06-17T13:23:15.079890779Z fluentbit_output_proc_records_total{name="stdout.0"} = 0
2024-06-17T13:23:15.079890779Z fluentbit_output_proc_bytes_total{name="stdout.0"} = 6005
2024-06-17T13:23:12.745225553Z fluentbit_output_errors_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_retries_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_retries_failed_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_dropped_records_total{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_retried_records_total{name="stdout.0"} = 0
2024-06-17T13:23:16.038871114Z fluentbit_process_start_time_seconds{hostname="cosmo-desktop2"} = 1718630592
2024-06-17T13:23:16.038871114Z fluentbit_build_info{hostname="cosmo-desktop2",version="3.1.0",os="linux"} = 1718630592
2024-06-17T13:23:16.038871114Z fluentbit_hot_reloaded_times{hostname="cosmo-desktop2"} = 0
2024-06-17T13:23:16.039507091Z fluentbit_storage_chunks = 0
2024-06-17T13:23:16.039507091Z fluentbit_storage_mem_chunks = 0
2024-06-17T13:23:16.039507091Z fluentbit_storage_fs_chunks = 0
2024-06-17T13:23:16.039507091Z fluentbit_storage_fs_chunks_up = 0
2024-06-17T13:23:16.039507091Z fluentbit_storage_fs_chunks_down = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_ingestion_paused{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_overlimit{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_memory_bytes{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_up{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_down{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_busy{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.721627690Z fluentbit_input_storage_chunks_busy_bytes{name="fluentbit_metrics.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_upstream_total_connections{name="stdout.0"} = 0
2024-06-17T13:23:12.745225553Z fluentbit_output_upstream_busy_connections{name="stdout.0"} = 0
2024-06-17T13:23:15.079890779Z fluentbit_output_chunk_available_capacity_percent{name="stdout.0"} = 100
[2024/06/17 22:23:16] [ warn] [engine] service will shutdown in max 5 seconds
[2024/06/17 22:23:16] [ info] [input] pausing fluentbit_metrics.0
[2024/06/17 22:23:16] [debug] [out flush] cb_destroy coro_id=1
[2024/06/17 22:23:16] [debug] [task] destroy task=0x5fd4930 (task_id=0)
[2024/06/17 22:23:17] [ info] [engine] service has stopped (0 pending tasks)
[2024/06/17 22:23:17] [ info] [input] pausing fluentbit_metrics.0
[2024/06/17 22:23:17] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/06/17 22:23:17] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==525311== 
==525311== HEAP SUMMARY:
==525311==     in use at exit: 0 bytes in 0 blocks
==525311==   total heap usage: 5,894 allocs, 5,894 frees, 1,796,548 bytes allocated
==525311== 
==525311== All heap blocks were freed -- no leaks are possible
==525311== 
==525311== For lists of detected and suppressed errors, rerun with: -s
==525311== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
