### PR TITLE
pack: fixed erroneous buffer size indicator

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -810,7 +810,7 @@ flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size)
             tmp_buf = flb_sds_increase(out_buf, realloc_size);
             if (tmp_buf) {
                 out_buf = tmp_buf;
-                out_size *= realloc_size;
+                out_size += realloc_size;
             }
             else {
                 flb_errno();


### PR DESCRIPTION
This PR fixes a bug introduced when the msgpack to json code was improved in order to minimize reallocation.