### PR TITLE
package: distro: dockerfiles: Install libcurl development package for oauthoicd on rdkafka

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -113,6 +113,11 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     apt-get download \
     libssl3 \
     libcurl4 \
+    libnghttp2-14 \
+    librtmp1 \
+    libssh2-1 \
+    libpsl5 \
+    libbrotli1 \
     libsasl2-2 \
     pkg-config \
     libpq5 \
@@ -214,6 +219,12 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     apt-get update && \
     apt-get install -y --no-install-recommends \
     libssl3 \
+    libcurl4 \
+    libnghttp2-14 \
+    librtmp1 \
+    libssh2-1 \
+    libpsl5 \
+    libbrotli1 \
     libsasl2-2 \
     pkg-config \
     libpq5 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -46,6 +46,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     make \
     tar \
     libssl-dev \
+    libcurl4-openssl-dev \
     libsasl2-dev \
     pkg-config \
     libsystemd-dev/bookworm-backports \
@@ -111,6 +112,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     apt-get update && \
     apt-get download \
     libssl3 \
+    libcurl4 \
     libsasl2-2 \
     pkg-config \
     libpq5 \

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -9,7 +9,7 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
     yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel libcurl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     yum install -y epel-release && \
     yum install -y cmake3

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel zlib-devel && \
+    cmake3 libyaml-devel zlib-devel libcurl-devel && \
     yum clean all
 
 # amazonlinux/2.arm64v8 base image
@@ -32,7 +32,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel zlib-devel && \
+    cmake3 libyaml-devel zlib-devel libcurl-devel && \
     yum clean all
 
 FROM amazonlinux:2023 as amazonlinux-2023-base
@@ -43,7 +43,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel zlib-devel && \
+    cmake3 libyaml-devel zlib-devel libcurl-devel && \
     yum clean all
 
 # hadolint ignore=DL3029
@@ -57,7 +57,7 @@ RUN yum -y update && \
     wget unzip systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
-    cmake3 libyaml-devel zlib-devel && \
+    cmake3 libyaml-devel zlib-devel libcurl-devel && \
     yum clean all
 
 # Common build for all distributions now

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -18,7 +18,7 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
     yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel libcurl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     yum install -y epel-release && \
     yum install -y cmake3 && \
@@ -38,7 +38,7 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
     yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel libcurl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel && \
     yum install -y epel-release && \
     yum install -y cmake3 && \
@@ -67,7 +67,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel \
     libyaml-devel zlib-devel && \
     yum clean all
 
@@ -91,7 +91,7 @@ RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel \
     libyaml-devel zlib-devel && \
     yum clean all
 
@@ -110,7 +110,7 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
     dnf -y install rpm-build ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel \
     libyaml-devel zlib-devel && \
     dnf clean all
 
@@ -128,7 +128,7 @@ RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-
     dnf -y install rpm-build ca-certificates gcc gcc-c++ cmake make bash \
     wget unzip systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
-    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel  \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel \
     libyaml-devel zlib-devel && \
     dnf clean all
 

--- a/packaging/distros/debian/Dockerfile
+++ b/packaging/distros/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/buster.arm64v8 base image
@@ -34,7 +34,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bullseye base image
@@ -47,7 +47,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bullseye.arm64v8 base image
@@ -62,7 +62,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bookworm base image
@@ -75,7 +75,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # debian/bookworm.arm64v8 base image
@@ -90,7 +90,7 @@ RUN apt-get -qq update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # raspbian/bullseye base image
@@ -31,7 +31,7 @@ RUN apt-get update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # raspbian/bookworm base image
@@ -44,7 +44,7 @@ RUN apt-get update && \
     cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev libyaml-dev pkg-config && \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && \
     make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all software-properties-common \
     software-properties-common libyaml-dev apt-transport-https  \
-    pkg-config libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.0 zlib1g-dev && \
+    pkg-config libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.0 \
+    libcurl4-openssl-dev zlib1g-dev && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main' && \
@@ -38,7 +39,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates gcc-8 g++-8 libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
     software-properties-common libyaml-dev apt-transport-https pkg-config zlib1g-dev && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
@@ -60,7 +61,7 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates gcc-8 g++-8 libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
     software-properties-common libyaml-dev apt-transport-https pkg-config zlib1g-dev && \
     wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
     gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
@@ -79,7 +80,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config zlib1g-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/20.04.arm64v8 base image
@@ -93,7 +95,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libyaml-dev pkg-config zlib1g-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/22.04 base image
@@ -105,7 +108,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/22.04.arm64v8 base image
@@ -119,7 +123,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
     # ubuntu/24.04 base image
@@ -131,7 +136,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # ubuntu/24.04.arm64v8 base image
@@ -145,7 +151,8 @@ RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
     cmake make bash wget unzip nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
-    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libyaml-dev pkg-config zlib1g-dev && \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev && \
     apt-get install -y --reinstall lsb-base lsb-release
 
 # Common build for all distributions now


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is because libkafka's SASL OAUTHBEARER mechanism depends on libcurl and OpenSSL.
We already installed a development package of OpenSSL in each of building containers but we didn't install a development package of libcurl.
This leads for degraded usability for rdkafka library and it makes not to be able to use SASL OAUTHBEARER mechanism on kafka plugins like below with #9859 patch:
```
[2025/01/22 11:55:30] [error] [flb_kafka] cannot configure 'sasl.oauthbearer.method' property with error: 'Configuration property "sasl.oauthbearer.method" not supported in this build: OAuth/OIDC depends on libcurl and OpenSSL which were not available at build time'
[2025/01/22 11:55:30] [error] [flb_kafka] cannot configure 'sasl.oauthbearer.client.id' property with error: 'Configuration property "sasl.oauthbearer.client.id" not supported in this build: OAuth/OIDC depends on libcurl and OpenSSL which were not available at build time'
[2025/01/22 11:55:30] [error] [flb_kafka] cannot configure 'sasl.oauthbearer.client.secret' property with error: 'Configuration property "sasl.oauthbearer.client.secret" not supported in this build: OAuth/OIDC depends on libcurl and OpenSSL which were not available at build time'
[2025/01/22 11:55:30] [error] [flb_kafka] cannot configure 'sasl.oauthbearer.token.endpoint.url' property with error: 'Configuration property "sasl.oauthbearer.token.endpoint.url" not supported in this build: OAuth/OIDC depends on libcurl and OpenSSL which were not available at build time'
[2025/01/22 11:55:30] [ info] [output:kafka:kafka.0] brokers='192.168.1.3:9092' topics='test'
```

This PR aims to fix this issue.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
