### PR TITLE
workflows: update for 3.1 release

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -502,8 +502,8 @@ jobs:
           TAG: ${{ steps.get-tag.outputs.tag }}
 
   staging-release-images-latest-tags:
-    # Only update latest tags for 3.0 releases
-    if: startsWith(github.event.inputs.version, '3.0')
+    # Only update latest tags for 3.1 releases
+    if: startsWith(github.event.inputs.version, '3.1')
     name: Release latest Linux container images
     runs-on: ubuntu-latest
     needs:
@@ -791,21 +791,21 @@ jobs:
           target_commitish: '2.1'
           make_latest: false
 
-      - name: Release 2.2 - not latest
+      - name: Release 3.0 - not latest
         uses: softprops/action-gh-release@v2
-        if: startsWith(inputs.version, '2.2')
+        if: startsWith(inputs.version, '3.0')
         with:
           body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
           draft: false
           generate_release_notes: true
           name: "Fluent Bit ${{ inputs.version }}"
           tag_name: v${{ inputs.version }}
-          target_commitish: '2.2'
+          target_commitish: '3.0'
           make_latest: false
 
-      - name: Release 3.0 and latest
+      - name: Release 3.1 and latest
         uses: softprops/action-gh-release@v2
-        if: startsWith(inputs.version, '3.0')
+        if: startsWith(inputs.version, '3.1')
         with:
           body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
           draft: false
@@ -898,8 +898,15 @@ jobs:
           ref: 2.2
           token: ${{ secrets.GH_PA_TOKEN }}
 
-      - name: Release 3.0 and latest
+      - name: Release 3.0 - not latest
         if: startsWith(inputs.version, '3.0')
+        uses: actions/checkout@v4
+        with:
+          repository: fluent/fluent-bit-docs
+          token: ${{ secrets.GH_PA_TOKEN }}
+
+      - name: Release 3.1 and latest
+        if: startsWith(inputs.version, '3.1')
         uses: actions/checkout@v4
         with:
           repository: fluent/fluent-bit-docs
@@ -977,8 +984,14 @@ jobs:
         with:
           ref: 2.2
 
-      - name: Release 3.0 and latest
+      - name: Release 3.0 not latest
         if: startsWith(inputs.version, '3.0')
+        uses: actions/checkout@v4
+        with:
+          ref: 3.0
+
+      - name: Release 3.1 latest
+        if: startsWith(inputs.version, '3.1')
         uses: actions/checkout@v4
 
       # Get the new version to use


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
