### PR TITLE
config_format: cf_yaml: Plug memory leaks on exception for processing variants on plugin elements

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2083,6 +2083,15 @@ static struct parser_state *state_pop(struct local_ctx *ctx)
         cfl_kvlist_destroy(last->keyvals);
     }
 
+    /* Teardown associated variant stuffs */
+    if (last->variant_kvlist_key != NULL) {
+        cfl_sds_destroy(last->variant_kvlist_key);
+    }
+
+    if (last->variant != NULL) {
+        cfl_variant_destroy(last->variant);
+    }
+
     state_destroy(last);
 
     if (cfl_list_size(&ctx->states) <= 0) {

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2060,7 +2060,7 @@ static int state_create_group(struct flb_cf *conf, struct parser_state *state, c
     return YAML_SUCCESS;
 }
 
-static struct parser_state *state_pop(struct local_ctx *ctx)
+static struct parser_state *state_pop_with_cleanup(struct local_ctx *ctx, int destroy_variants)
 {
     struct parser_state *last;
 
@@ -2083,13 +2083,15 @@ static struct parser_state *state_pop(struct local_ctx *ctx)
         cfl_kvlist_destroy(last->keyvals);
     }
 
-    /* Teardown associated variant stuffs */
-    if (last->variant_kvlist_key != NULL) {
-        cfl_sds_destroy(last->variant_kvlist_key);
-    }
+    if (destroy_variants == FLB_TRUE) {
+        /* Teardown associated variant stuffs */
+        if (last->variant_kvlist_key != NULL) {
+            cfl_sds_destroy(last->variant_kvlist_key);
+        }
 
-    if (last->variant != NULL) {
-        cfl_variant_destroy(last->variant);
+        if (last->variant != NULL) {
+            cfl_variant_destroy(last->variant);
+        }
     }
 
     state_destroy(last);
@@ -2099,6 +2101,11 @@ static struct parser_state *state_pop(struct local_ctx *ctx)
     }
 
     return cfl_list_entry_last(&ctx->states, struct parser_state, _head);
+}
+
+static struct parser_state *state_pop(struct local_ctx *ctx)
+{
+    return state_pop_with_cleanup(ctx, FLB_FALSE);
 }
 
 static void state_destroy(struct parser_state *s)
@@ -2273,7 +2280,7 @@ done:
 
     /* free all remaining states */
     if (code == -1) {
-        while ((state = state_pop(ctx)));
+        while ((state = state_pop_with_cleanup(ctx, FLB_TRUE)));
     }
     else {
         state = state_pop(ctx);

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -21,6 +21,7 @@
 #define FLB_001 FLB_TESTS_CONF_PATH "/issue_7559.yaml"
 #define FLB_002 FLB_TESTS_CONF_PATH "/processors.yaml"
 #define FLB_000_WIN FLB_TESTS_CONF_PATH "\\fluent-bit-windows.yaml"
+#define FLB_BROKEN_PLUGIN_VARIANT FLB_TESTS_CONF_PATH "/broken_plugin_variant.yaml"
 
 #ifdef _WIN32
 #define FLB_BASIC FLB_000_WIN
@@ -178,6 +179,20 @@ static void test_customs_section()
 
     flb_cf_dump(cf);
     flb_cf_destroy(cf);
+}
+
+static void test_broken_plugin_variant_yaml()
+{
+    struct flb_cf *cf;
+
+    cf = flb_cf_yaml_create(NULL, FLB_BROKEN_PLUGIN_VARIANT, NULL, 0);
+    TEST_CHECK(cf == NULL);
+
+    if (cf != NULL) {
+        TEST_CHECK_(cf != NULL, "somewhat config_format is created wrongly");
+        flb_cf_dump(cf);
+        flb_cf_destroy(cf);
+    }
 }
 
 static void test_slist_even()
@@ -443,6 +458,7 @@ static void test_processors()
 TEST_LIST = {
     { "basic"    , test_basic},
     { "customs section", test_customs_section},
+    { "broken_plugin_variant_yaml", test_broken_plugin_variant_yaml},
     { "slist odd", test_slist_odd},
     { "slist even", test_slist_even},
     { "parsers file conf", test_parser_conf},

--- a/tests/internal/data/config_format/yaml/broken_plugin_variant.yaml
+++ b/tests/internal/data/config_format/yaml/broken_plugin_variant.yaml
@@ -1,0 +1,34 @@
+env:
+  flush_interval: 1
+
+service:
+  http_server: "on"
+  Health_Check: "on"
+  log_level: info
+
+pipeline:
+    inputs:
+        - name: event_type
+          tag: event
+          type: logs
+          processors:
+            logs:
+              - name: log_replacer
+                replacement:
+                  some_extra_data:
+                    unsupported:
+                      hi: * # this character should be quoted
+                    some_string: "hello world"
+                    unquoted_literals:
+                        - some_int: 4
+                        - some_float: 3.1
+                        - some_bool: true
+                    quoted_literals:
+                        - some_quoted_int: "4"
+                        - some_quoted_float: '3.1'
+                        - some_quoted_bool: "true"
+
+    outputs:
+        - name: stdout
+          format: json
+          match: event


### PR DESCRIPTION
<!-- Provide summary of changes -->
These memory leaks are detected by OSSFuzz.
`(struct parser_state *)state->variant_kvlist_key` and `(struct parser_state *)state->variant` should be destroyed before tweardowning parser state value is cleaned up.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
