### PR TITLE
systemd: build: Add sethostname workaround for AmazonLinux2 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,24 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(FLB_LINUX_ON_AARCH64 On)
     add_definitions(-DFLB_LINUX_ON_AARCH64)
   endif()
+
+  find_program(CAT_EXEC cat)
+  if (CAT_EXEC)
+    set(RELEASE_FILE "/etc/system-release")
+    if (EXISTS ${RELEASE_FILE})
+      execute_process(COMMAND ${CAT_EXEC} ${RELEASE_FILE}
+        OUTPUT_VARIABLE CAT_SYSTEM_RELEASE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+
+      message(STATUS "##### cat /etc/system-release -- OK")
+
+      if (CAT_SYSTEM_RELEASE STREQUAL "Amazon Linux release 2 (Karoo)")
+        set(FLB_AMAZON_LINUX2 On)
+        add_definitions(-DFLB_AMAZON_LINUX2)
+      endif()
+    endif()
+  endif()
 endif()
 
 # Update CFLAGS

--- a/init/az2-sethostname.in
+++ b/init/az2-sethostname.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Set Hostname Workaround coreos/bugs#1272
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "/usr/bin/hostnamectl set-hostname $(curl -s http://169.254.169.254/latest/meta-data/hostname)"
+
+[Install]
+WantedBy=multi-user.target

--- a/init/az2-systemd.in
+++ b/init/az2-systemd.in
@@ -1,0 +1,17 @@
+[Unit]
+Description=@FLB_PROG_NAME@
+Documentation=https://docs.fluentbit.io/manual/
+Requires=network.target
+After=network.target
+Requires=sethostname.service
+After=sethostname.service
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/@FLB_OUT_NAME@
+EnvironmentFile=-/etc/default/@FLB_OUT_NAME@
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/@FLB_OUT_NAME@ -c /@CMAKE_INSTALL_SYSCONFDIR@/@FLB_OUT_NAME@/@FLB_OUT_NAME@.conf
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -546,13 +546,30 @@ if(FLB_BINARY)
   endif()
 
   if(SYSTEMD_UNITDIR)
-    set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
-    configure_file(
-      "${PROJECT_SOURCE_DIR}/init/systemd.in"
-      ${FLB_SYSTEMD_SCRIPT}
-      )
-    install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
-    install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
+    if (FLB_AMAZON_LINUX2)
+      set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
+      configure_file(
+        "${PROJECT_SOURCE_DIR}/init/az2-systemd.in"
+        ${FLB_SYSTEMD_SCRIPT}
+        )
+      install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
+      install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
+      set(FLB_HOSTNAME_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/sethostname.service")
+      configure_file(
+        "${PROJECT_SOURCE_DIR}/init/az2-sethostname.in"
+        ${FLB_HOSTNAME_SYSTEMD_SCRIPT}
+        )
+      install(FILES ${FLB_HOSTNAME_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
+      install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
+    else()
+      set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
+      configure_file(
+        "${PROJECT_SOURCE_DIR}/init/systemd.in"
+        ${FLB_SYSTEMD_SCRIPT}
+        )
+      install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
+      install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
+    endif()
   elseif(IS_DIRECTORY /usr/share/upstart)
     set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")
     configure_file(


### PR DESCRIPTION
In AmazonLinux2, it is built on top of coreos technology. So, this race condition bug is also existing there.
In this PR, I added a workaround which is proposed in https://github.com/fluent/fluent-bit/issues/9506#issue-2598519202.

This workaround is only effective for AmazonLinux2.

Closes https://github.com/fluent/fluent-bit/issues/9506

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    flush        1
    daemon       Off
    log_level    info
    http_server  Off
    http_listen  0.0.0.0
    http_port    2020
    storage.metrics on

[INPUT]
    name dummy
    tag  dummy.local

    # Read interval (sec) Default: 1
    interval_sec 10

[FILTER]
    Name  record_modifier
    Match *
    Record hostname ${HOSTNAME}
    Record filter_type record_modifiler

[OUTPUT]
    name  stdout
    match *
```

- [ ] Debug log output from testing the change

It's log for confirming on self-created AMI on AWS EC2 instance.

```
[ec2-user@ip-172-31-17-102 ~]$ systemctl status fluent-bit -l
● fluent-bit.service - Fluent Bit
   Loaded: loaded (/usr/lib/systemd/system/fluent-bit.service; enabled; vendor preset: disabled)
   Active: active (running) since 月 2025-01-20 08:07:20 UTC; 52s ago
     Docs: https://docs.fluentbit.io/manual/
 Main PID: 1034 (fluent-bit)
   CGroup: /system.slice/fluent-bit.service
           └─1034 /opt/fluent-bit/bin/fluent-bit -c //etc/fluent-bit/fluent-bit.conf

 1月 20 08:07:20 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [2025/01/20 08:07:20] [ info] [input:dummy:dummy.0] initializing
 1月 20 08:07:20 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [2025/01/20 08:07:20] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
 1月 20 08:07:20 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [2025/01/20 08:07:20] [ info] [sp] stream processor started
 1月 20 08:07:20 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [2025/01/20 08:07:20] [ info] [output:stdout:stdout.0] worker #0 started
 1月 20 08:07:30 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [0] dummy.local: [[1737360449.913292106, {}], {"message"=>"dummy", "hostname"=>"ip-172-31-17-102.ap-northeast-1.compute.internal", "filter_type"=>"record_modifiler"}]
 1月 20 08:07:40 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [0] dummy.local: [[1737360459.913322822, {}], {"message"=>"dummy", "hostname"=>"ip-172-31-17-102.ap-northeast-1.compute.internal", "filter_type"=>"record_modifiler"}]
 1月 20 08:07:50 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [0] dummy.local: [[1737360469.913313391, {}], {"message"=>"dummy", "hostname"=>"ip-172-31-17-102.ap-northeast-1.compute.internal", "filter_type"=>"record_modifiler"}]
 1月 20 08:08:00 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [0] dummy.local: [[1737360479.913316966, {}], {"message"=>"dummy", "hostname"=>"ip-172-31-17-102.ap-northeast-1.compute.internal", "filter_type"=>"record_modifiler"}]
 1月 20 08:08:10 ip-172-31-17-102.ap-northeast-1.compute.internal fluent-bit[1034]: [0] dummy.local: [[1737360489.913314708, {}], {"message"=>"dummy", "hostname"=>"ip-172-31-17-102.ap-northeast-1.compute.internal", "filter_type"=>"record_modifiler"}]
[ec2-user@ip-172-31-17-102 ~]$ hostname
ip-172-31-17-102.ap-northeast-1.compute.internal
```

Plus, the packer template for creating AMI:

```hcl
packer {
  required_plugins {
    amazon = {
      version = ">= 1.2.8"
      source  = "github.com/hashicorp/amazon"
    }
  }
}

source "amazon-ebs" "amazonlinux2" {
  ami_name      = "fbit-amazon-linux2-arm64"
  instance_type = "t4g.micro"
  region        = "ap-northeast-1"
  source_ami_filter {
    filters = {
      name                             = "*amzn2-ami-hvm-*"
      root-device-type                 = "ebs"
      virtualization-type              = "hvm"
      architecture                     = "arm64"
    }
    most_recent = true
    owners      = ["amazon"]
  }
  ssh_username = "ec2-user"
}

build {
  name    = "az2-fbit-packer"
  sources = [
    "source.amazon-ebs.amazonlinux2"
  ]

  provisioner "file" {
    source = "/path/to/fluent-bit/packaging/packages/amazonlinux/2/2025-01-20-15_52_36/fluent-bit-4.0.0-1.aarch64.rpm"
    destination = "/home/ec2-user/fluent-bit.rpm"
  }

  provisioner "file" {
    source = "/path/to/GitHub/aws_az2_ami/fluent-bit.conf"
    destination = "/home/ec2-user/fluent-bit.conf"
  }

  provisioner "shell" {
    inline = [
        "sudo yum install -y /home/ec2-user/fluent-bit.rpm",
        "sudo mv /home/ec2-user/fluent-bit.conf /etc/fluent-bit/fluent-bit.conf",
        "sudo systemctl enable fluent-bit"
    ]
  }
}
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
