### PR TITLE
http_server: hs: Handle IPv4 and IPv6 addresses

### DIFF
--- a/src/http_server/flb_hs.c
+++ b/src/http_server/flb_hs.c
@@ -71,7 +71,8 @@ struct flb_hs *flb_hs_create(const char *listen, const char *tcp_port,
                              struct flb_config *config)
 {
     int vid;
-    char tmp[32];
+    /* Accept IPv6 and IPv4 address */
+    char tmp[46];
     struct flb_hs *hs;
 
     hs = flb_calloc(1, sizeof(struct flb_hs));


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes https://github.com/fluent/fluent-bit/issues/9423.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    HTTP_Server  On
    HTTP_Listen  fe80::c97:XXXX:XXXX:XXX%en0 # Put valid IPv6 address
    HTTP_Port    2021
    Enable_Hot_Reload On
    Health_Check On

[INPUT]
    Name dummy
    Tag dummy.locals

[OUTPUT]
    Name  stdout
    Match *
```

- [x] Debug log output from testing the change

```
Fluent Bit v3.2.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |____ |/ __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \  / /  
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)_____/


[2024/10/01 15:46:34] [ info] Configuration:
[2024/10/01 15:46:34] [ info]  flush time     | 1.000000 seconds
[2024/10/01 15:46:34] [ info]  grace          | 5 seconds
[2024/10/01 15:46:34] [ info]  daemon         | 0
[2024/10/01 15:46:34] [ info] ___________
[2024/10/01 15:46:34] [ info]  inputs:
[2024/10/01 15:46:34] [ info]      dummy
[2024/10/01 15:46:34] [ info] ___________
[2024/10/01 15:46:34] [ info]  filters:
[2024/10/01 15:46:34] [ info] ___________
[2024/10/01 15:46:34] [ info]  outputs:
[2024/10/01 15:46:34] [ info]      stdout.0
[2024/10/01 15:46:34] [ info] ___________
[2024/10/01 15:46:34] [ info]  collectors:
[2024/10/01 15:46:34] [ info] [fluent bit] version=3.2.0, commit=eba9f73f33, pid=32408
[2024/10/01 15:46:34] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2024/10/01 15:46:34] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/10/01 15:46:34] [ info] [cmetrics] version=0.9.6
[2024/10/01 15:46:34] [ info] [ctraces ] version=0.5.6
[2024/10/01 15:46:34] [ info] [input:dummy:dummy.0] initializing
[2024/10/01 15:46:34] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2024/10/01 15:46:34] [debug] [dummy:dummy.0] created event channels: read=25 write=26
[2024/10/01 15:46:34] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2024/10/01 15:46:34] [ info] [output:stdout:stdout.0] worker #0 started
[2024/10/01 15:46:34] [ info] [http_server] listen iface=fe80::c97:XXXX:XXXX:XXX%en0 tcp_port=2021
[2024/10/01 15:46:34] [ info] [sp] stream processor started
[2024/10/01 15:46:36] [debug] [task] created task=0x600000d04000 id=0 OK
[2024/10/01 15:46:36] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1727765195.405922000, {}], {"message"=>"dummy"}]
[2024/10/01 15:46:36] [debug] [out flush] cb_destroy coro_id=0
[2024/10/01 15:46:36] [debug] [task] destroy task=0x600000d04000 (task_id=0)
[2024/10/01 15:46:37] [debug] [task] created task=0x600000d082c0 id=0 OK
[2024/10/01 15:46:37] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1727765196.405942000, {}], {"message"=>"dummy"}]
[2024/10/01 15:46:37] [debug] [out flush] cb_destroy coro_id=1
[2024/10/01 15:46:37] [debug] [task] destroy task=0x600000d082c0 (task_id=0)
[2024/10/01 15:46:38] [debug] [task] created task=0x600000d18000 id=0 OK
[2024/10/01 15:46:38] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1727765197.405945000, {}], {"message"=>"dummy"}]
[2024/10/01 15:46:38] [debug] [out flush] cb_destroy coro_id=2
[2024/10/01 15:46:38] [debug] [task] destroy task=0x600000d18000 (task_id=0)
[2024/10/01 15:46:39] [debug] [task] created task=0x600000d082c0 id=0 OK
[2024/10/01 15:46:39] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1727765198.405941000, {}], {"message"=>"dummy"}]
[2024/10/01 15:46:39] [debug] [out flush] cb_destroy coro_id=3
[2024/10/01 15:46:39] [debug] [task] destroy task=0x600000d082c0 (task_id=0)
[2024/10/01 15:46:40] [debug] [task] created task=0x600000d0c160 id=0 OK
[2024/10/01 15:46:40] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1727765199.406597000, {}], {"message"=>"dummy"}]
[2024/10/01 15:46:40] [debug] [out flush] cb_destroy coro_id=4
[2024/10/01 15:46:40] [debug] [task] destroy task=0x600000d0c160 (task_id=0)
^C[2024/10/01 15:46:40] [engine] caught signal (SIGINT)
[2024/10/01 15:46:40] [ info] [input] pausing dummy.0
[2024/10/01 15:46:40] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/10/01 15:46:40] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==2376819== 
==2376819== HEAP SUMMARY:
==2376819==     in use at exit: 0 bytes in 0 blocks
==2376819==   total heap usage: 5,797 allocs, 5,797 frees, 1,471,015 bytes allocated
==2376819== 
==2376819== All heap blocks were freed -- no leaks are possible
==2376819== 
==2376819== For lists of detected and suppressed errors, rerun with: -s
==2376819== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

On macOS,

```
Process 32734 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [32734]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x104d00000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [32732]

Date/Time:       2024-10-01 16:00:31.292 +0900
Launch Time:     2024-10-01 16:00:22.466 +0900
OS Version:      macOS 14.6.1 (23G93)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 16.0 (16A242d)

Physical footprint:         6706K
Physical footprint (peak):  6866K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 32734: 563 nodes malloced for 93 KB
Process 32734: 0 leaks for 0 total leaked bytes.

[2024/10/01 16:00:32] [engine] caught signal (SIGCONT)
[2024/10/01 16:00:32] Fluent Bit Dump
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
