### PR TITLE
out_prometheus_remote_write: Refresh expired AWS credentials

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -183,7 +183,7 @@ static int http_post(struct prometheus_remote_write_context *ctx,
          * - 200: OK
          * - 201: Created
          * - 202: Accepted
-         * - 203: no authorative resp
+         * - 203: no authoritative resp
          * - 204: No Content
          * - 205: Reset content
          *
@@ -200,10 +200,16 @@ static int http_post(struct prometheus_remote_write_context *ctx,
                 flb_plg_error(ctx->ins, "%s:%i, HTTP status=%i",
                               ctx->host, ctx->port, c->resp.status);
             }
+            #if defined(FLB_HAVE_SIGNV4) && defined(FLB_HAVE_AWS)
+            if (c->resp.status == 403 && ctx->has_aws_auth == FLB_TRUE) {
+                flb_plg_info(ctx->ins, "auth error, refreshing creds");
+                ctx->aws_provider->provider_vtable->refresh(ctx->aws_provider);
+            }
+            #endif
             out_ret = FLB_RETRY;
         }
         else if (c->resp.status == 400) {
-            /* Returned 400 status means unrecoverable. Immidiately
+            /* Returned 400 status means unrecoverable. Immediately
              * returning as a error. */
             if (ctx->log_response_payload &&
                 c->resp.payload && c->resp.payload_size > 0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Handle 403 http error code when credentials expired, credentials refreshed from `~/.aws/credentials`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes: #9670
Similar implementation already exists for `kinesis_streams`:
https://github.com/fluent/fluent-bit/blob/3178e6ea22cb8c74238acd8e298d1f3577618c0a/src/aws/flb_aws_util.c#L205

----
Steps to reproduce:
1. Create temporary credentials in `~/.aws/credentials` with min session duration time 900 (anything to reproduce quickly). Put the credentials form the command output to `~/.aws/credentials` under default profile.
```bash
aws sts assume-role --role-arn arn:aws:iam::<account_number>:role/prometheus_role --role-session-name tmp --duration-seconds 900
#or 
aws sts get-session-token     --duration-seconds 900     --serial-number arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):mfa/role_name     --token-code MFA-CODE <MFA code> 
```
2. Start fluent-bit with the following configuration file:
```
[SERVICE]
    Flush                      1
    Log_Level                  DEBUG

[INPUT]
    Name                       node_exporter_metrics
    Tag                        metrics
    Scrape_interval            30

[OUTPUT]
    Name                       prometheus_remote_write
    Match                      metrics
    Host                       aps-workspaces.us-west-2.amazonaws.com
    Port                       443
    Uri                        /workspaces/ws-<your workspaceid>/api/v1/remote_write
    AWS_Auth                   true
    AWS_region                 us-west-2
    Tls                        On
    Tls.verify                 On
    add_label                  test test
```


```bash
./bin/fluent-bit -c fluent-bit.conf
```

3. Wait until the credentials expire and fluent-bit prometheus_remote_write out plugin starts to fail with 403 credentials expired as shown in the example:
```
[2024/12/24 16:31:49] [error] [output:prometheus_remote_write:prometheus_remote_write.1] aps-workspaces.us-west-2.amazonaws.com:443, HTTP status=403
{"message":"The security token included in the request is expired"}
```
4. Repeat the step `#1` to refresh credentials in `~/.aws/credentials` with much fresh credentials (usually done by an automation):

**Before the PR fix:** Fluent-bit  keeps failing with 403 as it is using old expired credentials that are cached in memory
```
[error] [output:prometheus_remote_write:prometheus_remote_write.1] aps-workspaces.us-west-2.amazonaws.com:443, HTTP status=403
{"message":"The security token included in the request is expired"}
```

**After the PR fix:** Fluent-bit picks up fresh credentials without downtime.
```
[2024/12/24 18:45:21] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] auth error, refreshing creds
[2024/12/24 18:45:21] [debug] [aws_credentials] Refresh called on the env provider
[2024/12/24 18:45:21] [debug] [aws_credentials] Refresh called on the profile provider
[2024/12/24 18:45:21] [debug] [aws_credentials] Reading shared config file.
[2024/12/24 18:45:21] [debug] [aws_credentials] Reading shared credentials file.
[2024/12/24 18:45:21] [debug] [upstream] KA connection #89 to aps-workspaces.us-west-2.amazonaws.com:443 is now available
[2024/12/24 18:45:21] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] http_post result FLB_RETRY
...

[2024/12/24 18:45:43] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] signing request with AWS Sigv4
[2024/12/24 18:45:43] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] aps-workspaces.us-west-2.amazonaws.com:443, HTTP status=200
[2024/12/24 18:45:43] [debug] [upstream] KA connection #88 to aps-workspaces.us-west-2.amazonaws.com:443 is now available
[2024/12/24 18:45:43] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] http_post result FLB_OK
```

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved reliability for Prometheus Remote Write with AWS authentication: HTTP 403 responses now trigger an AWS credential refresh and a retry, reducing failures due to expired or invalid credentials.
  * Refined status handling to treat 403 separately from other non-OK responses; existing behaviors remain (success on 200–205, retry on other non-OK statuses, error on 400).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->