### PR TITLE
in_kubernetes_events: fix sqldb cleanup

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -648,14 +648,13 @@ static int k8s_events_cleanup_db(struct flb_input_instance *ins,
 {
     int ret;
     struct k8s_events *ctx = (struct k8s_events *)in_context;
-    time_t retention_time_ago;
-    time_t now = (cfl_time_now() / 1000000000);
+    uint64_t retention_time_ago;
 
     if (ctx->db == NULL) {
         FLB_INPUT_RETURN(0);
     }
 
-    retention_time_ago = now - (ctx->retention_time);
+    retention_time_ago = cfl_time_now() - (ctx->retention_time * 1000000000L);
     sqlite3_bind_int64(ctx->stmt_delete_old_kubernetes_events,
                         1, (int64_t)retention_time_ago);
     ret = sqlite3_step(ctx->stmt_delete_old_kubernetes_events);


### PR DESCRIPTION
Use correct precision of timestamps during in_kubernetes_events sqldb cleanup.

Fixes #9787 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
