### PR TITLE
tests/internal: fix use-after-free for input_chunks test input_chunk_dropping_chunks.

### DIFF
--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -304,19 +304,6 @@ void flb_test_input_chunk_dropping_chunks()
         TEST_CHECK(ret == 0);
     }
 
-    /* FORCE clean up test tasks*/
-    mk_list_foreach_safe(head, tmp, &i_ins->tasks) {
-        task = mk_list_entry(head, struct flb_task, _head);
-        flb_info("[task] cleanup test task");
-        flb_task_destroy(task, FLB_TRUE);
-    }
-
-    /* clean up test chunks */
-    mk_list_foreach_safe(head, tmp, &i_ins->chunks) {
-        ic = mk_list_entry(head, struct flb_input_chunk, _head);
-        flb_input_chunk_destroy(ic, FLB_TRUE);
-    }
-
     flb_time_msleep(2100);
     flb_stop(ctx);
     flb_destroy(ctx);


### PR DESCRIPTION
# Summary

There is a use-after-free bug in the internal test `input_chunks`, specifically in the sub-test `input_chunk_dropping_chunks`. This is caused by a premature and explicit freeing of all the chunks and explicit stopping of all the tasks by the test. This is done implicitly by either `flb_stop` or `flb_destroy`.

This PR simply eliminates this code to fix this potential use-after-free or double-free. This should make this test less flakey on macOS, as well as other operating systems.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
