### PR TITLE
[POC, Do not merge] input_chunk: split incoming buffer when it's too big

### DIFF
--- a/include/fluent-bit/flb_input_log.h
+++ b/include/fluent-bit/flb_input_log.h
@@ -25,17 +25,17 @@
 
 int flb_input_log_append(struct flb_input_instance *ins,
                          const char *tag, size_t tag_len,
-                         const void *buf, size_t buf_size);
+                         void *buf, size_t buf_size);
 
 int flb_input_log_append_records(struct flb_input_instance *ins,
                                  size_t records,
                                  const char *tag, size_t tag_len,
-                                 const void *buf, size_t buf_size);
+                                 void *buf, size_t buf_size);
 
 int flb_input_log_append_skip_processor_stages(struct flb_input_instance *ins,
                                                size_t processor_starting_stage,
                                                const char *tag,
                                                size_t tag_len,
-                                               const void *buf,
+                                               void *buf,
                                                size_t buf_size);
 #endif

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -616,6 +616,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
                                          file->sl_log_event_encoder->output_buffer,
                                          file->sl_log_event_encoder->output_length);
             flb_log_event_encoder_reset(file->sl_log_event_encoder);
+            flb_free(file->sl_log_event_encoder->output_buffer);
             flb_log_event_encoder_claim_internal_buffer_ownership(file->sl_log_event_encoder);
         }
     }

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -615,7 +615,7 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
                                          file->tag_len,
                                          file->sl_log_event_encoder->output_buffer,
                                          file->sl_log_event_encoder->output_length);
-
+            flb_log_event_encoder_claim_internal_buffer_ownership(file->sl_log_event_encoder);
             flb_log_event_encoder_reset(file->sl_log_event_encoder);
         }
     }

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -615,8 +615,8 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
                                          file->tag_len,
                                          file->sl_log_event_encoder->output_buffer,
                                          file->sl_log_event_encoder->output_length);
-            flb_log_event_encoder_claim_internal_buffer_ownership(file->sl_log_event_encoder);
             flb_log_event_encoder_reset(file->sl_log_event_encoder);
+            flb_log_event_encoder_claim_internal_buffer_ownership(file->sl_log_event_encoder);
         }
     }
     else if (file->skip_next) {

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -36,6 +36,7 @@
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/stream_processor/flb_sp.h>
 #include <fluent-bit/flb_ring_buffer.h>
+#include <fluent-bit/flb_log_event.h>
 #include <chunkio/chunkio.h>
 #include <monkey/mk_core.h>
 
@@ -1124,7 +1125,9 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
     }
 
     if (id >= 0) {
-        if (ic->busy == FLB_TRUE || cio_chunk_is_locked(ic->chunk)) {
+        if (ic->busy == FLB_TRUE || cio_chunk_is_locked(ic->chunk) ||
+            (flb_input_chunk_get_real_size(ic) + chunk_size) >
+                FLB_INPUT_CHUNK_FS_MAX_SIZE) {
             ic = NULL;
         }
         else if (cio_chunk_is_up(ic->chunk) == CIO_FALSE) {

--- a/src/flb_input_log.c
+++ b/src/flb_input_log.c
@@ -34,7 +34,7 @@ struct buffer_entry {
     struct mk_list _head;
 };
 
-static struct buffer_entry *new_buffer_entry(const void *buf, size_t buf_size)
+static struct buffer_entry *new_buffer_entry(void *buf, size_t buf_size)
 {
     struct buffer_entry *new_entry = flb_malloc(sizeof(struct buffer_entry));
     new_entry->buf_size = buf_size;
@@ -61,7 +61,6 @@ static int split_buffer_entry(struct buffer_entry *entry,
     void *tmp_encoder_buf;
     size_t tmp_encoder_buf_size;
     struct flb_log_event_encoder log_encoder;
-    int new_encoder = FLB_TRUE;
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
     int entries_processed;
@@ -144,7 +143,7 @@ static int input_log_append(struct flb_input_instance *ins,
                             size_t processor_starting_stage,
                             size_t records,
                             const char *tag, size_t tag_len,
-                            const void *buf, size_t buf_size)
+                            void *buf, size_t buf_size)
 {
     int ret;
     int processor_is_active;
@@ -217,7 +216,7 @@ static int input_log_append(struct flb_input_instance *ins,
 /* Take a msgpack serialized record and enqueue it as a chunk */
 int flb_input_log_append(struct flb_input_instance *ins,
                          const char *tag, size_t tag_len,
-                         const void *buf, size_t buf_size)
+                         void *buf, size_t buf_size)
 {
     int ret;
     size_t records;
@@ -232,7 +231,7 @@ int flb_input_log_append_skip_processor_stages(struct flb_input_instance *ins,
                                                size_t processor_starting_stage,
                                                const char *tag,
                                                size_t tag_len,
-                                               const void *buf,
+                                               void *buf,
                                                size_t buf_size)
 {
     return input_log_append(ins,
@@ -248,7 +247,7 @@ int flb_input_log_append_skip_processor_stages(struct flb_input_instance *ins,
 int flb_input_log_append_records(struct flb_input_instance *ins,
                                  size_t records,
                                  const char *tag, size_t tag_len,
-                                 const void *buf, size_t buf_size)
+                                 void *buf, size_t buf_size)
 {
     int ret;
 


### PR DESCRIPTION
This PR is a proof of concept for mitigating the issue where a chunk can be too large when received from an input plugin.

## Bug Explanation

When a large set of data is read at one time, all these records are appended into whichever chunk is the most recently active, and all the records are written at once. The check for the chunk size only happens after writing data to the chunk. So despite the chunk size being "limited" to 2M, this doesn't guarantee that it won't exceed that number. In this case, we could easily have a chunk that is right up close to the `2M` limit, and then have loads of data written to it leading to an excessively large chunk that once encoded can exceed write limits of output plugin APIs.

## Proposed Solution

This solution is an attempt to mitigate the problem without immense restructuring. The strategy is to examine the size of the incoming buffer, and if it exceeds the `FLB_CHUNK_FS_MAX_SIZE` (`2M`), the buffer is split into separate buffers that are under the max size, and are all appended to chunks separately. This is paired with a check when retrieving a new input chunk, which checks if appending the current buffer will exceed the chunk size limit, and if so a new chunk is created.

This solution is not perfect, but it was the best way I could find within my power (i.e. I don't consider major restructures to this code or `chunkio` to be "within my power").

Issues: #9374, #1938

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
