### PR TITLE
workflows: update daily builds for 3.2

### DIFF
--- a/.github/workflows/cron-unstable-build.yaml
+++ b/.github/workflows/cron-unstable-build.yaml
@@ -13,8 +13,8 @@ on:
   # Run nightly build at this time, bit of trial and error but this seems good.
   schedule:
     - cron: "0 6 * * *" # master build
-    - cron: "0 12 * * *" # 3.0 build
-    - cron: "0 18 * * *" # 3.1 build
+    - cron: "0 12 * * *" # 3.2 build
+    - cron: "0 18 * * *" # master build
 
 # We do not want a new unstable build to run whilst we are releasing the current unstable build.
 concurrency: unstable-build-release
@@ -55,13 +55,13 @@ jobs:
       - name: 3.0 run
         if: github.event_name == 'schedule' && github.event.schedule=='0 12 * * *'
         run: |
-          echo "cron_branch=3.0" >> $GITHUB_ENV
+          echo "cron_branch=3.2" >> $GITHUB_ENV
         shell: bash
 
-      - name: 3.1 run
+      - name: master run
         if: github.event_name == 'schedule' && github.event.schedule=='0 18 * * *'
         run: |
-          echo "cron_branch=3.1" >> $GITHUB_ENV
+          echo "cron_branch=master" >> $GITHUB_ENV
         shell: bash
 
       - name: Output the branch to use


### PR DESCRIPTION
Update to build 3.2 branch daily/nightly and remove unsupported regular builds.

We build master twice daily now to pick up changes more often.