### PR TITLE
out_es: custom http headers

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -51,6 +51,9 @@ struct flb_elasticsearch {
     char *type;
     int suppress_type_name;
 
+    /* Arbitrary HTTP headers */
+    struct mk_list *headers;
+
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added ability to set custom HTTP headers for Elasticsearch output

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[INPUT]
    name              tail
    path              /var/lib/docker/containers/**/*.log
    path_key         path
    multiline.parser  docker, cri
    Parser docker
    Docker_Mode  On

[INPUT]
    Name     syslog
    Listen   0.0.0.0
    Port     5140
    Parser   syslog-rfc3164
    Mode     tcp

[SERVICE]
    Flush        1
    Parsers_File parsers.conf

[Output]
    Name es
    Match *
    host victorialogs
    port 9428
    compress gzip
    path /insert/elasticsearch
    header AccountID 0
    header ProjectID 0
    header VL-Stream-Fields path
    header VL-Msg-Field log
    header VL-Time-Field @timestamp
```
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1390

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.