### PR TITLE
custom: add support for net properties to custom plugins.

### DIFF
--- a/include/fluent-bit/flb_custom.h
+++ b/include/fluent-bit/flb_custom.h
@@ -27,6 +27,10 @@
 #include <fluent-bit/flb_metrics.h>
 #endif
 
+/* Custom plugin flag masks */
+#define FLB_CUSTOM_NET_CLIENT   1   /* custom may use upstream net.* properties  */
+#define FLB_CUSTOM_NET_SERVER   2   /* custom may use downstream net.* properties  */
+
 struct flb_custom_instance;
 
 struct flb_custom_plugin {
@@ -57,7 +61,9 @@ struct flb_custom_instance {
     void *data;
     struct flb_custom_plugin *p;   /* original plugin          */
     struct mk_list properties;     /* config properties        */
+    struct mk_list net_properties; /* net properties           */
     struct mk_list *config_map;    /* configuration map        */
+    struct mk_list *net_config_map;/* net configuration map    */
     struct mk_list _head;          /* link to config->customs  */
 
     /*

--- a/src/flb_custom.c
+++ b/src/flb_custom.c
@@ -27,6 +27,8 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_upstream.h>
+#include <fluent-bit/flb_downstream.h>
 #include <chunkio/chunkio.h>
 
 static inline int instance_id(struct flb_config *config)
@@ -78,6 +80,16 @@ int flb_custom_set_property(struct flb_custom_instance *ins,
             return -1;
         }
         ins->log_level = ret;
+    }
+    else if (strncasecmp("net.", k, 4) == 0 && tmp) {
+        kv = flb_kv_item_create(&ins->net_properties, (char *) k, NULL);
+        if (!kv) {
+            if (tmp) {
+                flb_sds_destroy(tmp);
+            }
+            return -1;
+        }
+        kv->val = tmp;
     }
     else {
         /*
@@ -178,6 +190,7 @@ struct flb_custom_instance *flb_custom_new(struct flb_config *config,
     instance->log_level = -1;
 
     mk_list_init(&instance->properties);
+    mk_list_init(&instance->net_properties);
     mk_list_add(&instance->_head, &config->customs);
 
     return instance;
@@ -212,6 +225,28 @@ int flb_custom_plugin_property_check(struct flb_custom_instance *ins,
             return -1;
         }
         ins->config_map = config_map;
+
+        if ((p->flags & FLB_CUSTOM_NET_CLIENT) && (p->flags & FLB_CUSTOM_NET_SERVER)) {
+                flb_error("[custom] cannot configure upstream and downstream "
+                          "in the same custom plugin: '%s'",
+                          p->name);
+        }
+        if (p->flags & FLB_CUSTOM_NET_CLIENT) {
+                ins->net_config_map = flb_upstream_get_config_map(config);
+                if (ins->net_config_map == NULL) {
+                        flb_error("[custom] unable to load upstream properties: '%s'",
+                                  p->name);
+                        return -1;
+                }
+        }
+        else if (p->flags & FLB_CUSTOM_NET_SERVER) {
+                ins->net_config_map = flb_downstream_get_config_map(config);
+                if (ins->net_config_map == NULL) {
+                        flb_error("[custom] unable to load downstream properties: '%s'",
+                                  p->name);
+                        return -1;
+                }
+        }
 
         /* Validate incoming properties against config map */
         ret = flb_config_map_properties_check(ins->p->name,
@@ -293,6 +328,7 @@ void flb_custom_instance_destroy(struct flb_custom_instance *ins)
 
     /* release properties */
     flb_kv_release(&ins->properties);
+    flb_kv_release(&ins->net_properties);
 
     if (ins->alias) {
         flb_sds_destroy(ins->alias);

--- a/src/flb_custom.c
+++ b/src/flb_custom.c
@@ -325,6 +325,10 @@ void flb_custom_instance_destroy(struct flb_custom_instance *ins)
     if (ins->config_map) {
         flb_config_map_destroy(ins->config_map);
     }
+    /* destroy net config map */
+    if (ins->net_config_map) {
+        flb_config_map_destroy(ins->net_config_map);
+    }
 
     /* release properties */
     flb_kv_release(&ins->properties);

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -190,6 +190,12 @@ static int flb_custom_propery_check_all(struct flb_config *config)
             flb_config_map_destroy(ins->config_map);
             ins->config_map = NULL;
         }
+
+        /* destroy net config map (will be recreated at flb_start) */
+        if (ins->net_config_map) {
+            flb_config_map_destroy(ins->net_config_map);
+            ins->net_config_map = NULL;
+        }
     }
 
     return 0;


### PR DESCRIPTION
# Summary

Add support for downstream and upstream `net.*` properties for custom calyptia plugins.

# Description

Add support for either downstream or upstream net properties, ie: net.dns.mode, etc... for custom plugins. This support is activated by setting the custom plugin flag FLB_CUSTOM_NET_CLIENT or FLB_CUSTOM_NET_SERVER. At the moment custom plugins can only accept either downstream or upstream properties, not both.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
