### PR TITLE
s3_output_plugin: added new variable to enable or disable headers

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -141,7 +141,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
     if (ctx->content_type != NULL) {
         headers_len++;
     }
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+    if (ctx->compression == FLB_AWS_COMPRESS_GZIP && ctx->enable_content_encoding_header) {
         headers_len++;
     }
     if (ctx->canned_acl != NULL) {
@@ -171,7 +171,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n].val_len = strlen(ctx->content_type);
         n++;
     }
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+    if (ctx->compression == FLB_AWS_COMPRESS_GZIP && ctx->enable_content_encoding_header) {
         s3_headers[n] = content_encoding_header;
         n++;
     }
@@ -2375,6 +2375,11 @@ static struct flb_config_map config_map[] = {
     "'arrow' is only an available if Apache Arrow was enabled at compile time. "
     "Defaults to no compression. "
     "If 'gzip' is selected, the Content-Encoding HTTP Header will be set to 'gzip'."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "enable_content_encoding_header", "true",
+     0, FLB_TRUE, offsetof(struct flb_s3, enable_content_encoding_header),
+    "Set to false to disable the Content-Encoding: gzip header."
     },
     {
      FLB_CONFIG_MAP_STR, "content_type", NULL,

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -119,6 +119,7 @@ struct flb_s3 {
     int send_content_md5;
     int static_file_path;
     int compression;
+    int enable_content_encoding_header;
     int port;
     int insecure;
     size_t store_dir_limit_size;


### PR DESCRIPTION
When uploading an object to an AWS S3 bucket, a Content-Encoding header is automatically added to the object. When this object is later downloaded, web browsers recognize this header and automatically decompress the file. This behavior can lead to misleading file types across different operating systems, potentially causing compatibility issues or unexpected file handling.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
