### PR TITLE
build: Use signed char in RISC-V 64bit

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -196,12 +196,12 @@ jobs:
             --volume "/etc/machine-id:/etc/machine-id"
           install: |
             apt-get update
-            apt-get install -y gcc-7 g++-7 clang-6.0 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common#libsystemd-dev
-            ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
+            apt-get install -y gcc-7 g++-7 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common #clang-6.0 libsystemd-dev
+            # ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 
             update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
-            update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
+            # update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
           run: |
             cd build
             export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -189,18 +189,18 @@ jobs:
         id: build-and-test-on-qemu
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           shell: /bin/bash
           dockerRunArgs: |
             --volume "/var/lib/dbus/machine-id:/var/lib/dbus/machine-id"
             --volume "/etc/machine-id:/etc/machine-id"
           install: |
             apt-get update
-            apt-get install -y gcc-9 g++-9 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common #clang-6.0 libsystemd-dev
+            apt-get install -y gcc-12 g++-12 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common #clang-6.0 libsystemd-dev
             # ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 
-            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
-            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 90
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 90
             # update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
           run: |
             cd build

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -179,6 +179,7 @@ jobs:
       matrix:
         arch:
           - s390x
+          - riscv64
     steps:
       - name: Checkout Fluent Bit code
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -196,11 +196,11 @@ jobs:
             --volume "/etc/machine-id:/etc/machine-id"
           install: |
             apt-get update
-            apt-get install -y gcc-7 g++-7 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common #clang-6.0 libsystemd-dev
+            apt-get install -y gcc-9 g++-9 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common #clang-6.0 libsystemd-dev
             # ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
 
-            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 90
-            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
             # update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
           run: |
             cd build

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -196,12 +196,10 @@ jobs:
             --volume "/etc/machine-id:/etc/machine-id"
           install: |
             apt-get update
-            apt-get install -y gcc-12 g++-12 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common #clang-6.0 libsystemd-dev
-            # ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer || true
+            apt-get install -y gcc-12 g++-12 libyaml-dev cmake flex bison libssl-dev libbpf-dev linux-tools-common
 
             update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 90
             update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 90
-            # update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 90
           run: |
             cd build
             export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,11 @@ if (FLB_SYSTEM_LINUX)
   include(cmake/s390x.cmake)
 endif ()
 
+# Build for Linux - riscv64 arch
+if (FLB_SYSTEM_LINUX)
+  include(cmake/riscv64.cmake)
+endif ()
+
 # Enable signed char support on Linux AARCH64 if specified
 if (FLB_LINUX_ON_AARCH64)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")

--- a/cmake/riscv64.cmake
+++ b/cmake/riscv64.cmake
@@ -1,0 +1,8 @@
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64)")
+  message(STATUS "Forcing characters to be signed, as on x86_64.")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")
+  if(FLB_LUAJIT)
+    message(WARNING "LuaJIT is disabled, this platform does not support built-in LuaJIT and system provided one neither.")
+    set(FLB_LUAJIT OFF)
+  endif()
+endif ()


### PR DESCRIPTION
<!-- Provide summary of changes -->

Same as other platforms, we have to use signed char even if RISC-V 64bit(riscv64).
For testing on RISCV64, we can also use uraimo/run-on-arch-action action to set up with riscv64 emulator with qemu.

In my visionfive RISC-V 64bit board, I succeeded to pass signedness sensitive tests which are flb-it-pack and flb-it-utils.
This is also causing problems on AArch64 Linux.
And there is also occurring on RISCV64 Linux.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
