### PR TITLE
out_influxdb: Handle signed/unsigned integer as influx's integer of that representation

### DIFF
--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -171,11 +171,11 @@ static char *influxdb_format(const char *tag, int tag_len,
             }
             else if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64, v->via.u64);
+                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 "i", v->via.u64);
             }
             else if (v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64, v->via.i64);
+                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64 "i", v->via.i64);
             }
             else if (v->type == MSGPACK_OBJECT_FLOAT || v->type == MSGPACK_OBJECT_FLOAT32) {
                 val = tmp;

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -691,7 +691,7 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "use_integer", "false",
+     FLB_CONFIG_MAP_BOOL, "add_integer_suffix", "false",
      0, FLB_TRUE, offsetof(struct flb_influxdb, use_influxdb_integer),
      "Use influxdb line protocol's integer type suffix."
     },

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -176,11 +176,21 @@ static int influxdb_format(struct flb_config *config,
             }
             else if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 "i", v->via.u64);
+                if (ctx->use_influxdb_integer) {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 "i", v->via.u64);
+                }
+                else {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64, v->via.u64);
+                }
             }
             else if (v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64 "i", v->via.i64);
+                if (ctx->use_influxdb_integer) {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64 "i", v->via.i64);
+                }
+                else {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64, v->via.i64);
+                }
             }
             else if (v->type == MSGPACK_OBJECT_FLOAT || v->type == MSGPACK_OBJECT_FLOAT32) {
                 val = tmp;
@@ -678,6 +688,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "tag_keys", NULL,
      0, FLB_FALSE, 0,
      "Space separated list of keys that needs to be tagged."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "use_integer", "false",
+     0, FLB_TRUE, offsetof(struct flb_influxdb, use_influxdb_integer),
+     "Use influxdb line protocol's integer type suffix."
     },
 
     /* EOF */

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -580,6 +580,10 @@ static int cb_influxdb_exit(void *data, struct flb_config *config)
         flb_utils_split_free(ctx->tag_keys);
     }
 
+    if (ctx->seq_name) {
+        flb_free(ctx->seq_name);
+    }
+
     flb_upstream_destroy(ctx->u);
     flb_free(ctx);
 

--- a/plugins/out_influxdb/influxdb.h
+++ b/plugins/out_influxdb/influxdb.h
@@ -65,6 +65,9 @@ struct flb_influxdb {
     /* Arbitrary HTTP headers */
     struct mk_list *headers;
 
+    /* Use line protocol's integer type */
+    int use_influxdb_integer;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -124,6 +124,7 @@ if(FLB_IN_LIB)
   endif()
   FLB_RT_TEST(FLB_OUT_S3                "out_s3.c")
   FLB_RT_TEST(FLB_OUT_TD                "out_td.c")
+  FLB_RT_TEST(FLB_OUT_INFLUXDB          "out_influxdb.c")
 
 endif()
 

--- a/tests/runtime/out_influxdb.c
+++ b/tests/runtime/out_influxdb.c
@@ -1,0 +1,327 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2024 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
+#include "flb_tests_runtime.h"
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+#define JSON_BASIC "[12345678, {\"key\":\"value\"}]"
+static void cb_check_basic(void *ctx, int ffd,
+                           int res_ret, void *res_data, size_t res_size,
+                           void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "key=\"value\"";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+#define JSON_FLOAT "[12345678, {\"float\":1.3}]"
+static void cb_check_float_value(void *ctx, int ffd,
+                                 int res_ret, void *res_data, size_t res_size,
+                                 void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "float=1.3";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+#define JSON_INTEGER "[12345678, {\"int\":100}]"
+static void cb_check_int_value(void *ctx, int ffd,
+                               int res_ret, void *res_data, size_t res_size,
+                               void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "int=100i";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+
+#define JSON_NEGATIVE_INTEGER "[12345678, {\"int\":-200}]"
+static void cb_check_negative_int_value(void *ctx, int ffd,
+                                        int res_ret, void *res_data, size_t res_size,
+                                        void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "int=-200i";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+void flb_test_basic()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_basic,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_float_value()
+{
+    int ret;
+    int size = sizeof(JSON_FLOAT) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_float_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_FLOAT, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_integer_value()
+{
+    int ret;
+    int size = sizeof(JSON_INTEGER) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_int_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_INTEGER, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_negative_integer_value()
+{
+    int ret;
+    int size = sizeof(JSON_NEGATIVE_INTEGER) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_negative_int_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_NEGATIVE_INTEGER, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"basic"                  , flb_test_basic },
+    {"float"                  , flb_test_float_value },
+    {"integer"                , flb_test_integer_value },
+    {"negative_integer"       , flb_test_negative_integer_value },
+    {NULL, NULL}
+};

--- a/tests/runtime/out_influxdb.c
+++ b/tests/runtime/out_influxdb.c
@@ -289,7 +289,7 @@ void flb_test_integer_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "true",
+                   "add_integer_suffix", "true",
                    NULL);
 
     /* Enable test mode */
@@ -340,7 +340,7 @@ void flb_test_negative_integer_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "true",
+                   "add_integer_suffix", "true",
                    NULL);
 
     /* Enable test mode */
@@ -392,7 +392,7 @@ void flb_test_integer_as_float_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "false",
+                   "add_integer_suffix", "false",
                    NULL);
 
     /* Enable test mode */
@@ -443,7 +443,7 @@ void flb_test_negative_integer_as_float_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "false",
+                   "add_integer_suffix", "false",
                    NULL);
 
     /* Enable test mode */


### PR DESCRIPTION
This is because in their line protocol, it needs to add "i" suffix for handling a value as an integer:

| Datatype | Element(s)   | Description |
|:--------:|:------------:|:------------|
| Integer | Field values | Signed 64-bit integers (-9223372036854775808 to 9223372036854775807). Specify an integer with a trailing i on the number. Example: 1i |

So, we need to add "i" suffix for signed/unsigned integer values if needed.

ref: https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_reference/

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes https://github.com/fluent/fluent-bit/issues/9120.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```yaml
service:
    flush: 1
    log_level: debug

pipeline:
    inputs:
      - name: dummy
        dummy: "{\"key\":\"message\", \"number\":2}"

    outputs:
        - name: influxdb
          match: "*"
          host: localhost
          # add_integer_suffix: On
          Org: fluent
          database: fluent-bit
          auto_tags: on # Automatically tag keys where value is string. This option takes a boolean value: True/False, On/Off.
          # HTTP_Token: <awesome_token>
```


- [x] Debug log output from testing the change

```
Fluent Bit v3.1.7
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/08/30 17:42:17] [ info] Configuration:
[2024/08/30 17:42:17] [ info]  flush time     | 1.000000 seconds
[2024/08/30 17:42:17] [ info]  grace          | 5 seconds
[2024/08/30 17:42:17] [ info]  daemon         | 0
[2024/08/30 17:42:17] [ info] ___________
[2024/08/30 17:42:17] [ info]  inputs:
[2024/08/30 17:42:17] [ info]      dummy
[2024/08/30 17:42:17] [ info] ___________
[2024/08/30 17:42:17] [ info]  filters:
[2024/08/30 17:42:17] [ info] ___________
[2024/08/30 17:42:17] [ info]  outputs:
[2024/08/30 17:42:17] [ info]      influxdb.0
[2024/08/30 17:42:17] [ info] ___________
[2024/08/30 17:42:17] [ info]  collectors:
[2024/08/30 17:42:17] [ info] [fluent bit] version=3.1.7, commit=0d4d6bda2e, pid=21448
[2024/08/30 17:42:17] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2024/08/30 17:42:17] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/08/30 17:42:17] [ info] [cmetrics] version=0.9.4
[2024/08/30 17:42:17] [ info] [ctraces ] version=0.5.5
[2024/08/30 17:42:17] [ info] [input:dummy:dummy.0] initializing
[2024/08/30 17:42:17] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/08/30 17:42:17] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/08/30 17:42:17] [debug] [influxdb:influxdb.0] created event channels: read=23 write=24
[2024/08/30 17:42:17] [debug] [output:influxdb:influxdb.0] host=localhost port=8086
[2024/08/30 17:42:17] [ info] [sp] stream processor started
[2024/08/30 17:42:19] [debug] [task] created task=0x60000131c000 id=0 OK
[2024/08/30 17:42:19] [debug] [upstream] KA connection #31 to localhost:8086 is connected
[2024/08/30 17:42:19] [debug] [http_client] not using http_proxy for header
[2024/08/30 17:42:19] [debug] [output:influxdb:influxdb.0] http_do=0 OK
[2024/08/30 17:42:19] [debug] [upstream] KA connection #31 to localhost:8086 is now available
[2024/08/30 17:42:19] [debug] [out flush] cb_destroy coro_id=0
[2024/08/30 17:42:19] [debug] [task] destroy task=0x60000131c000 (task_id=0)
[2024/08/30 17:42:20] [debug] [task] created task=0x600001310000 id=0 OK
[2024/08/30 17:42:20] [debug] [upstream] KA connection #31 to localhost:8086 has been assigned (recycled)
[2024/08/30 17:42:20] [debug] [http_client] not using http_proxy for header
[2024/08/30 17:42:20] [debug] [output:influxdb:influxdb.0] http_do=0 OK
[2024/08/30 17:42:20] [debug] [upstream] KA connection #31 to localhost:8086 is now available
[2024/08/30 17:42:20] [debug] [out flush] cb_destroy coro_id=1
[2024/08/30 17:42:20] [debug] [task] destroy task=0x600001310000 (task_id=0)
[2024/08/30 17:42:21] [debug] [task] created task=0x60000131c000 id=0 OK
[2024/08/30 17:42:21] [debug] [upstream] KA connection #31 to localhost:8086 has been assigned (recycled)
[2024/08/30 17:42:21] [debug] [http_client] not using http_proxy for header
[2024/08/30 17:42:21] [debug] [output:influxdb:influxdb.0] http_do=0 OK
[2024/08/30 17:42:21] [debug] [upstream] KA connection #31 to localhost:8086 is now available
[2024/08/30 17:42:21] [debug] [out flush] cb_destroy coro_id=2
[2024/08/30 17:42:21] [debug] [task] destroy task=0x60000131c000 (task_id=0)
^C[2024/08/30 17:42:21] [engine] caught signal (SIGINT)
[2024/08/30 17:42:21] [ info] [input] pausing dummy.0
```

```
% influx query 'from(bucket: "fluent-bit") |> range(start: 2024-08-29T00:00:00Z, stop: now())'
Result: _result
Table: keys: [_start, _stop, _field, _measurement, _seq, key]
                   _start:time                      _stop:time           _field:string     _measurement:string             _seq:string              key:string                      _time:time                  _value:float
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ----------------------  ------------------------------  ----------------------------
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       0                 message  2024-08-30T08:10:35.384719000Z                             2
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       0                 message  2024-08-30T08:11:13.697479000Z                             2
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       0                 message  2024-08-30T08:42:13.262590000Z                             2
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       0                 message  2024-08-30T08:42:18.498846000Z                             2
Table: keys: [_start, _stop, _field, _measurement, _seq, key]
                   _start:time                      _stop:time           _field:string     _measurement:string             _seq:string              key:string                      _time:time                  _value:float
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ----------------------  ------------------------------  ----------------------------
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       1                 message  2024-08-30T08:10:36.383642000Z                             2
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       1                 message  2024-08-30T08:42:19.498964000Z                             2
Table: keys: [_start, _stop, _field, _measurement, _seq, key]
                   _start:time                      _stop:time           _field:string     _measurement:string             _seq:string              key:string                      _time:time                  _value:float
------------------------------  ------------------------------  ----------------------  ----------------------  ----------------------  ----------------------  ------------------------------  ----------------------------
2024-08-29T00:00:00.000000000Z  2024-08-30T08:43:37.233904000Z                  number                 dummy.0                       2                 message  2024-08-30T08:42:20.498893000Z                             2
```

To ingest already mapped as float field(s) with integer type, then got:

```
Fluent Bit v3.1.7
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/08/30 17:43:18] [ info] Configuration:
[2024/08/30 17:43:18] [ info]  flush time     | 1.000000 seconds
[2024/08/30 17:43:18] [ info]  grace          | 5 seconds
[2024/08/30 17:43:18] [ info]  daemon         | 0
[2024/08/30 17:43:18] [ info] ___________
[2024/08/30 17:43:18] [ info]  inputs:
[2024/08/30 17:43:18] [ info]      dummy
[2024/08/30 17:43:18] [ info] ___________
[2024/08/30 17:43:18] [ info]  filters:
[2024/08/30 17:43:18] [ info] ___________
[2024/08/30 17:43:18] [ info]  outputs:
[2024/08/30 17:43:18] [ info]      influxdb.0
[2024/08/30 17:43:18] [ info] ___________
[2024/08/30 17:43:18] [ info]  collectors:
[2024/08/30 17:43:18] [ info] [fluent bit] version=3.1.7, commit=0d4d6bda2e, pid=21954
[2024/08/30 17:43:18] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2024/08/30 17:43:18] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/08/30 17:43:18] [ info] [cmetrics] version=0.9.4
[2024/08/30 17:43:18] [ info] [ctraces ] version=0.5.5
[2024/08/30 17:43:18] [ info] [input:dummy:dummy.0] initializing
[2024/08/30 17:43:18] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/08/30 17:43:18] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/08/30 17:43:18] [debug] [influxdb:influxdb.0] created event channels: read=23 write=24
[2024/08/30 17:43:18] [debug] [output:influxdb:influxdb.0] host=localhost port=8086
[2024/08/30 17:43:18] [ info] [sp] stream processor started
[2024/08/30 17:43:20] [debug] [task] created task=0x6000037802c0 id=0 OK
[2024/08/30 17:43:20] [debug] [upstream] KA connection #31 to localhost:8086 is connected
[2024/08/30 17:43:20] [debug] [http_client] not using http_proxy for header
[2024/08/30 17:43:20] [error] [output:influxdb:influxdb.0] http_status=422
{"code":"unprocessable entity","message":"failure writing points to database: partial write: field type conflict: input field \"number\" on measurement \"dummy.0\" is type integer, already exists as type float dropped=1"}
[2024/08/30 17:43:20] [debug] [output:influxdb:influxdb.0] http_do=0 OK
[2024/08/30 17:43:20] [debug] [upstream] KA connection #31 to localhost:8086 is now available
[2024/08/30 17:43:20] [debug] [out flush] cb_destroy coro_id=0
[2024/08/30 17:43:20] [debug] [task] destroy task=0x6000037802c0 (task_id=0)
^C[2024/08/30 17:43:21] [engine] caught signal (SIGINT)
[2024/08/30 17:43:21] [ info] [input] pausing dummy.0
```

This is expected behavior because this indicates that the integer type of influxdb line protocol was used correctly.

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Without `use_integer: Off` (default value):

```
==1986869== 
==1986869== HEAP SUMMARY:
==1986869==     in use at exit: 0 bytes in 0 blocks
==1986869==   total heap usage: 3,543 allocs, 3,543 frees, 1,633,498 bytes allocated
==1986869== 
==1986869== All heap blocks were freed -- no leaks are possible
==1986869== 
==1986869== For lists of detected and suppressed errors, rerun with: -s
==1986869== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

With `use_integer: On`:

```
==1986130== 
==1986130== HEAP SUMMARY:
==1986130==     in use at exit: 0 bytes in 0 blocks
==1986130==   total heap usage: 3,566 allocs, 3,566 frees, 1,634,106 bytes allocated
==1986130== 
==1986130== All heap blocks were freed -- no leaks are possible
==1986130== 
==1986130== For lists of detected and suppressed errors, rerun with: -s
==1986130== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1451

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
