### PR TITLE
out_loki: fix removing keys defined by labels

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -916,13 +916,14 @@ static int prepare_remove_keys(struct flb_loki *ctx)
                 return -1;
             }
         }
-        size = mk_list_size(patterns);
+    }
+
+    size = mk_list_size(patterns);
+    if (size > 0) {
         flb_plg_debug(ctx->ins, "remove_mpa size: %d", size);
-        if (size > 0) {
-            ctx->remove_mpa = flb_mp_accessor_create(patterns);
-            if (ctx->remove_mpa == NULL) {
-                return -1;
-            }
+        ctx->remove_mpa = flb_mp_accessor_create(patterns);
+        if (ctx->remove_mpa == NULL) {
+            return -1;
         }
     }
 


### PR DESCRIPTION
When key is defined as a Loki label with labels, label_keys or label_map_path, the code is trying to remove them. However, if remove_keys is not defined, it never gets to the part that actually removes them. This looks like an obvious bug to me.

I moved the debug message to inside the if (size > 0) statement, because earlier it would only print it if it was actually trying to remove something. So without moving it it would spam it every time. And absence of the message would then indicate size == 0. Not sure if this is the best, though.

<!-- Provide summary of changes -->

I moved the code that removes the keys to outside the if (ctx->remove_keys)  statement.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
