### PR TITLE
workflows: increase size of container builders

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -33,6 +33,11 @@ on:
         type: string
         required: false
         default: ""
+      platforms:
+        description: The platforms to build for
+        type: string
+        required: false
+        default: 'linux/amd64, linux/arm64, linux/arm/v7, linux/s390x'
     secrets:
       token:
         description: The Github token or similar to authenticate with for the registry.
@@ -75,7 +80,7 @@ jobs:
     needs:
       - call-build-images-meta
     name: Multiarch container images to GHCR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     environment: ${{ inputs.environment }}
     permissions:
       contents: read
@@ -120,7 +125,7 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/s390x
+          platforms: ${{ inputs.platforms }}
           target: production
           # Must be disabled to provide legacy format images from the registry
           provenance: false
@@ -147,7 +152,7 @@ jobs:
           context: .
           tags: ${{ steps.debug-meta.outputs.tags }}
           labels: ${{ steps.debug-meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/s390x
+          platforms: ${{ inputs.platforms }}
           # Must be disabled to provide legacy format images from the registry
           provenance: false
           target: debug


### PR DESCRIPTION
Hitting errors building for release all the platforms so increasing the size of the runner to help.