### PR TITLE
in_kafka: boost throughput

### DIFF
--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -180,8 +180,11 @@ static int in_kafka_collect(struct flb_input_instance *ins,
 
         rd_kafka_message_destroy(rkm);
 
-        /* TO-DO: commit the record based on `ret` */
-        rd_kafka_commit(ctx->kafka.rk, NULL, 0);
+        
+        if(!ctx->enable_auto_commit) {
+            /* TO-DO: commit the record based on `ret` */
+            rd_kafka_commit(ctx->kafka.rk, NULL, 0);
+        }
 
         /* Break from the loop when reaching the limit of polling if available */
         if (ctx->polling_threshold != FLB_IN_KAFKA_UNLIMITED &&
@@ -427,6 +430,11 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_SIZE, "buffer_max_size", FLB_IN_KAFKA_BUFFER_MAX_SIZE,
     0, FLB_TRUE, offsetof(struct flb_in_kafka_config, buffer_max_size),
     "Set the maximum size of chunk"
+   },
+   {
+    FLB_CONFIG_MAP_BOOL, "enable_auto_commit", FLB_IN_KAFKA_ENABLE_AUTO_COMMIT,
+    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, enable_auto_commit),
+    "Rely on kafka auto-commit and commit messages in batches"
    },
    /* EOF */
    {0}

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -33,6 +33,7 @@
 #define FLB_IN_KAFKA_UNLIMITED             (size_t)-1
 #define FLB_IN_KAFKA_BUFFER_MAX_SIZE       "4M"
 #define FLB_IN_KAFKA_ENABLE_AUTO_COMMIT    "false"
+#define FLB_IN_KAFKA_POLL_TIMEOUT_MS       "550"        // same as kafka fetch.wait.max.ms + 10%
 
 enum {
     FLB_IN_KAFKA_FORMAT_NONE,

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -51,7 +51,7 @@ struct flb_in_kafka_config {
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
     bool enable_auto_commit;
-    int poll_timeount_ms;
+    int poll_timeout_ms;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -32,6 +32,7 @@
 #define FLB_IN_KAFKA_DEFAULT_FORMAT        "none"
 #define FLB_IN_KAFKA_UNLIMITED             (size_t)-1
 #define FLB_IN_KAFKA_BUFFER_MAX_SIZE       "4M"
+#define FLB_IN_KAFKA_ENABLE_AUTO_COMMIT    "false"
 
 enum {
     FLB_IN_KAFKA_FORMAT_NONE,
@@ -48,6 +49,7 @@ struct flb_in_kafka_config {
     int coll_fd;
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
+    bool enable_auto_commit;
 };
 
 #endif

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -50,6 +50,7 @@ struct flb_in_kafka_config {
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
     bool enable_auto_commit;
+    int poll_timeount_ms;
 };
 
 #endif


### PR DESCRIPTION
We have a Kafka cluster that ingests about 40k messages (about 60MB) of data per seconds. Fluent-bit in its current state stands no change to keep up with this load. Even Logstash is faster and vector is just consuming all these messages with ease.

Causes:
a) commits each message individually
b) a poll-timeout of just one 1ms (this completely overrides fetch.wait.max.ms from kafka)

probably related to "Batch processing is required in in_kafka. https://github.com/fluent/fluent-bit/issues/8030"

Testing: To activate the changes one need to

[INPUT]
Name kafka
threaded true   -> sets timeout fetch.wait.max.ms + 50ms (align our and kafkas timeout, ensures kafka triggers timeout)
enable_auto_commit true -> disable explicit commit call

-> The change doesn't do any dynamic allocations at all and therefore cant introduce any mem-leaks
-> The change has no impact on packaging

Throughput increased by more then a magnitude.