### PR TITLE
in_opentelemetry: Propogate tag in http2 metrics and trace handlers

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -2242,7 +2242,7 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
         cfl_list_foreach(iterator, &decoded_contexts) {
             context = cfl_list_entry(iterator, struct cmt, _head);
 
-            result = flb_input_metrics_append(ctx->ins, NULL, 0, context);
+            result = flb_input_metrics_append(ctx->ins, tag, cfl_sds_len(tag), context);
 
             if (result != 0) {
                 flb_plg_debug(ctx->ins, "could not ingest metrics context : %d", result);
@@ -2301,7 +2301,7 @@ static int process_payload_traces_proto_ng(struct flb_opentelemetry *ctx,
     }
 
     if (result == 0) {
-        result = flb_input_trace_append(ctx->ins, NULL, 0, decoded_context);
+        result = flb_input_trace_append(ctx->ins, tag, cfl_sds_len(tag), decoded_context);
         ctr_decode_opentelemetry_destroy(decoded_context);
     }
     else {


### PR DESCRIPTION
For some reason whoever first wrote the `in_opentelemetry` plugin's HTTP/2 codepaths wrote it in a way that no/null tags were what always got passed into the Fluentbit routing engine. This PR fixes up what should be the last remaining cases not passing the tag through - the metrics and trace cases of the HTTP/2 codepath specifically. Should fully fix #8734 (i.e. fix it for the (default!) HTTP/2 mode and not force users to use the HTTP/1 codepath to get this behaviour).

**Testing**
- [x] Example configuration file for the change attached

```yaml
service:
    log_level: debug
pipeline:
    inputs:
        - name: opentelemetry
          tag_from_uri: true
          http2: true
    outputs:
        - name: 'stdout'
          match: 'v1_metrics'
        - name: 'stdout'
          match: 'v1_traces'
```

- [ ] Debug log output from testing the change attached
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature - No

**Backporting**
- This fix probably should be backported to the latest stable release, but it should probably get merged to master first.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.