### PR TITLE
out_influxdb: Handle signed/unsigned integer as influx's integer of that representation [Backport 3.1]

### DIFF
--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -171,11 +171,11 @@ static char *influxdb_format(const char *tag, int tag_len,
             }
             else if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64, v->via.u64);
+                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 "i", v->via.u64);
             }
             else if (v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64, v->via.i64);
+                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64 "i", v->via.i64);
             }
             else if (v->type == MSGPACK_OBJECT_FLOAT || v->type == MSGPACK_OBJECT_FLOAT32) {
                 val = tmp;

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -691,7 +691,7 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "use_integer", "false",
+     FLB_CONFIG_MAP_BOOL, "add_integer_suffix", "false",
      0, FLB_TRUE, offsetof(struct flb_influxdb, use_influxdb_integer),
      "Use influxdb line protocol's integer type suffix."
     },

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -176,11 +176,21 @@ static int influxdb_format(struct flb_config *config,
             }
             else if (v->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 "i", v->via.u64);
+                if (ctx->use_influxdb_integer) {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64 "i", v->via.u64);
+                }
+                else {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRIu64, v->via.u64);
+                }
             }
             else if (v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
                 val = tmp;
-                val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64 "i", v->via.i64);
+                if (ctx->use_influxdb_integer) {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64 "i", v->via.i64);
+                }
+                else {
+                    val_len = snprintf(tmp, sizeof(tmp) - 1, "%" PRId64, v->via.i64);
+                }
             }
             else if (v->type == MSGPACK_OBJECT_FLOAT || v->type == MSGPACK_OBJECT_FLOAT32) {
                 val = tmp;
@@ -678,6 +688,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "tag_keys", NULL,
      0, FLB_FALSE, 0,
      "Space separated list of keys that needs to be tagged."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "use_integer", "false",
+     0, FLB_TRUE, offsetof(struct flb_influxdb, use_influxdb_integer),
+     "Use influxdb line protocol's integer type suffix."
     },
 
     /* EOF */

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -580,6 +580,10 @@ static int cb_influxdb_exit(void *data, struct flb_config *config)
         flb_utils_split_free(ctx->tag_keys);
     }
 
+    if (ctx->seq_name) {
+        flb_free(ctx->seq_name);
+    }
+
     flb_upstream_destroy(ctx->u);
     flb_free(ctx);
 

--- a/plugins/out_influxdb/influxdb.h
+++ b/plugins/out_influxdb/influxdb.h
@@ -65,6 +65,9 @@ struct flb_influxdb {
     /* Arbitrary HTTP headers */
     struct mk_list *headers;
 
+    /* Use line protocol's integer type */
+    int use_influxdb_integer;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -124,6 +124,7 @@ if(FLB_IN_LIB)
   endif()
   FLB_RT_TEST(FLB_OUT_S3                "out_s3.c")
   FLB_RT_TEST(FLB_OUT_TD                "out_td.c")
+  FLB_RT_TEST(FLB_OUT_INFLUXDB          "out_influxdb.c")
 
 endif()
 

--- a/tests/runtime/out_influxdb.c
+++ b/tests/runtime/out_influxdb.c
@@ -1,0 +1,327 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2024 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_sds.h>
+#include "flb_tests_runtime.h"
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
+static int get_output_num()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_output;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_num(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_output = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_num()
+{
+    set_output_num(0);
+}
+
+#define JSON_BASIC "[12345678, {\"key\":\"value\"}]"
+static void cb_check_basic(void *ctx, int ffd,
+                           int res_ret, void *res_data, size_t res_size,
+                           void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "key=\"value\"";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+#define JSON_FLOAT "[12345678, {\"float\":1.3}]"
+static void cb_check_float_value(void *ctx, int ffd,
+                                 int res_ret, void *res_data, size_t res_size,
+                                 void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "float=1.3";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+#define JSON_INTEGER "[12345678, {\"int\":100}]"
+static void cb_check_int_value(void *ctx, int ffd,
+                               int res_ret, void *res_data, size_t res_size,
+                               void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "int=100i";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+
+#define JSON_NEGATIVE_INTEGER "[12345678, {\"int\":-200}]"
+static void cb_check_negative_int_value(void *ctx, int ffd,
+                                        int res_ret, void *res_data, size_t res_size,
+                                        void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *index_line = "int=-200i";
+
+    set_output_num(1);
+
+    p = strstr(out, index_line);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
+void flb_test_basic()
+{
+    int ret;
+    int size = sizeof(JSON_BASIC) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_basic,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_BASIC, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_float_value()
+{
+    int ret;
+    int size = sizeof(JSON_FLOAT) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_float_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_FLOAT, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_integer_value()
+{
+    int ret;
+    int size = sizeof(JSON_INTEGER) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_int_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_INTEGER, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_negative_integer_value()
+{
+    int ret;
+    int size = sizeof(JSON_NEGATIVE_INTEGER) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_negative_int_value,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_NEGATIVE_INTEGER, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"basic"                  , flb_test_basic },
+    {"float"                  , flb_test_float_value },
+    {"integer"                , flb_test_integer_value },
+    {"negative_integer"       , flb_test_negative_integer_value },
+    {NULL, NULL}
+};

--- a/tests/runtime/out_influxdb.c
+++ b/tests/runtime/out_influxdb.c
@@ -289,7 +289,7 @@ void flb_test_integer_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "true",
+                   "add_integer_suffix", "true",
                    NULL);
 
     /* Enable test mode */
@@ -340,7 +340,7 @@ void flb_test_negative_integer_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "true",
+                   "add_integer_suffix", "true",
                    NULL);
 
     /* Enable test mode */
@@ -392,7 +392,7 @@ void flb_test_integer_as_float_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "false",
+                   "add_integer_suffix", "false",
                    NULL);
 
     /* Enable test mode */
@@ -443,7 +443,7 @@ void flb_test_negative_integer_as_float_value()
     out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
     flb_output_set(ctx, out_ffd,
                    "match", "test",
-                   "use_integer", "false",
+                   "add_integer_suffix", "false",
                    NULL);
 
     /* Enable test mode */


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backporting PR: https://github.com/fluent/fluent-bit/pull/9301.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
