### PR TITLE
core: endianness detection fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ elseif(FLB_SYSTEM_FREEBSD)
   set(WAMR_DISABLE_STACK_HW_BOUND_CHECK 1)
 endif()
 
+INCLUDE(TestBigEndian)
 include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)
@@ -771,6 +772,15 @@ check_c_source_compiles("
 if(FLB_HAVE_UNIX_SOCKET)
   FLB_DEFINITION(FLB_HAVE_UNIX_SOCKET)
 endif()
+
+# byte order detection
+test_big_endian(BIG_ENDIAN_SYSTEM_DETECTED)
+
+if (BIG_ENDIAN_SYSTEM_DETECTED)
+    FLB_DEFINITION(FLB_HAVE_BIG_ENDIAN_SYSTEM)
+else()
+    FLB_DEFINITION(FLB_HAVE_LITTLE_ENDIAN_SYSTEM)
+endif ()
 
 # Configuration file YAML format support
 if(FLB_CONFIG_YAML)

--- a/include/fluent-bit/flb_endian.h
+++ b/include/fluent-bit/flb_endian.h
@@ -55,9 +55,7 @@
 #define FLB_BIG_ENDIAN    1
 
 #ifndef FLB_BYTE_ORDER
-    #if defined(__BYTE_ORDER__) &&  __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        #define FLB_BYTE_ORDER FLB_BIG_ENDIAN
-    #elif defined(__BIG_ENDIAN__) || defined(__BIG_ENDIAN) || defined(_BIG_ENDIAN)
+    #ifdef FLB_HAVE_BIG_ENDIAN_SYSTEM
         #define FLB_BYTE_ORDER FLB_BIG_ENDIAN
     #else
         #define FLB_BYTE_ORDER FLB_LITTLE_ENDIAN


### PR DESCRIPTION
This PR addresses an issue with the byte order detection macro in `flb_endian.h` switching the buggy implementation with the proven cmake based detection mechanism used by msgpack-c. 