### PR TITLE
in_winetvlog: Handle buffer allocation error and not mapped error

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -282,7 +282,9 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid, int extract_sid)
                                    &len, &sid_type)) {
                 err = GetLastError();
                 if (err == ERROR_NONE_MAPPED) {
-                    strcpy_s(account, MAX_NAME, "NONE_MAPPED");
+                    flb_plg_debug(ctx->ins, "AccountSid is not mapped. code: %u", err);
+
+                    goto not_mapped_error;
                 }
                 else {
                     flb_plg_warn(ctx->ins, "LookupAccountSid Error %u", err);
@@ -295,6 +297,8 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid, int extract_sid)
             formatted = flb_sds_create_size(result_len);
             if (formatted == NULL) {
                 flb_plg_warn(ctx->ins, "create result buffer failed");
+
+                ret = -1;
 
                 goto error;
             }
@@ -327,12 +331,17 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid, int extract_sid)
             return ret;
         }
 
-    error:
+    not_mapped_error:
         ret = pack_wstr(ctx, wide_sid);
 
         LocalFree(wide_sid);
 
-        return -1;
+        return ret;
+
+    error:
+        LocalFree(wide_sid);
+
+        return ret;
     }
 
     return ret;

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -301,7 +301,7 @@ PWSTR get_message(EVT_HANDLE metadata, EVT_HANDLE handle, unsigned int *message_
     if (!buffer) {
         flb_error("failed to premalloc message buffer");
 
-        goto cleanup;
+        goto buffer_error;
     }
 
     // Get the size of the buffer
@@ -316,7 +316,7 @@ PWSTR get_message(EVT_HANDLE metadata, EVT_HANDLE handle, unsigned int *message_
                 flb_error("failed to malloc message buffer");
                 flb_free(previous_buffer);
 
-                goto cleanup;
+                goto buffer_error;
             }
 
             if (!EvtFormatMessage(metadata,
@@ -385,6 +385,8 @@ cleanup:
     if (buffer) {
         flb_free(buffer);
     }
+
+buffer_error:
 
     return message;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the previous implementation, I didn't fully considered for buffer allocation error and not mapped error.
This PR intended to handle them correctly.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
