### PR TITLE
in_winevtlog: Skip to translate SID for capability SIDs

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -277,6 +277,14 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid, int extract_sid)
 
     if (ConvertSidToStringSidW(sid, &wide_sid)) {
         if (extract_sid == FLB_TRUE) {
+            /* Skip to translate SID for capability SIDs.
+             * see also: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+             */
+            if (wcsnicmp(wide_sid, L"S-1-15-3-", 9) == 0) {
+                flb_plg_debug(ctx->ins, "This SID is one of the capability SIDs. Skip.");
+
+                goto not_mapped_error;
+            }
             if (!LookupAccountSidA(NULL, sid,
                                    account, &len, domain,
                                    &len, &sid_type)) {

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -278,7 +278,8 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid, int extract_sid)
     if (ConvertSidToStringSidW(sid, &wide_sid)) {
         if (extract_sid == FLB_TRUE) {
             /* Skip to translate SID for capability SIDs.
-             * see also: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+             * ref: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+             * See also: https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/sids-not-resolve-into-friendly-names
              */
             if (wcsnicmp(wide_sid, L"S-1-15-3-", 9) == 0) {
                 flb_plg_debug(ctx->ins, "This SID is one of the capability SIDs. Skip.");


### PR DESCRIPTION
<!-- Provide summary of changes -->
`S-1-15-3-` prefixed SIDs are not mapped for friendly names.
We should skip to query to retrieve associated names.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
