### PR TITLE
in_calyptia_fleet: fix 'unable to find fleet by name'.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -682,6 +682,10 @@ static msgpack_object *msgpack_lookup_map_key(msgpack_object *obj, const char *k
 
         key = &cur->key.via.str;
 
+        if (key->size != strlen(keyname)) {
+            continue;
+        }
+
         if (strncmp(key->ptr, keyname, key->size) == 0) {
             return &cur->val;
         }
@@ -799,7 +803,7 @@ static ssize_t parse_fleet_search_json(struct flb_in_calyptia_fleet_config *ctx,
             break;
         }
 
-        fleet = msgpack_lookup_map_key(map, "ID");
+        fleet = msgpack_lookup_map_key(map, "id");
         if (fleet == NULL) {
             flb_plg_error(ctx->ins, "unable to find fleet by name");
             break;


### PR DESCRIPTION
# Summary

Fleet is unable to work due to a breaking change to the Calyptia API. This update brings the code inline with that update.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
