### PR TITLE
Make `Time_System_Timezone` properly detect daylight savings

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -83,6 +83,7 @@ static inline time_t flb_parser_tm2time(const struct flb_tm *src,
 
     tmp = src->tm;
     if (use_system_timezone) {
+        tmp.tm_isdst = -1;
         res = mktime(&tmp);
     } else {
         res = timegm(&tmp) - flb_tm_gmtoff(src);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously, `Time_System_Timezone` would not work for timezone specifications like `America/Toronto` or `EST5EDT` because I neglected to set `tm_isdst` to `-1`, which prompts `mktime` to detect daylight savings time on its own.

This PR addresses this issue, and fixes the test data which was previously incorrect due to the existence of this bug.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#9197

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
