### PR TITLE
parser_json: Handle numeric timestamps

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -51,6 +51,7 @@ struct flb_parser {
     int time_system_timezone; /* use the system timezone as a fallback */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
+    double time_numeric_unit; /* divisor for numeric time, or <= 0 if not enabled */
     int logfmt_no_bare_keys; /* in logfmt parsers, require all keys to have values */
     char *time_frac_secs; /* time format have fractional seconds ? */
     struct flb_parser_types *types; /* type casting */

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -145,6 +145,26 @@ static void flb_interim_parser_destroy(struct flb_parser *parser)
     flb_free(parser);
 }
 
+static double flb_parser_time_numeric_unit(const char *time_fmt)
+{
+    if (!time_fmt) {
+        return 0.0;
+    }
+    if (!strcmp(time_fmt, "SECONDS")) {
+        return 1.0;
+    }
+    if (!strcmp(time_fmt, "MILLISECONDS")) {
+        return 1000.0;
+    }
+    if (!strcmp(time_fmt, "MICROSECONDS")) {
+        return 1000000.0;
+    }
+    if (!strcmp(time_fmt, "NANOSECONDS")) {
+        return 1000000000.0;
+    }
+    return 0.0;
+}
+
 struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *p_regex,
                                      int skip_empty,
@@ -230,6 +250,12 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     }
 
     p->name = flb_strdup(name);
+
+    p->time_numeric_unit = flb_parser_time_numeric_unit(time_fmt);
+    if (p->time_numeric_unit > 0) {
+        /* Don't try to use the fixed string (SECONDS/...) as a format */
+        time_fmt = NULL;
+    }
 
     if (time_fmt) {
         p->time_fmt_full = flb_strdup(time_fmt);

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -18,6 +18,8 @@
  */
 
 #define _GNU_SOURCE
+#include <math.h>
+#include <stdbool.h>
 #include <time.h>
 
 #include <fluent-bit/flb_parser.h>
@@ -25,36 +27,80 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_parser_decoder.h>
 
+static bool flb_parser_json_timestamp_str(struct flb_parser *parser,
+                                          const char *ptr, size_t len,
+                                          struct flb_time *out_time)
+{
+    int ret;
+    double tmfrac = 0;
+    struct flb_tm tm = {0};
+    time_t tmint = 0;
+
+    if (!parser->time_fmt) {
+        return false;
+    }
+
+    /* Lookup time */
+    ret = flb_parser_time_lookup(ptr, len, 0, parser, &tm, &tmfrac);
+    if (ret == -1) {
+        flb_warn("[parser:%s] invalid time format %s for '%.*s'",
+                 parser->name, parser->time_fmt_full, len > 254 ? 254 : (int)len, ptr);
+        return false;
+    }
+
+    tmint = flb_parser_tm2time(&tm, parser->time_system_timezone);
+
+    out_time->tm.tv_sec  = tmint;
+    out_time->tm.tv_nsec = tmfrac * 1000000000;
+
+    return true;
+}
+
+static bool flb_parser_json_timestamp_f64(struct flb_parser *parser,
+                                          double val,
+                                          struct flb_time *out_time)
+{
+    double tmfrac = 0;
+    double tmint = 0;
+
+    if (parser->time_numeric_unit <= 0) {
+        flb_warn("[parser:%s] invalid non-string time", parser->name);
+        return false;
+    }
+
+    tmfrac = modf(val / parser->time_numeric_unit, &tmint);
+
+    out_time->tm.tv_sec  = tmint;
+    out_time->tm.tv_nsec = tmfrac * 1000000000;
+
+    return true;
+}
+
 int flb_parser_json_do(struct flb_parser *parser,
                        const char *in_buf, size_t in_size,
                        void **out_buf, size_t *out_size,
                        struct flb_time *out_time)
 {
     int i;
-    int skip;
+    int time_index;
     int ret;
     int slen;
     int root_type;
     int records;
-    double tmfrac = 0;
+    bool time_ok;
     char *mp_buf = NULL;
     char *time_key;
     char *tmp_out_buf = NULL;
-    char tmp[255];
     size_t tmp_out_size = 0;
     size_t off = 0;
     size_t map_size;
     size_t mp_size;
-    size_t len;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer  mp_pck;
     msgpack_unpacked result;
     msgpack_object map;
     msgpack_object *k = NULL;
     msgpack_object *v = NULL;
-    time_t time_lookup;
-    struct flb_tm tm = {0};
-    struct flb_time *t;
     size_t consumed;
 
     consumed = 0;
@@ -121,7 +167,7 @@ int flb_parser_json_do(struct flb_parser *parser,
     }
 
     /* Do time resolution ? */
-    if (!parser->time_fmt) {
+    if (!parser->time_fmt && parser->time_numeric_unit <= 0) {
         msgpack_unpacked_destroy(&result);
 
         return (int) consumed;
@@ -137,7 +183,7 @@ int flb_parser_json_do(struct flb_parser *parser,
 
     /* Lookup time field */
     map_size = map.via.map.size;
-    skip = map_size;
+    time_index = map_size;
     for (i = 0; i < map_size; i++) {
         k = &map.via.map.ptr[i].key;
         v = &map.via.map.ptr[i].val;
@@ -162,14 +208,8 @@ int flb_parser_json_do(struct flb_parser *parser,
         }
 
         if (strncmp(k->via.str.ptr, time_key, k->via.str.size) == 0) {
+            time_index = i;
             /* We found the key, break the loop and keep the index */
-            if (parser->time_keep == FLB_FALSE) {
-                skip = i;
-                break;
-            }
-            else {
-                skip = -1;
-            }
             break;
         }
 
@@ -185,60 +225,47 @@ int flb_parser_json_do(struct flb_parser *parser,
     }
 
     /* Ensure we have an accurate type */
-    if (v->type != MSGPACK_OBJECT_STR) {
-        msgpack_unpacked_destroy(&result);
+    switch(v->type) {
+        case MSGPACK_OBJECT_STR:
+            time_ok = flb_parser_json_timestamp_str(parser, v->via.str.ptr, v->via.str.size, out_time);
+            break;
 
-        return (int) consumed;
+        case MSGPACK_OBJECT_FLOAT32:
+        case MSGPACK_OBJECT_FLOAT64:
+            time_ok = flb_parser_json_timestamp_f64(parser, v->via.f64, out_time);
+            break;
+
+        case MSGPACK_OBJECT_POSITIVE_INTEGER:
+            time_ok = flb_parser_json_timestamp_f64(parser, v->via.u64, out_time);
+            break;
+
+        default:
+            time_ok = false;
+            break;
     }
 
-    /* Lookup time */
-    ret = flb_parser_time_lookup(v->via.str.ptr, v->via.str.size,
-                                 0, parser, &tm, &tmfrac);
-    if (ret == -1) {
-        len = v->via.str.size;
-        if (len > sizeof(tmp) - 1) {
-            len = sizeof(tmp) - 1;
-        }
-        memcpy(tmp, v->via.str.ptr, len);
-        tmp[len] = '\0';
-        flb_warn("[parser:%s] invalid time format %s for '%s'",
-                 parser->name, parser->time_fmt_full, tmp);
-        time_lookup = 0;
-        skip = map_size;
-    }
-    else {
-        time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
-    }
+    if (time_ok && parser->time_keep == FLB_FALSE) {
+        /* Compose a new map without the time_key field */
+        msgpack_sbuffer_init(&mp_sbuf);
+        msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
-    /* Compose a new map without the time_key field */
-    msgpack_sbuffer_init(&mp_sbuf);
-    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
-
-    if (parser->time_keep == FLB_FALSE && skip < map_size) {
         msgpack_pack_map(&mp_pck, map_size - 1);
-    }
-    else {
-        msgpack_pack_map(&mp_pck, map_size);
-    }
 
-    for (i = 0; i < map_size; i++) {
-        if (i == skip) {
-            continue;
+        for (i = 0; i < map_size; i++) {
+            if (i == time_index) {
+                continue;
+            }
+
+            msgpack_pack_object(&mp_pck, map.via.map.ptr[i].key);
+            msgpack_pack_object(&mp_pck, map.via.map.ptr[i].val);
         }
 
-        msgpack_pack_object(&mp_pck, map.via.map.ptr[i].key);
-        msgpack_pack_object(&mp_pck, map.via.map.ptr[i].val);
+        /* Export the proper buffer */
+        flb_free(tmp_out_buf);
+
+        *out_buf = mp_sbuf.data;
+        *out_size = mp_sbuf.size;
     }
-
-    /* Export the proper buffer */
-    flb_free(tmp_out_buf);
-
-    *out_buf = mp_sbuf.data;
-    *out_size = mp_sbuf.size;
-
-    t = out_time;
-    t->tm.tv_sec  = time_lookup;
-    t->tm.tv_nsec = (tmfrac * 1000000000);
 
     msgpack_unpacked_destroy(&result);
 


### PR DESCRIPTION
The `time_unit_per_second` parser option enables parsing JSON numbers as timestamps. The same `time_key` is used as for `time_format`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
```
[PARSER]
	Name json
	Format json
	Time_Key timestamp
	Time_Unit_Per_Second 1
```

- [ ] Debug log output from testing the change

Can't your CI do that?

- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Can't your CI do that?

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.

Can't your CI do that?

- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

TODO

**Backporting**
- [ ] Backport to latest stable release.

Probably not?

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
