### PR TITLE
in_systemd: tests: Provide restoring way the previous behavior

### DIFF
--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -64,6 +64,7 @@ struct flb_systemd_config {
     int max_fields;            /* max number of fields per record */
     int max_entries;           /* max number of records per iteration */
     size_t threshold;         /* threshold for retriveing journal */
+    int compact_key;           /* Unify deprecated keys into an array */
 
 #ifdef FLB_HAVE_SQLDB
     flb_sds_t db_path;

--- a/tests/runtime/in_systemd.c
+++ b/tests/runtime/in_systemd.c
@@ -58,6 +58,40 @@ static void cb_check_cfl_variant_properties(void *ctx, int ffd,
     flb_sds_destroy(output);
 }
 
+static void cb_check_simply_processed_properties(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    flb_sds_t output;
+    char *result = NULL;
+
+    /* Convert from msgpack to JSON */
+    output = flb_msgpack_raw_to_json_sds(res_data, res_size);
+    TEST_CHECK(output != NULL);
+
+    result = strstr(output, "\"MESSAGE\":\"test native message with multiple values\"");
+    if (TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    result = strstr(output, "\"KEY\":\"another\"");
+    if (TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    result = strstr(output, "\"KEY2\":\"final_field\"");
+    if (TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    result = strstr(output, "\"KEY3\":\"wow\"");
+    if (TEST_CHECK(result != NULL)) {
+        TEST_MSG("output:%s\n", output);
+    }
+
+    flb_sds_destroy(output);
+}
+
 void flb_test_duplicated_keys()
 {
     int ret;
@@ -107,8 +141,59 @@ void flb_test_duplicated_keys()
     flb_destroy(ctx);
 }
 
+void flb_test_dont_compact_keys()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    flb_ctx_t *ctx;
+    char *message = "MESSAGE=test native message with multiple values\nKEY=value1\nKEY=value4\n"
+        "KEY2=value2\nKEY=another\nKEY2=value3\nKEY2=value5\nKEY3=howdy\nKEY3=prettygood\nKEY2=value10\n"
+        "KEY3=wow\nKEY2=final_field\n";
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "flush", "2",
+                    "grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    /* Systemd */
+    in_ffd = flb_input(ctx, (char *) "systemd", NULL);
+    flb_input_set(ctx, in_ffd,
+                  "tag", "test",
+                  "Read_From_Tail", "On",
+                  "Compact_Key", "Off",
+                  NULL);
+
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_input_set_test(ctx, in_ffd, "formatter",
+                             cb_check_simply_processed_properties,
+                             NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample to run test formatter */
+    ret = flb_lib_push(ctx, in_ffd, message, strlen(message));
+    TEST_CHECK(ret == 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     { "duplicated_keys", flb_test_duplicated_keys },
+    { "dont_compact_keys", flb_test_dont_compact_keys },
     { NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
The revised behavior needs more memory than just serializing one-by-one way.
So, for the lower memory environments or resource capped containers, we need to provide a restoring way with previous behavior.
With the previous behavior, the last element on the duplicated key is only effective when encoding as JSON.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
