### PR TITLE
in_http: support for msgpack .

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -30,6 +30,7 @@
 
 #define HTTP_CONTENT_JSON       0
 #define HTTP_CONTENT_URLENCODED 1
+#define HTTP_CONTENT_MSGPACK    2
 
 static inline char hex2nibble(char c)
 {
@@ -508,6 +509,101 @@ split_error:
     return ret;
 }
 
+static ssize_t parse_payload_msgpack(struct flb_http *ctx, flb_sds_t tag,
+                                     char *payload, size_t size)
+{
+    int              ret = FLB_EVENT_ENCODER_SUCCESS;
+    struct flb_time  tm;
+    size_t           offset = 0;
+    msgpack_unpacked result;
+    msgpack_object   *record;
+    msgpack_object   *metadata;
+    msgpack_object   *data;
+    flb_sds_t        tag_from_record = NULL;
+
+
+    msgpack_unpacked_init(&result);
+
+    while (ret == FLB_EVENT_ENCODER_SUCCESS &&
+           msgpack_unpack_next(&result, payload, size, &offset) == MSGPACK_UNPACK_SUCCESS) {
+
+        if (result.data.type != MSGPACK_OBJECT_ARRAY) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        record = &result.data;
+        metadata = &record->via.array.ptr[0];
+        data = &record->via.array.ptr[1];
+
+        if (ctx->tag_key) {
+            tag_from_record = tag_key(ctx, data);
+        }
+
+        ret = flb_log_event_encoder_begin_record(&ctx->log_encoder);
+
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        ret = flb_time_msgpack_to_time(&tm, &metadata->via.array.ptr[0]);
+
+        if (ret == -1) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        ret = flb_log_event_encoder_set_timestamp(
+                &ctx->log_encoder,
+                &tm);
+
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        ret = flb_log_event_encoder_set_body_from_msgpack_object(&ctx->log_encoder, data);
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        ret = flb_log_event_encoder_commit_record(&ctx->log_encoder);
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        if (tag_from_record) {
+            ret = flb_input_log_append(ctx->ins, tag_from_record,
+                                       flb_sds_len(tag_from_record),
+                                       ctx->log_encoder.output_buffer,
+                                       ctx->log_encoder.output_length);
+        }
+        else if (tag) {
+            ret = flb_input_log_append(ctx->ins, tag, flb_sds_len(tag),
+                                       ctx->log_encoder.output_buffer,
+                                       ctx->log_encoder.output_length);
+        }
+        else {
+            ret = flb_input_log_append(ctx->ins, NULL, 0,
+                                       ctx->log_encoder.output_buffer,
+                                       ctx->log_encoder.output_length);
+        }
+
+        if (ret != 0) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        flb_log_event_encoder_reset(&ctx->log_encoder);
+    }
+
+    msgpack_unpacked_destroy(&result);
+    return 0;
+}
+
 static int process_payload(struct flb_http *ctx, struct http_conn *conn,
                            flb_sds_t tag,
                            struct mk_http_session *session,
@@ -534,6 +630,11 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
         type = HTTP_CONTENT_URLENCODED;
     }
 
+    if (header->val.len == 19 &&
+        strncasecmp(header->val.data, "application/msgpack", 19) == 0) {
+        type = HTTP_CONTENT_MSGPACK;
+    }
+
     if (type == -1) {
         send_response(conn, 400, "error: invalid 'Content-Type'\n");
         return -1;
@@ -549,6 +650,9 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
     }
     else if (type == HTTP_CONTENT_URLENCODED) {
         ret = parse_payload_urlencoded(ctx, tag, request->data.data, request->data.len);
+    }
+    else if (type == HTTP_CONTENT_MSGPACK) {
+        ret = parse_payload_msgpack(ctx, tag, request->data.data, request->data.len);
     }
 
     if (ret != 0) {
@@ -919,6 +1023,10 @@ static int process_payload_ng(flb_sds_t tag,
         type = HTTP_CONTENT_URLENCODED;
     }
 
+    if (strcasecmp(request->content_type, "application/msgpack") == 0) {
+        type = HTTP_CONTENT_MSGPACK;
+    }
+
     if (type == -1) {
         send_response_ng(response, 400, "error: invalid 'Content-Type'\n");
         return -1;
@@ -938,6 +1046,13 @@ static int process_payload_ng(flb_sds_t tag,
         payload = (char *) request->body;
         if (payload) {
             return parse_payload_urlencoded(ctx, tag, payload, cfl_sds_len(payload));
+        }
+    }
+    else if (type == HTTP_CONTENT_MSGPACK) {
+        ctx = (struct flb_http *) request->stream->user_data;
+        payload = (char *) request->body;
+        if (payload) {
+            return parse_payload_msgpack(ctx, tag, payload, cfl_sds_len(payload));
         }
     }
 

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -29,6 +29,7 @@
 
 #define JSON_CONTENT_TYPE "application/json"
 #define JSON_CHARSET_CONTENT_TYPE "application/json; charset=utf-8"
+#define MSGPACK_CONTENT_TYPE "application/msgpack"
 
 struct http_client_ctx {
     struct flb_upstream      *u;
@@ -278,6 +279,153 @@ void flb_test_http()
     flb_upstream_conn_release(ctx->httpc->u_conn);
     test_ctx_destroy(ctx);
 }
+
+void flb_test_msgpack_legacy()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+    char buf[] = "\xdd\x00\x00\x00\x02\xdd\x00\x00"
+                "\x00\x02\xd7\x00\x65\xd3\x9c\x63"
+                "\x19\x36\xb8\xd5\x80\x81\xa7\x6d"
+                "\x65\x73\x73\x61\x67\x65\xa5\x64"
+                "\x75\x6d\x6d\x79\xbe";
+
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"message\":\"dummy\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    flb_input_set(ctx->flb, ctx->i_ffd, "http2", "off", NULL);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", buf, sizeof(buf),
+                        "127.0.0.1", 9880, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              MSGPACK_CONTENT_TYPE, strlen(MSGPACK_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 201)) {
+        TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_msgpack()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+    char buf[] = "\xdd\x00\x00\x00\x02\xdd\x00\x00"
+                "\x00\x02\xd7\x00\x65\xd3\x9c\x63"
+                "\x19\x36\xb8\xd5\x80\x81\xa7\x6d"
+                "\x65\x73\x73\x61\x67\x65\xa5\x64"
+                "\x75\x6d\x6d\x79\xbe";
+
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"message\":\"dummy\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", buf, sizeof(buf),
+                        "127.0.0.1", 9880, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              MSGPACK_CONTENT_TYPE, strlen(MSGPACK_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 201)) {
+        TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
 void flb_test_http_successful_response_code(char *response_code)
 {
     struct flb_lib_out_cb cb_data;
@@ -662,6 +810,8 @@ void flb_test_http_tag_key()
 
 TEST_LIST = {
     {"http", flb_test_http},
+    {"msgpack_legacy", flb_test_msgpack_legacy},
+    {"msgpack", flb_test_msgpack},
     {"successful_response_code_200", flb_test_http_successful_response_code_200},
     {"successful_response_code_204", flb_test_http_successful_response_code_204},
     {"failure_response_code_400_bad_json", flb_test_http_failure_400_bad_json},


### PR DESCRIPTION
# Summary

This is a backport of #8499 to the v3.1 series.

# Description

This patch adds support for msgpack payloads to the `in_http` plugin, which can be emitted by `out_http` and used to be the default format for it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
