### PR TITLE
out_calyptia: retry agent registration on flush callback

### DIFF
--- a/plugins/custom_calyptia/calyptia.c
+++ b/plugins/custom_calyptia/calyptia.c
@@ -293,6 +293,12 @@ static struct flb_output_instance *setup_cloud_output(struct flb_config *config,
     flb_output_set_property(cloud, "match", "_calyptia_cloud");
     flb_output_set_property(cloud, "api_key", ctx->api_key);
 
+    if (ctx->register_retry_on_flush) {
+        flb_output_set_property(cloud, "register_retry_on_flush", "true");
+    } else {
+        flb_output_set_property(cloud, "register_retry_on_flush", "false");
+    }
+
     if (ctx->store_path) {
         flb_output_set_property(cloud, "store_path", ctx->store_path);
     }
@@ -585,7 +591,11 @@ static struct flb_config_map config_map[] = {
      "Pipeline ID for reporting to calyptia cloud."
     },
 #endif /* FLB_HAVE_CHUNK_TRACE */
-
+    {
+     FLB_CONFIG_MAP_BOOL, "register_retry_on_flush", "true",
+     0, FLB_TRUE, offsetof(struct calyptia, register_retry_on_flush),
+     "Retry agent registration on flush if failed on init."
+    },
     /* EOF */
     {0}
 };

--- a/plugins/custom_calyptia/calyptia.h
+++ b/plugins/custom_calyptia/calyptia.h
@@ -53,6 +53,7 @@ struct calyptia {
     flb_sds_t fleet_max_http_buffer_size;
     flb_sds_t fleet_interval_sec;
     flb_sds_t fleet_interval_nsec;
+    bool register_retry_on_flush;   /* retry registration on flush if failed */
 };
 
 int set_fleet_input_properties(struct calyptia *ctx, struct flb_input_instance *fleet);

--- a/plugins/out_calyptia/calyptia.h
+++ b/plugins/out_calyptia/calyptia.h
@@ -80,6 +80,7 @@ struct flb_calyptia {
     flb_sds_t trace_endpoint;
     flb_sds_t pipeline_id;
 #endif /* FLB_HAVE_CHUNK_TRACE */
+    bool register_retry_on_flush;   /* retry registration on flush if failed */
 };
 
 #endif

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -61,29 +61,37 @@ if(FLB_OUT_LIB)
 endif()
 
 if (FLB_CUSTOM_CALYPTIA)
-    # Define common variables for calyptia tests
     set(CALYPTIA_TEST_LINK_LIBS
         fluent-bit-static
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
-    # Add calyptia input properties test
-    set(TEST_TARGET "flb-rt-calyptia_input_properties")
-    add_executable(${TEST_TARGET}
+    set(CALYPTIA_TESTS
+        "custom_calyptia_test.c"
+        "custom_calyptia_registration_retry_test.c"
         "custom_calyptia_input_test.c"
-        "../../plugins/custom_calyptia/calyptia.c"
     )
 
-    target_link_libraries(${TEST_TARGET}
-        ${CALYPTIA_TEST_LINK_LIBS}
-    )
+    foreach(TEST_SOURCE ${CALYPTIA_TESTS})
+        get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
-    add_test(NAME ${TEST_TARGET}
-            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
-            WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        set(TEST_TARGET "flb-rt-${TEST_NAME}")
+        add_executable(${TEST_TARGET}
+            ${TEST_SOURCE}
+            "../../plugins/custom_calyptia/calyptia.c"
+        )
 
-    set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
-    add_dependencies(${TEST_TARGET} fluent-bit-static)
+        target_link_libraries(${TEST_TARGET}
+            ${CALYPTIA_TEST_LINK_LIBS}
+        )
+
+        add_test(NAME ${TEST_TARGET}
+                 COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
+                 WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+
+        set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
+        add_dependencies(${TEST_TARGET} fluent-bit-static)
+    endforeach()
 endif()
 
 if(FLB_IN_EBPF)
@@ -220,10 +228,6 @@ if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_TD                "out_td.c")
   FLB_RT_TEST(FLB_OUT_INFLUXDB          "out_influxdb.c")
 
-endif()
-
-if (FLB_CUSTOM_CALYPTIA)
-  FLB_RT_TEST(FLB_CUSTOM_CALYPTIA "custom_calyptia_test.c")
 endif()
 
 if (FLB_PROCESSOR_METRICS_SELECTOR)

--- a/tests/runtime/custom_calyptia_registration_retry_test.c
+++ b/tests/runtime/custom_calyptia_registration_retry_test.c
@@ -1,0 +1,313 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_custom.h>
+#include <monkey/mk_core.h>
+#include <monkey/mk_lib.h>
+#include <fluent-bit/flb_time.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "flb_tests_runtime.h"
+
+#define MOCK_SERVER_HOST "127.0.0.1"
+#define MOCK_SERVER_PORT 9876
+
+static int registration_count = 0;
+
+static void mock_server_cb_empty_token(mk_request_t *request, void *data)
+{
+    registration_count++;
+    if (registration_count == 1) {
+        /* Use a local buffer with correct size */
+        const char *response = "{\"id\":\"test-id\"}";
+        size_t response_len = strlen(response); // Ensure size is accurate
+
+        mk_http_status(request, 200);
+        mk_http_header(request, "Content-Type", sizeof("Content-Type") - 1,
+                       "application/json", sizeof("application/json") - 1);
+        mk_http_send(request, response, response_len, NULL); // Use response_len
+    } else {
+        mk_http_status(request, 500);
+        mk_http_header(request, "Content-Type", sizeof("Content-Type") - 1,
+                       "text/plain", sizeof("text/plain") - 1);
+        mk_http_send(request, "Internal Server Error", sizeof("Internal Server Error") - 1, NULL);
+    }
+    mk_http_done(request);
+}
+
+static void mock_server_cb(mk_request_t *request, void *data)
+{
+    registration_count++;
+    mk_http_status(request, 500);
+    mk_http_header(request, "Content-Type", sizeof("Content-Type") - 1,
+                    "text/plain", sizeof("text/plain") - 1);
+    mk_http_send(request, "Internal Server Error", sizeof("Internal Server Error") - 1, NULL);
+    mk_http_done(request);
+}
+
+/* Test function */
+void test_calyptia_register_retry()
+{
+    flb_ctx_t *ctx;
+    int ret;
+    int in_ffd;
+    mk_ctx_t *mock_ctx;
+    int vid;
+    char tmp[256];
+    struct flb_custom_instance *calyptia;
+
+    /* Reset registration count */
+    registration_count = 0;
+
+    /* Init mock server */
+    mock_ctx = mk_create();
+    TEST_CHECK(mock_ctx != NULL);
+
+    /* Compose listen address */
+    snprintf(tmp, sizeof(tmp) - 1, "%s:%d", MOCK_SERVER_HOST, MOCK_SERVER_PORT);
+    ret = mk_config_set(mock_ctx, "Listen", tmp, NULL);
+    TEST_CHECK(ret == 0);
+
+    vid = mk_vhost_create(mock_ctx, NULL);
+    TEST_CHECK(vid >= 0);
+
+    ret = mk_vhost_handler(mock_ctx, vid, "/v1/agents", mock_server_cb, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = mk_vhost_handler(mock_ctx, vid, "/v1/agents/test-id", mock_server_cb, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = mk_start(mock_ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(500);  // Allow the mock server to initialize
+
+    /* Init Fluent Bit context */
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    ret = flb_service_set(ctx,
+                          "Log_Level", "debug",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Create dummy input */
+    in_ffd = flb_input(ctx, (char *)"dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Create custom Calyptia plugin */
+    calyptia = flb_custom_new(ctx->config, (char *)"calyptia", NULL);
+    TEST_CHECK(calyptia != NULL);
+
+    /* Set custom plugin properties */
+    flb_custom_set_property(calyptia, "api_key", "test-key");
+    flb_custom_set_property(calyptia, "log_level", "debug");
+    flb_custom_set_property(calyptia, "add_label", "pipeline_id test-pipeline-id");
+    flb_custom_set_property(calyptia, "calyptia_host", MOCK_SERVER_HOST);
+    flb_custom_set_property(calyptia, "calyptia_port", "9876");
+    flb_custom_set_property(calyptia, "register_retry_on_flush", "true");
+    flb_custom_set_property(calyptia, "calyptia_tls", "off");
+    flb_custom_set_property(calyptia, "calyptia_tls.verify", "off");
+
+    /* Start the engine */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* First registration attempt should have failed */
+    TEST_CHECK(registration_count == 1);
+
+    flb_time_msleep(1000); 
+    flb_lib_push(ctx, in_ffd, "{\"key\":\"val\"}", 13);
+
+    /* Wait for processing */
+    flb_time_msleep(10000);
+    TEST_CHECK(registration_count > 1);
+
+    /* Cleanup */
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    mk_stop(mock_ctx);
+    mk_destroy(mock_ctx);
+}
+
+static void test_calyptia_register_retry_empty_token()
+{
+    flb_ctx_t *ctx;
+    int ret;
+    int in_ffd;
+    mk_ctx_t *mock_ctx;
+    int vid;
+    char tmp[256];
+    struct flb_custom_instance *calyptia;
+
+    /* Reset registration count */
+    registration_count = 0;
+
+    /* Init mock server */
+    mock_ctx = mk_create();
+    TEST_CHECK(mock_ctx != NULL);
+
+    /* Compose listen address */
+    snprintf(tmp, sizeof(tmp) - 1, "%s:%d", MOCK_SERVER_HOST, MOCK_SERVER_PORT);
+    ret = mk_config_set(mock_ctx, "Listen", tmp, NULL);
+    TEST_CHECK(ret == 0);
+
+    vid = mk_vhost_create(mock_ctx, NULL);
+    TEST_CHECK(vid >= 0);
+
+    ret = mk_vhost_handler(mock_ctx, vid, "/v1/agents", mock_server_cb_empty_token, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = mk_vhost_handler(mock_ctx, vid, "/v1/agents/test-id", mock_server_cb_empty_token, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = mk_start(mock_ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(500);  // Allow the mock server to initialize
+
+    /* Init Fluent Bit context */
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    ret = flb_service_set(ctx,
+                          "Log_Level", "debug",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Create dummy input */
+    in_ffd = flb_input(ctx, (char *)"dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Create custom Calyptia plugin */
+    calyptia = flb_custom_new(ctx->config, (char *)"calyptia", NULL);
+    TEST_CHECK(calyptia != NULL);
+
+    /* Set custom plugin properties */
+    flb_custom_set_property(calyptia, "api_key", "test-key");
+    flb_custom_set_property(calyptia, "log_level", "debug");
+    flb_custom_set_property(calyptia, "add_label", "pipeline_id test-pipeline-id");
+    flb_custom_set_property(calyptia, "calyptia_host", MOCK_SERVER_HOST);
+    flb_custom_set_property(calyptia, "calyptia_port", "9876");
+    flb_custom_set_property(calyptia, "register_retry_on_flush", "false");
+    flb_custom_set_property(calyptia, "calyptia_tls", "off");
+    flb_custom_set_property(calyptia, "calyptia_tls.verify", "off");
+
+    /* Start the engine */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* First registration should be successful but with an empty token */
+    TEST_CHECK(registration_count == 1);
+
+    /* Push some data to trigger flush */
+    flb_time_msleep(1000);
+    flb_lib_push(ctx, in_ffd, "{\"key\":\"val\"}", 13);
+
+    /* Wait for processing */
+    flb_time_msleep(10000);
+
+    /* Verify the plugin fails due to empty token */
+    TEST_CHECK(registration_count == 1);
+
+    /* Cleanup */
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    mk_stop(mock_ctx);
+    mk_destroy(mock_ctx);
+}
+
+static void test_calyptia_register_retry_empty_token_retry_true()
+{
+    flb_ctx_t *ctx;
+    int ret;
+    int in_ffd;
+    mk_ctx_t *mock_ctx;
+    int vid;
+    char tmp[256];
+    struct flb_custom_instance *calyptia;
+
+    /* Reset registration count */
+    registration_count = 0;
+
+    /* Init mock server */
+    mock_ctx = mk_create();
+    TEST_CHECK(mock_ctx != NULL);
+
+    /* Compose listen address */
+    snprintf(tmp, sizeof(tmp) - 1, "%s:%d", MOCK_SERVER_HOST, MOCK_SERVER_PORT);
+    ret = mk_config_set(mock_ctx, "Listen", tmp, NULL);
+    TEST_CHECK(ret == 0);
+
+    vid = mk_vhost_create(mock_ctx, NULL);
+    TEST_CHECK(vid >= 0);
+
+    ret = mk_vhost_handler(mock_ctx, vid, "/v1/agents", mock_server_cb_empty_token, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = mk_vhost_handler(mock_ctx, vid, "/v1/agents/test-id", mock_server_cb_empty_token, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = mk_start(mock_ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(500);  // Allow the mock server to initialize
+
+    /* Init Fluent Bit context */
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    ret = flb_service_set(ctx,
+                          "Log_Level", "debug",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Create dummy input */
+    in_ffd = flb_input(ctx, (char *)"dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    /* Create custom Calyptia plugin */
+    calyptia = flb_custom_new(ctx->config, (char *)"calyptia", NULL);
+    TEST_CHECK(calyptia != NULL);
+
+    /* Set custom plugin properties */
+    flb_custom_set_property(calyptia, "api_key", "test-key");
+    flb_custom_set_property(calyptia, "log_level", "debug");
+    flb_custom_set_property(calyptia, "add_label", "pipeline_id test-pipeline-id");
+    flb_custom_set_property(calyptia, "calyptia_host", MOCK_SERVER_HOST);
+    flb_custom_set_property(calyptia, "calyptia_port", "9876");
+    flb_custom_set_property(calyptia, "register_retry_on_flush", "true");
+    flb_custom_set_property(calyptia, "calyptia_tls", "off");
+    flb_custom_set_property(calyptia, "calyptia_tls.verify", "off");
+
+    /* Start the engine */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* First registration should be successful but with an empty token */
+    TEST_CHECK(registration_count == 1);
+
+    /* Push some data to trigger flush */
+    flb_time_msleep(1000);
+    flb_lib_push(ctx, in_ffd, "{\"key\":\"val\"}", 13);
+
+    /* Wait for processing */
+    flb_time_msleep(10000);
+
+    /* Verify the plugin fails due to empty token */
+    TEST_CHECK(registration_count > 1);
+
+    /* Cleanup */
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    mk_stop(mock_ctx);
+    mk_destroy(mock_ctx);
+}
+
+TEST_LIST = {
+    {"register_retry", test_calyptia_register_retry},
+    {"register_retry_empty_token", test_calyptia_register_retry_empty_token},
+    {"register_retry_empty_token_retry_true", test_calyptia_register_retry_empty_token_retry_true},
+    {NULL, NULL}
+};


### PR DESCRIPTION
### Description

if register_retry_on_flush is set (default true, my proposal)0, agent registration is retried on each flush callback.
if set to false then registration will cause to abort the plugin initialisation.

**Testing**

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
Use with this configuration

```ini
[SERVICE]
    Log_Level debug

[CUSTOM]
    name                calyptia
    api_key xxx
    log_level           debug
    calyptia_host       localhost
    calyptia_port       5000
    calyptia_tls        off
    calyptia_tls.verify off
    register_retry_on_flush false
```

 If set to true (my proposed default)


```
[2024/11/27 22:09:00] [ warn] [output:calyptia:calyptia.0] agent registration failed
[2024/11/27 22:09:00] [debug] [out flush] cb_destroy coro_id=0
[2024/11/27 22:09:00] [debug] [retry] new retry created for task_id=0 attempts=1
[2024/11/27 22:09:00] [ warn] [engine] failed to flush chunk '57405-1732741739.505948000.flb', retry in 11 seconds: task_id=0, input=fluentbit_metrics.0 > output=calyptia.0 (out_id=0)

[2024/11/27 22:09:11] [ info] [output:calyptia:calyptia.0] agent_id not found and register_retry_on_flush=true, attempting registration
[2024/11/27 22:09:11] [debug] [net] socket #36 could not connect to ::1:5000
[2024/11/27 22:09:11] [debug] [net] socket #36 could not connect to 127.0.0.1:5000
[2024/11/27 22:09:11] [debug] [net] could not connect to localhost:5000
[2024/11/27 22:09:11] [debug] [upstream] connection #-1 failed to localhost:5000
[2024/11/27 22:09:11] [ warn] [output:calyptia:calyptia.0] agent registration failed
[2024/11/27 22:09:11] [debug] [out flush] cb_destroy coro_id=1
[2024/11/27 22:09:11] [debug] [task] task_id=0 reached retry-attempts limit 1/1
[2024/11/27 22:09:11] [error] [engine] chunk '57405-1732741739.505948000.flb' cannot be retried: task_id=0, input=fluentbit_metrics.0 > output=calyptia.0
[2024/11/27 22:09:11] [debug] [task] destroy task=0x60f000007c00 (task_id=0)
```

If set to false, registration terminates the initialisation.

```
[2024/11/27 22:10:12] [debug] [calyptia:calyptia.0] created event channels: read=29 write=30
[2024/11/27 22:10:12] [debug] [output:calyptia:calyptia.0] machine_id=73a2e3fa6b6844dd36fcd9970d39537980905f85972aa7f9c210080c55dcf3e2
[2024/11/27 22:10:12] [debug] [http_client] not using http_proxy for header
[2024/11/27 22:10:12] [error] [/Users/niedbalski/code/fluent/fluent-bit/src/flb_http_client.c:1376 errno=32] Broken pipe
[2024/11/27 22:10:12] [ warn] [output:calyptia:calyptia.0] http_do=-1
[2024/11/27 22:10:12] [ warn] [output:calyptia:calyptia.0] agent registration failed
[2024/11/27 22:10:12] [error] [output:calyptia:calyptia.0] agent registration failed and register_retry_on_flush=false
[2024/11/27 22:10:12] [error] [output] failed to initialize 'calyptia' plugin
[2024/11/27 22:10:12] [error] [engine] output initialization failed
[2024/11/27 22:10:12] [ info] [input] pausing fluentbit_metrics.0
[2024/11/27 22:10:12] [ info] [input] pausing storage_backlog.1
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
