### PR TITLE
filter_log_to_metrics: Add timer callback for emitting metrics

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.h
+++ b/plugins/filter_log_to_metrics/log_to_metrics.h
@@ -50,13 +50,13 @@
 
 #define FLB_MEM_BUF_LIMIT_DEFAULT  "10M"
 #define DEFAULT_LOG_TO_METRICS_NAMESPACE "log_metric"
-
+#define DEFAULT_INTERVAL_SEC  "0"
+#define DEFAULT_INTERVAL_NSEC "0"
 
 struct log_to_metrics_ctx {
     struct mk_list rules;
     struct flb_filter_instance *ins;
     struct cmt *cmt;
-
     struct flb_input_instance *input_ins;
 
     char **label_keys;
@@ -83,6 +83,12 @@ struct log_to_metrics_ctx {
     flb_sds_t tag;
     flb_sds_t emitter_name;
     size_t emitter_mem_buf_limit;
+    long flush_interval_sec;
+    long flush_interval_nsec;
+    int timer_interval;
+    int timer_mode;
+    struct flb_sched_timer *timer;
+    int new_data;
 };
 
 struct grep_rule


### PR DESCRIPTION
This PR will change the log_to_metrics filter to use a timer based metric inject and not directly inject metrics on every incoming log record anymore. This will lower the overall load and memory consumption especially in high-volume and high-cardinality situations.

cc @leonardo-albertovich @edsiper 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes https://github.com/fluent/fluent-bit/issues/9189
----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/1440
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
