### PR TITLE
in_splunk: splunk token validation must be case-insensitive

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -513,7 +513,7 @@ static int validate_auth_header(struct flb_splunk *ctx, struct mk_http_request *
                 continue;
             }
 
-            if (strncmp(splunk_token->header,
+            if (strncasecmp(splunk_token->header,
                         authorization,
                         splunk_token->length) == 0) {
                 flb_sds_destroy(authorization);
@@ -1046,7 +1046,7 @@ static int validate_auth_header_ng(struct flb_splunk *ctx, struct flb_http_reque
                 return SPLUNK_AUTH_UNAUTHORIZED;
             }
 
-            if (strncmp(splunk_token->header,
+            if (strncasecmp(splunk_token->header,
                         auth_header,
                         splunk_token->length) == 0) {
                 return SPLUNK_AUTH_SUCCESS;


### PR DESCRIPTION
Changes validation of received Splunk token to be case-insensitive, as the Splunk HEC does.

fixes #9517 


**Backporting**
- [x] Backport to latest stable release. #9519 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
