### PR TITLE
http_server and downstream: fix keepalive issues

### DIFF
--- a/include/fluent-bit/flb_downstream.h
+++ b/include/fluent-bit/flb_downstream.h
@@ -42,6 +42,9 @@ struct flb_downstream {
 
     struct mk_list         busy_queue;
     struct mk_list         destroy_queue;
+
+    /* this is a config map reference coming from the plugin net_setup field */
+    struct flb_net_setup  *net_setup;
 };
 
 static inline int flb_downstream_is_shutting_down(struct flb_downstream *downstream)

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -60,6 +60,12 @@ struct flb_config_map downstream_net[] = {
      "disabled, the timeout is logged as a debug message"
     },
 
+    {
+     FLB_CONFIG_MAP_BOOL, "net.keepalive", "true",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive),
+     "Enable or disable Keepalive support"
+    },
+
     /* EOF */
     {0}
 };
@@ -106,6 +112,9 @@ int flb_downstream_setup(struct flb_downstream *stream,
     if (stream->host == NULL) {
         return -1;
     }
+
+    /* map the net_setup config map coming from the caller */
+    stream->net_setup = net_setup;
 
     mk_list_init(&stream->busy_queue);
     mk_list_init(&stream->destroy_queue);


### PR DESCRIPTION
This PR is still work in progress. As of now keepalive issues are fixed, however we are waiting for some unit tests to validate proper behaviors on:

- in_http
- in_splunk
- in_elasticsearch
- ...

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
