### PR TITLE
in_calyptia_fleet: fleet id search by name must use exact name.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -948,7 +948,7 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
         return -1;
     }
 
-    flb_sds_printf(&url, "/v1/search?project_id=%s&resource=fleet&term=%s",
+    flb_sds_printf(&url, "/v1/search?project_id=%s&resource=fleet&term=%s&exact=true",
                    project_id, ctx->fleet_name);
 
     client = fleet_http_do(ctx, url);


### PR DESCRIPTION
Given that this search is to get a fleet id, it should only return either 0 or 1 match. For this, this must be case-sensitive and do not return partial matches.

This is based on https://github.com/chronosphereio/calyptia-backend/blob/2704bda975697f64fd962a3d0d2d3bc6dae247ac/components/cloud/spec/open-api.yml#L9706-L9709

and https://github.com/chronosphereio/calyptia-backend/blob/2704bda975697f64fd962a3d0d2d3bc6dae247ac/components/cloud/internal/postgres/search.go#L15-L19

----

Tests with the CLI:

Starting point is, I have a fleet named `TEST-case` 

```text
➜  ~ calyptia create fleet --name test-case
Error: fleet name taken
➜  ~ calyptia get fleet test-case
Error: could not find fleet "test-case"
➜  ~ calyptia get fleet TEST-case
NAME      TAGS AGE
TEST-case      1 hour
```

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
