### PR TITLE
out_datadog: Add support for setting a static hostname

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -247,6 +247,14 @@ static int datadog_format(struct flb_config *config,
                                           ctx->dd_service, flb_sds_len(ctx->dd_service));
         }
 
+        /* dd_hostname */
+        if (ctx->dd_hostname != NULL) {
+            dd_msgpack_pack_key_value_str(&mp_pck,
+                                          FLB_DATADOG_DD_HOSTNAME_KEY,
+                                          sizeof(FLB_DATADOG_DD_HOSTNAME_KEY) -1,
+                                          ctx->dd_hostname, flb_sds_len(ctx->dd_hostname));
+        }
+
         /* Append initial object k/v */
         ind = 0;
         for (i = 0; i < map_size; i++) {
@@ -513,6 +521,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_tags),
      "The tags you want to assign to your logs in Datadog. If unset, Datadog "
      "will expect the tags in the `ddtags` attribute."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "dd_hostname", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_hostname),
+     "The host that emitted logs should be associated with. If unset, Datadog "
+     "will expect the host to be set as `host`, `hostname`, or `syslog.hostname` "
+     "attributes. See Datadog Logs preprocessor documentation for up-to-date "
+     "of recognized attributes."
     },
 
     {

--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -27,6 +27,7 @@
 #define FLB_DATADOG_DEFAULT_PORT      443
 #define FLB_DATADOG_DEFAULT_TIME_KEY  "timestamp"
 #define FLB_DATADOG_DEFAULT_TAG_KEY   "tagkey"
+#define FLB_DATADOG_DD_HOSTNAME_KEY   "hostname"
 #define FLB_DATADOG_DD_SOURCE_KEY     "ddsource"
 #define FLB_DATADOG_DD_SERVICE_KEY    "service"
 #define FLB_DATADOG_DD_TAGS_KEY       "ddtags"
@@ -65,6 +66,7 @@ struct flb_out_datadog {
     int nb_additional_entries;
     flb_sds_t dd_source;
     flb_sds_t dd_service;
+    flb_sds_t dd_hostname;
     flb_sds_t dd_tags;
     flb_sds_t dd_message_key;
 


### PR DESCRIPTION
This PR adds support for setting a static hostname in the Datadog output plugin. This field is analogous to the existing `dd_service` and `dd_source` configuration options that can be used to set a static value.

If unset, the default behavior is backwards compatible. This behavior is to not set an explicity `hostname` field, but if the record has a field that is detected as the hostname in Datadog (such as `host` or `syslog.hostname`), it will be picked up.

Closes: #8971

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
