### PR TITLE
fix: correct misleading error message for undefined 'apikey'

### DIFF
--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -93,7 +93,7 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     /* configure URI */
     api_key = flb_output_get_property("apikey", ins);
     if (api_key == NULL) {
-        flb_plg_error(ctx->ins, "no ApiKey configuration key defined");
+        flb_plg_error(ctx->ins, "no apikey configuration key defined");
         flb_datadog_conf_destroy(ctx);
         return NULL;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes a misleading error message in the codebase. Previously, the error message referenced "ApiKey", which could mislead users into thinking they need to use uppercase letters in their configuration. The error message now correctly references "apikey", aligning with the Fluent Bit documentation and actual configuration syntax.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
N/A

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change: 
      N/A (This change affects only the error message and does not introduce functional changes.)
- [ ] Debug log output from testing the change: 
      Log output after the change:
      ```
      [error] no apikey configuration key defined
      ```
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found:
      N/A (This change only updates a string in the error message.)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
      N/A
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).
      N/A

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature: 
      N/A (This change does not require documentation updates.)

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release: 
      N/A

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
