### PR TITLE
workflows: remove qemu usage

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -99,9 +99,6 @@ jobs:
           ref: ${{ inputs.ref }}
           token: ${{ secrets.token }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -120,13 +120,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Set up Actuated mirror
-        if: contains(matrix.distro, 'arm' ) && (github.repository == 'fluent/fluent-bit')
-        uses: self-actuated/hub-mirror@master
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit/pull/9931

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
