### PR TITLE
in_http: Content-Type rejected for application/json when encoding value is present.

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -523,9 +523,8 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
         return -1;
     }
 
-    if (header->val.len >= 16 &&
-        (strncasecmp(header->val.data, "application/json ", 17) == 0 ||
-        strncasecmp(header->val.data, "application/json;", 17) == 0)) {
+    if ((header->val.len == 16 && strncasecmp(header->val.data, "application/json", 16) == 0) ||
+        (header->val.len > 16 && (strncasecmp(header->val.data, "application/json ", 17) == 0) || strncasecmp(header->val.data, "application/json;", 17) == 0)) {
         type = HTTP_CONTENT_JSON;
     }
 

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -523,8 +523,9 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
         return -1;
     }
 
-    if (header->val.len == 16 &&
-        strncasecmp(header->val.data, "application/json", 16) == 0) {
+    if (header->val.len >= 16 &&
+        (strncasecmp(header->val.data, "application/json ", 17) == 0 ||
+        strncasecmp(header->val.data, "application/json;", 17) == 0)) {
         type = HTTP_CONTENT_JSON;
     }
 

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -524,7 +524,8 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
     }
 
     if ((header->val.len == 16 && strncasecmp(header->val.data, "application/json", 16) == 0) ||
-        (header->val.len > 16 && (strncasecmp(header->val.data, "application/json ", 17) == 0) || strncasecmp(header->val.data, "application/json;", 17) == 0)) {
+        (header->val.len > 16 && (strncasecmp(header->val.data, "application/json ", 17) == 0) || 
+        strncasecmp(header->val.data, "application/json;", 17) == 0)) {
         type = HTTP_CONTENT_JSON;
     }
 

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -28,6 +28,7 @@
 #include "flb_tests_runtime.h"
 
 #define JSON_CONTENT_TYPE "application/json"
+#define JSON_CHARSET_CONTENT_TYPE "application/json; charset=utf-8"
 
 struct http_client_ctx {
     struct flb_upstream      *u;
@@ -350,14 +351,92 @@ void flb_test_http_successful_response_code(char *response_code)
     test_ctx_destroy(ctx);
 }
 
+void flb_test_http_json_charset_header(char *response_code)
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+
+    char *buf = "[{\"test\":\"msg\"}]";
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "http2", "off",
+                        "successful_response_code", response_code,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    flb_time_msleep(1500);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", buf, strlen(buf),
+                        "127.0.0.1", 9880, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CHARSET_CONTENT_TYPE, strlen(JSON_CHARSET_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == atoi(response_code))) {
+        TEST_MSG("http response code error. expect: %d, got: %d\n", atoi(response_code), c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_http_successful_response_code_200()
 {
     flb_test_http_successful_response_code("200");    
+    flb_test_http_json_charset_header("200");
 }
 
 void flb_test_http_successful_response_code_204()
 {
     flb_test_http_successful_response_code("204");    
+    flb_test_http_json_charset_header("204");
 }
 
 void flb_test_http_failure_400_bad_json() {


### PR DESCRIPTION
**Summary**
- Updated `http_prot` to handle json content type header with charset. 
- Include guard for content types that maybe be a flavor of `application/json` but of an unknown/unsupported content type. 
- Includes `in_http` runtime tests.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Current issue: https://github.com/fluent/fluent-bit/issues/9018
Other issue related to this PR fix https://github.com/fluent/fluent-bit/issues/5062

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A] Example configuration file for the change
- [N/A ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
