### PR TITLE
Fix type errors in cprofiles

### DIFF
--- a/lib/cprofiles/src/cprof_encode_text.c
+++ b/lib/cprofiles/src/cprof_encode_text.c
@@ -1909,7 +1909,7 @@ static int encode_cprof_resource_profiles(
                 struct cprof_resource_profiles *instance) {
     int result;
     struct cfl_list             *iterator;
-    struct cprof_scope_profile *scope_profile;
+    struct cprof_scope_profiles *scope_profiles;
 
     result = encode_string(context,
                             CFL_TRUE,
@@ -1958,11 +1958,11 @@ static int encode_cprof_resource_profiles(
 
         cfl_list_foreach(iterator,
                          &instance->scope_profiles) {
-            scope_profile = cfl_list_entry(
+            scope_profiles = cfl_list_entry(
                                 iterator,
                                 struct cprof_scope_profiles, _head);
 
-            result = encode_cprof_scope_profiles(context, scope_profile);
+            result = encode_cprof_scope_profiles(context, scope_profiles);
 
             if (result != CPROF_ENCODE_TEXT_SUCCESS) {
                 return result;

--- a/lib/cprofiles/src/cprof_profile.c
+++ b/lib/cprofiles/src/cprof_profile.c
@@ -98,7 +98,7 @@ void cprof_profile_destroy(struct cprof_profile *instance)
     struct cfl_list             *iterator_backup;
     struct cprof_attribute_unit *attribute_unit;
     struct cprof_value_type     *value_type;
-    struct cprof_mapping        *location;
+    struct cprof_location       *location;
     struct cprof_function       *function;
     struct cfl_list             *iterator;
     struct cprof_mapping        *mapping;


### PR DESCRIPTION
Fix type errors that prevent build on Fedora 40+.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
