### PR TITLE
workflows: disable s390x container builds for release

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -85,7 +85,6 @@ jobs:
           - amd64
           - arm64
           - arm/v7
-          - s390x
         target:
           - production
           - debug

--- a/.github/workflows/call-test-images.yaml
+++ b/.github/workflows/call-test-images.yaml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ linux/amd64, linux/arm64, linux/arm/v7, linux/s390x ]
+        arch: [ linux/amd64, linux/arm64, linux/arm/v7 ]
         include:
           # Rather than extract the specific central arch we just provide it
           - arch: linux/amd64
@@ -85,8 +85,6 @@ jobs:
             expected: arm64
           - arch: linux/arm/v7
             expected: arm
-          - arch: linux/s390x
-            expected: s390x
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
There are failures building for s390x, possibly down to emulation issues, and it is extending build times significantly so removing this target for now.

Unit tests and other support is left in, this is purely for release purposes.