### PR TITLE
workflows: resolve ubuntu 24 packaging problems

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -54,7 +54,7 @@ jobs:
   call-build-capture-source:
     # Capture source tarball and generate checksum for it
     name: Extract any supporting metadata
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
@@ -105,8 +105,8 @@ jobs:
   call-build-linux-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
-    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-latest usage.
-    runs-on: ${{ (contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit') && 'actuated-arm64-8cpu-16gb') || 'ubuntu-latest' }}
+    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-22.04 usage.
+    runs-on: ${{ (contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit') && 'actuated-arm64-8cpu-16gb') || 'ubuntu-22.04' }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/call-build-macos.yaml
+++ b/.github/workflows/call-build-macos.yaml
@@ -74,8 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "Normal macOS-latest runner (Intel)"
-            runner: macos-12
           - name: "Apple Silicon macOS runner"
             runner: macos-14
 
@@ -121,8 +119,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "Normal macOS-latest package (Intel)"
-            os: macos-12
           - name: "Apple Silicon macOS package"
             os: macos-14
 

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -172,7 +172,7 @@ jobs:
 
   staging-release-apt-packages:
     name: S3 - update APT packages bucket
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: release
     needs:
       - staging-release-version-check
@@ -327,7 +327,7 @@ jobs:
 
   staging-release-source-s3:
     name: S3 - update source bucket
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: release
     needs:
       - staging-release-version-check


### PR DESCRIPTION
Resolves issues with building on latest ubuntu 24 runners provided by Github.
Pinning to Ubuntu 22 for now to align with previous image working correctly until Github images stabilise.
macOS 12 is no longer available - just errors if you try to use it now so removed: https://github.com/actions/runner-images/issues/10721
This means no Intel builds available for macOS now, only Apple Silicon.

Resolves #9739.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Backporting**
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
