### PR TITLE
out_datadog: custom added ability ot set custom HTTP headers

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -368,6 +368,10 @@ static void cb_datadog_flush(struct flb_event_chunk *event_chunk,
     size_t b_sent;
     int ret = FLB_ERROR;
     int compressed = FLB_FALSE;
+    struct mk_list *head;
+    struct flb_config_map_val *mv;
+    struct flb_slist_entry *key = NULL;
+    struct flb_slist_entry *val = NULL;
 
     /* Get upstream connection */
     upstream_conn = flb_upstream_conn_get(ctx->upstream);
@@ -427,7 +431,15 @@ static void cb_datadog_flush(struct flb_event_chunk *event_chunk,
     if (compressed == FLB_TRUE) {
         flb_http_set_content_encoding_gzip(client);
     }
-    /* TODO: Append other headers if needed*/
+
+    flb_config_map_foreach(head, mv, ctx->headers) {
+        key = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+        val = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+
+        flb_http_add_header(client,
+                            key->str, flb_sds_len(key->str),
+                            val->str, flb_sds_len(val->str));
+    }
 
     /* finaly send the query */
     ret = flb_http_do(client, &b_sent);
@@ -492,6 +504,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "compresses the payload in GZIP format, "
      "Datadog supports and recommends setting this to 'gzip'."
+    },
+    {
+     FLB_CONFIG_MAP_SLIST_1, "header", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_out_datadog, headers),
+     "Add a HTTP header key/value pair. Multiple headers can be set"
     },
     {
      FLB_CONFIG_MAP_STR, "apikey", NULL,

--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -59,6 +59,7 @@ struct flb_out_datadog {
     flb_sds_t api_key;
     int include_tag_key;
     flb_sds_t tag_key;
+    struct mk_list *headers;
     bool remap;
 
     /* final result */


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added ability to set custom HTTP headers for Datadog output

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[INPUT]
    name              tail
    path              /var/lib/docker/containers/**/*.log
    path_key          path
    multiline.parser  docker, cri
    Parser            docker
    Docker_Mode       On

[SERVICE]
    Flush        1
    Parsers_File parsers.conf

[Output]
    name                  datadog
    match                 *
    host                  victorialogs
    port                  9428
    tls                   off
    compress              gzip
    apikey                test
    dd_service            test
    dd_source             data
    dd_message_key        log
    dd_tags               env:dev
    header                VL-Stream-Fields env
```
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1467

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.