### PR TITLE
aws_util: fix leading zeros in time_key strings

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -1003,9 +1003,9 @@ size_t flb_aws_strftime_precision(char **out_buf, const char *time_format,
 
     /* Replace %3N to millisecond, %9N and %L to nanosecond in time_format. */
     snprintf(millisecond_str, FLB_AWS_MILLISECOND_FORMATTER_LENGTH+1,
-             "%" PRIu64, (uint64_t) tms->tm.tv_nsec / 1000000);
+             "%03" PRIu64, (uint64_t) tms->tm.tv_nsec / 1000000);
     snprintf(nanosecond_str, FLB_AWS_NANOSECOND_FORMATTER_LENGTH+1,
-             "%" PRIu64, (uint64_t) tms->tm.tv_nsec);
+             "%09" PRIu64, (uint64_t) tms->tm.tv_nsec);
     for (i = 0; i < time_format_len; i++) {
         if (strncmp(time_format+i, FLB_AWS_MILLISECOND_FORMATTER, 3) == 0) {
             strncat(tmp_parsed_time_str, millisecond_str,


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes leading zeros in time_key strings.

The kinesis_datastream/kinesis_firehose ouput plugin can add timestamps by specifying the time_key/time_key_format parameters.

Format qualifiers include `%3N` for milliseconds and `%9N` / `%L` for nanoseconds.

In the current implementation, the number of digits in the timestamp is insufficient when milliseconds are smaller than 100 ms (e.g., `0xx` / `00x` ) or nanoseconds are smaller than 100 ms (e.g., `0xxxxxxxxxxx` / `00xxxxxxxxx` ).

Therefore, the number of digits has been corrected to be correct.

This fix was opened by @PettitWesley in https://github.com/fluent/fluent-bit/pull/8116, but there have been no changes for about 6 months, and I was troubled that this problem was not resolved.

Therefore, I created a new Pull request.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

- Fixes #7538 
- Fixes #8116

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.