### PR TITLE
out_s3: Plug memory leaks on gzipped buffers during the swapping contents

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1227,6 +1227,8 @@ static int put_all_chunks(struct flb_s3 *ctx)
                     flb_plg_error(ctx->ins, "Failed to compress data, uploading uncompressed data instead to prevent data loss");
                 } else {
                     flb_plg_info(ctx->ins, "Pre-compression chunk size is %zu, After compression, chunk is %zu bytes", buffer_size, payload_size);
+                    flb_free(buffer);
+
                     buffer = (void *) payload_buf;
                     buffer_size = payload_size;
                 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Almost fixing for https://github.com/fluent/fluent-bit/issues/9093.

From the issue, the following valgrind log:

```
==8530== 110,926,948 bytes in 21 blocks are definitely lost in loss record 46 of 47
==8530==    at 0x4C39185: malloc (vg_replace_malloc.c:442)
==8530==    by 0xF0898D: cio_file_content_copy (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0xF05568: cio_chunk_get_content_copy (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0xB82CE3: flb_fstore_file_content_copy (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0xA7F976: s3_store_file_read (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0xA76D08: construct_request_buffer (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0xA7688B: put_all_chunks (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0xA7AB85: cb_s3_exit (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0x54F705: flb_output_exit (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0x577545: flb_engine_shutdown (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0x57717B: flb_engine_start (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
==8530==    by 0x518F12: flb_lib_worker (in /opt/fluent-bit/code/fluent-bit/bin/fluent-bit)
```

could caused by missing free against the allocated buffer by construct_request_buffer.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```ini
[SERVICE]
    Flush        5
    Daemon       Off
    Log_Level    debug
    HTTP_Server  Off
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name dummy
    Tag  dummy.local
    dummy {"boolean": false, "int": 1, "long": 1, "float": 1.1, "double": 1.1, "bytes": "foo", "string": "foo"}
    # threaded on

[OUTPUT]
    Name  s3
    Match dummy*
    Region us-east-2
    bucket fbit-parquet-s3
    Use_Put_object true
    compression gzip
```

- [x] Debug log output from testing the change

```
Fluent Bit v3.1.5
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/07/30 19:51:00] [ info] Configuration:
[2024/07/30 19:51:00] [ info]  flush time     | 5.000000 seconds
[2024/07/30 19:51:00] [ info]  grace          | 5 seconds
[2024/07/30 19:51:00] [ info]  daemon         | 0
[2024/07/30 19:51:00] [ info] ___________
[2024/07/30 19:51:00] [ info]  inputs:
[2024/07/30 19:51:00] [ info]      dummy
[2024/07/30 19:51:00] [ info] ___________
[2024/07/30 19:51:00] [ info]  filters:
[2024/07/30 19:51:00] [ info] ___________
[2024/07/30 19:51:00] [ info]  outputs:
[2024/07/30 19:51:00] [ info]      s3.0
[2024/07/30 19:51:00] [ info] ___________
[2024/07/30 19:51:00] [ info]  collectors:
[2024/07/30 19:51:00] [ info] [fluent bit] version=3.1.5, commit=6df1f2bf7c, pid=4002732
[2024/07/30 19:51:00] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/07/30 19:51:00] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/07/30 19:51:00] [ info] [cmetrics] version=0.9.1
[2024/07/30 19:51:00] [ info] [ctraces ] version=0.5.2
[2024/07/30 19:51:00] [ info] [output:s3:s3.0] worker #0 started
[2024/07/30 19:51:00] [ info] [input:dummy:dummy.0] initializing
[2024/07/30 19:51:00] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/07/30 19:51:00] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/07/30 19:51:00] [debug] [s3:s3.0] created event channels: read=23 write=24
[2024/07/30 19:51:00] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2024/07/30 19:51:00] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2024/07/30 19:51:00] [debug] [aws_credentials] creating profile (null) provider
[2024/07/30 19:51:00] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2024/07/30 19:51:00] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2024/07/30 19:51:00] [debug] [aws_credentials] Not initializing ECS Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not set
[2024/07/30 19:51:00] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2024/07/30 19:51:00] [debug] [aws_credentials] Sync called on the EC2 provider
[2024/07/30 19:51:00] [debug] [aws_credentials] Init called on the env provider
[2024/07/30 19:51:00] [debug] [aws_credentials] upstream_set called on the EC2 provider
[2024/07/30 19:51:00] [ info] [sp] stream processor started
[2024/07/30 19:51:05] [debug] [task] created task=0x6141de0 id=0 OK
[2024/07/30 19:51:05] [debug] [output:s3:s3.0] task_id=0 assigned to thread #0
[2024/07/30 19:51:05] [debug] [output:s3:s3.0] Creating upload timer with frequency 60s
[2024/07/30 19:51:05] [debug] [task] destroy task=0x6141de0 (task_id=0)
[2024/07/30 19:51:05] [debug] [out flush] cb_destroy coro_id=0
^C[2024/07/30 19:51:06] [engine] caught signal (SIGINT)
[2024/07/30 19:51:06] [debug] [task] created task=0x61b26c0 id=0 OK
[2024/07/30 19:51:06] [debug] [output:s3:s3.0] task_id=0 assigned to thread #0
[2024/07/30 19:51:06] [ warn] [engine] service will shutdown in max 5 seconds
[2024/07/30 19:51:06] [debug] [out flush] cb_destroy coro_id=1
[2024/07/30 19:51:06] [ info] [input] pausing dummy.0
[2024/07/30 19:51:06] [debug] [task] destroy task=0x61b26c0 (task_id=0)
[2024/07/30 19:51:07] [ info] [engine] service has stopped (0 pending tasks)
[2024/07/30 19:51:07] [ info] [input] pausing dummy.0
[2024/07/30 19:51:07] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2024/07/30 19:51:07] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2024/07/30 19:51:07] [ info] [output:s3:s3.0] thread worker #0 stopped
[2024/07/30 19:51:07] [ info] [output:s3:s3.0] Pre-compression chunk size is 756, After compression, chunk is 167 bytes
[2024/07/30 19:51:08] [debug] [upstream] KA connection #25 to s3.us-east-2.amazonaws.com:443 is connected
[2024/07/30 19:51:08] [debug] [http_client] not using http_proxy for header
[2024/07/30 19:51:08] [debug] [aws_credentials] Requesting credentials from the env provider..
[2024/07/30 19:51:08] [debug] [upstream] KA connection #25 to s3.us-east-2.amazonaws.com:443 is now available
[2024/07/30 19:51:08] [debug] [output:s3:s3.0] PutObject http status=200
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==4002732== 
==4002732== HEAP SUMMARY:
==4002732==     in use at exit: 0 bytes in 0 blocks
==4002732==   total heap usage: 20,254 allocs, 20,254 frees, 3,901,196 bytes allocated
==4002732== 
==4002732== All heap blocks were freed -- no leaks are possible
==4002732== 
==4002732== For lists of detected and suppressed errors, rerun with: -s
==4002732== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
