### PR TITLE
tls: include X509 error string when verify result is not x509_V_OK.

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -684,6 +684,7 @@ static int tls_net_handshake(struct flb_tls *tls,
     char err_buf[256];
     struct tls_session *session = ptr_session;
     struct tls_context *ctx;
+    const char *x509_err;
 
     ctx = session->parent;
     pthread_mutex_lock(&ctx->mutex);
@@ -743,8 +744,9 @@ static int tls_net_handshake(struct flb_tls *tls,
             if (ret == 0) {
                 ssl_code = SSL_get_verify_result(session->ssl);
                 if (ssl_code != X509_V_OK) {
-                    flb_error("[tls] error: unexpected EOF with reason: %s",
-                              ERR_reason_error_string(ERR_get_error()));
+                    /* Refer to: https://x509errors.org/ */
+                    x509_err = X509_verify_cert_error_string(ssl_code);
+                    flb_error("[tls] certificate verification failed, reason: %s (X509 code: %ld)", x509_err, ssl_code);
                 }
                 else {
                     flb_error("[tls] error: unexpected EOF");


### PR DESCRIPTION
**Description**

Users with expired CA never got to understand the root cause by reading the log message, although this information is available on the x509 error details. (https://x509errors.org/) 
```
[2024/09/16 10:00:38] [error] [tls] error: unexpected EOF with reason: certificate verify failed
```

This patch adds the X509_verify_cert_error_string to the log message when SSL verification result != X509_V_OK.

With this patch applied, the following information is returned

```
[2024/10/28 22:35:46] [error] [tls] certificate verification failed, reason: unable to get local issuer certificate (X509 code: 20)
```

**Testing**

Configuration I have used.

```ini
[SERVICE]
    log_level debug

[CUSTOM]
    name calyptia
    api_key xxx
    fleet_name test-jorge
    calyptia_tls.verify on
    calyptia_host cloud-api-staging.calyptia.com
```

**Documentation**

N/A

**Backporting**

- [X] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
