### PR TITLE
upstream: Improve error message for misconfigured HTTP_PROXY variable - Backport to 3.1

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -290,7 +290,6 @@ struct flb_upstream *flb_upstream_create(struct flb_config *config,
                                         &proxy_username, &proxy_password,
                                         &proxy_host, &proxy_port);
         if (ret == -1) {
-            flb_errno();
             flb_free(u);
             return NULL;
         }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1128,7 +1128,7 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
 
 /*
  * flb_utils_proxy_url_split parses a proxy's information from a http_proxy URL.
- * The URL is in the form like `http://username:password@myproxy.com:8080`.
+ * The URL is in the form like `http://[username:password@]myproxy.com:8080`.
  * Note: currently only HTTP is supported.
  */
 int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
@@ -1147,9 +1147,11 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     /*  Parse protocol */
     proto_sep = strstr(in_url, "://");
     if (!proto_sep) {
+        flb_error("HTTP_PROXY variable must be set in the form of 'http://[username:password@]host:port'");
         return -1;
     }
     if (proto_sep == in_url) {
+        flb_error("HTTP_PROXY variable must be set in the form of 'http://[username:password@]host:port'");
         return -1;
     }
 
@@ -1160,6 +1162,7 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     }
     /* Only HTTP proxy is supported for now. */
     if (strcmp(protocol, "http") != 0) {
+        flb_error("only HTTP proxy is supported.");
         flb_free(protocol);
         return -1;
     }

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -758,7 +758,7 @@ static inline void encoded_to_buf(char *out, const char *in, int len)
 
 /*
  * Write string pointed by 'str' to the destination buffer 'buf'. It's make sure
- * to escape sepecial characters and convert utf-8 byte characters to string
+ * to escape special characters and convert utf-8 byte characters to string
  * representation.
  */
 int flb_utils_write_str(char *buf, int *off, size_t size,
@@ -1170,10 +1170,10 @@ int flb_utils_proxy_url_split(const char *in_url, char **out_protocol,
     /* Advance position after protocol */
     proto_sep += 3;
 
-    /* Seperate `username:password` and `host:port` */
+    /* Separate `username:password` and `host:port` */
     at_sep = strrchr(proto_sep, '@');
     if (at_sep) {
-        /* Parse username:passwrod part. */
+        /* Parse username:password part. */
         tmp = strchr(proto_sep, ':');
         if (!tmp) {
             flb_free(protocol);


### PR DESCRIPTION
**Backporting**
- [x] Backport to latest stable release.

This is backport of #9328


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
