### PR TITLE
packaging: raspbian:  support raspbian bookworm package creation

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -27,6 +27,8 @@ The [`distros`](./distros/) directory contains OCI container definitions used to
 | Debian        |   11                      | arm64v8 | debian/bullseye.arm64v8  |
 | Debian        |   10                      | x86_64  | debian/buster            |
 | Debian        |   10                      | arm64v8 | debian/buster.arm64v8    |
+| Ubuntu        |   24.04 / Noble Numbat    | x86_64  | ubuntu/24.04             |
+| Ubuntu        |   24.04 / Noble Numbat    | arm64v8 | ubuntu/24.04.arm64v8     |
 | Ubuntu        |   22.04 / Jammy Jellyfish | x86_64  | ubuntu/22.04             |
 | Ubuntu        |   22.04 / Jammy Jellyfish | arm64v8 | ubuntu/22.04.arm64v8     |
 | Ubuntu        |   20.04 / Focal Fossa     | x86_64  | ubuntu/20.04             |
@@ -34,6 +36,7 @@ The [`distros`](./distros/) directory contains OCI container definitions used to
 | Ubuntu        |   18.04 / Bionic Beaver   | x86_64  | ubuntu/18.04             |
 | Ubuntu        |   18.04 / Bionic Beaver   | arm64v8 | ubuntu/18.04.arm64v8     |
 | Ubuntu        |   16.04 / Xenial Xerus    | x86_64  | ubuntu/16.04             |
+| Raspbian      |   12 / Bookworm           | arm32v7 | raspbian/bookworm        |
 | Raspbian      |   11 / Bullseye           | arm32v7 | raspbian/bullseye        |
 | Raspbian      |   10 / Buster             | arm32v7 | raspbian/buster          |
 

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -107,6 +107,10 @@
         {
           "target": "raspbian/bullseye",
           "type": "deb"
+        },
+        {
+          "target": "raspbian/bookworm",
+          "type": "deb"
         }
       ],
       "windows_targets" : [

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -34,6 +34,19 @@ RUN apt-get update && \
     libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
+# raspbian/bookworm base image
+FROM balenalib/rpi-raspbian:bookworm as raspbian-bookworm-base
+ENV DEBIAN_FRONTEND noninteractive
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates build-essential \
+    cmake make bash sudo wget unzip dh-make \
+    libsystemd-dev zlib1g-dev flex bison \
+    libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
+    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    apt-get install -y --reinstall lsb-base lsb-release
+
 # Common build for all distributions now
 # hadolint ignore=DL3006
 FROM $BASE_BUILDER as builder


### PR DESCRIPTION
<!-- Provide summary of changes -->

I added raspbian/bookworm package on our packing system.

Related to https://github.com/fluent/fluent-bit/issues/9730.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
