### PR TITLE
Add dump-config option to print read configuration on startup

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -165,6 +165,7 @@ static void flb_help(int rc, struct flb_config *config)
     print_opt("-q, --quiet", "quiet mode");
     print_opt("-S, --sosreport", "support report for Enterprise customers");
     print_opt("-Y, --enable-hot-reload", "enable for hot reloading");
+    print_opt("-a, --dump-config", "print configuration on startup");
     print_opt("-W, --disable-thread-safety-on-hot-reloading", "disable thread safety on hot reloading");
     print_opt("-V, --version", "show version number");
     print_opt("-h, --help", "print this help");
@@ -948,12 +949,16 @@ int flb_main(int argc, char **argv)
     int opt;
     int ret;
     flb_sds_t json;
+    int dump_cfg;
 
     /* handle plugin properties:  -1 = none, 0 = input, 1 = output */
     int last_plugin = -1;
 
     /* local variables to handle config options */
     char *cfg_file = NULL;
+
+    /* do not dump config file on default */
+    dump_cfg = FLB_FALSE;
 
     /* config format context */
     struct flb_cf *cf;
@@ -1024,6 +1029,7 @@ int flb_main(int argc, char **argv)
         { "http_listen",     required_argument, NULL, 'L' },
         { "http_port",       required_argument, NULL, 'P' },
 #endif
+        { "dump-config",    no_argument       , NULL, 'a' },
         { "enable-hot-reload",     no_argument, NULL, 'Y' },
 #ifdef FLB_HAVE_CHUNK_TRACE
         { "enable-chunk-trace",    no_argument, NULL, 'Z' },
@@ -1063,7 +1069,7 @@ int flb_main(int argc, char **argv)
     /* Parse the command line options */
     while ((opt = getopt_long(argc, argv,
                               "b:c:dDf:C:i:m:o:R:F:p:e:"
-                              "t:T:l:vw:qVhJL:HP:s:SWYZ",
+                              "t:T:l:vw:qVhJL:HP:s:SWaYZ",
                               long_opts, NULL)) != -1) {
 
         switch (opt) {
@@ -1221,6 +1227,9 @@ int flb_main(int argc, char **argv)
         case 'Y':
             flb_cf_section_property_add(cf_opts, service->properties, FLB_CONF_STR_HOT_RELOAD, 0, "on", 0);
             break;
+        case 'a':
+            dump_cfg = FLB_TRUE;
+            break;
         case 'W':
             flb_cf_section_property_add(cf_opts, service->properties,
                                         FLB_CONF_STR_HOT_RELOAD_ENSURE_THREAD_SAFETY, 0, "off", 0);
@@ -1313,6 +1322,16 @@ int flb_main(int argc, char **argv)
     config->cf_main = tmp;
     cf = tmp;
 #endif
+
+    /* Print read config for debugging purposes */
+    if(dump_cfg) {
+        if (cf) {
+            printf("\nRead configuration:\n");
+            flb_cf_dump(cf);
+            fflush(stdout);
+            fflush(stderr);
+        }
+    }
 
     /* Check co-routine stack size */
     if (config->coro_stack_size < getpagesize()) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR will add "-a"  "--dump-config" argument option which will use the flb_cf_dump method to print the internal representation of the loaded configuration during startup. This can be very helpful for debugging purposes.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
