### PR TITLE
pack: do not multiply out_size by realloc_size

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -810,7 +810,7 @@ flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
             tmp_buf = flb_sds_increase(out_buf, realloc_size);
             if (tmp_buf) {
                 out_buf = tmp_buf;
-                out_size += realloc_size;
+                out_size = flb_sds_alloc(out_buf);
             }
             else {
                 flb_errno();

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -810,7 +810,7 @@ flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
             tmp_buf = flb_sds_increase(out_buf, realloc_size);
             if (tmp_buf) {
                 out_buf = tmp_buf;
-                out_size *= realloc_size;
+                out_size += realloc_size;
             }
             else {
                 flb_errno();


### PR DESCRIPTION
<!-- Provide summary of changes -->
In `flb_msgpack_raw_to_json_sds`, when the buffer is reallocated it calls `flb_sds_increase`. This increases the length by adding the `len` argument to the length and reallocating the sds object. After doing this, the `out_size` is multiplied by `realloc_size`. This does not match reality, as what happened in the reallocation was additive not multiplicative. This commit corrects the inconsistency.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #9192.
Fixes #8993.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
