### PR TITLE
http_server: Don't override keepalive for HTTP/2

### DIFF
--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -285,14 +285,6 @@ static int flb_http_server_should_connection_be_closed(
     server = parent_session->parent;
     downstream = server->downstream;
 
-     /*
-      * user config overrides any protocol defaults, this is set
-      * with the option 'net.keepalive: off`
-      */
-    if (!downstream->net_setup->keepalive) {
-        return FLB_TRUE;
-    }
-
     /* Version behaviors implemented in the following block :
      * HTTP/0.9 keep-alive is opt-in
      * HTTP/1.0 keep-alive is opt-in
@@ -303,6 +295,15 @@ static int flb_http_server_should_connection_be_closed(
     if (request->protocol_version < HTTP_PROTOCOL_VERSION_20) {
         /* HTTP/2 always keeps the connection open */
         return FLB_FALSE;
+    }
+
+    /*
+      * user config overrides any protocol defaults, this is set
+      * with the option 'net.keepalive: off`. This override is only
+      * effective less than HTTP/2.
+      */
+    if (!downstream->net_setup->keepalive) {
+        return FLB_TRUE;
     }
 
     /* Set the defaults per protocol version */

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -292,7 +292,7 @@ static int flb_http_server_should_connection_be_closed(
      * HTTP/2   keep-alive is "mandatory"
      */
 
-    if (request->protocol_version < HTTP_PROTOCOL_VERSION_20) {
+    if (request->protocol_version >= HTTP_PROTOCOL_VERSION_20) {
         /* HTTP/2 always keeps the connection open */
         return FLB_FALSE;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
HTTP/2 always requests to enable keepalive.

Also, handling for protocol version of HTTP/2 is inverted. So, I also fixed this conditional clause.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
