### PR TITLE
out_kinesis_streams: integrate with shared compression lib

### DIFF
--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -94,6 +94,16 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
         ctx->time_key_format = DEFAULT_TIME_KEY_FORMAT;
     }
 
+    tmp = flb_output_get_property("compression", ins);
+    if (tmp) {
+        ret = flb_aws_compression_get_type(tmp);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "unknown compression: %s", tmp);
+            goto error;
+        }
+        ctx->compression = ret;
+    }
+
     tmp = flb_output_get_property("log_key", ins);
     if (tmp) {
         ctx->log_key = tmp;
@@ -471,6 +481,15 @@ static struct flb_config_map config_map[] = {
      "Instead, it enables an immediate retry with no delay for networking "
      "errors, which may help improve throughput when there are transient/random "
      "networking issues."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "compression", NULL,
+     0, FLB_FALSE, 0,
+    "Compression type for log records. Each log record is individually compressed "
+    "and sent to Kinesis. 'gzip' and 'arrow' are the supported values. "
+    "'arrow' is only an available if Apache Arrow was enabled at compile time. "
+    "Defaults to no compression."
     },
 
     {

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -89,6 +89,7 @@ struct flb_kinesis {
     const char *role_arn;
     const char *log_key;
     const char *external_id;
+    int compression;
     int retry_requests;
     char *sts_endpoint;
     int custom_endpoint;

--- a/plugins/out_kinesis_streams/kinesis_api.c
+++ b/plugins/out_kinesis_streams/kinesis_api.c
@@ -36,6 +36,7 @@
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_base64.h>
+#include <fluent-bit/aws/flb_aws_compress.h>
 
 #include <monkey/mk_core.h>
 #include <msgpack.h>
@@ -226,6 +227,7 @@ static int process_event(struct flb_kinesis *ctx, struct flush *buf,
     struct tm *tmp;
     size_t len;
     size_t tmp_size;
+    void *compressed_tmp_buf;
     char *out_buf;
 
     tmp_buf_ptr = buf->tmp_buf + buf->tmp_buf_offset;
@@ -339,29 +341,52 @@ static int process_event(struct flb_kinesis *ctx, struct flush *buf,
     memcpy(tmp_buf_ptr + written, "\n", 1);
     written++;
 
-    /*
-     * check if event_buf is initialized and big enough
-     * Base64 encoding will increase size by ~4/3
-     */
-    size = (written * 1.5) + 4;
-    if (buf->event_buf == NULL || buf->event_buf_size < size) {
-        flb_free(buf->event_buf);
-        buf->event_buf = flb_malloc(size);
-        buf->event_buf_size = size;
-        if (buf->event_buf == NULL) {
+    if (ctx->compression == FLB_AWS_COMPRESS_NONE) {
+        /*
+         * check if event_buf is initialized and big enough
+         * Base64 encoding will increase size by ~4/3
+         */
+        size = (written * 1.5) + 4;
+        if (buf->event_buf == NULL || buf->event_buf_size < size) {
+            flb_free(buf->event_buf);
+            buf->event_buf = flb_malloc(size);
+            buf->event_buf_size = size;
+            if (buf->event_buf == NULL) {
+                flb_errno();
+                return -1;
+            }
+        }
+
+        tmp_buf_ptr = buf->tmp_buf + buf->tmp_buf_offset;
+        ret = flb_base64_encode((unsigned char *) buf->event_buf, size, &b64_len,
+                                    (unsigned char *) tmp_buf_ptr, written);
+        if (ret != 0) {
             flb_errno();
             return -1;
         }
+        written = b64_len;
     }
-
-    tmp_buf_ptr = buf->tmp_buf + buf->tmp_buf_offset;
-    ret = flb_base64_encode((unsigned char *) buf->event_buf, size, &b64_len,
-                                (unsigned char *) tmp_buf_ptr, written);
-    if (ret != 0) {
-        flb_errno();
-        return -1;
+    else {
+        /*
+         * compress event, truncating input if needed
+         * replace event buffer with compressed buffer
+         */
+        ret = flb_aws_compression_b64_truncate_compress(ctx->compression,
+                                                       MAX_B64_EVENT_SIZE,
+                                                       tmp_buf_ptr,
+                                                       written, &compressed_tmp_buf,
+                                                       &size); /* evaluate size */
+        
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "Unable to compress record, discarding, "
+                                    "%s", ctx->stream_name);
+            return 2;
+        }
+        flb_free(buf->event_buf);
+        buf->event_buf = compressed_tmp_buf;
+        compressed_tmp_buf = NULL;
+        written = size;
     }
-    written = b64_len;
 
     tmp_buf_ptr = buf->tmp_buf + buf->tmp_buf_offset;
     if ((buf->tmp_buf_size - buf->tmp_buf_offset) < written) {

--- a/plugins/out_kinesis_streams/kinesis_api.h
+++ b/plugins/out_kinesis_streams/kinesis_api.h
@@ -23,6 +23,7 @@
 #define PUT_RECORDS_PAYLOAD_SIZE         5242880
 #define MAX_EVENTS_PER_PUT               500
 #define MAX_EVENT_SIZE                   1048556 /* 1048576 - 20 bytes for partition key */
+#define MAX_B64_EVENT_SIZE               1365336  /* ceil(1024000 / 3) * 4 */
 
 /* number of characters needed to 'start' a PutRecords payload */
 #define PUT_RECORDS_HEADER_LEN      30


### PR DESCRIPTION
Support for gzip compression. Basically copied the approach used in out_kinesis_firehose.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
