### PR TITLE
network: fix IPV6 handling for accepting connections

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1758,10 +1758,16 @@ int flb_net_bind_udp(flb_sockfd_t fd, const struct sockaddr *addr,
 flb_sockfd_t flb_net_accept(flb_sockfd_t server_fd)
 {
     flb_sockfd_t remote_fd;
-    struct sockaddr sock_addr;
-    socklen_t socket_size = sizeof(struct sockaddr);
+    struct sockaddr_storage sock_addr = { 0 };
+    socklen_t socket_size = sizeof(sock_addr);
 
-    // return accept(server_fd, &sock_addr, &socket_size);
+    /* 
+     * sock_addr used to be a sockaddr struct, but this was too
+     * small of a structure to handle IPV6 addresses (#9053).
+     * This would cause accept() to not accept the connection (with no error),
+     * and a loop would occur continually trying to accept the connection.
+     * The sockaddr_storage can handle both IPV4 and IPV6.
+     */
 
 #ifdef FLB_HAVE_ACCEPT4
     remote_fd = accept4(server_fd, &sock_addr, &socket_size,

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1770,10 +1770,10 @@ flb_sockfd_t flb_net_accept(flb_sockfd_t server_fd)
      */
 
 #ifdef FLB_HAVE_ACCEPT4
-    remote_fd = accept4(server_fd, &sock_addr, &socket_size,
+    remote_fd = accept4(server_fd, (struct sockaddr*)&sock_addr, &socket_size,
                         SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
-    remote_fd = accept(server_fd, &sock_addr, &socket_size);
+    remote_fd = accept(server_fd, (struct sockaddr*)&sock_addr, &socket_size);
     flb_net_socket_nonblocking(remote_fd);
 #endif
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Addresses the issue of IPV6 addresses not being able to be stored properly, causing the connection to never by accepted and an endless loop occurring. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #9053 

**Testing**
Tested on Windows 11.

Config input/output sections used:
[INPUT]
Name tcp
Chunk_Size 32
Format json
Listen [::1]
Port 5170
tag cs.systemmonitoring

[OUTPUT]
Name stdout
Format json_lines
json_date_format iso8601
json_date_key utc_timestamp
Match cs.systemmonitoring

Client app would open a TCP socket connection, send a json payload, then close the connection. Prior to this fix only IPV4 would work, using IPV6 would cause an endless loop. This fix will allow both IPV4 and IPV6 to work.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
