### PR TITLE
processor_content_modifier: add support for Metrics processing

### DIFF
--- a/plugins/processor_content_modifier/CMakeLists.txt
+++ b/plugins/processor_content_modifier/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(src
   cm_config.c
   cm_logs.c
+  cm_metrics.c
   cm_traces.c
+  cm_opentelemetry.c
+  cm_utils.c
   cm.c
   )
 

--- a/plugins/processor_content_modifier/cm.c
+++ b/plugins/processor_content_modifier/cm.c
@@ -98,6 +98,24 @@ static int cb_process_traces(struct flb_processor_instance *ins,
 
 }
 
+static int cb_process_metrics(struct flb_processor_instance *ins,
+                              struct cmt *in_cmt,
+                              struct cmt **out_cmt,
+                              const char *tag,
+                              int tag_len)
+{
+    int ret;
+    struct content_modifier_ctx *ctx;
+
+    if (!ins->context) {
+        return FLB_PROCESSOR_FAILURE;
+    }
+    ctx = ins->context;
+
+    ret = cm_metrics_process(ins, ctx, in_cmt, out_cmt, tag, tag_len);
+    return ret;
+}
+
 static struct flb_config_map config_map[] = {
     {
         FLB_CONFIG_MAP_STR, "context", NULL,
@@ -144,7 +162,7 @@ struct flb_processor_plugin processor_content_modifier_plugin = {
     .description        = "Modify the content of Logs, Metrics and Traces",
     .cb_init            = cb_init,
     .cb_process_logs    = cb_process_logs,
-    .cb_process_metrics = NULL,
+    .cb_process_metrics = cb_process_metrics,
     .cb_process_traces  = cb_process_traces,
     .cb_exit            = cb_exit,
     .config_map         = config_map,

--- a/plugins/processor_content_modifier/cm.h
+++ b/plugins/processor_content_modifier/cm.h
@@ -116,5 +116,10 @@ int cm_traces_process(struct flb_processor_instance *ins,
                       struct ctrace *traces_context,
                       const char *tag, int tag_len);
 
+int cm_metrics_process(struct flb_processor_instance *ins,
+                       struct content_modifier_ctx *ctx,
+                       struct cmt *in_cmt,
+                       struct cmt **out_cmt,
+                       const char *tag, int tag_len);
 
 #endif

--- a/plugins/processor_content_modifier/cm_config.c
+++ b/plugins/processor_content_modifier/cm_config.c
@@ -218,6 +218,53 @@ static int set_context(struct content_modifier_ctx *ctx)
                  strcasecmp(ctx->context_str, "attributes") == 0) {
             context = CM_CONTEXT_METRIC_LABELS;
         }
+
+        /*
+         * OpenTelemetry contexts
+         * ----------------------
+         */
+        else if (strcasecmp(ctx->context_str, "otel_resource_attributes") == 0) {
+            context = CM_CONTEXT_OTEL_RESOURCE_ATTR;
+        }
+        else if (strcasecmp(ctx->context_str, "otel_scope_attributes") == 0) {
+            context = CM_CONTEXT_OTEL_SCOPE_ATTR;
+        }
+        else if (strcasecmp(ctx->context_str, "otel_scope_name") == 0) {
+            /*
+             * scope name is restricted to specific actions, make sure the user
+             * cannot messed it up
+             *
+             *   action              allowed ?
+             *   -----------------------------
+             *   CM_ACTION_INSERT       Yes
+             *   CM_ACTION_UPSERT       Yes
+             *   CM_ACTION_DELETE       Yes
+             *   CM_ACTION_RENAME        No
+             *   CM_ACTION_HASH         Yes
+             *   CM_ACTION_EXTRACT       No
+             *   CM_ACTION_CONVERT       No
+             */
+
+            if (ctx->action_type == CM_ACTION_RENAME ||
+                ctx->action_type == CM_ACTION_EXTRACT ||
+                ctx->action_type == CM_ACTION_CONVERT) {
+                flb_plg_error(ctx->ins, "action '%s' is not allowed for context '%s'",
+                              ctx->action_str, ctx->context_str);
+                return -1;
+            }
+
+            /* check that 'name' is the key set */
+            if (!ctx->key) {
+                ctx->key = flb_sds_create("name");
+            }
+            else if (strcasecmp(ctx->key, "name") != 0) {
+                flb_plg_error(ctx->ins, "context '%s' requires the name of the key to be 'name', no '%s'",
+                              ctx->context_str, ctx->key);
+                return -1;
+            }
+
+            context = CM_CONTEXT_OTEL_SCOPE_NAME;
+        }
         else {
             flb_plg_error(ctx->ins, "unknown metrics context '%s'", ctx->context_str);
             return -1;

--- a/plugins/processor_content_modifier/cm_opentelemetry.c
+++ b/plugins/processor_content_modifier/cm_opentelemetry.c
@@ -1,0 +1,272 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#include <fluent-bit/flb_processor_plugin.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_processor.h>
+#include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "cm.h"
+#include "cm_utils.h"
+
+#include <stdio.h>
+
+struct cfl_variant *cm_otel_get_or_create_attributes(struct cfl_kvlist *kvlist)
+{
+    int ret;
+    struct cfl_list *head;
+    struct cfl_list *tmp;
+    struct cfl_kvpair *kvpair;
+    struct cfl_variant *val;
+    struct cfl_kvlist *kvlist_tmp;
+
+    /* iterate resource to find the attributes field */
+    cfl_list_foreach_safe(head, tmp, &kvlist->list) {
+        kvpair = cfl_list_entry(head, struct cfl_kvpair, _head);
+        if (cfl_sds_len(kvpair->key) != 10) {
+            continue;
+        }
+
+        if (strncmp(kvpair->key, "attributes", 10) == 0) {
+            val = kvpair->val;
+            if (val->type != CFL_VARIANT_KVLIST) {
+                return NULL;
+            }
+
+            return val;
+        }
+    }
+
+    /* create an empty kvlist as the value of attributes */
+    kvlist_tmp = cfl_kvlist_create();
+    if (!kvlist_tmp) {
+        return NULL;
+    }
+
+    /* create the attributes kvpair */
+    ret = cfl_kvlist_insert_kvlist_s(kvlist, "attributes", 10, kvlist_tmp);
+    if (ret != 0) {
+        cfl_kvlist_destroy(kvlist_tmp);
+        return NULL;
+    }
+
+    /* get the last kvpair from the list */
+    kvpair = cfl_list_entry_last(&kvlist->list, struct cfl_kvpair, _head);
+    if (!kvpair) {
+        return NULL;
+    }
+
+    return kvpair->val;
+}
+
+static struct cfl_variant *otel_get_or_create_attributes(struct cfl_kvlist *kvlist)
+{
+    int ret;
+    struct cfl_list *head;
+    struct cfl_list *tmp;
+    struct cfl_kvpair *kvpair;
+    struct cfl_variant *val = NULL;
+    struct cfl_kvlist *kvlist_tmp;
+
+    /* iterate resource to find the attributes field */
+    cfl_list_foreach_safe(head, tmp, &kvlist->list) {
+        kvpair = cfl_list_entry(head, struct cfl_kvpair, _head);
+        if (cfl_sds_len(kvpair->key) != 10) {
+            continue;
+        }
+
+        if (strncmp(kvpair->key, "attributes", 10) == 0) {
+            val = kvpair->val;
+            if (val->type != CFL_VARIANT_KVLIST) {
+                return NULL;
+            }
+            return val;
+        }
+    }
+
+    /* create an empty kvlist as the value of attributes */
+    kvlist_tmp = cfl_kvlist_create();
+    if (!kvlist_tmp) {
+        return NULL;
+    }
+
+    /* create the attributes kvpair */
+    ret = cfl_kvlist_insert_kvlist_s(kvlist, "attributes", 10, kvlist_tmp);
+    if (ret != 0) {
+        cfl_kvlist_destroy(kvlist_tmp);
+        return NULL;
+    }
+
+    /* get the last kvpair from the list */
+    kvpair = cfl_list_entry_last(&kvlist->list, struct cfl_kvpair, _head);
+    if (!kvpair) {
+        return NULL;
+    }
+
+    return kvpair->val;
+}
+
+/*
+ * get attributes for resources and scope, context must be one of:
+ *
+ *  - CM_CONTEXT_OTEL_RESOURCE_ATTR
+ *  - CM_CONTEXT_OTEL_SCOPE_ATTR
+ */
+struct cfl_variant *cm_otel_get_attributes(int telemetry_type, int context, struct cfl_kvlist *kvlist)
+{
+    int key_len;
+    const char *key_buf;
+    struct cfl_variant *var;
+    struct cfl_variant *var_attr = NULL;
+
+    if (context == CM_CONTEXT_OTEL_RESOURCE_ATTR) {
+        key_buf = "resource";
+        key_len = 8;
+    }
+    else if (context == CM_CONTEXT_OTEL_SCOPE_ATTR) {
+        key_buf = "scope";
+        key_len = 5;
+    }
+    else {
+        return NULL;
+    }
+
+    var = cfl_kvlist_fetch_s(kvlist, (char *) key_buf, key_len);
+    if (!var) {
+        return NULL;
+    }
+
+    if (var->type != CFL_VARIANT_KVLIST) {
+        return NULL;
+    }
+
+    var_attr = otel_get_or_create_attributes(var->data.as_kvlist);
+    if (!var_attr) {
+        return NULL;
+    }
+
+    return var_attr;
+}
+
+static struct cfl_variant *otel_get_or_create_scope_metadata(int telemetry_type, struct cfl_kvlist *kvlist)
+{
+    int ret;
+    struct cfl_variant *var;
+    struct cfl_kvpair *kvpair;
+    struct cfl_kvlist *kvlist_tmp;
+
+    /* kvlist is the value of 'scope', lookup for scope->metadata */
+
+    var  = cfl_kvlist_fetch(kvlist, "metadata");
+    if (var) {
+        if (var->type != CFL_VARIANT_KVLIST) {
+            return NULL;
+        }
+
+        return var;
+    }
+
+    /* metadata don't exists, create it */
+    kvlist_tmp = cfl_kvlist_create();
+    if (!kvlist_tmp) {
+        return NULL;
+    }
+
+    ret = cfl_kvlist_insert_kvlist_s(kvlist, "metadata", 8, kvlist_tmp);
+    if (ret != 0) {
+        cfl_kvlist_destroy(kvlist_tmp);
+        return NULL;
+    }
+
+    kvpair = cfl_list_entry_last(&kvlist->list, struct cfl_kvpair, _head);
+    if (!kvpair) {
+        return NULL;
+    }
+
+    return kvpair->val;
+}
+
+/*
+ * Retrieve the kvlist that contains the scope metadata such as name and version,
+ * based on the telemetry type, the kvlist is expected to be in the following format:
+ *
+ *  - Logs: scope -> {name, version}
+ *  - Metrics: scope -> metadata -> {name, version}
+ *
+ *  If the paths are not found, those are "created".
+ */
+struct cfl_variant *cm_otel_get_scope_metadata(int telemetry_type, struct cfl_kvlist *kvlist)
+{
+    int ret;
+    struct cfl_variant *var = NULL;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_kvlist *kvlist_tmp;
+
+    if (!kvlist) {
+        return NULL;
+    }
+
+    /* retrieve the scope if exists */
+    var = cfl_kvlist_fetch(kvlist, "scope");
+    if (var) {
+        if (var->type != CFL_VARIANT_KVLIST) {
+            /* if exists and is not valid just fail */
+            return NULL;
+        }
+    }
+    else {
+        /* create "scope" inside kvlist */
+        kvlist_tmp = cfl_kvlist_create();
+        if (!kvlist_tmp) {
+            return NULL;
+        }
+
+        ret = cfl_kvlist_insert_kvlist_s(kvlist, "scope", 5, kvlist_tmp);
+        if (ret != 0) {
+            cfl_kvlist_destroy(kvlist_tmp);
+            return NULL;
+        }
+
+        kvpair = cfl_list_entry_last(&kvlist->list, struct cfl_kvpair, _head);
+        if (!kvpair) {
+            return NULL;
+        }
+
+        var = kvpair->val;
+    }
+
+    /*
+     * 'var' points to the value of 'scope', for logs telemetry data, just return
+     * the current variant, for metrics lookup for 'metadata' kvpair (or create it)
+     */
+
+    if (telemetry_type == CM_TELEMETRY_LOGS) {
+        return var;
+    }
+    else if (telemetry_type == CM_TELEMETRY_METRICS) {
+        var = otel_get_or_create_scope_metadata(telemetry_type, var->data.as_kvlist);
+    }
+
+    return var;
+}

--- a/plugins/processor_content_modifier/cm_opentelemetry.h
+++ b/plugins/processor_content_modifier/cm_opentelemetry.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PROCESSOR_CONTENT_MODIFIER_OTEL_H
+#define FLB_PROCESSOR_CONTENT_MODIFIER_OTEL_H
+
+#include <cfl/cfl.h>
+
+struct cfl_variant *cm_otel_get_attributes(int telemetry_type, int context, struct cfl_kvlist *kvlist);
+struct cfl_variant *cm_otel_get_scope_metadata(int telemetry_type, struct cfl_kvlist *kvlist);
+
+#endif

--- a/plugins/processor_content_modifier/cm_traces.c
+++ b/plugins/processor_content_modifier/cm_traces.c
@@ -23,8 +23,6 @@
 #include <fluent-bit/flb_processor.h>
 #include <cfl/cfl.h>
 
-//#include "variant_utils.h"
-
 #include "cm.h"
 #include "cm_utils.h"
 
@@ -117,9 +115,9 @@ static int span_convert_attribute(struct ctrace_span *span,
         return FLB_FALSE;
     }
 
-    ret = cfl_variant_convert(attribute,
-                              &converted_attribute,
-                              new_type);
+    ret = cm_utils_variant_convert(attribute,
+                                   &converted_attribute,
+                                   new_type);
 
     if (ret != FLB_TRUE) {
         return FLB_FALSE;
@@ -262,107 +260,6 @@ static int context_contains_attribute(struct ctrace *traces_context,
     return FLB_FALSE;
 }
 
-static int hex_encode(unsigned char *input_buffer,
-                      size_t input_length,
-                      cfl_sds_t *output_buffer)
-{
-    const char hex[] = "0123456789abcdef";
-    cfl_sds_t  result;
-    size_t     index;
-
-    if (cfl_sds_alloc(*output_buffer) <= (input_length * 2)) {
-        result = cfl_sds_increase(*output_buffer,
-                                  (input_length * 2) -
-                                  cfl_sds_alloc(*output_buffer));
-
-        if (result == NULL) {
-            return FLB_FALSE;
-        }
-
-        *output_buffer = result;
-    }
-
-    for (index = 0; index < input_length; index++) {
-        (*output_buffer)[index * 2 + 0] = hex[(input_buffer[index] >> 4) & 0xF];
-        (*output_buffer)[index * 2 + 1] = hex[(input_buffer[index] >> 0) & 0xF];
-    }
-
-    cfl_sds_set_len(*output_buffer, input_length * 2);
-
-    (*output_buffer)[index * 2] = '\0';
-
-    return FLB_TRUE;
-}
-
-static int hash_transformer(void *context, struct cfl_variant *value)
-{
-    unsigned char       digest_buffer[32];
-    struct cfl_variant *converted_value;
-    cfl_sds_t           encoded_hash;
-    int                 result;
-
-    if (value == NULL) {
-        return FLB_FALSE;
-    }
-
-    result = cfl_variant_convert(value,
-                                 &converted_value,
-                                 CFL_VARIANT_STRING);
-
-    if (result != FLB_TRUE) {
-        return FLB_FALSE;
-    }
-
-    if (cfl_sds_len(converted_value->data.as_string) == 0) {
-        cfl_variant_destroy(converted_value);
-        return FLB_TRUE;
-    }
-
-    result = flb_hash_simple(FLB_HASH_SHA256,
-                             (unsigned char *) converted_value->data.as_string,
-                             cfl_sds_len(converted_value->data.as_string),
-                             digest_buffer,
-                             sizeof(digest_buffer));
-
-    if (result != FLB_CRYPTO_SUCCESS) {
-        cfl_variant_destroy(converted_value);
-        return FLB_FALSE;
-    }
-
-    result = hex_encode(digest_buffer,
-                        sizeof(digest_buffer),
-                        &converted_value->data.as_string);
-
-    if (result != FLB_TRUE) {
-        cfl_variant_destroy(converted_value);
-        return FLB_FALSE;
-    }
-
-    encoded_hash = cfl_sds_create(converted_value->data.as_string);
-    if (encoded_hash == NULL) {
-        cfl_variant_destroy(converted_value);
-        return FLB_FALSE;
-    }
-    cfl_variant_destroy(converted_value);
-
-
-    if (value->type == CFL_VARIANT_STRING ||
-        value->type == CFL_VARIANT_BYTES) {
-        cfl_sds_destroy(value->data.as_string);
-    }
-    else if (value->type == CFL_VARIANT_ARRAY) {
-        cfl_array_destroy(value->data.as_array);
-    }
-    else if (value->type == CFL_VARIANT_KVLIST) {
-        cfl_kvlist_destroy(value->data.as_kvlist);
-    }
-
-    value->type = CFL_VARIANT_STRING;
-    value->data.as_string = encoded_hash;
-
-    return FLB_TRUE;
-}
-
 static int traces_context_hash_attribute(struct ctrace *traces_context,
                                          char *name)
 {
@@ -374,7 +271,7 @@ static int traces_context_hash_attribute(struct ctrace *traces_context,
                               struct ctrace_span, _head_global);
 
         if (span_contains_attribute(span, name) == FLB_TRUE) {
-            if (span_transform_attribute(span, name, hash_transformer) != FLB_TRUE) {
+            if (span_transform_attribute(span, name, cm_utils_hash_transformer) != FLB_TRUE) {
                 return FLB_FALSE;
             }
         }

--- a/plugins/processor_content_modifier/cm_utils.c
+++ b/plugins/processor_content_modifier/cm_utils.c
@@ -1,0 +1,357 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_processor.h>
+#include <fluent-bit/flb_pack.h>
+#include <cfl/cfl.h>
+
+#include "cm.h"
+#include "cm_utils.h"
+
+#include <math.h>
+static int hex_encode(unsigned char *input_buffer, size_t input_length, cfl_sds_t *output_buffer)
+{
+    const char hex[] = "0123456789abcdef";
+    cfl_sds_t  result;
+    size_t     index;
+
+    if (cfl_sds_alloc(*output_buffer) <= (input_length * 2)) {
+        result = cfl_sds_increase(*output_buffer,
+                                  (input_length * 2) -
+                                  cfl_sds_alloc(*output_buffer));
+
+        if (result == NULL) {
+            return FLB_FALSE;
+        }
+
+        *output_buffer = result;
+    }
+
+    for (index = 0; index < input_length; index++) {
+        (*output_buffer)[index * 2 + 0] = hex[(input_buffer[index] >> 4) & 0xF];
+        (*output_buffer)[index * 2 + 1] = hex[(input_buffer[index] >> 0) & 0xF];
+    }
+
+    cfl_sds_set_len(*output_buffer, input_length * 2);
+
+    (*output_buffer)[index * 2] = '\0';
+
+    return FLB_TRUE;
+}
+
+
+int cm_utils_hash_transformer(void *context, struct cfl_variant *value)
+{
+    unsigned char       digest_buffer[32];
+    struct cfl_variant *converted_value;
+    cfl_sds_t           encoded_hash;
+    int                 result;
+
+    if (value == NULL) {
+        return FLB_FALSE;
+    }
+
+    result = cm_utils_variant_convert(value,
+                                      &converted_value,
+                                      CFL_VARIANT_STRING);
+
+    if (result != FLB_TRUE) {
+        return FLB_FALSE;
+    }
+
+    if (cfl_variant_size_get(converted_value) == 0) {
+        cfl_variant_destroy(converted_value);
+        return FLB_TRUE;
+    }
+
+    result = flb_hash_simple(FLB_HASH_SHA256,
+                             (unsigned char *) converted_value->data.as_string,
+                             cfl_sds_len(converted_value->data.as_string),
+                             digest_buffer,
+                             sizeof(digest_buffer));
+
+    if (result != FLB_CRYPTO_SUCCESS) {
+        cfl_variant_destroy(converted_value);
+
+        return FLB_FALSE;
+    }
+
+    result = hex_encode(digest_buffer,
+                        sizeof(digest_buffer),
+                        &converted_value->data.as_string);
+
+    if (result != FLB_TRUE) {
+        cfl_variant_destroy(converted_value);
+
+        return FLB_FALSE;
+    }
+
+    encoded_hash = cfl_sds_create(converted_value->data.as_string);
+    cfl_variant_destroy(converted_value);
+    if (encoded_hash == NULL) {
+        return FLB_FALSE;
+    }
+
+    /* NOTE: this part does a manual modification of the variant content */
+    if (value->type == CFL_VARIANT_STRING ||
+        value->type == CFL_VARIANT_BYTES) {
+        if (value->referenced == CFL_FALSE) {
+            cfl_sds_destroy(value->data.as_string);
+        }
+    }
+    else if (value->type == CFL_VARIANT_ARRAY) {
+        cfl_array_destroy(value->data.as_array);
+    }
+    else if (value->type == CFL_VARIANT_KVLIST) {
+        cfl_kvlist_destroy(value->data.as_kvlist);
+    }
+
+    value->type = CFL_VARIANT_STRING;
+    value->data.as_string = encoded_hash;
+    value->referenced = CFL_FALSE;
+
+    cfl_variant_size_set(value, cfl_sds_len(encoded_hash));
+
+    return FLB_TRUE;
+}
+
+cfl_sds_t cm_utils_variant_convert_to_json(struct cfl_variant *value)
+{
+    cfl_sds_t      json_result;
+    mpack_writer_t writer;
+    char          *data;
+    size_t         size;
+
+    data = NULL;
+    size = 0;
+
+    mpack_writer_init_growable(&writer, &data, &size);
+
+    pack_cfl_variant(&writer, value);
+
+    mpack_writer_destroy(&writer);
+
+    json_result = flb_msgpack_raw_to_json_sds(data, size);
+
+    return json_result;
+}
+
+int cm_utils_variant_convert(struct cfl_variant *input_value,
+                             struct cfl_variant **output_value,
+                             int output_type)
+{
+    int ret;
+    int errno_backup;
+    int64_t as_int;
+    double as_double;
+    char buf[64];
+    char *str = NULL;
+    char *converstion_canary = NULL;
+    struct cfl_variant *tmp = NULL;
+
+    errno_backup = errno;
+
+    /* input: string, bytes or reference */
+    if (input_value->type == CFL_VARIANT_STRING || input_value->type == CFL_VARIANT_BYTES ||
+        input_value->type == CFL_VARIANT_REFERENCE) {
+
+        if (output_type == CFL_VARIANT_STRING ||
+            output_type == CFL_VARIANT_BYTES) {
+
+            tmp = cfl_variant_create_from_string_s(input_value->data.as_string,
+                                                   cfl_variant_size_get(input_value),
+                                                   CFL_FALSE);
+            if (!tmp) {
+                return CFL_FALSE;
+            }
+        }
+        else if (output_type == CFL_VARIANT_BOOL) {
+            as_int = CFL_FALSE;
+
+            if (cfl_variant_size_get(input_value) == 4 &&
+                strncasecmp(input_value->data.as_string, "true", 4) == 0) {
+                as_int = CFL_TRUE;
+            }
+            else if (cfl_variant_size_get(input_value) == 5 &&
+                strncasecmp(input_value->data.as_string, "false", 5) == 0) {
+                as_int = CFL_FALSE;
+            }
+
+            tmp = cfl_variant_create_from_bool(as_int);
+        }
+        else if (output_type == CFL_VARIANT_INT) {
+            errno = 0;
+
+            if (input_value->referenced) {
+                tmp = cfl_variant_create_from_string_s(input_value->data.as_string,
+                                                       cfl_variant_size_get(input_value),
+                                                       CFL_FALSE);
+                if (!tmp) {
+                    return CFL_FALSE;
+                }
+                str = tmp->data.as_string;
+            }
+            else {
+                str = input_value->data.as_string;
+            }
+
+            as_int = strtoimax(str, &converstion_canary, 10);
+            if (errno == ERANGE || errno == EINVAL) {
+                errno = errno_backup;
+                if (tmp) {
+                    cfl_variant_destroy(tmp);
+                }
+                return CFL_FALSE;
+            }
+
+            if (tmp) {
+                cfl_variant_destroy(tmp);
+            }
+
+            tmp = cfl_variant_create_from_int64(as_int);
+        }
+        else if (output_type == CFL_VARIANT_DOUBLE) {
+            errno = 0;
+            converstion_canary = NULL;
+
+            if (input_value->referenced) {
+                tmp = cfl_variant_create_from_string_s(input_value->data.as_string,
+                                                       cfl_variant_size_get(input_value),
+                                                       CFL_FALSE);
+                if (!tmp) {
+                    return CFL_FALSE;
+                }
+                str = tmp->data.as_string;
+            }
+            else {
+                str = input_value->data.as_string;
+            }
+
+            as_double = strtod(str, &converstion_canary);
+            if (errno == ERANGE) {
+                errno = errno_backup;
+                if (tmp) {
+                    cfl_variant_destroy(tmp);
+                }
+                return CFL_FALSE;
+            }
+
+            if (tmp) {
+                cfl_variant_destroy(tmp);
+            }
+
+            if (as_double == 0 && converstion_canary == input_value->data.as_string) {
+                errno = errno_backup;
+                return CFL_FALSE;
+            }
+
+            tmp = cfl_variant_create_from_double(as_double);
+        }
+        else {
+            return CFL_FALSE;
+        }
+    }
+    /* input: int */
+    else if (input_value->type == CFL_VARIANT_INT) {
+        if (output_type == CFL_VARIANT_STRING || output_type == CFL_VARIANT_BYTES) {
+            ret = snprintf(buf, sizeof(buf), "%" PRIi64, input_value->data.as_int64);
+            if (ret < 0 || ret >= sizeof(buf)) {
+                return CFL_FALSE;
+            }
+            tmp = cfl_variant_create_from_string_s(buf, ret, CFL_FALSE);
+        }
+        else if (output_type == CFL_VARIANT_BOOL) {
+            as_int = CFL_FALSE;
+            if (input_value->data.as_int64 != 0) {
+                as_int = CFL_TRUE;
+            }
+
+            tmp = cfl_variant_create_from_bool(as_int);
+        }
+        else if (output_type == CFL_VARIANT_INT) {
+            /* same type, do nothing */
+        }
+        else if (output_type == CFL_VARIANT_DOUBLE) {
+            as_double = (double) input_value->data.as_int64;
+            tmp = cfl_variant_create_from_double(as_double);
+        }
+        else {
+            return CFL_FALSE;
+        }
+    }
+    else if (input_value->type == CFL_VARIANT_DOUBLE) {
+        if (output_type == CFL_VARIANT_STRING ||
+            output_type == CFL_VARIANT_BYTES) {
+
+            ret = snprintf(buf, sizeof(buf), "%.17g", input_value->data.as_double);
+            if (ret < 0 || ret >= sizeof(buf)) {
+                return CFL_FALSE;
+            }
+            tmp = cfl_variant_create_from_string_s(buf, ret, CFL_FALSE);
+        }
+        else if (output_type == CFL_VARIANT_BOOL) {
+            as_int = CFL_FALSE;
+
+            if (input_value->data.as_double != 0) {
+                as_int = CFL_TRUE;
+            }
+
+            tmp = cfl_variant_create_from_bool(as_int);
+        }
+        else if (output_type == CFL_VARIANT_INT) {
+            as_int = (int64_t) round(input_value->data.as_double);
+            tmp = cfl_variant_create_from_int64(as_int);
+        }
+        else if (output_type == CFL_VARIANT_DOUBLE) {
+            as_double = input_value->data.as_int64;
+            tmp = cfl_variant_create_from_double(as_double);
+        }
+        else {
+            return CFL_FALSE;
+        }
+    }
+    else if (input_value->type == CFL_VARIANT_NULL) {
+        if (output_type == CFL_VARIANT_STRING ||
+            output_type == CFL_VARIANT_BYTES) {
+
+            tmp = cfl_variant_create_from_string_s("null", 4, CFL_FALSE);
+        }
+        else if (output_type == CFL_VARIANT_BOOL) {
+            tmp = cfl_variant_create_from_bool(CFL_FALSE);
+        }
+        else if (output_type == CFL_VARIANT_INT) {
+            tmp = cfl_variant_create_from_int64(0);
+        }
+        else if (output_type == CFL_VARIANT_DOUBLE) {
+            tmp = cfl_variant_create_from_double(0);
+        }
+        else {
+            return CFL_FALSE;
+        }
+    }
+    else {
+        return CFL_FALSE;
+    }
+
+    *output_value = tmp;
+    return FLB_TRUE;
+}

--- a/plugins/processor_content_modifier/cm_utils.h
+++ b/plugins/processor_content_modifier/cm_utils.h
@@ -629,5 +629,10 @@ int cfl_variant_convert(struct cfl_variant *input_value,
                         int output_type);
 
 
+int cm_utils_hash_transformer(void *context, struct cfl_variant *value);
+cfl_sds_t cm_utils_variant_convert_to_json(struct cfl_variant *value);
+int cm_utils_variant_convert(struct cfl_variant *input_value,
+                             struct cfl_variant **output_value,
+                             int output_type);
 
 #endif

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -660,11 +660,13 @@ int flb_processor_run(struct flb_processor *proc,
                         return -1;
                     }
 
-                    if (cur_buf != data) {
+                    if (cur_buf != data && cur_buf != tmp_buf) {
                         cmt_destroy(cur_buf);
                     }
 
-                    cur_buf = (void *)tmp_buf;
+                    if (tmp_buf != NULL) {
+                        cur_buf = tmp_buf;
+                    }
                 }
             }
             else if (type == FLB_PROCESSOR_TRACES) {

--- a/tests/runtime/processor_content_modifier.c
+++ b/tests/runtime/processor_content_modifier.c
@@ -2,8 +2,7 @@
 
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2019-2024 The Fluent Bit Authors
- *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
The following PR extends Content Modifier processor allowing to operate on metrics generated originally by OpenTelemetry. The following contexts are available for metrics:

- `otel_resource_attributes`
- `otel_scope_name`
- `otel_scope_version`

usage example:

```yaml
service:
  log_level: info

pipeline:
  inputs:
    - name: opentelemetry
      processors:
        metrics:
          - name: content_modifier
            context: otel_scope_name
            action: upsert
            value: "fluent-bit-scope"

          - name: content_modifier
            context: otel_scope_attributes
            action: upsert
            key: scope_attr_processor
            value: "attributes fluent-bit"

          - name: content_modifier
            context: otel_scope_name
            action: upsert
            value: "new-scope-name"

          - name: content_modifier
            context: otel_resource_attributes
            action: insert
            key: "added_by"
            value: "fluent-bit"

          - name: content_modifier
            context: otel_resource_attributes
            action: insert
            key: "http.url"
            value: https://fluentbit.io/blog/?this=that

          - name: content_modifier
            context: otel_resource_attributes
            action: upsert
            key: "added_by"
            value: "fluent-bit v3.2"

          - name: content_modifier
            context: otel_resource_attributes
            action: delete
            key: "service.name"

          - name: content_modifier
            context: otel_resource_attributes
            action: rename
            key: "telemetry.sdk.language"
            value: "my-sdk"

          - name: content_modifier
            context: otel_resource_attributes
            action: hash
            key: "host.hostname"

          - name: content_modifier
            context: otel_resource_attributes
            action: extract
            key: "http.url"
            pattern: ^(?<http_protocol>https?):\/\/(?<http_domain>[^\/\?]+)(?<http_path>\/[^?]*)?(?:\?(?<http_query_params>.*))?

          - name: content_modifier
            context: otel_resource_attributes
            action: insert
            key: "is_it_sunny"
            value: "true"

          - name: content_modifier
            context: otel_resource_attributes
            action: convert
            key: is_it_sunny
            converted_type: boolean

  outputs:
    - name: stdout
      match: "*"
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
