### PR TITLE
in_winevtlog: Use correct flag for EvtRender

### DIFF
--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -489,7 +489,7 @@ int get_string_inserts(EVT_HANDLE handle, PEVT_VARIANT *string_inserts_values,
 
     succeeded = EvtRender(context,
                           handle,
-                          EvtRenderContextValues,
+                          EvtRenderEventValues,
                           buffer_size,
                           values,
                           &buffer_size_used,


### PR DESCRIPTION
Fix the `flags` argument of one of the calls to `EvtRender`. It's currently using a value of the [EVT_RENDER_CONTEXT_FLAGS ](https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_render_context_flags) enum, which contains flags for creating the render context. This commit replaces it with the correct flag of the enum [EVT_RENDER_FLAGS](https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_render_flags), which is also used on the prior call to determine the buffer size.

Since both enum values are 0, this minor mistake is unlikely to have caused any issues.

----
**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
