### PR TITLE
in_syslog: Fix double free when no parser is set

### DIFF
--- a/plugins/in_syslog/syslog_conf.c
+++ b/plugins/in_syslog/syslog_conf.c
@@ -169,8 +169,6 @@ struct flb_syslog *syslog_conf_create(struct flb_input_instance *ins,
     }
 
     if (!ctx->parser) {
-        flb_log_event_encoder_destroy(ctx->log_encoder);
-
         flb_error("[in_syslog] parser not set");
         syslog_conf_destroy(ctx);
         return NULL;


### PR DESCRIPTION
When running syslog example:
 `bin/fluent-bit -i syslog -o stdout -f 1`

 if no parser is set we get a double-free:

```
  [2024/06/18 15:36:32] [ info] [fluent bit] version=3.1.0, commit=2bef95819e, pid=144050
  [2024/06/18 15:36:32] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, m  ax_chunks_up=128
  [2024/06/18 15:36:32] [ info] [cmetrics] version=0.9.1
  [2024/06/18 15:36:32] [ info] [ctraces ] version=0.5.1
  free(): double free detected in tcache 2
  [2024/06/18 15:36:32] [ info] [input:syslog:syslog.0] initializing
  zsh: IOT instruction  bin/fluent-bit -i syslog -o stdout -f 1
```

Remove the redundent flb_log_event_encoder_destroy, since that is already done in syslog_conf_destroy.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
`bin/fluent-bit -i syslog -o stdout -f 1`
- [x] Debug log output from testing the change

"parser not set" is displayed.

```
[2024/06/18 15:53:08] [ info] [fluent bit] version=3.1.0, commit=2bef95819e, pid=145607
[2024/06/18 15:53:08] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/06/18 15:53:08] [ info] [cmetrics] version=0.9.1
[2024/06/18 15:53:08] [ info] [ctraces ] version=0.5.1
[2024/06/18 15:53:08] [ info] [input:syslog:syslog.0] initializing
[2024/06/18 15:53:08] [ info] [input:syslog:syslog.0] storage_strategy='memory' (memory only)
[2024/06/18 15:53:08] [error] [in_syslog] parser not set
[2024/06/18 15:53:08] [error] [input:syslog:syslog.0] could not initialize plugin
[2024/06/18 15:53:08] [error] failed initialize input syslog.0
[2024/06/18 15:53:08] [error] [engine] input initialization failed
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Same output as before this fix, when running valgrind.

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
