### PR TITLE
out_splunk: remove raw endpoint

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -628,7 +628,6 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
     flb_sds_t buf_data;
     size_t resp_size;
     size_t buf_size;
-    char *endpoint;
     struct flb_splunk *ctx = out_context;
     struct flb_connection *u_conn;
     struct flb_http_client *c;
@@ -687,16 +686,8 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
         }
     }
 
-    /* Splunk URI endpoint */
-    if (ctx->splunk_send_raw) {
-        endpoint = FLB_SPLUNK_DEFAULT_URI_RAW;
-    }
-    else {
-        endpoint = FLB_SPLUNK_DEFAULT_URI_EVENT;
-    }
-
     /* Compose HTTP Client request */
-    c = flb_http_client(u_conn, FLB_HTTP_POST, endpoint,
+    c = flb_http_client(u_conn, FLB_HTTP_POST, FLB_SPLUNK_DEFAULT_ENDPOINT,
                         payload_buf, payload_size, NULL, 0, NULL, 0);
 
     /* HTTP Response buffer size, honor value set by the user */

--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -22,8 +22,7 @@
 
 #define FLB_SPLUNK_DEFAULT_HOST          "127.0.0.1"
 #define FLB_SPLUNK_DEFAULT_PORT          8088
-#define FLB_SPLUNK_DEFAULT_URI_RAW       "/services/collector/raw"
-#define FLB_SPLUNK_DEFAULT_URI_EVENT     "/services/collector/event"
+#define FLB_SPLUNK_DEFAULT_ENDPOINT      "/services/collector/event"
 #define FLB_SPLUNK_DEFAULT_TIME          "time"
 #define FLB_SPLUNK_DEFAULT_EVENT_HOST    "host"
 #define FLB_SPLUNK_DEFAULT_EVENT_SOURCE  "source"


### PR DESCRIPTION
Fixes #8927. This does **not** remove the ability to send raw events, i.e. using `Splunk_Send_Raw On`, but rather sends them to correct endpoint.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
