### PR TITLE
metrics: fix handling of old metric names (fix #9086)

### DIFF
--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -61,16 +61,14 @@
 
 struct flb_metric {
     int id;
-    int title_len;
-    char *title;
+    flb_sds_t title;
     size_t val;
     struct mk_list _head;
 };
 
 struct flb_metrics {
-    int title_len;         /* Title string length */
-    char *title;           /* Title or id for this metrics context */
     int count;             /* Total count of metrics registered */
+    flb_sds_t title;
     struct mk_list list;   /* Head of metrics list */
 };
 

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -83,31 +83,16 @@ struct flb_metrics *flb_metrics_create(const char *title)
     size_t threshold = FLB_METRIC_LENGTH_LIMIT;
 
     /* Create a metrics parent context */
-    metrics = flb_malloc(sizeof(struct flb_metrics));
+    metrics = flb_calloc(1, sizeof(struct flb_metrics));
     if (!metrics) {
         flb_errno();
         return NULL;
     }
     metrics->count = 0;
 
-    title_len = snprintf(NULL, 0, "%s", title);
-
-    if (title_len > threshold) {
-        title_len = threshold;
-        flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
-    }
-
-    allocated_title = flb_calloc(title_len + 1, sizeof(char));
-    if (allocated_title == NULL) {
-        flb_free(metrics);
-        return NULL;
-    }
-    metrics->title = allocated_title;
-
     /* Set metrics title */
     ret = flb_metrics_title(title, metrics);
     if (ret == -1) {
-        flb_free(metrics->title);
         flb_free(metrics);
         return NULL;
     }
@@ -120,23 +105,32 @@ struct flb_metrics *flb_metrics_create(const char *title)
 int flb_metrics_title(const char *title, struct flb_metrics *metrics)
 {
     int ret;
-    size_t size = snprintf(NULL, 0, "%s", title);
+    int len;
 
-    ret = snprintf(metrics->title, size, "%s", title);
-    if (ret == -1) {
+    len  = strlen(title);
+    if (len > FLB_METRIC_LENGTH_LIMIT) {
+        flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
+        len = FLB_METRIC_LENGTH_LIMIT;
+    }
+
+    if (metrics->title) {
+        flb_sds_destroy(metrics->title);
+    }
+
+    metrics->title = flb_sds_create_len(title, len);
+    if (!metrics->title) {
         flb_errno();
         return -1;
     }
 
-    metrics->title_len = strlen(metrics->title);
     return 0;
 }
 
 int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics)
 {
     int ret;
+    int len;
     struct flb_metric *m;
-    size_t size;
     size_t threshold = FLB_METRIC_LENGTH_LIMIT;
 
     /* Create context */
@@ -146,28 +140,19 @@ int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics)
         return -1;
     }
     m->val = 0;
-    size = strlen(title);
+    len = strlen(title);
 
-    if (size > threshold) {
-        size = threshold;
+    if (len > threshold) {
+        len = threshold;
         flb_warn("[%s] title '%s' was truncated", __FUNCTION__, title);
     }
 
-    m->title = flb_calloc(size + 1, sizeof(char));
-    if (m->title == NULL) {
-        flb_free(m);
-        return -1;
-    }
-
-    /* Write title */
-    ret = snprintf(m->title, size, "%s", title);
-    if (ret == -1) {
+    m->title = flb_sds_create_len(title, len);
+    if (!m->title) {
         flb_errno();
-        flb_free(m->title);
         flb_free(m);
         return -1;
     }
-    m->title_len = strlen(m->title);
 
     /* Assign an ID */
     if (id >= 0) {
@@ -175,7 +160,7 @@ int flb_metrics_add(int id, const char *title, struct flb_metrics *metrics)
         if (id_exists(id, metrics) == FLB_TRUE) {
             flb_error("[metrics] id=%i already exists for metric '%s'",
                       id, metrics->title);
-            flb_free(m->title);
+            flb_sds_destroy(m->title);
             flb_free(m);
             return -1;
         }
@@ -215,12 +200,12 @@ int flb_metrics_destroy(struct flb_metrics *metrics)
     mk_list_foreach_safe(head, tmp, &metrics->list) {
         m = mk_list_entry(head, struct flb_metric, _head);
         mk_list_del(&m->_head);
-        flb_free(m->title);
+        flb_sds_destroy(m->title);
         flb_free(m);
         count++;
     }
 
-    flb_free(metrics->title);
+    flb_sds_destroy(metrics->title);
     flb_free(metrics);
     return count;
 }
@@ -258,8 +243,8 @@ int flb_metrics_dump_values(char **out_buf, size_t *out_size,
 
     mk_list_foreach(head, &me->list) {
         m = mk_list_entry(head, struct flb_metric, _head);
-        msgpack_pack_str(&mp_pck, m->title_len);
-        msgpack_pack_str_body(&mp_pck, m->title, m->title_len);
+        msgpack_pack_str(&mp_pck, flb_sds_len(m->title));
+        msgpack_pack_str_body(&mp_pck, m->title, flb_sds_len(m->title));
         msgpack_pack_uint64(&mp_pck, m->val);
     }
 

--- a/src/flb_metrics_exporter.c
+++ b/src/flb_metrics_exporter.c
@@ -63,8 +63,8 @@ static int collect_inputs(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         }
 
         flb_metrics_dump_values(&buf, &s, i->metrics);
-        msgpack_pack_str(mp_pck, i->metrics->title_len);
-        msgpack_pack_str_body(mp_pck, i->metrics->title, i->metrics->title_len);
+        msgpack_pack_str(mp_pck, flb_sds_len(i->metrics->title));
+        msgpack_pack_str_body(mp_pck, i->metrics->title, flb_sds_len(i->metrics->title));
         msgpack_sbuffer_write(mp_sbuf, buf, s);
         flb_free(buf);
     }
@@ -100,8 +100,8 @@ static int collect_filters(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         }
 
         flb_metrics_dump_values(&buf, &s, i->metrics);
-        msgpack_pack_str(mp_pck, i->metrics->title_len);
-        msgpack_pack_str_body(mp_pck, i->metrics->title, i->metrics->title_len);
+        msgpack_pack_str(mp_pck, flb_sds_len(i->metrics->title));
+        msgpack_pack_str_body(mp_pck, i->metrics->title, flb_sds_len(i->metrics->title));
         msgpack_sbuffer_write(mp_sbuf, buf, s);
         flb_free(buf);
     }
@@ -137,8 +137,8 @@ static int collect_outputs(msgpack_sbuffer *mp_sbuf, msgpack_packer *mp_pck,
         }
 
         flb_metrics_dump_values(&buf, &s, i->metrics);
-        msgpack_pack_str(mp_pck, i->metrics->title_len);
-        msgpack_pack_str_body(mp_pck, i->metrics->title, i->metrics->title_len);
+        msgpack_pack_str(mp_pck, flb_sds_len(i->metrics->title));
+        msgpack_pack_str_body(mp_pck, i->metrics->title, flb_sds_len(i->metrics->title));
         msgpack_sbuffer_write(mp_sbuf, buf, s);
         flb_free(buf);
     }


### PR DESCRIPTION
Fixes #9086 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
