### PR TITLE
in_systemd: fix memory leak

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -138,7 +138,7 @@ static int systemd_enumerate_data_store(struct flb_config *config,
     const char *sep;
     const char *key;
     const char *val;
-    char *buf = NULL;
+    char *buf;
     struct cfl_kvlist *kvlist = format_context;
     struct flb_systemd_config *ctx = plugin_context;
     struct cfl_variant *cfl_val = NULL;
@@ -155,29 +155,17 @@ static int systemd_enumerate_data_store(struct flb_config *config,
 
     len = (sep - key);
     key_len = len;
-
-    if (ctx->lowercase == FLB_TRUE) {
-        /*
-         * Ensure buf to have enough space for the key because the libsystemd
-         * might return larger data than the threshold.
-         */
-        if (buf == NULL) {
-            buf = flb_sds_create_len(NULL, ctx->threshold);
-        }
-        if (flb_sds_alloc(buf) < len) {
-            buf = flb_sds_increase(buf, len - flb_sds_alloc(buf));
-        }
-        for (i = 0; i < len; i++) {
-            buf[i] = tolower(key[i]);
-        }
-        list_key = flb_sds_create_len(buf, key_len);
-    }
-    else {
-        list_key = flb_sds_create_len(key, key_len);
-    }
+    list_key = flb_sds_create_len(key, key_len);
 
     if (!list_key) {
         return -1;
+    }
+
+    if (ctx->lowercase == FLB_TRUE) {
+        buf = list_key;
+        for (i = 0; i < key_len; i++) {
+            buf[i] = tolower(buf[i]);
+        }
     }
 
     /* Check existence */
@@ -274,7 +262,6 @@ static int in_systemd_collect(struct flb_input_instance *ins,
     uint64_t usec;
     size_t length;
     const char *key;
-    char *buf = NULL;
 #ifdef FLB_HAVE_SQLDB
     char *cursor = NULL;
 #endif
@@ -457,8 +444,6 @@ static int in_systemd_collect(struct flb_input_instance *ins,
             break;
         }
     }
-
-    flb_sds_destroy(buf);
 
 #ifdef FLB_HAVE_SQLDB
     /* Save cursor */


### PR DESCRIPTION
Fix a memory leak in the systemd input plugin.
If option "lowercase" was on, the temporary buffer to convert a key to the lower-case string was not freed.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #9769

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
