### PR TITLE
unescape: Decode \u escaped characters for surrogate pairs correctly

### DIFF
--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -64,13 +64,26 @@ static int u8_wc_toutf8(char *dest, uint32_t ch)
     return 0;
 }
 
+static int u8_high_surrogate(uint32_t ch) {
+    return ch >= 0xD800 && ch <= 0xDBFF;
+}
+
+static int u8_low_surrogate(uint32_t ch) {
+    return ch >= 0xDC00 && ch <= 0xDFFF;
+}
+
+static uint32_t u8_combine_surrogates(uint32_t high, uint32_t low) {
+    return 0x10000 + (((high - 0xD800) << 10) | (low - 0xDC00));
+}
+
 /* assumes that src points to the character after a backslash
    returns number of input characters processed */
 static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
 {
-    uint32_t ch;
+    uint32_t ch = 0;
     char digs[9]="\0\0\0\0\0\0\0\0";
     int dno=0, i=1;
+    uint32_t low = 0;
 
     ch = (uint32_t)str[0];    /* take literal character */
 
@@ -107,8 +120,41 @@ static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
         while (i < size && hex_digit(str[i]) && dno < 4) {
             digs[dno++] = str[i++];
         }
-        if (dno > 0) {
-            ch = strtol(digs, NULL, 16);
+        if (dno != 4) {
+            /* Incomplete \u escape sequence */
+            goto invalid_sequence;
+        }
+        ch = strtol(digs, NULL, 16);
+        if (u8_low_surrogate(ch)) {
+            /* Invalid: low surrogate without preceding high surrogate */
+            goto invalid_sequence;
+        }
+        else if (u8_high_surrogate(ch)) {
+            /* Handle a surrogate pair.
+             * Note that i is already incremented with 4 here. */
+            if (i + 2 < size && str[i] == '\\' && str[i + 1] == 'u') {
+                dno = 0;
+                i += 2; /* Skip "\u" */
+                while (i < size && hex_digit(str[i]) && dno < 4) {
+                    digs[dno++] = str[i++];
+                }
+                if (dno != 4) {
+                    /* Incomplete low surrogate */
+                    goto invalid_sequence;
+                }
+                low = strtol(digs, NULL, 16);
+                if (u8_low_surrogate(low)) {
+                    ch = u8_combine_surrogates(ch, low);
+                }
+                else {
+                    /* Invalid: high surrogate not followed by low surrogate */
+                    goto invalid_sequence;
+                }
+            }
+            else {
+                /* Invalid: high surrogate not followed by \u */
+                goto invalid_sequence;
+            }
         }
     }
     else if (str[0] == 'U') {
@@ -122,6 +168,9 @@ static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
     *dest = ch;
 
     return i;
+
+invalid_sequence:
+    return -1;
 }
 
 int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf)

--- a/src/flb_unescape.c
+++ b/src/flb_unescape.c
@@ -122,11 +122,13 @@ static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
         }
         if (dno != 4) {
             /* Incomplete \u escape sequence */
+            ch = L'\uFFFD';
             goto invalid_sequence;
         }
         ch = strtol(digs, NULL, 16);
         if (u8_low_surrogate(ch)) {
             /* Invalid: low surrogate without preceding high surrogate */
+            ch = L'\uFFFD';
             goto invalid_sequence;
         }
         else if (u8_high_surrogate(ch)) {
@@ -140,6 +142,7 @@ static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
                 }
                 if (dno != 4) {
                     /* Incomplete low surrogate */
+                    ch = L'\uFFFD';
                     goto invalid_sequence;
                 }
                 low = strtol(digs, NULL, 16);
@@ -148,11 +151,13 @@ static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
                 }
                 else {
                     /* Invalid: high surrogate not followed by low surrogate */
+                    ch = L'\uFFFD';
                     goto invalid_sequence;
                 }
             }
             else {
                 /* Invalid: high surrogate not followed by \u */
+                ch = L'\uFFFD';
                 goto invalid_sequence;
             }
         }
@@ -165,12 +170,12 @@ static int u8_read_escape_sequence(const char *str, int size, uint32_t *dest)
             ch = strtol(digs, NULL, 16);
         }
     }
+
+invalid_sequence:
+
     *dest = ch;
 
     return i;
-
-invalid_sequence:
-    return -1;
 }
 
 int flb_unescape_string_utf8(const char *in_buf, int sz, char *out_buf)

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -520,6 +520,76 @@ void test_utf8_to_json()
     utf8_tests_destroy(n_tests);
 }
 
+void test_json_pack_surrogate_pairs()
+{
+    int i;
+    int ret;
+    int len;
+    int type;
+    int items;
+    char *p_in;
+    char *p_unescaped;
+    size_t len_in;
+    char *out_buf;
+    size_t out_size;
+    char *data_in[] = {
+        "{\"text\":\"\\ud83e\\udd17\"}",
+        "{\"text\":\"thinking...\\ud83e\\uddd0\"}",
+        "{\"text\":\"\\ud83e\\udee1\"}",
+    };
+    char *data_unescaped[] = {
+        "🤗",
+        "thinking...🧐",
+        "🫡",
+    };
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object val;
+    size_t off = 0;
+
+    items = sizeof(data_in) / sizeof(char *);
+    for (i = 0; i < items; i++) {
+        p_in = data_in[i];
+        len_in = strlen(p_in);
+        p_unescaped = data_unescaped[i];
+
+        /* Pack raw JSON as msgpack */
+        ret = flb_pack_json(p_in, len_in, &out_buf, &out_size, &type, NULL);
+        TEST_CHECK(ret == 0);
+
+        /* Unpack 'text' value and compare it to the original raw */
+        off = 0;
+        msgpack_unpacked_init(&result);
+        ret = msgpack_unpack_next(&result, out_buf, out_size, &off);
+        TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+
+        /* Check parent type is a map */
+        root = result.data;
+        TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
+
+        /* Get map value */
+        val = root.via.map.ptr[0].val;
+        TEST_CHECK(val.type == MSGPACK_OBJECT_STR);
+
+        /* Compare bytes length */
+        len = strlen(p_unescaped);
+        TEST_CHECK(len == val.via.str.size);
+        if (len != val.via.str.size) {
+            printf("failed comparing string length\n");
+        }
+
+        /* Compare raw bytes */
+        ret = memcmp(val.via.str.ptr, p_unescaped, len);
+        TEST_CHECK(ret == 0);
+        if (ret != 0) {
+            printf("failed comparing to original value\n");
+        }
+
+        msgpack_unpacked_destroy(&result);
+        flb_free(out_buf);
+    }
+}
+
 void test_json_pack_bug1278()
 {
     int i;
@@ -910,5 +980,6 @@ TEST_LIST = {
 
     /* Mixed bytes, check JSON encoding */
     { "utf8_to_json", test_utf8_to_json},
+    { "json_pack_surrogate_pairs", test_json_pack_surrogate_pairs},
     { 0 }
 };

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -590,6 +590,76 @@ void test_json_pack_surrogate_pairs()
     }
 }
 
+void test_json_pack_surrogate_pairs_with_replacement()
+{
+    int i;
+    int ret;
+    int len;
+    int type;
+    int items;
+    char *p_in;
+    char *p_unescaped;
+    size_t len_in;
+    char *out_buf;
+    size_t out_size;
+    char *data_in[] = {
+        "{\"text\":\"\\fddd,\"}",
+        "{\"text\":\"\\udee1,\"}",
+        "{\"text\":\"\\ud83e,|,\"}",
+    };
+    char *data_unescaped[] = {
+        "\fddd,",
+        "�,",
+        "�,|,",
+    };
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object val;
+    size_t off = 0;
+
+    items = sizeof(data_in) / sizeof(char *);
+    for (i = 0; i < items; i++) {
+        p_in = data_in[i];
+        len_in = strlen(p_in);
+        p_unescaped = data_unescaped[i];
+
+        /* Pack raw JSON as msgpack */
+        ret = flb_pack_json(p_in, len_in, &out_buf, &out_size, &type, NULL);
+        TEST_CHECK(ret == 0);
+
+        /* Unpack 'text' value and compare it to the original raw */
+        off = 0;
+        msgpack_unpacked_init(&result);
+        ret = msgpack_unpack_next(&result, out_buf, out_size, &off);
+        TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+
+        /* Check parent type is a map */
+        root = result.data;
+        TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
+
+        /* Get map value */
+        val = root.via.map.ptr[0].val;
+        TEST_CHECK(val.type == MSGPACK_OBJECT_STR);
+
+        /* Compare bytes length */
+        len = strlen(p_unescaped);
+        TEST_CHECK(len == val.via.str.size);
+        if (len != val.via.str.size) {
+            printf("failed comparing string length\n");
+        }
+
+        /* Compare raw bytes */
+        ret = memcmp(val.via.str.ptr, p_unescaped, len);
+        TEST_CHECK(ret == 0);
+        if (ret != 0) {
+            printf("failed comparing to original value\n");
+        }
+
+        msgpack_unpacked_destroy(&result);
+        flb_free(out_buf);
+    }
+}
+
 void test_json_pack_bug1278()
 {
     int i;
@@ -981,5 +1051,7 @@ TEST_LIST = {
     /* Mixed bytes, check JSON encoding */
     { "utf8_to_json", test_utf8_to_json},
     { "json_pack_surrogate_pairs", test_json_pack_surrogate_pairs},
+    { "json_pack_surrogate_pairs_with_replacement",
+      test_json_pack_surrogate_pairs_with_replacement},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, we ignore surrogate pairs for \u escape on Unicode representation.
To handle this, we need to process with surrogate pairs manner.
Noe that this representation is also encoded `\uXXXX` representation on creating JSON.
On creating msgpack, this unescaping operation is effective. 

Closes https://github.com/fluent/fluent-bit/issues/9712.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
$ bin/fluent-bit -i stdin -o stdout
```

and send `{"text": "\ud83e\udd17"}` in the same terminal.

- [x] Debug log output from testing the change

```
Fluent Bit v4.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/01/06 18:17:45] [ info] Configuration:
[2025/01/06 18:17:45] [ info]  flush time     | 1.000000 seconds
[2025/01/06 18:17:45] [ info]  grace          | 5 seconds
[2025/01/06 18:17:45] [ info]  daemon         | 0
[2025/01/06 18:17:45] [ info] ___________
[2025/01/06 18:17:45] [ info]  inputs:
[2025/01/06 18:17:45] [ info]      stdin
[2025/01/06 18:17:45] [ info] ___________
[2025/01/06 18:17:45] [ info]  filters:
[2025/01/06 18:17:45] [ info] ___________
[2025/01/06 18:17:45] [ info]  outputs:
[2025/01/06 18:17:45] [ info]      stdout.0
[2025/01/06 18:17:45] [ info] ___________
[2025/01/06 18:17:45] [ info]  collectors:
[2025/01/06 18:17:45] [ info] [fluent bit] version=4.0.0, commit=09214ebc7b, pid=74663
[2025/01/06 18:17:45] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2025/01/06 18:17:45] [ info] [storage] ver=1.2.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/01/06 18:17:45] [ info] [simd    ] NEON
[2025/01/06 18:17:45] [ info] [cmetrics] version=0.9.9
[2025/01/06 18:17:45] [ info] [ctraces ] version=0.5.7
[2025/01/06 18:17:45] [ info] [input:stdin:stdin.0] initializing
[2025/01/06 18:17:45] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2025/01/06 18:17:45] [debug] [stdin:stdin.0] created event channels: read=25 write=26
[2025/01/06 18:17:45] [debug] [input:stdin:stdin.0] buf_size=16000
[2025/01/06 18:17:45] [debug] [stdout:stdout.0] created event channels: read=28 write=29
[2025/01/06 18:17:45] [ info] [sp] stream processor started
[2025/01/06 18:17:45] [ info] [output:stdout:stdout.0] worker #0 started
{"text": "\ud83e\udd17"}
[2025/01/06 18:17:47] [debug] [task] created task=0x6000032ec000 id=0 OK
[2025/01/06 18:17:47] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] stdin.0: [[1736155066.742995000, {}], {"text"=>"🤗"}]
[2025/01/06 18:17:47] [debug] [out flush] cb_destroy coro_id=0
[2025/01/06 18:17:47] [debug] [task] destroy task=0x6000032ec000 (task_id=0)
^C[2025/01/06 18:17:48] [engine] caught signal (SIGINT)
[2025/01/06 18:17:48] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/01/06 18:17:48] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==80122== 
==80122== HEAP SUMMARY:
==80122==     in use at exit: 0 bytes in 0 blocks
==80122==   total heap usage: 2,999 allocs, 2,999 frees, 1,341,761 bytes allocated
==80122== 
==80122== All heap blocks were freed -- no leaks are possible
==80122== 
==80122== For lists of detected and suppressed errors, rerun with: -s
==80122== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
