### PR TITLE
stream_processor: fix operator precedence for logical operations

### DIFF
--- a/src/stream_processor/parser/sql.y
+++ b/src/stream_processor/parser/sql.y
@@ -1,4 +1,4 @@
-%name-prefix="flb_sp_"  // replace with %define api.prefix {flb_sp_}
+%name-prefix "flb_sp_"  // replace with %define api.prefix {flb_sp_}
 %define api.pure full
 %define parse.error verbose
 %parse-param { struct flb_sp_cmd *cmd };
@@ -98,6 +98,10 @@ void yyerror(struct flb_sp_cmd *cmd, const char *query, void *scanner, const cha
 %type <integer> aggregate_func
 %type <integer> COUNT AVG SUM MAX MIN TIMESERIES_FORECAST
 
+/* Define operator precedence and associativity for logical operations in conditions */
+%left OR   // Lowest precedence for OR
+%left AND  // Middle precedence for AND
+%right NOT // Highest precedence for NOT
 
 %destructor { flb_free ($$); } IDENTIFIER
 
@@ -293,7 +297,7 @@ select: SELECT keys FROM source window where groupby limit ';'
                    $$ = flb_sp_cmd_operation(cmd, $2, NULL, FLB_EXP_PAR);
                  }
                  |
-                 NOT condition
+                 NOT condition %prec NOT
                  {
                    $$ = flb_sp_cmd_operation(cmd, $2, NULL, FLB_EXP_NOT);
                  }

--- a/tests/internal/include/sp_cb_functions.h
+++ b/tests/internal/include/sp_cb_functions.h
@@ -206,6 +206,36 @@ static void cb_record_not_contains(int id, struct task_check *check,
     TEST_CHECK(ret == 0);
 }
 
+static void cb_select_and_or_precedence(int id, struct task_check *check,
+                                        char *buf, size_t size)
+{
+    int ret;
+
+    /* Expect all 11 rows */
+    ret = mp_count_rows(buf, size);
+    TEST_CHECK_(ret == 11, "expected 11 rows but got %d", ret);
+}
+
+static void cb_select_not_or_precedence(int id, struct task_check *check,
+                                        char *buf, size_t size)
+{
+    int ret;
+
+    /* Expect all 11 rows */
+    ret = mp_count_rows(buf, size);
+    TEST_CHECK_(ret == 11, "expected 11 rows but got %d", ret);
+}
+
+static void cb_select_not_and_precedence(int id, struct task_check *check,
+                                         char *buf, size_t size)
+{
+    int ret;
+
+    /* Expect 0 rows */
+    ret = mp_count_rows(buf, size);
+    TEST_CHECK_(ret == 0, "expected 0 rows but got %d", ret);
+}
+
 /* Callback functions to perform checks over results */
 static void cb_select_sub_blue(int id, struct task_check *check,
                                char *buf, size_t size)

--- a/tests/internal/include/sp_select_keys.h
+++ b/tests/internal/include/sp_select_keys.h
@@ -126,6 +126,26 @@ struct task_check select_keys_checks[] = {
         "SELECT id FROM TAG:'samples' WHERE @record.contains(x);",
         cb_record_not_contains,
     },
+
+    /* Operator precedence */
+    {
+        18, 0, 0, 0,
+        "and_or_precedence",
+        "SELECT id FROM STREAM:FLB WHERE false AND true OR true;",
+        cb_select_and_or_precedence,
+    },
+    {
+        19, 0, 0, 0,
+        "not_or_precedence",
+        "SELECT id FROM STREAM:FLB WHERE NOT true OR true;",
+        cb_select_not_or_precedence,
+    },
+    {
+        20, 0, 0, 0,
+        "not_and_precedence",
+        "SELECT id FROM STREAM:FLB WHERE NOT true AND false;",
+        cb_select_not_and_precedence,
+    },
 };
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/fluent/fluent-bit/issues/3763

### Summary
This pull request addresses the issue where the precedence of logical operators (`AND`, `OR`, `NOT`) was not defined in the grammar for the stream processor. 

### Changes Made
- Added precedence rules for `NOT`, `AND`, and `OR` operators to the Bison grammar file.
  - `NOT` now has the highest precedence.
  - `AND` has middle precedence.
  - `OR` has the lowest precedence.

### Issue Addressed
Fixes GitHub issue: stream_processor: precedence of AND, OR, and NOT not defined in grammar.

### Impact
This change ensures that logical operations in conditions are parsed with the correct precedence, aligning with expected logical operation rules.

### Testing
Please verify that the logical operations in conditions are handled correctly according to the new precedence rules.

Feel free to reach out if there are any questions or further adjustments needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected boolean operator precedence in queries: NOT now binds tighter than AND, which binds tighter than OR, ensuring accurate evaluation of complex WHERE clauses.

* **Tests**
  * Added tests covering AND/OR/NOT precedence combinations to validate parsing and prevent regressions.

* **Chores**
  * Updated parser/public interface and symbol naming — may affect integrations that call the parser directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->