### PR TITLE
out_datadog: fix typo for `dd_hostname` documentation

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -528,7 +528,7 @@ static struct flb_config_map config_map[] = {
      "The host that emitted logs should be associated with. If unset, Datadog "
      "will expect the host to be set as `host`, `hostname`, or `syslog.hostname` "
      "attributes. See Datadog Logs preprocessor documentation for up-to-date "
-     "of recognized attributes."
+     "recognized attributes."
     },
 
     {


### PR DESCRIPTION
Just a typo fix so I skipped the normal PR checklist.