### PR TITLE
ci: support 3.2 releases as latest version

### DIFF
--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -14,6 +14,7 @@ on:
   schedule:
     - cron: "0 6 * * *" # master build
     - cron: "0 12 * * *" # 3.0 build
+    - cron: "0 18 * * *" # 3.1 build
 
 # We do not want a new unstable build to run whilst we are releasing the current unstable build.
 concurrency: unstable-build-release
@@ -55,6 +56,12 @@ jobs:
         if: github.event_name == 'schedule' && github.event.schedule=='0 12 * * *'
         run: |
           echo "cron_branch=3.0" >> $GITHUB_ENV
+        shell: bash
+
+      - name: 3.1 run
+        if: github.event_name == 'schedule' && github.event.schedule=='0 18 * * *'
+        run: |
+          echo "cron_branch=3.1" >> $GITHUB_ENV
         shell: bash
 
       - name: Output the branch to use

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -502,9 +502,8 @@ jobs:
           TAG: ${{ steps.get-tag.outputs.tag }}
 
   staging-release-images-latest-tags:
-    # Only update latest tags for 3.1 releases
-    if: startsWith(github.event.inputs.version, '3.1')
-    # if: startsWith(github.event.inputs.version, '4.0')
+    # Only update latest tags for 3.2 releases
+    if: startsWith(github.event.inputs.version, '3.2')
     name: Release latest Linux container images
     runs-on: ubuntu-latest
     needs:
@@ -804,8 +803,7 @@ jobs:
           target_commitish: '3.0'
           make_latest: false
 
-      - name: Release 3.1 and latest
-        # TODO: change to 3.1 branch once 4.0 series is ready
+      - name: Release 3.1 - not latest
         uses: softprops/action-gh-release@v2
         if: startsWith(inputs.version, '3.1')
         with:
@@ -814,18 +812,19 @@ jobs:
           generate_release_notes: true
           name: "Fluent Bit ${{ inputs.version }}"
           tag_name: v${{ inputs.version }}
-          make_latest: true
+          target_commitish: '3.1'
+          make_latest: false
 
-      # - name: Release 4.0 and latest
-      #   uses: softprops/action-gh-release@v2
-      #   if: startsWith(inputs.version, '4.0')
-      #   with:
-      #     body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
-      #     draft: false
-      #     generate_release_notes: true
-      #     name: "Fluent Bit ${{ inputs.version }}"
-      #     tag_name: v${{ inputs.version }}
-      #     make_latest: true
+      - name: Release 3.2 and latest
+        uses: softprops/action-gh-release@v2
+        if: startsWith(inputs.version, '3.2')
+        with:
+          body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
+          draft: false
+          generate_release_notes: true
+          name: "Fluent Bit ${{ inputs.version }}"
+          tag_name: v${{ inputs.version }}
+          make_latest: true
 
   staging-release-windows-checksums:
     name: Get Windows checksums for new release
@@ -919,20 +918,20 @@ jobs:
           ref: 3.0
           token: ${{ secrets.GH_PA_TOKEN }}
 
-      - name: Release 3.1 and latest
-        # TODO: change to 3.1 branch once 4.0 series is ready
+      - name: Release 3.1 - not latest
         if: startsWith(inputs.version, '3.1')
         uses: actions/checkout@v4
         with:
           repository: fluent/fluent-bit-docs
+          ref: 3.1
           token: ${{ secrets.GH_PA_TOKEN }}
 
-      # - name: Release 4.0 and latest
-      #   if: startsWith(inputs.version, '4.0')
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: fluent/fluent-bit-docs
-      #     token: ${{ secrets.GH_PA_TOKEN }}
+      - name: Release 3.2 and latest
+        if: startsWith(inputs.version, '3.2')
+        uses: actions/checkout@v4
+        with:
+          repository: fluent/fluent-bit-docs
+          token: ${{ secrets.GH_PA_TOKEN }}
 
       - name: Ensure we have the script we need
         run: |
@@ -1018,8 +1017,8 @@ jobs:
         with:
           ref: 3.1
 
-      - name: Release 4.0
-        if: startsWith(inputs.version, '4.0')
+      - name: Release 3.2
+        if: startsWith(inputs.version, '3.2')
         uses: actions/checkout@v4
         with:
           ref: master

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -13,7 +13,7 @@
 # docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7,linux/s390x" -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz ./dockerfiles/
 
 # Set this to the current release version: it gets done so as part of the release.
-ARG RELEASE_VERSION=3.1.7
+ARG RELEASE_VERSION=3.2.0
 
 # For multi-arch builds - assumption is running on an AMD64 host
 FROM multiarch/qemu-user-static:x86_64-arm AS qemu-arm32

--- a/fluent-bit-3.2.0.bb
+++ b/fluent-bit-3.2.0.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2ee41112a44fe7014dce33e26468ba93"
 SECTION = "net"
 
 PR = "r0"
-PV = "3.1.7"
+PV = "3.2.0"
 
 SRCREV = "v${PV}"
 SRC_URI = "git://github.com/fluent/fluent-bit.git;nobranch=1"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
 base: core18
-version: '3.1.7'
+version: '3.2.0'
 summary: High performance logs and stream processor
 description: |
   Fluent Bit is a high performance log processor and stream processor for Linux.


### PR DESCRIPTION
CI updates to support 3.2 releases.

Do not merge until ready to release 3.2.0.

Note this assumes a `3.1` branch for docs as well.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
