### PR TITLE
3.1: backport fixes 2024-09-26

### DIFF
--- a/lib/ctraces/CMakeLists.txt
+++ b/lib/ctraces/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # CTraces Version
 set(CTR_VERSION_MAJOR  0)
 set(CTR_VERSION_MINOR  5)
-set(CTR_VERSION_PATCH  5)
+set(CTR_VERSION_PATCH  6)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -682,6 +682,10 @@ static msgpack_object *msgpack_lookup_map_key(msgpack_object *obj, const char *k
 
         key = &cur->key.via.str;
 
+        if (key->size != strlen(keyname)) {
+            continue;
+        }
+
         if (strncmp(key->ptr, keyname, key->size) == 0) {
             return &cur->val;
         }
@@ -799,7 +803,7 @@ static ssize_t parse_fleet_search_json(struct flb_in_calyptia_fleet_config *ctx,
             break;
         }
 
-        fleet = msgpack_lookup_map_key(map, "ID");
+        fleet = msgpack_lookup_map_key(map, "id");
         if (fleet == NULL) {
             flb_plg_error(ctx->ins, "unable to find fleet by name");
             break;

--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -244,7 +244,7 @@ static flb_sds_t get_agent_metadata(struct flb_calyptia *ctx)
     msgpack_pack_str_body(&mp_pck, "os", 2);
 #ifdef FLB_SYSTEM_WINDOWS
     len = strlen("windows");
-    msgpack_pack_str(&mp_pck);
+    msgpack_pack_str(&mp_pck, len);
     msgpack_pack_str_body(&mp_pck, "windows", len);
 #elif FLB_SYSTEM_MACOS
     len = strlen("macos");

--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -239,6 +239,52 @@ static flb_sds_t get_agent_metadata(struct flb_calyptia *ctx)
     msgpack_pack_str(&mp_pck, 9);
     msgpack_pack_str_body(&mp_pck, "community", 9);
 
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 2);
+    msgpack_pack_str_body(&mp_pck, "os", 2);
+#ifdef FLB_SYSTEM_WINDOWS
+    len = strlen("windows");
+    msgpack_pack_str(&mp_pck);
+    msgpack_pack_str_body(&mp_pck, "windows", len);
+#elif FLB_SYSTEM_MACOS
+    len = strlen("macos");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "macos", len);
+#elif __linux__
+    len = strlen("linux");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "linux", len);
+#else
+    len = strlen("unknown");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "unknown", len);
+#endif
+
+    flb_mp_map_header_append(&mh);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "arch", 4);
+#if defined(__arm__) || defined(_M_ARM)
+    len = strlen("arm");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "arm", len);
+#elif defined(__aarch64__)
+    len = strlen("arm64");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "arm64", len);
+#elif defined(__amd64__) || defined(_M_AMD64)
+    len = strlen("x86_64");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "x86_64", len);
+#elif defined(__i686__) || defined(_M_I86)
+    len = strlen("x86");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "x86", len);
+#else
+    len = strlen("unknown");
+    msgpack_pack_str(&mp_pck, len);
+    msgpack_pack_str_body(&mp_pck, "unknown", len);
+#endif
+
     /* machineID */
     flb_mp_map_header_append(&mh);
     msgpack_pack_str(&mp_pck, 9);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2083,6 +2083,15 @@ static struct parser_state *state_pop(struct local_ctx *ctx)
         cfl_kvlist_destroy(last->keyvals);
     }
 
+    /* Teardown associated variant stuffs */
+    if (last->variant_kvlist_key != NULL) {
+        cfl_sds_destroy(last->variant_kvlist_key);
+    }
+
+    if (last->variant != NULL) {
+        cfl_variant_destroy(last->variant);
+    }
+
     state_destroy(last);
 
     if (cfl_list_size(&ctx->states) <= 0) {

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2060,7 +2060,7 @@ static int state_create_group(struct flb_cf *conf, struct parser_state *state, c
     return YAML_SUCCESS;
 }
 
-static struct parser_state *state_pop(struct local_ctx *ctx)
+static struct parser_state *state_pop_with_cleanup(struct local_ctx *ctx, int destroy_variants)
 {
     struct parser_state *last;
 
@@ -2083,13 +2083,15 @@ static struct parser_state *state_pop(struct local_ctx *ctx)
         cfl_kvlist_destroy(last->keyvals);
     }
 
-    /* Teardown associated variant stuffs */
-    if (last->variant_kvlist_key != NULL) {
-        cfl_sds_destroy(last->variant_kvlist_key);
-    }
+    if (destroy_variants == FLB_TRUE) {
+        /* Teardown associated variant stuffs */
+        if (last->variant_kvlist_key != NULL) {
+            cfl_sds_destroy(last->variant_kvlist_key);
+        }
 
-    if (last->variant != NULL) {
-        cfl_variant_destroy(last->variant);
+        if (last->variant != NULL) {
+            cfl_variant_destroy(last->variant);
+        }
     }
 
     state_destroy(last);
@@ -2099,6 +2101,11 @@ static struct parser_state *state_pop(struct local_ctx *ctx)
     }
 
     return cfl_list_entry_last(&ctx->states, struct parser_state, _head);
+}
+
+static struct parser_state *state_pop(struct local_ctx *ctx)
+{
+    return state_pop_with_cleanup(ctx, FLB_FALSE);
 }
 
 static void state_destroy(struct parser_state *s)
@@ -2273,7 +2280,7 @@ done:
 
     /* free all remaining states */
     if (code == -1) {
-        while ((state = state_pop(ctx)));
+        while ((state = state_pop_with_cleanup(ctx, FLB_TRUE)));
     }
     else {
         state = state_pop(ctx);

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -1443,6 +1443,7 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
         }
         msgpack_unpacked_destroy(&result);
         group->mp_sbuf.size = 0;
+        group->mp_md_sbuf.size = 0;
     }
     else if (len > 0) {
         /* Pack raw content as Fluent Bit record */

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -21,6 +21,7 @@
 #define FLB_001 FLB_TESTS_CONF_PATH "/issue_7559.yaml"
 #define FLB_002 FLB_TESTS_CONF_PATH "/processors.yaml"
 #define FLB_000_WIN FLB_TESTS_CONF_PATH "\\fluent-bit-windows.yaml"
+#define FLB_BROKEN_PLUGIN_VARIANT FLB_TESTS_CONF_PATH "/broken_plugin_variant.yaml"
 
 #ifdef _WIN32
 #define FLB_BASIC FLB_000_WIN
@@ -178,6 +179,20 @@ static void test_customs_section()
 
     flb_cf_dump(cf);
     flb_cf_destroy(cf);
+}
+
+static void test_broken_plugin_variant_yaml()
+{
+    struct flb_cf *cf;
+
+    cf = flb_cf_yaml_create(NULL, FLB_BROKEN_PLUGIN_VARIANT, NULL, 0);
+    TEST_CHECK(cf == NULL);
+
+    if (cf != NULL) {
+        TEST_CHECK_(cf != NULL, "somewhat config_format is created wrongly");
+        flb_cf_dump(cf);
+        flb_cf_destroy(cf);
+    }
 }
 
 static void test_slist_even()
@@ -443,6 +458,7 @@ static void test_processors()
 TEST_LIST = {
     { "basic"    , test_basic},
     { "customs section", test_customs_section},
+    { "broken_plugin_variant_yaml", test_broken_plugin_variant_yaml},
     { "slist odd", test_slist_odd},
     { "slist even", test_slist_even},
     { "parsers file conf", test_parser_conf},

--- a/tests/internal/data/config_format/yaml/broken_plugin_variant.yaml
+++ b/tests/internal/data/config_format/yaml/broken_plugin_variant.yaml
@@ -1,0 +1,34 @@
+env:
+  flush_interval: 1
+
+service:
+  http_server: "on"
+  Health_Check: "on"
+  log_level: info
+
+pipeline:
+    inputs:
+        - name: event_type
+          tag: event
+          type: logs
+          processors:
+            logs:
+              - name: log_replacer
+                replacement:
+                  some_extra_data:
+                    unsupported:
+                      hi: * # this character should be quoted
+                    some_string: "hello world"
+                    unquoted_literals:
+                        - some_int: 4
+                        - some_float: 3.1
+                        - some_bool: true
+                    quoted_literals:
+                        - some_quoted_int: "4"
+                        - some_quoted_float: '3.1'
+                        - some_quoted_bool: "true"
+
+    outputs:
+        - name: stdout
+          format: json
+          match: event


### PR DESCRIPTION
- 5afc24144 filter_multiline: Reset group metadata buffer on flush
- dc08a18ff in_calyptia_fleet: fix 'unable to find fleet by name'.
- fd7bdd62f lib: ctraces: upgrade to v0.5.6
- e430fe6b8 out_calyptia: add missing parameter for msgpack_str for windows os field.
- 6b70766f0 out_calyptia: register OS and architecture for agents.
- dc2ac8dc2 config_format: cf_yaml: Cleanup variants only if occurred an exception
- a4371405c config_format: cf_yaml: tests: Add a test case for broken plugin variant
- 0702144d3 config_format: cf_yaml: Plug memory leaks on exception for variants on plugin elements

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
