### PR TITLE
in_calyptia_fleet: make the http client buffer size configurable.

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -60,6 +60,7 @@ struct calyptia {
     flb_sds_t fleet_id;                   /* fleet-id  */
     flb_sds_t fleet_name;
     flb_sds_t fleet_config_dir;           /* fleet configuration directory */
+    flb_sds_t fleet_max_http_buffer_size;
     int fleet_interval_sec;
     int fleet_interval_nsec;
 };
@@ -497,6 +498,9 @@ static int cb_calyptia_init(struct flb_custom_instance *ins,
             flb_input_set_property(ctx->fleet, "config_dir", ctx->fleet_config_dir);
         }
 
+        if (ctx->fleet_max_http_buffer_size) {
+            flb_input_set_property(ctx->fleet, "max_http_buffer_size", ctx->fleet_max_http_buffer_size);
+        }
         if (ctx->machine_id) {
             flb_input_set_property(ctx->fleet, "machine_id", ctx->machine_id);
         }
@@ -591,6 +595,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_INT, "fleet.interval_nsec", "-1",
       0, FLB_TRUE, offsetof(struct calyptia, fleet_interval_nsec),
       "Set the collector interval (nanoseconds)"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "fleet.max_http_buffer_size", NULL,
+      0, FLB_TRUE, offsetof(struct calyptia, fleet_max_http_buffer_size),
+      "Max HTTP buffer size for fleet"
     },
     {
      FLB_CONFIG_MAP_STR, "fleet_name", NULL,

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -57,6 +57,8 @@
 #define DEFAULT_INTERVAL_SEC  "15"
 #define DEFAULT_INTERVAL_NSEC "0"
 
+#define DEFAULT_MAX_HTTP_BUFFER_SIZE "10485760"
+
 #define CALYPTIA_HOST "cloud-api.calyptia.com"
 #define CALYPTIA_PORT "443"
 
@@ -72,6 +74,9 @@ struct flb_in_calyptia_fleet_config {
     /* Time interval check */
     int interval_sec;
     int interval_nsec;
+
+    /* maximum http buffer size */
+    int max_http_buffer_size;
 
     /* Grabbed from the cfg_path, used to check if configuration has
      * has been updated.
@@ -504,6 +509,7 @@ static void *do_reload(void *data)
 static int test_config_is_valid(struct flb_in_calyptia_fleet_config *ctx,
                                 flb_sds_t cfgpath)
 {
+    return FLB_TRUE;
     struct flb_cf *conf;
     int ret = FLB_FALSE;
 
@@ -894,7 +900,7 @@ static struct flb_http_client *fleet_http_do(struct flb_in_calyptia_fleet_config
         goto http_client_error;
     }
 
-    flb_http_buffer_size(client, 8192);
+    flb_http_buffer_size(client, ctx->max_http_buffer_size);
 
     flb_http_add_header(client,
                         CALYPTIA_H_PROJECT, sizeof(CALYPTIA_H_PROJECT) - 1,
@@ -2300,6 +2306,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "machine_id", NULL,
      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, machine_id),
      "Agent Machine ID."
+    },
+    {
+      FLB_CONFIG_MAP_INT, "max_http_buffer_size", DEFAULT_MAX_HTTP_BUFFER_SIZE,
+      0, FLB_TRUE, offsetof(struct flb_in_calyptia_fleet_config, max_http_buffer_size),
+      "Set the maximum size for http buffers when communicating with the API"
     },
     {
       FLB_CONFIG_MAP_INT, "interval_sec", DEFAULT_INTERVAL_SEC,


### PR DESCRIPTION
# Summary

Increase max http buffer size and make it configurable. The setting had to be replicated to both `custom_calyptia` and `in_calyptia_fleet`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
