### PR TITLE
in_http: fix parsing of root JSON object

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -276,10 +276,11 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
 
     msgpack_unpacked_init(&result);
     while (msgpack_unpack_next(&result, buf, size, &off) == MSGPACK_UNPACK_SUCCESS) {
+        obj = &result.data;
+
         if (result.data.type == MSGPACK_OBJECT_MAP) {
             tag_from_record = NULL;
             if (ctx->tag_key) {
-                obj = &result.data;
                 tag_from_record = tag_key(ctx, obj);
             }
 
@@ -301,7 +302,6 @@ int process_pack(struct flb_http *ctx, flb_sds_t tag, char *buf, size_t size)
             flb_log_event_encoder_reset(&ctx->log_encoder);
         }
         else if (result.data.type == MSGPACK_OBJECT_ARRAY) {
-            obj = &result.data;
             for (i = 0; i < obj->via.array.size; i++) {
                 record = obj->via.array.ptr[i];
 
@@ -523,8 +523,8 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
         return -1;
     }
 
-    if ((header->val.len == 16 && strncasecmp(header->val.data, "application/json", 16) == 0) ||
-        (header->val.len > 16 && (strncasecmp(header->val.data, "application/json ", 17) == 0) || 
+    if (((header->val.len == 16 && strncasecmp(header->val.data, "application/json", 16) == 0)) ||
+        ((header->val.len > 16 && (strncasecmp(header->val.data, "application/json ", 17) == 0)) ||
         strncasecmp(header->val.data, "application/json;", 17) == 0)) {
         type = HTTP_CONTENT_JSON;
     }


### PR DESCRIPTION
This patch fixes the problem where a JSON object cannot be ingested by using in_http, e.g:

```bash
curl -d '{"key1":"value1","key2":"value2"}' -XPOST -H "content-type: application/json" http://localhost:8888/app.log
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
