### PR TITLE
custom_calyptia: honour collector interval in secs and nano secs.

### DIFF
--- a/plugins/custom_calyptia/calyptia.h
+++ b/plugins/custom_calyptia/calyptia.h
@@ -1,0 +1,59 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_CALYPTIA_H
+#define FLB_CALYPTIA_H
+
+struct calyptia {
+    /* config map options */
+    flb_sds_t api_key;
+    flb_sds_t store_path;
+    flb_sds_t cloud_host;
+    flb_sds_t cloud_port;
+    flb_sds_t machine_id;
+    int machine_id_auto_configured;
+
+/* used for reporting chunk trace records. */
+#ifdef FLB_HAVE_CHUNK_TRACE
+    flb_sds_t pipeline_id;
+#endif /* FLB_HAVE_CHUNK_TRACE */
+
+    int cloud_tls;
+    int cloud_tls_verify;
+
+    /* config reader for 'add_label' */
+    struct mk_list *add_labels;
+
+    /* instances */
+    struct flb_input_instance *i;
+    struct flb_output_instance *o;
+    struct flb_input_instance *fleet;
+    struct flb_custom_instance *ins;
+
+    /* Fleet configuration */
+    flb_sds_t fleet_id;                   /* fleet-id  */
+    flb_sds_t fleet_name;
+    flb_sds_t fleet_config_dir;           /* fleet configuration directory */
+    flb_sds_t fleet_max_http_buffer_size;
+    flb_sds_t fleet_interval_sec;
+    flb_sds_t fleet_interval_nsec;
+};
+
+int set_fleet_input_properties(struct calyptia *ctx, struct flb_input_instance *fleet);
+#endif /* FLB_CALYPTIA_H */

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -2233,7 +2233,6 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
     ctx->collect_fd = -1;
     ctx->fleet_id_found = FLB_FALSE;
 
-
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *) ctx);
     if (ret == -1) {
@@ -2278,14 +2277,16 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
         return -1;
     }
 
+    /* Log initial interval values */
+    flb_plg_debug(ctx->ins, "initial collector interval: sec=%d nsec=%d",
+                  ctx->interval_sec, ctx->interval_nsec);
+
     if (ctx->interval_sec <= 0 && ctx->interval_nsec <= 0) {
         /* Illegal settings. Override them. */
         ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
         ctx->interval_nsec = atoi(DEFAULT_INTERVAL_NSEC);
-    }
-
-    if (ctx->interval_sec < atoi(DEFAULT_INTERVAL_SEC)) {
-        ctx->interval_sec = atoi(DEFAULT_INTERVAL_SEC);
+        flb_plg_info(ctx->ins, "invalid interval settings, using defaults: sec=%d nsec=%d",
+                    ctx->interval_sec, ctx->interval_nsec);
     }
 
     /* Set the context */
@@ -2328,6 +2329,8 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
     }
 
     ctx->collect_fd = ret;
+    flb_plg_info(ctx->ins, "fleet collector initialized with interval: %d sec %d nsec",
+                 ctx->interval_sec, ctx->interval_nsec);
 
     return 0;
 }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -60,6 +60,32 @@ if(FLB_OUT_LIB)
   FLB_RT_TEST(FLB_IN_KUBERNETES_EVENTS "in_kubernetes_events.c")
 endif()
 
+if (FLB_CUSTOM_CALYPTIA)
+    # Define common variables for calyptia tests
+    set(CALYPTIA_TEST_LINK_LIBS
+        fluent-bit-static
+        ${CMAKE_THREAD_LIBS_INIT}
+    )
+
+    # Add calyptia input properties test
+    set(TEST_TARGET "flb-rt-calyptia_input_properties")
+    add_executable(${TEST_TARGET}
+        "custom_calyptia_input_test.c"
+        "../../plugins/custom_calyptia/calyptia.c"
+    )
+
+    target_link_libraries(${TEST_TARGET}
+        ${CALYPTIA_TEST_LINK_LIBS}
+    )
+
+    add_test(NAME ${TEST_TARGET}
+            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
+            WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+
+    set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
+    add_dependencies(${TEST_TARGET} fluent-bit-static)
+endif()
+
 if(FLB_IN_EBPF)
     # Define common variables
     set(EBPF_TEST_INCLUDE_DIRS

--- a/tests/runtime/custom_calyptia_input_test.c
+++ b/tests/runtime/custom_calyptia_input_test.c
@@ -1,0 +1,172 @@
+#include <stdio.h>
+#include <string.h>
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_env.h>
+#include <fluent-bit/flb_custom_plugin.h>
+#include "flb_tests_runtime.h"
+#include "../../plugins/custom_calyptia/calyptia.h"
+
+/* Test context structure */
+struct test_context {
+    struct calyptia *ctx;
+    struct flb_input_instance *fleet;
+    struct flb_config *config;
+};
+
+/* Initialize test context */
+static struct test_context *init_test_context()
+{
+    struct test_context *t_ctx = flb_calloc(1, sizeof(struct test_context));
+    if (!t_ctx) {
+        return NULL;
+    }
+
+    t_ctx->config = flb_config_init();
+    if (!t_ctx->config) {
+        flb_free(t_ctx);
+        return NULL;
+    }
+
+    t_ctx->ctx = flb_calloc(1, sizeof(struct calyptia));
+    if (!t_ctx->ctx) {
+        flb_config_exit(t_ctx->config);
+        flb_free(t_ctx);
+        return NULL;
+    }
+
+    /* Initialize plugin instance for logging */
+    t_ctx->ctx->ins = flb_calloc(1, sizeof(struct flb_custom_instance));
+    if (!t_ctx->ctx->ins) {
+        flb_free(t_ctx->ctx);
+        flb_config_exit(t_ctx->config);
+        flb_free(t_ctx);
+        return NULL;
+    }
+
+    /* Initialize test values in ctx */
+    t_ctx->ctx->api_key = flb_strdup("test_api_key");
+    t_ctx->ctx->fleet_config_dir = flb_strdup("/test/config/dir");
+    t_ctx->ctx->fleet_id = flb_strdup("test_fleet_id");
+    t_ctx->ctx->fleet_name = flb_strdup("test_fleet");
+    t_ctx->ctx->machine_id = flb_strdup("test_machine_id");
+    t_ctx->ctx->fleet_max_http_buffer_size = flb_strdup("1024");
+    t_ctx->ctx->fleet_interval_sec = flb_strdup("60");
+    t_ctx->ctx->fleet_interval_nsec = flb_strdup("500000000");
+
+    t_ctx->fleet = flb_input_new(t_ctx->config, "calyptia_fleet", NULL, FLB_FALSE);
+    if (!t_ctx->fleet) {
+        if (t_ctx->ctx->ins) flb_free(t_ctx->ctx->ins);
+        flb_free(t_ctx->ctx);
+        flb_config_exit(t_ctx->config);
+        flb_free(t_ctx);
+        return NULL;
+    }
+
+    return t_ctx;
+}
+
+static void cleanup_test_context(struct test_context *t_ctx)
+{
+    if (!t_ctx) {
+        return;
+    }
+
+    if (t_ctx->fleet) {
+        /* Input instance cleanup */
+        flb_input_instance_destroy(t_ctx->fleet);
+    }
+
+    if (t_ctx->ctx) {
+        if (t_ctx->ctx->api_key) flb_free(t_ctx->ctx->api_key);
+        if (t_ctx->ctx->fleet_config_dir) flb_free(t_ctx->ctx->fleet_config_dir);
+        if (t_ctx->ctx->fleet_id) flb_free(t_ctx->ctx->fleet_id);
+        if (t_ctx->ctx->fleet_name) flb_free(t_ctx->ctx->fleet_name);
+        if (t_ctx->ctx->machine_id) flb_free(t_ctx->ctx->machine_id);
+        if (t_ctx->ctx->fleet_max_http_buffer_size) flb_free(t_ctx->ctx->fleet_max_http_buffer_size);
+        if (t_ctx->ctx->fleet_interval_sec) flb_free(t_ctx->ctx->fleet_interval_sec);
+        if (t_ctx->ctx->fleet_interval_nsec) flb_free(t_ctx->ctx->fleet_interval_nsec);
+        if (t_ctx->ctx->ins) flb_free(t_ctx->ctx->ins);
+        flb_free(t_ctx->ctx);
+    }
+
+    if (t_ctx->config) {
+        /* Destroy the config which will cleanup any remaining instances */
+        flb_config_exit(t_ctx->config);
+    }
+
+    flb_free(t_ctx);
+}
+
+void test_set_fleet_input_properties()
+{
+    struct test_context *t_ctx = init_test_context();
+    TEST_CHECK(t_ctx != NULL);
+
+    /* Test setting properties */
+    int ret = set_fleet_input_properties(t_ctx->ctx, t_ctx->fleet);
+    TEST_CHECK(ret == 0);
+
+    /* Verify properties were set correctly */
+    const char *value;
+
+    /* Check api_key */
+    value = flb_input_get_property("api_key", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("api_key expected=%s got=%s", t_ctx->ctx->api_key, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->api_key) == 0);
+
+    /* Check config_dir */
+    value = flb_input_get_property("config_dir", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("config_dir expected=%s got=%s", t_ctx->ctx->fleet_config_dir, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->fleet_config_dir) == 0);
+
+    /* Check fleet_id */
+    value = flb_input_get_property("fleet_id", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("fleet_id expected=%s got=%s", t_ctx->ctx->fleet_id, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->fleet_id) == 0);
+
+    /* Check fleet_name */
+    value = flb_input_get_property("fleet_name", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("fleet_name expected=%s got=%s", t_ctx->ctx->fleet_name, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->fleet_name) == 0);
+
+    /* Check machine_id */
+    value = flb_input_get_property("machine_id", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("machine_id expected=%s got=%s", t_ctx->ctx->machine_id, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->machine_id) == 0);
+
+    /* Check max_http_buffer_size */
+    value = flb_input_get_property("max_http_buffer_size", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("max_http_buffer_size expected=%s got=%s", t_ctx->ctx->fleet_max_http_buffer_size, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->fleet_max_http_buffer_size) == 0);
+
+    // /* Check interval_sec */
+    value = flb_input_get_property("interval_sec", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("interval_sec expected=%s got=%s", t_ctx->ctx->fleet_interval_sec, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->fleet_interval_sec) == 0);
+
+    // /* Check interval_nsec */
+    value = flb_input_get_property("interval_nsec", t_ctx->fleet);
+    TEST_CHECK(value != NULL);
+    TEST_MSG("interval_nsec expected=%s got=%s", t_ctx->ctx->fleet_interval_nsec, value);
+    TEST_CHECK(value && strcmp(value, t_ctx->ctx->fleet_interval_nsec) == 0);
+
+    ret = set_fleet_input_properties(t_ctx->ctx, NULL);
+    TEST_CHECK(ret == -1);
+
+    cleanup_test_context(t_ctx);
+}
+
+/* Define test list */
+TEST_LIST = {
+    {"set_fleet_input_properties", test_set_fleet_input_properties},
+    {NULL, NULL}
+};


### PR DESCRIPTION
## Description

This change makes the custom calyptia plugin honour the configured collector
 interval (both in secs and nanosecs) that is cascaded to the instantiated input fleet plugin.

Also, I took the chance to add unit test to validate the cascade of properties to the underlying
fleet plugin.

**Testing**

- [ ] Example configuration file for the change

```ini
[SERVICE]
    log_level trace

[CUSTOM]
    Name calyptia
    API_Key xxxx.xxxx
    fleet_id e01085df-49d1-451d-b89f-226cd381369c
    Calyptia_Host cloud-api.calyptia.com
    fleet.interval_sec 120
```

- [ ] Debug log output from testing the change



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
