### PR TITLE
in_systemd: fix buffer over-read

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -218,16 +218,16 @@ static int systemd_enumerate_data_store(struct flb_config *config,
 
             cfl_array_append_string_s(array,
                                       tmp_val->data.as_string,
-                                      strlen(tmp_val->data.as_string),
+                                      tmp_val->size,
                                       CFL_FALSE);
-            cfl_array_append_string_s(array, (char *)val, strlen(val), CFL_FALSE);
+            cfl_array_append_string_s(array, (char *)val, len, CFL_FALSE);
             cfl_kvlist_insert_array_s(kvlist, list_key, key_len, array);
             cfl_variant_destroy(tmp_val);
             break;
         case CFL_VARIANT_ARRAY:
             /* Just appending the newly arrived field(s) */
             array = tmp_val->data.as_array;
-            cfl_array_append_string_s(array, (char *)val, strlen(val), CFL_FALSE);
+            cfl_array_append_string_s(array, (char *)val, len, CFL_FALSE);
             break;
         default:
             /* nop */
@@ -236,7 +236,7 @@ static int systemd_enumerate_data_store(struct flb_config *config,
     }
     else {
         cfl_kvlist_insert_string_s(kvlist, list_key, key_len,
-                                   (char *)val, strlen(val), CFL_FALSE);
+                                   (char *)val, len, CFL_FALSE);
     }
 
     flb_sds_destroy(list_key);


### PR DESCRIPTION
Fix for #9788 buffer over-reads in the systemd input plugin.
In systemd_enumerate_data_store: when copying the item value the input string may not be 0-terminated, so relying on strlen may lead to reads beyond the end of the buffer. Use the known string length instead of strlen.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
