### PR TITLE
aws_credentials_http: Add support for EKS Pod Identities

### DIFF
--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -359,6 +359,27 @@ int try_lock_provider(struct flb_aws_provider *provider);
 
 void unlock_provider(struct flb_aws_provider *provider);
 
+/*
+ * HTTP Credentials Provider - retrieve credentials from a local http server
+ * Used to implement the Container Credentials provider.
+ * Equivalent to:
+ * https://github.com/aws/aws-sdk-go/tree/master/aws/credentials/endpointcreds
+ */
+
+struct flb_aws_provider_http {
+    struct flb_aws_credentials *creds;
+    time_t next_refresh;
+
+    struct flb_aws_client *client;
+
+    /* Endpoint to request credentials */
+    flb_sds_t endpoint;
+    flb_sds_t path;
+
+    /* Auth token */
+    flb_sds_t auth_token;
+    flb_sds_t auth_token_file;
+};
 
 #endif
 #endif /* FLB_HAVE_AWS */

--- a/include/fluent-bit/flb_aws_credentials.h
+++ b/include/fluent-bit/flb_aws_credentials.h
@@ -257,18 +257,28 @@ struct flb_aws_provider *flb_aws_env_provider_create();
  * used by host and path.
  */
 struct flb_aws_provider *flb_http_provider_create(struct flb_config *config,
-                                                  flb_sds_t host,
+                                                  flb_sds_t endpoint,
                                                   flb_sds_t path,
+                                                  flb_sds_t auth_token,
                                                   struct
                                                   flb_aws_client_generator
                                                   *generator);
 
+struct flb_aws_provider *flb_local_http_provider_create(struct flb_config *config,
+                                                        flb_sds_t endpoint,
+                                                        flb_sds_t auth_token,
+                                                        struct
+                                                        flb_aws_client_generator
+                                                        *generator);
+
+
+
 /*
- * ECS Provider
- * The ECS Provider is just a wrapper around the HTTP Provider
- * with the ECS credentials endpoint.
+ * Container Provider
+ * The Container Provider is just a wrapper around the HTTP Provider
+ * with the ECS/EKS credentials endpoint.
  */
-struct flb_aws_provider *flb_ecs_provider_create(struct flb_config *config,
+struct flb_aws_provider *flb_container_provider_create(struct flb_config *config,
                                                  struct
                                                  flb_aws_client_generator
                                                  *generator);

--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -144,12 +144,20 @@ flb_sds_t flb_aws_xml_error(char *response, size_t response_len);
 flb_sds_t flb_aws_error(char *response, size_t response_len);
 
 /*
- * Similar to 'flb_aws_error', except it prints the JSON error type and message
- * to the user in a error log.
+ * Similar to 'flb_aws_error', except it prints the JSON error __type and message
+ * field values to the user in a error log.
  * 'api' is the name of the API that was called; this is used in the error log.
  */
 void flb_aws_print_error(char *response, size_t response_len,
                          char *api, struct flb_output_instance *ins);
+
+/*
+ * Similar to 'flb_aws_error', except it prints the JSON error Code and Message
+ * field values to the user in a error log.
+ * 'api' is the name of the API that was called; this is used in the error log.
+ */
+void flb_aws_print_error_code(char *response, size_t response_len,
+                              char *api);
 
 /* Similar to 'flb_aws_print_error', but for APIs that return XML */
 void flb_aws_print_xml_error(char *response, size_t response_len,

--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -581,11 +581,11 @@ static struct flb_aws_provider *standard_chain_create(struct flb_config
         }
     }
 
-    sub_provider = flb_ecs_provider_create(config, generator);
+    sub_provider = flb_container_provider_create(config, generator);
     if (sub_provider) {
-        /* ECS Provider will fail creation if we are not running in ECS */
+        /* HTTP Provider will fail creation if we are not running in ECS/EKS */
         mk_list_add(&sub_provider->_head, &implementation->sub_providers);
-        flb_debug("[aws_credentials] Initialized ECS Provider in standard chain");
+        flb_debug("[aws_credentials] Initialized HTTP Provider in standard chain");
     }
 
     sub_provider = flb_ec2_provider_create(config, generator);

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -343,6 +343,12 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
         goto error;
     }
 
+    /* Remove port from host header, EKS Pod Identities breaks without this */
+    ret = flb_http_strip_port_from_host(c);
+    if (ret != 0) {
+        flb_warn("[aws_http_client] failed to remove port from Host header");
+    }
+
     /* Increase the maximum HTTP response buffer size to fit large responses from AWS services */
     ret = flb_http_buffer_size(c, FLB_MAX_AWS_RESP_BUFFER_SIZE);
     if (ret != 0) {

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1036,6 +1036,8 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
     char *p;
     char *tmp;
     char *sep;
+    char *v6_start;
+    char *v6_end;
 
     /* Protocol */
     p = strstr(in_url, "://");
@@ -1057,9 +1059,26 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
 
     /* Check for first '/' */
     sep = strchr(p, '/');
-    tmp = strchr(p, ':');
+    v6_start = strchr(p, '[');
+    v6_end = strchr(p, ']');
 
-    /* Validate port separator is found before the first slash */
+    /* 
+     * Validate port separator is found before the first slash,
+     * If IPv6, ensure it is after the ']',
+     * but only if before the first slash
+     */
+    if (v6_start && v6_end) {
+        if (sep && v6_end > sep) {
+            tmp = strchr(p, ':');
+        }
+        else {
+            tmp = strchr(v6_end, ':');
+        }
+    }
+    else {
+        tmp = strchr(p, ':');
+    }
+
     if (sep && tmp) {
         if (tmp > sep) {
             tmp = NULL;

--- a/tests/internal/aws_credentials_http.c
+++ b/tests/internal/aws_credentials_http.c
@@ -12,28 +12,13 @@
 
 #include "flb_tests_internal.h"
 
-#define ACCESS_KEY_HTTP "http_akid"
-#define SECRET_KEY_HTTP "http_skid"
-#define TOKEN_HTTP      "http_token"
+#include "../include/aws_client_mock.h"
+#include "../include/aws_client_mock.c"
 
-#define TOKEN_FILE_ENV_VAR "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"
-#define HTTP_TOKEN_FILE FLB_TESTS_DATA_PATH "/data/aws_credentials/\
-http_token_file.txt"
+#include "aws_credentials_test_internal.h"
 
-#define HTTP_CREDENTIALS_RESPONSE "{\n\
-    \"AccessKeyId\": \"http_akid\",\n\
-    \"Expiration\": \"2025-10-24T23:00:23Z\",\n\
-    \"RoleArn\": \"TASK_ROLE_ARN\",\n\
-    \"SecretAccessKey\": \"http_skid\",\n\
-    \"Token\": \"http_token\"\n\
-}"
+#define HTTP_TOKEN_FILE AWS_TEST_DATA_PATH("http_token_file.txt")
 
-/*
- * Unexpected/invalid HTTP response. The goal of this is not to test anything
- * that might happen in production, but rather to test the error handling
- * code for the providers. This helps ensure all code paths are tested and
- * the error handling code does not introduce memory leaks.
- */
 #define HTTP_RESPONSE_MALFORMED  "{\n\
     \"AccessKeyId\": \"http_akid\",\n\
     \"partially-correct\": \"json\",\n\
@@ -41,525 +26,84 @@ http_token_file.txt"
     \"but incomplete\": \"and not terminated with a closing brace\",\n\
     \"Token\": \"http_token\""
 
+/*
+ * Setup test & Initialize test environment
+ */
+void setup_test(struct flb_aws_client_mock_request_chain *request_chain,
+                struct flb_aws_provider **out_provider, struct flb_config **out_config) {
+    struct flb_aws_provider *provider;
+    struct flb_config *config;
+
+    /* Initialize test environment */
+    config = flb_config_init();
+    TEST_ASSERT(config != NULL);
+
+    flb_aws_client_mock_configure_generator(request_chain);
+
+    /* Init provider */
+    provider = flb_container_provider_create(config, flb_aws_client_get_mock_generator());
+    TEST_ASSERT(provider != NULL);
+
+    *out_config = config;
+    *out_provider = provider;
+}
+
+/* Test clean up */
+void cleanup_test(struct flb_aws_provider *provider, struct flb_config *config) {
+    flb_aws_client_mock_destroy_generator();
+    if (provider != NULL) {
+        ((struct flb_aws_provider_http *) (provider->implementation))->client = NULL;
+        flb_aws_provider_destroy(provider);
+        provider = NULL;
+    }
+    if (config != NULL) {
+        flb_config_exit(config);
+        config = NULL;
+    }
+}
 
 /*
- * Global Variable that allows us to check the number of calls
- * made in each test
+ * Unexpected/invalid HTTP response. The goal of this is not to test anything
+ * that might happen in production, but rather to test the error handling
+ * code for the providers. This helps ensure all code paths are tested and
+ * the error handling code does not introduce memory leaks.
  */
-int g_request_count;
-
-struct flb_http_client *request_happy_case(struct flb_aws_client *aws_client,
-                                           int method, const char *uri)
-{
-    struct flb_http_client *c = NULL;
-
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    TEST_CHECK(strstr(uri, "happy-case") != NULL);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 200;
-    c->resp.payload = HTTP_CREDENTIALS_RESPONSE;
-    c->resp.payload_size = strlen(HTTP_CREDENTIALS_RESPONSE);
-
-    return c;
-}
-
-struct flb_http_client *request_auth_token_case(struct flb_aws_client *aws_client,
-                                                int method, const char *uri,
-                                                struct flb_aws_header *dynamic_headers,
-                                                size_t dynamic_headers_len)
-{
-    struct flb_http_client *c = NULL;
-
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    TEST_CHECK(strstr(uri, "auth-token") != NULL);
-
-    TEST_CHECK(dynamic_headers_len == 1);
-
-    TEST_CHECK(strstr(dynamic_headers[0].key, "Authorization") != NULL);
-
-    TEST_CHECK(strstr(dynamic_headers[0].val, "this-is-a-fake-http-jwt") != NULL);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 200;
-    c->resp.payload = HTTP_CREDENTIALS_RESPONSE;
-    c->resp.payload_size = strlen(HTTP_CREDENTIALS_RESPONSE);
-
-    return c;
-}
-
-/* unexpected output test- see description for HTTP_RESPONSE_MALFORMED */
-struct flb_http_client *request_malformed(struct flb_aws_client *aws_client,
-                                          int method, const char *uri)
-{
-    struct flb_http_client *c = NULL;
-
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    TEST_CHECK(strstr(uri, "malformed") != NULL);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 200;
-    c->resp.payload = HTTP_RESPONSE_MALFORMED;
-    c->resp.payload_size = strlen(HTTP_RESPONSE_MALFORMED);
-
-    return c;
-}
-
-struct flb_http_client *request_error_case(struct flb_aws_client *aws_client,
-                                           int method, const char *uri)
-{
-    struct flb_http_client *c = NULL;
-
-    TEST_CHECK(method == FLB_HTTP_GET);
-
-    TEST_CHECK(strstr(uri, "error-case") != NULL);
-
-    /* create an http client so that we can set the response */
-    c = flb_calloc(1, sizeof(struct flb_http_client));
-    if (!c) {
-        flb_errno();
-        return NULL;
-    }
-    mk_list_init(&c->headers);
-
-    c->resp.status = 400;
-    c->resp.payload = NULL;
-    c->resp.payload_size = 0;
-
-    return c;
-}
-
-/* test/mock version of the flb_aws_client request function */
-struct flb_http_client *test_http_client_request(struct flb_aws_client *aws_client,
-                                                 int method, const char *uri,
-                                                 const char *body, size_t body_len,
-                                                 struct flb_aws_header *dynamic_headers,
-                                                 size_t dynamic_headers_len)
-{
-    g_request_count++;
-    /*
-     * route to the correct test case fn using the uri
-     */
-    if (strstr(uri, "happy-case") != NULL) {
-        return request_happy_case(aws_client, method, uri);
-    } else if (strstr(uri, "auth-token") != NULL) {
-        return request_auth_token_case(aws_client, method, uri,
-                                       dynamic_headers,
-                                       dynamic_headers_len);
-    } else if (strstr(uri, "error-case") != NULL) {
-        return request_error_case(aws_client, method, uri);
-    } else if (strstr(uri, "malformed") != NULL) {
-        return request_malformed(aws_client, method, uri);
-    }
-
-    /* uri should match one of the above conditions */
-    flb_errno();
-    return NULL;
-
-}
-
-/* Test/mock flb_aws_client */
-static struct flb_aws_client_vtable test_vtable = {
-    .request = test_http_client_request,
-};
-
-struct flb_aws_client *test_http_client_create()
-{
-    struct flb_aws_client *client = flb_calloc(1,
-                                                sizeof(struct flb_aws_client));
-    if (!client) {
-        flb_errno();
-        return NULL;
-    }
-    client->client_vtable = &test_vtable;
-    return client;
-}
-
-/* Generator that returns clients with the test vtable */
-static struct flb_aws_client_generator test_generator = {
-    .create = test_http_client_create,
-};
-
-struct flb_aws_client_generator *generator_in_test()
-{
-    return &test_generator;
-}
-
-/* http and container providers */
-static void test_http_provider()
-{
-    struct flb_aws_provider *provider;
-    struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
-    flb_sds_t endpoint;
-    flb_sds_t path;
-
-    g_request_count = 0;
-
-    config = flb_config_init();
-
-    if (config == NULL) {
-        return;
-    }
-
-    endpoint = flb_sds_create("http://127.0.0.1");
-    if (!endpoint) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    path = flb_sds_create("/happy-case");
-    if (!path) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    provider = flb_http_provider_create(config, endpoint, path, NULL,
-                                 generator_in_test());
-
-    if (!provider) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    /* repeated calls to get credentials should return the same set */
-    creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
-
-    flb_aws_credentials_destroy(creds);
-
-    creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
-
-    flb_aws_credentials_destroy(creds);
-
-    /* refresh should return 0 (success) */
-    ret = provider->provider_vtable->refresh(provider);
-    TEST_CHECK(ret == 0);
-
-    /*
-     * Request count should be 2:
-     * - One for the first call to get_credentials (2nd should hit cred cache)
-     * - One for the call to refresh
-     */
-    TEST_CHECK(g_request_count == 2);
-
-    flb_aws_provider_destroy(provider);
-    flb_config_exit(config);
-}
-
-static void test_http_provider_auth_token()
-{
-    struct flb_aws_provider *provider;
-    struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
-    flb_sds_t endpoint;
-    flb_sds_t path;
-    flb_sds_t auth_token;
-
-    g_request_count = 0;
-
-    config = flb_config_init();
-
-    if (config == NULL) {
-        return;
-    }
-
-    endpoint = flb_sds_create("http://127.0.0.1");
-    if (!endpoint) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    path = flb_sds_create("/auth-token");
-    if (!path) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    auth_token = flb_sds_create("this-is-a-fake-http-jwt");
-    if (!auth_token) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    provider = flb_http_provider_create(config, endpoint, path, auth_token,
-                                 generator_in_test());
-
-    if (!provider) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    /* repeated calls to get credentials should return the same set */
-    creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
-
-    flb_aws_credentials_destroy(creds);
-
-    creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
-
-    flb_aws_credentials_destroy(creds);
-
-    /* refresh should return 0 (success) */
-    ret = provider->provider_vtable->refresh(provider);
-    TEST_CHECK(ret == 0);
-
-    /*
-     * Request count should be 2:
-     * - One for the first call to get_credentials (2nd should hit cred cache)
-     * - One for the call to refresh
-     */
-    TEST_CHECK(g_request_count == 2);
-
-    flb_aws_provider_destroy(provider);
-    flb_config_exit(config);
-}
-
-static void test_local_http_provider()
-{
-    struct flb_aws_provider *provider;
-    struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
-    flb_sds_t endpoint;
-    flb_sds_t auth_token;
-
-    g_request_count = 0;
-
-    config = flb_config_init();
-
-    if (config == NULL) {
-        return;
-    }
-
-    endpoint = flb_sds_create("http://127.0.0.1/auth-token");
-    if (!endpoint) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    /* tests that the token file takes precedence */
-    auth_token = flb_sds_create("this-is-the-wrong-jwt");
-    if (!auth_token) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    setenv(TOKEN_FILE_ENV_VAR, HTTP_TOKEN_FILE, 1);
-
-    provider = flb_local_http_provider_create(config, endpoint, auth_token,
-                                 generator_in_test());
-
-    if (!provider) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    /* repeated calls to get credentials should return the same set */
-    creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
-
-    flb_aws_credentials_destroy(creds);
-
-    creds = provider->provider_vtable->get_credentials(provider);
-    if (!creds) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    TEST_CHECK(strcmp(ACCESS_KEY_HTTP, creds->access_key_id) == 0);
-    TEST_CHECK(strcmp(SECRET_KEY_HTTP, creds->secret_access_key) == 0);
-    TEST_CHECK(strcmp(TOKEN_HTTP, creds->session_token) == 0);
-
-    flb_aws_credentials_destroy(creds);
-
-    /* refresh should return 0 (success) */
-    ret = provider->provider_vtable->refresh(provider);
-    TEST_CHECK(ret == 0);
-
-    /*
-     * Request count should be 2:
-     * - One for the first call to get_credentials (2nd should hit cred cache)
-     * - One for the call to refresh
-     */
-    TEST_CHECK(g_request_count == 2);
-
-    unsetenv(TOKEN_FILE_ENV_VAR);
-    flb_aws_provider_destroy(provider);
-    flb_config_exit(config);
-}
-
-static void test_http_provider_error_case()
-{
-    struct flb_aws_provider *provider;
-    struct flb_aws_credentials *creds;
-    int ret;
-    struct flb_config *config;
-    flb_sds_t endpoint;
-    flb_sds_t path;
-
-    g_request_count = 0;
-
-    config = flb_config_init();
-
-    if (config == NULL) {
-        return;
-    }
-
-    endpoint = flb_sds_create("http://127.0.0.1");
-    if (!endpoint) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    path = flb_sds_create("/error-case");
-    if (!path) {
-        flb_errno();
-        flb_config_exit(config);
-        return;    if (path) {
-        flb_sds_destroy(path);
-    }
-    }
-
-    provider = flb_http_provider_create(config, endpoint, path, NULL,
-                                        generator_in_test());
-
-    if (!provider) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    /* get_credentials will fail */
-    creds = provider->provider_vtable->get_credentials(provider);
-    TEST_CHECK(creds == NULL);
-
-    creds = provider->provider_vtable->get_credentials(provider);
-    TEST_CHECK(creds == NULL);
-
-    /* refresh should return -1 (failure) */
-    ret = provider->provider_vtable->refresh(provider);
-    TEST_CHECK(ret < 0);
-
-    /*
-     * Request count should be 3:
-     * - Each call to get_credentials and refresh invokes the client's
-     * request method and returns a request failure.
-     */
-    TEST_CHECK(g_request_count == 3);
-
-    flb_aws_provider_destroy(provider);
-    flb_config_exit(config);
-}
-
 static void test_http_provider_malformed_response()
 {
     struct flb_aws_provider *provider;
     struct flb_aws_credentials *creds;
-    int ret;
     struct flb_config *config;
-    flb_sds_t endpoint;
-    flb_sds_t path;
+    int ret;
 
-    g_request_count = 0;
+    setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/iam_credentials/pod1", 1);
 
-    config = flb_config_init();
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, HTTP_RESPONSE_MALFORMED),
+            set(PAYLOAD_SIZE, strlen(HTTP_RESPONSE_MALFORMED))
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, HTTP_RESPONSE_MALFORMED),
+            set(PAYLOAD_SIZE, strlen(HTTP_RESPONSE_MALFORMED))
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, HTTP_RESPONSE_MALFORMED),
+            set(PAYLOAD_SIZE, strlen(HTTP_RESPONSE_MALFORMED))
+        )
+    ), &provider, &config);
 
-    if (config == NULL) {
-        return;
-    }
-
-    mk_list_init(&config->upstreams);
-
-    endpoint = flb_sds_create("http://127.0.0.1");
-    if (!endpoint) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-    path = flb_sds_create("/malformed");
-    if (!path) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
-
-    provider = flb_http_provider_create(config, endpoint, path, NULL,
-                                 generator_in_test());
-
-    if (!provider) {
-        flb_errno();
-        flb_config_exit(config);
-        return;
-    }
+    flb_time_msleep(1000);
 
     /* get_credentials will fail */
     creds = provider->provider_vtable->get_credentials(provider);
@@ -577,18 +121,430 @@ static void test_http_provider_malformed_response()
      * - Each call to get_credentials and refresh invokes the client's
      * request method and returns a request failure.
      */
-    TEST_CHECK(g_request_count == 3);
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
 
-    flb_aws_provider_destroy(provider);
-    flb_config_exit(config);
+    cleanup_test(provider, config);
+}
+
+static void test_http_provider_ecs_case()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    struct flb_config *config;
+    int ret;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/iam_credentials/pod1", 1);
+
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER_COUNT, 0),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"), // Expires Year 3021
+            set(PAYLOAD_SIZE, 257)
+        )
+    ), &provider, &config);
+
+    flb_time_msleep(1000);
+
+    /* Repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /* Retrieve refreshed credentials from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test(provider, config);
+}
+
+static void test_http_provider_eks_with_token()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    struct flb_config *config;
+    int ret;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "password", 1);
+
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "password"),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "password"),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        )
+    ), &provider, &config);
+
+    flb_time_msleep(1000);
+
+    /* Repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /* Retrieve refreshed credentials from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test(provider, config);
+}
+
+static void test_http_provider_eks_with_token_file()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    struct flb_config *config;
+    int ret;
+
+    /* 
+     * tests validation of valid non-default local loopback IP
+     * tests token file takes precedence over token variable
+     */
+    setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://127.0.0.7:80/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "password", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", HTTP_TOKEN_FILE, 1);
+
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "this-is-a-fake-http-jwt"),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "this-is-a-fake-http-jwt"),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        )
+    ), &provider, &config);
+
+    flb_time_msleep(1000);
+
+    /* Repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /* Retrieve refreshed credentials from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test(provider, config);
+}
+
+static void test_http_provider_https_endpoint()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    struct flb_config *config;
+    int ret;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "https://customers-vpc-credential-vending-server/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", HTTP_TOKEN_FILE, 1);
+
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "this-is-a-fake-http-jwt"),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"XACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"XSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"XTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "this-is-a-fake-http-jwt"),
+            set(STATUS, 200),
+            set(PAYLOAD, "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-16T18:29:09Z\",\n"
+                "  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"YACCESSEKSXXX\",\n  \"SecretAccessKey\""
+                " : \"YSECRETEKSXXXXXXXXXXXXXX\",\n  \"Token\" : \"YTOKENEKSXXXXXXXXXXXXXXX==\",\n"
+                "  \"Expiration\" : \"3021-09-17T00:41:00Z\"\n}"),
+            set(PAYLOAD_SIZE, 257)
+        )
+    ), &provider, &config);
+
+    flb_time_msleep(1000);
+
+    /* Repeated calls to get credentials should return the same set */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Retrieve from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("XACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("XSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("XTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret == 0);
+
+    /* Retrieve refreshed credentials from cache */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds != NULL);
+    TEST_CHECK(strcmp("YACCESSEKSXXX", creds->access_key_id) == 0);
+    TEST_CHECK(strcmp("YSECRETEKSXXXXXXXXXXXXXX", creds->secret_access_key) == 0);
+    TEST_CHECK(strcmp("YTOKENEKSXXXXXXXXXXXXXXX==", creds->session_token) == 0);
+
+    flb_aws_credentials_destroy(creds);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test(provider, config);
+}
+
+static void test_http_provider_server_failure()
+{
+    struct flb_aws_provider *provider;
+    struct flb_aws_credentials *creds;
+    struct flb_config *config;
+    int ret;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "https://customers-vpc-credential-vending-server/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", HTTP_TOKEN_FILE, 1);
+
+    setup_test(FLB_AWS_CLIENT_MOCK(
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "this-is-a-fake-http-jwt"),
+            set(STATUS, 400),
+            set(PAYLOAD, "{\"Message\": \"Invalid Authorization token\",\"Code\": \"ClientError\"}"),
+            set(PAYLOAD_SIZE, 64)
+        ),
+        response(
+            expect(URI, "/iam_credentials/pod1"),
+            expect(METHOD, FLB_HTTP_GET),
+            expect(HEADER, "Authorization", "this-is-a-fake-http-jwt"),
+            set(STATUS, 500),
+            set(PAYLOAD, "{\"Message\": \"Internal Server Error\",\"Code\": \"ServerError\"}"),
+            set(PAYLOAD_SIZE, 58)
+        )
+    ), &provider, &config);
+
+    flb_time_msleep(1000);
+
+    /* Endpoint failure, no creds returnd */
+    creds = provider->provider_vtable->get_credentials(provider);
+    TEST_ASSERT(creds == NULL);
+
+    /* refresh should return 0 (success) */
+    ret = provider->provider_vtable->refresh(provider);
+    TEST_CHECK(ret != 0);
+
+    /* Check we have exhausted our response list */
+    TEST_CHECK(flb_aws_client_mock_generator_count_unused_requests() == 0);
+
+    cleanup_test(provider, config);
+}
+
+static void test_http_validator_invalid_auth_token()
+{
+    struct flb_aws_provider *provider;
+    struct flb_config *config;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.70.2:80/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "password\\r\\n", 1);
+
+    flb_aws_client_mock_configure_generator(NULL);
+
+    config = flb_calloc(1, sizeof(struct flb_config));
+    TEST_ASSERT(config != NULL);
+    mk_list_init(&config->upstreams);
+
+    /* provider creation will fail with error message indicating port was invalid */
+    provider = flb_container_provider_create(config, flb_aws_client_get_mock_generator());
+    TEST_ASSERT(provider == NULL);
+
+    flb_aws_client_mock_destroy_generator();
+    flb_free(config);
+}
+
+static void test_http_validator_invalid_host()
+{
+    struct flb_aws_provider *provider;
+    struct flb_config *config;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://104.156.107.142:80/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "password", 1);
+
+    flb_aws_client_mock_configure_generator(NULL);
+
+    config = flb_calloc(1, sizeof(struct flb_config));
+    TEST_ASSERT(config != NULL);
+    mk_list_init(&config->upstreams);
+
+    /* provider creation will fail with error message indicating host was invalid */
+    provider = flb_container_provider_create(config, flb_aws_client_get_mock_generator());
+    TEST_ASSERT(provider == NULL);
+
+    flb_aws_client_mock_destroy_generator();
+    flb_free(config);
+}
+
+static void test_http_validator_invalid_port()
+{
+    struct flb_aws_provider *provider;
+    struct flb_config *config;
+
+    setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.70.2:AA/iam_credentials/pod1", 1);
+    setenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", "password", 1);
+
+    flb_aws_client_mock_configure_generator(NULL);
+
+    config = flb_calloc(1, sizeof(struct flb_config));
+    TEST_ASSERT(config != NULL);
+    mk_list_init(&config->upstreams);
+
+    /* provider creation will fail with error message indicating port was invalid */
+    provider = flb_container_provider_create(config, flb_aws_client_get_mock_generator());
+    TEST_ASSERT(provider == NULL);
+
+    flb_aws_client_mock_destroy_generator();
+    flb_free(config);
 }
 
 TEST_LIST = {
-    { "test_http_provider" , test_http_provider},
-    { "test_http_provider_auth_token" , test_http_provider_auth_token},
-    { "test_local_http_provider" , test_local_http_provider},
-    { "test_http_provider_error_case" , test_http_provider_error_case},
-    { "test_http_provider_malformed_response" ,
-    test_http_provider_malformed_response},
+    { "test_http_provider_malformed_response" , test_http_provider_malformed_response},
+    { "test_http_provider_ecs_case" , test_http_provider_ecs_case},
+    { "test_http_provider_eks_with_token" , test_http_provider_eks_with_token},
+    { "test_http_provider_eks_with_token_file" , test_http_provider_eks_with_token_file},
+    { "test_http_provider_https_endpoint" , test_http_provider_https_endpoint},
+    { "test_http_provider_server_failure" , test_http_provider_server_failure},
+    { "test_http_validator_invalid_auth_token" , test_http_validator_invalid_auth_token},
+    { "test_http_validator_invalid_host" , test_http_validator_invalid_host},
+    { "test_http_validator_invalid_port" , test_http_validator_invalid_port},
     { 0 }
 };

--- a/tests/internal/data/aws_credentials/http_token_file.txt
+++ b/tests/internal/data/aws_credentials/http_token_file.txt
@@ -1,0 +1,1 @@
+this-is-a-fake-http-jwt

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -35,6 +35,10 @@ struct url_check url_checks[] = {
     {0, "https://fluentbit.io:1234", "https", "fluentbit.io", "1234", "/"},
     {0, "https://fluentbit.io:1234/", "https", "fluentbit.io", "1234", "/"},
     {0, "https://fluentbit.io:1234/v", "https", "fluentbit.io", "1234", "/v"},
+    {0, "http://[fd00:ec2::23]", "http", "fd00:ec2::23", "80", "/"},
+    {0, "http://[fd00:ec2::23]:81", "http", "fd00:ec2::23", "81", "/"},
+    {0, "http://[fd00:ec2::23]:81/something", "http", "fd00:ec2::23", "81", "/something"},
+    {0, "http://[fd00:ec2::23]/something", "http", "fd00:ec2::23", "80", "/something"},
     {-1, "://", NULL, NULL, NULL, NULL},
 };
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR initially includes two commits, as I had to patch `flb_utils` for IPv6 clusters to work.

This patch rewrites how the HTTP credentials provider works to allow both ECS and EKS identities to work. It is based on the aws-sdk-go-v2 implementation.

It validates that the endpoint is correct if the transport is HTTP, but does not support DNS resolution, however based on how the pod identity agent works today, DNS should not be needed. If the transport is HTTPS, which will not be the case when using EKS Pod Identities today, any endpoint is allowed. This is in line with how the AWS SDK works.

Similarly to the SDK, it also reads the authentication token environment variables, with the file taking precedence over the raw token variable.

This has been tested against an EKS 1.30 cluster with AL2023 nodes, but it would be great if someone else could test this too rather than just taking my word for it :smile:. I did test with an ECS cluster as well to ensure that did not break as a result of this change, but I don't generally use ECS, so if someone else could validate this that would be great.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8550

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change - installed on EKS with the fluent-bit helm chart with an image override, with an S3 destination, with no annotation on the service account, a pod identity configured, and the node role not having permission to use S3 (I don't think I set the IMDS hop limit to 1 in my testing)
- [x] Debug log output from testing the change
```
[2024/06/26 12:50:33] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2024/06/26 12:50:33] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2024/06/26 12:50:33] [debug] [aws_credentials] creating profile (null) provider
[2024/06/26 12:50:33] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2024/06/26 12:50:33] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2024/06/26 12:50:33] [debug] [aws_credentials] Configuring HTTP provider with http://[fd00:ec2::23]/v1/credentials
[2024/06/26 12:50:33] [debug] [aws_credentials] Initialized HTTP Provider in standard chain
[2024/06/26 12:50:33] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2024/06/26 12:50:33] [debug] [aws_credentials] Sync called on the http provider
[2024/06/26 12:50:33] [debug] [aws_credentials] Sync called on the EC2 provider
[2024/06/26 12:50:33] [debug] [aws_credentials] Init called on the env provider
[2024/06/26 12:50:33] [debug] [aws_credentials] Init called on the profile provider
[2024/06/26 12:50:33] [debug] [aws_credentials] Reading shared config file.
[2024/06/26 12:50:33] [debug] [aws_credentials] Shared config file /root/.aws/config does not exist
[2024/06/26 12:50:33] [debug] [aws_credentials] Reading shared credentials file.
[2024/06/26 12:50:33] [debug] [aws_credentials] Shared credentials file /root/.aws/credentials does not exist
[2024/06/26 12:50:33] [debug] [aws_credentials] Init called on the http provider
[2024/06/26 12:50:33] [debug] [aws_credentials] loading auth token file
[2024/06/26 12:50:33] [debug] [http_client] not using http_proxy for header
[2024/06/26 12:50:34] [debug] [aws_credentials] upstream_set called on the http provider
[2024/06/26 12:50:34] [debug] [aws_credentials] upstream_set called on the EC2 provider
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
Not sure how I'd test this in-cluster, but the tests for the credential provider should be evidence enough. If more test cases are needed I'm happy to write them
```
valgrind --leak-check=full ./bin/flb-it-aws_credentials_http
==726645== Memcheck, a memory error detector
==726645== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==726645== Using Valgrind-3.23.0 and LibVEX; rerun with -h for copyright info
==726645== Command: ./bin/flb-it-aws_credentials_http
==726645== 
Test test_http_provider...                      [2024/06/26 22:52:50] [ warn] [aws_credentials] Credential expiration '2025-10-24T23:00:23Z' is greater than 12 hours in the future. This should not be possible.
[2024/06/26 22:52:50] [ warn] [aws_credentials] Credential expiration '2025-10-24T23:00:23Z' is greater than 12 hours in the future. This should not be possible.
==726645== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==726645== Warning: invalid file descriptor -1 in syscall close()
Test test_http_provider_auth_token...           [2024/06/26 22:52:50] [ warn] [aws_credentials] Credential expiration '2025-10-24T23:00:23Z' is greater than 12 hours in the future. This should not be possible.
[2024/06/26 22:52:50] [ warn] [aws_credentials] Credential expiration '2025-10-24T23:00:23Z' is greater than 12 hours in the future. This should not be possible.
==726645== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==726645== Warning: invalid file descriptor -1 in syscall close()
Test test_local_http_provider...                [2024/06/26 22:52:50] [ warn] [aws_credentials] Credential expiration '2025-10-24T23:00:23Z' is greater than 12 hours in the future. This should not be possible.
[2024/06/26 22:52:50] [ warn] [aws_credentials] Credential expiration '2025-10-24T23:00:23Z' is greater than 12 hours in the future. This should not be possible.
==726645== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==726645== Warning: invalid file descriptor -1 in syscall close()
Test test_http_provider_error_case...           [2024/06/26 22:52:50] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2024/06/26 22:52:50] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
==726645== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==726645== Warning: invalid file descriptor -1 in syscall close()
Test test_http_provider_malformed_response...   [2024/06/26 22:52:51] [error] [aws_credentials] Could not parse credentials response - invalid JSON.
[2024/06/26 22:52:51] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2024/06/26 22:52:51] [error] [aws_credentials] Could not parse credentials response - invalid JSON.
[2024/06/26 22:52:51] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
[2024/06/26 22:52:51] [error] [aws_credentials] Could not parse credentials response - invalid JSON.
==726645== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==726645== Warning: invalid file descriptor -1 in syscall close()
SUCCESS: All unit tests have passed.
==726645== 
==726645== HEAP SUMMARY:
==726645==     in use at exit: 0 bytes in 0 blocks
==726645==   total heap usage: 8,637 allocs, 8,637 frees, 895,672 bytes allocated
==726645== 
==726645== All heap blocks were freed -- no leaks are possible
==726645== 
==726645== For lists of detected and suppressed errors, rerun with: -s
==726645== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/1400

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.
I'm fine with this being in a minor release instead of a patch, given the testing it should receive

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
