### PR TITLE
dockerfile: enable SIMD optimization for x86_64, amd64, arm64 and aarch64

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -65,7 +65,15 @@ COPY . ./
 # We split the builder setup out so people can target it or use as a base image without doing a full build.
 FROM builder-base AS builder
 WORKDIR /src/fluent-bit/build/
-RUN cmake -DFLB_RELEASE=On \
+
+# SIMD support: x86_64, amd64 and arm64
+ARG SIMD_CMAKE_FLAG=""
+RUN SIMD_CMAKE_FLAG="" && \
+    case "$(uname -m)" in \
+        "x86_64"|"amd64"|"aarch64"|"arm64") \
+            SIMD_CMAKE_FLAG="-DFLB_SIMD=On";; \
+    esac && \
+    cmake -DFLB_RELEASE=On \
     -DFLB_JEMALLOC=On \
     -DFLB_TLS=On \
     -DFLB_SHARED_LIB=Off \
@@ -78,6 +86,7 @@ RUN cmake -DFLB_RELEASE=On \
     -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
     -DFLB_LOG_NO_CONTROL_CHARS=On \
     -DFLB_CHUNK_TRACE="$FLB_CHUNK_TRACE" \
+    $SIMD_CMAKE_FLAG \
     ..
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
