### PR TITLE
config_format: windows: Handle static config on windows correctly

### DIFF
--- a/src/config_format/flb_cf_fluentbit.c
+++ b/src/config_format/flb_cf_fluentbit.c
@@ -502,7 +502,7 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
      * workaround to retrieve the lines.
      */
     size_t off = 0;
-    while (static_fgets(buf, FLB_CF_BUF_SIZE, in_data, &off)) {
+    while (static_fgets(buf, FLB_DEFAULT_CF_BUF_SIZE, in_data, &off)) {
 #else
     /* normal mode, read lines into a buffer */
     /* note that we use "fgets_ptr" so we can continue reading after realloc */
@@ -518,10 +518,15 @@ static int read_config(struct flb_cf *cf, struct local_ctx *ctx,
             /* after a successful line read, restore "fgets_ptr" to point to the
              * beginning of buffer */
             fgets_ptr = buf;
-        } else if (feof(f)) {
+        }
+#ifndef FLB_HAVE_STATIC_CONF
+        /* When using static conf build, FILE pointer is absent and
+         * always as NULL. */
+        else if (feof(f)) {
             /* handle EOF without a newline(CRLF or LF) */
             fgets_ptr = buf;
         }
+#endif
 #ifndef FLB_HAVE_STATIC_CONF
         else {
             /* resize the line buffer */

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2767,8 +2767,8 @@ static struct parser_state *state_create(struct file_state *parent, struct file_
 
 #else
 
-    s->file->name = flb_sds_create("***static***");
-    s->file->path = flb_sds_create("***static***");
+    state->file->name = flb_sds_create("***static***");
+    state->file->path = flb_sds_create("***static***");
 
 #endif
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the current master on Fluent Bit, we didn't follow the changes of enabling FLB_STATIC_CONF case.
With tons of changes after we introduced that option on cmake, this option does not work for using enabling with `-DFLB_STATIC_CONF=/path/to/confdir`.

I followed the subsequent changes since that feature was introduced and plug a NULL pointer exception for `feof(3)`.
This is because this is always needed for reading from the actual configuration files. However, reading from buffer on memory is not needed to check the end of the contents for Fluent Bit configuration.

I supposed that we can omit that checker when enabling static config.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes https://github.com/fluent/fluent-bit/issues/9556.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
