### PR TITLE
workflows: linux: Compile and execute internal test on non-amd64 platforms Linux

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -205,7 +205,7 @@ jobs:
             cd build
             export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
             export FLB_OPTION="-DFLB_WITHOUT_flb-it-network=1 -DFLB_WITHOUT_flb-it-fstore=1"
-            export FLB_OMIT_OPTION="-DFLB_WITHOUT_flb-it-utils=1 -DFLB_WITHOUT_flb-it-pack=1"
+            export FLB_OMIT_OPTION=""
             export GLOBAL_OPTION="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
             export FLB_UNIT_TEST_OPTION="-DFLB_TESTS_INTERNAL=On"
             export FLB_OPT="${FLB_OPTION} ${GLOBAL_OPTION} ${FLB_UNIT_TEST_OPTION} ${FLB_OMIT_OPTION}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -145,9 +145,10 @@ jobs:
             cd build
             export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
             export FLB_OPTION="-DFLB_WITHOUT_flb-it-network=1 -DFLB_WITHOUT_flb-it-fstore=1"
+            export FLB_OMIT_OPTION="-DFLB_WITHOUT_flb-it-utils=1 -DFLB_WITHOUT_flb-it-pack=1"
             export GLOBAL_OPTION="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
             export FLB_UNIT_TEST_OPTION="-DFLB_TESTS_INTERNAL=On"
-            export FLB_OPT="${FLB_OPTION} ${GLOBAL_OPTION} ${FLB_UNIT_TEST_OPTION}"
+            export FLB_OPT="${FLB_OPTION} ${GLOBAL_OPTION} ${FLB_UNIT_TEST_OPTION} ${FLB_OMIT_OPTION}"
 
             echo "CC = gcc, CXX = gcc, FLB_OPT = $FLB_OPT"
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -138,14 +138,12 @@ jobs:
         uses: self-actuated/hub-mirror@master
 
       - name: Setup environment
-        if: github.repository == 'fluent/fluent-bit'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-9 g++-9 clang-12 cmake flex bison libsystemd-dev gcovr libyaml-dev
           sudo ln -s /usr/bin/llvm-symbolizer-12 /usr/bin/llvm-symbolizer || true
 
       - name: Build and test with actuated runners
-        if: github.repository == 'fluent/fluent-bit'
         run: |
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
             sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -111,7 +111,7 @@ jobs:
           FLB_OPT: ${{ matrix.flb_option }}
 
 
-  run-qemu-aarch64-unit-tests:
+  run-qemu-ubuntu-unit-tests:
     # We chain this after Linux one as there are CPU time costs for QEMU emulation
     needs:
       - run-ubuntu-unit-tests
@@ -119,15 +119,18 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      matrix:
+        arch:
+          - aarch64
     steps:
       - name: Checkout Fluent Bit code
         uses: actions/checkout@v4
 
-      - name: Prepare and build with QEMU aarch64
+      - name: Prepare and build with QEMU ${{ matrix.arch }}
         uses: uraimo/run-on-arch-action@v2
-        id: aarch64-build-on-qemu-aarch64
+        id: build-and-test-on-qemu
         with:
-          arch: aarch64
+          arch: ${{ matrix.arch }}
           distro: ubuntu20.04
           shell: /bin/bash
           dockerRunArgs: |
@@ -167,7 +170,7 @@ jobs:
     needs:
       - run-macos-unit-tests
       - run-ubuntu-unit-tests
-      - run-qemu-aarch64-unit-tests
+      - run-qemu-ubuntu-unit-tests
     steps:
       - name: Check build matrix status
         # Ignore MacOS failures

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - aarch64
+          - s390x
     steps:
       - name: Checkout Fluent Bit code
         uses: actions/checkout@v4
@@ -209,8 +209,10 @@ jobs:
             export GLOBAL_OPTION="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
             export FLB_UNIT_TEST_OPTION="-DFLB_TESTS_INTERNAL=On"
             export FLB_OPT="${FLB_OPTION} ${GLOBAL_OPTION} ${FLB_UNIT_TEST_OPTION} ${FLB_OMIT_OPTION}"
+            export CC=gcc
+            export CXX=gcc
 
-            echo "CC = gcc, CXX = gcc, FLB_OPT = $FLB_OPT"
+            echo "CC = $CC, CXX = $CXX, FLB_OPT = $FLB_OPT"
 
             cmake ${FLB_OPT}  ../
             make -j $nparallel

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -110,6 +110,63 @@ jobs:
           CXX: g++
           FLB_OPT: ${{ matrix.flb_option }}
 
+  run-aarch64-unit-tests:
+    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-latest usage.
+    runs-on: ${{(github.repository == 'fluent/fluent-bit') && 'actuated-arm64-8cpu-16gb' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    # We chain this after Linux one as there are costs for actuated workers
+    needs:
+      - run-ubuntu-unit-tests
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Aarch64 actuated testing"
+            flb_option: "-DFLB_WITHOUT_flb-it-network=1 -DFLB_WITHOUT_flb-it-fstore=1"
+            omit_option: "-DFLB_WITHOUT_flb-it-utils=1 -DFLB_WITHOUT_flb-it-pack=1"
+            global_option: "-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
+            unit_test_option: "-DFLB_TESTS_INTERNAL=On"
+            compiler: gcc
+    steps:
+      - name: Checkout Fluent Bit code
+        uses: actions/checkout@v4
+
+      - name: Set up Actuated mirror
+        if: github.repository == 'fluent/fluent-bit'
+        uses: self-actuated/hub-mirror@master
+
+      - name: Setup environment
+        if: github.repository == 'fluent/fluent-bit'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-9 g++-9 clang-12 cmake flex bison libsystemd-dev gcovr libyaml-dev
+          sudo ln -s /usr/bin/llvm-symbolizer-12 /usr/bin/llvm-symbolizer || true
+
+      - name: Build and test with actuated runners
+        if: github.repository == 'fluent/fluent-bit'
+        run: |
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 90
+
+            export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
+            export FLB_OPTION="${{ matrix.config.flb_option }}"
+            export FLB_OMIT_OPTION="${{ matrix.config.omit_option }}"
+            export GLOBAL_OPTION="${{ matrix.config.global_option }}"
+            export FLB_UNIT_TEST_OPTION="${{ matrix.config.unit_test_option }}"
+            export FLB_OPT="${FLB_OPTION} ${GLOBAL_OPTION} ${FLB_UNIT_TEST_OPTION} ${FLB_OMIT_OPTION}"
+
+            echo "CC = ${{ matrix.config.compiler }}, CXX = ${{ matrix.config.compiler }}, FLB_OPT = $FLB_OPT"
+
+            cmake ${FLB_OPT}  ../
+            make -j $nparallel
+            ctest -j $nparallel --build-run-dir . --output-on-failure
+        working-directory: build
+        env:
+          CC: ${{ matrix.config.compiler }}
+          CXX: ${{ matrix.config.compiler }}
 
   run-qemu-ubuntu-unit-tests:
     # We chain this after Linux one as there are CPU time costs for QEMU emulation
@@ -170,6 +227,7 @@ jobs:
     needs:
       - run-macos-unit-tests
       - run-ubuntu-unit-tests
+      - run-aarch64-unit-tests
       - run-qemu-ubuntu-unit-tests
     steps:
       - name: Check build matrix status

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -118,7 +118,7 @@ jobs:
     # We chain this after Linux one as there are costs for actuated workers
     needs:
       - run-ubuntu-unit-tests
-    timeout-minutes: 60
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -110,6 +110,52 @@ jobs:
           CXX: g++
           FLB_OPT: ${{ matrix.flb_option }}
 
+
+  run-qemu-aarch64-unit-tests:
+    # We chain this after Linux one as there are CPU time costs for QEMU emulation
+    needs:
+      - run-ubuntu-unit-tests
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Fluent Bit code
+        uses: actions/checkout@v4
+
+      - name: Prepare and build with QEMU aarch64
+        uses: uraimo/run-on-arch-action@v2
+        id: aarch64-build-on-qemu-aarch64
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          shell: /bin/bash
+          dockerRunArgs: |
+            --volume "/var/lib/dbus/machine-id:/var/lib/dbus/machine-id"
+            --volume "/etc/machine-id:/etc/machine-id"
+          install: |
+            apt-get update
+            apt-get install -y gcc-7 g++-7 clang-6.0 libyaml-dev cmake flex bison libssl-dev #libsystemd-dev
+            ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
+
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
+            update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
+          run: |
+            cd build
+            export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
+            export FLB_OPTION="-DFLB_WITHOUT_flb-it-network=1 -DFLB_WITHOUT_flb-it-fstore=1"
+            export GLOBAL_OPTION="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"
+            export FLB_UNIT_TEST_OPTION="-DFLB_TESTS_INTERNAL=On"
+            export FLB_OPT="${FLB_OPTION} ${GLOBAL_OPTION} ${FLB_UNIT_TEST_OPTION}"
+
+            echo "CC = gcc, CXX = gcc, FLB_OPT = $FLB_OPT"
+
+            cmake ${FLB_OPT}  ../
+            make -j $nparallel
+            ctest -j $nparallel --build-run-dir . --output-on-failure
+
+
   # Required check looks at this so do not remove
   run-all-unit-tests:
     if: always()
@@ -120,6 +166,7 @@ jobs:
     needs:
       - run-macos-unit-tests
       - run-ubuntu-unit-tests
+      - run-qemu-aarch64-unit-tests
     steps:
       - name: Check build matrix status
         # Ignore MacOS failures


### PR DESCRIPTION
This workflow could be used for aarch64 Linux testing purpose such as #8851.

Also, `uraimo/run-on-arch-action@v2` workflow component can handle s390x and ppc64le architectures by QEMU emulations.
So, we can add these targets in the future.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
