### PR TITLE
input: disable coroutines for custom events and input callbacks that do not support coroutines.

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -109,6 +109,7 @@ int flb_io_net_connect(struct flb_connection *connection,
     int ret;
     int async = FLB_FALSE;
     flb_sockfd_t fd = -1;
+    int flags = flb_connection_get_flags(connection);
     // struct flb_upstream *u = u_conn->u;
 
     if (connection->fd > 0) {
@@ -119,7 +120,7 @@ int flb_io_net_connect(struct flb_connection *connection,
     }
 
     /* Check which connection mode must be done */
-    if (coro) {
+    if (coro && (flags & FLB_IO_ASYNC)) {
         async = flb_upstream_is_async(connection->upstream);
     }
     else {

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -512,7 +512,8 @@ int flb_tls_session_create(struct flb_tls *tls,
     struct flb_tls_session *session;
     int                     result;
     char                   *vhost;
-    int                     flag;
+    int                     evflag;
+    int                     cflag = flb_connection_get_flags(connection);
 
     session = flb_calloc(1, sizeof(struct flb_tls_session));
 
@@ -562,13 +563,13 @@ int flb_tls_session_create(struct flb_tls *tls,
             goto cleanup;
         }
 
-        flag = 0;
+        evflag = 0;
 
         if (result == FLB_TLS_WANT_WRITE) {
-            flag = MK_EVENT_WRITE;
+            evflag = MK_EVENT_WRITE;
         }
         else if (result == FLB_TLS_WANT_READ) {
-            flag = MK_EVENT_READ;
+            evflag = MK_EVENT_READ;
         }
 
         /*
@@ -579,7 +580,7 @@ int flb_tls_session_create(struct flb_tls *tls,
          * In the other case for an async socket 'th' is NOT NULL so the code
          * is under a coroutine context and it can yield.
          */
-        if (co == NULL) {
+        if (co == NULL && (cflag & FLB_IO_ASYNC)) {
             flb_trace("[io_tls] server handshake connection #%i in process to %s",
                       connection->fd,
                       flb_connection_get_remote_address(connection));
@@ -614,7 +615,7 @@ int flb_tls_session_create(struct flb_tls *tls,
         result = mk_event_add(connection->evl,
                               connection->fd,
                               FLB_ENGINE_EV_THREAD,
-                              flag,
+                              evflag,
                               &connection->event);
 
         connection->event.priority = FLB_ENGINE_PRIORITY_CONNECT;

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -580,7 +580,7 @@ int flb_tls_session_create(struct flb_tls *tls,
          * In the other case for an async socket 'th' is NOT NULL so the code
          * is under a coroutine context and it can yield.
          */
-        if (co == NULL && (cflag & FLB_IO_ASYNC)) {
+        if (co == NULL || !(cflag & FLB_IO_ASYNC)) {
             flb_trace("[io_tls] server handshake connection #%i in process to %s",
                       connection->fd,
                       flb_connection_get_remote_address(connection));


### PR DESCRIPTION
# Summary

Code that does not specifically support coroutines can result in a segmentation fault when coroutines are used during I/O and network calls. Under most circumstances this should not occur but if an input plugin shares the same thread as any output plugin that can inadvertently enable coroutines for all input plugins as well as causing custom events to use coroutines as well.

~~This PR mitigates this by juggling out the thread local storage used by coroutines during collect callbacks for non-coroutine inputs as well as custom events which do not have a way to express their compatibility with coroutines.~~

This PR has been refactored so that both the `flb_io_net_connect` and `flb_tls_session_create` functions respect the `FLB_IO_ASYNC` flag instead of assuming it when coroutines have been initialized.

This also mitigates the issue for `FLB_ENGINE_EV_CUSTOM`:

```
[2024/09/11 19:44:27] [debug] [upstream] KA connection #44 to cloud-api.calyptia.com:443 is now available
Process 69510 stopped
* thread #2, name = 'flb-pipeline', stop reason = breakpoint 1.1
    frame #0: 0x00000001001288a8 calyptia-fluent-bit`flb_engine_start(config=0x0000000101900200) at flb_engine.c:1040:22
   1037	                /* Init coroutine */
   1038	                flb_coro_resume(output_flush->coro);
   1039	            }
-> 1040	            else if (event->type == FLB_ENGINE_EV_CUSTOM) {
   1041	                event->handler(event);
   1042	            }
   1043	            else if (event->type == FLB_ENGINE_EV_THREAD) {
Target 0: (calyptia-fluent-bit) stopped.
(lldb) c
Process 69510 resuming
[0] logs: [[1726094665.418981000, {"id"=>"uuid", "email"=>"test@account.com", "external_email"=>"foo@bar.com", "first_name"=>"Test", "last_name"=>"User", "created_by"=>"no-idea", "state"=>2, "type"=>1, "user_account.provider"=>4, "user_account.provider_id"=>"THIS_IS_A_PROVIDER", "service_account.id"=>"692c02c283cca2aa9722499313c805c064639a855a85b791607b89ef77c27639", "service_account.email"=>"service@account.com", "service_account.name"=>"This Is a Service Account", "service_account.created_by"=>"Some guy in IT called Roy", "service_account.version"=>65541, "service_account.permission"=>3, "service_account.source_client"=>"The Source of everything: 42", "service_account.slug"=>"Captain Slug to you!", "First"=>"Psot!", "tenant_active.id"=>"78e8b9ab-6735-4a5e-9c4c-cb38d26de21d"}], {"service"=>"startup-test", "severity"=>"INFO"}]
[2024/09/11 19:44:28] [debug] [out flush] cb_destroy coro_id=0
[2024/09/11 19:44:28] [debug] [task] destroy task=0x105504b40 (task_id=0)
[2024/09/11 19:44:28] [debug] [out flush] cb_destroy coro_id=0
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [Y] Backport to latest stable release.


I have backported this PR to the 3.0 and 3.1 series:
- 3.0: #9389
- 3.1: #9390

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
