### PR TITLE
in_process_exporter_metrics: Fix error logic when directory cannot be…

### DIFF
--- a/plugins/in_process_exporter_metrics/pe_process.c
+++ b/plugins/in_process_exporter_metrics/pe_process.c
@@ -759,8 +759,10 @@ static int process_proc_fds(struct flb_pe *ctx, uint64_t ts,
 
     snprintf(fd_procfs, sizeof(fd_procfs) - 1, "%s/%s", process->str, "fd");
     dir = opendir(fd_procfs);
-    if (dir == NULL && errno == EACCES) {
-        flb_plg_debug(ctx->ins, "NO read access for path: %s", fd_procfs);
+    if (dir == NULL) {
+        if (errno == EACCES) {
+            flb_plg_debug(ctx->ins, "NO read access for path: %s", fd_procfs);
+        }
         return -1;
     }
 


### PR DESCRIPTION
… opened.

Fixes https://github.com/fluent/fluent-bit/issues/9548

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [n/a] Example configuration file for the change
- [n/a] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [n/a] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [n/a] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [n/a] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [n/a] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
