### PR TITLE
tests: in_kubernetes_events: backport flake test fix from #9877.

### DIFF
--- a/tests/runtime/in_kubernetes_events.c
+++ b/tests/runtime/in_kubernetes_events.c
@@ -328,6 +328,7 @@ void flb_test_events_v1_with_lastTimestamp()
     int ret;
     int num;
     const char *filename = "eventlist_v1_with_lastTimestamp";
+    int trys;
 
     clear_output_num();
 
@@ -347,8 +348,10 @@ void flb_test_events_v1_with_lastTimestamp()
     ret = flb_start(ctx->flb);
     TEST_CHECK(ret == 0);
 
-    // waiting to flush 
-    flb_time_msleep(1500);
+    // waiting to flush
+    for (trys = 0; trys < 5 && get_output_num() <= 0; trys++) {
+        flb_time_msleep(1000);
+    }
 
     num = get_output_num();
     if (!TEST_CHECK(num > 0))  {
@@ -365,6 +368,7 @@ void flb_test_events_v1_with_creationTimestamp()
     int ret;
     int num;
     const char *filename = "eventlist_v1_with_creationTimestamp";
+    int trys;
 
     clear_output_num();
 
@@ -384,8 +388,10 @@ void flb_test_events_v1_with_creationTimestamp()
     ret = flb_start(ctx->flb);
     TEST_CHECK(ret == 0);
 
-    // waiting to flush 
-    flb_time_msleep(1500);
+    // waiting to flush
+    for (trys = 0; trys < 5 && get_output_num() <= 0; trys++) {
+        flb_time_msleep(1000);
+    }
 
     num = get_output_num();
     if (!TEST_CHECK(num > 0))  {
@@ -399,6 +405,7 @@ void flb_test_events_with_chunkedrecv()
 {
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
+    int trys;
 
     int ret;
     int num;
@@ -423,8 +430,10 @@ void flb_test_events_with_chunkedrecv()
     ret = flb_start(ctx->flb);
     TEST_CHECK(ret == 0);
 
-    // waiting to flush 
-    flb_time_msleep(5000);
+    // waiting to flush
+    for (trys = 0; trys < 5 && get_output_num() <= 1; trys++) {
+        flb_time_msleep(1000);
+    }
 
     num = get_output_num();
     if (!TEST_CHECK(num >= 2))  {


### PR DESCRIPTION
Backport the test fix in #9877 to the 3.2 series.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
