### PR TITLE
wasm: in_exec_wasi: filter_wasm: Make configurable for wasm heap and stack sizes

### DIFF
--- a/include/fluent-bit/wasm/flb_wasm.h
+++ b/include/fluent-bit/wasm/flb_wasm.h
@@ -27,6 +27,17 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_log_event.h>
 
+#define FLB_WASM_DEFAULT_HEAP_SIZE  8192
+#define FLB_WASM_DEFAULT_STACK_SIZE 8192
+
+struct flb_wasm_config {
+    size_t heap_size;
+    size_t stack_size;
+    int stdinfd;
+    int stdoutfd;
+    int stderrfd;
+};
+
 /* WASM Context */
 struct flb_wasm {
     wasm_module_t module;
@@ -41,9 +52,11 @@ struct flb_wasm {
 };
 
 void flb_wasm_init(struct flb_config *config);
+struct flb_wasm_config *flb_wasm_config_init(struct flb_config *config);
+void flb_wasm_config_destroy(struct flb_wasm_config *wasm_config);
 struct flb_wasm *flb_wasm_instantiate(struct flb_config *config, const char *wasm_path,
                                       struct mk_list *acessible_dir_list,
-                                      int stdinfd, int stdoutfd, int stderrfd);
+                                      struct flb_wasm_config *wasm_config);
 
 char *flb_wasm_call_function_format_json(struct flb_wasm *fw, const char *function_name,
                                          const char* tag_data, size_t tag_len,

--- a/plugins/filter_wasm/filter_wasm.h
+++ b/plugins/filter_wasm/filter_wasm.h
@@ -38,12 +38,18 @@ enum {
 #define FLB_FMT_STR_JSON    "json"
 #define FLB_FMT_STR_MSGPACK "msgpack"
 
+#define DEFAULT_WASM_HEAP_SIZE  "8192"
+#define DEFAULT_WASM_STACK_SIZE "8192"
+
 struct flb_filter_wasm {
     flb_sds_t wasm_path;
     struct mk_list *accessible_dir_list; /* list of directories to be
                                           * accesible from WASM */
     flb_sds_t wasm_function_name;
     int event_format;
+    size_t wasm_heap_size;
+    size_t wasm_stack_size;
+    struct flb_wasm_config *wasm_conf;
     struct flb_filter_instance *ins;
     struct flb_wasm *wasm;
 };

--- a/plugins/in_exec_wasi/in_exec_wasi.c
+++ b/plugins/in_exec_wasi/in_exec_wasi.c
@@ -74,7 +74,14 @@ static int in_exec_wasi_collect(struct flb_input_instance *ins,
         }
     }
 
-    wasm = flb_wasm_instantiate(config, ctx->wasi_path, ctx->accessible_dir_list, -1, fileno(stdoutp), -1);
+    if (ctx->wasm_conf == NULL) {
+        flb_plg_error(ctx->ins, "wasm_conf cannot be NULL");
+        return -1;
+    }
+    ctx->wasm_conf->stdoutfd = fileno(stdoutp);
+
+    wasm = flb_wasm_instantiate(config, ctx->wasi_path, ctx->accessible_dir_list,
+                                ctx->wasm_conf);
     if (wasm == NULL) {
         flb_plg_debug(ctx->ins, "instantiate wasm [%s] failed", ctx->wasi_path);
         goto collect_end;
@@ -289,6 +296,7 @@ static int in_exec_wasi_init(struct flb_input_instance *in,
                         struct flb_config *config, void *data)
 {
     struct flb_exec_wasi *ctx = NULL;
+    struct flb_wasm_config *wasm_conf = NULL;
     int ret = -1;
 
     /* Allocate space for the configuration */
@@ -341,6 +349,20 @@ static int in_exec_wasi_init(struct flb_input_instance *in,
         flb_plg_error(in, "could not set collector for exec input plugin");
         goto init_error;
     }
+
+    wasm_conf = flb_wasm_config_init(config);
+    if (wasm_conf == NULL) {
+        goto init_error;
+    }
+    ctx->wasm_conf = wasm_conf;
+
+    if (ctx->wasm_heap_size > FLB_WASM_DEFAULT_HEAP_SIZE) {
+        wasm_conf->heap_size = ctx->wasm_heap_size;
+    }
+    if (ctx->wasm_stack_size > FLB_WASM_DEFAULT_STACK_SIZE) {
+        wasm_conf->stack_size = ctx->wasm_stack_size;
+    }
+
     ctx->coll_fd = ret;
 
     return 0;
@@ -391,6 +413,7 @@ static int in_exec_wasi_exit(void *data, struct flb_config *config)
 {
     struct flb_exec_wasi *ctx = data;
 
+    flb_wasm_config_destroy(ctx->wasm_conf);
     flb_wasm_destroy_all(config);
     delete_exec_wasi_config(ctx);
     return 0;
@@ -432,6 +455,16 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_BOOL, "bool", "false",
       0, FLB_TRUE, offsetof(struct flb_exec_wasi, oneshot),
       "execute the command only once"
+    },
+    {
+      FLB_CONFIG_MAP_SIZE, "wasm_heap_size", DEFAULT_WASM_HEAP_SIZE,
+      0, FLB_TRUE, offsetof(struct flb_exec_wasi, wasm_heap_size),
+      "Set the heap size of wasm runtime"
+    },
+    {
+      FLB_CONFIG_MAP_SIZE, "wasm_stack_size", DEFAULT_WASM_STACK_SIZE,
+      0, FLB_TRUE, offsetof(struct flb_exec_wasi, wasm_stack_size),
+      "Set the stack size of wasm runtime"
     },
     /* EOF */
     {0}

--- a/plugins/in_exec_wasi/in_exec_wasi.h
+++ b/plugins/in_exec_wasi/in_exec_wasi.h
@@ -34,6 +34,9 @@
 #define DEFAULT_INTERVAL_SEC  "1"
 #define DEFAULT_INTERVAL_NSEC "0"
 
+#define DEFAULT_WASM_HEAP_SIZE  "8192"
+#define DEFAULT_WASM_STACK_SIZE "8192"
+
 struct flb_exec_wasi {
     flb_sds_t wasi_path;
     struct mk_list *accessible_dir_list; /* list of directories to be
@@ -44,10 +47,13 @@ struct flb_exec_wasi {
     size_t buf_size;
     struct flb_input_instance *ins;
     struct flb_wasm *wasm;
+    struct flb_wasm_config *wasm_conf;
     int oneshot;
     flb_pipefd_t ch_manager[2];
     int interval_sec;
     int interval_nsec;
+    size_t wasm_heap_size;
+    size_t wasm_stack_size;
     struct flb_log_event_encoder log_encoder;
     int coll_fd;
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, heap and stack sizes for Wasm is fixed and not configurable.
This PR indented to make them configurable.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
    Flush        1
    Daemon       Off
    Log_Level    debug
    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020
    Hot_Reload   On
    Grace 5

[INPUT]
    Name dummy
    Tag dummy.locals
    Dummy {"message":"dummy","wasm_float1":1.0,"wasm_float2":100.0,"wasm_int1":1,"wasm_int2":100}

[FILTER]
    Name wasm
    WASM_Path rust_clib_filter.aot
    Function_Name rust_clib_filter
    accessible_paths .

[OUTPUT]
    Name  stdout
    Match *
```

```ini
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    debug
    HTTP_Server  Off
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name exec_wasi
    Tag  exec.wasi.local
    WASI_path wasi_serde_json.wasm
    Parser wasi
    accessible_paths .

[OUTPUT]
    Name  stdout
    Match *

```

- [x] Debug log output from testing the change

```log
Fluent Bit v3.1.5
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/08/09 18:47:23] [ info] Configuration:
[2024/08/09 18:47:23] [ info]  flush time     | 1.000000 seconds
[2024/08/09 18:47:23] [ info]  grace          | 5 seconds
[2024/08/09 18:47:23] [ info]  daemon         | 0
[2024/08/09 18:47:23] [ info] ___________
[2024/08/09 18:47:23] [ info]  inputs:
[2024/08/09 18:47:23] [ info]      dummy
[2024/08/09 18:47:23] [ info] ___________
[2024/08/09 18:47:23] [ info]  filters:
[2024/08/09 18:47:23] [ info]      wasm.0
[2024/08/09 18:47:23] [ info] ___________
[2024/08/09 18:47:23] [ info]  outputs:
[2024/08/09 18:47:23] [ info]      stdout.0
[2024/08/09 18:47:23] [ info] ___________
[2024/08/09 18:47:23] [ info]  collectors:
[2024/08/09 18:47:23] [ info] [fluent bit] version=3.1.5, commit=725640616f, pid=1913275
[2024/08/09 18:47:23] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/08/09 18:47:23] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/08/09 18:47:23] [ info] [cmetrics] version=0.9.3
[2024/08/09 18:47:23] [ info] [ctraces ] version=0.5.3
[2024/08/09 18:47:23] [ info] [input:dummy:dummy.0] initializing
[2024/08/09 18:47:23] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/08/09 18:47:23] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/08/09 18:47:23] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/08/09 18:47:23] [ info] [output:stdout:stdout.0] worker #0 started
[2024/08/09 18:47:23] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2024/08/09 18:47:23] [ info] [sp] stream processor started
[2024/08/09 18:47:25] [debug] [task] created task=0x7072f0036ba0 id=0 OK
[2024/08/09 18:47:25] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1723196844.280299405, {}], {"lang"=>"Rust", "message"=>"dummy", "original"=>"{"message":"dummy","wasm_float1":1.0,"wasm_float2":100.0,"wasm_int1":1,"wasm_int2":100}", "tag"=>"dummy.locals", "time"=>"2024-08-09T09:47:24.280299405 +0000"}]
[2024/08/09 18:47:25] [debug] [out flush] cb_destroy coro_id=0
[2024/08/09 18:47:25] [debug] [task] destroy task=0x7072f0036ba0 (task_id=0)
^C[2024/08/09 18:47:25] [engine] caught signal (SIGINT)
[2024/08/09 18:47:25] [debug] [task] created task=0x7072f0038530 id=0 OK
[2024/08/09 18:47:25] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2024/08/09 18:47:25] [ warn] [engine] service will shutdown in max 5 seconds
[2024/08/09 18:47:25] [ info] [input] pausing dummy.0
[0] dummy.locals: [[1723196845.280252631, {}], {"lang"=>"Rust", "message"=>"dummy", "original"=>"{"message":"dummy","wasm_float1":1.0,"wasm_float2":100.0,"wasm_int1":1,"wasm_int2":100}", "tag"=>"dummy.locals", "time"=>"2024-08-09T09:47:25.280252631 +0000"}]
[2024/08/09 18:47:25] [debug] [out flush] cb_destroy coro_id=1
[2024/08/09 18:47:25] [debug] [task] destroy task=0x7072f0038530 (task_id=0)
[2024/08/09 18:47:26] [ info] [engine] service has stopped (0 pending tasks)
[2024/08/09 18:47:26] [ info] [input] pausing dummy.0
[2024/08/09 18:47:26] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/08/09 18:47:26] [ info] [output:stdout:stdout.0] thread worker #5035 
```

```
Fluent Bit v3.1.5
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/08/09 18:48:22] [ info] Configuration:
[2024/08/09 18:48:22] [ info]  flush time     | 1.000000 seconds
[2024/08/09 18:48:22] [ info]  grace          | 5 seconds
[2024/08/09 18:48:22] [ info]  daemon         | 0
[2024/08/09 18:48:22] [ info] ___________
[2024/08/09 18:48:22] [ info]  inputs:
[2024/08/09 18:48:22] [ info]      exec_wasi
[2024/08/09 18:48:22] [ info] ___________
[2024/08/09 18:48:22] [ info]  filters:
[2024/08/09 18:48:22] [ info] ___________
[2024/08/09 18:48:22] [ info]  outputs:
[2024/08/09 18:48:22] [ info]      stdout.0
[2024/08/09 18:48:22] [ info] ___________
[2024/08/09 18:48:22] [ info]  collectors:
[2024/08/09 18:48:22] [ info] [fluent bit] version=3.1.5, commit=725640616f, pid=1913719
[2024/08/09 18:48:22] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/08/09 18:48:22] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/08/09 18:48:22] [ info] [cmetrics] version=0.9.3
[2024/08/09 18:48:22] [ info] [ctraces ] version=0.5.3
[2024/08/09 18:48:22] [ info] [input:exec_wasi:exec_wasi.0] initializing
[2024/08/09 18:48:22] [ info] [input:exec_wasi:exec_wasi.0] storage_strategy='memory' (memory only)
[2024/08/09 18:48:22] [debug] [exec_wasi:exec_wasi.0] created event channels: read=21 write=22
[2024/08/09 18:48:22] [debug] [input:exec_wasi:exec_wasi.0] interval_sec=1 interval_nsec=0 oneshot=0 buf_size=4096
[2024/08/09 18:48:22] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/08/09 18:48:22] [ info] [sp] stream processor started
[2024/08/09 18:48:22] [ info] [output:stdout:stdout.0] worker #0 started
[2024/08/09 18:48:23] [debug] [task] created task=0x7579a007e1c0 id=0 OK
[2024/08/09 18:48:23] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] exec.wasi.local: [[1723196902.306833567, {}], {"age"=>43, "name"=>"John Doe", "phones"=>["+44 1234567", "+44 2345678"]}]
[2024/08/09 18:48:23] [debug] [out flush] cb_destroy coro_id=0
[2024/08/09 18:48:23] [debug] [task] destroy task=0x7579a007e1c0 (task_id=0)
^C[2024/08/09 18:48:24] [engine] caught signal (SIGINT)
[2024/08/09 18:48:24] [debug] [task] created task=0x7579a007fdd0 id=0 OK
[2024/08/09 18:48:24] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2024/08/09 18:48:24] [ warn] [engine] service will shutdown in max 5 seconds
[2024/08/09 18:48:24] [ info] [input] pausing exec_wasi.0
[0] exec.wasi.local: [[1723196903.291697447, {}], {"age"=>43, "name"=>"John Doe", "phones"=>["+44 1234567", "+44 2345678"]}]
[2024/08/09 18:48:24] [debug] [out flush] cb_destroy coro_id=1
[2024/08/09 18:48:24] [debug] [task] destroy task=0x7579a007fdd0 (task_id=0)
[2024/08/09 18:48:24] [ info] [engine] service has stopped (0 pending tasks)
[2024/08/09 18:48:24] [ info] [input] pausing exec_wasi.0
[2024/08/09 18:48:24] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/08/09 18:48:24] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
