### PR TITLE
out_prometheus_exporter: Handle multiply concatenated metrics type of events

### DIFF
--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -199,6 +199,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
                                             event_chunk->size, &off)) == ok) {
 
         if (ret != 0) {
+            flb_sds_destroy(text);
             FLB_OUTPUT_RETURN(FLB_ERROR);
         }
 

--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -217,6 +217,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
         tmp = cmt_encode_prometheus_create(cmt, add_ts);
         if (!tmp) {
             cmt_destroy(cmt);
+            flb_sds_destroy(text);
             FLB_OUTPUT_RETURN(FLB_ERROR);
         }
         ret = flb_sds_cat_safe(&text, tmp, flb_sds_len(tmp));

--- a/plugins/out_prometheus_exporter/prom.c
+++ b/plugins/out_prometheus_exporter/prom.c
@@ -175,44 +175,66 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     int add_ts;
     size_t off = 0;
     flb_sds_t metrics;
-    cfl_sds_t text;
+    cfl_sds_t text = NULL;
+    cfl_sds_t tmp = NULL;
     struct cmt *cmt;
     struct prom_exporter *ctx = out_context;
+    int ok = CMT_DECODE_MSGPACK_SUCCESS;
+
+    text = flb_sds_create_size(128);
+    if (text == NULL) {
+        flb_plg_debug(ctx->ins, "failed to allocate buffer for text representation of metrics");
+        FLB_OUTPUT_RETURN(FLB_ERROR);
+    }
 
     /*
      * A new set of metrics has arrived, perform decoding, apply labels,
      * convert to Prometheus text format and store the output in the
      * hash table for metrics.
+     * Note that metrics might be concatenated. So, we need to consume
+     * until the end of event_chunk.
      */
-    ret = cmt_decode_msgpack_create(&cmt,
-                                    (char *) event_chunk->data,
-                                    event_chunk->size, &off);
-    if (ret != 0) {
-        FLB_OUTPUT_RETURN(FLB_ERROR);
-    }
+    while ((ret = cmt_decode_msgpack_create(&cmt,
+                                            (char *) event_chunk->data,
+                                            event_chunk->size, &off)) == ok) {
 
-    /* append labels set by config */
-    append_labels(ctx, cmt);
+        if (ret != 0) {
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
 
-    /* add timestamp in the output format ? */
-    if (ctx->add_timestamp) {
-        add_ts = CMT_TRUE;
-    }
-    else {
-        add_ts = CMT_FALSE;
-    }
+        /* append labels set by config */
+        append_labels(ctx, cmt);
 
-    /* convert to text representation */
-    text = cmt_encode_prometheus_create(cmt, add_ts);
-    if (!text) {
+        /* add timestamp in the output format ? */
+        if (ctx->add_timestamp) {
+            add_ts = CMT_TRUE;
+        }
+        else {
+            add_ts = CMT_FALSE;
+        }
+
+        /* convert to text representation */
+        tmp = cmt_encode_prometheus_create(cmt, add_ts);
+        if (!tmp) {
+            cmt_destroy(cmt);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+        ret = flb_sds_cat_safe(&text, tmp, flb_sds_len(tmp));
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "could not concatenate text representant coming from: %s",
+                          flb_input_name(ins));
+            cmt_encode_prometheus_destroy(tmp);
+            flb_sds_destroy(text);
+            cmt_destroy(cmt);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+        cmt_encode_prometheus_destroy(tmp);
         cmt_destroy(cmt);
-        FLB_OUTPUT_RETURN(FLB_ERROR);
     }
-    cmt_destroy(cmt);
 
     if (cfl_sds_len(text) == 0) {
         flb_plg_debug(ctx->ins, "context without metrics (empty)");
-        cmt_encode_text_destroy(text);
+        flb_sds_destroy(text);
         FLB_OUTPUT_RETURN(FLB_OK);
     }
 
@@ -221,11 +243,11 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not store metrics coming from: %s",
                       flb_input_name(ins));
-        cmt_encode_prometheus_destroy(text);
+        flb_sds_destroy(text);
         cmt_destroy(cmt);
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
-    cmt_encode_prometheus_destroy(text);
+    flb_sds_destroy(text);
 
     /* retrieve a full copy of all metrics */
     metrics = hash_format_metrics(ctx);


### PR DESCRIPTION
Like as ctraces, there is a possibility to handle concatenated metrics type of events payloads during processing #9119.
This is because in_statsd of metrics ingestion mode requests to handle cmetrics payloads which is ingested events more one times per a cycle.
Currently, we need to handle manually for multiply concatenated cmetrics payloads to handle multiple ingestion for metrics type of events.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
$ bin/fluent-bit -i fluentbit_metrics -o prometheus_exporter -v
```
- [x] Debug log output from testing the change
```log
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/07/23 16:50:08] [ info] Configuration:
[2024/07/23 16:50:08] [ info]  flush time     | 1.000000 seconds
[2024/07/23 16:50:08] [ info]  grace          | 5 seconds
[2024/07/23 16:50:08] [ info]  daemon         | 0
[2024/07/23 16:50:08] [ info] ___________
[2024/07/23 16:50:08] [ info]  inputs:
[2024/07/23 16:50:08] [ info]      fluentbit_metrics
[2024/07/23 16:50:08] [ info] ___________
[2024/07/23 16:50:08] [ info]  filters:
[2024/07/23 16:50:08] [ info] ___________
[2024/07/23 16:50:08] [ info]  outputs:
[2024/07/23 16:50:08] [ info]      prometheus_exporter.0
[2024/07/23 16:50:08] [ info] ___________
[2024/07/23 16:50:08] [ info]  collectors:
[2024/07/23 16:50:08] [ info] [fluent bit] version=3.1.4, commit=82a222f60f, pid=3598557
[2024/07/23 16:50:08] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/07/23 16:50:08] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/07/23 16:50:08] [ info] [cmetrics] version=0.9.1
[2024/07/23 16:50:08] [ info] [ctraces ] version=0.5.2
[2024/07/23 16:50:08] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2024/07/23 16:50:08] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2024/07/23 16:50:08] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=21 write=22
[2024/07/23 16:50:08] [debug] [prometheus_exporter:prometheus_exporter.0] created event channels: read=23 write=24
[2024/07/23 16:50:08] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2024/07/23 16:50:08] [ info] [sp] stream processor started
[2024/07/23 16:50:11] [debug] [task] created task=0x5f1bf90 id=0 OK
[2024/07/23 16:50:11] [debug] [out flush] cb_destroy coro_id=0
[2024/07/23 16:50:11] [debug] [task] destroy task=0x5f1bf90 (task_id=0)
[2024/07/23 16:50:13] [debug] [task] created task=0x8c95a50 id=0 OK
[2024/07/23 16:50:13] [debug] [out flush] cb_destroy coro_id=1
[2024/07/23 16:50:13] [debug] [task] destroy task=0x8c95a50 (task_id=0)
^C[2024/07/23 16:50:14] [engine] caught signal (SIGINT)
[2024/07/23 16:50:14] [ warn] [engine] service will shutdown in max 5 seconds
[2024/07/23 16:50:14] [ info] [input] pausing fluentbit_metrics.0
[2024/07/23 16:50:14] [ info] [engine] service has stopped (0 pending tasks)
[2024/07/23 16:50:14] [ info] [input] pausing fluentbit_metrics.0
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```log
==3598557== 
==3598557== HEAP SUMMARY:
==3598557==     in use at exit: 0 bytes in 0 blocks
==3598557==   total heap usage: 8,750 allocs, 8,750 frees, 11,432,040 bytes allocated
==3598557== 
==3598557== All heap blocks were freed -- no leaks are possible
==3598557== 
==3598557== For lists of detected and suppressed errors, rerun with: -s
==3598557== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
