### PR TITLE
in_winevtlog: Permit absence of publisher metadata

### DIFF
--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -415,15 +415,14 @@ PWSTR get_description(EVT_HANDLE handle, LANGID langID, unsigned int *message_si
     }
     values = (PEVT_VARIANT)buffer;
 
+    /* Metadata can be NULL because forwarded events do not have an
+     * associated publisher metadata. */
     metadata = EvtOpenPublisherMetadata(
             NULL, // TODO: Remote handle
             values[0].StringVal,
             NULL,
             MAKELCID(langID, SORT_DEFAULT),
             0);
-    if (metadata == NULL) {
-        goto cleanup;
-    }
 
     message = get_message(metadata, handle, message_size);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

When subscribing Forwarded events channels such as ForwardedEvents channel, PublisherMetadata could be absent.
This is the side note for this phenomenon:

> [in] PublisherMetadata

> A handle to the provider's metadata that the [EvtOpenPublisherMetadata](https://learn.microsoft.com/en-us/windows/desktop/api/winevt/nf-winevt-evtopenpublishermetadata) function returns. The handle acts as a formatting context for the event or message identifier.

> You can set this parameter to NULL if the Windows Event Collector service forwarded the event. Forwarded events include a RenderingInfo section that contains the rendered message strings.

ref: https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage

So, FormatEventMessage function should handle NULL in case of publisherMetadata to be returned NULL. However, when handling NULL case of publisherMetadata, we need to pre-allocate at the minimalistic size of buffer. Presumably, it should be set as 512 bytes by default for this use case.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```powershell
PS> /path/to/bin/fluent-bit.exe -i winevtlog -pchannels=ForwardedEvents -p read_existing_events=On -o stdout
```

- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
