### PR TITLE
in_splunk: test: Handle 1.0 suffixed endpoints

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -834,7 +834,8 @@ int splunk_prot_handle(struct flb_splunk *ctx, struct splunk_conn *conn,
     flb_log_event_encoder_reset(&ctx->log_encoder);
 
     if (request->method == MK_METHOD_POST) {
-        if (strcasecmp(uri, "/services/collector/raw") == 0) {
+        if (strcasecmp(uri, "/services/collector/raw/1.0") == 0 ||
+            strcasecmp(uri, "/services/collector/raw") == 0) {
             ret = process_hec_raw_payload(ctx, conn, tag, session, request);
 
             if (!ret) {
@@ -842,7 +843,8 @@ int splunk_prot_handle(struct flb_splunk *ctx, struct splunk_conn *conn,
             }
             send_json_message_response(conn, 200, "{\"text\":\"Success\",\"code\":0}");
         }
-        else if (strcasecmp(uri, "/services/collector/event") == 0 ||
+        else if (strcasecmp(uri, "/services/collector/event/1.0") == 0 ||
+                 strcasecmp(uri, "/services/collector/event") == 0 ||
                  strcasecmp(uri, "/services/collector") == 0) {
             ret = process_hec_payload(ctx, conn, tag, session, request);
 
@@ -1151,7 +1153,8 @@ int splunk_prot_handle_ng(struct flb_http_request *request,
         return -1;
     }
 
-    if (strcasecmp(request->path, "/services/collector/raw") == 0) {
+    if (strcasecmp(request->path, "/services/collector/raw/1.0") == 0 ||
+        strcasecmp(request->path, "/services/collector/raw") == 0) {
         ret = process_hec_raw_payload_ng(request, response, tag, context);
 
         if (ret != 0) {
@@ -1163,7 +1166,8 @@ int splunk_prot_handle_ng(struct flb_http_request *request,
 
         ret = 0;
     }
-    else if (strcasecmp(request->path, "/services/collector/event") == 0 ||
+    else if (strcasecmp(request->path, "/services/collector/event/1.0") == 0 ||
+             strcasecmp(request->path, "/services/collector/event") == 0 ||
              strcasecmp(request->path, "/services/collector") == 0) {
         ret = process_hec_payload_ng(request, response, tag, context);
 

--- a/tests/runtime/in_splunk.c
+++ b/tests/runtime/in_splunk.c
@@ -370,7 +370,7 @@ void flb_test_splunk_collector_event()
     flb_test_splunk(8810, "/services/collector/event");
 }
 
-void flb_test_splunk_raw(int port)
+void flb_test_splunk_raw(int port, char *endpoint)
 {
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
@@ -413,7 +413,7 @@ void flb_test_splunk_raw(int port)
     ctx->httpc = splunk_client_ctx_create(port);
     TEST_CHECK(ctx->httpc != NULL);
 
-    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/services/collector/raw", buf, strlen(buf),
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, endpoint, buf, strlen(buf),
                         "127.0.0.1", port, NULL, 0);
     ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
                               JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
@@ -448,7 +448,7 @@ void flb_test_splunk_raw(int port)
 
 void flb_test_splunk_collector_raw()
 {
-    flb_test_splunk_raw(8811);
+    flb_test_splunk_raw(8811, "/services/collector/raw");
 }
 
 void flb_test_splunk_raw_multilines(int port)
@@ -910,11 +910,25 @@ void flb_test_splunk_collector_raw_hec_token_key()
     flb_test_splunk_auth_header(8817, "/services/collector/raw");
 }
 
+/* 1.0 endpoints */
+
+void flb_test_splunk_collector_raw_1_0()
+{
+    flb_test_splunk_raw(8818, "/services/collector/raw/1.0");
+}
+
+void flb_test_splunk_collector_event_1_0()
+{
+    flb_test_splunk(8819, "/services/collector/event/1.0");
+}
+
 TEST_LIST = {
     {"health", flb_test_splunk_health},
     {"collector", flb_test_splunk_collector},
     {"collector_event", flb_test_splunk_collector_event},
+    {"collector_event_1.0", flb_test_splunk_collector_event_1_0},
     {"collector_raw", flb_test_splunk_collector_raw},
+    {"collector_raw_1.0", flb_test_splunk_collector_raw_1_0},
     {"collector_raw_multilines", flb_test_splunk_collector_raw_multilines},
     {"collector_gzip", flb_test_splunk_collector_gzip},
     {"collector_event_gzip", flb_test_splunk_collector_event_gzip},


### PR DESCRIPTION
<!-- Provide summary of changes -->
In Splunk HEC protocol, we need to handle 1.0 suffixed endpoints for event and raw type of payloads of Splunk HEC.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
