### PR TITLE
cfl_record_accessor: cfl_ra_key: Implement generic CFL based record accessor

### DIFF
--- a/include/fluent-bit/flb_cfl_ra_key.h
+++ b/include/fluent-bit/flb_cfl_ra_key.h
@@ -1,0 +1,74 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_CFL_RA_KEY_H
+#define FLB_CFL_RA_KEY_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/record_accessor/flb_ra_parser.h>
+#include <monkey/mk_core.h>
+#include <cfl/cfl.h>
+
+#include <stdbool.h>
+
+enum cfl_ra_types {
+    FLB_CFL_RA_BOOL = 0,
+    FLB_CFL_RA_INT,
+    FLB_CFL_RA_FLOAT,
+    FLB_CFL_RA_STRING,
+    FLB_CFL_RA_NULL
+};
+
+/* condition value types */
+typedef union {
+    bool boolean;
+    int64_t i64;
+    double f64;
+    flb_sds_t string;
+} cfl_ra_val;
+
+/* Represent any value object */
+struct flb_cfl_ra_value {
+    int type;
+    struct cfl_variant v;
+    cfl_ra_val val;
+};
+
+struct flb_cfl_ra_value *flb_cfl_ra_key_to_value(flb_sds_t ckey,
+                                                   struct cfl_variant vobj,
+                                                   struct mk_list *subkeys);
+void flb_cfl_ra_key_value_destroy(struct flb_cfl_ra_value *v);
+
+int flb_cfl_ra_key_value_get(flb_sds_t ckey, struct cfl_variant vobj,
+                             struct mk_list *subkeys,
+                             cfl_sds_t *start_key,
+                             cfl_sds_t *out_key, struct cfl_variant **out_val);
+
+int flb_cfl_ra_key_strcmp(flb_sds_t ckey, struct cfl_variant vobj,
+                          struct mk_list *subkeys, char *str, int len);
+int flb_cfl_ra_key_regex_match(flb_sds_t ckey, struct cfl_variant vobj,
+                               struct mk_list *subkeys, struct flb_regex *regex,
+                               struct flb_regex_search *result);
+int flb_cfl_ra_key_value_append(struct flb_ra_parser *rp, struct cfl_variant *vobj,
+                                struct cfl_variant *in_val);
+int flb_cfl_ra_key_value_update(struct flb_ra_parser *rp,  struct cfl_variant *vobj,
+                                cfl_sds_t in_key, struct cfl_variant *in_val);
+#endif

--- a/include/fluent-bit/flb_cfl_record_accessor.h
+++ b/include/fluent-bit/flb_cfl_record_accessor.h
@@ -1,0 +1,64 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_CFL_RECORD_ACCESSOR_H
+#define FLB_CFL_RECORD_ACCESSOR_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_sds_list.h>
+#include <monkey/mk_core.h>
+#include <cfl/cfl.h>
+
+struct flb_cfl_record_accessor {
+    size_t size_hint;
+    flb_sds_t pattern;
+    struct mk_list list;         /* List of parsed strings */
+    struct mk_list _head;        /* Head to custom list (only used by flb_mp.h) */
+};
+void flb_cfl_ra_destroy(struct flb_cfl_record_accessor *cra);
+int flb_cfl_ra_subkey_count(struct flb_cfl_record_accessor *cra);
+struct flb_cfl_record_accessor *flb_cfl_ra_create(char *str, int translate_env);
+flb_sds_t flb_cfl_ra_create_str_from_list(struct flb_sds_list *str_list);
+struct flb_cfl_record_accessor *flb_cfl_ra_create_from_list(struct flb_sds_list *str_list, int translate_env);
+flb_sds_t flb_cfl_ra_translate(struct flb_cfl_record_accessor *cra,
+                                char *tag, int tag_len,
+                                struct cfl_variant var, struct flb_regex_search *result);
+flb_sds_t flb_cfl_ra_translate_check(struct flb_cfl_record_accessor *cra,
+                                      char *tag, int tag_len,
+                                      struct cfl_variant var, struct flb_regex_search *result,
+                                      int check);
+void flb_cfl_ra_dump(struct flb_cfl_record_accessor *cra);
+int flb_cfl_ra_is_static(struct flb_cfl_record_accessor *cra);
+int flb_cfl_ra_strcmp(struct flb_cfl_record_accessor *ra, struct cfl_variant var,
+                      char *str, int len);
+int flb_cfl_ra_regex_match(struct flb_cfl_record_accessor *cra, struct cfl_variant var,
+                           struct flb_regex *regex, struct flb_regex_search *result);
+int flb_cfl_ra_get_kv_pair(struct flb_cfl_record_accessor *ra,
+                           struct cfl_variant var,
+                           cfl_sds_t *start_key,
+                           cfl_sds_t *out_key, struct cfl_variant **out_val);
+struct flb_cfl_ra_value *flb_cfl_ra_get_value_object(struct flb_cfl_record_accessor *cra,
+                                                     struct cfl_variant var);
+int flb_cfl_ra_update_kv_pair(struct flb_cfl_record_accessor *cra, struct cfl_variant var,
+                              cfl_sds_t in_key, struct cfl_variant *in_val);
+int flb_cfl_ra_append_kv_pair(struct flb_cfl_record_accessor *cra, struct cfl_variant var,
+                              struct cfl_variant *in_val);
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ set(src
   flb_notification.c
   flb_lock.c
   flb_cfl_ra_key.c
+  flb_cfl_record_accessor.c
   )
 
 # Config format

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(src
   flb_msgpack_append_message.c
   flb_notification.c
   flb_lock.c
+  flb_cfl_ra_key.c
   )
 
 # Config format

--- a/src/flb_cfl_ra_key.c
+++ b/src/flb_cfl_ra_key.c
@@ -1,0 +1,833 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_regex.h>
+#include <fluent-bit/flb_cfl_ra_key.h>
+#include <fluent-bit/record_accessor/flb_ra_parser.h>
+#include <cfl/cfl.h>
+#include <limits.h>
+
+/* Map cfl variant into flb_cfl_ra_value representation */
+static int cfl_variant_to_ra_value(struct cfl_variant v,
+                                   struct flb_cfl_ra_value *result)
+{
+    result->v = v;
+
+    /* Compose result with found value */
+    if (v.type == CFL_VARIANT_BOOL) {
+        result->type = FLB_CFL_RA_BOOL;
+        result->val.boolean = v.data.as_bool;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_INT) {
+        result->type = FLB_CFL_RA_INT;
+        result->val.i64 = v.data.as_int64;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_UINT) {
+        result->type = FLB_CFL_RA_INT;
+        result->val.i64 = v.data.as_uint64;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_DOUBLE) {
+        result->type = FLB_CFL_RA_FLOAT;
+        result->val.f64 = v.data.as_double;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_NULL) {
+        result->type = FLB_CFL_RA_NULL;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_STRING) {
+        result->type = FLB_CFL_RA_STRING;
+        result->val.string = v.data.as_string;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_BYTES) {
+        result->type = FLB_CFL_RA_STRING;
+        result->val.string = v.data.as_bytes;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_ARRAY) {
+        /* return boolean 'true', just denoting the existence of the key */
+        result->type = FLB_CFL_RA_BOOL;
+        result->val.boolean = true;
+        return 0;
+    }
+    else if (v.type == CFL_VARIANT_KVLIST) {
+        /* return boolean 'true', just denoting the existence of the key */
+        result->type = FLB_CFL_RA_BOOL;
+        result->val.boolean = true;
+        return 0;
+    }
+
+    return -1;
+}
+
+static struct cfl_kvpair *cfl_variant_kvpair_get(struct cfl_variant *vobj, cfl_sds_t key)
+{
+    struct cfl_list *head;
+    struct cfl_kvlist *kvlist;
+    struct cfl_kvpair *kvpair;
+
+    if (!vobj) {
+        return NULL;
+    }
+
+    switch (vobj->type) {
+    case CFL_VARIANT_BOOL:
+    case CFL_VARIANT_INT:
+    case CFL_VARIANT_UINT:
+    case CFL_VARIANT_DOUBLE:
+    case CFL_VARIANT_NULL:
+    case CFL_VARIANT_REFERENCE:
+    case CFL_VARIANT_STRING:
+    case CFL_VARIANT_BYTES:
+    case CFL_VARIANT_ARRAY:
+        return NULL;
+    case CFL_VARIANT_KVLIST:
+        break;
+    }
+
+    kvlist = vobj->data.as_kvlist;
+    cfl_list_foreach_r(head, &kvlist->list) {
+        kvpair = cfl_list_entry(head, struct cfl_kvpair, _head);
+
+        if (cfl_sds_len(key) != cfl_sds_len(kvpair->key)) {
+            continue;
+        }
+
+        if (strncmp(key, kvpair->key, cfl_sds_len(key)) == 0) {
+            return kvpair;
+        }
+    }
+
+    return NULL;
+}
+
+/* Lookup perfect match of sub-keys and cfl_variant content */
+static int subkey_to_variant(struct cfl_variant *vobj, struct mk_list *subkeys,
+                             cfl_sds_t *out_key, struct cfl_variant **out_val)
+{
+    int levels;
+    int matched = 0;
+    cfl_sds_t found = NULL;
+    cfl_sds_t key = NULL;
+    struct cfl_variant *val = NULL;
+    struct cfl_kvpair *kvpair = NULL;
+    struct mk_list *head;
+    struct cfl_variant cur;
+    struct flb_ra_subentry *entry = NULL;
+
+    /* Expected number of map levels in the map */
+    levels = mk_list_size(subkeys);
+
+    cur = *vobj;
+
+    mk_list_foreach(head, subkeys) {
+        /* expected entry */
+        entry = mk_list_entry(head, struct flb_ra_subentry, _head);
+
+        /* Array Handling */
+        if (entry->type == FLB_RA_PARSER_ARRAY_ID) {
+            /* check the current cfl_variant is a kvlist */
+            if (cur.type != CFL_VARIANT_ARRAY) {
+                return -1;
+            }
+
+            /* Index limit and ensure no overflow */
+            if (entry->array_id == INT_MAX ||
+                cfl_array_size(cur.data.as_array) < entry->array_id + 1) {
+                return -1;
+            }
+
+            val = cur.data.as_array->entries[entry->array_id];
+            cur = *val;
+            key = NULL; /* fill NULL since the type is array. */
+            goto next;
+        }
+
+        if (cur.type != CFL_VARIANT_KVLIST) {
+            break;
+        }
+
+        kvpair = cfl_variant_kvpair_get(&cur, entry->str);
+        if (kvpair == NULL) {
+            found = NULL;
+            continue;
+        }
+
+        key = kvpair->key;
+        val = kvpair->val;
+
+        found = key;
+        cur = *val;
+
+    next:
+        matched++;
+
+        if (levels == matched) {
+            break;
+        }
+    }
+
+    /* No matches */
+    if (found == NULL || (matched > 0 && levels != matched)) {
+        return -1;
+    }
+
+    *out_key = key;
+    *out_val = val;
+
+    return 0;
+}
+
+
+struct flb_cfl_ra_value *flb_cfl_ra_key_to_value(flb_sds_t ckey,
+                                                 struct cfl_variant vobj,
+                                                 struct mk_list *subkeys)
+{
+    int ret;
+    struct cfl_variant *out_val = NULL;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_variant *val = NULL;
+    cfl_sds_t out_key = NULL;
+    struct flb_cfl_ra_value *result = NULL;
+
+    /* Get the kvpair in the variant */
+    kvpair = cfl_variant_kvpair_get(&vobj, ckey);
+    if (kvpair == NULL) {
+        return NULL;
+    }
+
+    /* Reference entries */
+    val = kvpair->val;
+
+    /* Create the result context */
+    result = flb_calloc(1, sizeof(struct flb_cfl_ra_value));
+    if (!result) {
+        flb_errno();
+        return NULL;
+    }
+    result->v = *val;
+
+    if ((val->type == CFL_VARIANT_ARRAY || val->type == CFL_VARIANT_KVLIST)
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
+        ret = subkey_to_variant(val, subkeys, &out_key, &out_val);
+        if (ret == 0) {
+            ret = cfl_variant_to_ra_value(*out_val, result);
+            if (ret == -1) {
+                flb_free(result);
+                return NULL;
+            }
+            return result;
+        }
+        else {
+            flb_free(result);
+            return NULL;
+        }
+    }
+    else {
+        ret = cfl_variant_to_ra_value(*val, result);
+        if (ret == -1) {
+            flb_error("[ra key] cannot process key value");
+            flb_free(result);
+            return NULL;
+        }
+    }
+
+    return result;
+}
+
+int flb_cfl_ra_key_value_get(flb_sds_t ckey, struct cfl_variant vobj,
+                             struct mk_list *subkeys,
+                             cfl_sds_t *start_key,
+                             cfl_sds_t *out_key, struct cfl_variant **out_val)
+{
+    int ret;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_variant *val = NULL;
+    cfl_sds_t o_key = NULL;
+    struct cfl_variant *o_val = NULL;
+
+    /* Get the kvpair in the variant */
+    kvpair = cfl_variant_kvpair_get(&vobj, ckey);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    /* Reference entries */
+    *start_key = kvpair->key;
+    val = kvpair->val;
+
+    if ((val->type == CFL_VARIANT_ARRAY || val->type == CFL_VARIANT_KVLIST)
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
+        ret = subkey_to_variant(val, subkeys, &o_key, &o_val);
+        if (ret == 0) {
+            *out_key = o_key;
+            *out_val = o_val;
+            return 0;
+        }
+    }
+    else {
+        *out_key = kvpair->key;
+        *out_val = kvpair->val;
+        return 0;
+    }
+
+    return -1;
+}
+
+void flb_cfl_ra_key_value_destroy(struct flb_cfl_ra_value *v)
+{
+    flb_free(v);
+}
+
+static int cfl_variant_strcmp(struct cfl_variant v, char *str, int len)
+{
+    if (v.type != CFL_VARIANT_STRING) {
+        return -1;
+    }
+
+    if (cfl_sds_len(v.data.as_string) != len) {
+        return -1;
+    }
+
+    return strncmp(v.data.as_string, str, len);
+}
+
+int flb_cfl_ra_key_strcmp(flb_sds_t ckey, struct cfl_variant vobj,
+                          struct mk_list *subkeys, char *str, int len)
+{
+    int ret;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_variant *val;
+    cfl_sds_t out_key;
+    struct cfl_variant *out_val;
+
+    /* Get the kvpair in the variant */
+    kvpair = cfl_variant_kvpair_get(&vobj, ckey);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    val = kvpair->val;
+
+    if ((val->type == CFL_VARIANT_ARRAY || val->type == CFL_VARIANT_KVLIST)
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
+        ret = subkey_to_variant(val, subkeys, &out_key, &out_val);
+        if (ret == 0) {
+            return cfl_variant_strcmp(*out_val, str, len);
+        }
+        else {
+            return -1;
+        }
+    }
+
+    return cfl_variant_strcmp(*val, str, len);
+}
+
+int flb_cfl_ra_key_regex_match(flb_sds_t ckey, struct cfl_variant vobj,
+                               struct mk_list *subkeys, struct flb_regex *regex,
+                               struct flb_regex_search *result)
+{
+    int ret;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_variant *val;
+    cfl_sds_t out_key;
+    struct cfl_variant *out_val;
+
+    /* Get the key position in the map */
+    kvpair = cfl_variant_kvpair_get(&vobj, ckey);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    val = kvpair->val;
+
+    if ((val->type == CFL_VARIANT_ARRAY || val->type == CFL_VARIANT_KVLIST)
+        && subkeys != NULL && mk_list_size(subkeys) > 0) {
+        ret = subkey_to_variant(val, subkeys, &out_key, &out_val);
+        if (ret == 0) {
+            if (out_val->type != CFL_VARIANT_STRING) {
+                return -1;
+            }
+
+            if (result) {
+                /* Regex + capture mode */
+                return flb_regex_do(regex,
+                                    (char *) out_val->data.as_string,
+                                    cfl_sds_len(out_val->data.as_string),
+                                    result);
+            }
+            else {
+                /* No capture */
+                return flb_regex_match(regex,
+                                       (unsigned char *) out_val->data.as_string,
+                                       cfl_sds_len(out_val->data.as_string));
+            }
+        }
+        return -1;
+    }
+
+    if (val->type != CFL_VARIANT_STRING) {
+        return -1;
+    }
+
+    if (result) {
+        /* Regex + capture mode */
+        return flb_regex_do(regex,
+                            (char *) out_val->data.as_string,
+                            cfl_sds_len(out_val->data.as_string),
+                            result);
+    }
+    else {
+        /* No capture */
+        return flb_regex_match(regex, (unsigned char *) out_val->data.as_string,
+                               cfl_sds_len(out_val->data.as_string));
+    }
+
+    return -1;
+}
+
+static int update_subkey(struct cfl_variant *vobj, struct mk_list *subkeys,
+                         int levels, int *matched,
+                         flb_sds_t in_key, struct cfl_variant *in_val);
+
+static int update_subkey_array(struct cfl_variant *vobj, struct mk_list *subkeys,
+                               int levels, int *matched,
+                               flb_sds_t in_key, struct cfl_variant *in_val)
+{
+    struct flb_ra_subentry *entry;
+    struct cfl_array *array;
+    int i;
+    int ret;
+    int size;
+
+    entry = mk_list_entry_first(subkeys, struct flb_ra_subentry, _head);
+
+    /* check the current msgpack object is an array */
+    if (vobj->type != CFL_VARIANT_ARRAY) {
+        flb_error("%s: object is not array", __FUNCTION__);
+        return -1;
+    }
+    array = vobj->data.as_array;
+
+    size = cfl_array_size(array);
+    /* Index limit and ensure no overflow */
+    if (entry->array_id == INT_MAX ||
+        size < entry->array_id + 1) {
+        flb_trace("%s: out of index", __FUNCTION__);
+            return -1;
+    }
+
+    for (i=0; i<size; i++) {
+        if (i != entry->array_id) {
+            continue;
+        }
+        *matched += 1;
+        if (levels == *matched) {
+            flb_trace("%s: update val matched=%d", __FUNCTION__, *matched);
+            /* update value */
+            continue;
+        }
+
+        if (subkeys->next == NULL) {
+            flb_trace("%s: end of subkey", __FUNCTION__);
+            return -1;
+        }
+        ret = update_subkey(array->entries[i], subkeys->next,
+                            levels, matched,
+                            in_key, in_val);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+    return 0;
+}
+
+static int update_subkey_kvlist(struct cfl_variant *vobj, struct mk_list *subkeys,
+                                int levels, int *matched,
+                                cfl_sds_t in_key, struct cfl_variant *in_val)
+{
+    struct flb_ra_subentry *entry;
+    int ret;
+    flb_sds_t key = NULL;
+    flb_sds_t tmp = NULL;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_kvpair *pair = NULL;
+    struct cfl_variant *val = NULL;
+    struct cfl_list *head = NULL;
+
+    entry = mk_list_entry_first(subkeys, struct flb_ra_subentry, _head);
+    /* check the current msgpack object is a map */
+    if (vobj->type != CFL_VARIANT_KVLIST) {
+        flb_trace("%s: variant is not cfl_kvlist", __FUNCTION__);
+        return -1;
+    }
+
+    kvlist = vobj->data.as_kvlist;
+    if (kvlist == NULL) {
+        return -1;
+    }
+
+    /* Get the kvpair in the variant */
+    kvpair = cfl_variant_kvpair_get(vobj, entry->str);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    cfl_list_foreach(head, &kvlist->list) {
+        pair = cfl_list_entry(head,
+                              struct cfl_kvpair, _head);
+
+        if (cfl_sds_len(kvpair->key) != cfl_sds_len(pair->key)) {
+            continue;
+        }
+        if (strcasecmp(pair->key, kvpair->key) != 0) {
+            continue;
+        }
+        *matched += 1;
+        if (levels == *matched) {
+            flb_trace("%s update key/val matched=%d", __FUNCTION__, *matched);
+            if (in_key != NULL && in_val != NULL) {
+                cfl_kvlist_insert(kvlist, in_key, in_val);
+                if (pair) {
+                    cfl_kvpair_destroy(pair);
+                }
+            }
+            else if (in_key != NULL) {
+                tmp = kvpair->key;
+                kvpair->key = cfl_sds_create_len(in_key, cfl_sds_len(in_key));
+                if (!kvpair->key) {
+                    kvpair->key = tmp;
+                    return 0;
+                }
+                flb_sds_destroy(tmp);
+            }
+            else if (in_val != NULL) {
+                key = cfl_sds_create_len(pair->key, cfl_sds_len(pair->key));
+                if (key == NULL) {
+                    return -1;
+                }
+                cfl_kvlist_insert(kvlist, key, in_val);
+                cfl_sds_destroy(key);
+                if (pair) {
+                    cfl_kvpair_destroy(pair);
+                }
+            }
+            return 0;
+        }
+        /* No need to dig into further elements */
+        if (*matched > levels) {
+            return 0;
+        }
+        if (subkeys->next == NULL) {
+            flb_trace("%s: end of subkey", __FUNCTION__);
+            return -1;
+        }
+
+        val = pair->val;
+        ret = update_subkey(val, subkeys->next,
+                            levels, matched,
+                            in_key, in_val);
+        if (ret < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int update_subkey(struct cfl_variant *vobj, struct mk_list *subkeys,
+                         int levels, int *matched,
+                         cfl_sds_t in_key, struct cfl_variant *in_val)
+{
+    struct flb_ra_subentry *entry;
+
+    entry = mk_list_entry_first(subkeys, struct flb_ra_subentry, _head);
+
+    if (entry->type == FLB_RA_PARSER_ARRAY_ID) {
+        return update_subkey_array(vobj, subkeys,
+                                   levels, matched,
+                                   in_key, in_val);
+    }
+    return update_subkey_kvlist(vobj, subkeys, levels, matched, in_key, in_val);
+}
+
+int flb_cfl_ra_key_value_update(struct flb_ra_parser *rp,  struct cfl_variant *vobj,
+                                cfl_sds_t in_key, struct cfl_variant *in_val)
+{
+    int i;
+    int kv_size;
+    int ret;
+    int levels;
+    int matched = 0;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_variant *val;
+    cfl_sds_t p_key;
+    flb_sds_t tmp = NULL;
+
+    /* Get the kvpair in the cfl_variant */
+    kvpair = cfl_variant_kvpair_get(vobj, rp->key->name);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    if (vobj->type != CFL_VARIANT_KVLIST) {
+        return -1;
+    }
+    kvlist = vobj->data.as_kvlist;
+
+    levels = mk_list_size(rp->key->subkeys);
+
+    kv_size = cfl_kvlist_count(kvlist);
+
+    if (levels == 0) {
+        /* update key/val */
+        if (in_key != NULL && in_val != NULL) {
+            cfl_kvlist_insert(kvlist, in_key, in_val);
+        }
+        else if (in_key != NULL) {
+            tmp = kvpair->key;
+            kvpair->key = cfl_sds_create_len(in_key, cfl_sds_len(in_key));
+            if (!kvpair->key) {
+                kvpair->key = tmp;
+                return 0;
+            }
+            flb_sds_destroy(tmp);
+        }
+        else if (in_val != NULL) {
+            p_key = cfl_sds_create_len(kvpair->key, cfl_sds_len(kvpair->key));
+            if (!p_key) {
+                return -1;
+            }
+            cfl_kvlist_insert(kvlist, p_key, in_val);
+            cfl_sds_destroy(p_key);
+        }
+
+        return 0;
+    }
+
+    for (i=0; i<kv_size; i++) {
+        val = kvpair->val;
+        ret = update_subkey(val, rp->key->subkeys,
+                            levels, &matched,
+                            in_key, in_val);
+        if (ret < 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int append_subkey(struct cfl_variant *vobj, struct mk_list *subkeys,
+                         int levels, int *matched,
+                         struct cfl_variant *in_val);
+
+static int append_subkey_array(struct cfl_variant *vobj, struct mk_list *subkeys,
+                               int levels, int *matched,
+                               struct cfl_variant *in_val)
+{
+    struct flb_ra_subentry *entry;
+    struct cfl_array *array;
+    int i;
+    int ret;
+    int size;
+
+    /* check the current msgpack object is an array */
+    if (vobj->type != CFL_VARIANT_ARRAY) {
+        flb_trace("%s: object is not array", __FUNCTION__);
+        return -1;
+    }
+
+    array = vobj->data.as_array;
+    size = cfl_array_size(array);
+
+    entry = mk_list_entry_first(subkeys, struct flb_ra_subentry, _head);
+
+    if (levels == *matched) {
+        /* append val */
+        cfl_array_append(array, in_val);
+
+        *matched = -1;
+        return 0;
+    }
+
+    /* Index limit and ensure no overflow */
+    if (entry->array_id == INT_MAX ||
+        size < entry->array_id + 1) {
+        flb_trace("%s: out of index", __FUNCTION__);
+            return -1;
+    }
+
+    for (i=0; i<size; i++) {
+        if (i != entry->array_id) {
+            continue;
+        }
+        if (*matched >= 0) {
+            *matched += 1;
+        }
+        if (subkeys->next == NULL) {
+            flb_trace("%s: end of subkey", __FUNCTION__);
+            return -1;
+        }
+        ret = append_subkey(array->entries[i], subkeys->next,
+                            levels, matched,
+                            in_val);
+        if (ret < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int append_subkey_kvlist(struct cfl_variant *vobj, struct mk_list *subkeys,
+                                int levels, int *matched,
+                                struct cfl_variant *in_val)
+{
+    struct flb_ra_subentry *entry;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvpair *kvpair = NULL;
+    struct cfl_kvpair *pair = NULL;
+    struct cfl_variant *val = NULL;
+    struct cfl_list *head = NULL;
+    int ret;
+
+    /* check the current cfl_variant is a kvlist */
+    if (vobj->type != CFL_VARIANT_KVLIST) {
+        flb_trace("%s: object is not kvlist", __FUNCTION__);
+        return -1;
+    }
+
+    kvlist = vobj->data.as_kvlist;
+    if (kvlist == NULL) {
+        return -1;
+    }
+
+    entry = mk_list_entry_first(subkeys, struct flb_ra_subentry, _head);
+
+    if (levels == *matched) {
+        /* append val */
+        cfl_kvlist_insert(kvlist, entry->str, in_val);
+
+        *matched = -1;
+        return 0;
+    }
+
+    /* Get the kvpair in the variant */
+    kvpair = cfl_variant_kvpair_get(vobj, entry->str);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    cfl_list_foreach(head, &kvlist->list) {
+        pair = cfl_list_entry(head,
+                              struct cfl_kvpair, _head);
+
+        if (strcasecmp(kvpair->key, pair->key) != 0) {
+            continue;
+        }
+
+        if (*matched >= 0) {
+            *matched += 1;
+        }
+        if (*matched > levels) {
+            return 0;
+        }
+
+        if (subkeys->next == NULL) {
+            flb_trace("%s: end of subkey", __FUNCTION__);
+            return -1;
+        }
+
+        val = pair->val;
+        ret = append_subkey(val, subkeys->next,
+                            levels, matched,
+                            in_val);
+        if (ret < 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int append_subkey(struct cfl_variant *vobj, struct mk_list *subkeys,
+                         int levels, int *matched,
+                         struct cfl_variant *in_val)
+{
+    struct flb_ra_subentry *entry;
+
+    entry = mk_list_entry_first(subkeys, struct flb_ra_subentry, _head);
+
+    if (entry->type == FLB_RA_PARSER_ARRAY_ID) {
+        return append_subkey_array(vobj, subkeys,
+                                   levels, matched,
+                                   in_val);
+    }
+    return append_subkey_kvlist(vobj, subkeys, levels, matched, in_val);
+}
+
+int flb_cfl_ra_key_value_append(struct flb_ra_parser *rp, struct cfl_variant *vobj,
+                                struct cfl_variant *in_val)
+{
+    struct cfl_kvlist *kvlist;
+    struct cfl_kvpair *kvpair;
+    struct cfl_variant *val;
+    int ref_level;
+    int ret;
+    int matched = 0;
+
+    if (vobj->type != CFL_VARIANT_KVLIST) {
+        return -1;
+    }
+
+    kvlist = vobj->data.as_kvlist;
+
+    /* Decrement since the last key doesn't exist */
+    ref_level = mk_list_size(rp->key->subkeys) - 1;
+    if (ref_level < 0) {
+        /* no subkeys */
+        cfl_kvlist_insert(kvlist, rp->key->name, in_val);
+        return 0;
+    }
+
+    /* Get the kvpair in the cfl_variant */
+    kvpair = cfl_variant_kvpair_get(vobj, rp->key->name);
+    if (kvpair == NULL) {
+        return -1;
+    }
+
+    val = kvpair->val;
+    ret = append_subkey(val, rp->key->subkeys,
+                        ref_level, &matched,
+                        in_val);
+    if (ret < 0) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/flb_cfl_record_accessor.c
+++ b/src/flb_cfl_record_accessor.c
@@ -1,0 +1,982 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_sds_list.h>
+#include <fluent-bit/flb_cfl_record_accessor.h>
+#include <fluent-bit/flb_cfl_ra_key.h>
+#include <fluent-bit/record_accessor/flb_ra_parser.h>
+#include <monkey/mk_core.h>
+
+#include <ctype.h>
+
+static struct flb_ra_parser *cfl_ra_parse_string(struct flb_cfl_record_accessor *cra,
+                                                 flb_sds_t buf, int start, int end)
+{
+    int len;
+    struct flb_ra_parser *rp;
+
+    len = end - start;
+    rp = flb_ra_parser_string_create(buf + start, len);
+    if (!rp) {
+        return NULL;
+    }
+
+    return rp;
+}
+
+/* Create a parser context for a key map or function definition */
+static struct flb_ra_parser *cfl_ra_parse_meta(struct flb_cfl_record_accessor *cra,
+                                               flb_sds_t buf, int start, int end)
+{
+    int len;
+    struct flb_ra_parser *rp;
+
+    len = end - start;
+    rp = flb_ra_parser_meta_create(buf + start, len);
+    if (!rp) {
+        return NULL;
+    }
+
+    return rp;
+}
+
+/*
+ * Supported data
+ *
+ * ${X}                               => environment variable
+ * $key, $key['x'], $key['x'][N]['z'] => record key value or array index
+ * $0, $1,..$9                        => regex id
+ * $X()                               => built-in function
+ */
+static int cfl_ra_parse_buffer(struct flb_cfl_record_accessor *cra, flb_sds_t buf)
+{
+    int i;
+    int n;
+    int c;
+    int t;
+    int len;
+    int pre = 0;
+    int end = 0;
+    int quote_cnt;
+    struct flb_ra_parser *rp;
+    struct flb_ra_parser *rp_str = NULL;
+
+    len = flb_sds_len(buf);
+
+    for (i = 0; i < len; i++) {
+        if (buf[i] != '$') {
+            continue;
+        }
+
+        /*
+         * Before to add the number entry, add the previous text
+         * before hitting this.
+         */
+        if (i > pre) {
+            rp = cfl_ra_parse_string(cra, buf, pre, i);
+            if (!rp) {
+                return -1;
+            }
+            mk_list_add(&rp->_head, &cra->list);
+        }
+        pre = i;
+
+
+        n = i + 1;
+        if (n >= len) {
+            /* Finalize, nothing to do */
+            break;
+        }
+
+        /*
+         * If the next character is a digit like $0,$1,$2..$9, means the user wants to use
+         * the result of a regex capture.
+         *
+         * We support up to 10 regex ids [0-9]
+         */
+        if (isdigit(buf[n])) {
+            /* Add REGEX_ID entry */
+            c = atoi(buf + n);
+            rp = flb_ra_parser_regex_id_create(c);
+            if (!rp) {
+                return -1;
+            }
+
+            mk_list_add(&rp->_head, &cra->list);
+            i++;
+            pre = i + 1;
+            continue;
+        }
+
+        /*
+         * If the next 3 character are 'TAG', the user might want to include the tag or
+         * part of it (e.g: TAG[n]).
+         */
+        if (n + 2 < len && strncmp(buf + n, "TAG", 3) == 0) {
+            /* Check if some [] was added */
+            if (n + 4 < len) {
+                end = -1;
+                if (buf[n + 3] == '[') {
+                    t = n + 3;
+
+                    /* Look for the ending ']' */
+                    end = mk_string_char_search(buf + t, ']', len - t);
+                    if (end == 0) {
+                        end = -1;
+                    }
+
+                    /* continue processsing */
+                    c = atoi(buf + t + 1);
+
+                    rp = flb_ra_parser_tag_part_create(c);
+                    if (!rp) {
+                        return -1;
+                    }
+                    mk_list_add(&rp->_head, &cra->list);
+
+                    i = t + end + 1;
+                    pre = i;
+                    continue;
+                }
+            }
+
+            /* Append full tag */
+            rp = flb_ra_parser_tag_create();
+            if (!rp) {
+                return -1;
+            }
+            mk_list_add(&rp->_head, &cra->list);
+            i = n + 3;
+            pre = n + 3;
+            continue;
+        }
+
+        quote_cnt = 0;
+        for (end = i + 1; end < len; end++) {
+            if (buf[end] == '\'') {
+                ++quote_cnt;
+            }
+            else if (buf[end] == '.' && (quote_cnt & 0x01)) {
+                /* ignore '.' if it is inside a string/subkey */
+                continue;
+            }
+            else if (buf[end] == '.' || buf[end] == ' ' || buf[end] == ',' || buf[end] == '"') {
+                break;
+            }
+        }
+        if (end > len) {
+            end = len;
+        }
+
+        /* Parse the content, we use 'end' as the separator position  */
+        rp = cfl_ra_parse_meta(cra, buf, i, end);
+        if (!rp) {
+            return -1;
+        }
+
+        /* Generate fixed length string */
+        if (pre < i) {
+            rp_str = cfl_ra_parse_string(cra, buf, pre, i);
+            if (!rp_str) {
+                flb_ra_parser_destroy(rp);
+                return -1;
+            }
+        }
+        else {
+            rp_str = NULL;
+        }
+
+        if (rp_str) {
+            mk_list_add(&rp_str->_head, &cra->list);
+        }
+        mk_list_add(&rp->_head, &cra->list);
+        pre = end;
+        i = end;
+    }
+
+    /* Append remaining string */
+    if ((i - 1 > end && pre < i) || i == 1 /*allow single character*/) {
+        end = flb_sds_len(buf);
+        rp_str = cfl_ra_parse_string(cra, buf, pre, end);
+        if (rp_str) {
+            mk_list_add(&rp_str->_head, &cra->list);
+        }
+    }
+
+    return 0;
+}
+
+void flb_cfl_ra_destroy(struct flb_cfl_record_accessor *cra)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+
+    mk_list_foreach_safe(head, tmp, &cra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        mk_list_del(&rp->_head);
+        flb_ra_parser_destroy(rp);
+    }
+
+    if (cra->pattern) {
+        flb_sds_destroy(cra->pattern);
+    }
+    flb_free(cra);
+}
+
+int flb_cfl_ra_subkey_count(struct flb_cfl_record_accessor *cra)
+{
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+    int ret = -1;
+    int tmp;
+
+    if (cra == NULL) {
+        return -1;
+    }
+    mk_list_foreach(head, &cra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        tmp = flb_ra_parser_subkey_count(rp);
+        if (tmp > ret) {
+            ret = tmp;
+        }
+    }
+
+    return ret;
+}
+
+struct flb_cfl_record_accessor *flb_cfl_ra_create(char *str, int translate_env)
+{
+    int ret;
+    size_t hint = 0;
+    char *p;
+    flb_sds_t buf = NULL;
+    flb_sds_t tmp_str;
+    struct flb_env *env;
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+    struct flb_cfl_record_accessor *cra;
+
+    /* temporary copy of 'str' to workaround potential issues literal parsing */
+    tmp_str = flb_sds_create(str);
+    if (!tmp_str) {
+        flb_error("[cfl record accessor] cannot allocate temporary buffer");
+        return NULL;
+    }
+
+    p = tmp_str;
+    if (translate_env == FLB_TRUE) {
+        /*
+         * Check if some environment variable has been created as part of the
+         * string. Upon running the environment variable will be pre-set in the
+         * string.
+         */
+        env = flb_env_create();
+        if (!env) {
+            flb_error("[cfl record accessor] cannot create environment context");
+            flb_sds_destroy(tmp_str);
+            return NULL;
+        }
+
+        /* Translate string */
+        buf = flb_env_var_translate(env, str);
+        if (!buf) {
+            flb_error("[cfl record accessor] cannot translate string");
+            flb_env_destroy(env);
+            flb_sds_destroy(tmp_str);
+            return NULL;
+        }
+        flb_env_destroy(env);
+        p = buf;
+    }
+
+    /* Allocate context */
+    cra = flb_calloc(1, sizeof(struct flb_cfl_record_accessor));
+    if (!cra) {
+        flb_errno();
+        flb_error("[cfl record accessor] cannot create context");
+        if (buf) {
+            flb_sds_destroy(buf);
+        }
+        flb_sds_destroy(tmp_str);
+        return NULL;
+    }
+
+    cra->pattern = tmp_str;
+    mk_list_init(&cra->list);
+
+    /*
+     * The buffer needs to processed where we create a list of parts, basically
+     * a linked list of sds using 'slist' api.
+     */
+    ret = cfl_ra_parse_buffer(cra, p);
+    if (buf) {
+        flb_sds_destroy(buf);
+    }
+    if (ret == -1) {
+        flb_cfl_ra_destroy(cra);
+        return NULL;
+    }
+
+    /* Calculate a hint of an outgoing size buffer */
+    mk_list_foreach(head, &cra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        if (rp->key) {
+            if (rp->type == FLB_RA_PARSER_REGEX_ID) {
+                hint += 32;
+            }
+            else {
+                hint += flb_sds_len(rp->key->name);
+            }
+        }
+    }
+    cra->size_hint = hint + 128;
+    return cra;
+}
+
+/*
+  flb_ra_create_str_from_list returns record accessor string from string list.
+  e.g. {"aa", "bb", "cc", NULL} -> "$aa['bb']['cc']"
+  Return value should be freed using flb_sds_destroy after using.
+*/
+flb_sds_t flb_cfl_ra_create_str_from_list(struct flb_sds_list *str_list)
+{
+    int i = 0;
+    int ret_i = 0;
+    int offset = 0;
+
+    char *fmt = NULL;
+    char **strs = NULL;
+    flb_sds_t str;
+    flb_sds_t tmp_sds;
+
+    if (str_list == NULL || flb_sds_list_size(str_list) == 0) {
+        return NULL;
+    }
+
+    str = flb_sds_create_size(256);
+    if (str == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    strs = flb_sds_list_create_str_array(str_list);
+    if (strs == NULL) {
+        flb_error("%s flb_sds_list_create_str_array failed", __FUNCTION__);
+        flb_sds_destroy(str);
+        return NULL;
+    }
+
+    while(strs[i] != NULL) {
+        if (i == 0) {
+            fmt = "$%s";
+        }
+        else {
+            fmt = "['%s']";
+        }
+
+        ret_i = snprintf(str+offset, flb_sds_alloc(str)-offset-1, fmt, strs[i]);
+        if (ret_i > flb_sds_alloc(str)-offset-1) {
+            tmp_sds = flb_sds_increase(str, ret_i);
+            if (tmp_sds == NULL) {
+                flb_errno();
+                flb_sds_list_destroy_str_array(strs);
+                flb_sds_destroy(str);
+                return NULL;
+            }
+            str = tmp_sds;
+            ret_i = snprintf(str+offset, flb_sds_alloc(str)-offset-1, fmt, strs[i]);
+            if (ret_i > flb_sds_alloc(str)-offset-1) {
+                flb_errno();
+                flb_sds_list_destroy_str_array(strs);
+                flb_sds_destroy(str);
+                return NULL;
+            }
+        }
+        offset += ret_i;
+        i++;
+    }
+    flb_sds_list_destroy_str_array(strs);
+
+    return str;
+}
+
+struct flb_cfl_record_accessor *flb_cfl_ra_create_from_list(struct flb_sds_list *str_list, int translate_env)
+{
+    flb_sds_t tmp = NULL;
+    struct flb_cfl_record_accessor *ret = NULL;
+
+    tmp = flb_cfl_ra_create_str_from_list(str_list);
+    if (tmp == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    ret = flb_cfl_ra_create(tmp, translate_env);
+    flb_sds_destroy(tmp);
+
+    return ret;
+}
+
+void flb_cfl_ra_dump(struct flb_cfl_record_accessor *cra)
+{
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+
+    mk_list_foreach(head, &cra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        printf("\n");
+        flb_ra_parser_dump(rp);
+    }
+}
+
+static flb_sds_t cfl_ra_translate_regex_id(struct flb_ra_parser *rp,
+                                           struct flb_regex_search *result,
+                                           flb_sds_t buf)
+{
+    int ret;
+    ptrdiff_t start;
+    ptrdiff_t end;
+    flb_sds_t tmp;
+
+    ret = flb_regex_results_get(result, rp->id, &start, &end);
+    if (ret == -1) {
+        return buf;
+    }
+
+    tmp = flb_sds_cat(buf, result->str + start, end - start);
+    return tmp;
+}
+
+static flb_sds_t cfl_ra_translate_tag(struct flb_ra_parser *rp, flb_sds_t buf,
+                                      char *tag, int tag_len)
+{
+    flb_sds_t tmp;
+
+    tmp = flb_sds_cat(buf, tag, tag_len);
+    return tmp;
+}
+
+static flb_sds_t cfl_ra_translate_tag_part(struct flb_ra_parser *rp, flb_sds_t buf,
+                                           char *tag, int tag_len)
+{
+    int i = 0;
+    int id = -1;
+    int end;
+    flb_sds_t tmp = buf;
+
+    while (i < tag_len) {
+        end = mk_string_char_search(tag + i, '.', tag_len - i);
+        if (end == -1) {
+            if (i == 0) {
+                break;
+            }
+            end = tag_len - i;
+        }
+        id++;
+        if (rp->id == id) {
+            tmp = flb_sds_cat(buf, tag + i, end);
+            break;
+        }
+
+        i += end + 1;
+    }
+
+    /* No dots in the tag */
+    if (rp->id == 0 && id == -1 && i < tag_len) {
+        tmp = flb_sds_cat(buf, tag, tag_len);
+        return tmp;
+    }
+
+    return tmp;
+}
+
+static flb_sds_t cfl_ra_translate_string(struct flb_ra_parser *rp, flb_sds_t buf)
+{
+    flb_sds_t tmp;
+
+    tmp = flb_sds_cat(buf, rp->key->name, flb_sds_len(rp->key->name));
+    return tmp;
+}
+
+static int cfl_to_json(struct cfl_variant *var, flb_sds_t buf)
+{
+    int i = 0;
+    int ret;
+    int loop = 0;
+    struct cfl_list *head;
+    struct cfl_kvpair *kv;
+    struct cfl_kvlist *kvlist;
+
+    switch (var->type) {
+    case CFL_VARIANT_NULL:
+        flb_sds_cat(buf, "null", 4);
+        break;
+    case CFL_VARIANT_BOOL:
+        if (var->data.as_bool) {
+            flb_sds_cat(buf, "true", 4);
+        }
+        else {
+            flb_sds_cat(buf, "false", 5);
+        }
+        break;
+    case CFL_VARIANT_INT: {
+        char tmp[32] = {0};
+        i = snprintf(tmp, sizeof(tmp)-1, "%"PRId64, var->data.as_int64);
+        flb_sds_cat(buf, tmp, i);
+        break;
+    }
+    case CFL_VARIANT_UINT: {
+        char tmp[32] = {0};
+        i = snprintf(tmp, sizeof(tmp)-1, "%"PRIu64, var->data.as_uint64);
+        flb_sds_cat(buf, tmp, i);
+        break;
+    }
+    case CFL_VARIANT_DOUBLE: {
+        char tmp[512] = {0};
+        i = snprintf(tmp, sizeof(tmp)-1, "%"PRIu64, var->data.as_uint64);
+        flb_sds_cat(buf, tmp, i);
+        break;
+    }
+    case CFL_VARIANT_STRING:
+        flb_sds_cat(buf, "\"", 1);
+        flb_sds_cat(buf, var->data.as_string, cfl_sds_len(var->data.as_string));
+        flb_sds_cat(buf, "\"", 1);
+        break;
+    case CFL_VARIANT_BYTES:
+        flb_sds_cat(buf, "\"", 1);
+        flb_sds_cat(buf, var->data.as_string, cfl_sds_len(var->data.as_bytes));
+        flb_sds_cat(buf, "\"", 1);
+        break;
+    case CFL_VARIANT_ARRAY: {
+        struct cfl_array *array = var->data.as_array;
+        loop = cfl_array_size(array);
+
+        flb_sds_cat(buf, "[", 1);
+        if (loop != 0) {
+            for (i = 0; i < loop - 1; i++) {
+                cfl_to_json(array->entries[i], buf);
+                flb_sds_cat(buf, ",", 1);
+            }
+        }
+        cfl_to_json(array->entries[loop-1], buf);
+        flb_sds_cat(buf, "]", 1);
+        break;
+    }
+    case CFL_VARIANT_KVLIST:
+        kvlist = var->data.as_kvlist;
+        flb_sds_cat(buf, "{", 1);
+        cfl_list_foreach(head, &kvlist->list) {
+            kv = cfl_list_entry(head, struct cfl_kvpair, _head);
+
+            /* key */
+            flb_sds_cat(buf, "\"", 1);
+            flb_sds_cat(buf, kv->key, cfl_sds_len(kv->key));
+            flb_sds_cat(buf, "\"", 1);
+
+            /* separator */
+            flb_sds_cat(buf, ":", 1);
+
+            /* value */
+            ret = cfl_to_json(kv->val, buf);
+            if (ret == -1) {
+                return -1;
+            }
+            break;
+        }
+        flb_sds_cat(buf, "}", 1);
+    }
+
+    return 0;
+}
+
+static flb_sds_t cfl_ra_translate_keymap(struct flb_ra_parser *rp, flb_sds_t buf,
+                                         struct cfl_variant vobj, int *found)
+{
+    int ret;
+    int len;
+    char *js;
+    char str[32];
+    flb_sds_t tmp = NULL;
+    struct flb_cfl_ra_value *crv;
+
+    /* Lookup key or subkey value */
+    if (rp->key == NULL) {
+        *found = FLB_FALSE;
+        return buf;
+    }
+
+    crv = flb_cfl_ra_key_to_value(rp->key->name, vobj, rp->key->subkeys);
+    if (!crv) {
+        *found = FLB_FALSE;
+        return buf;
+    }
+    else {
+        *found = FLB_TRUE;
+    }
+
+    /* Based on data type, convert to it string representation */
+    if (crv->type == FLB_CFL_RA_BOOL) {
+        /* Check if is a kvlist or a real bool */
+        if (crv->v.type == CFL_VARIANT_KVLIST) {
+            js = flb_sds_create_size(1024);
+            /* Convert cfl_variant to JSON string */
+            ret = cfl_to_json(&crv->v, js);
+            if (ret == -1) {
+                len = strlen(js);
+                tmp = flb_sds_cat(buf, js, len);
+                flb_free(js);
+            }
+        }
+        else if (crv->v.type == CFL_VARIANT_BOOL) {
+            if (crv->val.boolean) {
+                tmp = flb_sds_cat(buf, "true", 4);
+            }
+            else {
+                tmp = flb_sds_cat(buf, "false", 5);
+            }
+        }
+    }
+    else if (crv->type == FLB_CFL_RA_INT) {
+        len = snprintf(str, sizeof(str) - 1, "%" PRId64, crv->val.i64);
+        tmp = flb_sds_cat(buf, str, len);
+    }
+    else if (crv->type == FLB_CFL_RA_FLOAT) {
+        len = snprintf(str, sizeof(str) - 1, "%f", crv->val.f64);
+        if (len >= sizeof(str)) {
+            tmp = flb_sds_cat(buf, str, sizeof(str)-1);
+        }
+        else {
+            tmp = flb_sds_cat(buf, str, len);
+        }
+    }
+    else if (crv->type == FLB_CFL_RA_STRING) {
+        tmp = flb_sds_cat(buf, crv->val.string, flb_sds_len(crv->val.string));
+    }
+    else if (crv->type == FLB_CFL_RA_NULL) {
+        tmp = flb_sds_cat(buf, "null", 4);
+    }
+
+    flb_cfl_ra_key_value_destroy(crv);
+    return tmp;
+}
+
+/*
+ * Translate a cfl record accessor buffer, tag and records are optional
+ * parameters.
+ *
+ * For safety, the function returns a newly created string that needs
+ * to be destroyed by the caller.
+ */
+flb_sds_t flb_cfl_ra_translate(struct flb_cfl_record_accessor *cra,
+                               char *tag, int tag_len,
+                               struct cfl_variant var, struct flb_regex_search *result)
+{
+    return flb_cfl_ra_translate_check(cra, tag, tag_len, var, result, FLB_FALSE);
+}
+
+/*
+ * Translate a cfl record accessor buffer, tag and records are optional
+ * parameters.
+ *
+ * For safety, the function returns a newly created string that needs
+ * to be destroyed by the caller.
+ *
+ * Returns NULL if `check` is FLB_TRUE and any key lookup in the record failed
+ */
+flb_sds_t flb_cfl_ra_translate_check(struct flb_cfl_record_accessor *cra,
+                                     char *tag, int tag_len,
+                                     struct cfl_variant var, struct flb_regex_search *result,
+                                     int check)
+{
+    flb_sds_t tmp = NULL;
+    flb_sds_t buf;
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+    int found = FLB_FALSE;
+
+    buf = flb_sds_create_size(cra->size_hint);
+    if (!buf) {
+        flb_error("[cfl record accessor] cannot create outgoing buffer");
+        return NULL;
+    }
+
+    mk_list_foreach(head, &cra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        if (rp->type == FLB_RA_PARSER_STRING) {
+            tmp = cfl_ra_translate_string(rp, buf);
+        }
+        else if (rp->type == FLB_RA_PARSER_KEYMAP) {
+            tmp = cfl_ra_translate_keymap(rp, buf, var, &found);
+            if (check == FLB_TRUE && found == FLB_FALSE) {
+                flb_warn("[cfl record accessor] translation failed, root key=%s", rp->key->name);
+                flb_sds_destroy(buf);
+                return NULL;
+            }
+        }
+        else if (rp->type == FLB_RA_PARSER_REGEX_ID && result) {
+            tmp = cfl_ra_translate_regex_id(rp, result, buf);
+        }
+        else if (rp->type == FLB_RA_PARSER_TAG && tag) {
+            tmp = cfl_ra_translate_tag(rp, buf, tag, tag_len);
+        }
+        else if (rp->type == FLB_RA_PARSER_TAG_PART && tag) {
+            tmp = cfl_ra_translate_tag_part(rp, buf, tag, tag_len);
+        }
+
+        /* else if (rp->type == FLB_RA_PARSER_FUNC) { */
+        /*     tmp = cfl_ra_translate_func(rp, buf, tag, tag_len); */
+        /* } */
+
+        if (!tmp) {
+            flb_error("[cfl record accessor] translation failed");
+            flb_sds_destroy(buf);
+            return NULL;
+        }
+        if (tmp != buf) {
+            buf = tmp;
+        }
+    }
+
+    return buf;
+}
+
+/*
+ * If the cfl record accessor rules do not generate content based on a keymap or
+ * regex, it's considered to be 'static', so the value returned will always be
+ * the same.
+ *
+ * If the 'ra' is static, return FLB_TRUE, otherwise FLB_FALSE.
+ */
+int flb_cfl_ra_is_static(struct flb_cfl_record_accessor *cra)
+{
+    struct mk_list *head;
+    struct flb_ra_parser *rp;
+
+    mk_list_foreach(head, &cra->list) {
+        rp = mk_list_entry(head, struct flb_ra_parser, _head);
+        if (rp->type == FLB_RA_PARSER_STRING) {
+            continue;
+        }
+        else if (rp->type == FLB_RA_PARSER_KEYMAP) {
+            return FLB_FALSE;
+        }
+        else if (rp->type == FLB_RA_PARSER_REGEX_ID) {
+            return FLB_FALSE;
+        }
+        else if (rp->type == FLB_RA_PARSER_TAG) {
+            continue;
+        }
+        else if (rp->type == FLB_RA_PARSER_TAG_PART) {
+            continue;
+        }
+    }
+
+    return FLB_TRUE;
+}
+
+/*
+ * Compare a string value against the first entry of a record accessor component, used
+ * specifically when the record accessor refers to a single key name.
+ */
+int flb_cfl_ra_strcmp(struct flb_cfl_record_accessor *ra, struct cfl_variant var,
+                      char *str, int len)
+{
+    struct flb_ra_parser *rp;
+
+    rp = mk_list_entry_first(&ra->list, struct flb_ra_parser, _head);
+    return flb_cfl_ra_key_strcmp(rp->key->name, var, rp->key->subkeys,
+                                 rp->key->name, flb_sds_len(rp->key->name));
+}
+
+/*
+ * Check if a regular expression matches a cfl record accessor key in the
+ * given cfl_object
+ */
+int flb_cfl_ra_regex_match(struct flb_cfl_record_accessor *cra, struct cfl_variant var,
+                           struct flb_regex *regex, struct flb_regex_search *result)
+{
+    struct flb_ra_parser *rp;
+
+    rp = mk_list_entry_first(&cra->list, struct flb_ra_parser, _head);
+    if (rp == NULL || rp->key == NULL) {
+        return -1;
+    }
+    return flb_cfl_ra_key_regex_match(rp->key->name, var, rp->key->subkeys,
+                                      regex, result);
+}
+
+static struct flb_ra_parser* get_ra_parser(struct flb_cfl_record_accessor *cra)
+{
+    struct flb_ra_parser *rp = NULL;
+
+    if (mk_list_size(&cra->list) == 0) {
+        return NULL;
+    }
+    rp = mk_list_entry_first(&cra->list, struct flb_ra_parser, _head);
+    if (!rp->key) {
+        return NULL;
+    }
+    return rp;
+}
+
+/*
+ * If 'cfl record accessor' pattern matches an entry in the 'cfl', set the
+ * reference in 'out_key' and 'out_val' for the entries in question.
+ *
+ * Returns FLB_TRUE if the pattern matched a kv pair, otherwise it returns
+ * FLB_FALSE.
+ */
+int flb_cfl_ra_get_kv_pair(struct flb_cfl_record_accessor *cra,
+                           struct cfl_variant var,
+                           cfl_sds_t *start_key,
+                           cfl_sds_t *out_key, struct cfl_variant **out_val)
+{
+    struct flb_ra_parser *rp;
+
+    rp = get_ra_parser(cra);
+    if (rp == NULL) {
+        return FLB_FALSE;
+    }
+
+    return flb_cfl_ra_key_value_get(rp->key->name, var, rp->key->subkeys,
+                                    start_key, out_key, out_val);
+}
+
+
+struct flb_cfl_ra_value *flb_cfl_ra_get_value_object(struct flb_cfl_record_accessor *cra,
+                                                     struct cfl_variant var)
+{
+    struct flb_ra_parser *rp;
+
+    rp = get_ra_parser(cra);
+    if (rp == NULL) {
+        return NULL;
+    }
+
+    return flb_cfl_ra_key_to_value(rp->key->name, var, rp->key->subkeys);
+}
+
+/**
+ *  Update key and/or value of the map using record accessor.
+ *
+ *  @param cra   the record accessor to specify key/value pair
+ *  @param cfl  the original cfl_object.
+ *  @param in_key   the pointer to overwrite key. If NULL, key will not be updated.
+ *  @param in_val   the pointer to overwrite val. If NULL, val will not be updated.
+ *
+ *  @return result of the API. 0:success, -1:fail
+ */
+
+int flb_cfl_ra_update_kv_pair(struct flb_cfl_record_accessor *cra, struct cfl_variant var,
+                              cfl_sds_t in_key, struct cfl_variant *in_val)
+{
+    struct flb_ra_parser *rp;
+    int ret;
+
+    cfl_sds_t s_key = NULL;
+    cfl_sds_t o_key = NULL;
+    struct cfl_variant *o_val = NULL;
+
+    if (in_key == NULL && in_val == NULL) {
+        /* no key and value. nothing to do */
+        flb_error("%s: no inputs", __FUNCTION__);
+        return -1;
+    }
+    else if (cra == NULL) {
+        /* invalid input */
+        flb_error("%s: invalid input", __FUNCTION__);
+        return -1;
+    }
+    else if (flb_cfl_ra_get_kv_pair(cra, var, &s_key, &o_key, &o_val) != 0) {
+        /* key and value are not found */
+        flb_error("%s: no value", __FUNCTION__);
+        return -1;
+    }
+
+    rp = get_ra_parser(cra);
+    if (rp == NULL) {
+        return -1;
+    }
+
+    ret = flb_cfl_ra_key_value_update(rp, &var, in_key, in_val);
+    if (ret < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ *  Add key and/or value of the map using record accessor.
+ *  If key already exists, the API fails.
+ *
+ *  @param cra  the record accessor to specify key.
+ *  @param vobj the original cfl_object.
+ *  @param in_val   the pointer to add val.
+ *
+ *  @return result of the API. 0:success, -1:fail
+ */
+
+int flb_cfl_ra_append_kv_pair(struct flb_cfl_record_accessor *cra, struct cfl_variant var,
+                              struct cfl_variant *in_val)
+{
+    struct flb_ra_parser *rp;
+    int ret;
+
+    cfl_sds_t s_key = NULL;
+    cfl_sds_t o_key = NULL;
+    struct cfl_variant *o_val = NULL;
+
+    if (in_val == NULL) {
+        /* no key and value. nothing to do */
+        flb_error("%s: no value", __FUNCTION__);
+        return -1;
+    }
+    else if (cra == NULL) {
+        /* invalid input */
+        flb_error("%s: invalid input", __FUNCTION__);
+        return -1;
+    }
+
+    flb_cfl_ra_get_kv_pair(cra, var, &s_key, &o_key, &o_val);
+    if (o_key != NULL && o_val != NULL) {
+        /* key and value already exist */
+        flb_error("%s: already exist", __FUNCTION__);
+        return -1;
+    }
+
+    rp = get_ra_parser(cra);
+    if (rp == NULL || rp->key == NULL) {
+        return -1;
+    }
+
+    ret = flb_cfl_ra_key_value_append(rp, &var, in_val);
+    if (ret < 0) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -87,6 +87,7 @@ if(FLB_RECORD_ACCESSOR)
   set(UNIT_TESTS_FILES
     ${UNIT_TESTS_FILES}
     record_accessor.c
+    cfl_record_accessor.c
     )
 endif()
 

--- a/tests/internal/cfl_record_accessor.c
+++ b/tests/internal/cfl_record_accessor.c
@@ -1,0 +1,1499 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_sds_list.h>
+#include <fluent-bit/flb_cfl_record_accessor.h>
+#include <fluent-bit/record_accessor/flb_ra_parser.h>
+#include <msgpack.h>
+
+#include "flb_tests_internal.h"
+
+#include <stdlib.h>
+
+void cb_keys()
+{
+    struct flb_cfl_record_accessor *cra;
+
+    printf("\n=== test ===");
+    cra = flb_cfl_ra_create("$aaa['a'] extra $bbb['b'] final access", FLB_TRUE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+    TEST_CHECK(mk_list_size(&cra->list) == 4);
+    flb_cfl_ra_dump(cra);
+    flb_cfl_ra_destroy(cra);
+
+    printf("\n=== test ===");
+    cra = flb_cfl_ra_create("$b['x']['y']", FLB_TRUE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+    TEST_CHECK(mk_list_size(&cra->list) == 1);
+    flb_cfl_ra_dump(cra);
+    flb_cfl_ra_destroy(cra);
+
+    printf("\n=== test ===");
+    cra = flb_cfl_ra_create("$z", FLB_TRUE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+    TEST_CHECK(mk_list_size(&cra->list) == 1);
+    flb_cfl_ra_dump(cra);
+    flb_cfl_ra_destroy(cra);
+
+    printf("\n=== test ===");
+    cra = flb_cfl_ra_create("abc", FLB_TRUE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+    TEST_CHECK(mk_list_size(&cra->list) == 1);
+    flb_cfl_ra_dump(cra);
+    flb_cfl_ra_destroy(cra);
+
+    cra = flb_cfl_ra_create("$abc['a'", FLB_TRUE);
+    TEST_CHECK(cra == NULL);
+
+    cra = flb_cfl_ra_create("", FLB_TRUE);
+    flb_cfl_ra_destroy(cra);
+}
+
+void cb_dash_key()
+{
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_variant *vobj = NULL;
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* kvlist: "{\"key-dash\" => \"something\"}" */
+    cfl_kvlist_insert_string(kvlist, "key-dash", "something");
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key-dash");
+    fmt_out = "something";
+
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    str = flb_cfl_ra_translate(cra, NULL, -1, *vobj, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    cfl_variant_destroy(vobj);
+    flb_cfl_ra_destroy(cra);
+}
+
+void cb_translate()
+{
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /*     "{\"k1\": \"string\", \"k2\": true, \"k3\": false," \ */
+    /*     " \"k4\": 0.123456789, \"k5\": 123456789,"          \ */
+    /*     " \"k6\": {\"s1\": {\"s2\": \"nested\"}}}"; */
+    cfl_kvlist_insert_string(kvlist, "k1", "string");
+    cfl_kvlist_insert_bool(kvlist, "k2", CFL_TRUE);
+    cfl_kvlist_insert_bool(kvlist, "k3", CFL_FALSE);
+    cfl_kvlist_insert_double(kvlist, "k4", (double)0.123456789);
+    cfl_kvlist_insert_int64(kvlist, "k5", 123456789);
+    cfl_kvlist_insert_string(nested, "s2", "nested");
+    cfl_kvlist_insert_kvlist(inner, "s1", nested);
+    cfl_kvlist_insert_kvlist(kvlist, "k6", inner);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Set environment variables */
+    putenv("FLB_ENV=translated");
+
+    /* Formatter */
+    fmt =                                                               \
+        "START k1 => \"$k1\", k2 => $k2 (bool), k3 => $k3 (bool), "    \
+        "k4 => $k4 (float), k5 => $k5 (int),"                           \
+        "k6 => $k6['s1']['s2'] (nested), k8 => $k8 (nothing), ${FLB_ENV} END";
+
+    fmt_out = \
+        "START k1 => \"string\", k2 => true (bool), "                   \
+        "k3 => false (bool), k4 => 0.123457 (float), "                  \
+        "k5 => 123456789 (int),k6 => nested (nested), "           \
+        "k8 =>  (nothing), translated END";
+
+    cra = flb_cfl_ra_create(fmt, FLB_TRUE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    str = flb_cfl_ra_translate(cra, NULL, -1, *vobj, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        goto error;
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+error:
+    flb_sds_destroy(str);
+    cfl_variant_destroy(vobj);
+    flb_cfl_ra_destroy(cra);
+}
+
+void cb_translate_tag()
+{
+    char *fmt;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /*     "{\"k1\": \"string\", \"k2\": true, \"k3\": false," \ */
+    /*     " \"k4\": 0.123456789, \"k5\": 123456789,"          \ */
+    /*     " \"k6\": {\"s1\": {\"s2\": \"nested\"}}}"; */
+    cfl_kvlist_insert_string(kvlist, "k1", "string");
+    cfl_kvlist_insert_bool(kvlist, "k2", CFL_TRUE);
+    cfl_kvlist_insert_bool(kvlist, "k3", CFL_FALSE);
+    cfl_kvlist_insert_double(kvlist, "k4", (double)0.123456789);
+    cfl_kvlist_insert_int64(kvlist, "k5", 123456789);
+    cfl_kvlist_insert_string(nested, "s2", "nested");
+    cfl_kvlist_insert_kvlist(inner, "s1", nested);
+    cfl_kvlist_insert_kvlist(kvlist, "k6", inner);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    fmt = "$TAG";
+    cra = flb_cfl_ra_create(fmt, FLB_TRUE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    str = flb_cfl_ra_translate(cra, "testapp", 7, *vobj, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+    TEST_CHECK(flb_sds_len(str) == 7);
+
+    flb_sds_destroy(str);
+    cfl_variant_destroy(vobj);
+    flb_cfl_ra_destroy(cra);
+}
+
+void cb_dots_subkeys()
+{
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", \"kubernetes\": {\"annotations\": " */
+    /* "{\"fluentbit.io/tag\": \"thetag\"}}}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_kvlist(kvlist, "kubernetes", inner);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes['annotations']['fluentbit.io/tag']");
+    fmt_out = "thetag";
+
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    str = flb_cfl_ra_translate(cra, NULL, -1, *vobj, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    cfl_variant_destroy(vobj);
+    flb_cfl_ra_destroy(cra);
+}
+
+void cb_array_id()
+{
+    char *fmt;
+    char *fmt_out;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['fluentbit.io/tag']");
+    fmt_out = "thetag";
+
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    str = flb_cfl_ra_translate(cra, NULL, -1, *vobj, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(fmt_out));
+    TEST_CHECK(memcmp(str, fmt_out, strlen(fmt_out)) == 0);
+    printf("== input ==\n%s\n== output ==\n%s\n", str, fmt_out);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    cfl_variant_destroy(vobj);
+    flb_cfl_ra_destroy(cra);
+}
+
+void cb_get_kv_pair()
+{
+    int ret;
+    char *fmt;
+    char *fmt_out;
+    struct flb_cfl_record_accessor *cra;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+    cfl_sds_t start_key;
+    cfl_sds_t out_key;
+    struct cfl_variant *out_val;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['fluentbit.io/tag']");
+    fmt_out = "thetag";
+
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    ret = flb_cfl_ra_get_kv_pair(cra, *vobj, &start_key, &out_key, &out_val);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(out_val->type == CFL_VARIANT_STRING);
+    TEST_CHECK(cfl_sds_len(out_val->data.as_string) == strlen(fmt_out));
+    TEST_CHECK(memcmp(out_val->data.as_string, fmt_out, strlen(fmt_out)) == 0);
+
+    flb_sds_destroy(fmt);
+    cfl_variant_destroy(vobj);
+    flb_cfl_ra_destroy(cra);
+}
+
+static int order_lookup_check(struct cfl_variant *vobj,
+                              char *fmt, char *expected_out)
+{
+    char *fmt_out;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+
+    /* Check bool is 'true' */
+    fmt = flb_sds_create(fmt);
+    if (!TEST_CHECK(fmt != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+    fmt_out = expected_out;
+
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation */
+    str = flb_cfl_ra_translate(cra, NULL, -1, *vobj, NULL);
+    TEST_CHECK(str != NULL);
+    if (!str) {
+        exit(EXIT_FAILURE);
+    }
+
+    TEST_CHECK(flb_sds_len(str) == strlen(expected_out));
+    if (flb_sds_len(str) != strlen(expected_out)) {
+        printf("received: '%s', expected: '%s'\n", str, fmt_out);
+    }
+
+    TEST_CHECK(memcmp(str, expected_out, strlen(expected_out)) == 0);
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(cra);
+
+    return 0;
+}
+
+void cb_key_order_lookup()
+{
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Sample cfl_object structure */
+    /* "{\"key\": \"abc\", \"bool\": false, \"bool\": true, " */
+    /*    "\"str\": \"first\", \"str\": \"second\", " */
+    /*    "\"num\": 0, \"num\": 1}"; */
+    cfl_kvlist_insert_string(kvlist, "key", "abc");
+    cfl_kvlist_insert_bool(kvlist, "bool", CFL_FALSE);
+    cfl_kvlist_insert_bool(kvlist, "bool", CFL_TRUE);
+    cfl_kvlist_insert_string(kvlist, "str", "first");
+    cfl_kvlist_insert_string(kvlist, "str", "second");
+    cfl_kvlist_insert_int64(kvlist, "num", 0);
+    cfl_kvlist_insert_int64(kvlist, "num", 1);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    printf("\n-- record --\n");
+    cfl_variant_print(stdout, vobj);
+
+    /* check expected outputs per record accessor pattern */
+    order_lookup_check(vobj, "$bool", "true");
+    order_lookup_check(vobj, "$str" , "second");
+    order_lookup_check(vobj, "$num" , "1");
+
+    cfl_variant_destroy(vobj);
+}
+
+void cb_update_key_val()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_key = "updated_key";
+    char *fmt_out_val = "updated_val";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    cfl_sds_t in_key = NULL;
+    struct cfl_variant *in_val = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create key object to overwrite */
+    in_key = cfl_sds_create("updated_key");
+    /* create value object to overwrite */
+    in_val = cfl_variant_create_from_string("updated_val");
+    if (in_val == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['fluentbit.io/tag']");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$kubernetes[2]['annotations']['updated_key']");
+    updated_cra = flb_cfl_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_cfl_ra_update_kv_pair(cra, *vobj, in_key, in_val);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(updated_cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(cfl_sds_len(out_key) == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == CFL_VARIANT_STRING);
+    TEST_CHECK(cfl_sds_len(out_val->data.as_string) == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->data.as_string, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(updated_cra);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+    cfl_sds_destroy(in_key);
+}
+
+void cb_update_val()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_val = "updated_val";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    struct cfl_variant *in_val = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create value object to overwrite */
+    in_val = cfl_variant_create_from_string("updated_val");
+    if (in_val == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['fluentbit.io/tag']");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_cfl_ra_update_kv_pair(cra, *vobj, NULL, in_val);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == CFL_VARIANT_STRING);
+    TEST_CHECK(cfl_sds_len(out_val->data.as_string) == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->data.as_string, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+}
+
+void cb_update_key()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_key = "updated_key";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    cfl_sds_t in_key = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create key object to overwrite */
+    in_key = cfl_sds_create("updated_key");
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['fluentbit.io/tag']");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$kubernetes[2]['annotations']['updated_key']");
+    updated_cra = flb_cfl_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_cfl_ra_update_kv_pair(cra, *vobj, in_key, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(updated_cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        goto error;
+    }
+
+    /* Check updated key */
+    TEST_CHECK(cfl_sds_len(out_key) == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+error:
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(cra);
+    flb_cfl_ra_destroy(updated_cra);
+    cfl_variant_destroy(vobj);
+    cfl_sds_destroy(in_key);
+}
+
+void cb_update_root_key()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_key = "updated_key";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    cfl_sds_t in_key = NULL;
+    struct cfl_variant *in_val = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create key object to overwrite */
+    in_key = flb_sds_create("updated_key");
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key1");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$updated_key");
+    updated_cra = flb_cfl_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_cfl_ra_update_kv_pair(cra, *vobj, in_key, in_val);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(updated_cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(cfl_sds_len(out_key) == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(updated_cra);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+    cfl_sds_destroy(in_key);
+}
+
+void cb_update_root_key_val()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_key = "updated_key";
+    char *fmt_out_val = "updated_val";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    cfl_sds_t in_key = NULL;
+    struct cfl_variant *in_val = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create key object to overwrite */
+    in_key = flb_sds_create("updated_key");
+    /* create value object to overwrite */
+    in_val = cfl_variant_create_from_string("updated_val");
+    if (in_val == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$key1");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$updated_key");
+    updated_cra = flb_cfl_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Update only value */
+    ret = flb_cfl_ra_update_kv_pair(cra, *vobj, in_key, in_val);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(updated_cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(cfl_sds_len(out_key) == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == CFL_VARIANT_STRING);
+    TEST_CHECK(cfl_sds_len(out_val->data.as_string) == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->data.as_string, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(updated_cra);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+    cfl_sds_destroy(in_key);
+}
+
+void cb_ra_translate_check()
+{
+    char *fmt;
+    flb_sds_t str;
+    struct flb_cfl_record_accessor *cra;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"root.with/symbols\": \"something\"}"; */
+    cfl_kvlist_insert_string(kvlist, "root.with/symbols", "something");
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    int check_translation = FLB_TRUE;
+
+    /* Formatter */
+    fmt = flb_sds_create("$root");
+    if (!TEST_CHECK(fmt != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    TEST_CHECK(cra != NULL);
+    if (!cra) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do translation - with check enabled */
+    str = flb_cfl_ra_translate_check(cra, NULL, -1, *vobj, NULL, check_translation);
+    /* since translation fails and check is enabled, it returns NULL */
+    TEST_CHECK(str == NULL);
+    if (str) {
+        exit(EXIT_FAILURE);
+    }
+
+    flb_sds_destroy(str);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+}
+
+struct char_list_cobj_ra_str{
+    char **strs;
+    char *expect;
+};
+
+void cb_ra_create_str_from_list()
+{
+    char *case1[] = {"a", NULL};
+    char *case2[] = {"aa", "bb", "cc", NULL};
+
+    struct char_list_cobj_ra_str testcases[] = {
+        { .strs = &case1[0], .expect = "$a"},
+        { .strs = &case2[0], .expect = "$aa['bb']['cc']"},
+    };
+    size_t case_size = sizeof(testcases)/sizeof(struct char_list_cobj_ra_str);
+    int case_i;
+    struct flb_sds_list *list = NULL;
+    flb_sds_t ret_str;
+    char *str;
+    int i;
+    int ret;
+
+    for (case_i = 0; case_i < case_size; case_i++) {
+        list = flb_sds_list_create();
+        if (!TEST_CHECK(list != NULL)) {
+            TEST_MSG("%d: flb_sds_list_create failed", case_i);
+            exit(EXIT_FAILURE);
+        }
+        i = 0;
+        while(testcases[case_i].strs[i] != NULL) {
+            str = testcases[case_i].strs[i];
+            ret = flb_sds_list_add(list, str, strlen(str));
+            if (!TEST_CHECK(ret == 0)) {
+                TEST_MSG("%d: flb_sds_list_add failed", case_i);
+                flb_sds_list_destroy(list);
+                exit(EXIT_FAILURE);
+            }
+            i++;
+        }
+
+        ret_str = flb_cfl_ra_create_str_from_list(list);
+        if (!TEST_CHECK(ret_str != NULL)) {
+            TEST_MSG("%d: flb_ra_create_str_from failed", case_i);
+            flb_sds_list_destroy(list);
+            exit(EXIT_FAILURE);
+        }
+        if (!TEST_CHECK(strcmp(testcases[case_i].expect, ret_str) == 0)) {
+            TEST_MSG("%d: strcmp error.got=%s expect=%s", case_i, ret_str, testcases[case_i].expect);
+        }
+
+        flb_sds_destroy(ret_str);
+        flb_sds_list_destroy(list);
+    }
+
+
+    /* Error if we pass empty list */
+    list = flb_sds_list_create();
+    if (!TEST_CHECK(list != NULL)) {
+        TEST_MSG("flb_sds_list_create failed");
+        exit(EXIT_FAILURE);
+    }
+    ret_str = flb_cfl_ra_create_str_from_list(list);
+    if (!TEST_CHECK(ret_str == NULL)) {
+        TEST_MSG("flb_ra_create_str_from should be failed");
+        flb_sds_list_destroy(list);
+        exit(EXIT_FAILURE);
+    }
+    flb_sds_list_destroy(list);
+}
+
+void cb_add_key_val()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_key = "add_key";
+    char *fmt_out_val = "add_val";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    struct cfl_variant *in_val = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create value object to overwrite */
+    in_val = cfl_variant_create_from_string("add_val");
+    if (in_val == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$kubernetes[2]['annotations']['add_key']");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$kubernetes[2]['annotations']['add_key']");
+    updated_cra = flb_cfl_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Add key/value */
+    ret = flb_cfl_ra_append_kv_pair(cra, *vobj, in_val);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(updated_cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(cfl_sds_len(out_key) == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == CFL_VARIANT_STRING);
+    TEST_CHECK(cfl_sds_len(out_val->data.as_string) == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->data.as_string, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(updated_cra);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+}
+
+void cb_add_root_key_val()
+{
+    int ret;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_kvlist *nested = NULL;
+    struct cfl_kvlist *inner = NULL;
+    struct cfl_array *array = NULL;
+    struct cfl_variant *vobj = NULL;
+
+    flb_sds_t fmt = NULL;
+    flb_sds_t updated_fmt = NULL;
+    char *fmt_out_key = "add_key";
+    char *fmt_out_val = "add_val";
+
+    cfl_sds_t start_key = NULL;
+    cfl_sds_t out_key = NULL;
+    struct cfl_variant *out_val = NULL;
+
+    struct cfl_variant *in_val = NULL;
+
+    struct flb_cfl_record_accessor *cra = NULL;
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+
+    /* Sample kvlist */
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    inner = cfl_kvlist_create();
+    if (inner == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    nested = cfl_kvlist_create();
+    if (nested == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    array = cfl_array_create(3);
+    if (array == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* create value object to overwrite */
+    in_val = cfl_variant_create_from_string("add_val");
+    if (in_val == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* /\* Sample message structure *\/ */
+    /* "{\"key1\": \"something\", " */
+    /* "\"kubernetes\": " */
+    /* "   [true, " */
+    /* "    false, " */
+    /* "    {\"a\": false, " */
+    /* "     \"annotations\": { " */
+    /* "                       \"fluentbit.io/tag\": \"thetag\"" */
+    /* "}}]}"; */
+    cfl_kvlist_insert_string(kvlist, "key1", "something");
+    cfl_kvlist_insert_string(nested, "fluentbit.io/tag", "thetag");
+    cfl_kvlist_insert_kvlist(inner, "annotations", nested);
+    cfl_kvlist_insert_bool(inner, "a", CFL_FALSE);
+    cfl_array_append_bool(array, CFL_TRUE);
+    cfl_array_append_bool(array, CFL_FALSE);
+    cfl_array_append_kvlist(array, inner);
+    cfl_kvlist_insert_array(kvlist, "kubernetes", array);
+
+    /* Set up CFL variant(vobj) */
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj == NULL) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    fmt = flb_sds_create("$add_key");
+    cra = flb_cfl_ra_create(fmt, FLB_FALSE);
+    if(!TEST_CHECK(cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Formatter */
+    updated_fmt = flb_sds_create("$add_key");
+    updated_cra = flb_cfl_ra_create(updated_fmt, FLB_FALSE);
+    if(!TEST_CHECK(updated_cra != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Add key/value */
+    ret = flb_cfl_ra_append_kv_pair(cra, *vobj, in_val);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_cfl_ra_get_kv_pair(updated_cra, *vobj, &start_key, &out_key, &out_val);
+    if (!TEST_CHECK(ret == 0)) {
+        printf("print out_result\n");
+        cfl_variant_print(stdout, vobj);
+        exit(EXIT_FAILURE);
+    }
+
+    /* Check updated key */
+    TEST_CHECK(cfl_sds_len(out_key) == strlen(fmt_out_key));
+    TEST_CHECK(memcmp(out_key, fmt_out_key, strlen(fmt_out_key)) == 0);
+
+    /* Check updated val */
+    TEST_CHECK(out_val->type == CFL_VARIANT_STRING);
+    TEST_CHECK(cfl_sds_len(out_val->data.as_string) == strlen(fmt_out_val));
+    TEST_CHECK(memcmp(out_val->data.as_string, fmt_out_val, strlen(fmt_out_val)) == 0);
+
+    flb_sds_destroy(updated_fmt);
+    flb_sds_destroy(fmt);
+    flb_cfl_ra_destroy(updated_cra);
+    flb_cfl_ra_destroy(cra);
+    cfl_variant_destroy(vobj);
+}
+
+TEST_LIST = {
+    { "keys"                   , cb_keys},
+    { "dash_key"               , cb_dash_key},
+    { "translate"              , cb_translate},
+    { "translate_tag"          , cb_translate_tag},
+    { "dots_subkeys"           , cb_dots_subkeys},
+    { "array_id"               , cb_array_id},
+    { "get_kv_pair"            , cb_get_kv_pair},
+    { "key_order_lookup"       , cb_key_order_lookup},
+    { "update_key_val"         , cb_update_key_val},
+    { "update_val"             , cb_update_val},
+    { "update_key"             , cb_update_key},
+    { "update_root_key_val"    , cb_update_root_key_val},
+    { "update_root_key"        , cb_update_root_key},
+    { "add_key_val"            , cb_add_key_val},
+    { "add_root_key_val"       , cb_add_root_key_val},
+    { "flb_ra_translate_check" , cb_ra_translate_check},
+    { "ra_create_str_from_list", cb_ra_create_str_from_list},
+    { NULL }
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, we didn't implement CFL based record accessor. Which is also called as cobj.
This leads that we're not able to access nested cobjets in processor plugins.
To resolve this, I implemented cobj based record accessor and that infrastructure, cobj_ra_key.

In cobj based record accessor, the same mechanism of parser for record accessor syntax is able to use.
So, I didn't implement cobj specific parser of that syntax.
The main difference of the accessor is creating cobj based record accessor related sturct and use it there.
Other part is mostly copy and paste and then adjust for the operation of cobj.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

The written down test cases are not causing memory leaks:

```
$ valgrind bin/flb-it-cobj_record_accessor -v
<snip>
==878874== 
==878874== HEAP SUMMARY:
==878874==     in use at exit: 0 bytes in 0 blocks
==878874==   total heap usage: 16,823 allocs, 16,823 frees, 1,681,429 bytes allocated
==878874== 
==878874== All heap blocks were freed -- no leaks are possible
==878874== 
==878874== For lists of detected and suppressed errors, rerun with: -s
==878874== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
