### PR TITLE
in_winevtlog: out_s3: Fix windows build failures

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -450,7 +450,7 @@ static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT value
             }
             break;
         case EvtVarTypeEvtXml:
-            if (pack_wstr(ctx, values[i].XmlVal, ctx)) {
+            if (pack_wstr(ctx, values[i].XmlVal)) {
                 pack_nullstr(ctx);
             }
             break;

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -380,7 +380,11 @@ static int init_seq_index(void *context) {
     }
 
     /* Create directory path if it doesn't exist */
+#ifdef FLB_SYSTEM_WINDOWS
+    ret = mkdir(ctx->metadata_dir);
+#else
     ret = mkdir(ctx->metadata_dir, 0700);
+#endif
     if (ret < 0 && errno != EEXIST) {
         flb_plg_error(ctx->ins, "Failed to create metadata directory");
         return -1;


### PR DESCRIPTION
<!-- Provide summary of changes -->

In Windows, mkdir does not have second argument.
Plus, pack_wstr in pack.c in in_winevtlog does not have third argument.

Today or yesterday, it seems that the windows-latest worker is upgraded. So, these previously warnings are treated as compilation errors.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
