### PR TITLE
network: use TCP_KEEPALIVE instead of TCP_KEEPIDLE in OSX

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -324,9 +324,12 @@ int flb_net_socket_tcp_keepalive(flb_sockfd_t fd, struct flb_net_setup *net)
                      (const void *) &enabled, sizeof(enabled));
 
     if (ret == 0 && time >= 0) {
-        ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
-                         (const void *) &time, sizeof(time));
-    }
+#ifdef __APPLE__
+        ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE,
+#else
+                ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+#endif
+                (const void *) &time, sizeof(time));    }
 
     if (ret == 0 && interval >= 0) {
         ret = setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,


### PR DESCRIPTION
The build fails in OSX because TCP_KEEPIDLE doesn't exist in the netinet lib, instead TCP_KEEPALIVE should be used.

Not sure if the ifdef should be here or not. I'd appreciate the feedback.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
