### PR TITLE
out_opentelemetry: auto configure HTTP/2 protocol when gRPC is enabled

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -361,10 +361,9 @@ int opentelemetry_post(struct opentelemetry_context *ctx,
     }
 
     response = flb_http_client_request_execute(request);
-
     if (response == NULL) {
-        flb_debug("http request execution error");
-
+        flb_plg_warn(ctx->ins, "error performing HTTP request, remote host=%s:%i connection error",
+                     ctx->host, ctx->port);
         flb_http_client_request_destroy(request, FLB_TRUE);
 
         return FLB_RETRY;
@@ -381,7 +380,6 @@ int opentelemetry_post(struct opentelemetry_context *ctx,
      * - 205: Reset content
      *
      */
-
     if (response->status < 200 || response->status > 205) {
         if (ctx->log_response_payload &&
             response->body != NULL &&

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -45,7 +45,7 @@ struct opentelemetry_body_key {
 /* Plugin context */
 struct opentelemetry_context {
     int   enable_http2_flag;
-    char *enable_http2;
+    flb_sds_t enable_http2;
     int   enable_grpc_flag;
 
     /* HTTP Auth */

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -560,17 +560,35 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
 
     ctx->enable_http2_flag = FLB_TRUE;
 
+    /* if gRPC has been enabled, auto-enable HTTP/2 to make end-user life easier */
+    if (ctx->enable_grpc_flag && !flb_utils_bool(ctx->enable_http2)) {
+        flb_plg_info(ctx->ins, "gRPC enabled, HTTP/2 has been auto-enabled");
+        flb_sds_destroy(ctx->enable_http2);
+        ctx->enable_http2 = flb_sds_create("on");
+    }
+
+    /*
+     * 'force' aims to be used for plaintext communication when HTTP/2 is set. Note that
+     * moving forward it wont be necessary since we are now setting some special defaults
+     * in case of gRPC is enabled (which is the only case where HTTP/2 is mandatory).
+     */
     if (strcasecmp(ctx->enable_http2, "force") == 0) {
         http_protocol_version = HTTP_PROTOCOL_VERSION_20;
     }
     else if (flb_utils_bool(ctx->enable_http2)) {
-        http_protocol_version = HTTP_PROTOCOL_VERSION_AUTODETECT;
+        if (!ins->use_tls) {
+            http_protocol_version = HTTP_PROTOCOL_VERSION_20;
+        }
+        else {
+            http_protocol_version = HTTP_PROTOCOL_VERSION_AUTODETECT;
+        }
     }
     else {
         http_protocol_version = HTTP_PROTOCOL_VERSION_11;
 
         ctx->enable_http2_flag = FLB_FALSE;
     }
+
 
     ret = flb_http_client_ng_init(&ctx->http_client,
                                   NULL,


### PR DESCRIPTION
Previously, enabling gRPC required setting both `grpc: on` and `http2: on`. For plaintext communication, users had to set `http2: force`, which was confusing.
    
This change simplifies the config:
    
- `grpc: on` now automatically enables HTTP/2.
- Plaintext gRPC works without needing `http2: force`.
    
This PR improves usability by reducing unnecessary config steps.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
