### PR TITLE
out_kinesis_streams: Add Port config option for Kinesis plugin

### DIFF
--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -113,6 +113,11 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
         ctx->custom_endpoint = FLB_FALSE;
     }
 
+    tmp = flb_output_get_property("port", ins);
+    if (tmp) {
+        ctx->port = tmp;
+    }
+
     tmp = flb_output_get_property("sts_endpoint", ins);
     if (tmp) {
         ctx->sts_endpoint = (char *) tmp;
@@ -255,7 +260,7 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
     ctx->kinesis_client->region = (char *) ctx->region;
     ctx->kinesis_client->retry_requests = ctx->retry_requests;
     ctx->kinesis_client->service = "kinesis";
-    ctx->kinesis_client->port = 443;
+    ctx->kinesis_client->port = ctx->port;
     ctx->kinesis_client->flags = 0;
     ctx->kinesis_client->proxy = NULL;
     ctx->kinesis_client->static_headers = &content_type_header;
@@ -438,6 +443,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "endpoint", NULL,
      0, FLB_FALSE, 0,
      "Specify a custom endpoint for the Kinesis API"
+    },
+
+    {
+     FLB_CONFIG_MAP_INT, "port", 443,
+     0, FLB_FALSE, 0,
+     "Specify a port for the Kinesis API"
     },
 
     {

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -113,11 +113,6 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
         ctx->custom_endpoint = FLB_FALSE;
     }
 
-    tmp = flb_output_get_property("port", ins);
-    if (tmp) {
-        ctx->port = tmp;
-    }
-
     tmp = flb_output_get_property("sts_endpoint", ins);
     if (tmp) {
         ctx->sts_endpoint = (char *) tmp;
@@ -446,8 +441,8 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_INT, "port", 443,
-     0, FLB_FALSE, 0,
+     FLB_CONFIG_MAP_INT, "port", "443",
+     0, FLB_TRUE, offsetof(struct flb_kinesis, port),
      "Specify a port for the Kinesis API"
     },
 

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -89,6 +89,7 @@ struct flb_kinesis {
     const char *role_arn;
     const char *log_key;
     const char *external_id;
+    const int port;
     int retry_requests;
     char *sts_endpoint;
     int custom_endpoint;

--- a/tests/runtime/out_kinesis.c
+++ b/tests/runtime/out_kinesis.c
@@ -33,6 +33,7 @@ void flb_test_firehose_success(void)
     flb_output_set(ctx, out_ffd,"stream", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"time_key", "time", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+    flb_output_set(ctx, out_ffd,"port", "443", NULL);
 
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);


### PR DESCRIPTION
<!-- Provide summary of changes -->
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Add option to configure port for Kinesis plugin
----
Addresses #9160 
**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1421
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
