### PR TITLE
out_stdout: Consume entire metrics type of buffers

### DIFF
--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -107,24 +107,32 @@ static void print_metrics_text(struct flb_output_instance *ins,
     size_t off = 0;
     cfl_sds_t text;
     struct cmt *cmt = NULL;
+    int ok = CMT_DECODE_MSGPACK_SUCCESS;
 
     /* get cmetrics context */
-    ret = cmt_decode_msgpack_create(&cmt, (char *) data, bytes, &off);
-    if (ret != 0) {
-        flb_plg_error(ins, "could not process metrics payload");
-        return;
+    while((ret = cmt_decode_msgpack_create(&cmt,
+                                           (char *) data,
+                                           bytes, &off)) == ok) {
+        if (ret != 0) {
+            flb_plg_error(ins, "could not process metrics payload");
+            return;
+        }
+
+        /* convert to text representation */
+        text = cmt_encode_text_create(cmt);
+
+        /* destroy cmt context */
+        cmt_destroy(cmt);
+
+        printf("%s", text);
+        fflush(stdout);
+
+        cmt_encode_text_destroy(text);
     }
 
-    /* convert to text representation */
-    text = cmt_encode_text_create(cmt);
-
-    /* destroy cmt context */
-    cmt_destroy(cmt);
-
-    printf("%s", text);
-    fflush(stdout);
-
-    cmt_encode_text_destroy(text);
+    if (ret != ok) {
+        flb_plg_debug(ins, "cmt decode msgpack returned : %d", ret);
+    }
 }
 #endif
 


### PR DESCRIPTION
Like as ctraces events, there is possibilities to have multiple concatenated cmetrics buffers case.
For instance, calling flb_input_metrics_append more than one per a cycle, msgpack payload of cmetrics have multiply concatenated contexts of cmetrics.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
