### PR TITLE
in_tail: disable debug fs event logs for inputs targeting fluentbit's own logfile

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_env.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/multiline/flb_ml.h>
 #include <fluent-bit/multiline/flb_ml_parser.h>
@@ -25,6 +26,8 @@
 #include <stdlib.h>
 #include <fcntl.h>
 
+#include "fluent-bit/flb_sds.h"
+#include "mk_core/mk_list.h"
 #include "tail_fs.h"
 #include "tail_db.h"
 #include "tail_config.h"
@@ -135,6 +138,41 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
         flb_plg_error(ctx->ins, "no input 'path' was given");
         flb_tail_config_destroy(ctx);
         return NULL;
+    }
+
+    ctx->disable_debug_eventlogs = false;
+    /* Don't write debug logs for any tail plugins that are watching the
+       file Fluentbit itself is writing logs out to, to avoid an ouroboros
+       infinite logging loop, unless explicitly opted into via env var
+    */
+    char *buf2;
+    struct flb_env *env;
+    env = config->env;
+    buf2 = (char *)flb_env_get(env, "FLB_ALLOW_SERVICE_TAIL_DEBUG");
+
+    {
+        struct mk_list *head;
+        struct flb_slist_entry *pattern;
+        mk_list_foreach(head, ctx->path_list) {
+            pattern = mk_list_entry(head, struct flb_slist_entry, _head);
+
+            flb_plg_info(ctx->ins, "check for path %s", pattern->str);
+            // XXX: should probably expand the pattern for this check
+            if (strcmp(pattern->str, config->log_file) == 0) {
+                flb_sds_t msgbuf = flb_sds_create_size(256);
+                flb_sds_printf(&msgbuf, "This tail plugin instance targets the same path as the Fluentbit logging service file output.");
+
+                if (!buf2) {
+                    ctx->disable_debug_eventlogs = true;
+                    flb_sds_printf(&msgbuf, " Tail event debug logging will not be emitted for this plugin instance without FLB_ALLOW_SERVICE_TAIL_DEBUG");
+                }
+                else {
+                    flb_sds_printf(&msgbuf, " Tail event debug logging has been enabled via FLB_ALLOW_SERVICE_TAIL_DEBUG - large log volume likely to occur");
+                }
+                flb_plg_debug(ctx->ins, "%s", msgbuf);
+                flb_sds_destroy(msgbuf);
+            }
+        }
     }
 
     /* Config: seconds interval before to re-scan the path */

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_log_event.h>
+#include <stdbool.h>
 #ifdef FLB_HAVE_REGEX
 #include <fluent-bit/flb_regex.h>
 #endif
@@ -146,6 +147,8 @@ struct flb_tail_config {
 
     /* List of shell patterns used to exclude certain file names */
     struct mk_list *exclude_list;
+
+    bool disable_debug_eventlogs;
 
     /* Plugin input instance */
     struct flb_input_instance *ins;

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -50,6 +50,10 @@ static int debug_event_mask(struct flb_tail_config *ctx,
         return 0;
     }
 
+    if (ctx->disable_debug_eventlogs) {
+        return 0;
+    }
+
     if (file) {
         buf_size = file->name_len + 128;
     }


### PR DESCRIPTION
Addresses #9641 

**Testing**

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
- [ ] Documentation required for this feature - yes, probably, TODO

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
