### PR TITLE
out_cloudwatch_logs: fix disabled auto_create_group

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -53,8 +53,7 @@ static struct flb_aws_header content_type_header = {
 static int validate_log_group_class(struct flb_cloudwatch *ctx)
 {
     if (ctx->create_group == FLB_FALSE) {
-        flb_plg_error(ctx->ins, "Configuring log_group_class requires `auto_create_group On`.");
-        return -1;
+        return 0;
     }
 
     if (ctx->log_group_class == NULL || strlen(ctx->log_group_class) == 0) {


### PR DESCRIPTION
Fixes #8949

Since release 3.0.7 `auto_create_group` couldn't be set to Off anymore. That was a breaking change.

I didn't see any reason why `log_group_class_type` and `log_group_class` should be set, as they're not used when `[auto_]create_group` is off.

Please review @PettitWesley @edsiper

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- [X] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
