### PR TITLE
lib: nghttp2: CMakeLists.txt: do not require a CXX compiler

### DIFF
--- a/lib/nghttp2/CMakeLists.txt
+++ b/lib/nghttp2/CMakeLists.txt
@@ -24,7 +24,7 @@
 
 cmake_minimum_required(VERSION 3.0)
 # XXX using 1.8.90 instead of 1.9.0-DEV
-project(nghttp2 VERSION 1.58.90)
+project(nghttp2 VERSION 1.58.90 LANGUAGES C)
 
 # See versioning rule:
 #  https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
@@ -122,29 +122,31 @@ else()
   set(HINT_NORETURN)
 endif()
 
-include(ExtractValidFlags)
-foreach(_cxx1x_flag -std=c++14)
-  extract_valid_cxx_flags(_cxx1x_flag_supported ${_cxx1x_flag})
-  if(_cxx1x_flag_supported)
-    set(CXX1XCXXFLAGS ${_cxx1x_flag})
-    break()
-  endif()
-endforeach()
+if(NOT ENABLE_LIB_ONLY)
+  include(ExtractValidFlags)
+  foreach(_cxx1x_flag -std=c++14)
+    extract_valid_cxx_flags(_cxx1x_flag_supported ${_cxx1x_flag})
+    if(_cxx1x_flag_supported)
+      set(CXX1XCXXFLAGS ${_cxx1x_flag})
+      break()
+    endif()
+  endforeach()
 
-include(CMakePushCheckState)
-include(CheckCXXSourceCompiles)
-cmake_push_check_state()
-set(CMAKE_REQUIRED_DEFINITIONS "${CXX1XCXXFLAGS}")
-# Check that std::future is available.
-check_cxx_source_compiles("
-#include <vector>
-#include <future>
-int main() { std::vector<std::future<int>> v; }" HAVE_STD_FUTURE)
-# Check that std::map::emplace is available for g++-4.7.
-check_cxx_source_compiles("
-#include <map>
-int main() { std::map<int, int>().emplace(1, 2); }" HAVE_STD_MAP_EMPLACE)
-cmake_pop_check_state()
+  include(CMakePushCheckState)
+  include(CheckCXXSourceCompiles)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_DEFINITIONS "${CXX1XCXXFLAGS}")
+  # Check that std::future is available.
+  check_cxx_source_compiles("
+  #include <vector>
+  #include <future>
+  int main() { std::vector<std::future<int>> v; }" HAVE_STD_FUTURE)
+  # Check that std::map::emplace is available for g++-4.7.
+  check_cxx_source_compiles("
+  #include <map>
+  int main() { std::map<int, int>().emplace(1, 2); }" HAVE_STD_MAP_EMPLACE)
+  cmake_pop_check_state()
+endif()
 
 
 # Checks for libraries.
@@ -177,7 +179,7 @@ endif()
 # openssl (for src)
 include(CheckSymbolExists)
 set(HAVE_OPENSSL    ${OPENSSL_FOUND})
-if(OPENSSL_FOUND)
+if(NOT ENABLE_LIB_ONLY AND OPENSSL_FOUND)
   set(OPENSSL_INCLUDE_DIRS  ${OPENSSL_INCLUDE_DIR})
   cmake_push_check_state()
   set(CMAKE_REQUIRED_INCLUDES   "${OPENSSL_INCLUDE_DIR}")


### PR DESCRIPTION
Allow fluent-bit to be compiled without C++ compiler.
This follows on PR https://github.com/fluent/fluent-bit/pull/9277.

Upstream: https://github.com/nghttp2/nghttp2/commit/d9d266124c9f851bab7927321da6637d930367e2

:exclamation: Note for the reviewer, it's also fine to bump nghttp2 to e.g. [v1.64.0](https://github.com/nghttp2/nghttp2/releases/tag/v1.64.0). :exclamation:

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
