### PR TITLE
filter: Add dropped_bytes_total / drop_bytes metrics

### DIFF
--- a/include/fluent-bit/flb_filter.h
+++ b/include/fluent-bit/flb_filter.h
@@ -106,6 +106,7 @@ struct flb_filter_instance {
     struct cmt_counter *cmt_bytes;        /* m: filter_bytes_total        */
     struct cmt_counter *cmt_add_records;  /* m: filter_add_records_total  */
     struct cmt_counter *cmt_drop_records; /* m: filter_drop_records_total */
+    struct cmt_counter *cmt_drop_bytes;   /* m: filter_drop_bytes_total   */
 
 #ifdef FLB_HAVE_METRICS
     struct flb_metrics *metrics;   /* metrics                  */

--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -43,10 +43,11 @@
 #include <cmetrics/cmt_filter.h>
 
 /* Metrics IDs for general purpose (used by core and Plugins */
-#define FLB_METRIC_N_RECORDS   0
-#define FLB_METRIC_N_BYTES     1
-#define FLB_METRIC_N_DROPPED   2
-#define FLB_METRIC_N_ADDED     3
+#define FLB_METRIC_N_RECORDS       0
+#define FLB_METRIC_N_BYTES         1
+#define FLB_METRIC_N_DROPPED       2
+#define FLB_METRIC_N_ADDED         3
+#define FLB_METRIC_N_DROPPED_BYTES 4
 
 /* Genaral output plugin metrics */
 #define FLB_METRIC_OUT_OK_RECORDS      10       /* proc_records   */

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -220,6 +220,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
                     /* [OLD] Summarize all records removed */
                     flb_metrics_sum(FLB_METRIC_N_DROPPED,
                                     in_records, f_ins->metrics);
+                    flb_metrics_sum(FLB_METRIC_N_DROPPED_BYTES,
+                                    dropped_size, f_ins->metrics);
 #endif
                     break;
                 }
@@ -239,6 +241,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
                         /* [OLD] Summarize new records */
                         flb_metrics_sum(FLB_METRIC_N_ADDED,
                                         diff, f_ins->metrics);
+                        flb_metrics_sum(FLB_METRIC_N_DROPPED_BYTES,
+                                        dropped_size, f_ins->metrics);
                     }
                     else if (out_records < in_records) {
                         diff = (in_records - out_records);
@@ -252,6 +256,8 @@ void flb_filter_do(struct flb_input_chunk *ic,
                         /* [OLD] Summarize dropped records */
                         flb_metrics_sum(FLB_METRIC_N_DROPPED,
                                         diff, f_ins->metrics);
+                        flb_metrics_sum(FLB_METRIC_N_DROPPED_BYTES,
+                                        dropped_size, f_ins->metrics);
                     }
 #endif
 
@@ -584,6 +590,7 @@ int flb_filter_init(struct flb_config *config, struct flb_filter_instance *ins)
     flb_metrics_add(FLB_METRIC_N_ADDED, "add_records", ins->metrics);
     flb_metrics_add(FLB_METRIC_N_RECORDS, "records", ins->metrics);
     flb_metrics_add(FLB_METRIC_N_BYTES, "bytes", ins->metrics);
+    flb_metrics_add(FLB_METRIC_N_DROPPED_BYTES, "drop_bytes", ins->metrics);
 #endif
 
     /*


### PR DESCRIPTION
<!-- Provide summary of changes -->
To observe more precisely for filter plugins, we need to add dropped bytes metrics into ordinary metrics for filter plugins.
The dropped size should be a monotonic value. So, I choose counter type of cmetrics to handle it.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    HTTP_Server On
    HTTP_Port 2020

[INPUT]
    Name dummy
    Dummy {"endpoint":"localhost", "value":"something"}
    Tag dummy

[FILTER]
    Name grep
    Match *
    Exclude value something

[OUTPUT]
    Name stdout
```
- [x] Debug log output from testing the change

```
% bin/fluent-bit -c grep.conf -v
Fluent Bit v3.2.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |____ |/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/

[2024/09/25 13:23:44] [ info] Configuration:
[2024/09/25 13:23:44] [ info]  flush time     | 1.000000 seconds
[2024/09/25 13:23:44] [ info]  grace          | 5 seconds
[2024/09/25 13:23:44] [ info]  daemon         | 0
[2024/09/25 13:23:44] [ info] ___________
[2024/09/25 13:23:44] [ info]  inputs:
[2024/09/25 13:23:44] [ info]      dummy
[2024/09/25 13:23:44] [ info] ___________
[2024/09/25 13:23:44] [ info]  filters:
[2024/09/25 13:23:44] [ info]      grep.0
[2024/09/25 13:23:44] [ info] ___________
[2024/09/25 13:23:44] [ info]  outputs:
[2024/09/25 13:23:44] [ info]      stdout.0
[2024/09/25 13:23:44] [ info] ___________
[2024/09/25 13:23:44] [ info]  collectors:
[2024/09/25 13:23:44] [ info] [fluent bit] version=3.2.0, commit=41b90b777c, pid=647
[2024/09/25 13:23:44] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2024/09/25 13:23:44] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/09/25 13:23:44] [ info] [cmetrics] version=0.9.6
[2024/09/25 13:23:44] [ info] [ctraces ] version=0.5.5
[2024/09/25 13:23:44] [ info] [input:dummy:dummy.0] initializing
[2024/09/25 13:23:44] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/09/25 13:23:44] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2024/09/25 13:23:44] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2024/09/25 13:23:44] [ info] [output:stdout:stdout.0] worker #0 started
[2024/09/25 13:23:44] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2024/09/25 13:23:44] [ info] [sp] stream processor started
^C[2024/09/25 13:23:52] [engine] caught signal (SIGINT)
[2024/09/25 13:23:52] [ info] [input] pausing dummy.0
[2024/09/25 13:23:52] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/09/25 13:23:52] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

```
$ curl localhost:2020/api/v1/metrics
{"input":{"dummy.0":{"records":0,"bytes":0}},"filter":{"grep.0":{"drop_records":4,"add_records":0,"records":4,"bytes":0,"drop_bytes":228}},"output":{"stdout.0":{"proc_records":0,"proc_bytes":0,"errors":0,"retries":0,"retries_failed":0,"dropped_records":0,"retried_records":0}}}
```

```
curl localhost:2020/api/v2/metrics                                                                               [OK]
2024-09-25T04:24:15.750972436Z fluentbit_uptime{hostname="Hiroshis-MacBook-Pro.local"} = 7
2024-09-25T04:24:08.747121548Z fluentbit_input_bytes_total{name="dummy.0"} = 0
2024-09-25T04:24:08.747121548Z fluentbit_input_records_total{name="dummy.0"} = 0
2024-09-25T04:24:14.751790810Z fluentbit_filter_records_total{name="grep.0"} = 6
2024-09-25T04:24:14.751790810Z fluentbit_filter_bytes_total{name="grep.0"} = 0
2024-09-25T04:24:08.747220046Z fluentbit_filter_add_records_total{name="grep.0"} = 0
2024-09-25T04:24:14.751790810Z fluentbit_filter_drop_records_total{name="grep.0"} = 6
2024-09-25T04:24:14.751790810Z fluentbit_filter_drop_bytes_total{name="grep.0"} = 342
2024-09-25T04:24:08.747280629Z fluentbit_output_proc_records_total{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_proc_bytes_total{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_errors_total{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_retries_total{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_retries_failed_total{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_dropped_records_total{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_retried_records_total{name="stdout.0"} = 0
2024-09-25T04:24:15.750972436Z fluentbit_process_start_time_seconds{hostname="Hiroshis-MacBook-Pro.local"} = 1727238248
2024-09-25T04:24:15.750972436Z fluentbit_build_info{hostname="Hiroshis-MacBook-Pro.local",version="3.2.0",os="macos"} = 1727238248
2024-09-25T04:24:15.750972436Z fluentbit_hot_reloaded_times{hostname="Hiroshis-MacBook-Pro.local"} = 0
2024-09-25T04:24:15.751103393Z fluentbit_storage_chunks = 0
2024-09-25T04:24:15.751103393Z fluentbit_storage_mem_chunks = 0
2024-09-25T04:24:15.751103393Z fluentbit_storage_fs_chunks = 0
2024-09-25T04:24:15.751103393Z fluentbit_storage_fs_chunks_up = 0
2024-09-25T04:24:15.751103393Z fluentbit_storage_fs_chunks_down = 0
2024-09-25T04:24:08.747121548Z fluentbit_input_ingestion_paused{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_overlimit{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_memory_bytes{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_chunks{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_chunks_up{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_chunks_down{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_chunks_busy{name="dummy.0"} = 0
2024-09-25T04:24:13.750772332Z fluentbit_input_storage_chunks_busy_bytes{name="dummy.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_upstream_total_connections{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_upstream_busy_connections{name="stdout.0"} = 0
2024-09-25T04:24:08.747280629Z fluentbit_output_chunk_available_capacity_percent{name="stdout.0"} = 100
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==18599== 
==18599== HEAP SUMMARY:
==18599==     in use at exit: 0 bytes in 0 blocks
==18599==   total heap usage: 54,246 allocs, 54,246 frees, 14,867,130 bytes allocated
==18599== 
==18599== All heap blocks were freed -- no leaks are possible
==18599== 
==18599== For lists of detected and suppressed errors, rerun with: -s
==18599== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
