### PR TITLE
in_elasticsearch: Store log_encoder pointer (CID 508245)

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch.h
+++ b/plugins/in_elasticsearch/in_elasticsearch.h
@@ -42,7 +42,7 @@ struct flb_in_elasticsearch {
     char cluster_name[16];
     char node_name[12];
 
-    struct flb_log_event_encoder log_encoder;
+    struct flb_log_event_encoder *log_encoder;
 
     struct flb_input_instance *ins;
 

--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
@@ -418,9 +418,9 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
                 }
 
                 if (error_op == FLB_FALSE) {
-                    flb_log_event_encoder_reset(&ctx->log_encoder);
+                    flb_log_event_encoder_reset(ctx->log_encoder);
 
-                    ret = flb_log_event_encoder_begin_record(&ctx->log_encoder);
+                    ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
                     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
                         flb_sds_destroy(write_op);
@@ -431,7 +431,7 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
                     }
 
                     ret = flb_log_event_encoder_set_timestamp(
-                            &ctx->log_encoder,
+                            ctx->log_encoder,
                             &tm);
 
                     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
@@ -444,7 +444,7 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
 
                     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
                         ret = flb_log_event_encoder_append_body_values(
-                                &ctx->log_encoder,
+                                ctx->log_encoder,
                                 FLB_LOG_EVENT_CSTRING_VALUE((char *) ctx->meta_key),
                                 FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE(&result.data));
                     }
@@ -469,7 +469,7 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
                         map_copy_entry = &result.data.via.map.ptr[map_copy_index];
 
                         ret = flb_log_event_encoder_append_body_values(
-                                &ctx->log_encoder,
+                                ctx->log_encoder,
                                 FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE(&map_copy_entry->key),
                                 FLB_LOG_EVENT_MSGPACK_OBJECT_VALUE(&map_copy_entry->val));
                     }
@@ -481,7 +481,7 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
                         break;
                     }
 
-                    ret = flb_log_event_encoder_commit_record(&ctx->log_encoder);
+                    ret = flb_log_event_encoder_commit_record(ctx->log_encoder);
 
                     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
                         flb_plg_error(ctx->ins, "event encoder error : %d", ret);
@@ -501,8 +501,8 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
                         flb_input_log_append(ctx->ins,
                                              tag_from_record,
                                              flb_sds_len(tag_from_record),
-                                             ctx->log_encoder.output_buffer,
-                                             ctx->log_encoder.output_length);
+                                             ctx->log_encoder->output_buffer,
+                                             ctx->log_encoder->output_length);
 
                         flb_sds_destroy(tag_from_record);
                     }
@@ -510,17 +510,17 @@ static int process_ndpack(struct flb_in_elasticsearch *ctx, flb_sds_t tag, char 
                         flb_input_log_append(ctx->ins,
                                              tag,
                                              flb_sds_len(tag),
-                                             ctx->log_encoder.output_buffer,
-                                             ctx->log_encoder.output_length);
+                                             ctx->log_encoder->output_buffer,
+                                             ctx->log_encoder->output_length);
                     }
                     else {
                         /* use default plugin Tag (it internal name, e.g: http.0 */
                         flb_input_log_append(ctx->ins, NULL, 0,
-                                             ctx->log_encoder.output_buffer,
-                                             ctx->log_encoder.output_length);
+                                             ctx->log_encoder->output_buffer,
+                                             ctx->log_encoder->output_length);
                     }
 
-                    flb_log_event_encoder_reset(&ctx->log_encoder);
+                    flb_log_event_encoder_reset(ctx->log_encoder);
                 }
                 if (op_ret) {
                     if (flb_sds_cmp(write_op, "index", op_str_size) == 0) {

--- a/plugins/in_elasticsearch/in_elasticsearch_config.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_config.c
@@ -59,15 +59,12 @@ struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_ins
      * moment so we want to make sure that it stays that way!
      */
 
-    ret = flb_log_event_encoder_init(&ctx->log_encoder,
-                                     FLB_LOG_EVENT_FORMAT_DEFAULT);
-
-    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
-        flb_plg_error(ctx->ins, "error initializing event encoder : %d", ret);
-
+    ctx->log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (ctx->log_encoder == NULL) {
+        flb_plg_error(ctx->ins, "event encoder initialization error");
         in_elasticsearch_config_destroy(ctx);
 
-        return ctx = NULL;
+        return NULL;
     }
 
 
@@ -76,7 +73,7 @@ struct flb_in_elasticsearch *in_elasticsearch_config_create(struct flb_input_ins
 
 int in_elasticsearch_config_destroy(struct flb_in_elasticsearch *ctx)
 {
-    flb_log_event_encoder_destroy(&ctx->log_encoder);
+    flb_log_event_encoder_destroy(ctx->log_encoder);
 
     /* release all connections */
     in_elasticsearch_bulk_conn_release_all(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
