### PR TITLE
config: complete Yaml support

### DIFF
--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -56,6 +56,7 @@ enum section_type {
     FLB_CF_SERVICE = 0,           /* [SERVICE]           */
     FLB_CF_PARSER,                /* [PARSER]            */
     FLB_CF_MULTILINE_PARSER,      /* [MULTILINE_PARSER]  */
+    FLB_CF_STREAM_PROCESSOR,      /* STREAM_PROCESSOR    */
     FLB_CF_CUSTOM,                /* [CUSTOM]            */
     FLB_CF_INPUT,                 /* [INPUT]             */
     FLB_CF_FILTER,                /* [FILTER]            */
@@ -96,6 +97,9 @@ struct flb_cf {
     /* parsers */
     struct mk_list parsers;
     struct mk_list multiline_parsers;
+
+    /* stream processor: every entry is added as a task */
+    struct mk_list stream_processors;
 
     /* custom plugins */
     struct mk_list customs;

--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -58,6 +58,7 @@ enum section_type {
     FLB_CF_MULTILINE_PARSER,      /* multiline_parser    */
     FLB_CF_STREAM_PROCESSOR,      /* stream_processor    */
     FLB_CF_PLUGINS,               /* plugins             */
+    FLB_CF_UPSTREAM_SERVERS,      /* upstream_servers    */
     FLB_CF_CUSTOM,                /* [CUSTOM]            */
     FLB_CF_INPUT,                 /* [INPUT]             */
     FLB_CF_FILTER,                /* [FILTER]            */
@@ -104,6 +105,9 @@ struct flb_cf {
 
     /* external plugins (.so) */
     struct mk_list plugins;
+
+    /* upstream servers */
+    struct mk_list upstream_servers;
 
     /* 'custom' type plugins */
     struct mk_list customs;

--- a/include/fluent-bit/config_format/flb_cf.h
+++ b/include/fluent-bit/config_format/flb_cf.h
@@ -55,8 +55,9 @@ enum cf_file_format {
 enum section_type {
     FLB_CF_SERVICE = 0,           /* [SERVICE]           */
     FLB_CF_PARSER,                /* [PARSER]            */
-    FLB_CF_MULTILINE_PARSER,      /* [MULTILINE_PARSER]  */
-    FLB_CF_STREAM_PROCESSOR,      /* STREAM_PROCESSOR    */
+    FLB_CF_MULTILINE_PARSER,      /* multiline_parser    */
+    FLB_CF_STREAM_PROCESSOR,      /* stream_processor    */
+    FLB_CF_PLUGINS,               /* plugins             */
     FLB_CF_CUSTOM,                /* [CUSTOM]            */
     FLB_CF_INPUT,                 /* [INPUT]             */
     FLB_CF_FILTER,                /* [FILTER]            */
@@ -101,7 +102,10 @@ struct flb_cf {
     /* stream processor: every entry is added as a task */
     struct mk_list stream_processors;
 
-    /* custom plugins */
+    /* external plugins (.so) */
+    struct mk_list plugins;
+
+    /* 'custom' type plugins */
     struct mk_list customs;
 
     /* pipeline */

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -75,7 +75,7 @@ enum {
     FLB_PARSER_TYPE_HEX,
 };
 
-static inline time_t flb_parser_tm2time(const struct flb_tm *src, 
+static inline time_t flb_parser_tm2time(const struct flb_tm *src,
                                         int use_system_timezone)
 {
     struct tm tmp;
@@ -107,6 +107,8 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      struct flb_config *config);
 int flb_parser_conf_file_stat(const char *file, struct flb_config *config);
 int flb_parser_conf_file(const char *file, struct flb_config *config);
+int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
+                                       struct flb_config *config);
 void flb_parser_destroy(struct flb_parser *parser);
 struct flb_parser *flb_parser_get(const char *name, struct flb_config *config);
 int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -109,6 +109,9 @@ int flb_parser_conf_file_stat(const char *file, struct flb_config *config);
 int flb_parser_conf_file(const char *file, struct flb_config *config);
 int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
                                        struct flb_config *config);
+int flb_parser_load_multiline_parser_definitions(const char *cfg, struct flb_cf *cf,
+                                                 struct flb_config *config);
+
 void flb_parser_destroy(struct flb_parser *parser);
 struct flb_parser *flb_parser_get(const char *name, struct flb_config *config);
 int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,

--- a/include/fluent-bit/flb_plugin.h
+++ b/include/fluent-bit/flb_plugin.h
@@ -47,8 +47,12 @@ struct flb_plugins {
 struct flb_plugins *flb_plugin_create();
 int flb_plugin_load(char *path, struct flb_plugins *ctx,
                     struct flb_config *config);
+
 int flb_plugin_load_router(char *path, struct flb_config *config);
+
 int flb_plugin_load_config_file(const char *file, struct flb_config *config);
+int flb_plugin_load_config_format(struct flb_cf *cf, struct flb_config *config);
+
 void flb_plugin_destroy(struct flb_plugins *ctx);
 
 #endif

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -589,21 +589,21 @@ static void print_current_properties(struct parser_state *state)
     struct cfl_variant *var;
     int idx;
 
-    flb_info("%*s[%s] PROPERTIES:", state->level*2, "", section_names[state->section]);
+    flb_debug("%*s[%s] PROPERTIES:", state->level*2, "", section_names[state->section]);
 
     cfl_list_foreach(head, &state->keyvals->list) {
         prop = cfl_list_entry(head, struct cfl_kvpair, _head);
         switch (prop->val->type) {
         case CFL_VARIANT_STRING:
-            flb_info("%*s%s: %s", (state->level+2)*2, "", prop->key, prop->val->data.as_string);
+            flb_debug("%*s%s: %s", (state->level+2)*2, "", prop->key, prop->val->data.as_string);
             break;
         case CFL_VARIANT_ARRAY:
-            flb_info("%*s%s: [", (state->level+2)*2, "", prop->key);
+            flb_debug("%*s%s: [", (state->level+2)*2, "", prop->key);
             for (idx = 0; idx < prop->val->data.as_array->entry_count; idx++) {
                 var = cfl_array_fetch_by_index(prop->val->data.as_array, idx);
-                flb_info("%*s%s", (state->level+3)*2, "", var->data.as_string);
+                flb_debug("%*s%s", (state->level+3)*2, "", var->data.as_string);
             }
-            flb_info("%*s]", (state->level+2)*2, "");
+            flb_debug("%*s]", (state->level+2)*2, "");
             break;
         }
     }

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -125,6 +125,9 @@ struct flb_cf *flb_cf_create()
     /* external plugins (*.so) */
     mk_list_init(&ctx->plugins);
 
+    /* upstream servers */
+    mk_list_init(&ctx->upstream_servers);
+
     /* 'custom' type plugins */
     mk_list_init(&ctx->customs);
 
@@ -180,6 +183,9 @@ static enum section_type get_section_type(char *name, int len)
     }
     else if (strncasecmp(name, "plugins", len) == 0) {
         return FLB_CF_PLUGINS;
+    }
+    else if (strncasecmp(name, "upstream_servers", len) == 0) {
+        return FLB_CF_UPSTREAM_SERVERS;
     }
     else if (strncasecmp(name, "custom", len) == 0 ||
              strncasecmp(name, "customs", len) == 0) {
@@ -652,6 +658,9 @@ struct flb_cf_section *flb_cf_section_create(struct flb_cf *cf, char *name, int 
     else if (type == FLB_CF_PLUGINS) {
         mk_list_add(&s->_head_section, &cf->plugins);
     }
+    else if (type == FLB_CF_UPSTREAM_SERVERS) {
+        mk_list_add(&s->_head_section, &cf->upstream_servers);
+    }
     else if (type == FLB_CF_CUSTOM) {
         mk_list_add(&s->_head_section, &cf->customs);
     }
@@ -750,6 +759,8 @@ static char *section_type_str(int type)
         return "STREAM_PROCESSOR";
     case FLB_CF_PLUGINS:
         return "PLUGINS";
+    case FLB_CF_UPSTREAM_SERVERS:
+        return "UPSTREAM_SERVERS";
     case FLB_CF_CUSTOM:
         return "CUSTOM";
     case FLB_CF_INPUT:

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -119,6 +119,9 @@ struct flb_cf *flb_cf_create()
     mk_list_init(&ctx->parsers);
     mk_list_init(&ctx->multiline_parsers);
 
+    /* stream processors */
+    mk_list_init(&ctx->stream_processors);
+
     /* custom plugins */
     mk_list_init(&ctx->customs);
 
@@ -160,29 +163,32 @@ int flb_cf_set_origin_format(struct flb_cf *cf, int format)
 
 static enum section_type get_section_type(char *name, int len)
 {
-    if (strncasecmp(name, "SERVICE", len) == 0) {
+    if (strncasecmp(name, "service", len) == 0) {
         return FLB_CF_SERVICE;
     }
-    else if (strncasecmp(name, "PARSER", len) == 0) {
+    else if (strncasecmp(name, "parser", len) == 0) {
         return FLB_CF_PARSER;
     }
-    else if (strncasecmp(name, "MULTILINE_PARSER", len) == 0) {
+    else if (strncasecmp(name, "multiline_parser", len) == 0) {
         return FLB_CF_MULTILINE_PARSER;
     }
-    else if (strncasecmp(name, "CUSTOM", len) == 0 ||
-             strncasecmp(name, "CUSTOMS", len) == 0) {
+    else if (strncasecmp(name, "stream_processor", len) == 0) {
+        return FLB_CF_STREAM_PROCESSOR;
+    }
+    else if (strncasecmp(name, "custom", len) == 0 ||
+             strncasecmp(name, "customs", len) == 0) {
         return FLB_CF_CUSTOM;
     }
-    else if (strncasecmp(name, "INPUT", len) == 0 ||
-             strncasecmp(name, "INPUTS", len) == 0) {
+    else if (strncasecmp(name, "input", len) == 0 ||
+             strncasecmp(name, "inputs", len) == 0) {
         return FLB_CF_INPUT;
     }
-    else if (strncasecmp(name, "FILTER", len) == 0 ||
-             strncasecmp(name, "FILTERS", len) == 0) {
+    else if (strncasecmp(name, "filter", len) == 0 ||
+             strncasecmp(name, "filters", len) == 0) {
         return FLB_CF_FILTER;
     }
-    else if (strncasecmp(name, "OUTPUT", len) == 0 ||
-             strncasecmp(name, "OUTPUTS", len) == 0) {
+    else if (strncasecmp(name, "output", len) == 0 ||
+             strncasecmp(name, "outputs", len) == 0) {
         return FLB_CF_OUTPUT;
     }
 
@@ -634,6 +640,9 @@ struct flb_cf_section *flb_cf_section_create(struct flb_cf *cf, char *name, int 
     else if (type == FLB_CF_MULTILINE_PARSER) {
         mk_list_add(&s->_head_section, &cf->multiline_parsers);
     }
+    else if (type == FLB_CF_STREAM_PROCESSOR) {
+        mk_list_add(&s->_head_section, &cf->stream_processors);
+    }
     else if (type == FLB_CF_CUSTOM) {
         mk_list_add(&s->_head_section, &cf->customs);
     }
@@ -728,6 +737,8 @@ static char *section_type_str(int type)
         return "PARSER";
     case FLB_CF_MULTILINE_PARSER:
         return "MULTILINE_PARSER";
+    case FLB_CF_STREAM_PROCESSOR:
+        return "STREAM_PROCESSOR";
     case FLB_CF_CUSTOM:
         return "CUSTOM";
     case FLB_CF_INPUT:

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -122,7 +122,10 @@ struct flb_cf *flb_cf_create()
     /* stream processors */
     mk_list_init(&ctx->stream_processors);
 
-    /* custom plugins */
+    /* external plugins (*.so) */
+    mk_list_init(&ctx->plugins);
+
+    /* 'custom' type plugins */
     mk_list_init(&ctx->customs);
 
     /* pipeline */
@@ -174,6 +177,9 @@ static enum section_type get_section_type(char *name, int len)
     }
     else if (strncasecmp(name, "stream_processor", len) == 0) {
         return FLB_CF_STREAM_PROCESSOR;
+    }
+    else if (strncasecmp(name, "plugins", len) == 0) {
+        return FLB_CF_PLUGINS;
     }
     else if (strncasecmp(name, "custom", len) == 0 ||
              strncasecmp(name, "customs", len) == 0) {
@@ -643,6 +649,9 @@ struct flb_cf_section *flb_cf_section_create(struct flb_cf *cf, char *name, int 
     else if (type == FLB_CF_STREAM_PROCESSOR) {
         mk_list_add(&s->_head_section, &cf->stream_processors);
     }
+    else if (type == FLB_CF_PLUGINS) {
+        mk_list_add(&s->_head_section, &cf->plugins);
+    }
     else if (type == FLB_CF_CUSTOM) {
         mk_list_add(&s->_head_section, &cf->customs);
     }
@@ -739,6 +748,8 @@ static char *section_type_str(int type)
         return "MULTILINE_PARSER";
     case FLB_CF_STREAM_PROCESSOR:
         return "STREAM_PROCESSOR";
+    case FLB_CF_PLUGINS:
+        return "PLUGINS";
     case FLB_CF_CUSTOM:
         return "CUSTOM";
     case FLB_CF_INPUT:

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -945,6 +945,11 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
         return -1;
     }
 
+    ret = flb_plugin_load_config_format(cf, config);
+    if (ret == -1) {
+        return -1;
+    }
+
     ret = configure_plugins_type(config, cf, FLB_CF_CUSTOM);
     if (ret == -1) {
         return -1;

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -907,11 +907,21 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
         /* Extra sanity checks */
         if (strcasecmp(s->name, "parser") == 0 ||
             strcasecmp(s->name, "multiline_parser") == 0) {
-            fprintf(stderr,
-                    "Sections 'multiline_parser' and 'parser' are not valid in "
-                    "the main configuration file. It belongs to \n"
-                    "the 'parsers_file' configuration files.\n");
-            return -1;
+
+            /*
+             * Classic mode configuration don't allow parser or multiline_parser
+             * to be defined in the main configuration file.
+             */
+            if (cf->format == FLB_CF_CLASSIC) {
+                fprintf(stderr,
+                        "Sections 'multiline_parser' and 'parser' are not valid in "
+                        "the main configuration file. It belongs to \n"
+                        "the 'parsers_file' configuration files.\n");
+                return -1;
+            }
+            else {
+                /* Yaml allow parsers definitions in any Yaml file, all good */
+            }
         }
     }
 
@@ -923,6 +933,11 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
             ckv = cfl_list_entry(chead, struct cfl_kvpair, _head);
             flb_config_set_property(config, ckv->key, ckv->val->data.as_string);
         }
+    }
+
+    ret = flb_parser_load_parser_definitions("", cf, config);
+    if (ret == -1) {
+        return -1;
     }
 
     ret = configure_plugins_type(config, cf, FLB_CF_CUSTOM);

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -940,6 +940,11 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
         return -1;
     }
 
+    ret = flb_parser_load_multiline_parser_definitions("", cf, config);
+    if (ret == -1) {
+        return -1;
+    }
+
     ret = configure_plugins_type(config, cf, FLB_CF_CUSTOM);
     if (ret == -1) {
         return -1;

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -313,15 +313,15 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
             p->time_frac_secs = (tmp + 2);
         }
 
-        /* 
-         * Fall back to the system timezone 
-         * if there is no zone parsed from the log.  
+        /*
+         * Fall back to the system timezone
+         * if there is no zone parsed from the log.
          */
         p->time_system_timezone = time_system_timezone;
 
-        /* 
-         * Optional fixed timezone offset, only applied if 
-         * not falling back to system timezone. 
+        /*
+         * Optional fixed timezone offset, only applied if
+         * not falling back to system timezone.
          */
         if (!p->time_system_timezone && time_offset) {
             diff = 0;
@@ -481,9 +481,9 @@ static flb_sds_t get_parser_key(struct flb_config *config,
     return val;
 }
 
-/* Config file: read 'parser' definitions */
-static int parser_conf_file(const char *cfg, struct flb_cf *cf,
-                            struct flb_config *config)
+/* Load each parser definition set in 'struct flb_cf *cf' */
+int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
+                                       struct flb_config *config)
 {
     int i = 0;
     flb_sds_t name;
@@ -541,7 +541,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
                       name, cfg);
             goto fconf_early_error;
         }
-        
+
         /* skip_empty_values */
         skip_empty = FLB_TRUE;
         tmp_str = get_parser_key(config, cf, s, "skip_empty_values");
@@ -605,7 +605,7 @@ static int parser_conf_file(const char *cfg, struct flb_cf *cf,
         /* Create the parser context */
         if (!flb_parser_create(name, format, regex, skip_empty,
                                time_fmt, time_key, time_offset, time_keep, time_strict,
-                               time_system_timezone, logfmt_no_bare_keys, types, types_len, 
+                               time_system_timezone, logfmt_no_bare_keys, types, types_len,
                                decoders, config)) {
             goto fconf_error;
         }
@@ -946,8 +946,8 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
         return -1;
     }
 
-    /* process 'parser' sections */
-    ret = parser_conf_file(cfg, cf, config);
+    /* load the parser definitions */
+    ret = flb_parser_load_parser_definitions(cfg, cf, config);
     if (ret == -1) {
         flb_cf_destroy(cf);
         return -1;

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -680,6 +680,17 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     return -1;
 }
 
+static int multiline_rule_create(struct flb_ml_parser *ml_parser,
+                                 char *from_state,
+                                 char *regex_pattern,
+                                 char *to_state)
+{
+    int ret;
+
+    ret = flb_ml_rule_create(ml_parser, from_state, regex_pattern, to_state, NULL);
+    return ret;
+}
+
 static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
                                       struct flb_cf_section *section,
                                       struct flb_config *config)
@@ -692,7 +703,47 @@ static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
     struct flb_slist_entry *from_state;
     struct flb_slist_entry *regex_pattern;
     struct flb_slist_entry *tmp;
+    struct mk_list *g_head;
+    struct flb_cf_group *group;
+    struct cfl_variant *var_state;
+    struct cfl_variant *var_regex;
+    struct cfl_variant *var_next_state;
 
+    /* Check if we have groups (coming from Yaml style config */
+    mk_list_foreach(g_head, &section->groups) {
+        /* Every group is a rule */
+        group = cfl_list_entry(g_head, struct flb_cf_group, _head);
+
+        var_state = cfl_kvlist_fetch(group->properties, "state");
+        if (!var_state || var_state->type != CFL_VARIANT_STRING) {
+            flb_error("[multiline parser: %s] invalid 'state' key", ml_parser->name);
+            return -1;
+        }
+
+        var_regex = cfl_kvlist_fetch(group->properties, "regex");
+        if (!var_regex || var_regex->type != CFL_VARIANT_STRING) {
+            flb_error("[multiline parser: %s] invalid 'regex' key", ml_parser->name);
+            return -1;
+        }
+
+        var_next_state = cfl_kvlist_fetch(group->properties, "next_state");
+        if (!var_next_state || var_next_state->type != CFL_VARIANT_STRING) {
+            flb_error("[multiline parser: %s] invalid 'next_state' key", ml_parser->name);
+            return -1;
+        }
+
+        ret = multiline_rule_create(ml_parser,
+                                    var_state->data.as_string,
+                                    var_regex->data.as_string,
+                                    var_next_state->data.as_string);
+
+        if (ret == -1) {
+            flb_error("[multiline parser: %s] error creating rule", ml_parser->name);
+            return -1;
+        }
+    }
+
+    /* Multiline rules set by a Fluent Bit classic mode config */
     cfl_list_foreach(head, &section->properties->list) {
         entry = cfl_list_entry(head, struct cfl_kvpair, _head);
 
@@ -705,7 +756,7 @@ static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
         ret = flb_slist_split_tokens(&list, entry->val->data.as_string, 3);
         if (ret == -1) {
             flb_error("[multiline parser: %s] invalid section on key '%s'",
-                      ml_parser->name, entry->key);
+                    ml_parser->name, entry->key);
             return -1;
         }
 
@@ -734,11 +785,10 @@ static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
             return -1;
         }
 
-        ret = flb_ml_rule_create(ml_parser,
-                                 from_state->str,
-                                 regex_pattern->str,
-                                 to_state,
-                                 NULL);
+        ret = multiline_rule_create(ml_parser,
+                                    from_state->str,
+                                    regex_pattern->str,
+                                    to_state);
         if (ret == -1) {
             flb_error("[multiline parser: %s] error creating rule",
                       ml_parser->name);
@@ -762,8 +812,8 @@ static int multiline_load_regex_rules(struct flb_ml_parser *ml_parser,
 
 
 /* config file: read 'multiline_parser' sections */
-static int multiline_parser_conf_file(const char *cfg, struct flb_cf *cf,
-                                      struct flb_config *config)
+int flb_parser_load_multiline_parser_definitions(const char *cfg, struct flb_cf *cf,
+                                                 struct flb_config *config)
 {
     int ret;
     int type;
@@ -780,6 +830,10 @@ static int multiline_parser_conf_file(const char *cfg, struct flb_cf *cf,
     struct mk_list *head;
     struct flb_cf_section *s;
     struct flb_ml_parser *ml_parser;
+
+    /*
+     * debug content of cf: flb_cf_dump(cf);
+     */
 
     /* read all 'multiline_parser' sections */
     mk_list_foreach(head, &cf->multiline_parsers) {
@@ -954,7 +1008,7 @@ int flb_parser_conf_file(const char *file, struct flb_config *config)
     }
 
     /* processs 'multiline_parser' sections */
-    ret = multiline_parser_conf_file(cfg, cf, config);
+    ret = flb_parser_load_multiline_parser_definitions(cfg, cf, config);
     if (ret == -1) {
         flb_cf_destroy(cf);
         return -1;

--- a/src/flb_plugin.c
+++ b/src/flb_plugin.c
@@ -393,7 +393,6 @@ int flb_plugin_load_config_file(const char *file, struct flb_config *config)
     struct flb_cf_section *section;
     struct cfl_kvpair *entry;
 
-    printf("load from config file\n");
 #ifndef FLB_HAVE_STATIC_CONF
     ret = stat(file, &st);
     if (ret == -1 && errno == ENOENT) {
@@ -423,7 +422,17 @@ int flb_plugin_load_config_file(const char *file, struct flb_config *config)
         return -1;
     }
 
-    /* read all 'plugins' sections */
+    /*
+     * pass to the config_format loader also in case some Yaml have been included in
+     * the service section through the option 'plugins_file'
+     */
+    ret = flb_plugin_load_config_format(cf, config);
+    if (ret == -1) {
+        flb_cf_destroy(cf);
+        return -1;
+    }
+
+    /* (classic mode) read all 'plugins' sections */
     mk_list_foreach(head, &cf->sections) {
         section = mk_list_entry(head, struct flb_cf_section, _head);
         if (strcasecmp(section->name, "plugins") != 0) {

--- a/src/flb_plugin.c
+++ b/src/flb_plugin.c
@@ -353,6 +353,33 @@ int flb_plugin_load_router(char *path, struct flb_config *config)
     return 0;
 }
 
+int flb_plugin_load_config_format(struct flb_cf *cf, struct flb_config *config)
+{
+    int ret;
+    struct mk_list *head;
+    struct cfl_list *head_e;
+    struct flb_cf_section *section;
+    struct cfl_kvpair *entry;
+
+    /* read all 'plugins' sections */
+    mk_list_foreach(head, &cf->plugins) {
+        section = mk_list_entry(head, struct flb_cf_section, _head_section);
+
+        cfl_list_foreach(head_e, &section->properties->list) {
+            entry = cfl_list_entry(head_e, struct cfl_kvpair, _head);
+
+            /* Load plugin with router function */
+            ret = flb_plugin_load_router(entry->key, config);
+            if (ret == -1) {
+                flb_cf_destroy(cf);
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 /* Load plugins from a configuration file */
 int flb_plugin_load_config_file(const char *file, struct flb_config *config)
 {
@@ -366,6 +393,7 @@ int flb_plugin_load_config_file(const char *file, struct flb_config *config)
     struct flb_cf_section *section;
     struct cfl_kvpair *entry;
 
+    printf("load from config file\n");
 #ifndef FLB_HAVE_STATIC_CONF
     ret = stat(file, &st);
     if (ret == -1 && errno == ENOENT) {

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -443,6 +443,7 @@ struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
             c++;
         }
     }
+#ifdef FLB_HAVE_LIBYAML
     else if (cf->format == FLB_CF_YAML) {
         mk_list_foreach(head, &cf->upstream_servers) {
             section = mk_list_entry(head, struct flb_cf_section, _head_section);
@@ -499,6 +500,7 @@ struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
             }
         }
     }
+#endif
 
     if (c == 0) {
         flb_error("[upstream_ha] no nodes defined");

--- a/src/flb_upstream_ha.c
+++ b/src/flb_upstream_ha.c
@@ -363,10 +363,13 @@ struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
     char path[PATH_MAX + 1];
     struct stat st;
     struct mk_list *head;
+    struct mk_list *g_head;
     struct flb_upstream_ha *ups;
     struct flb_upstream_node *node;
     struct flb_cf *cf = NULL;
     struct flb_cf_section *section;
+    struct flb_cf_group *group;
+    struct flb_cf_section *node_section;
 
 #ifndef FLB_HAVE_STATIC_CONF
     ret = stat(file, &st);
@@ -394,49 +397,107 @@ struct flb_upstream_ha *flb_upstream_ha_from_file(const char *file,
         return NULL;
     }
 
-    /* 'upstream' sections are under enum section_type FLB_CF_OTHER */
-    section = flb_cf_section_get_by_name(cf, "upstream");
-    if (!section) {
-        flb_error("[upstream_ha] section name 'upstream' could not be found");
-        flb_cf_destroy(cf);
-        return NULL;
-    }
-
-    /* upstream name */
-    tmp = flb_cf_section_property_get_string(cf, section, "name");
-    if (!tmp) {
-        flb_error("[upstream_ha] missing name for upstream at %s", cfg);
-        flb_cf_destroy(cf);
-        return NULL;
-    }
-
-    ups = flb_upstream_ha_create(tmp);
-    flb_sds_destroy(tmp);
-    if (!ups) {
-        flb_error("[upstream_ha] cannot create context");
-        flb_cf_destroy(cf);
-        return NULL;
-    }
-
-    /* 'node' sections */
-    mk_list_foreach(head, &cf->sections) {
-        section = mk_list_entry(head, struct flb_cf_section, _head);
-        if (strcasecmp(section->name, "node") != 0) {
-            continue;
-        }
-
-        /* Read section info and create a Node context */
-        node = create_node(c, cf, section, config);
-        if (!node) {
-            flb_error("[upstream_ha] cannot register node on upstream '%s'",
-                      tmp);
-            flb_upstream_ha_destroy(ups);
+    if (cf->format == FLB_CF_FLUENTBIT) {
+        /* 'upstream' sections are under enum section_type FLB_CF_OTHER */
+        section = flb_cf_section_get_by_name(cf, "upstream");
+        if (!section) {
+            flb_error("[upstream_ha] section name 'upstream' could not be found");
             flb_cf_destroy(cf);
             return NULL;
         }
 
-        flb_upstream_ha_node_add(ups, node);
-        c++;
+        /* upstream name */
+        tmp = flb_cf_section_property_get_string(cf, section, "name");
+        if (!tmp) {
+            flb_error("[upstream_ha] missing name for upstream at %s", cfg);
+            flb_cf_destroy(cf);
+            return NULL;
+        }
+
+        ups = flb_upstream_ha_create(tmp);
+        flb_sds_destroy(tmp);
+        if (!ups) {
+            flb_error("[upstream_ha] cannot create context");
+            flb_cf_destroy(cf);
+            return NULL;
+        }
+
+        /* 'node' sections */
+        mk_list_foreach(head, &cf->sections) {
+            section = mk_list_entry(head, struct flb_cf_section, _head);
+            if (strcasecmp(section->name, "node") != 0) {
+                continue;
+            }
+
+            /* Read section info and create a Node context */
+            node = create_node(c, cf, section, config);
+            if (!node) {
+                flb_error("[upstream_ha] cannot register node on upstream '%s'",
+                        tmp);
+                flb_upstream_ha_destroy(ups);
+                flb_cf_destroy(cf);
+                return NULL;
+            }
+
+            flb_upstream_ha_node_add(ups, node);
+            c++;
+        }
+    }
+    else if (cf->format == FLB_CF_YAML) {
+        mk_list_foreach(head, &cf->upstream_servers) {
+            section = mk_list_entry(head, struct flb_cf_section, _head_section);
+
+            /* upstream name */
+            tmp = flb_cf_section_property_get_string(cf, section, "name");
+            if (!tmp) {
+                flb_error("[upstream_ha] missing name for upstream at %s", cfg);
+                flb_cf_destroy(cf);
+                return NULL;
+            }
+
+            ups = flb_upstream_ha_create(tmp);
+            flb_sds_destroy(tmp);
+            if (!ups) {
+                flb_error("[upstream_ha] cannot create context");
+                flb_cf_destroy(cf);
+                return NULL;
+            }
+
+            /* iterate nodes (groups) */
+            mk_list_foreach(g_head, &section->groups) {
+                group = mk_list_entry(g_head, struct flb_cf_group, _head);
+
+                /*
+                 * create temporary node section: the node creation function needs a section,
+                 * which is not the same as the group but similar: we just map the name and
+                 * properties.
+                 */
+                node_section = flb_calloc(1, sizeof(struct flb_cf_section));
+                if (!node_section) {
+                    flb_errno();
+                    flb_upstream_ha_destroy(ups);
+                    flb_cf_destroy(cf);
+                    return NULL;
+                }
+                node_section->name = group->name;
+                node_section->properties = group->properties;
+
+                /* Read section info and create a Node context */
+                node = create_node(c, cf, node_section, config);
+                if (!node) {
+                    flb_error("[upstream_ha] cannot register node on upstream '%s'",
+                            tmp);
+                    flb_upstream_ha_destroy(ups);
+                    flb_cf_destroy(cf);
+                    flb_free(node_section);
+                    return NULL;
+                }
+                flb_free(node_section);
+
+                flb_upstream_ha_node_add(ups, node);
+                c++;
+            }
+        }
     }
 
     if (c == 0) {

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -728,29 +728,31 @@ struct flb_sp *flb_sp_create(struct flb_config *config)
     }
 
     /* register stream processor tasks registered through Yaml config */
-    mk_list_foreach(head, &config->cf_main->stream_processors) {
-        section = mk_list_entry(head, struct flb_cf_section, _head_section);
+    if (config->cf_main) {
+        mk_list_foreach(head, &config->cf_main->stream_processors) {
+            section = mk_list_entry(head, struct flb_cf_section, _head_section);
 
-        /* task name */
-        var = cfl_kvlist_fetch(section->properties, "name");
-        if (!var || var->type != CFL_VARIANT_STRING) {
-            flb_error("[sp] missing 'name' property in stream_processor section");
-            continue;
-        }
-        task_name = var->data.as_string;
+            /* task name */
+            var = cfl_kvlist_fetch(section->properties, "name");
+            if (!var || var->type != CFL_VARIANT_STRING) {
+                flb_error("[sp] missing 'name' property in stream_processor section");
+                continue;
+            }
+            task_name = var->data.as_string;
 
-        /* task exec/query */
-        var = cfl_kvlist_fetch(section->properties, "exec");
-        if (!var || var->type != CFL_VARIANT_STRING) {
-            flb_error("[sp] missing 'exec' property in stream_processor section");
-            continue;
-        }
-        task_exec = var->data.as_string;
+            /* task exec/query */
+            var = cfl_kvlist_fetch(section->properties, "exec");
+            if (!var || var->type != CFL_VARIANT_STRING) {
+                flb_error("[sp] missing 'exec' property in stream_processor section");
+                continue;
+            }
+            task_exec = var->data.as_string;
 
-        /* create task */
-        task = flb_sp_task_create(sp, task_name, task_exec);
-        if (!task) {
-            continue;
+            /* create task */
+            task = flb_sp_task_create(sp, task_name, task_exec);
+            if (!task) {
+                continue;
+            }
         }
     }
 

--- a/src/stream_processor/flb_sp.c
+++ b/src/stream_processor/flb_sp.c
@@ -96,10 +96,19 @@ static int sp_config_file(struct flb_config *config, struct flb_sp *sp,
         return -1;
     }
 
-    /* Read all 'stream_task' sections */
+    /*
+     * Note on reading the sections
+     * ----------------------------
+     * Classic mode configuration looks for [STREAM_TASK], while the
+     * new Yaml parser expects the section names to be stream_processor.
+     *
+     * On Yaml mode, each pair of "name/exec" is set as an independent section,
+     * so the adjusted code below works for both type of files.
+     */
     mk_list_foreach(head, &cf->sections) {
         section = mk_list_entry(head, struct flb_cf_section, _head);
-        if (strcasecmp(section->name, "stream_task") != 0) {
+        if (strcasecmp(section->name, "stream_task") != 0 &&
+            strcasecmp(section->name, "stream_processor") != 0) {
             continue;
         }
 
@@ -689,10 +698,14 @@ struct flb_sp *flb_sp_create(struct flb_config *config)
     int i = 0;
     int ret;
     char buf[32];
+    char *task_name;
+    char *task_exec;
     struct mk_list *head;
     struct flb_sp *sp;
     struct flb_slist_entry *e;
     struct flb_sp_task *task;
+    struct cfl_variant *var;
+    struct flb_cf_section *section;
 
     /* Allocate context */
     sp = flb_malloc(sizeof(struct flb_sp));
@@ -709,6 +722,33 @@ struct flb_sp *flb_sp_create(struct flb_config *config)
         snprintf(buf, sizeof(buf) - 1, "flb-console:%i", i);
         i++;
         task = flb_sp_task_create(sp, buf, e->str);
+        if (!task) {
+            continue;
+        }
+    }
+
+    /* register stream processor tasks registered through Yaml config */
+    mk_list_foreach(head, &config->cf_main->stream_processors) {
+        section = mk_list_entry(head, struct flb_cf_section, _head_section);
+
+        /* task name */
+        var = cfl_kvlist_fetch(section->properties, "name");
+        if (!var || var->type != CFL_VARIANT_STRING) {
+            flb_error("[sp] missing 'name' property in stream_processor section");
+            continue;
+        }
+        task_name = var->data.as_string;
+
+        /* task exec/query */
+        var = cfl_kvlist_fetch(section->properties, "exec");
+        if (!var || var->type != CFL_VARIANT_STRING) {
+            flb_error("[sp] missing 'exec' property in stream_processor section");
+            continue;
+        }
+        task_exec = var->data.as_string;
+
+        /* create task */
+        task = flb_sp_task_create(sp, task_name, task_exec);
         if (!task) {
             continue;
         }

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -20,7 +20,13 @@
 #define FLB_000 FLB_TESTS_CONF_PATH "/fluent-bit.yaml"
 #define FLB_001 FLB_TESTS_CONF_PATH "/issue_7559.yaml"
 #define FLB_002 FLB_TESTS_CONF_PATH "/processors.yaml"
+
+#ifdef _WIN32
+#define FLB_003 FLB_TESTS_CONF_PATH "\\parsers_and_multiline_parsers.yaml"
+#else
 #define FLB_003 FLB_TESTS_CONF_PATH "/parsers_and_multiline_parsers.yaml"
+#endif
+
 #define FLB_004 FLB_TESTS_CONF_PATH "/stream_processor.yaml"
 #define FLB_005 FLB_TESTS_CONF_PATH "/plugins.yaml"
 #define FLB_006 FLB_TESTS_CONF_PATH "/upstream.yaml"

--- a/tests/internal/data/config_format/yaml/extra_parser.yaml
+++ b/tests/internal/data/config_format/yaml/extra_parser.yaml
@@ -1,0 +1,16 @@
+parsers:
+  - name: json-2
+    format: json
+
+multiline_parsers:
+  - name: exception_test-2
+    type: regex
+    flush_timeout: 1000
+    rules:
+      - state: start_state
+        regex: "/(Dec \\d+ \\d+\\:\\d+\\:\\d+)(.*)/"
+        next_state: cont
+
+      - state: cont
+        regex: "/^\\s+at.*/"
+        next_state: cont

--- a/tests/internal/data/config_format/yaml/parsers_and_multiline_parsers.yaml
+++ b/tests/internal/data/config_format/yaml/parsers_and_multiline_parsers.yaml
@@ -1,0 +1,42 @@
+---
+service:
+  log_level: info
+  #parsers_file: parsers_multiline.conf
+
+includes:
+    - extra_parser.yaml
+
+parsers:
+  - name: json
+    format: json
+
+  - name: docker
+    format: json
+    time_key: time
+    time_format: "%Y-%m-%dT%H:%M:%S.%L"
+    time_keep: true
+
+multiline_parsers:
+  - name: exception_test
+    type: regex
+    flush_timeout: 1000
+    rules:
+      - state: start_state
+        regex: "/(Dec \\d+ \\d+\\:\\d+\\:\\d+)(.*)/"
+        next_state: cont
+
+      - state: cont
+        regex: "/^\\s+at.*/"
+        next_state: cont
+
+pipeline:
+  inputs:
+    - name: tail
+      path: ../test_multiline.log
+      read_from_head: true
+      multiline.parser: multiline-regex-test
+
+  outputs:
+    - name: stdout
+      match: '*'
+      format: json_lines

--- a/tests/internal/data/config_format/yaml/plugins.yaml
+++ b/tests/internal/data/config_format/yaml/plugins.yaml
@@ -1,0 +1,16 @@
+---
+
+plugins:
+  - /path/to/out_gstdout.so
+  - /path/to/out_fluent.so
+
+service:
+  log_level: info
+
+pipeline:
+  inputs:
+    - name: random
+
+  outputs:
+    - name: gstdout
+      match: '*'

--- a/tests/internal/data/config_format/yaml/stream_processor.yaml
+++ b/tests/internal/data/config_format/yaml/stream_processor.yaml
@@ -1,0 +1,22 @@
+---
+
+stream_processor:
+  - name: create_results
+    exec: CREATE STREAM results WITH (tag='500_error') AS SELECT * FROM STREAM:tail.0 WHERE http_status=500;
+
+  - name: select_results
+    exec: SELECT * FROM STREAM:results WHERE http_status=500;
+
+service:
+  log_level: info
+
+pipeline:
+  inputs:
+    - name: tail
+      path: test_multiline.log
+      read_from_head: true
+
+  outputs:
+    - name: stdout
+      match: '*'
+      format: json_lines

--- a/tests/internal/data/config_format/yaml/upstream.yaml
+++ b/tests/internal/data/config_format/yaml/upstream.yaml
@@ -1,0 +1,38 @@
+---
+
+upstream_servers:
+  - name: forward-balancing
+    nodes:
+      - name: node-1
+        host: 127.0.0.1
+        port: 43000
+
+      - name: node-2
+        host: 127.0.0.1
+        port: 44000
+
+      - name: node-3
+        host: 127.0.0.1
+        port: 45000
+        tls: true
+        tls_verify: false
+        shared_key: secret
+
+  - name: forward-balancing-2
+    nodes:
+      - name: node-A
+        host: 192.168.1.10
+        port: 50000
+
+      - name: node-B
+        host: 192.168.1.11
+        port: 51000
+
+pipeline:
+  inputs:
+    - name: random
+
+  outputs:
+    - name: stdout
+      match: '*'
+


### PR DESCRIPTION
The following PR/branch implements the final pieces for full Yaml support. Components that are being added to Yaml

- [x] parsers
- [x] multiline parsers
- [x] stream processor
- [x] plugins
- [x] upstream servers


__Parsers__

Parsers are now supported in the main config file or through an included Yaml file, definition:

```yaml
parsers:
  - name: json
    format: json

  - name: docker2
    format: json
    time_key: time
    time_format: "%Y-%m-%dT%H:%M:%S.%L"
    time_keep: true
```

Note that this functionality is compatible with the old service `parsers_file` directive.

__Multiline Parsers__

Multiline parsers combine logs that are split across multiple events into one, keeping the full message together, like with stack traces or detailed logs.

The current implementation in Yaml differs a bit in syntax from classic format, however there are no breaking changes. Here is an example of one multiline parser defined in the main file and other through an included file that also defines a similar section (multiline parser contain 2 rules):

```yaml
includes:
    - more_parsers.yaml
    
multiline_parsers:
  - name: multiline-regex-test
    type: regex
    flush_timeout: 1000
    rules:
      - state: start_state
        regex: '/([a-zA-Z]+ \d+ \d+:\d+:\d+)(.*)/'
        next_state: cont
      - state: cont
        regex: '/^\s+at.*/'
        next_state: cont


pipeline:
  inputs:
    - name: tail
      path: ../test_multiline.log
      read_from_head: true
      multiline.parser: multiline-regex-test

  outputs:
    - name: stdout
      match: '*'
      format: json_lines

```

__Stream Processor__

The [stream processor](https://docs.fluentbit.io/manual/stream-processing/introduction) is a little known but power functionality that allows to create new streams of data based on results done by SQL queries (including aggregation), when configured it runs right after the last filter (if set). The following is the new format to expose stream processor tasks in Yaml:

```yaml
stream_processor:
  - name: stream_chile
    exec: CREATE STREAM country_test WITH (tag='only_chile') AS SELECT word, num FROM STREAM:tail.0 WHERE country='Chile';
    
parsers:
  - name: json
    format: json

pipeline:
  inputs:
    - name: tail
      path: ../sp-samples*.log
      parser: json
      read_from_head: true

  outputs:
    - name: stdout
      match: 'only_chile'
      format: json_lines
```

__Plugins__

While Fluent Bit ships with built-in plugins, it also supports to load external plugins at runtime, this mechanism is used to load Go or Wasm plugins which are built as shared object files (.so).  Yaml is extended in two ways:

__1__. inline Yaml section

```yaml
---

plugins:
  - /home/edsiper/c/fluent-bit-go/examples/out_gstdout/out_gstdout.so

service:
  log_level: info
  plugins_file: other_plugins.yaml

pipeline:
  inputs:
    - name: random

  outputs:
    - name: gstdout
      match: '*'

```

__2__. Yaml plugins file included through `service` section `plugins_file` option:

```yaml
service:
  log_level: info
  plugins_file: extra_plugins.yaml

pipeline:
  inputs:
    - name: random

  outputs:
    - name: gstdout
      match: '*'
```

where `extra_plugins.yaml` might contain the definition described in __1__:

```yaml
plugins:
  - /home/edsiper/c/fluent-bit-go/examples/out_gstdout/out_gstdout.so

```

__Upstream Servers__

Certain output plugins supports mechanisms to connect to different endpoints through the definition of [upstream servers](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers). This PR introduces the new configuration format for Yaml.  

The new directive `upstream_servers` can define blocks of upstreams servers that are composed by one or multiple nodes, the example below defines 2 upstreams and each one with it own nodes:

```yaml
upstream_servers:
  - name: forward-balancing
    nodes:
      - name: node-1
        host: 127.0.0.1
        port: 43000

      - name: node-2
        host: 127.0.0.1
        port: 44000

      - name: node-3
        host: 127.0.0.1
        port: 45000
        tls: true
        tls_verify: false
        shared_key: secret

  - name: forward-balancing-2
    nodes:
      - name: node-A
        host: 192.168.1.10
        port: 50000

      - name: node-B
        host: 192.168.1.11
        port: 51000
```

This upstream servers can be now defined globally, however the output plugins that supports this functionality like Forward or Elasticsearch needs to add an extra configuration option to specify the upstream server to use: note that the current classic config mode they load a file and it assumes that's the only one supported.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
