### PR TITLE
stackdriver: Add latency metric for write log entries HTTP request.

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2829,6 +2829,9 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     struct flb_connection *u_conn;
     struct flb_http_client *c;
     int compressed = FLB_FALSE;
+    uint64_t write_entries_start = 0;
+    uint64_t write_entries_end = 0;
+    float write_entries_latency = 0.0;
 #ifdef FLB_HAVE_METRICS
     char *name = (char *) flb_output_name(ctx->ins);
     uint64_t ts = cfl_time_now();
@@ -2923,8 +2926,13 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
         flb_http_set_content_encoding_gzip(c);
     }
 
+    write_entries_start = cfl_time_now();
+
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
+
+    write_entries_end = cfl_time_now();
+    write_entries_latency = (float)(write_entries_end - write_entries_start) / 1000000000.0;
 
     /* validate response */
     if (ret != 0) {
@@ -2994,6 +3002,9 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
 #ifdef FLB_HAVE_METRICS
     if (ret_code == FLB_OK) {
         cmt_counter_inc(ctx->cmt_successful_requests, ts, 1, (char *[]) {name});
+        if (write_entries_latency > 0.0) {
+          cmt_histogram_observe(ctx->cmt_write_entries_latency, ts, write_entries_latency, 1, (char *[]) {name});
+        }
         add_record_metrics(ctx, ts, (int) event_chunk->total_events, 200, 0);
 
         /* OLD api */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -27,6 +27,8 @@
 #include <fluent-bit/flb_regex.h>
 #include <fluent-bit/flb_metrics.h>
 
+#include <cmetrics/cmt_histogram.h>
+
 /* refresh token every 50 minutes */
 #define FLB_STD_TOKEN_REFRESH 3000
 
@@ -218,6 +220,7 @@ struct flb_stackdriver {
     struct cmt_counter *cmt_requests_total;
     struct cmt_counter *cmt_proc_records_total;
     struct cmt_counter *cmt_retried_records_total;
+    struct cmt_histogram *cmt_write_entries_latency;
 #endif
 
     /* plugin instance */


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add metric to measure the round trip latency for write entries HTTP request to Cloud Logging.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
This is an observability improvement.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
New metric is exposed to v2 metrics endpoint.

```
curl -s http://127.0.0.1:2020/api/v2/metrics/prometheus

# HELP fluentbit_stackdriver_write_entries_latency Latency of Cloud Logging WriteLogEntries HTTP request.
# TYPE fluentbit_stackdriver_write_entries_latency histogram
fluentbit_stackdriver_write_entries_latency_bucket{le="1.0",name="stackdriver-cp-v3-container"} 2326
fluentbit_stackdriver_write_entries_latency_bucket{le="2.0",name="stackdriver-cp-v3-container"} 2329
fluentbit_stackdriver_write_entries_latency_bucket{le="4.0",name="stackdriver-cp-v3-container"} 2329
fluentbit_stackdriver_write_entries_latency_bucket{le="8.0",name="stackdriver-cp-v3-container"} 2329
fluentbit_stackdriver_write_entries_latency_bucket{le="16.0",name="stackdriver-cp-v3-container"} 2329
fluentbit_stackdriver_write_entries_latency_bucket{le="32.0",name="stackdriver-cp-v3-container"} 2329
fluentbit_stackdriver_write_entries_latency_bucket{le="64.0",name="stackdriver-cp-v3-container"} 2329
fluentbit_stackdriver_write_entries_latency_bucket{le="+Inf",name="stackdriver-cp-v3-container"} 0
fluentbit_stackdriver_write_entries_latency_sum{name="stackdriver-cp-v3-container"} 261.11756087094545
fluentbit_stackdriver_write_entries_latency_count{name="stackdriver-cp-v3-container"} 2329
# HELP fluentbit_stackdriver_write_entries_latency Latency of Cloud Logging WriteLogEntries HTTP request.
# TYPE fluentbit_stackdriver_write_entries_latency histogram
fluentbit_stackdriver_write_entries_latency_bucket{le="1.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="2.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="4.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="8.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="16.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="32.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="64.0",name="stackdriver-cp-v3-gce_instance"} 762
fluentbit_stackdriver_write_entries_latency_bucket{le="+Inf",name="stackdriver-cp-v3-gce_instance"} 0
fluentbit_stackdriver_write_entries_latency_sum{name="stackdriver-cp-v3-gce_instance"} 84.148241396993399
fluentbit_stackdriver_write_entries_latency_count{name="stackdriver-cp-v3-gce_instance"} 762
```

- [ ] Example configuration file for the change
`[N/A]`
- [ ] Debug log output from testing the change
`[N/A]`
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
cmake -DFLB_DEV=On -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On -DFLB_VALGRIND=On ../ && make -j 8

valgrind ./bin/flb-rt-out_stackdriver

SUCCESS: All unit tests have passed.
==1394023==
==1394023== HEAP SUMMARY:
==1394023==     in use at exit: 56 bytes in 1 blocks
==1394023==   total heap usage: 290,010 allocs, 290,009 frees, 126,380,731 bytes allocated
==1394023==
==1394023== LEAK SUMMARY:
==1394023==    definitely lost: 0 bytes in 0 blocks
==1394023==    indirectly lost: 0 bytes in 0 blocks
==1394023==      possibly lost: 0 bytes in 0 blocks
==1394023==    still reachable: 56 bytes in 1 blocks
==1394023==         suppressed: 0 bytes in 0 blocks
==1394023== Rerun with --leak-check=full to see details of leaked memory
==1394023==
==1394023== For lists of detected and suppressed errors, rerun with: -s
==1394023== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
`[N/A]`
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).
`[N/A]`

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
