### PR TITLE
workflows: remove s390x and armv7 platforms for container builds

### DIFF
--- a/.github/workflows/staging-build.yaml
+++ b/.github/workflows/staging-build.yaml
@@ -79,6 +79,7 @@ jobs:
       username: ${{ github.actor }}
       image: ${{ github.repository }}/staging
       environment: staging
+      platforms: 'linux/amd64, linux/arm64'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       cosign_private_key: ${{ secrets.COSIGN_PRIVATE_KEY }}


### PR DESCRIPTION
Resolving config failures for release by disabling unsupported image platforms.