### PR TITLE
log_to_metrics: allow custom namespace and subsystem

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.h
+++ b/plugins/filter_log_to_metrics/log_to_metrics.h
@@ -49,6 +49,7 @@
 #define MAX_LABEL_COUNT 32
 
 #define FLB_MEM_BUF_LIMIT_DEFAULT  "10M"
+#define DEFAULT_LOG_TO_METRICS_NAMESPACE "log_metric"
 
 
 struct log_to_metrics_ctx
@@ -57,6 +58,8 @@ struct log_to_metrics_ctx
     struct flb_filter_instance *ins;
     int mode;
     flb_sds_t metric_name;
+    flb_sds_t metric_namespace;
+    flb_sds_t metric_subsystem;
     flb_sds_t metric_description;
     struct cmt *cmt;
     struct flb_input_instance *input_ins;

--- a/tests/runtime/filter_log_to_metrics.c
+++ b/tests/runtime/filter_log_to_metrics.c
@@ -199,6 +199,8 @@ void flb_test_log_to_metrics_counter_k8s(void)
     const char *expected = "\"value\":5.0,\"labels\":[\"k8s-dummy\","
                            "\"testpod\",\"mycontainer\",\"abc123\","
                            "\"def456\",\"red\",\"right\"]";
+    const char *expected2 = "{\"ns\":\"log_metric\",\"ss\":\"counter\","
+                            "\"name\":\"test\",\"desc\":\"Counts messages\"}";
 
     ctx = flb_create();
     flb_service_set(ctx, "Flush", "0.200000000", "Grace", "1", "Log_Level",
@@ -219,6 +221,7 @@ void flb_test_log_to_metrics_counter_k8s(void)
                          "metric_mode", "counter",
                          "metric_name", "test",
                          "metric_description", "Counts messages",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "on",
                          "label_field", "color",
                          "label_field", "direction",
@@ -242,6 +245,10 @@ void flb_test_log_to_metrics_counter_k8s(void)
     if (!TEST_CHECK(result != NULL)) {
         TEST_MSG("expected substring:\n%s\ngot:\n%s\n", expected, finalString);
     }
+    result = strstr(finalString, expected2);
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("expected substring:\n%s\ngot:\n%s\n", expected, finalString);
+    }
 
     filter_test_destroy(ctx);
 
@@ -260,6 +267,8 @@ void flb_test_log_to_metrics_counter(void)
     char *input = JSON_MSG1;
     char finalString[32768] = "";
     const char *expected = "\"value\":5.0,\"labels\":[\"red\",\"right\"]";
+    const char *expected2 = "{\"ns\":\"myns\",\"ss\":\"subsystem\","
+                            "\"name\":\"test\",\"desc\":\"Counts messages\"}";
 
     ctx = flb_create();
     flb_service_set(ctx, "Flush", "0.200000000", "Grace", "1", "Log_Level",
@@ -280,6 +289,8 @@ void flb_test_log_to_metrics_counter(void)
                          "metric_mode", "counter",
                          "metric_name", "test",
                          "metric_description", "Counts messages",
+                         "metric_subsystem", "subsystem",
+                         "metric_namespace", "myns",
                          "kubernetes_mode", "off",
                          "label_field", "color",
                          "label_field", "direction",
@@ -299,6 +310,10 @@ void flb_test_log_to_metrics_counter(void)
     }
     wait_with_timeout(2000, finalString);
     result = strstr(finalString, expected);
+    if (!TEST_CHECK(result != NULL)) {
+        TEST_MSG("expected substring:\n%s\ngot:\n%s\n", expected, finalString);
+    }
+    result = strstr(finalString, expected2);
     if (!TEST_CHECK(result != NULL)) {
         TEST_MSG("expected substring:\n%s\ngot:\n%s\n", expected, finalString);
     }
@@ -346,6 +361,7 @@ void flb_test_log_to_metrics_counter_k8s_two_tuples(void)
                          "metric_mode", "counter",
                          "metric_name", "test",
                          "metric_description", "Counts two different messages",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "on",
                          "label_field", "color",
                          "label_field", "direction",
@@ -414,6 +430,7 @@ void flb_test_log_to_metrics_gauge(void)
                          "metric_mode", "gauge",
                          "metric_name", "test",
                          "metric_description", "Reports gauge from messages",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "off",
                          "value_field", "duration",
                          "label_field", "color",
@@ -478,6 +495,7 @@ void flb_test_log_to_metrics_histogram(void)
                          "metric_mode", "histogram",
                          "metric_name", "test",
                          "metric_description", "Histogram of duration",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "off",
                          "value_field", "duration",
                          "label_field", "color",
@@ -542,6 +560,7 @@ void flb_test_log_to_metrics_reg(void)
                          "metric_mode", "counter",
                          "metric_name", "test",
                          "metric_description", "Counts messages with regex",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "off",
                          "label_field", "color",
                          "label_field", "direction",
@@ -607,6 +626,7 @@ void flb_test_log_to_metrics_empty_label_keys_regex(void)
                          "metric_mode", "counter",
                          "metric_name", "test",
                          "metric_description", "Counts messages with regex",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "off",
                          "regex", "message .*el.*",
                          NULL);
@@ -668,6 +688,7 @@ void flb_test_log_to_metrics_label(void)
                          "metric_mode", "counter",
                          "metric_name", "test",
                          "metric_description", "Counts messages",
+                         "metric_subsystem", "",
                          "kubernetes_mode", "off",
                          "add_label", "pod_name $kubernetes['pod_name']",
                          NULL);


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR allows to change namespace and subsystem for log_to_metrics. 
 
----

**Testing**
Before we can approve your change; please submit the following in a comment:
- [X] Example configuration file for the change
```
[SERVICE]
    Flush     1
    Daemon    off
    Log_Level info


[INPUT]
    Name               dummy
    Dummy              {"message":"dummy", "kubernetes":{"namespace_name": "default", "docker_id": "abc123", "pod_name": "pod1", "container_name": "mycontainer", "pod_id": "def456", "labels":{"app": "app1"}}, "duration": 20, "color": "red", "shape": "circle"}
    Tag                dummy.log
    Interval_sec               10


[FILTER]
    name               log_to_metrics
    match              dummy.log*
    tag                test_metric
    metric_mode        counter
    metric_name        count_all_dummy_messages
    metric_description This metric counts dummy messages
    metric_namespace my_ns
    metric_subsystem my_susbsystem

[OUTPUT]
    Name stdout
    Match test_metric
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
