### PR TITLE
security: supported versions now are 3.1.x and 3.2.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,10 @@
 
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 3.x     | :white_check_mark: |
-| < 3.0   | :x:                |
+|---------| ------------------ |
+| 3.2.x   | :white_check_mark: |
+| 3.1.x   | :white_check_mark: |
+| < 3.1   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Moving 3.0 out of support.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
