### PR TITLE
in_statsd: Implement metrics type of ingestion way

### DIFF
--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -39,6 +39,7 @@
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_encode_splunk_hec.h>
 #include <cmetrics/cmt_encode_cloudwatch_emf.h>
+#include <cmetrics/cmt_decode_statsd.h>
 #include <cmetrics/cmt_filter.h>
 
 /* Metrics IDs for general purpose (used by core and Plugins */

--- a/plugins/in_statsd/statsd.c
+++ b/plugins/in_statsd/statsd.c
@@ -36,6 +36,7 @@ struct flb_statsd {
     char *buf;                         /* buffer */
     char listen[256];                  /* listening address (RFC-2181) */
     char port[6];                      /* listening port (RFC-793) */
+    int  metrics;                      /* Import as metrics */
     flb_sockfd_t server_fd;            /* server socket */
     flb_pipefd_t coll_fd;              /* server handler */
     struct flb_input_instance *ins;    /* input instance */
@@ -209,6 +210,10 @@ static int cb_statsd_receive(struct flb_input_instance *ins,
     char *line;
     int len;
     struct flb_statsd *ctx = data;
+#ifdef FLB_HAVE_METRICS
+    struct cmt *cmt = NULL;
+    int cmt_flags = 0;
+#endif
 
     /* Receive a UDP datagram */
     len = recv(ctx->server_fd, ctx->buf, MAX_PACKET_SIZE - 1, 0);
@@ -218,33 +223,56 @@ static int cb_statsd_receive(struct flb_input_instance *ins,
     }
     ctx->buf[len] = '\0';
 
-    ret = FLB_EVENT_ENCODER_SUCCESS;
-    /* Process all messages in buffer */
-    line = strtok(ctx->buf, "\n");
-    while (line != NULL) {
-        flb_plg_trace(ctx->ins, "received a line: '%s'", line);
-
-        ret = statsd_process_line(ctx, line);
-
-        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
-            flb_plg_error(ctx->ins, "failed to process line: '%s'", line);
-
-            break;
+#ifdef FLB_HAVE_METRICS
+    if (ctx->metrics == FLB_TRUE) {
+        cmt_flags |= CMT_DECODE_STATSD_GAUGE_OBSERVER;
+        flb_plg_trace(ctx->ins, "received a buf: '%s'", ctx->buf);
+        ret = cmt_decode_statsd_create(&cmt, ctx->buf, len, cmt_flags);
+        if (ret != CMT_DECODE_STATSD_SUCCESS) {
+            flb_plg_error(ctx->ins, "failed to process buf: '%s'", ctx->buf);
+            return -1;
         }
 
-        line = strtok(NULL, "\n");
-    }
+        /* Append the updated metrics */
+        ret = flb_input_metrics_append(ins, NULL, 0, cmt);
+        if (ret != 0) {
+            flb_plg_error(ins, "could not append metrics");
+        }
 
-    if (ctx->log_encoder->output_length > 0) {
-        flb_input_log_append(ctx->ins, NULL, 0,
-                             ctx->log_encoder->output_buffer,
-                             ctx->log_encoder->output_length);
+        cmt_destroy(cmt);
     }
     else {
-        flb_plg_error(ctx->ins, "log event encoding error : %d", ret);
-    }
+#endif
+        ret = FLB_EVENT_ENCODER_SUCCESS;
+        /* Process all messages in buffer */
+        line = strtok(ctx->buf, "\n");
+        while (line != NULL) {
+            flb_plg_trace(ctx->ins, "received a line: '%s'", line);
 
-    flb_log_event_encoder_reset(ctx->log_encoder);
+            ret = statsd_process_line(ctx, line);
+
+            if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+                flb_plg_error(ctx->ins, "failed to process line: '%s'", line);
+
+                break;
+            }
+
+            line = strtok(NULL, "\n");
+        }
+
+        if (ctx->log_encoder->output_length > 0) {
+            flb_input_log_append(ctx->ins, NULL, 0,
+                                 ctx->log_encoder->output_buffer,
+                                 ctx->log_encoder->output_length);
+        }
+        else {
+            flb_plg_error(ctx->ins, "log event encoding error : %d", ret);
+        }
+
+        flb_log_event_encoder_reset(ctx->log_encoder);
+#ifdef FLB_HAVE_METRICS
+    }
+#endif
 
     return 0;
 }
@@ -365,8 +393,13 @@ static int cb_statsd_exit(void *data, struct flb_config *config)
 }
 
 static struct flb_config_map config_map[] = {
+   {
+    FLB_CONFIG_MAP_BOOL, "metrics", "off",
+    0, FLB_TRUE, offsetof(struct flb_statsd, metrics),
+    "Ingest as metrics type of events."
+   },
     /* EOF */
-    {0}    
+    {0}
 };
 
 /* Plugin reference */


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```console
$ bin/fluent-bit -i statsd -p metrics=On -o stdout -v
```
- [x] Debug log output from testing the change
```log
Fluent Bit v3.1.6
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/08/14 17:18:01] [ info] Configuration:
[2024/08/14 17:18:01] [ info]  flush time     | 1.000000 seconds
[2024/08/14 17:18:01] [ info]  grace          | 5 seconds
[2024/08/14 17:18:01] [ info]  daemon         | 0
[2024/08/14 17:18:01] [ info] ___________
[2024/08/14 17:18:01] [ info]  inputs:
[2024/08/14 17:18:01] [ info]      statsd
[2024/08/14 17:18:01] [ info] ___________
[2024/08/14 17:18:01] [ info]  filters:
[2024/08/14 17:18:01] [ info] ___________
[2024/08/14 17:18:01] [ info]  outputs:
[2024/08/14 17:18:01] [ info]      stdout.0
[2024/08/14 17:18:01] [ info] ___________
[2024/08/14 17:18:01] [ info]  collectors:
[2024/08/14 17:18:01] [ info] [fluent bit] version=3.1.6, commit=5b663fde5e, pid=2043159
[2024/08/14 17:18:01] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/08/14 17:18:01] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/08/14 17:18:01] [ info] [cmetrics] version=0.9.4
[2024/08/14 17:18:01] [ info] [ctraces ] version=0.5.5
[2024/08/14 17:18:01] [ info] [input:statsd:statsd.0] initializing
[2024/08/14 17:18:01] [ info] [output:stdout:stdout.0] worker #0 started
[2024/08/14 17:18:01] [ info] [input:statsd:statsd.0] storage_strategy='memory' (memory only)
[2024/08/14 17:18:01] [debug] [statsd:statsd.0] created event channels: read=21 write=22
[2024/08/14 17:18:01] [ info] [input:statsd:statsd.0] start UDP server on 0.0.0.0:8125
[2024/08/14 17:18:01] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2024/08/14 17:18:01] [ info] [sp] stream processor started
2024-08-14T08:18:03.562424694Z click{incremental="true",hello="tag"} = 1000
2024-08-14T08:18:03.591477424Z active{incremental="true"} = 9900
2024-08-14T08:18:03.593118033Z inactive{hi="from_fluent-bit"} = 2320
[2024/08/14 17:18:04] [debug] [task] created task=0x5f114e0 id=0 OK
[2024/08/14 17:18:04] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2024/08/14 17:18:04] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2024/08/14 17:18:04] [debug] [out flush] cb_destroy coro_id=0
[2024/08/14 17:18:04] [debug] [task] destroy task=0x5f114e0 (task_id=0)
^C[2024/08/14 17:18:05] [engine] caught signal (SIGINT)
[2024/08/14 17:18:05] [ warn] [engine] service will shutdown in max 5 seconds
[2024/08/14 17:18:05] [ info] [input] pausing statsd.0
[2024/08/14 17:18:06] [ info] [engine] service has stopped (0 pending tasks)
[2024/08/14 17:18:06] [ info] [input] pausing statsd.0
[2024/08/14 17:18:06] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/08/14 17:18:06] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

### Sending Multiple Payloads from Another Terminal

```
$ echo "click:+10|c|@0.01|#hello:tag" | nc -q0 -u 127.0.0.1 8125
  echo "active:+99|g|@0.01"     | nc -q0 -u 127.0.0.1 8125
 echo "inactive:29|g|@0.0125|#hi:from_fluent-bit"     | nc -q0 -u 127.0.0.1 8125

```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==2043159== 
==2043159== HEAP SUMMARY:
==2043159==     in use at exit: 0 bytes in 0 blocks
==2043159==   total heap usage: 3,142 allocs, 3,142 frees, 853,189 bytes allocated
==2043159== 
==2043159== All heap blocks were freed -- no leaks are possible
==2043159== 
==2043159== For lists of detected and suppressed errors, rerun with: -s
==2043159== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

TBD

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

#### Additional Note

This PR needs to ingest multiple times per a cycle.
So, the metrics contexts of buffers sometimes concatenated and to be needed to loop to consume EOF.
This should be handled in #9118 and https://github.com/fluent/fluent-bit/pull/9122.

This PR also depends on https://github.com/fluent/cmetrics/pull/210.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
