### PR TITLE
in_prometheus_remote_write: prom_rw_prot: Fix string in http response code 400

### DIFF
--- a/plugins/in_prometheus_remote_write/prom_rw_prot.c
+++ b/plugins/in_prometheus_remote_write/prom_rw_prot.c
@@ -79,7 +79,7 @@ static int send_response(struct flb_input_instance *in,
     }
     else if (http_status == 400) {
         flb_sds_printf(&out,
-                       "HTTP/1.1 400 Forbidden\r\n"
+                       "HTTP/1.1 400 Bad Request\r\n"
                        "Server: Fluent Bit v%s\r\n"
                        "Content-Length: %i\r\n\r\n%s",
                        FLB_VERSION_STR,
@@ -233,7 +233,7 @@ int prom_rw_prot_uncompress(struct mk_http_session *session,
 
 
 /*
- * Handle an incoming request. It perform extra checks over the request, if
+ * Handle an incoming request. It performs extra checks over the request, if
  * everything is OK, it enqueue the incoming payload.
  */
 int prom_rw_prot_handle(struct flb_prom_remote_write *ctx,
@@ -410,7 +410,7 @@ static int send_response_ng(struct flb_http_response *response,
         flb_http_response_set_message(response, "No Content");
     }
     else if (http_status == 400) {
-        flb_http_response_set_message(response, "Forbidden");
+        flb_http_response_set_message(response, "Bad Request");
     }
 
     if (message != NULL) {


### PR DESCRIPTION
It's replying with `400 Forbidden`; it should be `400 Bad Request`


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
