### PR TITLE
http_client: out_es: lib: implement http client response testing mechanism

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -100,6 +100,71 @@ struct flb_http_debug {
     int (*cb_debug_request_payload);
 };
 
+/* To make opaque struct */
+struct flb_http_client;
+
+/*
+ * Tests callbacks
+ * ===============
+ */
+struct flb_test_http_response {
+    /*
+     * Response Test Mode
+     * ====================
+     * When the response test enable the test response mode, it needs to
+     * keep a reference of the context and other information:
+     *
+     * - rt_ctx : flb_http_client context
+     *
+     * - rt_status : HTTP response code
+     *
+     * - rt_in_callback: intermediary function to receive the results of
+     *                  the http response test function.
+     *
+     * - rt_data: opaque data type for rt_in_callback()
+     */
+
+    /* runtime library context */
+    void *rt_ctx;
+
+    /* HTTP status */
+    int rt_status;
+
+    /* optional response context */
+    void *response_ctx;
+
+    /*
+     * "response test callback": this function pointer is used by Fluent Bit
+     * http client testing mode to reference a test function that must retrieve the
+     * results of 'callback'. Consider this an intermediary function to
+     * transfer the results to the runtime test.
+     *
+     * This function is private and should not be set manually in the plugin
+     * code, it's set on src/flb_http_client.c .
+     */
+    void (*rt_resp_callback) (void *, int, void *, size_t, void *);
+
+    /*
+     * opaque data type passed by the runtime library to be used on
+     * rt_in_callback().
+     */
+    void *rt_data;
+
+    /*
+     * Callback
+     * =========
+     * "HTTP response callback": it references the plugin function that performs
+     * to validate HTTP response by HTTP client. This entry is mostly to
+     * expose the plugin local function.
+     */
+    int (*callback) (/* plugin that ingested the records */
+                     struct flb_http_client *,
+                     const void *,   /* incoming response data */
+                     size_t,         /* incoming response size */
+                     void **,        /* output buffer      */
+                     size_t *);      /* output buffer size */
+};
+
 /* Set a request type */
 struct flb_http_client {
     /* Upstream connection */
@@ -133,6 +198,10 @@ struct flb_http_client {
     /* Response */
     struct flb_http_client_response resp;
 
+    /* Tests */
+    int test_mode;
+    struct flb_test_http_response test_response;
+
     /* Reference to Callback context */
     void *cb_ctx;
 };
@@ -145,6 +214,13 @@ struct flb_http_client *flb_http_client(struct flb_connection *u_conn,
                                         const char *body, size_t body_len,
                                         const char *host, int port,
                                         const char *proxy, int flags);
+
+/* For fulfilling HTTP response testing (dummy client) */
+struct flb_http_client *flb_http_dummy_client(struct flb_connection *u_conn,
+                                              int method, const char *uri,
+                                              const char *body, size_t body_len,
+                                              const char *host, int port,
+                                              const char *proxy, int flags);
 
 int flb_http_add_header(struct flb_http_client *c,
                         const char *key, size_t key_len,
@@ -161,6 +237,12 @@ int flb_http_set_keepalive(struct flb_http_client *c);
 int flb_http_set_content_encoding_gzip(struct flb_http_client *c);
 int flb_http_set_callback_context(struct flb_http_client *c,
                                   struct flb_callback *cb_ctx);
+int flb_http_set_response_test(struct flb_http_client *c, char *test_name,
+                               const void *data, size_t len,
+                               int status,
+                               void (*resp_callback) (void *, int, void *, size_t, void *),
+                               void *resp_callback_data);
+int flb_http_push_response(struct flb_http_client *c, const void *data, size_t len);
 
 int flb_http_get_response_data(struct flb_http_client *c, size_t bytes_consumed);
 int flb_http_do_request(struct flb_http_client *c, size_t *bytes);

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -68,6 +68,9 @@ FLB_EXPORT int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                                    void *test_ctx);
 FLB_EXPORT int flb_output_set_callback(flb_ctx_t *ctx, int ffd, char *name,
                                        void (*cb)(char *, void *, void *));
+FLB_EXPORT int flb_output_set_http_test(flb_ctx_t *ctx, int ffd, char *test_name,
+                                        void (*out_response) (void *, int, int, void *, size_t, void *),
+                                        void *out_callback_data);
 
 FLB_EXPORT int flb_filter_set(flb_ctx_t *ctx, int ffd, ...);
 FLB_EXPORT int flb_service_set(flb_ctx_t *ctx, ...);
@@ -83,6 +86,9 @@ FLB_EXPORT int flb_loop(flb_ctx_t *ctx);
 /* data ingestion for "lib" input instance */
 FLB_EXPORT int flb_lib_push(flb_ctx_t *ctx, int ffd, const void *data, size_t len);
 FLB_EXPORT int flb_lib_config_file(flb_ctx_t *ctx, const char *path);
+
+/* Emulate ingestions of HTTP responses for output plugins */
+FLB_EXPORT int flb_lib_response(flb_ctx_t *ctx, int ffd, int status, const void *data, size_t len);
 
 /* library context handling */
 FLB_EXPORT void flb_context_set(flb_ctx_t *ctx);

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -633,7 +633,7 @@ static int add_host_and_content_length(struct flb_http_client *c)
     return 0;
 }
 
-struct flb_http_client *flb_http_client(struct flb_connection *u_conn,
+struct flb_http_client *create_http_client(struct flb_connection *u_conn,
                                         int method, const char *uri,
                                         const char *body, size_t body_len,
                                         const char *host, int port,
@@ -745,22 +745,79 @@ struct flb_http_client *flb_http_client(struct flb_connection *u_conn,
         c->query_string = p;
     }
 
+    /* Response */
+    c->resp.content_length = -1;
+    c->resp.connection_close = -1;
+
+    if (body && body_len > 0) {
+        c->body_buf = body;
+        c->body_len = body_len;
+    }
+
+    /* 'Read' buffer size */
+    c->resp.data = flb_malloc(FLB_HTTP_DATA_SIZE_MAX);
+    if (!c->resp.data) {
+        flb_errno();
+        flb_http_client_destroy(c);
+        return NULL;
+    }
+    c->resp.data[0] = '\0';
+    c->resp.data_len  = 0;
+    c->resp.data_size = FLB_HTTP_DATA_SIZE_MAX;
+    c->resp.data_size_max = FLB_HTTP_DATA_SIZE_MAX;
+
+    /* Tests */
+    c->test_mode = FLB_FALSE;
+    c->test_response.callback = NULL;
+
+    return c;
+}
+
+struct flb_http_client *flb_http_dummy_client(struct flb_connection *u_conn,
+                                              int method, const char *uri,
+                                              const char *body, size_t body_len,
+                                              const char *host, int port,
+                                              const char *proxy, int flags)
+{
+    struct flb_http_client *c;
+
+    c = create_http_client(u_conn, method, uri,
+                           body, body_len,
+                           host, port,
+                           proxy, flags);
+
+    if (!c) {
+        return NULL;
+    }
+
+    return c;
+}
+
+struct flb_http_client *flb_http_client(struct flb_connection *u_conn,
+                                        int method, const char *uri,
+                                        const char *body, size_t body_len,
+                                        const char *host, int port,
+                                        const char *proxy, int flags)
+{
+    int ret;
+    struct flb_http_client *c;
+
+    c = create_http_client(u_conn, method, uri,
+                           body, body_len,
+                           host, port,
+                           proxy, flags);
+
+    if (!c) {
+        return NULL;
+    }
+
     /* Is Upstream connection using keepalive mode ? */
     if (flb_stream_get_flag_status(&u_conn->upstream->base, FLB_IO_TCP_KA)) {
         c->flags |= FLB_HTTP_KA;
     }
 
-    /* Response */
-    c->resp.content_length = -1;
-    c->resp.connection_close = -1;
-
     if ((flags & FLB_HTTP_10) == 0) {
         c->flags |= FLB_HTTP_11;
-    }
-
-    if (body && body_len > 0) {
-        c->body_buf = body;
-        c->body_len = body_len;
     }
 
     add_host_and_content_length(c);
@@ -775,18 +832,6 @@ struct flb_http_client *flb_http_client(struct flb_connection *u_conn,
             return NULL;
         }
     }
-
-    /* 'Read' buffer size */
-    c->resp.data = flb_malloc(FLB_HTTP_DATA_SIZE_MAX);
-    if (!c->resp.data) {
-        flb_errno();
-        flb_http_client_destroy(c);
-        return NULL;
-    }
-    c->resp.data[0] = '\0';
-    c->resp.data_len  = 0;
-    c->resp.data_size = FLB_HTTP_DATA_SIZE_MAX;
-    c->resp.data_size_max = FLB_HTTP_DATA_SIZE_MAX;
 
     return c;
 }
@@ -1069,6 +1114,91 @@ int flb_http_set_callback_context(struct flb_http_client *c,
 {
     c->cb_ctx = cb_ctx;
     return 0;
+}
+
+int flb_http_set_response_test(struct flb_http_client *c, char *test_name,
+                               const void *data, size_t len,
+                               int status,
+                               void (*resp_callback) (void *, int, void *, size_t, void *),
+                               void *resp_callback_data)
+{
+    if (!c) {
+        return -1;
+    }
+
+    /*
+     * Enabling a test, set the http_client instance in 'test' mode, so no real
+     * http request is invoked, only the desired implemented test.
+     */
+
+    /* Response test */
+    if (strcmp(test_name, "response") == 0) {
+        c->test_mode = FLB_TRUE;
+        c->test_response.rt_ctx = c;
+        c->test_response.rt_status = status;
+        c->test_response.rt_resp_callback = resp_callback;
+        c->test_response.rt_data = resp_callback_data;
+        if (data != NULL && len > 0) {
+            c->resp.payload = (char *)data;
+            c->resp.payload_size = len;
+            c->resp.status = status;
+        }
+    }
+    else {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int flb_http_run_response_test(struct flb_http_client *c,
+                                      const void *data, size_t len)
+{
+    int ret = 0;
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_test_http_response  *htr;
+
+    if (!c) {
+        return -1;
+    }
+
+    htr = &c->test_response;
+
+    /* Invoke the output plugin formatter test callback */
+    ret = htr->callback(c,
+                        data, len,
+                        &out_buf, &out_size);
+
+    /* Call the runtime test callback checker */
+    if (htr->rt_resp_callback) {
+        htr->rt_resp_callback(htr->rt_ctx,
+                              ret,
+                              out_buf, out_size,
+                              htr->rt_data);
+    }
+    else {
+        flb_free(out_buf);
+    }
+
+    return 0;
+}
+
+/* Push some response into the http client */
+static int flb_http_stub_response(struct flb_http_client *c)
+{
+    int ret = 0;
+
+    if (!c) {
+        return -1;
+    }
+
+    /* If http client's test_responses is registered, run the stub. */
+    if (c->test_response.callback != NULL && c->resp.payload != NULL) {
+        ret = flb_http_run_response_test(c, c->resp.payload, c->resp.payload_size);
+    }
+
+    return ret;
 }
 
 int flb_http_add_auth_header(struct flb_http_client *c,
@@ -1361,6 +1491,10 @@ int flb_http_get_response_data(struct flb_http_client *c, size_t bytes_consumed)
 int flb_http_do(struct flb_http_client *c, size_t *bytes)
 {
     int ret;
+
+    if (c->test_mode == FLB_TRUE) {
+        return flb_http_stub_response(c);
+    }
 
     ret = flb_http_do_request(c, bytes);
     if (ret != 0) {

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -347,6 +347,37 @@ int flb_input_set_processor(flb_ctx_t *ctx, int ffd, struct flb_processor *proc)
     return 0;
 }
 
+int flb_output_set_http_test(flb_ctx_t *ctx, int ffd, char *test_name,
+                             void (*out_response) (void *, int, int, void *, size_t, void *),
+                             void *out_callback_data)
+{
+    struct flb_output_instance *o_ins;
+
+    o_ins = out_instance_get(ctx, ffd);
+    if (!o_ins) {
+        return -1;
+    }
+
+    /*
+     * Enabling a test, set the output instance in 'test' mode, so no real
+     * flush callback is invoked, only the desired implemented test.
+     */
+
+    /* Response test */
+    if (strcmp(test_name, "response") == 0) {
+        o_ins->test_mode = FLB_TRUE;
+        o_ins->test_response.rt_ctx = ctx;
+        o_ins->test_response.rt_ffd = ffd;
+        o_ins->test_response.rt_out_response = out_response;
+        o_ins->test_response.rt_data = out_callback_data;
+    }
+    else {
+        return -1;
+    }
+
+    return 0;
+}
+
 static inline int flb_config_map_property_check(char *plugin_name, struct mk_list *config_map, char *key, char *val)
 {
     struct flb_kv *kv;
@@ -638,6 +669,41 @@ int flb_lib_free(void* data)
 }
 
 
+static int flb_output_run_response(flb_ctx_t *ctx, struct flb_output_instance *o_ins,
+                                   int status, const void *data, size_t len)
+{
+    int ret;
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_test_out_response *resp;
+
+    if (!o_ins) {
+        return -1;
+    }
+
+    resp = &o_ins->test_response;
+
+    /* Invoke the input plugin formatter test callback */
+    ret = resp->callback(ctx->config,
+                         o_ins->context,
+                         status, data, len,
+                         &out_buf, &out_size);
+
+    /* Call the runtime test callback checker */
+    if (resp->rt_out_response) {
+        resp->rt_out_response(resp->rt_ctx,
+                              resp->rt_ffd,
+                              ret,
+                              out_buf, out_size,
+                              resp->rt_data);
+    }
+    else {
+        flb_free(out_buf);
+    }
+
+    return 0;
+}
+
 /* Push some data into the Engine */
 int flb_lib_push(flb_ctx_t *ctx, int ffd, const void *data, size_t len)
 {
@@ -658,6 +724,29 @@ int flb_lib_push(flb_ctx_t *ctx, int ffd, const void *data, size_t len)
     if (ret == -1) {
         flb_errno();
         return -1;
+    }
+    return ret;
+}
+
+/* Emulate some data from the response */
+int flb_lib_response(flb_ctx_t *ctx, int ffd, int status, const void *data, size_t len)
+{
+    int ret;
+    struct flb_output_instance *o_ins;
+
+    if (ctx->status == FLB_LIB_NONE || ctx->status == FLB_LIB_ERROR) {
+        flb_error("[lib] cannot push data, engine is not running");
+        return -1;
+    }
+
+    o_ins = out_instance_get(ctx, ffd);
+    if (!o_ins) {
+        return -1;
+    }
+
+    /* If input's test_formatter is registered, priorize to run it. */
+    if (o_ins->test_response.callback != NULL) {
+        ret = flb_output_run_response(ctx, o_ins, status, data, len);
     }
     return ret;
 }

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -729,6 +729,7 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
 
     /* Tests */
     instance->test_formatter.callback = plugin->test_formatter.callback;
+    instance->test_response.callback = plugin->test_response.callback;
 
 
     return instance;

--- a/tests/runtime/data/es/json_es.h
+++ b/tests/runtime/data/es/json_es.h
@@ -15,3 +15,37 @@
 #define JSON_DOTS                                                       \
     "[1448403340,"                                                      \
     "{\".le.vel\":\"error\", \".fo.o\":[{\".o.k\": [{\".b.ar\": \"baz\"}]}]}]"
+
+#define JSON_RESPONSE_SUCCESSES "{\"errors\":false,\"took\":0,\"items\":[" \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"dcfJBJIBHhdJuKsoC7Tm\",\"_version\":1,\"result\":\"created\"," \
+    "\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":6,\"_primary_term\":1,\"status\":201}}," \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"dsfJBJIBHhdJuKsoC7Tm\",\"_version\":1,\"result\":\"created\"," \
+    "\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":7,\"_primary_term\":1,\"status\":201}}," \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"d8fJBJIBHhdJuKsoC7Tm\",\"_version\":1,\"result\":\"created\"," \
+    "\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":8,\"_primary_term\":1,\"status\":201}}," \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"eMfJBJIBHhdJuKsoC7Tm\",\"_version\":1,\"result\":\"created\"," \
+    "\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":9,\"_primary_term\":1,\"status\":201}}]}"
+
+#define JSON_RESPONSE_SUCCESSES_SIZE 783
+
+#define JSON_RESPONSE_PARTIALLY_SUCCESS "{\"errors\":true,\"took\":316737025,\"items\":" \
+    "[{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"hxELapEB_XqxG5Ydupgb\",\"_version\":1,\"result\":\"created\"," \
+    "\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":7,\"_primary_term\":1,\"status\":201}}," \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"iBELapEB_XqxG5Ydupgb\",\"status\":400," \
+    "\"error\":{\"type\":\"document_parsing_exception\"," \
+    "\"reason\":\"[1:65] failed to parse field [_id] of type [_id] in document with id 'iBELapEB_XqxG5Ydupgb'. " \
+    "Preview of field's value: 'fhHraZEB_XqxG5Ydzpjv'\"," \
+    "\"caused_by\":{\"type\":\"document_parsing_exception\"," \
+    "\"reason\":\"[1:65] Field [_id] is a metadata field and cannot be added inside a document. " \
+    "Use the index API request parameters.\"}}}}," \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"iRELapEB_XqxG5Ydupgb\",\"status\":400," \
+    "\"error\":{\"type\":\"document_parsing_exception\"," \
+    "\"reason\":\"[1:65] failed to parse field [_id] of type [_id] in document with id 'iRELapEB_XqxG5Ydupgb'. " \
+    "Preview of field's value: 'fhHraZEB_XqxG5Ydzpjv'\"," \
+    "\"caused_by\":{\"type\":\"document_parsing_exception\"," \
+    "\"reason\":\"[1:65] Field [_id] is a metadata field and cannot be added inside a document. " \
+    "Use the index API request parameters.\"}}}}," \
+    "{\"create\":{\"_index\":\"fluent-bit\",\"_id\":\"ihELapEB_XqxG5Ydupgb\",\"_version\":1,\"result\":\"created\"," \
+    "\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":8,\"_primary_term\":1,\"status\":201}}]}"
+
+#define JSON_RESPONSE_PARTIALLY_SUCCESS_SIZE 1322


### PR DESCRIPTION
<!-- Provide summary of changes -->

We wanted to run unit testing for HTTP responses due to confirm this introduced mechanism should be validated on CI:
https://github.com/fluent/fluent-bit/pull/9236

 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes https://github.com/fluent/fluent-bit/issues/9260.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
