### PR TITLE
processor_labels: add support for record accessor in values

### DIFF
--- a/plugins/processor_labels/labels.c
+++ b/plugins/processor_labels/labels.c
@@ -28,6 +28,7 @@
 #include <fluent-bit/flb_processor.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_record_accessor.h>
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_histogram.h>
@@ -43,6 +44,16 @@
 
 typedef int (*label_transformer)(struct cmt_metric *, cfl_sds_t *value);
 
+struct label_kv {
+    cfl_sds_t key;
+    cfl_sds_t val;
+    /*
+     * record accessor is only set if a '$' string exists in the
+     * given value string, otherwise the string is copied directly into 'val'
+     */
+    struct flb_record_accessor *ra;
+    struct cfl_list _head;
+};
 struct internal_processor_context {
     struct mk_list *update_list;
     struct mk_list *insert_list;
@@ -262,11 +273,11 @@ static int process_label_modification_kvlist_setting(
                 struct mk_list *source_list,
                 struct cfl_list *destination_list)
 {
-    struct cfl_kv             *processed_pair;
     struct flb_config_map_val *source_entry;
     struct mk_list            *iterator;
     struct flb_slist_entry    *value;
     struct flb_slist_entry    *key;
+    struct label_kv           *kv_node;
 
     if (source_list == NULL ||
         mk_list_is_empty(source_list) == 0) {
@@ -290,29 +301,82 @@ static int process_label_modification_kvlist_setting(
         value = mk_list_entry_last(source_entry->val.list,
                                    struct flb_slist_entry, _head);
 
-        processed_pair = cfl_kv_item_create(destination_list,
-                                            key->str,
-                                            value->str);
-
-        if (processed_pair == NULL) {
-            flb_plg_error(plugin_instance,
-                          "could not append label %s=%s\n",
-                          key->str,
-                          value->str);
-
+        kv_node = flb_malloc(sizeof(struct label_kv));
+        if (kv_node == NULL) {
+            flb_errno();
             return -1;
         }
+
+        /* only initialize record accessor if a pattern is found */
+        if (strchr(value->str, '$') != NULL) {
+            kv_node->ra = flb_ra_create(value->str, FLB_FALSE);
+            if (kv_node->ra == NULL) {
+                flb_plg_error(plugin_instance,
+                              "could not create record accessor for '%s'",
+                              value->str);
+                return -1;
+            }
+        }
+        else {
+            kv_node->ra = NULL;
+        }
+
+        kv_node->key = cfl_sds_create(key->str);
+        if (kv_node->key == NULL) {
+            flb_ra_destroy(kv_node->ra);
+            flb_free(kv_node);
+            flb_plg_error(plugin_instance,
+                          "could not create label key '%s'",
+                          key->str);
+            return -1;
+        }
+
+        kv_node->val = cfl_sds_create(value->str);
+        if (kv_node->val == NULL) {
+            cfl_sds_destroy(kv_node->key);
+            flb_ra_destroy(kv_node->ra);
+            flb_free(kv_node);
+            flb_plg_error(plugin_instance,
+                          "could not create label value '%s'",
+                          value->str);
+            return -1;
+        }
+
+        cfl_list_add(&kv_node->_head, destination_list);
     }
 
     return 0;
 }
 
+static void destroy_label_kv_list(struct cfl_list *list)
+{
+    struct cfl_list  *tmp;
+    struct cfl_list  *iterator;
+    struct label_kv *kv_node;
+
+    cfl_list_foreach_safe(iterator, tmp, list) {
+        kv_node = cfl_list_entry(iterator, struct label_kv, _head);
+
+        cfl_sds_destroy(kv_node->key);
+        cfl_sds_destroy(kv_node->val);
+
+        if (kv_node->ra != NULL) {
+            flb_ra_destroy(kv_node->ra);
+        }
+
+        cfl_list_del(&kv_node->_head);
+        flb_free(kv_node);
+    }
+}
+
 static void destroy_context(struct internal_processor_context *context)
 {
     if (context != NULL) {
-        cfl_kv_release(&context->update_labels);
-        cfl_kv_release(&context->insert_labels);
-        cfl_kv_release(&context->upsert_labels);
+
+        destroy_label_kv_list(&context->update_labels);
+        destroy_label_kv_list(&context->insert_labels);
+        destroy_label_kv_list(&context->upsert_labels);
+
         flb_slist_destroy(&context->delete_labels);
         flb_slist_destroy(&context->hash_labels);
 
@@ -320,70 +384,69 @@ static void destroy_context(struct internal_processor_context *context)
     }
 }
 
-static struct internal_processor_context *
-        create_context(struct flb_processor_instance *processor_instance,
-                       struct flb_config *config)
+static struct internal_processor_context *create_context(struct flb_processor_instance *processor_instance,
+                                                         struct flb_config *config)
 {
-    struct internal_processor_context *context;
     int                                result;
+    struct internal_processor_context *context;
 
     context = flb_calloc(1, sizeof(struct internal_processor_context));
-
-    if (context != NULL) {
-        context->instance = processor_instance;
-        context->config = config;
-
-        cfl_kv_init(&context->update_labels);
-        cfl_kv_init(&context->insert_labels);
-        cfl_kv_init(&context->upsert_labels);
-        flb_slist_create(&context->delete_labels);
-        flb_slist_create(&context->hash_labels);
-
-        result = flb_processor_instance_config_map_set(processor_instance, (void *) context);
-
-        if (result == 0) {
-            result = process_label_modification_kvlist_setting(processor_instance,
-                                                               "update",
-                                                               context->update_list,
-                                                               &context->update_labels);
-        }
-
-        if (result == 0) {
-            result = process_label_modification_kvlist_setting(processor_instance,
-                                                               "insert",
-                                                               context->insert_list,
-                                                               &context->insert_labels);
-        }
-
-        if (result == 0) {
-            result = process_label_modification_kvlist_setting(processor_instance,
-                                                               "upsert",
-                                                               context->upsert_list,
-                                                               &context->upsert_labels);
-        }
-
-        if (result == 0) {
-            result = process_label_modification_list_setting(processor_instance,
-                                                             "delete",
-                                                             context->delete_list,
-                                                             &context->delete_labels);
-        }
-
-        if (result == 0) {
-            result = process_label_modification_list_setting(processor_instance,
-                                                             "hash",
-                                                             context->hash_list,
-                                                             &context->hash_labels);
-        }
-
-        if (result != 0) {
-            destroy_context(context);
-
-            context = NULL;
-        }
-    }
-    else {
+    if (!context) {
         flb_errno();
+        return NULL;
+    }
+
+    context->instance = processor_instance;
+    context->config = config;
+
+    cfl_list_init(&context->update_labels);
+    cfl_list_init(&context->insert_labels);
+    cfl_list_init(&context->upsert_labels);
+
+    flb_slist_create(&context->delete_labels);
+    flb_slist_create(&context->hash_labels);
+
+    result = flb_processor_instance_config_map_set(processor_instance, (void *) context);
+
+    if (result == 0) {
+        result = process_label_modification_kvlist_setting(processor_instance,
+                                                            "update",
+                                                            context->update_list,
+                                                            &context->update_labels);
+    }
+
+    if (result == 0) {
+        result = process_label_modification_kvlist_setting(processor_instance,
+                                                            "insert",
+                                                            context->insert_list,
+                                                            &context->insert_labels);
+    }
+
+    if (result == 0) {
+        result = process_label_modification_kvlist_setting(processor_instance,
+                                                            "upsert",
+                                                            context->upsert_list,
+                                                            &context->upsert_labels);
+    }
+
+    if (result == 0) {
+        result = process_label_modification_list_setting(processor_instance,
+                                                            "delete",
+                                                            context->delete_list,
+                                                            &context->delete_labels);
+    }
+
+    if (result == 0) {
+        result = process_label_modification_list_setting(processor_instance,
+                                                            "hash",
+                                                            context->hash_list,
+                                                            &context->hash_labels);
+    }
+
+    if (result != 0) {
+        destroy_context(context);
+
+        context = NULL;
     }
 
     return context;
@@ -1470,25 +1533,64 @@ static int metrics_context_remove_dynamic_label(struct cmt *metrics_context,
     return FLB_TRUE;
 }
 
+/*
+ * Retrieve the value based on a potential record_accessor patern or a direct
+ * mapping of the value set in the configuration. If the returned buffer
+ * must be freed by the caller, then 'destroy_buf' will be set to FLB_TRUE,
+ * otherwise it will be set to FLB_FALSE.
+ */
+static flb_sds_t get_label_value(struct label_kv *pair, char *tag, int tag_len, int *destroy_buf)
+{
+    flb_sds_t value;
+    msgpack_object o = {0};
+
+    *destroy_buf = FLB_FALSE;
+
+    if (pair->ra != NULL) {
+        /* get the value using a record accessor pattern */
+        value = flb_ra_translate(pair->ra, tag, tag_len, o, NULL);
+        if (value == NULL) {
+            return NULL;
+        }
+    }
+    else {
+        /* use the pre-defined string */
+        value = pair->val;
+    }
+
+    return value;
+}
+
 static int update_labels(struct cmt *metrics_context,
+                         char *tag, int tag_len,
                          struct cfl_list *labels)
 {
-    struct cfl_list *iterator;
     int              result;
-    struct cfl_kv   *pair;
+    int              destroy_buf = FLB_FALSE;
+    struct cfl_list *iterator;
+    struct label_kv *pair;
+    flb_sds_t        value = NULL;
 
     cfl_list_foreach(iterator, labels) {
-        pair = cfl_list_entry(iterator, struct cfl_kv, _head);
+        pair = cfl_list_entry(iterator, struct label_kv, _head);
 
         result = metrics_context_contains_dynamic_label(metrics_context,
                                                         pair->key);
+        value = get_label_value(pair, tag, tag_len, &destroy_buf);
+        if (value == NULL) {
+            return FLB_FALSE;
+        }
 
         if (result == FLB_TRUE) {
             result = metrics_context_update_dynamic_label(metrics_context,
                                                           pair->key,
-                                                          pair->val);
+                                                          value);
+
 
             if (result == FLB_FALSE) {
+                if (destroy_buf == FLB_TRUE) {
+                    flb_sds_destroy(value);
+                }
                 return FLB_FALSE;
             }
         }
@@ -1499,26 +1601,36 @@ static int update_labels(struct cmt *metrics_context,
         if (result == FLB_TRUE) {
             result = metrics_context_update_static_label(metrics_context,
                                                          pair->key,
-                                                         pair->val);
+                                                         value);
 
             if (result == FLB_FALSE) {
+                if (destroy_buf == FLB_TRUE) {
+                    flb_sds_destroy(value);
+                }
                 return FLB_FALSE;
             }
         }
+    }
+
+    if (destroy_buf == FLB_TRUE) {
+        flb_sds_destroy(value);
     }
 
     return FLB_PROCESSOR_SUCCESS;
 }
 
 static int insert_labels(struct cmt *metrics_context,
+                         char *tag, int tag_len,
                          struct cfl_list *labels)
 {
-    struct cfl_list *iterator;
     int              result;
-    struct cfl_kv   *pair;
+    int              destroy_buf = FLB_FALSE;
+    struct cfl_list *iterator;
+    struct label_kv *pair;
+    flb_sds_t        value = NULL;
 
     cfl_list_foreach(iterator, labels) {
-        pair = cfl_list_entry(iterator, struct cfl_kv, _head);
+        pair = cfl_list_entry(iterator, struct label_kv, _head);
 
         result = metrics_context_contains_dynamic_label(metrics_context,
                                                         pair->key);
@@ -1527,11 +1639,19 @@ static int insert_labels(struct cmt *metrics_context,
             continue;
         }
 
+        value = get_label_value(pair, tag, tag_len, &destroy_buf);
+        if (value == NULL) {
+            return FLB_FALSE;
+        }
+
         result = metrics_context_insert_dynamic_label(metrics_context,
                                                       pair->key,
-                                                      pair->val);
+                                                      value);
 
         if (result == FLB_FALSE) {
+            if (destroy_buf == FLB_TRUE) {
+                flb_sds_destroy(value);
+            }
             return FLB_FALSE;
         }
 
@@ -1541,26 +1661,43 @@ static int insert_labels(struct cmt *metrics_context,
         if (result == FLB_TRUE) {
             result = metrics_context_insert_static_label(metrics_context,
                                                          pair->key,
-                                                         pair->val);
+                                                         value);
+
 
             if (result == FLB_FALSE) {
+                if (destroy_buf == FLB_TRUE) {
+                    flb_sds_destroy(value);
+                }
                 return FLB_FALSE;
             }
         }
     }
 
+    if (destroy_buf == FLB_TRUE) {
+        flb_sds_destroy(value);
+    }
+
     return FLB_PROCESSOR_SUCCESS;
 }
 
+
 static int upsert_labels(struct cmt *metrics_context,
+                         char *tag, int tag_len,
                          struct cfl_list *labels)
 {
-    struct cfl_list *iterator;
     int              result;
-    struct cfl_kv   *pair;
+    int destroy_buf = FLB_FALSE;
+    struct cfl_list *iterator;
+    struct label_kv  *pair;
+    flb_sds_t value = NULL;
 
     cfl_list_foreach(iterator, labels) {
-        pair = cfl_list_entry(iterator, struct cfl_kv, _head);
+        pair = cfl_list_entry(iterator, struct label_kv, _head);
+
+        value = get_label_value(pair, tag, tag_len, &destroy_buf);
+        if (value == NULL) {
+            return FLB_FALSE;
+        }
 
         result = metrics_context_contains_dynamic_label(metrics_context,
                                                         pair->key);
@@ -1568,21 +1705,31 @@ static int upsert_labels(struct cmt *metrics_context,
         if (result == FLB_TRUE) {
             result = metrics_context_upsert_dynamic_label(metrics_context,
                                                           pair->key,
-                                                          pair->val);
+                                                          value);
 
             if (result == FLB_FALSE) {
+                if (destroy_buf == FLB_TRUE) {
+                    flb_sds_destroy(value);
+                }
                 return FLB_FALSE;
             }
         }
         else {
             result = metrics_context_upsert_static_label(metrics_context,
                                                          pair->key,
-                                                         pair->val);
+                                                         value);
 
             if (result == FLB_FALSE) {
+                if (destroy_buf == FLB_TRUE) {
+                    flb_sds_destroy(value);
+                }
                 return FLB_FALSE;
             }
         }
+    }
+
+    if (destroy_buf == FLB_TRUE) {
+        flb_sds_destroy(value);
     }
 
     return FLB_PROCESSOR_SUCCESS;
@@ -1724,17 +1871,17 @@ static int cb_process_metrics(struct flb_processor_instance *processor_instance,
                            &processor_context->delete_labels);
 
     if (result == FLB_PROCESSOR_SUCCESS) {
-        result = update_labels(out_cmt,
+        result = update_labels(out_cmt, (char *) tag, tag_len,
                                &processor_context->update_labels);
     }
 
     if (result == FLB_PROCESSOR_SUCCESS) {
-        result = upsert_labels(out_cmt,
+        result = upsert_labels(out_cmt, (char *) tag, tag_len,
                                &processor_context->upsert_labels);
     }
 
     if (result == FLB_PROCESSOR_SUCCESS) {
-        result = insert_labels(out_cmt,
+        result = insert_labels(out_cmt, (char *) tag, tag_len,
                                &processor_context->insert_labels);
     }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -239,6 +239,10 @@ if (FLB_PROCESSOR_METRICS_SELECTOR)
   FLB_RT_TEST(FLB_PROCESSOR_METRICS_SELECTOR "processor_metrics_selector.c")
 endif()
 
+if (FLB_PROCESSOR_LABELS)
+  FLB_RT_TEST(FLB_PROCESSOR_LABELS "processor_labels.c")
+endif()
+
 if (FLB_PROCESSOR_CONTENT_MODIFIER)
   FLB_RT_TEST(FLB_PROCESSOR_CONTENT_MODIFIER "processor_content_modifier.c")
 endif()

--- a/tests/runtime/processor_labels.c
+++ b/tests/runtime/processor_labels.c
@@ -1,0 +1,563 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_runtime.h"
+
+/* iterate in the text per line, and count the number of matches */
+static int count_metrics_matches(char *metrics_text, const char *pattern)
+{
+    int len;
+    int count = 0;
+    char *line_start;
+    char *line_end;
+    char buf[1024];
+
+    line_start = metrics_text;
+
+    /* Iterate through the text to find lines */
+    while (*line_start != '\0') {
+        /* Find the end of the current line */
+        line_end = strchr(line_start, '\n');
+        if (line_end == NULL) {
+            line_end = line_start + strlen(line_start);
+        }
+
+        /* copy the text line to a temporary buffer */
+        len = line_end - line_start;
+        strncpy(buf, line_start, len);
+        buf[len] = '\0';
+
+        /* Check if the pattern exists in the current line */
+        if (strstr(buf, pattern) != NULL) {
+            count++;
+        }
+
+        /* Move to the next line */
+        if (*line_end == '\0') {
+            break;
+        }
+        line_start = line_end + 1;
+    }
+
+    return count;
+}
+
+static int cb_insert_labels(void *record, size_t size, void *data)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text = NULL;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return -1;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+    TEST_CHECK(text != NULL);
+
+    TEST_CHECK(count_metrics_matches(text, "static=\"ok\"") == 9);
+    TEST_CHECK(count_metrics_matches(text, "dynamic=\"test\"") == 9);
+
+    if (record) {
+        flb_free(record);
+    }
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+    cmt_encode_text_destroy(text);
+
+    return 0;
+}
+
+static void insert_label()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct flb_lib_out_cb cb_data;
+
+    struct cfl_variant var_static = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "static ok",
+    };
+    struct cfl_variant var_dynamic = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "dynamic $TAG",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_insert_labels;
+    cb_data.data = NULL;
+
+    /* Create context */
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "event_type", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "type", "metrics", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "interval_sec", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Processor */
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "labels");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_unit_set_property(pu, "insert", &var_static);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(pu, "insert", &var_dynamic);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+static int cb_update_labels(void *record, size_t size, void *data)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text = NULL;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return -1;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+    TEST_CHECK(text != NULL);
+
+    /* it should only update the metrics which contains a label with the name 'hostname' */
+    TEST_CHECK(count_metrics_matches(text, "hostname=\"updated\"") == 2);
+
+    /* now check the updated value of 'app' which should include the dynamic tag */
+    TEST_CHECK(count_metrics_matches(text, "app=\"mytag.test\"") == 2);
+
+    if (record) {
+        flb_free(record);
+    }
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+    cmt_encode_text_destroy(text);
+
+    return 0;
+}
+
+static void update_label()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    flb_ctx_t *ctx;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct flb_lib_out_cb cb_data;
+
+    struct cfl_variant var_static = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "hostname updated",
+    };
+    struct cfl_variant var_dynamic = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "app mytag.$TAG",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_update_labels;
+    cb_data.data = NULL;
+
+    /* Create context */
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "event_type", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "type", "metrics", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "interval_sec", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Processor */
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "labels");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_unit_set_property(pu, "update", &var_static);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(pu, "update", &var_dynamic);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+static int cb_upsert_labels(void *record, size_t size, void *data)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text = NULL;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return -1;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+    TEST_CHECK(text != NULL);
+
+    /* it should only update the metrics which contains a label with the name 'hostname' */
+    TEST_CHECK(count_metrics_matches(text, "hostname=\"updated-2\"") == 8);
+
+    /* now check the updated value of 'app' which should include the dynamic tag */
+    TEST_CHECK(count_metrics_matches(text, "dynamic-host=\"test\"") == 9);
+    if (record) {
+        flb_free(record);
+    }
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+    cmt_encode_text_destroy(text);
+
+    return 0;
+}
+
+static void upsert_label()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct flb_lib_out_cb cb_data;
+
+    struct cfl_variant var_static = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "hostname updated-2",
+    };
+    struct cfl_variant var_dynamic = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "dynamic-host $TAG",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_upsert_labels;
+    cb_data.data = NULL;
+
+    /* Create context */
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "event_type", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "type", "metrics", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "interval_sec", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Processor */
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "labels");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_unit_set_property(pu, "upsert", &var_static);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_processor_unit_set_property(pu, "upsert", &var_dynamic);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+static int cb_delete_labels(void *record, size_t size, void *data)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text = NULL;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return -1;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+    TEST_CHECK(text != NULL);
+
+    /* it should only update the metrics which contains a label with the name 'hostname' */
+    TEST_CHECK(count_metrics_matches(text, "hostname=\"") == 0);
+
+    if (record) {
+        flb_free(record);
+    }
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+    cmt_encode_text_destroy(text);
+
+    return 0;
+}
+
+static void delete_label()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct flb_lib_out_cb cb_data;
+
+    struct cfl_variant var_static = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "hostname",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_delete_labels;
+    cb_data.data = NULL;
+
+    /* Create context */
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "event_type", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "type", "metrics", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "interval_sec", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Processor */
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "labels");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_unit_set_property(pu, "delete", &var_static);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+
+static int cb_hash_labels(void *record, size_t size, void *data)
+{
+    int ret;
+    size_t off = 0;
+    cfl_sds_t text = NULL;
+    struct cmt *cmt = NULL;
+
+    /* get cmetrics context */
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &off);
+    if (ret != 0) {
+        flb_error("could not process metrics payload");
+        return -1;
+    }
+
+    /* convert to text representation */
+    text = cmt_encode_text_create(cmt);
+    TEST_CHECK(text != NULL);
+
+    /* it should only update the metrics which contains a label with the name 'hostname' */
+    TEST_CHECK(count_metrics_matches(text, "hostname=\"49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763\"") == 2);
+
+    if (record) {
+        flb_free(record);
+    }
+
+    /* destroy cmt context */
+    cmt_destroy(cmt);
+    cmt_encode_text_destroy(text);
+
+    return 0;
+}
+
+static void hash_label()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    struct flb_lib_out_cb cb_data;
+
+    struct cfl_variant var_static = {
+        .type = CFL_VARIANT_STRING,
+        .data.as_string = "hostname",
+    };
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_hash_labels;
+    cb_data.data = NULL;
+
+    /* Create context */
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "2",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "event_type", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "type", "metrics", NULL);
+    TEST_CHECK(ret == 0);
+    ret = flb_input_set(ctx, in_ffd, "interval_sec", "1", NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Processor */
+    proc = flb_processor_create(ctx->config, "unit_test", NULL, 0);
+    TEST_CHECK(proc != NULL);
+
+    pu = flb_processor_unit_create(proc, FLB_PROCESSOR_METRICS, "labels");
+    TEST_CHECK(pu != NULL);
+
+    ret = flb_processor_unit_set_property(pu, "hash", &var_static);
+    TEST_CHECK(ret == 0);
+
+    /* set up processor */
+    ret = flb_input_set_processor(ctx, in_ffd, proc);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "lib", &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500); /* waiting flush */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST_LIST = {
+#ifdef FLB_HAVE_METRICS
+    {"insert_label", insert_label},
+    {"update_label", update_label},
+    {"upsert_label", upsert_label},
+    {"delete_label", delete_label},
+    {"hash_label",   hash_label},
+#endif
+    {NULL, NULL}
+};
+


### PR DESCRIPTION
Label processors allow to manipulate the labels from metrics, this PR extends the actions `insert`, `update` and `upsert` to support a record accessor pattern that helps to use the `$TAG` variable that can be populated dinamically, e.g:

```yaml
service:
  flush: 1

pipeline:
  inputs:
    - name: event_type
      type: metrics
      tag: my_test

      processors:
        metrics:
          - name: labels
            upsert: tag $TAG

  outputs:
    - name: stdout
      match: '*'
```

Fluent Bit output:

```
______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/01/15 22:16:42] [ info] [fluent bit] version=4.0.0, commit=27734ee3e6, pid=1586419
[2025/01/15 22:16:42] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/01/15 22:16:42] [ info] [simd    ] disabled
[2025/01/15 22:16:42] [ info] [cmetrics] version=0.9.9
[2025/01/15 22:16:42] [ info] [ctraces ] version=0.5.7
[2025/01/15 22:16:42] [ info] [input:event_type:event_type.0] initializing
[2025/01/15 22:16:42] [ info] [input:event_type:event_type.0] storage_strategy='memory' (memory only)
[2025/01/15 22:16:42] [ info] [output:stdout:stdout.0] worker #0 started
[2025/01/15 22:16:42] [ info] [input:event_type:event_type.0] thread instance initialized
[2025/01/15 22:16:42] [ info] [sp] stream processor started
[2025/01/15 22:16:43] [ info] [input:event_type:event_type.0] [OK] collector_time
2025-01-16T04:16:43.837152867Z kubernetes_network_load_counter{tag="my_test"} = 3
2025-01-16T04:16:43.837152867Z kubernetes_network_load_counter{tag="my_test",hostname="localhost",app="cmetrics"} = 1
2025-01-16T04:16:43.837152867Z kubernetes_network_load_counter{tag="my_test",hostname="localhost",app="test"} = 12.15
2025-01-16T04:16:43.837152867Z kubernetes_network_load_gauge{tag="my_test"} = 1
2025-01-16T04:16:43.837152867Z k8s_disk_load_summary{tag="my_test"} = { quantiles = { 0.1=1.1, 0.2=2.2, 0.3=3.3, 0.4=4.4, 0.5=5.5 }, sum=51.6129, count=10 }
2025-01-16T04:16:43.837152867Z k8s_disk_load_summary{tag="my_test",my_label="my_label"} = { quantiles = { 0.1=0.1, 0.2=0.2, 0.3=0.3, 0.4=0.4, 0.5=0.5 }, sum=51.6129, count=5 }
2025-01-16T04:16:43.837152867Z k8s_disk_load_summary{tag="my_test",my_label="my_val"} = { quantiles = { 0.1=11.11, 0.2=0, 0.3=33.33, 0.4=44.44, 0.5=55.55 }, sum=51.6129, count=10 }
2025-01-16T04:16:43.837152867Z k8s_network_load_histogram{tag="my_test"} = { buckets = { 0.05=2, 5=3, 10=4, +Inf=0 }, sum=1013.02, count=5 }
2025-01-16T04:16:43.837152867Z k8s_network_load_histogram{tag="my_test",my_label="my_val"} = { buckets = { 0.05=2, 5=3, 10=4, +Inf=0 }, sum=1013.02, count=5 }
```

This PR also adds a new unit test for the processor.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
