### PR TITLE
file_sqldb :  Removed db shared check through shared member valriable

### DIFF
--- a/src/flb_sqldb.c
+++ b/src/flb_sqldb.c
@@ -52,11 +52,6 @@ struct flb_sqldb *flb_sqldb_open(const char *path, const char *desc,
     mk_list_foreach(head, &config->sqldb_list) {
         db_temp = mk_list_entry(head, struct flb_sqldb, _head);
 
-        /* Only lookup for original database, not contexts already shared */
-        if (db_temp->shared == FLB_TRUE) {
-            continue;
-        }
-
         if (strcmp(db_temp->path, path) == 0) {
             break;
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->
While initializing the db handlers , there is check db_temp->shared == TRUE .
However the check does not see if the db name is same for the stanzas or not , It just checks the 1st DB where shared is true and skips the rest check . 
Let's consider 2 different configurations .

[INPUT]
    name tail
    path /mnt/a.log
    db /mnt/a.db
    storage.type filesystem
[INPUT]
    name tail
    path /mnt/b.log
    db /mnt/a.db
    storage.type filesystem
[INPUT]
    name tail
    path /mnt/c.log
    db /mnt/c.db
    storage.type filesystem

Expectation
2 databases should be created in sqlite3 , but 1 database is created -- a

[INPUT]
    name tail
    path /mnt/a.log
    db /mnt/a.db
    storage.type filesystem
[INPUT]
    name tail
    path /mnt/b.log
    db /mnt/b.db
    storage.type filesystem
[INPUT]
    name tail
    path /mnt/c.log
    db /mnt/a.db
    storage.type filesystem

Expectation
2 databases should be created in sqlite3  and 2 database is created -- a,b

This behavior is inconsistent due to the shared check .

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
