### PR TITLE
packaing: test: centos7: Fix packaging test

### DIFF
--- a/packaging/centos7-repo.sh
+++ b/packaging/centos7-repo.sh
@@ -1,4 +1,4 @@
-#!bin/sh
+#!/bin/sh
 
 sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
 sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo

--- a/packaging/centos7-repo.sh
+++ b/packaging/centos7-repo.sh
@@ -1,0 +1,4 @@
+#!bin/sh
+
+sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -55,7 +55,6 @@ do
     LOG_FILE=$(mktemp)
 
     VAULT=0
-    SCRIPT=""
     # Fix to use Vault on CentOS 7
     case ${IMAGE} in
         centos:7)

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -54,6 +54,20 @@ do
     echo "Testing $IMAGE"
     LOG_FILE=$(mktemp)
 
+    VAULT=0
+    SCRIPT=""
+    # Fix to use Vault on CentOS 7
+    case ${IMAGE} in
+        centos:7)
+            VAULT=1
+            REPO_SCRIPT=$SCRIPT_DIR/centos7-repo.sh
+            REPO_SCRIPT_PATH=$(realpath "$REPO_SCRIPT")
+            EXTRA_MOUNTS="-v $REPO_SCRIPT_PATH:/centos7-repo.sh:ro $EXTRA_MOUNTS"
+            ;;
+        *)
+            ;;
+    esac
+
     # We do want word splitting for EXTRA_MOUNTS
     # shellcheck disable=SC2086
     $CONTAINER_RUNTIME run --rm -t \
@@ -65,7 +79,7 @@ do
         -e FLUENT_BIT_INSTALL_YUM_PARAMETERS="${FLUENT_BIT_INSTALL_YUM_PARAMETERS:-}" \
         $EXTRA_MOUNTS \
         "$IMAGE" \
-        sh -c "$INSTALL_CMD && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
+        sh -c "[ $VAULT -eq 1 ] && sh /centos7-repo.sh || true && $INSTALL_CMD && /opt/fluent-bit/bin/fluent-bit --version" | tee "$LOG_FILE"
     check_version "$LOG_FILE"
     rm -f "$LOG_FILE"
 done


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
