### PR TITLE
in_node_exporter_metrics: systemd: treat states as boolean values.

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_systemd_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_systemd_linux.c
@@ -459,24 +459,28 @@ static int ne_systemd_update_unit_state(struct flb_ne *ctx)
             }
 
             for(index = 0 ; index < 5 ; index++) {
-                cmt_gauge_add(ctx->systemd_unit_state,
-                              timestamp,
-                              0,
-                              3,
-                              (char *[]){ unit.name,
+                if (strcmp(unit_states[index], unit.active_state) == 0) {
+                    cmt_gauge_set(ctx->systemd_unit_state,
+                                  timestamp,
+                                  1,
+                                  3,
+                                  (char *[]){ unit.name,
                                           unit_states[index],
                                           unit.type
-                                        });
+                                  }
+                    );
+                }
+                else {
+                    cmt_gauge_set(ctx->systemd_unit_state,
+                                  timestamp,
+                                  0,
+                                  3,
+                                  (char *[]){ unit.name,
+                                              unit_states[index],
+                                              unit.type
+                                  });
+                }
             }
-
-            cmt_gauge_inc(ctx->systemd_unit_state,
-                          timestamp,
-                          3,
-                          (char *[]){ unit.name,
-                                      unit.active_state,
-                                      unit.type
-                                    });
-
 
             if (unit.type != NULL) {
                 free(unit.type);


### PR DESCRIPTION
# Summary

Rewrite the node_exporter_metrics so that the state of systemd units is a boolean instead of incrementing it, ie:

```
node_systemd_unit_state{...name="keepalived.service",state="active"} 12
node_systemd_unit_state{...name="keepalived.service",state="inactive"} 257
```

This would instead be:

```
node_systemd_unit_state{...name="keepalived.service",state="active"} 0
node_systemd_unit_state{...name="keepalived.service",state="inactive"} 1
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
