### PR TITLE
in_http: reduce duplicate code

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -278,8 +278,9 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
     while (msgpack_unpack_next(&result, buf, size, &off) == MSGPACK_UNPACK_SUCCESS) {
         if (result.data.type == MSGPACK_OBJECT_MAP) {
             tag_from_record = NULL;
+            obj = &result.data;
+
             if (ctx->tag_key) {
-                obj = &result.data;
                 tag_from_record = tag_key(ctx, obj);
             }
 
@@ -390,6 +391,24 @@ static ssize_t parse_payload_json(struct flb_http *ctx, flb_sds_t tag,
     flb_free(pack);
 
     return ret;
+}
+
+static ssize_t parse_payload_json_ng(flb_sds_t tag,
+                                     struct flb_http_request *request)
+{
+    int ret;
+    int out_size;
+    char *pack;
+    struct flb_pack_state pack_state;
+    struct flb_http *ctx;
+    char *payload;
+    size_t size;
+
+    ctx = (struct flb_http *) request->stream->user_data;
+    payload = (char *) request->body;
+    size = cfl_sds_len(request->body);
+
+    return parse_payload_json(ctx, tag, payload, size);
 }
 
 static ssize_t parse_payload_urlencoded(struct flb_http *ctx, flb_sds_t tag,
@@ -760,141 +779,6 @@ static int send_response_ng(struct flb_http_response *response,
     flb_http_response_commit(response);
 
     return 0;
-}
-
-static int process_pack_ng(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
-{
-    int ret;
-    size_t off = 0;
-    msgpack_unpacked result;
-    struct flb_time tm;
-    int i = 0;
-    msgpack_object *obj;
-    msgpack_object record;
-    flb_sds_t tag_from_record = NULL;
-
-    flb_time_get(&tm);
-
-    msgpack_unpacked_init(&result);
-    while (msgpack_unpack_next(&result, buf, size, &off) == MSGPACK_UNPACK_SUCCESS) {
-        if (result.data.type == MSGPACK_OBJECT_MAP) {
-            tag_from_record = NULL;
-            obj = &result.data;
-
-            if (ctx->tag_key) {
-                tag_from_record = tag_key(ctx, obj);
-            }
-
-            if (tag_from_record) {
-                ret = process_pack_record(ctx, &tm, tag_from_record, obj);
-                flb_sds_destroy(tag_from_record);
-            }
-            else if (tag) {
-                ret = process_pack_record(ctx, &tm, tag, obj);
-            }
-            else {
-                ret = process_pack_record(ctx, &tm, NULL, obj);
-            }
-
-            if (ret != 0) {
-                goto log_event_error;
-            }
-
-            flb_log_event_encoder_reset(&ctx->log_encoder);
-        }
-        else if (result.data.type == MSGPACK_OBJECT_ARRAY) {
-            obj = &result.data;
-            for (i = 0; i < obj->via.array.size; i++)
-            {
-                record = obj->via.array.ptr[i];
-
-                if (tag_from_record) {
-                    ret = process_pack_record(ctx, &tm, tag_from_record, &record);
-                    flb_sds_destroy(tag_from_record);
-                }
-                else if (tag) {
-                    ret = process_pack_record(ctx, &tm, tag, &record);
-                }
-                else {
-                    ret = process_pack_record(ctx, &tm, NULL, &record);
-                }
-
-                if (ret != 0) {
-                    goto log_event_error;
-                }
-
-                /* TODO : Optimize this
-                 *
-                 * This is wasteful, considering that we are emitting a series
-                 * of records we should start and commit each one and then
-                 * emit them all at once after the loop.
-                 */
-
-                flb_log_event_encoder_reset(&ctx->log_encoder);
-            }
-
-            break;
-        }
-        else {
-            flb_plg_error(ctx->ins, "skip record from invalid type: %i",
-                         result.data.type);
-
-            msgpack_unpacked_destroy(&result);
-
-            return -1;
-        }
-    }
-
-    msgpack_unpacked_destroy(&result);
-    return 0;
-
-log_event_error:
-    flb_plg_error(ctx->ins, "Error encoding record : %d", ret);
-    msgpack_unpacked_destroy(&result);
-    return -1;
-}
-
-static ssize_t parse_payload_json_ng(flb_sds_t tag,
-                                     struct flb_http_request *request)
-{
-    int ret;
-    int out_size;
-    char *pack;
-    struct flb_pack_state pack_state;
-    struct flb_http *ctx;
-    char *payload;
-    size_t size;
-
-    ctx = (struct flb_http *) request->stream->user_data;
-    payload = (char *) request->body;
-    size = cfl_sds_len(request->body);
-
-    /* Initialize packer */
-    flb_pack_state_init(&pack_state);
-
-    /* Pack JSON as msgpack */
-    ret = flb_pack_json_state(payload, size,
-                              &pack, &out_size, &pack_state);
-    flb_pack_state_reset(&pack_state);
-
-    /* Handle exceptions */
-    if (ret == FLB_ERR_JSON_PART) {
-        flb_plg_warn(ctx->ins, "JSON data is incomplete, skipping");
-        return -1;
-    }
-    else if (ret == FLB_ERR_JSON_INVAL) {
-        flb_plg_warn(ctx->ins, "invalid JSON message, skipping");
-        return -1;
-    }
-    else if (ret == -1) {
-        return -1;
-    }
-
-    /* Process the packaged JSON and return the last byte used */
-    ret = process_pack_ng(ctx, tag, pack, out_size);
-    flb_free(pack);
-
-    return ret;
 }
 
 static int process_payload_ng(flb_sds_t tag,

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -277,6 +277,80 @@ void flb_test_http()
     flb_upstream_conn_release(ctx->httpc->u_conn);
     test_ctx_destroy(ctx);
 }
+
+void flb_test_http_legacy()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+
+    char *buf = "{\"test\":\"msg\"}";
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "http2", "off",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", buf, strlen(buf),
+                        "127.0.0.1", 9880, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 201)) {
+        TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_http_successful_response_code(char *response_code)
 {
     struct flb_lib_out_cb cb_data;
@@ -584,6 +658,7 @@ void flb_test_http_tag_key()
 
 TEST_LIST = {
     {"http", flb_test_http},
+    {"http_legacy", flb_test_http_legacy},
     {"successful_response_code_200", flb_test_http_successful_response_code_200},
     {"successful_response_code_204", flb_test_http_successful_response_code_204},
     {"failure_response_code_400_bad_json", flb_test_http_failure_400_bad_json},


### PR DESCRIPTION
# Summary

Reduce duplicate code in the `in_http` plugin by consolidating calls between the legacy and nghttp2 functions, specifically the following functions:

- process_pack_ng
- parse_payload_json_ng
  - now a simple wrapper above parse_payload_json

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
