### PR TITLE
out_splunk: Extend retrying HTTP status code

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -768,8 +768,13 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
              * them:
              *
              * https://docs.splunk.com/Documentation/Splunk/8.0.5/Data/TroubleshootHTTPEventCollector#Possible_error_codes
+             * From trouble shoot document on Splunk secure gateway,
+             * 408 and 429 should be also handled as try again:
+             *
+             * https://docs.splunk.com/Documentation/SecureGateway/3.5.15/Admin/TroubleshootGateway#Troubleshoot_error_codes
              */
-            ret = (c->resp.status < 400 || c->resp.status >= 500) ?
+            ret = (c->resp.status < 400 || c->resp.status >= 500 ||
+                   c->resp.status == 408 || c->resp.status == 429) ?
                 FLB_RETRY : FLB_ERROR;
 
 


### PR DESCRIPTION
408 and 429 also should be treated as retry.

Related to https://github.com/fluent/fluent-bit/issues/9371.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
