### PR TITLE
in_ebpf: Prepare build directory for building eBPF objects

### DIFF
--- a/plugins/in_ebpf/CMakeLists.txt
+++ b/plugins/in_ebpf/CMakeLists.txt
@@ -34,6 +34,9 @@ file(GLOB_RECURSE TRACE_C_FILES ${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/*/bpf
 set(TRACE_OBJ_FILES "")
 set(TRACE_SKEL_HEADERS "")
 
+add_custom_target(ebpf-generated-directory ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/plugins/in_ebpf/traces/includes/generated/)
+
 # Iterate over each trace bpf.c file to generate corresponding .o and .skel.h files
 foreach(TRACE_C_FILE ${TRACE_C_FILES})
   # Get the filename and parent directory name (for uniqueness)
@@ -61,7 +64,7 @@ foreach(TRACE_C_FILE ${TRACE_C_FILES})
             -I${VMLINUX_PATH}         # Include the correct vmlinux.h based on architecture
             -c ${TRACE_C_FILE}
             -o ${TRACE_OBJ_FILE}
-    DEPENDS ${TRACE_C_FILE}
+    DEPENDS ${TRACE_C_FILE} ebpf-generated-directory
   )
 
   # Generate skeleton header for each compiled BPF object file


### PR DESCRIPTION
<!-- Provide summary of changes -->
Without the generated directory creation before compiling eBPF objects, I get failed to compile eBPF objects for in_ebpf plugin.
After adding that creation of directory, I succeeded to compile in_ebpf plugin in Ubuntu 24.04 with 6.11 (noble-proposed) Kernel and its associated linux-tools. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
