### PR TITLE
node_exporter_metrics: Align the collecting metrics of unit statuses

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_systemd_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_systemd_linux.c
@@ -459,7 +459,7 @@ static int ne_systemd_update_unit_state(struct flb_ne *ctx)
             }
 
             for(index = 0 ; index < 5 ; index++) {
-                cmt_gauge_add(ctx->systemd_unit_state,
+                cmt_gauge_set(ctx->systemd_unit_state,
                               timestamp,
                               0,
                               3,
@@ -469,8 +469,9 @@ static int ne_systemd_update_unit_state(struct flb_ne *ctx)
                                         });
             }
 
-            cmt_gauge_inc(ctx->systemd_unit_state,
+            cmt_gauge_set(ctx->systemd_unit_state,
                           timestamp,
+                          1,
                           3,
                           (char *[]){ unit.name,
                                       unit.active_state,


### PR DESCRIPTION
<!-- Provide summary of changes -->

In the original node_exporter, it only uses 0 or 1 which means that this status is active or not.
To represent this specification on Fluent Bit, we need to fill as 0 at first. Then, we need filling with 1 for the active statuses.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
$bin/fluent-bit -i node_exporter_metrics -o stdout -v
```

- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==3791369== 
==3791369== HEAP SUMMARY:
==3791369==     in use at exit: 0 bytes in 0 blocks
==3791369==   total heap usage: 228,729 allocs, 228,729 frees, 13,302,851,339 bytes allocated
==3791369== 
==3791369== All heap blocks were freed -- no leaks are possible
==3791369== 
==3791369== For lists of detected and suppressed errors, rerun with: -s
==3791369== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
