### PR TITLE
in_kafka: boost throughput

### DIFF
--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -180,8 +180,11 @@ static int in_kafka_collect(struct flb_input_instance *ins,
 
         rd_kafka_message_destroy(rkm);
 
-        /* TO-DO: commit the record based on `ret` */
-        rd_kafka_commit(ctx->kafka.rk, NULL, 0);
+        
+        if(!ctx->enable_auto_commit) {
+            /* TO-DO: commit the record based on `ret` */
+            rd_kafka_commit(ctx->kafka.rk, NULL, 0);
+        }
 
         /* Break from the loop when reaching the limit of polling if available */
         if (ctx->polling_threshold != FLB_IN_KAFKA_UNLIMITED &&
@@ -427,6 +430,11 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_SIZE, "buffer_max_size", FLB_IN_KAFKA_BUFFER_MAX_SIZE,
     0, FLB_TRUE, offsetof(struct flb_in_kafka_config, buffer_max_size),
     "Set the maximum size of chunk"
+   },
+   {
+    FLB_CONFIG_MAP_BOOL, "enable_auto_commit", FLB_IN_KAFKA_ENABLE_AUTO_COMMIT,
+    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, enable_auto_commit),
+    "Relay on kafka auto-commit and commit messages in batches"
    },
    /* EOF */
    {0}

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -449,7 +449,7 @@ static struct flb_config_map config_map[] = {
    {
     FLB_CONFIG_MAP_BOOL, "enable_auto_commit", FLB_IN_KAFKA_ENABLE_AUTO_COMMIT,
     0, FLB_TRUE, offsetof(struct flb_in_kafka_config, enable_auto_commit),
-    "Relay on kafka auto-commit and commit messages in batches"
+    "Rely on kafka auto-commit and commit messages in batches"
    },
    /* EOF */
    {0}

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -32,6 +32,7 @@
 #define FLB_IN_KAFKA_DEFAULT_FORMAT        "none"
 #define FLB_IN_KAFKA_UNLIMITED             (size_t)-1
 #define FLB_IN_KAFKA_BUFFER_MAX_SIZE       "4M"
+#define FLB_IN_KAFKA_ENABLE_AUTO_COMMIT    "false"
 
 enum {
     FLB_IN_KAFKA_FORMAT_NONE,
@@ -48,6 +49,7 @@ struct flb_in_kafka_config {
     int coll_fd;
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
+    bool enable_auto_commit;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -50,6 +50,7 @@ struct flb_in_kafka_config {
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
     bool enable_auto_commit;
+    int poll_timeount_ms;
 };
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
We have a Kafka cluster with about 40k messages and 25MB of data per seconds. Fluent-bit stands no change to keep up with this load in its current state where it 

a) commits each message individually 
b) a poll-timeout of just one 1ms  (this completely overrides fetch.wait.max.ms from kafka)

Even Logstash is faster and vector is just consuming all these messages with ease. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
probably related to "Batch processing is required in in_kafka. #8030"

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

To activate the changes one need to 
 
[INPUT]
    Name kafka
    threaded true                               -> sets timeout so that it will be limited by fetch.wait.max.ms in any practical scenario
    enable_auto_commit true          -> disable explicit commit call

 -> The change doesn't do any dynamic allocations at all and therefore cant introduce any mem-leaks
 -> The change has no impact on packaging at all 

**Documentation**
- Documentation is prepared and follows in a second 

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- Minor change that doesn't require to wait for a major release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
