### PR TITLE
upstream_ha: upstream_node: process verify hostname on HA settings

### DIFF
--- a/include/fluent-bit/flb_upstream_node.h
+++ b/include/fluent-bit/flb_upstream_node.h
@@ -36,6 +36,7 @@ struct flb_upstream_node {
 #ifdef FLB_HAVE_TLS
     /* TLS: given configuration */
     int tls_verify;           /* Verify certs (default: true) */
+    int tls_verify_hostname;  /* Verify hostname (default: false) */
     int tls_debug;            /* mbedtls debug level          */
     char *tls_ca_path;        /* Path to certificates         */
     char *tls_ca_file;        /* CA root cert                 */
@@ -65,6 +66,7 @@ struct flb_upstream_node {
 struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t host,
                                                    flb_sds_t port,
                                                    int tls, int tls_verify,
+                                                   int tls_verify_hostname,
                                                    int tls_debug,
                                                    const char *tls_vhost,
                                                    const char *tls_ca_path,

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -79,6 +79,7 @@ static struct flb_upstream_node *flb_upstream_node_create_url(struct flb_azure_k
 
                     node = flb_upstream_node_create(
                         NULL, sds_host, sds_port, FLB_TRUE, ctx->ins->tls->verify,
+                        ctx->ins->tls->verify_hostname,
                         ctx->ins->tls->debug, ctx->ins->tls->vhost, NULL, NULL, NULL,
                         NULL, NULL, kv, config);
 

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -120,6 +120,7 @@ static struct flb_upstream_node *create_node(int id,
     int vlen;
     int tls = FLB_FALSE;
     int tls_verify = FLB_TRUE;
+    int tls_verify_hostname = FLB_FALSE;
     int tls_debug = 1;
     char key[32];
     char *tmp;
@@ -138,7 +139,8 @@ static struct flb_upstream_node *create_node(int id,
     const char *known_keys[] = {"name", "host", "port",
                                 "tls", "tls.vhost", "tls.verify", "tls.debug",
                                 "tls.ca_path", "tls.ca_file", "tls.crt_file",
-                                "tls.key_file", "tls.key_passwd", NULL};
+                                "tls.key_file", "tls.key_passwd",
+                                "tls.verify_hostname", NULL};
 
     struct flb_upstream_node *node;
 
@@ -177,6 +179,13 @@ static struct flb_upstream_node *create_node(int id,
     tmp = flb_cf_section_property_get_string(cf, s, "tls.verify");
     if (tmp) {
         tls_verify = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
+    }
+
+    /* tls.verify_hostname */
+    tmp = flb_cf_section_property_get_string(cf, s, "tls.verify_hostname");
+    if (tmp) {
+        tls_verify_hostname = flb_utils_bool(tmp);
         flb_sds_destroy(tmp);
     }
 
@@ -252,6 +261,7 @@ static struct flb_upstream_node *create_node(int id,
     }
 
     node = flb_upstream_node_create(name, host, port, tls, tls_verify,
+                                    tls_verify_hostname,
                                     tls_debug, tls_vhost, tls_ca_path, tls_ca_file,
                                     tls_crt_file, tls_key_file,
                                     tls_key_passwd, ht, config);

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -265,6 +265,32 @@ static struct flb_upstream_node *create_node(int id,
                                     tls_debug, tls_vhost, tls_ca_path, tls_ca_file,
                                     tls_crt_file, tls_key_file,
                                     tls_key_passwd, ht, config);
+
+    /* Teardown for created flb_sds_t stuffs by flb_cf_section_property_get_string(). */
+    if (tls_vhost != NULL) {
+        flb_sds_destroy(tls_vhost);
+    }
+
+    if (tls_ca_path != NULL) {
+        flb_sds_destroy(tls_ca_path);
+    }
+
+    if (tls_ca_file != NULL) {
+        flb_sds_destroy(tls_ca_file);
+    }
+
+    if (tls_crt_file != NULL) {
+        flb_sds_destroy(tls_crt_file);
+    }
+
+    if (tls_key_file != NULL) {
+        flb_sds_destroy(tls_key_file);
+    }
+
+    if (tls_key_passwd != NULL) {
+        flb_sds_destroy(tls_key_passwd);
+    }
+
     return node;
 }
 

--- a/src/flb_upstream_node.c
+++ b/src/flb_upstream_node.c
@@ -30,6 +30,7 @@
 struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t host,
                                                    flb_sds_t port,
                                                    int tls, int tls_verify,
+                                                   int tls_verify_hostname,
                                                    int tls_debug,
                                                    const char *tls_vhost,
                                                    const char *tls_ca_path,
@@ -40,6 +41,7 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
                                                    struct flb_hash_table *ht,
                                                    struct flb_config *config)
 {
+    int ret;
     int i_port;
     int io_flags;
     char tmp[255];
@@ -143,6 +145,16 @@ struct flb_upstream_node *flb_upstream_node_create(flb_sds_t name, flb_sds_t hos
             return NULL;
         }
         node->tls_enabled = FLB_TRUE;
+        if (tls_verify_hostname == FLB_TRUE) {
+            ret = flb_tls_set_verify_hostname(node->tls, tls_verify_hostname);
+            if (ret == -1) {
+                flb_error("[upstream_node] error set up to verify hostname in TLS context "
+                          "on node '%s'", name);
+                flb_upstream_node_destroy(node);
+
+                return NULL;
+            }
+        }
     }
 #endif
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Reported in https://github.com/fluent/fluent-bit/issues/9152#issuecomment-2277689385.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

Certificates are used from here: https://github.com/fluent/fluent-bit/issues/8072#issue-1954001284

Client side:


```ini
[SERVICE]
    flush 1
    log_level debug

[INPUT]
    name  dummy
    dummy {"message": "custom dummy message"}

[OUTPUT]
    name   forward
    match  *
    Upstream      upstream-ha.conf
```

upstream-ha.conf

```ini
[UPSTREAM]
    name        forward-balancing
[NODE]
    name          node-1
    host          other.fluent-backoffice.de
    port          24224
    tls           on
    tls.verify    on
    tls.verify_hostname on
    tls.ca_file   /path/to/necessary-certs/fluent-root.crt
    tls.crt_file  /path/to/necessary-certs/fluent-client.crt
    tls.key_file  /path/to/necessary-certs/fluent-client.key
```

Server side:

```
[SERVICE]
    flush 1
    log_level debug

[INPUT]
    name   forward
    listen 0.0.0.0
    port   24224
    tls             on
    tls.verify      on
    tls.debug       4
    tls.ca_file      /path/to/necessary-certs/fluent-root.crt
    tls.crt_file     /path/to/necessary-certs/fluent-backoffice.crt
    tls.key_file     /path/to/necessary-certs/fluent-backoffice.key

[OUTPUT]
    name stdout
    match *
```

- [x] Debug log output from testing the change

With this change, upstream_ha refuses to connect with invalid certificates which have a wrong server CN.

```
Fluent Bit v3.1.5
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/08/13 17:17:11] [ info] Configuration:
[2024/08/13 17:17:11] [ info]  flush time     | 1.000000 seconds
[2024/08/13 17:17:11] [ info]  grace          | 5 seconds
[2024/08/13 17:17:11] [ info]  daemon         | 0
[2024/08/13 17:17:11] [ info] ___________
[2024/08/13 17:17:11] [ info]  inputs:
[2024/08/13 17:17:11] [ info]      dummy
[2024/08/13 17:17:11] [ info] ___________
[2024/08/13 17:17:11] [ info]  filters:
[2024/08/13 17:17:11] [ info] ___________
[2024/08/13 17:17:11] [ info]  outputs:
[2024/08/13 17:17:11] [ info]      forward.0
[2024/08/13 17:17:11] [ info] ___________
[2024/08/13 17:17:11] [ info]  collectors:
[2024/08/13 17:17:11] [ info] [fluent bit] version=3.1.5, commit=725640616f, pid=1982141
[2024/08/13 17:17:11] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/08/13 17:17:11] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/08/13 17:17:11] [ info] [cmetrics] version=0.9.3
[2024/08/13 17:17:11] [ info] [ctraces ] version=0.5.3
[2024/08/13 17:17:12] [ info] [input:dummy:dummy.0] initializing
[2024/08/13 17:17:12] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/08/13 17:17:12] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/08/13 17:17:12] [debug] [forward:forward.0] created event channels: read=23 write=24
[2024/08/13 17:17:12] [debug] [upstream_ha] opening file upstream-ha.conf
[2024/08/13 17:17:12] [ info] [output:forward:forward.0] worker #1 started
[2024/08/13 17:17:12] [ info] [sp] stream processor started
[2024/08/13 17:17:12] [ info] [output:forward:forward.0] worker #0 started
[2024/08/13 17:17:13] [debug] [task] created task=0x6182060 id=0 OK
[2024/08/13 17:17:13] [debug] [output:forward:forward.0] task_id=0 assigned to thread #0
[2024/08/13 17:17:13] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/08/13 17:17:13] [debug] [tls] connection #49 SSL_connect: before SSL initialization
[2024/08/13 17:17:13] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:13] [debug] [tls] connection #49 WANT_READ
[2024/08/13 17:17:14] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:14] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS read server hello
[2024/08/13 17:17:14] [debug] [retry] new retry created for task_id=0 attempts=1
[2024/08/13 17:17:14] [debug] [tls] connection #49 SSL_connect: TLSv1.3 read encrypted extensions
[2024/08/13 17:17:14] [ warn] [engine] failed to flush chunk '1982141-1723537032.793889074.flb', retry in 6 seconds: task_id=0, input=dummy.0 > output=forward.0 (out_id=0)
[2024/08/13 17:17:14] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS read server certificate request
[2024/08/13 17:17:14] [debug] [tls] connection #49 SSL3 alert write:fatal:bad certificate
[2024/08/13 17:17:14] [error] [tls] connection #49 SSL_connect: error in error
[2024/08/13 17:17:14] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/08/13 17:17:14] [debug] [upstream] connection #49 failed to other.fluent-backoffice.de:24224
[2024/08/13 17:17:14] [error] [output:forward:forward.0] no upstream connections available
[2024/08/13 17:17:14] [debug] [out flush] cb_destroy coro_id=0
[2024/08/13 17:17:14] [debug] [task] created task=0x8250af0 id=1 OK
[2024/08/13 17:17:14] [debug] [output:forward:forward.0] task_id=1 assigned to thread #1
[2024/08/13 17:17:14] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL_connect: before SSL initialization
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:14] [debug] [tls] connection #50 WANT_READ
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS read server hello
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL_connect: TLSv1.3 read encrypted extensions
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS read server certificate request
[2024/08/13 17:17:14] [debug] [tls] connection #50 SSL3 alert write:fatal:bad certificate
[2024/08/13 17:17:14] [error] [tls] connection #50 SSL_connect: error in error
[2024/08/13 17:17:14] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/08/13 17:17:14] [debug] [upstream] connection #50 failed to other.fluent-backoffice.de:24224
[2024/08/13 17:17:14] [error] [output:forward:forward.0] no upstream connections available
[2024/08/13 17:17:14] [debug] [out flush] cb_destroy coro_id=0
[2024/08/13 17:17:14] [debug] [retry] new retry created for task_id=1 attempts=1
[2024/08/13 17:17:14] [ warn] [engine] failed to flush chunk '1982141-1723537033.792273399.flb', retry in 8 seconds: task_id=1, input=dummy.0 > output=forward.0 (out_id=0)
^C[2024/08/13 17:17:15] [engine] caught signal (SIGINT)
[2024/08/13 17:17:15] [debug] [task] created task=0x82f9970 id=2 OK
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] task_id=2 assigned to thread #0
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/08/13 17:17:15] [ warn] [engine] service will shutdown in max 5 seconds
[2024/08/13 17:17:15] [debug] [engine] re-scheduled retry=0x824a870 for task 0
[2024/08/13 17:17:15] [debug] [engine] re-scheduled retry=0x82f9760 for task 1
[2024/08/13 17:17:15] [ info] [input] pausing dummy.0
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] task_id=0 assigned to thread #1
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] task_id=1 assigned to thread #0
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: before SSL initialization
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:15] [debug] [tls] connection #50 WANT_READ
[2024/08/13 17:17:15] [debug] [tls] connection #51 SSL_connect: before SSL initialization
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL_connect: before SSL initialization
[2024/08/13 17:17:15] [debug] [tls] connection #51 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:15] [debug] [tls] connection #51 WANT_READ
[2024/08/13 17:17:15] [debug] [tls] connection #49 WANT_READ
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS read server hello
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: TLSv1.3 read encrypted extensions
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS read server certificate request
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL3 alert write:fatal:bad certificate
[2024/08/13 17:17:15] [error] [tls] connection #50 SSL_connect: error in error
[2024/08/13 17:17:15] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/08/13 17:17:15] [debug] [upstream] connection #50 failed to other.fluent-backoffice.de:24224
[2024/08/13 17:17:15] [error] [output:forward:forward.0] no upstream connections available
[2024/08/13 17:17:15] [debug] [out flush] cb_destroy coro_id=1
[2024/08/13 17:17:15] [debug] [retry] new retry created for task_id=2 attempts=1
[2024/08/13 17:17:15] [ warn] [engine] failed to flush chunk '1982141-1723537034.773227003.flb', retry in 1 seconds: task_id=2, input=dummy.0 > output=forward.0 (out_id=0)
[2024/08/13 17:17:15] [ info] [task] dummy/dummy.0 has 3 pending task(s):
[2024/08/13 17:17:15] [ info] [task]   task_id=0 still running on route(s): forward/forward.0 
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] request 51 bytes to flush
[2024/08/13 17:17:15] [ info] [task]   task_id=1 still running on route(s): forward/forward.0 
[2024/08/13 17:17:15] [ info] [task]   task_id=2 still running on route(s): forward/forward.0 
[2024/08/13 17:17:15] [debug] [output:forward:forward.0] task_id=2 assigned to thread #1
[2024/08/13 17:17:15] [ info] [input] pausing dummy.0
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: before SSL initialization
[2024/08/13 17:17:15] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:15] [debug] [tls] connection #50 WANT_READ
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS read server hello
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL_connect: TLSv1.3 read encrypted extensions
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL_connect: SSLv3/TLS read server certificate request
[2024/08/13 17:17:15] [debug] [tls] connection #49 SSL3 alert write:fatal:bad certificate
[2024/08/13 17:17:15] [error] [tls] connection #49 SSL_connect: error in error
[2024/08/13 17:17:15] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/08/13 17:17:15] [debug] [upstream] connection #49 failed to other.fluent-backoffice.de:24224
[2024/08/13 17:17:15] [error] [output:forward:forward.0] no upstream connections available
[2024/08/13 17:17:15] [debug] [out flush] cb_destroy coro_id=1
[2024/08/13 17:17:15] [debug] [task] task_id=0 reached retry-attempts limit 1/1
[2024/08/13 17:17:15] [error] [engine] chunk '1982141-1723537032.793889074.flb' cannot be retried: task_id=0, input=dummy.0 > output=forward.0
[2024/08/13 17:17:15] [debug] [task] destroy task=0x6182060 (task_id=0)
[2024/08/13 17:17:16] [debug] [tls] connection #51 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:16] [debug] [tls] connection #51 SSL_connect: SSLv3/TLS read server hello
[2024/08/13 17:17:16] [debug] [tls] connection #51 SSL_connect: TLSv1.3 read encrypted extensions
[2024/08/13 17:17:16] [debug] [tls] connection #51 SSL_connect: SSLv3/TLS read server certificate request
[2024/08/13 17:17:16] [debug] [tls] connection #51 SSL3 alert write:fatal:bad certificate
[2024/08/13 17:17:16] [error] [tls] connection #51 SSL_connect: error in error
[2024/08/13 17:17:16] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/08/13 17:17:16] [debug] [upstream] connection #51 failed to other.fluent-backoffice.de:24224
[2024/08/13 17:17:16] [error] [output:forward:forward.0] no upstream connections available
[2024/08/13 17:17:16] [debug] [out flush] cb_destroy coro_id=2
[2024/08/13 17:17:16] [debug] [task] task_id=1 reached retry-attempts limit 1/1
[2024/08/13 17:17:16] [error] [engine] chunk '1982141-1723537033.792273399.flb' cannot be retried: task_id=1, input=dummy.0 > output=forward.0
[2024/08/13 17:17:16] [debug] [task] destroy task=0x8250af0 (task_id=1)
[2024/08/13 17:17:16] [ info] [input] pausing dummy.0
[2024/08/13 17:17:16] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS write client hello
[2024/08/13 17:17:16] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS read server hello
[2024/08/13 17:17:16] [debug] [tls] connection #50 SSL_connect: TLSv1.3 read encrypted extensions
[2024/08/13 17:17:16] [debug] [tls] connection #50 SSL_connect: SSLv3/TLS read server certificate request
[2024/08/13 17:17:16] [debug] [tls] connection #50 SSL3 alert write:fatal:bad certificate
[2024/08/13 17:17:16] [error] [tls] connection #50 SSL_connect: error in error
[2024/08/13 17:17:16] [error] [tls] error: unexpected EOF with reason: certificate verify failed
[2024/08/13 17:17:16] [debug] [upstream] connection #50 failed to other.fluent-backoffice.de:24224
[2024/08/13 17:17:16] [error] [output:forward:forward.0] no upstream connections available
[2024/08/13 17:17:16] [debug] [out flush] cb_destroy coro_id=2
[2024/08/13 17:17:16] [debug] [task] task_id=2 reached retry-attempts limit 1/1
[2024/08/13 17:17:16] [error] [engine] chunk '1982141-1723537034.773227003.flb' cannot be retried: task_id=2, input=dummy.0 > output=forward.0
[2024/08/13 17:17:16] [debug] [task] destroy task=0x82f9970 (task_id=2)
[2024/08/13 17:17:17] [ info] [engine] service has stopped (0 pending tasks)
[2024/08/13 17:17:17] [ info] [input] pausing dummy.0
[2024/08/13 17:17:17] [ info] [output:forward:forward.0] thread worker #0 stopping...
[2024/08/13 17:17:17] [ info] [output:forward:forward.0] thread worker #1 stopping...
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==1982141== 
==1982141== HEAP SUMMARY:
==1982141==     in use at exit: 0 bytes in 0 blocks
==1982141==   total heap usage: 32,508 allocs, 32,508 frees, 4,428,213 bytes allocated
==1982141== 
==1982141== All heap blocks were freed -- no leaks are possible
==1982141== 
==1982141== For lists of detected and suppressed errors, rerun with: -s
==1982141== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
