### PR TITLE
cfl_record_accessor: Plug resource leaks (CID 516097)

### DIFF
--- a/src/flb_cfl_record_accessor.c
+++ b/src/flb_cfl_record_accessor.c
@@ -532,72 +532,72 @@ static int cfl_to_json(struct cfl_variant *var, flb_sds_t buf)
 
     switch (var->type) {
     case CFL_VARIANT_NULL:
-        flb_sds_cat(buf, "null", 4);
+        flb_sds_cat_safe(&buf, "null", 4);
         break;
     case CFL_VARIANT_BOOL:
         if (var->data.as_bool) {
-            flb_sds_cat(buf, "true", 4);
+            flb_sds_cat_safe(&buf, "true", 4);
         }
         else {
-            flb_sds_cat(buf, "false", 5);
+            flb_sds_cat_safe(&buf, "false", 5);
         }
         break;
     case CFL_VARIANT_INT: {
         char tmp[32] = {0};
         i = snprintf(tmp, sizeof(tmp)-1, "%"PRId64, var->data.as_int64);
-        flb_sds_cat(buf, tmp, i);
+        flb_sds_cat_safe(&buf, tmp, i);
         break;
     }
     case CFL_VARIANT_UINT: {
         char tmp[32] = {0};
         i = snprintf(tmp, sizeof(tmp)-1, "%"PRIu64, var->data.as_uint64);
-        flb_sds_cat(buf, tmp, i);
+        flb_sds_cat_safe(&buf, tmp, i);
         break;
     }
     case CFL_VARIANT_DOUBLE: {
         char tmp[512] = {0};
         i = snprintf(tmp, sizeof(tmp)-1, "%"PRIu64, var->data.as_uint64);
-        flb_sds_cat(buf, tmp, i);
+        flb_sds_cat_safe(&buf, tmp, i);
         break;
     }
     case CFL_VARIANT_STRING:
-        flb_sds_cat(buf, "\"", 1);
-        flb_sds_cat(buf, var->data.as_string, cfl_sds_len(var->data.as_string));
-        flb_sds_cat(buf, "\"", 1);
+        flb_sds_cat_safe(&buf, "\"", 1);
+        flb_sds_cat_safe(&buf, var->data.as_string, cfl_sds_len(var->data.as_string));
+        flb_sds_cat_safe(&buf, "\"", 1);
         break;
     case CFL_VARIANT_BYTES:
-        flb_sds_cat(buf, "\"", 1);
-        flb_sds_cat(buf, var->data.as_string, cfl_sds_len(var->data.as_bytes));
-        flb_sds_cat(buf, "\"", 1);
+        flb_sds_cat_safe(&buf, "\"", 1);
+        flb_sds_cat_safe(&buf, var->data.as_string, cfl_sds_len(var->data.as_bytes));
+        flb_sds_cat_safe(&buf, "\"", 1);
         break;
     case CFL_VARIANT_ARRAY: {
         struct cfl_array *array = var->data.as_array;
         loop = cfl_array_size(array);
 
-        flb_sds_cat(buf, "[", 1);
+        flb_sds_cat_safe(&buf, "[", 1);
         if (loop != 0) {
             for (i = 0; i < loop - 1; i++) {
                 cfl_to_json(array->entries[i], buf);
-                flb_sds_cat(buf, ",", 1);
+                flb_sds_cat_safe(&buf, ",", 1);
             }
         }
         cfl_to_json(array->entries[loop-1], buf);
-        flb_sds_cat(buf, "]", 1);
+        flb_sds_cat_safe(&buf, "]", 1);
         break;
     }
     case CFL_VARIANT_KVLIST:
         kvlist = var->data.as_kvlist;
-        flb_sds_cat(buf, "{", 1);
+        flb_sds_cat_safe(&buf, "{", 1);
         cfl_list_foreach(head, &kvlist->list) {
             kv = cfl_list_entry(head, struct cfl_kvpair, _head);
 
             /* key */
-            flb_sds_cat(buf, "\"", 1);
-            flb_sds_cat(buf, kv->key, cfl_sds_len(kv->key));
-            flb_sds_cat(buf, "\"", 1);
+            flb_sds_cat_safe(&buf, "\"", 1);
+            flb_sds_cat_safe(&buf, kv->key, cfl_sds_len(kv->key));
+            flb_sds_cat_safe(&buf, "\"", 1);
 
             /* separator */
-            flb_sds_cat(buf, ":", 1);
+            flb_sds_cat_safe(&buf, ":", 1);
 
             /* value */
             ret = cfl_to_json(kv->val, buf);
@@ -606,7 +606,7 @@ static int cfl_to_json(struct cfl_variant *var, flb_sds_t buf)
             }
             break;
         }
-        flb_sds_cat(buf, "}", 1);
+        flb_sds_cat_safe(&buf, "}", 1);
     }
 
     return 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
