### PR TITLE
plugin_proxy: Allow to execute flush callback on Golang side during hot-reloading

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -50,15 +50,6 @@ static void proxy_cb_flush(struct flb_event_chunk *event_chunk,
     (void) i_ins;
     (void) config;
 
-    /* To prevent flush callback executions, we need to check the
-     * status of hot-reloading. The actual problem is: we don't have
-     * pause procedure/mechanism for output plugin. For now, we just halt the
-     * flush callback here during hot-reloading is in progress. */
-    if (config->shutdown_by_hot_reloading == FLB_TRUE) {
-        flb_trace("[GO] hot-reloading is in progress. Retry flushing");
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
-
 #ifdef FLB_HAVE_PROXY_GO
     if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
         flb_trace("[GO] entering go_flush()");


### PR DESCRIPTION
Removes the code which prevented flush callback on Golang side during hot-reloading

Fixes #9733 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
