### PR TITLE
upstream: Improve error message for misconfigured HTTP_PROXY variable

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -290,7 +290,6 @@ struct flb_upstream *flb_upstream_create(struct flb_config *config,
                                         &proxy_username, &proxy_password,
                                         &proxy_host, &proxy_port);
         if (ret == -1) {
-            flb_errno();
             flb_free(u);
             return NULL;
         }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1128,7 +1128,7 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
 
 /*
  * flb_utils_proxy_url_split parses a proxy's information from a http_proxy URL.
- * The URL is in the form like `http://username:password@myproxy.com:8080`.
+ * The URL is in the form like `http://[username:password@]myproxy.com:8080`.
  * Note: currently only HTTP is supported.
  */
 int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
@@ -1147,9 +1147,11 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     /*  Parse protocol */
     proto_sep = strstr(in_url, "://");
     if (!proto_sep) {
+        flb_error("HTTP_PROXY variable must be set in the form of 'http://[username:password@]host:port'");
         return -1;
     }
     if (proto_sep == in_url) {
+        flb_error("HTTP_PROXY variable must be set in the form of 'http://[username:password@]host:port'");
         return -1;
     }
 
@@ -1160,6 +1162,7 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     }
     /* Only HTTP proxy is supported for now. */
     if (strcmp(protocol, "http") != 0) {
+        flb_error("only HTTP proxy is supported.");
         flb_free(protocol);
         return -1;
     }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -758,7 +758,7 @@ static inline void encoded_to_buf(char *out, const char *in, int len)
 
 /*
  * Write string pointed by 'str' to the destination buffer 'buf'. It's make sure
- * to escape sepecial characters and convert utf-8 byte characters to string
+ * to escape special characters and convert utf-8 byte characters to string
  * representation.
  */
 int flb_utils_write_str(char *buf, int *off, size_t size,
@@ -1170,10 +1170,10 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     /* Advance position after protocol */
     proto_sep += 3;
 
-    /* Seperate `username:password` and `host:port` */
+    /* Separate `username:password` and `host:port` */
     at_sep = strrchr(proto_sep, '@');
     if (at_sep) {
-        /* Parse username:passwrod part. */
+        /* Parse username:password part. */
         tmp = strchr(proto_sep, ':');
         if (!tmp) {
             flb_free(protocol);


### PR DESCRIPTION
Added specific messages for errors inside the function `flb_utils_proxy_url_split()`.
Removed the call to `flb_errno()` since errors are displayed by `flb_utils_proxy_url_split`.

Fixes #9327 

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
Config for repro from #9327.

```text
Fluent Bit v3.2.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/09/02 14:51:40] [ info] Configuration:
[2024/09/02 14:51:40] [ info]  flush time     | 1.000000 seconds
[2024/09/02 14:51:40] [ info]  grace          | 5 seconds
[2024/09/02 14:51:40] [ info]  daemon         | 0
[2024/09/02 14:51:40] [ info] ___________
[2024/09/02 14:51:40] [ info]  inputs:
[2024/09/02 14:51:40] [ info]      dummy
[2024/09/02 14:51:40] [ info] ___________
[2024/09/02 14:51:40] [ info]  filters:
[2024/09/02 14:51:40] [ info] ___________
[2024/09/02 14:51:40] [ info]  outputs:
[2024/09/02 14:51:40] [ info]      stdout.0
[2024/09/02 14:51:40] [ info]      http.1
[2024/09/02 14:51:40] [ info] ___________
[2024/09/02 14:51:40] [ info]  collectors:
[2024/09/02 14:51:40] [ info] [fluent bit] version=3.2.0, commit=c69a6dfe9b, pid=1711
[2024/09/02 14:51:40] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2024/09/02 14:51:40] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/09/02 14:51:40] [ info] [cmetrics] version=0.9.5
[2024/09/02 14:51:40] [ info] [ctraces ] version=0.5.5
[2024/09/02 14:51:40] [ info] [input:dummy:dummy.0] initializing
[2024/09/02 14:51:40] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/09/02 14:51:40] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/09/02 14:51:40] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/09/02 14:51:40] [debug] [http:http.1] created event channels: read=30 write=31
[2024/09/02 14:51:40] [ info] [input] pausing dummy.0
[2024/09/02 14:51:40] [debug] [upstream] config->http_proxy: hostname.domain.tld
[2024/09/02 14:51:40] [ info] [output:stdout:stdout.0] worker #0 started
[2024/09/02 14:51:40] [error] HTTP_PROXY variable must be set in the form of 'http://[username:password@]host:port'
[2024/09/02 14:51:40] [error] [output] failed to initialize 'http' plugin
[2024/09/02 14:51:40] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/09/02 14:51:40] [error] [engine] output initialization failed
[2024/09/02 14:51:40] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```


- [x] Debug log output from testing the change



<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature

[Current documentation](https://docs.fluentbit.io/manual/administration/http-proxy#http-proxy) is correct.

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
