### PR TITLE
in_tail: Introduce read_interval option

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -612,6 +612,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_tail_config, progress_check_interval_nsec),
     },
     {
+     FLB_CONFIG_MAP_TIME, "read_interval_sec", "0s",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, read_interval_sec),
+    },
+    {
+     FLB_CONFIG_MAP_INT, "read_interval_nsec", "250000000",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, read_interval_nsec),
+    },
+    {
      FLB_CONFIG_MAP_TIME, "rotate_wait", FLB_TAIL_ROTATE_WAIT,
      0, FLB_TRUE, offsetof(struct flb_tail_config, rotate_wait),
      "specify the number of extra time in seconds to monitor a file once is "

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -97,6 +97,9 @@ struct flb_tail_config {
     int progress_check_interval;      /* watcher interval             */
     int progress_check_interval_nsec; /* watcher interval             */
 
+    int read_interval_sec;      /* seconds to re-read file, only used by fs_stat */
+    int read_interval_nsec;     /* nanoseconds to re-read file, only used by fs_stat */
+
 #ifdef FLB_HAVE_INOTIFY
     int   inotify_watcher;     /* enable/disable inotify monitor */
 #endif

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -184,9 +184,11 @@ int flb_tail_fs_stat_init(struct flb_input_instance *in,
 
     flb_plg_debug(ctx->ins, "flb_tail_fs_stat_init() initializing stat tail input");
 
-    /* Set a manual timer to collect events every 0.250 seconds */
+    /* Set a manual timer to collect events managed by 'read_interval' property */
     ret = flb_input_set_collector_time(in, tail_fs_event,
-                                       0, 250000000, config);
+                                       ctx->read_interval_sec,
+                                       ctx->read_interval_nsec,
+                                       config);
     if (ret < 0) {
         return -1;
     }


### PR DESCRIPTION
fs_stat uses a fixed interval to read watched files. Users may choose higher interval for lower overhead or lower interval for lower latency. This commit allows users to configure it.



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change

```
[INPUT]
    Name             tail
    Alias            kube_containers
    Path             /tmp/log/*.log
    Multiline        Off
    Mem_Buf_Limit    5MB
    Buffer_Max_Size  1MB
    Skip_Long_Lines  On
    Refresh_Interval 10
    Read_from_Head   True
    Inotify_Watcher false
    Read_Interval_Sec 12
    Read_Interval_Nsec 10

[OUTPUT]
    Name   stdout
    Match  *

```

- [X] Debug log output from testing the change

[valgrind.log](https://github.com/user-attachments/files/16115659/valgrind.log)
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
[valgrind.log](https://github.com/user-attachments/files/16115659/valgrind.log)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
