### PR TITLE
node_exporter_metrics: Use real_path for complaining on glob error

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -302,7 +302,7 @@ int ne_utils_path_scan(struct flb_ne *ctx, const char *mount, const char *path,
             flb_plg_error(ctx->ins, "no memory space available");
             return -1;
         case GLOB_ABORTED:
-            flb_plg_error(ctx->ins, "read error, check permissions: %s", path);
+            flb_plg_error(ctx->ins, "read error, check permissions: %s", real_path);
             return -1;;
         case GLOB_NOMATCH:
             ret = stat(path, &st);


### PR DESCRIPTION
<!-- Provide summary of changes -->
On exception happened, we just omitted to print the path of aborted path without mount point.
This is sometimes troublesome to distinguish where should cause the permission issue or just absent path.
In this case, we need to display the real_path which contains the full path of handling of glob.
 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
$ bin/fluent-bit -i node_exporter_metrics -p metrics=cpu -p path.sysfs=/host/sysfs -o stdout -v
```

- [x] Debug log output from testing the change


```
[2024/11/19 19:03:18] [error] [input:node_exporter_metrics:node_exporter_metrics.0] read error, check permissions: /host/sysfs/devices/system/cpu/cpu[0-9]*
```

More details:

```
Fluent Bit v3.2.1
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |____ |/ __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \  / /  
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)_____/


[2024/11/19 19:03:14] [ info] Configuration:
[2024/11/19 19:03:14] [ info]  flush time     | 1.000000 seconds
[2024/11/19 19:03:14] [ info]  grace          | 5 seconds
[2024/11/19 19:03:14] [ info]  daemon         | 0
[2024/11/19 19:03:14] [ info] ___________
[2024/11/19 19:03:14] [ info]  inputs:
[2024/11/19 19:03:14] [ info]      node_exporter_metrics
[2024/11/19 19:03:14] [ info] ___________
[2024/11/19 19:03:14] [ info]  filters:
[2024/11/19 19:03:14] [ info] ___________
[2024/11/19 19:03:14] [ info]  outputs:
[2024/11/19 19:03:14] [ info]      stdout.0
[2024/11/19 19:03:14] [ info] ___________
[2024/11/19 19:03:14] [ info]  collectors:
[2024/11/19 19:03:14] [ info] [fluent bit] version=3.2.1, commit=600b5a955b, pid=184063
[2024/11/19 19:03:14] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/11/19 19:03:14] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2024/11/19 19:03:14] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2024/11/19 19:03:14] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /host/sysfs
[2024/11/19 19:03:14] [ info] [simd    ] SSE2
[2024/11/19 19:03:14] [error] [input:node_exporter_metrics:node_exporter_metrics.0] read error, check permissions: /host/sysfs/devices/system/cpu/cpu[0-9]*
[2024/11/19 19:03:14] [ info] [cmetrics] version=0.9.9
[2024/11/19 19:03:14] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics cpu
[2024/11/19 19:03:14] [ info] [ctraces ] version=0.5.7
[2024/11/19 19:03:14] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2024/11/19 19:03:14] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2024/11/19 19:03:14] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2024/11/19 19:03:14] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2024/11/19 19:03:14] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=38 write=39
[2024/11/19 19:03:14] [debug] [stdout:stdout.0] created event channels: read=42 write=43
[2024/11/19 19:03:14] [ info] [output:stdout:stdout.0] worker #0 started
[2024/11/19 19:03:14] [ info] [sp] stream processor started
[2024/11/19 19:03:18] [error] [input:node_exporter_metrics:node_exporter_metrics.0] read error, check permissions: /host/sysfs/devices/system/cpu/cpu[0-9]*
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="idle"} = 39476.639999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="iowait"} = 35.140000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="nice"} = 0.81999999999999995
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="softirq"} = 0.68999999999999995
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="system"} = 147.06
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="0",mode="user"} = 306.79000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="idle"} = 39780
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="iowait"} = 71.519999999999996
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="nice"} = 0.17999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="softirq"} = 0.87
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="system"} = 61.060000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="1",mode="user"} = 149.44
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="idle"} = 39567.449999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="iowait"} = 34
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="nice"} = 0.28999999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="softirq"} = 1.3500000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="system"} = 150.90000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="2",mode="user"} = 252.12
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="idle"} = 39906.410000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="iowait"} = 6.4500000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="softirq"} = 0.42999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="system"} = 36.859999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="3",mode="user"} = 124.73999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="idle"} = 39480.760000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="iowait"} = 132.31999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="nice"} = 0.22
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="softirq"} = 0.75
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="system"} = 152.71000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="4",mode="user"} = 287.63999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="idle"} = 39908.449999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="iowait"} = 7.75
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="nice"} = 0.02
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="softirq"} = 0.53000000000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="system"} = 35.740000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="5",mode="user"} = 123.31999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="idle"} = 39607.989999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="iowait"} = 39.340000000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="nice"} = 0.20000000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="softirq"} = 0.52000000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="system"} = 135.84
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="6",mode="user"} = 230.72
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="idle"} = 39916.459999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="iowait"} = 6.1900000000000004
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="nice"} = 0.029999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="softirq"} = 0.37
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="system"} = 35.600000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="7",mode="user"} = 120.81
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="idle"} = 38771.029999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="iowait"} = 309.20999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="nice"} = 6.3499999999999996
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="softirq"} = 1.05
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="system"} = 253.72999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="8",mode="user"} = 675.94000000000005
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="idle"} = 39796.269999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="iowait"} = 32.159999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="nice"} = 0.34999999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="softirq"} = 0.34999999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="system"} = 62.640000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="9",mode="user"} = 184.58000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="idle"} = 38951.300000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="iowait"} = 220.24000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="nice"} = 4.1799999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="softirq"} = 0.60999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="system"} = 242.93000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="10",mode="user"} = 596.59000000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="idle"} = 39764.599999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="iowait"} = 34.390000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="nice"} = 0.58999999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="softirq"} = 1.3600000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="system"} = 70.599999999999994
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="11",mode="user"} = 191.55000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="idle"} = 39560.370000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="iowait"} = 35.82
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="nice"} = 0.55000000000000004
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="softirq"} = 0.38
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="system"} = 134.80000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="12",mode="user"} = 284.49000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="idle"} = 39302.730000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="iowait"} = 9.0999999999999996
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="nice"} = 0.29999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="softirq"} = 0.35999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="system"} = 224.53
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="13",mode="user"} = 181.38
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="idle"} = 39506.480000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="iowait"} = 30.59
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="nice"} = 0.12
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="softirq"} = 0.63
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="system"} = 175.84999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="14",mode="user"} = 291.44999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="idle"} = 39917.410000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="iowait"} = 4.3399999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="softirq"} = 0.46000000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="system"} = 34.539999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="15",mode="user"} = 121.02
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="idle"} = 39678.349999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="iowait"} = 14.720000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="nice"} = 0.57999999999999996
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="softirq"} = 0.45000000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="system"} = 119.81999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="16",mode="user"} = 217.80000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="idle"} = 39714.57
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="iowait"} = 14.43
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="nice"} = 0.26000000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="softirq"} = 0.41999999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="system"} = 106.81999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="17",mode="user"} = 206.18000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="idle"} = 39742.400000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="iowait"} = 10.94
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="nice"} = 0.51000000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="softirq"} = 2
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="system"} = 90.469999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="18",mode="user"} = 199.18000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="idle"} = 39789.029999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="iowait"} = 9.1899999999999995
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="nice"} = 0.16
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="softirq"} = 0.41999999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="system"} = 80.079999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="19",mode="user"} = 178.44
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="idle"} = 38615.239999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="iowait"} = 9.2100000000000009
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="nice"} = 0.01
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="softirq"} = 0.70999999999999996
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="system"} = 504.27999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="20",mode="user"} = 596.52999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="idle"} = 38787.019999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="iowait"} = 4.9400000000000004
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="nice"} = 0.029999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="softirq"} = 0.98999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="system"} = 460.26999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="21",mode="user"} = 500.91000000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="idle"} = 38766.279999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="iowait"} = 5.2400000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="nice"} = 0.01
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="softirq"} = 0.34000000000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="system"} = 479.99000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="22",mode="user"} = 507.27999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="idle"} = 38736.260000000002
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="iowait"} = 5.0099999999999998
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="nice"} = 0.029999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="softirq"} = 0.45000000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="system"} = 514.32000000000005
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="23",mode="user"} = 504.24000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="idle"} = 39605.269999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="iowait"} = 4.1600000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="nice"} = 0.089999999999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="softirq"} = 0.48999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="system"} = 144.36000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="24",mode="user"} = 172.44999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="idle"} = 39683.57
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="iowait"} = 3.8900000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="nice"} = 0.070000000000000007
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="softirq"} = 1.1000000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="system"} = 141.06999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="25",mode="user"} = 170.50999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="idle"} = 39628.129999999997
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="iowait"} = 5.5700000000000003
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="nice"} = 0.02
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="softirq"} = 0.25
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="system"} = 161.71000000000001
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="26",mode="user"} = 189.59999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="idle"} = 39696.32
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="iowait"} = 5.1699999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="irq"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="nice"} = 0.02
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="softirq"} = 0.29999999999999999
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="steal"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="system"} = 118.06
2024-11-19T10:03:18.411164692Z node_cpu_seconds_total{cpu="27",mode="user"} = 165.16999999999999
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="0",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="0",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="1",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="1",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="2",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="2",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="3",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="3",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="4",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="4",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="5",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="5",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="6",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="6",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="7",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="7",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="8",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="8",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="9",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="9",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="10",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="10",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="11",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="11",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="12",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="12",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="13",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="13",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="14",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="14",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="15",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="15",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="16",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="16",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="17",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="17",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="18",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="18",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="19",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="19",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="20",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="20",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="21",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="21",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="22",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="22",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="23",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="23",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_to[2024/11/19 19:03:19] [debug] [task] created task=0x5f63f80 id=0 OK
tal{cpu="24",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="24",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="25",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="25",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="26",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="26",mode="nice"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="27",mode="user"} = 0
2024-11-19T10:03:18.411164692Z node_cpu_guest_seconds_total{cpu="27",mode="nice"} = 0
[2024/11/19 19:03:19] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2024/11/19 19:03:19] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2024/11/19 19:03:19] [debug] [out flush] cb_destroy coro_id=0
[2024/11/19 19:03:19] [debug] [task] destroy task=0x5f63f80 (task_id=0)
^C[2024/11/19 19:03:19] [engine] caught signal (SIGINT)
[2024/11/19 19:03:19] [ warn] [engine] service will shutdown in max 5 seconds
[2024/11/19 19:03:19] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2024/11/19 19:03:20] [ info] [engine] service has stopped (0 pending tasks)
[2024/11/19 19:03:20] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2024/11/19 19:03:20] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2024/11/19 19:03:20] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2024/11/19 19:03:20] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==184063== 
==184063== HEAP SUMMARY:
==184063==     in use at exit: 0 bytes in 0 blocks
==184063==   total heap usage: 11,236 allocs, 11,236 frees, 50,887,381 bytes allocated
==184063== 
==184063== All heap blocks were freed -- no leaks are possible
==184063== 
==184063== For lists of detected and suppressed errors, rerun with: -s
==184063== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
