### PR TITLE
multiline: introduce static cri parser backend, providing 9mb/s performance gain over current regex cri parser

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -31,6 +31,7 @@
 #define FLB_PARSER_JSON  2
 #define FLB_PARSER_LTSV  3
 #define FLB_PARSER_LOGFMT 4
+#define FLB_PARSER_CRI   5
 
 struct flb_parser_types {
     char *key;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ if(FLB_PARSER)
     flb_parser_regex.c
     flb_parser_json.c
     flb_parser_decoder.c
+    flb_parser_cri.c
     flb_parser_ltsv.c
     flb_parser_logfmt.c
     )

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -112,6 +112,10 @@ int flb_parser_logfmt_do(struct flb_parser *parser,
                          void **out_buf, size_t *out_size,
                          struct flb_time *out_time);
 
+int flb_parser_cri_do(struct flb_parser *parser,
+                         const char *buf, size_t length,
+                         void **out_buf, size_t *out_size,
+                         struct flb_time *out_time);
 /*
  * This function is used to free all aspects of a parser
  * which is provided by the caller of flb_create_parser.
@@ -201,6 +205,9 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     }
     else if (strcasecmp(format, "logfmt") == 0) {
         p->type = FLB_PARSER_LOGFMT;
+    }
+    else if (strcasecmp(format, "cri") == 0) {
+        p->type = FLB_PARSER_CRI;
     }
     else {
         flb_error("[parser:%s] Invalid format %s", name, format);
@@ -1005,6 +1012,10 @@ int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,
     }
     else if (parser->type == FLB_PARSER_LOGFMT) {
         return flb_parser_logfmt_do(parser, buf, length,
+                                  out_buf, out_size, out_time);
+    }
+    else if (parser->type == FLB_PARSER_CRI) {
+        return flb_parser_cri_do(parser, buf, length,
                                   out_buf, out_size, out_time);
     }
 

--- a/src/flb_parser_cri.c
+++ b/src/flb_parser_cri.c
@@ -1,0 +1,139 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define _GNU_SOURCE
+#include <time.h>
+
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_parser_decoder.h>
+#include <fluent-bit/flb_unescape.h>
+#include <fluent-bit/flb_mem.h>
+
+#define CRI_SPACE_DELIM " "
+
+int flb_parser_cri_do(struct flb_parser *parser,
+                        const char *in_buf, size_t in_size,
+                        void **out_buf, size_t *out_size,
+                        struct flb_time *out_time)
+{
+    int ret;
+    time_t time_lookup = 0;
+    double tmfrac = 0;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+    char *dec_out_buf;
+    size_t dec_out_size;
+    size_t map_size = 4;  /* always 4 fields for CRI */
+    char *time_key;
+    size_t time_key_len;
+    char* end_of_line = NULL;
+    char* token_end = NULL;
+
+    if (parser->time_key) {
+        time_key = parser->time_key;
+    }
+    else {
+        time_key = "time";
+    }
+    time_key_len = strlen(time_key);
+
+    /* Prepare new outgoing buffer */
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&tmp_pck, map_size);
+
+    /* Time */
+    token_end = strpbrk(in_buf, CRI_SPACE_DELIM);
+    if (token_end == NULL) {
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return -1;
+    }
+    token_end = token_end + 1; /* time + a space */
+
+    struct flb_tm tm = {0};
+    ret = flb_parser_time_lookup(in_buf, token_end-in_buf-1,
+        0, parser, &tm, &tmfrac);
+    if (ret == -1) {
+        flb_error("[parser:%s] Invalid time format %s",
+                    parser->name, parser->time_fmt_full);
+        return -1;
+    }
+
+    msgpack_pack_str(&tmp_pck, time_key_len);
+    msgpack_pack_str_body(&tmp_pck, time_key, time_key_len);
+    msgpack_pack_str(&tmp_pck, token_end-in_buf-1);
+    msgpack_pack_str_body(&tmp_pck, in_buf, token_end-in_buf-1);
+
+    /* Stream */
+    if (!(!strncmp(token_end, "stdout ", 7) || !strncmp(token_end, "stderr ", 7))) {
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return -1;
+    }
+
+    msgpack_pack_str(&tmp_pck, 6);
+    msgpack_pack_str_body(&tmp_pck, "stream", 6);
+    msgpack_pack_str(&tmp_pck, 6);
+    msgpack_pack_str_body(&tmp_pck, token_end, 6);
+    token_end = token_end + 7; /* stream + a space */
+
+    /* Partial/Full Indicator (P|F) */
+    if (!(!strncmp(token_end, "F ", 2) || !strncmp(token_end, "P ", 2))) {
+        msgpack_sbuffer_destroy(&tmp_sbuf);
+        return -1;
+    }
+    msgpack_pack_str(&tmp_pck, 2);
+    msgpack_pack_str_body(&tmp_pck, "_p", 2);
+    msgpack_pack_str(&tmp_pck, 1);
+    msgpack_pack_str_body(&tmp_pck, token_end, 1);
+    token_end = token_end + 2; /* indicator + a space */
+
+    /* Log */
+    end_of_line = strpbrk(token_end, "\n");
+    if (end_of_line == NULL ) {
+        end_of_line = in_buf+in_size;
+    }
+    msgpack_pack_str(&tmp_pck, 3);
+    msgpack_pack_str_body(&tmp_pck, "log", 3);
+    msgpack_pack_str(&tmp_pck, end_of_line-token_end);
+    msgpack_pack_str_body(&tmp_pck, token_end, end_of_line-token_end);
+
+    /* Export results */
+    time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+    out_time->tm.tv_sec = time_lookup;
+    out_time->tm.tv_nsec = (tmfrac * 1000000000);
+
+    *out_buf = tmp_sbuf.data;
+    *out_size = tmp_sbuf.size;
+
+    /* Check if some decoder was specified */
+    if (parser->decoders) {
+        ret = flb_parser_decoder_do(parser->decoders,
+                                    tmp_sbuf.data, tmp_sbuf.size,
+                                    &dec_out_buf, &dec_out_size);
+        if (ret == 0) {
+            *out_buf = dec_out_buf;
+            *out_size = dec_out_size;
+            msgpack_sbuffer_destroy(&tmp_sbuf);
+        }
+    }
+
+    return end_of_line-in_buf;
+}

--- a/src/multiline/flb_ml_parser.c
+++ b/src/multiline/flb_ml_parser.c
@@ -21,7 +21,6 @@
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/multiline/flb_ml.h>
 #include <fluent-bit/multiline/flb_ml_rule.h>
-#include <fluent-bit/multiline/flb_ml_mode.h>
 #include <fluent-bit/multiline/flb_ml_group.h>
 
 int flb_ml_parser_init(struct flb_ml_parser *ml_parser)

--- a/src/multiline/flb_ml_parser_cri.c
+++ b/src/multiline/flb_ml_parser_cri.c
@@ -21,19 +21,17 @@
 #include <fluent-bit/multiline/flb_ml.h>
 #include <fluent-bit/multiline/flb_ml_parser.h>
 
-#define FLB_ML_CRI_REGEX                                                \
-  "^(?<time>.+?) (?<stream>stdout|stderr) (?<_p>F|P) (?<log>.*)$"
 #define FLB_ML_CRI_TIME                         \
   "%Y-%m-%dT%H:%M:%S.%L%z"
 
-/* Creates a parser for Docker */
+/* Creates a parser for CRI */
 static struct flb_parser *cri_parser_create(struct flb_config *config)
 {
     struct flb_parser *p;
 
     p = flb_parser_create("_ml_cri",               /* parser name */
-                          "regex",                 /* backend type */
-                          FLB_ML_CRI_REGEX,        /* regex */
+                          "cri",                   /* backend type */
+                          NULL,                    /* regex */
                           FLB_FALSE,               /* skip_empty */
                           FLB_ML_CRI_TIME,         /* time format */
                           "time",                  /* time key */
@@ -49,13 +47,12 @@ static struct flb_parser *cri_parser_create(struct flb_config *config)
     return p;
 }
 
-/* Our first multiline mode: 'docker' */
 struct flb_ml_parser *flb_ml_parser_cri(struct flb_config *config)
 {
     struct flb_parser *parser;
     struct flb_ml_parser *mlp;
 
-    /* Create a Docker parser */
+    /* Create a CRI parser */
     parser = cri_parser_create(config);
     if (!parser) {
         return NULL;


### PR DESCRIPTION
<!-- Provide summary of changes -->
As part of #9399, I have been looking into performance improvements in fluent-bit. Specifically for apps in k8s that are creating many logs within a short amount of time (ie logging >15mb/s). 

Test setup: 
Hardware: GCP n2-standard-8 w/ ssd bootdisk
With config: (see full config in example config section)
```
  inputs:
    - name: tail
      path: /app/cache/containers/*.log
      tag: kube.*
      skip_long_lines: on
      refresh_interval: 1
      buffer_chunk_size: 250K
      buffer_max_size: 250K
      threaded: on
      rotate_wait: 300
      storage.type: filesystem
  outputs:
    - name: "null"
      match: "*"
      workers: 3
```
1. with no `multiline.parser: cri` (or any parser present) - i am able to achieve - 49.224Mb/s throughput
2. adding a standard cri parser - regex (current) version - fluent-bit 3.1.8
-  `multiline.parser: cri` added to tail input above - throughput is 18.571Mb/s
3. using the cri parser from this PR -
-  `multiline.parser: cri`added to tail input above  - throughput is 27.572Mb/s **~9mb/s gain by not using a regex parser**

Improving the multiline parsing speed should also considerably cut down on issues from log tail rotations (log rotations missed when fluentbit is backed up), since parsing is much more performant.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X ] Example configuration file for the change
Using the k8s_perf_test from #9399 with the following service config: 
```
service:
  flush: 0.5
  log_level: info
  daemon: off
  parsers_file: parsers.conf
  http_server: on
  http_listen: 0.0.0.0
  http_port: 2030
  storage.metrics: on
  storage.path: /app/cache/flb_storage
  storage.backlog.mem_limit: 512M
  storage.delete_irrecoverable_chunks: on
  storage.total_limit_size: 25G
pipeline:
  inputs:
    - name: tail
      path: /app/cache/containers/*.log
      tag: kube.*
      skip_long_lines: on
      refresh_interval: 1
      buffer_chunk_size: 250K
      buffer_max_size: 250K
      threaded: on
      multiline.parser: cri
      rotate_wait: 300
      storage.type: filesystem
  outputs:
    - name: "null"
      match: "*"
      workers: 3
```

- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
valgrind --leak-check=full ./bin/flb-it-multiline
...

SUCCESS: All unit tests have passed.
==45752== 
==45752== HEAP SUMMARY:
==45752==     in use at exit: 0 bytes in 0 blocks
==45752==   total heap usage: 22,203 allocs, 22,203 frees, 7,605,275 bytes allocated
==45752== 
==45752== All heap blocks were freed -- no leaks are possible
==45752== 
==45752== Use --track-origins=yes to see where uninitialised values come from
==45752== For lists of detected and suppressed errors, rerun with: -s
==45752== ERROR SUMMARY: 32 errors from 2 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature
- no new documentation, parser is meant to be backward compatible

