### PR TITLE
out_s3: replace MAX_UPLOAD_ERRORS constant with retry_limit

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1202,12 +1202,12 @@ static int put_all_chunks(struct flb_s3 *ctx)
                 continue;
             }
 
-            if (chunk->failures >= MAX_UPLOAD_ERRORS) {
+            if (chunk->failures >= ctx->ins->retry_limit) {
                 flb_plg_warn(ctx->ins,
                              "Chunk for tag %s failed to send %i times, "
                              "will not retry",
-                             (char *) fsf->meta_buf, MAX_UPLOAD_ERRORS);
-                flb_fstore_file_inactive(ctx->fs, fsf);
+                             (char *) fsf->meta_buf, ctx->ins->retry_limit);
+                flb_fstore_file_delete(ctx->fs, fsf);
                 continue;
             }
 
@@ -1484,13 +1484,17 @@ static struct multipart_upload *get_upload(struct flb_s3 *ctx,
     struct mk_list *tmp;
     struct mk_list *head;
 
+    if (mk_list_is_empty(&ctx->uploads)) {
+        return NULL;
+    }
+
     mk_list_foreach_safe(head, tmp, &ctx->uploads) {
         tmp_upload = mk_list_entry(head, struct multipart_upload, _head);
 
         if (tmp_upload->upload_state == MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS) {
             continue;
         }
-        if (tmp_upload->upload_errors >= MAX_UPLOAD_ERRORS) {
+        if (tmp_upload->upload_errors >= ctx->ins->retry_limit) {
             tmp_upload->upload_state = MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS;
             flb_plg_error(ctx->ins, "Upload for %s has reached max upload errors",
                           tmp_upload->s3_key);
@@ -1727,10 +1731,10 @@ static void s3_upload_queue(struct flb_config *config, void *out_context)
 
             /* If retry limit was reached, discard file and remove file from queue */
             upload_contents->retry_counter++;
-            if (upload_contents->retry_counter >= MAX_UPLOAD_ERRORS) {
+            if (upload_contents->retry_counter >= ctx->ins->retry_limit) {
                 flb_plg_warn(ctx->ins, "Chunk file failed to send %d times, will not "
                              "retry", upload_contents->retry_counter);
-                s3_store_file_inactive(ctx, upload_contents->upload_file);
+                s3_store_file_delete(ctx, upload_contents->upload_file);
                 multipart_upload_destroy(upload_contents->m_upload_file);
                 remove_from_queue(upload_contents);
                 continue;
@@ -1805,7 +1809,7 @@ static void cb_s3_upload(struct flb_config *config, void *data)
         m_upload = mk_list_entry(head, struct multipart_upload, _head);
         complete = FLB_FALSE;
 
-        if (m_upload->complete_errors >= MAX_UPLOAD_ERRORS) {
+        if (m_upload->complete_errors >= ctx->ins->retry_limit) {
             flb_plg_error(ctx->ins,
                           "Upload for %s has reached max completion errors, "
                           "plugin will give up", m_upload->s3_key);
@@ -2162,11 +2166,11 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
                         m_upload_file, file_first_log_time);
     }
 
-    /* Discard upload_file if it has failed to upload MAX_UPLOAD_ERRORS times */
-    if (upload_file != NULL && upload_file->failures >= MAX_UPLOAD_ERRORS) {
+    /* Discard upload_file if it has failed to upload ctx->ins->retry_limit times */
+    if (upload_file != NULL && upload_file->failures >= ctx->ins->retry_limit) {
         flb_plg_warn(ctx->ins, "File with tag %s failed to send %d times, will not "
-                     "retry", event_chunk->tag, MAX_UPLOAD_ERRORS);
-        s3_store_file_inactive(ctx, upload_file);
+                     "retry", event_chunk->tag, ctx->ins->retry_limit);
+        s3_store_file_delete(ctx, upload_file);
         upload_file = NULL;
     }
 
@@ -2272,7 +2276,7 @@ static int cb_s3_exit(void *data, struct flb_config *config)
                 continue;
             }
 
-            if (m_upload->bytes > 0) {
+            if (m_upload->bytes > 0 && m_upload->complete_errors < ctx->ins->retry_limit) {
                 m_upload->upload_state = MULTIPART_UPLOAD_STATE_COMPLETE_IN_PROGRESS;
                 mk_list_del(&m_upload->_head);
                 ret = complete_multipart_upload(ctx, m_upload);
@@ -2280,6 +2284,7 @@ static int cb_s3_exit(void *data, struct flb_config *config)
                     multipart_upload_destroy(m_upload);
                 }
                 else {
+                    m_upload->complete_errors += 1;
                     mk_list_add(&m_upload->_head, &ctx->uploads);
                     flb_plg_error(ctx->ins, "Could not complete upload %s",
                                   m_upload->s3_key);

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -45,18 +45,6 @@
 /* Allowed max file size 1 GB for publishing to S3 */
 #define MAX_FILE_SIZE_PUT_OBJECT        1000000000 
 
-#define DEFAULT_UPLOAD_TIMEOUT 3600
-
-/*
- * If we see repeated errors on an upload/chunk, we will discard it
- * This saves us from scenarios where something goes wrong and an upload can
- * not proceed (may be some other process completed it or deleted the upload)
- * instead of erroring out forever, we eventually discard the upload.
- *
- * The same is done for chunks, just to be safe, even though realistically
- * I can't think of a reason why a chunk could become unsendable.
- */
-#define MAX_UPLOAD_ERRORS 5
 
 struct upload_queue {
     struct s3_file *upload_file;
@@ -95,8 +83,9 @@ struct multipart_upload {
 
     struct mk_list _head;
 
-    /* see note for MAX_UPLOAD_ERRORS */
+    /* counter for chunk upload errors */
     int upload_errors;
+    /* counter for multipart upload completion errors */
     int complete_errors;
 };
 


### PR DESCRIPTION
This change replaces the constant for the maximum upload errors in the output plugin out_s3 with the user-configurable retry_limit variable and fixes a segfault that occurred when building with debug flags.

Previous attempts for older Fluent Bit versions (https://github.com/fluent/fluent-bit/pull/6475, https://github.com/fluent/fluent-bit/pull/6063) were not merged to master, presumably because of stability issues.

On our test systems, we can now configure the retry_limit and therefore better handle situations with network instabilities and prolonged network interruptions.

Fixes https://github.com/fluent/fluent-bit/issues/8595

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
  [OUTPUT]
      Name s3
      Match *
      Bucket fluentbit
      Endpoint http://127.0.0.1:9000
      Retry_Limit 3
      Preserve_Data_Ordering true
      Total_File_Size 15M
      Use_Put_Object false
- [x] Debug log output from testing the change

![Screenshot-retry-limit-3](https://github.com/fluent/fluent-bit/assets/33552836/d1bdb903-ad12-4ee8-b806-8700adb3795d)

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

![Screenshot-valgrind-ok](https://github.com/fluent/fluent-bit/assets/33552836/cf2b5670-9a2c-4eb2-b2f6-d3bad369b523)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- `[N/A]` Documentation required for this feature

The [docs](https://docs.fluentbit.io/manual/pipeline/outputs/s3) claim already that the retry_limit is taken into account.

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
