### PR TITLE
lib: ctraces: upgrade to v0.5.2

### DIFF
--- a/lib/ctraces/CMakeLists.txt
+++ b/lib/ctraces/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # CTraces Version
 set(CTR_VERSION_MAJOR  0)
 set(CTR_VERSION_MINOR  5)
-set(CTR_VERSION_PATCH  1)
+set(CTR_VERSION_PATCH  2)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/lib/ctraces/include/ctraces/ctr_variant_utils.h
+++ b/lib/ctraces/include/ctraces/ctr_variant_utils.h
@@ -420,6 +420,7 @@ static inline int unpack_cfl_variant_string(mpack_reader_t *reader,
     }
 
     (*value)->type = CFL_VARIANT_STRING;
+    (*value)->size = value_length;
 
     return 0;
 }
@@ -465,6 +466,7 @@ static inline int unpack_cfl_variant_binary(mpack_reader_t *reader,
     }
 
     (*value)->type = CFL_VARIANT_BYTES;
+    (*value)->size = value_length;
 
     return 0;
 }


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
