### PR TITLE
opentelemetry: initial addition of the experimental otlp profile signal

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -202,6 +202,14 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "profiles_support", "false",
+     0, FLB_TRUE, offsetof(struct flb_opentelemetry, profile_support_enabled),
+     "This is an experimental feature whoses specification is not stable yet, " \
+     "feel free to test it but please do not enable this in production " \
+     "environments"
+    },
+
+    {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, buffer_max_size),
      ""

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -38,6 +38,7 @@ struct flb_opentelemetry {
     int raw_traces;
     int  tag_from_uri;
     flb_sds_t logs_metadata_key;
+    int profile_support_enabled;
 
     struct flb_input_instance *ins;
 


### PR DESCRIPTION
This PR will not build until the accompanying PR that introduces cprofiles in the system is merged and this one is rebased