### PR TITLE
lib: execute pthread_join only when tid != 0 in flb_stop.

### DIFF
--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -792,11 +792,17 @@ int flb_stop(flb_ctx_t *ctx)
          * There is a chance the worker thread is still active while
          * the service exited for some reason (plugin action). Always
          * wait and double check that the child thread is not running.
+         *
+         * We check the value of tid first to avoid crashes on some 
+         * linux distributions.
          */
+
+        if (tid != 0) {
 #if defined(FLB_SYSTEM_MACOS)
-        pthread_cancel(tid);
+            pthread_cancel(tid);
 #endif
-        pthread_join(tid, NULL);
+            pthread_join(tid, NULL);
+        }
         return 0;
     }
 


### PR DESCRIPTION
# Summary

This PR wraps the call to `pthread_join` in `flb_stop` in a conditional for `tid != 0`. 

Calling `pthread_join` with `tid` == 0 is undefined. Technically it should return `ESRCH` but CentOS and RHEL do not seem to conform.

The following crash occurs:

```
[2024/09/26 18:09:24] [engine] caught signal (SIGHUP)
[2024/09/26 18:09:24] [ info] reloading instance pid=551 tid=0x7ffff7fe5d80
[2024/09/26 18:09:24] [error] [config] section 'dummmy' tried to instance a plugin name that doesn't exist

Thread 1 "calyptia-fluent" received signal SIGSEGV, Segmentation fault.
0x00007ffff78094f0 in __pthread_timedjoin_ex () from /lib64/libpthread.so.0
(gdb) bt
#0  0x00007ffff78094f0 in __pthread_timedjoin_ex () from /lib64/libpthread.so.0
#1  0x000000000050ddac in flb_stop ()
#2  0x00000000005426b5 in flb_reload ()
#3  0x0000000000486898 in flb_main ()
#4  0x00007ffff4a23493 in __libc_start_main () from /lib64/libc.so.6
#5  0x000000000048433e in _start ()
```

Debugging the actual code in `__pthread_timedjoin_ex` we can see it is in fact a `NULL` dereference:

```
(gdb) x/4i $rip
=> 0x7ffff78094f0 <__pthread_timedjoin_ex+16>:	mov    0x2d0(%rdi),%r8d
   0x7ffff78094f7 <__pthread_timedjoin_ex+23>:	mov    %fs:0x28,%rax
   0x7ffff7809500 <__pthread_timedjoin_ex+32>:	mov    %rax,0x38(%rsp)
   0x7ffff7809505 <__pthread_timedjoin_ex+37>:	xor    %eax,%eax
(gdb) info registers
rax            0x1                 1
rbx            0x0                 0
rcx            0x1                 1
rdx            0x0                 0
rsi            0x0                 0
rdi            0x0                 0
rbp            0x0                 0x0
rsp            0x7fffffffe9e0      0x7fffffffe9e0
r8             0x2a                42
```

# Root cause analysis

The value of `tid` is derived from `ctx->config->worker` [here](https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L788):

```c
    tid = ctx->config->worker;

    if (ctx->status == FLB_LIB_NONE || ctx->status == FLB_LIB_ERROR) {
        /*
         * There is a chance the worker thread is still active while
         * the service exited for some reason (plugin action). Always
         * wait and double check that the child thread is not running.
         */
#if defined(FLB_SYSTEM_MACOS)
        pthread_cancel(tid);
#endif
        pthread_join(tid, NULL);
        return 0;
    }
```

The call to `pthread_join` checks `ctx->status`, which is not changed when `ctx->config->worker ` is [set](https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L708
):

```c
    /* spawn worker thread */
    config = ctx->config;
    ret = mk_utils_worker_spawn(flb_lib_worker, ctx, &tid);
    if (ret == -1) {
        return -1;
    }
    config->worker = tid;

    /* Wait for the started signal so we can return to the caller */
```

The value of `ctx->status` can be set to the following values which are defined in [flb_lib.h](https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/include/fluent-bit/flb_lib.h#L27):

- FLB_LIB_ERROR     -1
- FLB_LIB_NONE       0
- FLB_LIB_OK         1

The places where `ctx->status` is set do not correlate with the value of `ctx->config->worker` at all:

- https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L168
- https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L680
- https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L726
- https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L732
- https://github.com/fluent/fluent-bit/blob/f36c95620224b0a372e4ce481e3dd58b6670251f/src/flb_lib.c#L741

In fact we might want to just check the value of `ctx->config->worker` and not `ctx->status` before joining it. There is a correlation between both values but I do not see it as being strong enough to depend upon one or the other.

The code that calls `pthread_join` behind that conditional is also meant for extraordinary or erroneous circumstances and therefore being defensive to me does not seem to be a bad policy.

# References

- https://stackoverflow.com/questions/52734792/what-will-happen-if-the-pthreadid-is-zero-in-pthread-joinpthreadid-null-on-an

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release: #9429.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
