### PR TITLE
workflows: update for 3.1 branch

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -504,6 +504,7 @@ jobs:
   staging-release-images-latest-tags:
     # Only update latest tags for 3.1 releases
     if: startsWith(github.event.inputs.version, '3.1')
+    # if: startsWith(github.event.inputs.version, '4.0')
     name: Release latest Linux container images
     runs-on: ubuntu-latest
     needs:
@@ -804,6 +805,7 @@ jobs:
           make_latest: false
 
       - name: Release 3.1 and latest
+        # TODO: change to 3.1 branch once 4.0 series is ready
         uses: softprops/action-gh-release@v2
         if: startsWith(inputs.version, '3.1')
         with:
@@ -813,6 +815,17 @@ jobs:
           name: "Fluent Bit ${{ inputs.version }}"
           tag_name: v${{ inputs.version }}
           make_latest: true
+
+      # - name: Release 4.0 and latest
+      #   uses: softprops/action-gh-release@v2
+      #   if: startsWith(inputs.version, '4.0')
+      #   with:
+      #     body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
+      #     draft: false
+      #     generate_release_notes: true
+      #     name: "Fluent Bit ${{ inputs.version }}"
+      #     tag_name: v${{ inputs.version }}
+      #     make_latest: true
 
   staging-release-windows-checksums:
     name: Get Windows checksums for new release
@@ -903,14 +916,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: fluent/fluent-bit-docs
+          ref: 3.0
           token: ${{ secrets.GH_PA_TOKEN }}
 
       - name: Release 3.1 and latest
+        # TODO: change to 3.1 branch once 4.0 series is ready
         if: startsWith(inputs.version, '3.1')
         uses: actions/checkout@v4
         with:
           repository: fluent/fluent-bit-docs
           token: ${{ secrets.GH_PA_TOKEN }}
+
+      # - name: Release 4.0 and latest
+      #   if: startsWith(inputs.version, '4.0')
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: fluent/fluent-bit-docs
+      #     token: ${{ secrets.GH_PA_TOKEN }}
 
       - name: Ensure we have the script we need
         run: |
@@ -984,15 +1006,23 @@ jobs:
         with:
           ref: 2.2
 
-      - name: Release 3.0 not latest
+      - name: Release 3.0
         if: startsWith(inputs.version, '3.0')
         uses: actions/checkout@v4
         with:
           ref: 3.0
 
-      - name: Release 3.1 latest
+      - name: Release 3.1
         if: startsWith(inputs.version, '3.1')
         uses: actions/checkout@v4
+        with:
+          ref: 3.1
+
+      - name: Release 4.0
+        if: startsWith(inputs.version, '4.0')
+        uses: actions/checkout@v4
+        with:
+          ref: master
 
       # Get the new version to use
       - name: 'Get next minor version'


### PR DESCRIPTION
CI updates now we have a `3.1` branch - also added placeholders for 4.0 releases from `master` but this will need updates to the workflow to remove 3.1 as the `latest` release.

Related to https://github.com/fluent/fluent-bit/pull/9440