### PR TITLE
backport: resolve build failures for CentOS 7 and Windows on 3.0

### DIFF
--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -4,13 +4,14 @@
 FROM centos:7
 
 # hadolint ignore=DL3032, DL3033
-RUN yum -y update && \
+RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+    yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
-    wget -q http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    rpm -ivh epel-release-latest-7.noarch.rpm && \
+    yum install -y epel-release && \
     yum install -y cmake3
 
 COPY . /src/

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -13,13 +13,14 @@ FROM multiarch/qemu-user-static:x86_64-aarch64 as multiarch-aarch64
 FROM centos:7 as centos-7-base
 
 # hadolint ignore=DL3033
-RUN yum -y update && \
+RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+    yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
-    wget -q http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    rpm -ivh epel-release-latest-7.noarch.rpm && \
+    yum install -y epel-release && \
     yum install -y cmake3 && \
     yum clean all
 
@@ -32,13 +33,14 @@ FROM arm64v8/centos:7 as centos-7.arm64v8-base
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
 # hadolint ignore=DL3033
-RUN yum -y update && \
+RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
+    yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
-    wget -q http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    rpm -ivh epel-release-latest-7.noarch.rpm && \
+    yum install -y epel-release && \
     yum install -y cmake3 && \
     yum clean all
 

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -380,7 +380,11 @@ static int init_seq_index(void *context) {
     }
 
     /* Create directory path if it doesn't exist */
+#ifdef FLB_SYSTEM_WINDOWS
+    ret = mkdir(ctx->metadata_dir);
+#else
     ret = mkdir(ctx->metadata_dir, 0700);
+#endif
     if (ret < 0 && errno != EEXIST) {
         flb_plg_error(ctx->ins, "Failed to create metadata directory");
         return -1;
@@ -921,11 +925,11 @@ static int cb_s3_init(struct flb_output_instance *ins,
         ctx->timer_ms = UPLOAD_TIMER_MIN_WAIT;
     }
 
-    /* 
-     * S3 must ALWAYS use sync mode 
+    /*
+     * S3 must ALWAYS use sync mode
      * In the timer thread we do a mk_list_foreach_safe on the queue of uplaods and chunks
      * Iterating over those lists is not concurrent safe. If a flush call ran at the same time
-     * And deleted an item from the list, this could cause a crash/corruption. 
+     * And deleted an item from the list, this could cause a crash/corruption.
      */
     flb_stream_disable_async_mode(&ctx->s3_client->upstream->base);
 
@@ -1227,6 +1231,8 @@ static int put_all_chunks(struct flb_s3 *ctx)
                     flb_plg_error(ctx->ins, "Failed to compress data, uploading uncompressed data instead to prevent data loss");
                 } else {
                     flb_plg_info(ctx->ins, "Pre-compression chunk size is %zu, After compression, chunk is %zu bytes", buffer_size, payload_size);
+                    flb_free(buffer);
+
                     buffer = (void *) payload_buf;
                     buffer_size = payload_size;
                 }
@@ -1392,7 +1398,6 @@ static int s3_put_object(struct flb_s3 *ctx, const char *tag, time_t file_first_
         ret = write_seq_index(ctx->seq_index_file, ctx->seq_index);
         if (ret < 0 && access(ctx->seq_index_file, F_OK) == 0) {
             ctx->seq_index--;
-            flb_sds_destroy(s3_key);
             flb_plg_error(ctx->ins, "Failed to update sequential index metadata file");
             return -1;
         }


### PR DESCRIPTION
Resolves #9414 by including fixes from `master` for:
- #9157 
- #9212
- #9293

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
