### PR TITLE
in_ebpf: core: Prepare eBPF skeletons before starting to compile in_ebpf plugin properly

### DIFF
--- a/plugins/in_ebpf/CMakeLists.txt
+++ b/plugins/in_ebpf/CMakeLists.txt
@@ -112,7 +112,7 @@ foreach(TRACE_C_FILE ${TRACE_C_FILES})
 endforeach()
 
 # Create a custom target specifically for generating eBPF skeletons
-add_custom_target(generate_skeletons DEPENDS ${TRACE_SKEL_HEADERS})
+add_custom_target(flb-ebpf-generate_skeletons DEPENDS ${TRACE_SKEL_HEADERS})
 
 # Create a custom target to compile all eBPF programs (all trace bpf.c files)
 add_custom_target(compile_ebpf ALL DEPENDS ${TRACE_OBJ_FILES} ${TRACE_SKEL_HEADERS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -509,6 +509,11 @@ if(FLB_BINARY)
     add_dependencies(fluent-bit-bin flb-static-conf)
   endif()
 
+  # in_ebpf
+  if(FLB_IN_EBPF)
+    add_dependencies(fluent-bit-bin flb-ebpf-generate_skeletons)
+  endif()
+
   if(FLB_REGEX)
     target_link_libraries(fluent-bit-bin onigmo-static)
   endif()


### PR DESCRIPTION
When enabling in_ebpf plugin, we encountered that the skeletons are not existing before proper timing to scan the header dependencies. This leads missing headers for in_ebpf and causes compilation errors especially we use parallel building for 2 or more numbers on `-j` option in make.
This PR fixes such dependency glitches.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
