### PR TITLE
in_node_exporter_metrics: fix size of core_throttles_set

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_cpu_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpu_linux.c
@@ -98,7 +98,7 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
     struct flb_slist_entry *entry;
     const char *pattern = "/devices/system/cpu/cpu[0-9]*";
     /* Status arrays */
-    uint64_t core_throttles_set[32][256];
+    uint64_t core_throttles_set[256][256];
     uint64_t package_throttles_set[32];
 
     ret = ne_utils_path_scan(ctx, ctx->path_sysfs, pattern, NE_SCAN_DIR, &list);


### PR DESCRIPTION
…nux.c

The issue is in ne_cpu_linux.c
In core_throttles_set[n][m], n has size 32 only.
On my PC, I have 44 cores and physical_package_id can have max value of 88. 

On  line 140 we see:
 if (core_throttles_set[physical_package_id][core_id] != 0)

This accesses array at index 88, that has size of only 32.
This causes a segmentation fault.
Because we access data from invalid address outside the range of buffer. 

Fix: The size is changed to 256 to accomodate high core count. 

Signed-off-by: Faran Abdullah faran.abdullah@ebryx.com

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
