### PR TITLE
out_datadog: fix default message key remapping

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -276,8 +276,7 @@ static int datadog_format(struct flb_config *config,
             }
 
             /* Mapping between input keys to specific datadog keys */
-            if (ctx->dd_message_key != NULL &&
-                dd_compare_msgpack_obj_key_with_str(k, ctx->dd_message_key,
+            if (dd_compare_msgpack_obj_key_with_str(k, ctx->dd_message_key,
                                                     flb_sds_len(ctx->dd_message_key)) == FLB_TRUE) {
                 msgpack_pack_str(&mp_pck, sizeof(FLB_DATADOG_DD_MESSAGE_KEY)-1);
                 msgpack_pack_str_body(&mp_pck, FLB_DATADOG_DD_MESSAGE_KEY,
@@ -550,7 +549,7 @@ static struct flb_config_map config_map[] = {
      "This property is ignored"
     },
     {
-     FLB_CONFIG_MAP_STR, "dd_message_key", NULL,
+     FLB_CONFIG_MAP_STR, "dd_message_key", FLB_DATADOG_DEFAULT_LOG_KEY,
      0, FLB_TRUE, offsetof(struct flb_out_datadog, dd_message_key),
      "By default, the plugin searches for the key 'log' "
      "and remap the value to the key 'message'. "

--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -27,12 +27,12 @@
 #define FLB_DATADOG_DEFAULT_PORT      443
 #define FLB_DATADOG_DEFAULT_TIME_KEY  "timestamp"
 #define FLB_DATADOG_DEFAULT_TAG_KEY   "tagkey"
+#define FLB_DATADOG_DEFAULT_LOG_KEY   "log"
 #define FLB_DATADOG_DD_HOSTNAME_KEY   "hostname"
 #define FLB_DATADOG_DD_SOURCE_KEY     "ddsource"
 #define FLB_DATADOG_DD_SERVICE_KEY    "service"
 #define FLB_DATADOG_DD_TAGS_KEY       "ddtags"
 #define FLB_DATADOG_DD_MESSAGE_KEY    "message"
-#define FLB_DATADOG_DD_LOG_KEY        "log"
 
 #define FLB_DATADOG_REMAP_PROVIDER    "ecs"
 #define FLB_DATADOG_TAG_SEPERATOR     ","


### PR DESCRIPTION
Fixes #8982.

This patch fixes the code to honor the documented behavior: If the 'dd_message_key' config option is not supplied, the 'log' key in the record will now be remapped to the datadog equivalent.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
