### PR TITLE
out_influxdb: allow stripping of tag prefix

### DIFF
--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -126,6 +126,10 @@ static int influxdb_format(struct flb_config *config,
             ctx->seq++;
         }
 
+        /* Find the overlap betwen the tag and a given prefix (to be removed):
+        If the prefix matches the tag for exactly the length of the prefix and
+        the tag is longer than the prefix, we have a valid match. */
+        prefix_offset = 0;
         prefix_match = strncmp(tag, ctx->prefix, ctx->prefix_len);
         if (prefix_match == 0) {
             if (tag_len > ctx->prefix_len) {
@@ -133,6 +137,7 @@ static int influxdb_format(struct flb_config *config,
             }
         }
 
+        /* Read the tag offset by the length of the prefix to remove it. */
         ret = influxdb_bulk_append_header(bulk_head,
                                           tag + prefix_offset,
                                           tag_len - prefix_offset,
@@ -379,7 +384,7 @@ static int cb_influxdb_init(struct flb_output_instance *ins, struct flb_config *
     }
     ctx->seq_len = strlen(ctx->seq_name);
 
-    /* prefix */
+    /* prefix to be removed from the tag */
     tmp = flb_output_get_property("strip_prefix", ins);
     if (!tmp) {
         ctx->prefix = flb_strdup("");

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -614,6 +614,10 @@ static int cb_influxdb_exit(void *data, struct flb_config *config)
         flb_free(ctx->seq_name);
     }
 
+    if (ctx->prefix) {
+        flb_free(ctx->prefix);
+    }
+
     flb_upstream_destroy(ctx->u);
     flb_free(ctx);
 

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -74,6 +74,8 @@ static int influxdb_format(struct flb_config *config,
     char *str = NULL;
     size_t str_size;
     char tmp[128];
+    int prefix_match = 0;
+    int prefix_offset = 0;
     msgpack_object map;
     struct flb_time tm;
     struct influxdb_bulk *bulk = NULL;
@@ -124,8 +126,16 @@ static int influxdb_format(struct flb_config *config,
             ctx->seq++;
         }
 
+        prefix_match = strncmp(tag, ctx->prefix, ctx->prefix_len);
+        if (prefix_match == 0) {
+            if (tag_len > ctx->prefix_len) {
+                prefix_offset = ctx->prefix_len;
+            }
+        }
+
         ret = influxdb_bulk_append_header(bulk_head,
-                                          tag, tag_len,
+                                          tag + prefix_offset,
+                                          tag_len - prefix_offset,
                                           seq,
                                           ctx->seq_name, ctx->seq_len);
         if (ret == -1) {
@@ -368,6 +378,15 @@ static int cb_influxdb_init(struct flb_output_instance *ins, struct flb_config *
         ctx->seq_name = flb_strdup(tmp);
     }
     ctx->seq_len = strlen(ctx->seq_name);
+
+    /* prefix */
+    tmp = flb_output_get_property("strip_prefix", ins);
+    if (!tmp) {
+        ctx->prefix = flb_strdup("");
+    } else {
+        ctx->prefix = flb_strdup(tmp);
+    }
+    ctx->prefix_len = strlen(ctx->prefix);
 
     if (ctx->custom_uri) {
         /* custom URI endpoint (e.g: Grafana */
@@ -695,6 +714,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "add_integer_suffix", "false",
      0, FLB_TRUE, offsetof(struct flb_influxdb, use_influxdb_integer),
      "Use influxdb line protocol's integer type suffix."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "strip_prefix", NULL,
+     0, FLB_FALSE, 0,
+     "Prefix to be removed from the record tag when writing influx measurements."
     },
 
     /* EOF */

--- a/plugins/out_influxdb/influxdb.h
+++ b/plugins/out_influxdb/influxdb.h
@@ -56,6 +56,10 @@ struct flb_influxdb {
     char *seq_name;
     int seq_len;
 
+    /* prefix */
+    char *prefix;
+    int prefix_len;
+
     /* auto_tags: on/off */
     int auto_tags;
 

--- a/plugins/out_influxdb/influxdb.h
+++ b/plugins/out_influxdb/influxdb.h
@@ -56,7 +56,7 @@ struct flb_influxdb {
     char *seq_name;
     int seq_len;
 
-    /* prefix */
+    /* prefix to be removed from the tag */
     char *prefix;
     int prefix_len;
 


### PR DESCRIPTION
This removes a defined prefix from measurement names which might otherwise be shared between many measurements in the same data bucket.

When writing to a range of different buckets, routing to the corresponding out_influxdb instances happens on tag matches. This change allows to match on tag prefixes, but strip them from the measurement name. This avoids having identical prefixes for all measurement names in the same data bucket.

To achieve this, read from char tag[] with an offset when writing the measurement name, provided the prefix matches the tag completely and the overlap is at most tag_length - 1 characters.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
https://github.com/fluent/fluent-bit-docs/pull/1468
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional prefix-stripping for InfluxDB output: when configured, the specified prefix is removed from tags before they are emitted.

- Configuration
  - Added a new per-output setting to specify the prefix to remove from tags (and its length is handled automatically).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->