### PR TITLE
tests: runtime_shell: custom_calyptia prevent fail on macOS at cleanup

### DIFF
--- a/.github/workflows/skipped-unit-tests.yaml
+++ b/.github/workflows/skipped-unit-tests.yaml
@@ -10,7 +10,6 @@ on:
       - 'packaging/**'
       - '.gitignore'
       - 'appveyor.yml'
-      - '**.sh'
       - 'examples/**'
 
 jobs:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,10 +15,13 @@ on:
       - 'packaging/**'
       - '.gitignore'
       - 'appveyor.yml'
-      - '**.sh'
       - 'examples/**'
     branches:
       - master
+      - 3.2
+      - 3.1
+      - 3.0
+      - 2.2
       - 2.1
       - 2.0
       - 1.9

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -115,7 +115,6 @@ jobs:
           CC: gcc
           CXX: g++
           FLB_OPT: ${{ matrix.flb_option }}
-          CALYPTIA_FLEET_TOKEN: ${{ secrets.CALYPTIA_FLEET_TOKEN }}
 
   run-aarch64-unit-tests:
     # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-latest usage.

--- a/tests/runtime_shell/custom_calyptia.sh
+++ b/tests/runtime_shell/custom_calyptia.sh
@@ -27,7 +27,7 @@ test_custom_calyptia_fleet_yaml() {
     fi
 
     # Clean up
-    kill -15 $FLB_PID
+    kill -15 $FLB_PID || true
 }
 
 test_custom_calyptia_fleet_toml() {
@@ -57,7 +57,7 @@ test_custom_calyptia_fleet_toml() {
     fi
 
     # Clean up
-    kill -15 $FLB_PID
+    kill -15 $FLB_PID || true
 }
 
 # The following command launch the unit test


### PR DESCRIPTION
Resolve issue with macOS framework failing on cleanup.
Fixed an issue with `*.sh` changes not running unit tests.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
