### PR TITLE
in_opentelemetry: handle missing or invalid content-type headers in metrics and traces handlers

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -2175,6 +2175,12 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
 
     offset = 0;
 
+    if (request->content_type == NULL) {
+        flb_error("[otel] content type missing");
+
+        return -1;
+    }
+
     if (strcasecmp(request->content_type, "application/grpc") == 0) {
         if (cfl_sds_len(request->body) < 5) {
             return -1;
@@ -2220,6 +2226,12 @@ static int process_payload_traces_proto_ng(struct flb_opentelemetry *ctx,
     int            result;
 
     offset = 0;
+
+    if (request->content_type == NULL) {
+        flb_error("[otel] content type missing");
+
+        return -1;
+    }
 
     if (strcasecmp(request->content_type, "application/grpc") == 0) {
         if (cfl_sds_len(request->body) < 5) {

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -2191,11 +2191,17 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
                                                  cfl_sds_len(request->body) - 5,
                                                  &offset);
     }
-    else {
+    else if (strcasecmp(request->content_type, "application/x-protobuf") == 0 ||
+             strcasecmp(request->content_type, "application/json") == 0) {
         result = cmt_decode_opentelemetry_create(&decoded_contexts,
                                                 request->body,
                                                 cfl_sds_len(request->body),
                                                 &offset);
+    }
+    else {
+        flb_plg_error(ctx->ins, "Unsupported content type %s", request->content_type);
+
+        return -1;
     }
 
     if (result == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
@@ -2243,11 +2249,17 @@ static int process_payload_traces_proto_ng(struct flb_opentelemetry *ctx,
                                                  cfl_sds_len(request->body) - 5,
                                                  &offset);
     }
-    else {
+    else if (strcasecmp(request->content_type, "application/x-protobuf") == 0 ||
+             strcasecmp(request->content_type, "application/json") == 0) {
         result = ctr_decode_opentelemetry_create(&decoded_context,
                                                 request->body,
                                                 cfl_sds_len(request->body),
                                                 &offset);
+    }
+    else {
+        flb_plg_error(ctx->ins, "Unsupported content type %s", request->content_type);
+
+        return -1;
     }
 
     if (result == 0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #8983 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
