### PR TITLE
core: memory alignment feature addition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ option(FLB_WINDOWS_DEFAULTS    "Build with predefined Windows settings"     Yes)
 option(FLB_WASM                "Build with WASM runtime support"            Yes)
 option(FLB_WAMRC               "Build with WASM AOT compiler executable"    No)
 option(FLB_WASM_STACK_PROTECT  "Build with WASM runtime with strong stack protector flags" No)
+option(FLB_ENFORCE_ALIGNMENT   "Enable limited platform specific aligned memory access" No)
 
 # Native Metrics Support (cmetrics)
 option(FLB_METRICS             "Enable metrics support"       Yes)
@@ -336,6 +337,11 @@ if(FLB_IPO STREQUAL "On" OR (FLB_IPO STREQUAL "ReleaseOnly" AND FLB_RELEASE))
   else()
     message(Warning "IPO is not supported on this platform")
   endif()
+endif()
+
+# Memory alignment enforcement
+if(FLB_ENFORCE_ALIGNMENT)
+  FLB_DEFINITION(FLB_ENFORCE_ALIGNMENT)
 endif()
 
 # Harden release binary against security vulnerabilities

--- a/include/fluent-bit/flb_endian.h
+++ b/include/fluent-bit/flb_endian.h
@@ -51,4 +51,17 @@
 #define be64toh(x) OSSwapBigToHostInt64(x)
 #endif
 
+#define FLB_LITTLE_ENDIAN 0
+#define FLB_BIG_ENDIAN    1
+
+#ifndef FLB_BYTE_ORDER
+    #if defined(__BYTE_ORDER__) &&  __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        #define FLB_BYTE_ORDER FLB_BIG_ENDIAN
+    #elif defined(__BIG_ENDIAN__) || defined(__BIG_ENDIAN) || defined(_BIG_ENDIAN)
+        #define FLB_BYTE_ORDER FLB_BIG_ENDIAN
+    #else
+        #define FLB_BYTE_ORDER FLB_LITTLE_ENDIAN
+    #endif
+#endif
+
 #endif

--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -19,6 +19,7 @@
 
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_byteswap.h>
+#include <fluent-bit/flb_compat.h>
 
 static int create_empty_map(struct flb_log_event_decoder *context) {
     msgpack_packer  packer;
@@ -179,8 +180,15 @@ int flb_log_event_decoder_decode_timestamp(msgpack_object *input,
             return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
         }
 
-        output->tm.tv_sec  = (int32_t) FLB_BSWAP_32(*((uint32_t *) &input->via.ext.ptr[0]));
-        output->tm.tv_nsec = (int32_t) FLB_BSWAP_32(*((uint32_t *) &input->via.ext.ptr[4]));
+        output->tm.tv_sec  = 
+            (int32_t) FLB_BSWAP_32(
+                        FLB_ALIGNED_DWORD_READ(
+                            (unsigned char *) &input->via.ext.ptr[0]));
+
+        output->tm.tv_nsec  = 
+            (int32_t) FLB_BSWAP_32(
+                        FLB_ALIGNED_DWORD_READ(
+                            (unsigned char *) &input->via.ext.ptr[4]));
     }
     else {
         return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;


### PR DESCRIPTION
This PR adds a new feature flag named `FLB_ENFORCE_ALIGNMENT` which can be used to ensure that when decoding the timestamp field from a record fluent-bit ensures that the memory access operation is aligned which is not the case normally due to how the msgpack wire protocol packs `ext` types.

While it's clear that exchanging one read operation for seven reads and a few more writes is undesirable to say the least, this  is the only way I found to ensure that the output machine code was not tampered with in any of the compiler and architecture combinations.

There are two alternative implementations for this function using either two individual `DWORD` reads : 


```
uint32_t __attribute__((optimize("-O0"))) FLB_ALIGNED_DWORD_READ(char *source) {
    uintptr_t      alignment_offset;
    unsigned char *aligned_address;
    uint64_t       result;

    alignment_offset = ((uintptr_t) source) % sizeof(uint32_t);
    aligned_address = (unsigned char *) &source[alignment_offset * -1];

    result = ((uint64_t *) aligned_address)[0];

    result >>= (alignment_offset * 8);
    result  &= 0xFFFFFFFF;

    return (uint32_t) result;
}
```

Or one `QWORD` read (which is translated to one "load pair of DWORDs" operation in ARMv7) :

```
uint32_t __attribute__((optimize("-O0"))) FLB_ALIGNED_DWORD_READ(char *source) {
    uintptr_t      alignment_offset;
    unsigned char *aligned_address;
    uint32_t       result[2];

    alignment_offset = ((uintptr_t) source) % sizeof(uint32_t);
    aligned_address = (unsigned char *) &source[alignment_offset * -1];

    result[0]   = ((uint32_t *) aligned_address)[0];
    result[0] >>= (alignment_offset * 8);

    result[1]   = ((uint32_t *) aligned_address)[1];
    result[1] <<= ((sizeof(uint32_t) - alignment_offset) * 8);

    return (uint32_t) result[0] | result[1];
}
```

However, both of these alternatives could exceed the bounds of a memory page given the "right" pointer resulting in a segment violation and more importantly, the code is way less straightforward and thus error prone with questionable (if any) performance gains in return.

I wanted to add this context so anyone who takes the time to review these changes or tries to improve the code in the future has enough information to avoid wasting time, getting frustrated or worse causing a regression.

Two additional useful pieces of information :

1. If you want to verify the machine code generated use godbolt is the easiest way to be able to inspect a wide range of architecture, compiler and compiler flag combinations.
2. Using [Cpulator](https://cpulator.01xz.net/?sys=arm) you can easily test the code because it does support the relevant [CPU flags](https://developer.arm.com/documentation/den0013/d/ARM-Processor-Modes-and-Registers/Registers/System-control-register--SCTLR-?lang=en)
3. It should be possible and maybe even desirable to create an integration test using either the unicorn emulator or qemu, however, that's not included in this PR.
