### PR TITLE
in_splunk: Process strict check for credentials

### DIFF
--- a/plugins/in_splunk/splunk.h
+++ b/plugins/in_splunk/splunk.h
@@ -49,6 +49,7 @@ struct flb_splunk {
     /* Token Auth */
     struct mk_list auth_tokens;
     flb_sds_t ingested_auth_header;
+    size_t ingested_auth_header_len;
     int store_token_in_metadata;
     flb_sds_t store_token_key;
 

--- a/plugins/in_splunk/splunk.h
+++ b/plugins/in_splunk/splunk.h
@@ -34,6 +34,7 @@
 
 struct flb_splunk_tokens {
     flb_sds_t header;
+    size_t    length;
     struct mk_list _head;
 };
 

--- a/plugins/in_splunk/splunk_config.c
+++ b/plugins/in_splunk/splunk_config.c
@@ -78,6 +78,7 @@ static int setup_hec_tokens(struct flb_splunk *ctx)
             }
 
             splunk_token->header = auth_header;
+            splunk_token->length = flb_sds_len(auth_header);
 
             /* Link to parent list */
             mk_list_add(&splunk_token->_head, &ctx->auth_tokens);

--- a/plugins/in_splunk/splunk_config.c
+++ b/plugins/in_splunk/splunk_config.c
@@ -45,8 +45,9 @@ static int setup_hec_tokens(struct flb_splunk *ctx)
     struct mk_list *head = NULL;
     struct mk_list *kvs = NULL;
     struct flb_split_entry *cur = NULL;
-    flb_sds_t   auth_header;
+    flb_sds_t   auth_header = NULL;
     struct flb_splunk_tokens *splunk_token;
+    flb_sds_t credential = NULL;
 
     raw_token = flb_input_get_property("splunk_token", ctx->ins);
     if (raw_token) {
@@ -64,7 +65,19 @@ static int setup_hec_tokens(struct flb_splunk *ctx)
                 goto error;
             }
 
-            ret = flb_sds_cat_safe(&auth_header, cur->value, strlen(cur->value));
+            credential = flb_sds_create_len(cur->value, strlen(cur->value));
+            if (credential == NULL) {
+                flb_plg_warn(ctx->ins, "error on flb_sds allocation");
+                continue;
+            }
+
+            ret = flb_sds_trim(credential);
+            if (ret == -1) {
+                flb_plg_warn(ctx->ins, "error on trimming for a credential candidate");
+                goto error;
+            }
+
+            ret = flb_sds_cat_safe(&auth_header, credential, flb_sds_len(credential));
             if (ret < 0) {
                 flb_plg_error(ctx->ins, "error on token generation");
                 goto error;
@@ -79,6 +92,8 @@ static int setup_hec_tokens(struct flb_splunk *ctx)
 
             splunk_token->header = auth_header;
             splunk_token->length = flb_sds_len(auth_header);
+
+            flb_sds_destroy(credential);
 
             /* Link to parent list */
             mk_list_add(&splunk_token->_head, &ctx->auth_tokens);
@@ -96,6 +111,9 @@ split_error:
 error:
     if (kvs != NULL) {
         flb_utils_split_free(kvs);
+    }
+    if (credential != NULL) {
+        flb_sds_destroy(credential);
     }
     return -1;
 }

--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -241,7 +241,8 @@ static int process_raw_payload_pack(struct flb_splunk *ctx, flb_sds_t tag, char 
                 ret = flb_log_event_encoder_append_metadata_values(
                     &ctx->log_encoder,
                     FLB_LOG_EVENT_CSTRING_VALUE("hec_token"),
-                    FLB_LOG_EVENT_CSTRING_VALUE(ctx->ingested_auth_header));
+                    FLB_LOG_EVENT_STRING_VALUE(ctx->ingested_auth_header,
+                                               ctx->ingested_auth_header_len));
             }
         }
     }
@@ -251,7 +252,8 @@ static int process_raw_payload_pack(struct flb_splunk *ctx, flb_sds_t tag, char 
                 ret = flb_log_event_encoder_append_body_values(
                     &ctx->log_encoder,
                     FLB_LOG_EVENT_CSTRING_VALUE(ctx->store_token_key),
-                    FLB_LOG_EVENT_CSTRING_VALUE(ctx->ingested_auth_header),
+                    FLB_LOG_EVENT_STRING_VALUE(ctx->ingested_auth_header,
+                                               ctx->ingested_auth_header_len),
                     FLB_LOG_EVENT_CSTRING_VALUE("log"),
                     FLB_LOG_EVENT_STRING_VALUE(buf, size));
 
@@ -315,7 +317,8 @@ static void process_flb_log_append(struct flb_splunk *ctx, msgpack_object *recor
                 ret = flb_log_event_encoder_append_metadata_values(
                     &ctx->log_encoder,
                     FLB_LOG_EVENT_CSTRING_VALUE("hec_token"),
-                    FLB_LOG_EVENT_CSTRING_VALUE(ctx->ingested_auth_header));
+                    FLB_LOG_EVENT_STRING_VALUE(ctx->ingested_auth_header,
+                                               ctx->ingested_auth_header_len));
             }
         }
     }
@@ -334,7 +337,8 @@ static void process_flb_log_append(struct flb_splunk *ctx, msgpack_object *recor
                 ret = flb_log_event_encoder_append_body_values(
                     &ctx->log_encoder,
                     FLB_LOG_EVENT_CSTRING_VALUE(ctx->store_token_key),
-                    FLB_LOG_EVENT_CSTRING_VALUE(ctx->ingested_auth_header));
+                    FLB_LOG_EVENT_STRING_VALUE(ctx->ingested_auth_header,
+                                               ctx->ingested_auth_header_len));
             }
         }
         else {
@@ -598,6 +602,7 @@ static int process_hec_payload(struct flb_splunk *ctx, struct splunk_conn *conn,
     if (header_auth->key.data != NULL) {
         if (strncasecmp(header_auth->val.data, "Splunk ", 7) == 0) {
             ctx->ingested_auth_header = header_auth->val.data;
+            ctx->ingested_auth_header_len = header_auth->val.len;
         }
     }
 
@@ -663,6 +668,7 @@ static int process_hec_raw_payload(struct flb_splunk *ctx, struct splunk_conn *c
     if (header_auth->key.data != NULL) {
         if (strncasecmp(header_auth->val.data, "Splunk ", 7) == 0) {
             ctx->ingested_auth_header = header_auth->val.data;
+            ctx->ingested_auth_header_len = header_auth->val.len;
         }
     }
 
@@ -1022,6 +1028,7 @@ static int process_hec_payload_ng(struct flb_http_request *request,
     if (ret != 0 && size > 0) {
         if (strncasecmp(auth_header, "Splunk ", 7) == 0) {
             ctx->ingested_auth_header = auth_header;
+            ctx->ingested_auth_header_len = strlen(auth_header);
         }
     }
 
@@ -1057,6 +1064,7 @@ static int process_hec_raw_payload_ng(struct flb_http_request *request,
     if (ret != 0 && size > 0) {
         if (strncasecmp(auth_header, "Splunk ", 7) == 0) {
             ctx->ingested_auth_header = auth_header;
+            ctx->ingested_auth_header_len = strlen(auth_header);
         }
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
We should process struct checking for credentials.
Adding length comparisons would be better to proceed the credential authentication.
Plus, spaces around commas will be trimmed. So, the attached configurations are valid even if including spaces around the comma.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[INPUT]
    Name splunk
    Tag splunk.test.ingest
    Port 8090
    Splunk_Token 7bba8847-4aee-4e62-ba7b-08c6139e42b9 , 4e63c0c9-c3b5-4a0a-bf4d-bfd5bc0d0070
    store_token_in_metadata Off
    Buffer_Max_Size 10M
    http2 Off
    tls On
    tls.verify Off
    tls.crt_file ./cert/ca_cert.pem
    tls.key_file ./cert/ca_key.pem
    tls.key_passwd fluentd

[OUTPUT]
    Name stdout
    Match *
```

Or,

```
[INPUT]
    Name splunk
    Tag splunk.test.ingest
    Port 8090
    Splunk_Token 7bba8847-4aee-4e62-ba7b-08c6139e42b9 , 4e63c0c9-c3b5-4a0a-bf4d-bfd5bc0d0070
    store_token_in_metadata Off
    Buffer_Max_Size 10M
    http2 Off
    tls Off
    tls.verify Off
    tls.crt_file ./cert/ca_cert.pem
    tls.key_file ./cert/ca_key.pem
    tls.key_passwd fluentd

[OUTPUT]
    Name stdout
    Match *
```

- [x] Debug log output from testing the change

```log
Fluent Bit v3.1.3
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/07/16 17:29:03] [ info] Configuration:
[2024/07/16 17:29:03] [ info]  flush time     | 1.000000 seconds
[2024/07/16 17:29:03] [ info]  grace          | 5 seconds
[2024/07/16 17:29:03] [ info]  daemon         | 0
[2024/07/16 17:29:03] [ info] ___________
[2024/07/16 17:29:03] [ info]  inputs:
[2024/07/16 17:29:03] [ info]      splunk
[2024/07/16 17:29:03] [ info] ___________
[2024/07/16 17:29:03] [ info]  filters:
[2024/07/16 17:29:03] [ info] ___________
[2024/07/16 17:29:03] [ info]  outputs:
[2024/07/16 17:29:03] [ info]      stdout.0
[2024/07/16 17:29:03] [ info] ___________
[2024/07/16 17:29:03] [ info]  collectors:
[2024/07/16 17:29:03] [ info] [fluent bit] version=3.1.3, commit=8b4d95e3c8, pid=3019829
[2024/07/16 17:29:03] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/07/16 17:29:03] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/07/16 17:29:03] [ info] [cmetrics] version=0.9.1
[2024/07/16 17:29:03] [ info] [ctraces ] version=0.5.1
[2024/07/16 17:29:03] [ info] [input:splunk:splunk.0] initializing
[2024/07/16 17:29:03] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/07/16 17:29:03] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/07/16 17:29:03] [debug] [downstream] listening on 0.0.0.0:8090
[2024/07/16 17:29:03] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/07/16 17:29:03] [ info] [sp] stream processor started
[2024/07/16 17:29:03] [ info] [output:stdout:stdout.0] worker #0 started
[2024/07/16 17:29:05] [debug] [input:splunk:splunk.0] Mark as unknown type for ingested payloads
[2024/07/16 17:29:05] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/07/16 17:29:05] [debug] [task] created task=0x61b2490 id=0 OK
[2024/07/16 17:29:05] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.test.ingest: [[1721118545.322137895, {}], {"event"=>"Pony 1 has left the barn", "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[1] splunk.test.ingest: [[1721118545.322137895, {}], {"event"=>"Pony 2 has left the barn", "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[2] splunk.test.ingest: [[1721118545.322137895, {}], {"event"=>"Pony 3 has left the barn", "nested"=>{"key1"=>"value1"}, "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[2024/07/16 17:29:05] [debug] [out flush] cb_destroy coro_id=0
[2024/07/16 17:29:05] [debug] [task] destroy task=0x61b2490 (task_id=0)
^C[2024/07/16 17:29:06] [engine] caught signal (SIGINT)
[2024/07/16 17:29:06] [ warn] [engine] service will shutdown in max 5 seconds
[2024/07/16 17:29:06] [ info] [input] pausing splunk.0
[2024/07/16 17:29:07] [ info] [engine] service has stopped (0 pending tasks)
[2024/07/16 17:29:07] [ info] [input] pausing splunk.0
[2024/07/16 17:29:07] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/07/16 17:29:07] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

Or,

```log
Fluent Bit v3.1.3
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/07/16 17:28:22] [ info] Configuration:
[2024/07/16 17:28:22] [ info]  flush time     | 1.000000 seconds
[2024/07/16 17:28:22] [ info]  grace          | 5 seconds
[2024/07/16 17:28:22] [ info]  daemon         | 0
[2024/07/16 17:28:22] [ info] ___________
[2024/07/16 17:28:22] [ info]  inputs:
[2024/07/16 17:28:22] [ info]      splunk
[2024/07/16 17:28:22] [ info] ___________
[2024/07/16 17:28:22] [ info]  filters:
[2024/07/16 17:28:22] [ info] ___________
[2024/07/16 17:28:22] [ info]  outputs:
[2024/07/16 17:28:22] [ info]      stdout.0
[2024/07/16 17:28:22] [ info] ___________
[2024/07/16 17:28:22] [ info]  collectors:
[2024/07/16 17:28:22] [ info] [fluent bit] version=3.1.3, commit=8b4d95e3c8, pid=3019675
[2024/07/16 17:28:22] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/07/16 17:28:22] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/07/16 17:28:22] [ info] [cmetrics] version=0.9.1
[2024/07/16 17:28:22] [ info] [ctraces ] version=0.5.1
[2024/07/16 17:28:22] [ info] [input:splunk:splunk.0] initializing
[2024/07/16 17:28:22] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2024/07/16 17:28:22] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2024/07/16 17:28:22] [debug] [downstream] listening on 0.0.0.0:8090
[2024/07/16 17:28:22] [ info] [output:stdout:stdout.0] worker #0 started
[2024/07/16 17:28:22] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/07/16 17:28:22] [ info] [sp] stream processor started
[2024/07/16 17:28:24] [debug] [input:splunk:splunk.0] Mark as unknown type for ingested payloads
[2024/07/16 17:28:24] [debug] [socket] could not validate socket status for #40 (don't worry)
[2024/07/16 17:28:25] [debug] [task] created task=0x61b86b0 id=0 OK
[0] splunk.test.ingest: [[1721118504.774888159, {}], {"event"=>"Pony 1 has left the barn", "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[1] splunk.test.ingest: [[1721118504.774888159, {}], {"event"=>"Pony 2 has left the barn", "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[2] splunk.test.ingest: [[1721118504.774888159, {}], {"event"=>"Pony 3 has left the barn", "nested"=>{"key1"=>"value1"}, "@splunk_token"=>"Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9"}]
[2024/07/16 17:28:25] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2024/07/16 17:28:25] [debug] [out flush] cb_destroy coro_id=0
[2024/07/16 17:28:25] [debug] [task] destroy task=0x61b86b0 (task_id=0)
^C[2024/07/16 17:28:26] [engine] caught signal (SIGINT)
[2024/07/16 17:28:26] [ warn] [engine] service will shutdown in max 5 seconds
[2024/07/16 17:28:26] [ info] [input] pausing splunk.0
[2024/07/16 17:28:26] [ info] [engine] service has stopped (0 pending tasks)
[2024/07/16 17:28:26] [ info] [input] pausing splunk.0
[2024/07/16 17:28:26] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/07/16 17:28:26] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

curl requests

```
$ curl -k "https://localhost:8090/services/collector" \
    -H "Authorization: Splunk 7bba8847-4aee-4e62-ba7b-08c6139e42b9" -H "application/json" \
    -d '{"event": "Pony 1 has left the barn"}{"event": "Pony 2 has left the barn"}{"event": "Pony 3 has left the barn", "nested": {"key1": "value1"}}' -vvv
$ curl -k "https://localhost:8090/services/collector" \
    -H "Authorization: Splunk 4e63c0c9-c3b5-4a0a-bf4d-bfd5bc0d0070" -H "application/json" \
    -d '{"event": "Pony 1 has left the barn"}{"event": "Pony 2 has left the barn"}{"event": "Pony 3 has left the barn", "nested": {"key1": "value1"}}' -vvv
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


```
==3019829== 
==3019829== HEAP SUMMARY:
==3019829==     in use at exit: 0 bytes in 0 blocks
==3019829==   total heap usage: 17,443 allocs, 17,443 frees, 2,611,669 bytes allocated
==3019829== 
==3019829== All heap blocks were freed -- no leaks are possible
==3019829== 
==3019829== For lists of detected and suppressed errors, rerun with: -s
==3019829== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

And


```
==3019675== 
==3019675== HEAP SUMMARY:
==3019675==     in use at exit: 0 bytes in 0 blocks
==3019675==   total heap usage: 17,444 allocs, 17,444 frees, 2,611,935 bytes allocated
==3019675== 
==3019675== All heap blocks were freed -- no leaks are possible
==3019675== 
==3019675== For lists of detected and suppressed errors, rerun with: -s
==3019675== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
