### PR TITLE
in_forward: Use full width of gzip header for checking whether concatenated or not

### DIFF
--- a/include/fluent-bit/flb_gzip.h
+++ b/include/fluent-bit/flb_gzip.h
@@ -38,5 +38,6 @@ int flb_gzip_decompressor_dispatch(struct flb_decompression_context *context,
                                    void *out_data, size_t *out_size);
 
 int flb_is_http_session_gzip_compressed(struct mk_http_session *session);
+size_t flb_gzip_count(const char *data, size_t len, size_t **out_borders, size_t border_count);
 
 #endif

--- a/tests/internal/gzip.c
+++ b/tests/internal/gzip.c
@@ -40,7 +40,69 @@ void test_compress()
     flb_free(str);
 }
 
+void test_concatenated_gzip_count()
+{
+     int ret;
+    int sample_len;
+    char *in_data = morpheus;
+    size_t in_len;
+    void *str;
+    size_t len;
+    flb_sds_t payload = NULL;
+    flb_sds_t payload2 = NULL;
+    size_t border_count = 0;
+
+    sample_len = strlen(morpheus);
+    in_len = sample_len;
+    ret = flb_gzip_compress(in_data, in_len, &str, &len);
+    TEST_CHECK(ret == 0);
+
+    payload = flb_sds_create_len((char *)str, len);
+    payload2 = flb_sds_create_len((char *)str, len);
+    ret = flb_sds_cat_safe(&payload, payload2, flb_sds_len(payload2));
+    TEST_CHECK(ret == 0);
+
+    border_count = flb_gzip_count(payload, flb_sds_len(payload), NULL, 0);
+    TEST_CHECK(border_count == 1);
+
+    flb_free(str);
+    flb_sds_destroy(payload);
+    flb_sds_destroy(payload2);
+}
+
+void test_not_overflow_for_concatenated_gzip()
+{
+    const char data[] = {
+        0x00, 0x00, /* Initial padding */
+        0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, /* First gzip header (valid header) */
+        0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, /* Second gzip header (valid header) */
+        0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, /* Third gzip header (valid header) */
+    };
+    size_t len = sizeof(data);
+    size_t *borders = NULL;
+    size_t border_count = 0;
+    size_t count = 0;
+
+    /* Vaild gzip payloads have to 18 bytes lentgh at least.
+     * So, we get only 2 of vaild parts.
+     */
+    border_count = flb_gzip_count(data, len, NULL, 0);
+    TEST_CHECK(border_count == 2);
+
+    borders = (size_t *)flb_calloc(1, sizeof(size_t) * (border_count + 1));
+    TEST_CHECK(borders != NULL);
+
+    count = flb_gzip_count(data, len, &borders, border_count);
+    TEST_CHECK(count == 2);
+
+    if (borders != NULL) {
+        free(borders);
+    }
+}
+
 TEST_LIST = {
     {"compress", test_compress},
+    {"count",  test_concatenated_gzip_count},
+    {"not_overflow", test_not_overflow_for_concatenated_gzip},
     { 0 }
 };


### PR DESCRIPTION
Using for concatenated gzip conformation with magic bytes, compression method and OS flags.

* 0x1f & 0x8b
* 8 (deflate)
* skip 7 bytes
* OS flags <--- Added in this PR

Follows up for https://github.com/fluent/fluent-bit/pull/8665.
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
