### PR TITLE
Regression fix: Selects docker image target fpr local-build-all.sh

### DIFF
--- a/packaging/local-build-all.sh
+++ b/packaging/local-build-all.sh
@@ -24,9 +24,10 @@ rm -rf "${PACKAGING_OUTPUT_DIR:?}/*"
 
 # Iterate over each target and attempt to build it.
 # Verify that an RPM or DEB is created.
-jq -cr '.linux_targets[]' "$JSON_FILE_NAME" | while read -r DISTRO
+jq -cr '.linux_targets[] | .target' "$JSON_FILE_NAME" | while read -r DISTRO
+
 do
-    echo "$DISTRO"
+    echo "DISTRO: $DISTRO"
     FLB_OUT_DIR="$PACKAGING_OUTPUT_DIR" /bin/bash "$SCRIPT_DIR"/build.sh -d "$DISTRO" "$@"
     if [[ -z $(find "${SCRIPT_DIR}/packages/$DISTRO/$PACKAGING_OUTPUT_DIR/" -type f \( -iname "*-bit-*.rpm" -o -iname "*-bit-*.deb" \) | head -n1) ]]; then
         echo "Unable to find any binary packages in: ${SCRIPT_DIR}/packages/$DISTRO/$PACKAGING_OUTPUT_DIR"


### PR DESCRIPTION
<!-- Provide summary of changes -->
Build config format has changes in this commit: https://github.com/fluent/fluent-bit/commit/e4c982757dbb67330eb0f50dc6eba6bbb153cefd#diff-c08c571600c3c85d24ce5e2af55959c64188e70844c69e941a2ea91ecd7691e1
this commit adjusts `local-build-all.sh` script to the new config format.

**Before:**
![Screenshot from 2024-12-25 02-24-32](https://github.com/user-attachments/assets/4cd5b84d-1153-48e2-99a7-7ee97e2e2d0a)
**After:**
![Screenshot from 2024-12-25 02-58-59](https://github.com/user-attachments/assets/f2cc17c0-d967-4cf5-aeff-34be50e8574d)

A side note: Seems like a docker image is missing from public docker hub (or private docker registry not specified) `flb-amazonlinux/2.arm64v8`:
```
ERROR: failed to solve: arm64v8/amazonlinux:2: failed to resolve source metadata for docker.io/arm64v8/amazonlinux:2: no match for platform in manifest: not found
+ echo 'Error building main docker image flb-amazonlinux/2.arm64v8'
Error building main docker image flb-amazonlinux/2.arm64v8
+ exit 1
```


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
