### PR TITLE
input_chunk: fix input plugin metrics not counting records re-emitted by filters downstream

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1579,6 +1579,26 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     flb_chunk_trace_do_input(ic);
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
+    /* Update 'input' metrics */
+#ifdef FLB_HAVE_METRICS
+    if (ic->total_records > 0) {
+        /* timestamp */
+        ts = cfl_time_now();
+
+        /* fluentbit_input_records_total */
+        cmt_counter_add(in->cmt_records, ts, ic->added_records,
+                        1, (char *[]) {(char *) flb_input_name(in)});
+
+        /* fluentbit_input_bytes_total */
+        cmt_counter_add(in->cmt_bytes, ts, buf_size,
+                        1, (char *[]) {(char *) flb_input_name(in)});
+
+        /* OLD api */
+        flb_metrics_sum(FLB_METRIC_N_RECORDS, ic->added_records, in->metrics);
+        flb_metrics_sum(FLB_METRIC_N_BYTES, buf_size, in->metrics);
+    }
+#endif
+
     filtered_data_buffer = NULL;
     final_data_buffer = (char *) buf;
     final_data_size = buf_size;
@@ -1618,26 +1638,6 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
         ic->added_records = 0;
         ic->total_records = total_records_start;
     }
-
-    /* Update 'input' metrics */
-#ifdef FLB_HAVE_METRICS
-    if (ic->total_records > 0) {
-        /* timestamp */
-        ts = cfl_time_now();
-
-        /* fluentbit_input_records_total */
-        cmt_counter_add(in->cmt_records, ts, ic->added_records,
-                        1, (char *[]) {(char *) flb_input_name(in)});
-
-        /* fluentbit_input_bytes_total */
-        cmt_counter_add(in->cmt_bytes, ts, buf_size,
-                        1, (char *[]) {(char *) flb_input_name(in)});
-
-        /* OLD api */
-        flb_metrics_sum(FLB_METRIC_N_RECORDS, ic->added_records, in->metrics);
-        flb_metrics_sum(FLB_METRIC_N_BYTES, buf_size, in->metrics);
-    }
-#endif
 
     if (ret == -1) {
         flb_error("[input chunk] error writing data from %s instance",


### PR DESCRIPTION
<!-- Provide summary of changes -->
move input metrics collections before applying filters.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #8729

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
