### PR TITLE
out_gelf: test: Implement injecting tag capability

### DIFF
--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_random.h>
 #include <fluent-bit/flb_config_map.h>
 #include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_msgpack_append_message.h>
 #include <msgpack.h>
 
 #include <stdio.h>
@@ -228,6 +229,51 @@ static int gelf_send_udp(struct flb_out_gelf_config *ctx, char *msg,
     return 0;
 }
 
+static int inject_tag(msgpack_object *map,
+                      struct flb_event_chunk *event_chunk,
+                      struct flb_out_gelf_config *ctx,
+                      char** out_buf, int* out_size)
+{
+    int i;
+    int len;
+    size_t map_num;
+    char *ret_buf;
+    msgpack_sbuffer sbuf;
+    msgpack_packer  pck;
+
+    len = map->via.map.size;
+    map_num = 1 + len;
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&pck, map_num);
+
+    for (i = 0; i < len; i++) {
+        msgpack_pack_object(&pck, map->via.map.ptr[i].key);
+        msgpack_pack_object(&pck, map->via.map.ptr[i].val);
+    }
+
+    for (i = 0; i < 1; i++){
+        msgpack_pack_str(&pck, strlen(ctx->tag_key));
+        msgpack_pack_str_body(&pck, ctx->tag_key, strlen(ctx->tag_key));
+        msgpack_pack_str(&pck, flb_sds_len(event_chunk->tag));
+        msgpack_pack_str_body(&pck, event_chunk->tag, flb_sds_len(event_chunk->tag));
+    }
+
+    *out_size = sbuf.size;
+    ret_buf  = flb_malloc(sbuf.size);
+    *out_buf = ret_buf;
+    if (*out_buf == NULL) {
+        flb_errno();
+        msgpack_sbuffer_destroy(&sbuf);
+        return -1;
+    }
+    memcpy(*out_buf, sbuf.data, sbuf.size);
+    msgpack_sbuffer_destroy(&sbuf);
+
+    return 0;
+}
+
 static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
                           struct flb_output_flush *out_flush,
                           struct flb_input_instance *i_ins,
@@ -246,6 +292,8 @@ static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
     struct flb_out_gelf_config *ctx = out_context;
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
+    char *tag_injected_map;
+    int injected_size;
 
     if (ctx->mode != FLB_GELF_UDP) {
         u_conn = flb_upstream_conn_get(ctx->u);
@@ -279,15 +327,29 @@ static void cb_gelf_flush(struct flb_event_chunk *event_chunk,
 
         map = *log_event.body;
 
-        size = (size * 1.4);
-        s = flb_sds_create_size(size);
-        if (s == NULL) {
-            flb_log_event_decoder_destroy(&log_decoder);
-            FLB_OUTPUT_RETURN(FLB_ERROR);
-        }
+        if (ctx->tag_key) {
+            ret = inject_tag(&map, event_chunk, ctx, &tag_injected_map, &injected_size);
 
-        tmp = flb_msgpack_to_gelf(&s, &map, &log_event.timestamp,
-                                  &(ctx->fields));
+            if (ret != 0) {
+                flb_log_event_decoder_destroy(&log_decoder);
+                FLB_OUTPUT_RETURN(FLB_ERROR);
+            }
+
+            tmp = flb_msgpack_raw_to_gelf(tag_injected_map, injected_size, &log_event.timestamp,
+                                          &(ctx->fields));
+            flb_free(tag_injected_map);
+        }
+        else {
+            size = (size * 1.4);
+            s = flb_sds_create_size(size);
+            if (s == NULL) {
+                flb_log_event_decoder_destroy(&log_decoder);
+                FLB_OUTPUT_RETURN(FLB_ERROR);
+            }
+
+            tmp = flb_msgpack_to_gelf(&s, &map, &log_event.timestamp,
+                                      &(ctx->fields));
+        }
         if (tmp != NULL) {
             s = tmp;
             if (ctx->mode == FLB_GELF_UDP) {
@@ -497,6 +559,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "mode", "udp",
      0, FLB_FALSE, 0,
      "The protocol to use. 'tls', 'tcp' or 'udp'"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "gelf_tag_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_gelf_config, tag_key),
+     "Tag key name (Optional in GELF)"
     },
     {
      FLB_CONFIG_MAP_STR, "gelf_short_message_key", NULL,

--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -27,7 +27,6 @@
 #include <fluent-bit/flb_random.h>
 #include <fluent-bit/flb_config_map.h>
 #include <fluent-bit/flb_log_event_decoder.h>
-#include <fluent-bit/flb_msgpack_append_message.h>
 #include <msgpack.h>
 
 #include <stdio.h>

--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -237,7 +237,6 @@ static int inject_tag(msgpack_object *map,
     int i;
     int len;
     size_t map_num;
-    char *ret_buf;
     msgpack_sbuffer sbuf;
     msgpack_packer  pck;
 
@@ -260,16 +259,8 @@ static int inject_tag(msgpack_object *map,
         msgpack_pack_str_body(&pck, event_chunk->tag, flb_sds_len(event_chunk->tag));
     }
 
+    *out_buf = sbuf.data;
     *out_size = sbuf.size;
-    ret_buf  = flb_malloc(sbuf.size);
-    *out_buf = ret_buf;
-    if (*out_buf == NULL) {
-        flb_errno();
-        msgpack_sbuffer_destroy(&sbuf);
-        return -1;
-    }
-    memcpy(*out_buf, sbuf.data, sbuf.size);
-    msgpack_sbuffer_destroy(&sbuf);
 
     return 0;
 }

--- a/plugins/out_gelf/gelf.c
+++ b/plugins/out_gelf/gelf.c
@@ -252,12 +252,10 @@ static int inject_tag(msgpack_object *map,
         msgpack_pack_object(&pck, map->via.map.ptr[i].val);
     }
 
-    for (i = 0; i < 1; i++){
-        msgpack_pack_str(&pck, strlen(ctx->tag_key));
-        msgpack_pack_str_body(&pck, ctx->tag_key, strlen(ctx->tag_key));
-        msgpack_pack_str(&pck, flb_sds_len(event_chunk->tag));
-        msgpack_pack_str_body(&pck, event_chunk->tag, flb_sds_len(event_chunk->tag));
-    }
+    msgpack_pack_str(&pck, strlen(ctx->tag_key));
+    msgpack_pack_str_body(&pck, ctx->tag_key, strlen(ctx->tag_key));
+    msgpack_pack_str(&pck, flb_sds_len(event_chunk->tag));
+    msgpack_pack_str_body(&pck, event_chunk->tag, flb_sds_len(event_chunk->tag));
 
     *out_buf = sbuf.data;
     *out_size = sbuf.size;

--- a/plugins/out_gelf/gelf.h
+++ b/plugins/out_gelf/gelf.h
@@ -38,6 +38,7 @@ struct flb_out_gelf_config {
     char *pckt_buf;
     int compress;
     unsigned int seed;
+    flb_sds_t tag_key;
 
     int mode;
 

--- a/tests/internal/gelf.c
+++ b/tests/internal/gelf.c
@@ -94,8 +94,60 @@ void test_gelf_pack_msec()
     msgpack_sbuffer_destroy(&mp_sbuf);
 }
 
+
+#define EXPECTED_OUT_TAG \
+    "{\"version\":\"1.1\", \"short_message\":\"true, 2019, str\", \"_t2\":\"false\", "\
+    "\"_tag\":\"test.gelf.fluent-bit\", \"timestamp\":337647600.012}"
+
+/* https://github.com/fluent/fluent-bit/issues/8921 */
+void test_gelf_pack_tag_key()
+{
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+    struct flb_time ts;
+    struct flb_gelf_fields fields = {0};
+    flb_sds_t out;
+
+    /* Pack sample msgpack */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+
+    ts.tm.tv_sec =  337647600;
+    ts.tm.tv_nsec =  12341111; /* 12.34msec */
+
+    msgpack_pack_map(&mp_pck, 3);
+    msgpack_pack_str(&mp_pck, 2);
+    msgpack_pack_str_body(&mp_pck, "t1", 2);
+    msgpack_pack_array(&mp_pck, 3);
+    msgpack_pack_true(&mp_pck);
+    msgpack_pack_uint64(&mp_pck, 2019);
+    msgpack_pack_str(&mp_pck, 3);
+    msgpack_pack_str_body(&mp_pck, "str", 3);
+    msgpack_pack_str(&mp_pck, 2);
+    msgpack_pack_str_body(&mp_pck, "t2", 2);
+    msgpack_pack_false(&mp_pck);
+    msgpack_pack_str(&mp_pck, 3);
+    msgpack_pack_str_body(&mp_pck, "tag", 3);
+    msgpack_pack_str(&mp_pck, 20);
+    msgpack_pack_str_body(&mp_pck, "test.gelf.fluent-bit", 20);
+
+    fields.short_message_key = flb_sds_create("t1");
+    /* tag is automatically interpreted by predefined fields.tag_key in config_map.*/
+    out = flb_msgpack_raw_to_gelf(mp_sbuf.data, mp_sbuf.size, &ts, &fields);
+    TEST_CHECK(out != NULL);
+
+    if(!TEST_CHECK(strcmp(out, EXPECTED_OUT_TAG) == 0)) {
+        TEST_MSG("out=%s", out);
+    }
+    flb_sds_destroy(out);
+    flb_sds_destroy(fields.short_message_key);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
 TEST_LIST = {
     {"gelf_pack",      test_gelf_pack},
     {"gelf_pack_msec", test_gelf_pack_msec},
+    {"self_pack_tag",  test_gelf_pack_tag_key},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
To align the behavior of Fluentd side of gelf plugin, we need to implement a capability to inject tag information to gelf records if available.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes https://github.com/fluent/fluent-bit/issues/8921

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

### Without Tag

```console
$ bin/fluent-bit -i dummy -pdummy='{"message":"dummy","send":"from fluent-bit"}' -o gelf -p port=12202 -pgelf_short_message_key=message -v
```
### With Tag

```
$ bin/fluent-bit -i dummy -pdummy='{"message":"dummy","send":"from fluent-bit"}' -o gelf -p port=12202 -pgelf_short_message_key=message -pgelf_tag_key=tag -v
```

- [x] Debug log output from testing the change

### Without Tag

```log
Fluent Bit v3.1.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/07/03 18:23:40] [ info] Configuration:
[2024/07/03 18:23:40] [ info]  flush time     | 1.000000 seconds
[2024/07/03 18:23:40] [ info]  grace          | 5 seconds
[2024/07/03 18:23:40] [ info]  daemon         | 0
[2024/07/03 18:23:40] [ info] ___________
[2024/07/03 18:23:40] [ info]  inputs:
[2024/07/03 18:23:40] [ info]      dummy
[2024/07/03 18:23:40] [ info] ___________
[2024/07/03 18:23:40] [ info]  filters:
[2024/07/03 18:23:40] [ info] ___________
[2024/07/03 18:23:40] [ info]  outputs:
[2024/07/03 18:23:40] [ info]      gelf.0
[2024/07/03 18:23:40] [ info] ___________
[2024/07/03 18:23:40] [ info]  collectors:
[2024/07/03 18:23:40] [ info] [fluent bit] version=3.1.0, commit=060418c51b, pid=2526257
[2024/07/03 18:23:40] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/07/03 18:23:40] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/07/03 18:23:40] [ info] [cmetrics] version=0.9.1
[2024/07/03 18:23:40] [ info] [ctraces ] version=0.5.1
[2024/07/03 18:23:40] [ info] [input:dummy:dummy.0] initializing
[2024/07/03 18:23:40] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/07/03 18:23:40] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/07/03 18:23:40] [debug] [gelf:gelf.0] created event channels: read=23 write=24
[2024/07/03 18:23:40] [ info] [sp] stream processor started
[2024/07/03 18:23:42] [debug] [task] created task=0x5f05920 id=0 OK
[2024/07/03 18:23:42] [debug] [out flush] cb_destroy coro_id=0
[2024/07/03 18:23:42] [debug] [task] destroy task=0x5f05920 (task_id=0)
[2024/07/03 18:23:43] [debug] [task] created task=0x5fa8b00 id=0 OK
[2024/07/03 18:23:43] [debug] [out flush] cb_destroy coro_id=1
[2024/07/03 18:23:43] [debug] [task] destroy task=0x5fa8b00 (task_id=0)
[2024/07/03 18:23:44] [debug] [task] created task=0x604bc60 id=0 OK
[2024/07/03 18:23:44] [debug] [out flush] cb_destroy coro_id=2
[2024/07/03 18:23:44] [debug] [task] destroy task=0x604bc60 (task_id=0)
[2024/07/03 18:23:45] [debug] [task] created task=0x60f0e00 id=0 OK
[2024/07/03 18:23:45] [debug] [out flush] cb_destroy coro_id=3
[2024/07/03 18:23:45] [debug] [task] destroy task=0x60f0e00 (task_id=0)
[2024/07/03 18:23:46] [debug] [task] created task=0x6193f60 id=0 OK
[2024/07/03 18:23:46] [debug] [out flush] cb_destroy coro_id=4
[2024/07/03 18:23:46] [debug] [task] destroy task=0x6193f60 (task_id=0)
[2024/07/03 18:23:47] [debug] [task] created task=0x61e9100 id=0 OK
[2024/07/03 18:23:47] [debug] [out flush] cb_destroy coro_id=5
[2024/07/03 18:23:47] [debug] [task] destroy task=0x61e9100 (task_id=0)
[2024/07/03 18:23:48] [debug] [task] created task=0x61f7bd0 id=0 OK
[2024/07/03 18:23:48] [debug] [out flush] cb_destroy coro_id=6
[2024/07/03 18:23:48] [debug] [task] destroy task=0x61f7bd0 (task_id=0)
^C[2024/07/03 18:23:48] [engine] caught signal (SIGINT)
[2024/07/03 18:23:48] [debug] [task] created task=0x620ac10 id=0 OK
[2024/07/03 18:23:48] [ warn] [engine] service will shutdown in max 5 seconds
[2024/07/03 18:23:48] [ info] [input] pausing dummy.0
[2024/07/03 18:23:48] [debug] [out flush] cb_destroy coro_id=7
[2024/07/03 18:23:48] [debug] [task] destroy task=0x620ac10 (task_id=0)
[2024/07/03 18:23:49] [ info] [engine] service has stopped (0 pending tasks)
[2024/07/03 18:23:49] [ info] [input] pausing dummy.0
```


![Screenshot 2024-07-03 at 18-29-01 Graylog - Message f41a64e0-391d-11ef-92f1-0242ac140009 on graylog_0](https://github.com/fluent/fluent-bit/assets/700876/98d32d91-51bd-4340-ac97-43c1bd639988)

### With Tag

```log
Fluent Bit v3.1.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

___________.__                        __    __________.__  __          ________  
\_   _____/|  |  __ __   ____   _____/  |_  \______   \__|/  |_  ___  _\_____  \ 
 |    __)  |  | |  |  \_/ __ \ /    \   __\  |    |  _/  \   __\ \  \/ / _(__  < 
 |     \   |  |_|  |  /\  ___/|   |  \  |    |    |   \  ||  |    \   / /       \
 \___  /   |____/____/  \___  >___|  /__|    |______  /__||__|     \_/ /______  /
     \/                     \/     \/               \/                        \/ 

[2024/07/03 18:25:55] [ info] Configuration:
[2024/07/03 18:25:55] [ info]  flush time     | 1.000000 seconds
[2024/07/03 18:25:55] [ info]  grace          | 5 seconds
[2024/07/03 18:25:55] [ info]  daemon         | 0
[2024/07/03 18:25:55] [ info] ___________
[2024/07/03 18:25:55] [ info]  inputs:
[2024/07/03 18:25:55] [ info]      dummy
[2024/07/03 18:25:55] [ info] ___________
[2024/07/03 18:25:55] [ info]  filters:
[2024/07/03 18:25:55] [ info] ___________
[2024/07/03 18:25:55] [ info]  outputs:
[2024/07/03 18:25:55] [ info]      gelf.0
[2024/07/03 18:25:55] [ info] ___________
[2024/07/03 18:25:55] [ info]  collectors:
[2024/07/03 18:25:55] [ info] [fluent bit] version=3.1.0, commit=060418c51b, pid=2528848
[2024/07/03 18:25:55] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/07/03 18:25:55] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/07/03 18:25:55] [ info] [cmetrics] version=0.9.1
[2024/07/03 18:25:55] [ info] [ctraces ] version=0.5.1
[2024/07/03 18:25:55] [ info] [input:dummy:dummy.0] initializing
[2024/07/03 18:25:55] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/07/03 18:25:55] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/07/03 18:25:55] [debug] [gelf:gelf.0] created event channels: read=23 write=24
[2024/07/03 18:25:55] [ info] [sp] stream processor started
[2024/07/03 18:25:57] [debug] [task] created task=0x5f05f10 id=0 OK
[2024/07/03 18:25:57] [debug] [out flush] cb_destroy coro_id=0
[2024/07/03 18:25:57] [debug] [task] destroy task=0x5f05f10 (task_id=0)
[2024/07/03 18:25:58] [debug] [task] created task=0x5fad530 id=0 OK
[2024/07/03 18:25:58] [debug] [out flush] cb_destroy coro_id=1
[2024/07/03 18:25:58] [debug] [task] destroy task=0x5fad530 (task_id=0)
[2024/07/03 18:25:59] [debug] [task] created task=0x6054ad0 id=0 OK
[2024/07/03 18:25:59] [debug] [out flush] cb_destroy coro_id=2
[2024/07/03 18:25:59] [debug] [task] destroy task=0x6054ad0 (task_id=0)
^C[2024/07/03 18:25:59] [engine] caught signal (SIGINT)
[2024/07/03 18:25:59] [debug] [task] created task=0x60fc0c0 id=0 OK
[2024/07/03 18:25:59] [ warn] [engine] service will shutdown in max 5 seconds
[2024/07/03 18:25:59] [ info] [input] pausing dummy.0
[2024/07/03 18:25:59] [debug] [out flush] cb_destroy coro_id=3
[2024/07/03 18:25:59] [debug] [task] destroy task=0x60fc0c0 (task_id=0)
[2024/07/03 18:26:00] [ info] [engine] service has stopped (0 pending tasks)
[2024/07/03 18:26:00] [ info] [input] pausing dummy.0
```
![Screenshot 2024-07-03 at 18-28-45 Graylog - Message 422d1e70-391e-11ef-92f1-0242ac140009 on graylog_0](https://github.com/fluent/fluent-bit/assets/700876/31346414-2a47-4f8a-b592-a76be771d395)




<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

### Without Tag

```log
==2702941== 
==2702941== HEAP SUMMARY:
==2702941==     in use at exit: 0 bytes in 0 blocks
==2702941==   total heap usage: 3,082 allocs, 3,082 frees, 3,092,196 bytes allocated
==2702941== 
==2702941== All heap blocks were freed -- no leaks are possible
==2702941== 
==2702941== For lists of detected and suppressed errors, rerun with: -s
==2702941== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

### With Tag

```log
==2700665== 
==2700665== HEAP SUMMARY:
==2700665==     in use at exit: 0 bytes in 0 blocks
==2700665==   total heap usage: 3,084 allocs, 3,084 frees, 2,469,413 bytes allocated
==2700665== 
==2700665== All heap blocks were freed -- no leaks are possible
==2700665== 
==2700665== For lists of detected and suppressed errors, rerun with: -s
==2700665== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1403

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
