### PR TITLE
in_opentelemetry: add support for OpenTelemetry JSON traces

### DIFF
--- a/lib/ctraces/.github/workflows/build.yaml
+++ b/lib/ctraces/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -52,12 +52,42 @@ jobs:
           git clone --recursive https://github.com/calyptia/ctraces.git
         shell: bash
 
+      - name: Check out the branch (1.8.3 version of Git)
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          git checkout "$BRANCH_NAME"
+        shell: bash
+        working-directory: ctraces
+
       - name: Run compilation
         run: |
           cmake3 -DCTR_TESTS=on -DCTR_DEV=on .
           make
         shell: bash
         working-directory: ctraces
+
+  build-debian:
+    name: Debian Buster build to confirm no issues once used downstream
+    runs-on: ubuntu-latest
+    container: debian:buster
+    steps:
+      - name: Set up base image dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential cmake make git
+        shell: bash
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run compilation
+        run: |
+          cmake -DCTR_TESTS=On .
+          make all
+          CTEST_OUTPUT_ON_FAILURE=1 make test
+        shell: bash
 
   build-unix-arm64:
     name: Build sources on arm64 for ${{ matrix.os }} - ${{ matrix.compiler }}
@@ -70,15 +100,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}
-        uses: uraimo/run-on-arch-action@v2.2.1
+        uses: uraimo/run-on-arch-action@v2.8.1
         with:
           arch: aarch64
-          distro: ubuntu20.04
+          distro: ubuntu_latest
           run: |
             apt-get update && \
             apt-get install -y --no-install-recommends \
@@ -104,7 +134,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -134,7 +164,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -144,3 +174,29 @@ jobs:
           # dependencies_debian: ''
           cmakeflags: '-DCTR_TESTS=On -DCMT_DEV=on .'
           build_command: make all
+
+  # this job provides the single required status for PRs to be merged into main.
+  # instead of updating the protected branch status in github, developers can update the needs section below
+  # to require additional status checks to protect main.
+  # the job uses the alls-green action to get around the github issue that treats a "skipped" required status check
+  # as passed. github will skip a job if an upstream needed job fails, which would defeat the purpose of this required
+  # status check.
+  test-required-checks-complete:
+    # note: this step always has to run in order to check if the dependent jobs passed. by default github skips running a job
+    # if the needed jobs upstream failed.
+    if: always()
+    needs:
+      - build-windows
+      - build-centos
+      - build-debian
+      - build-unix-arm64
+      - build-unix-amd64
+      - build-analysis-tests
+    name: Required checks complete
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/lib/ctraces/.github/workflows/lint.yaml
+++ b/lib/ctraces/.github/workflows/lint.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Shellcheck
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ludeeus/action-shellcheck@master
 
   actionlint-pr:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Markdownlint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run markdownlint
         uses: actionshub/markdownlint@v3.1.4

--- a/lib/ctraces/.github/workflows/packages.yaml
+++ b/lib/ctraces/.github/workflows/packages.yaml
@@ -18,15 +18,15 @@ jobs:
       matrix:
         format: [ rpm, deb ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
             submodules: true
 
-      - uses: uraimo/run-on-arch-action@v2.2.1
+      - uses: uraimo/run-on-arch-action@v2.8.1
         name: Build the ${{matrix.format}} packages
         with:
           arch: aarch64
-          distro: ubuntu20.04
+          distro: ubuntu_latest
           run: |
             apt-get update && \
             apt-get install -y --no-install-recommends \
@@ -34,12 +34,12 @@ jobs:
             cmake \
             file \
             rpm \
-            make 
+            make
             cmake .
             echo ${{ matrix.format }} | awk '{print toupper($0)}' | xargs -I{} cpack -G {}
 
       - name: Store the master package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.format }}-arm64
           path: |
@@ -53,7 +53,7 @@ jobs:
         format: [ rpm, deb ]
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
             submodules: true
 
@@ -63,23 +63,51 @@ jobs:
           echo ${{ matrix.format }} | awk '{print toupper($0)}' | xargs -I{} cpack -G {}
 
       - name: Store the master package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.format }}-amd64
           path: |
             ./*.${{matrix.format}}
+
+  build-macos-packages-arm64:
+    name: build macOS Apple Silicon packages
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+          - format: productbuild
+            arch: apple
+            ext: pkg
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build the ${{matrix.config.format}} packages
+        run:  |
+          cmake . -DCPACK_GENERATOR=${{ matrix.config.format }}
+          echo ${{ matrix.config.format }} | xargs -I{} cpack -G {}
+
+      - name: Store the master package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.config.format }}-${{matrix.config.arch}}
+          path: |
+            ./*-${{matrix.config.arch}}.${{matrix.config.ext}}
 
   release:
     name: Create release and upload packages
     needs:
       - build-distro-packages-amd64
       - build-distro-packages-arm64
+      - build-macos-packages-arm64
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Download all artefacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 
@@ -99,7 +127,7 @@ jobs:
             artifacts/**/*
 
       - name: Release on tag
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true

--- a/lib/ctraces/CMakeLists.txt
+++ b/lib/ctraces/CMakeLists.txt
@@ -26,8 +26,8 @@ endif()
 
 # CTraces Version
 set(CTR_VERSION_MAJOR  0)
-set(CTR_VERSION_MINOR  5)
-set(CTR_VERSION_PATCH  7)
+set(CTR_VERSION_MINOR  6)
+set(CTR_VERSION_PATCH  0)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/lib/ctraces/include/ctraces/ctr_link.h
+++ b/lib/ctraces/include/ctraces/ctr_link.h
@@ -28,6 +28,7 @@ struct ctrace_link {
 	cfl_sds_t trace_state;            /* trace_state           */
     struct ctrace_attributes *attr;   /* attributes */
     uint32_t dropped_attr_count;      /* number of attributes that were discarded */
+    uint32_t flags;                   /* flags */
 
     /* --- INTERNAL --- */
     struct cfl_list _head;            /* link to 'struct span->links' list */
@@ -44,6 +45,7 @@ struct ctrace_link *ctr_link_create_with_cid(struct ctrace_span *span,
 int ctr_link_set_trace_state(struct ctrace_link *link, char *trace_state);
 int ctr_link_set_attributes(struct ctrace_link *link, struct ctrace_attributes *attr);
 void ctr_link_set_dropped_attr_count(struct ctrace_link *link, uint32_t count);
+void ctr_link_set_flags(struct ctrace_link *link, uint32_t flags);
 
 void ctr_link_destroy(struct ctrace_link *link);
 

--- a/lib/ctraces/include/ctraces/ctr_span.h
+++ b/lib/ctraces/include/ctraces/ctr_span.h
@@ -68,6 +68,7 @@ struct ctrace_span {
     struct ctrace_id *span_id;        /* the unique span ID    */
     struct ctrace_id *parent_span_id; /* any parent ? a NULL means a root span */
     cfl_sds_t trace_state;            /* trace state */
+    int32_t flags;                    /* flags */
 
     cfl_sds_t name;                   /* user-name assigned */
 
@@ -83,6 +84,8 @@ struct ctrace_span {
 
     struct cfl_list links;            /* links */
     uint32_t dropped_links_count;     /* number of links that were discarded */
+
+    cfl_sds_t schema_url;             /* schema URL */
 
     struct ctrace_span_status status; /* status code */
 
@@ -105,8 +108,13 @@ struct ctrace_span *ctr_span_create(struct ctrace *ctx, struct ctrace_scope_span
 
 void ctr_span_destroy(struct ctrace_span *span);
 
+/* Span fields */
 int ctr_span_set_status(struct ctrace_span *span, int code, char *message);
 void ctr_span_set_dropped_events_count(struct ctrace_span *span, uint32_t count);
+void ctr_span_set_dropped_links_count(struct ctrace_span *span, uint32_t count);
+int ctr_span_set_trace_state(struct ctrace_span *span, char *state, int len);
+int ctr_span_set_flags(struct ctrace_span *span, uint32_t flags);
+void ctr_span_set_schema_url(struct ctrace_span *span, char *url);
 
 /* span IDs */
 int ctr_span_set_trace_id(struct ctrace_span *span, void *buf, size_t len);
@@ -117,6 +125,7 @@ int ctr_span_set_parent_span_id(struct ctrace_span *span, void *buf, size_t len)
 int ctr_span_set_parent_span_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid);
 
 /* attributes */
+int ctr_span_set_attributes(struct ctrace_span *span, struct ctrace_attributes *attr);
 int ctr_span_set_attribute_string(struct ctrace_span *span, char *key, char *value);
 int ctr_span_set_attribute_bool(struct ctrace_span *span, char *key, int b);
 int ctr_span_set_attribute_int64(struct ctrace_span *span, char *key, int64_t value);
@@ -142,6 +151,7 @@ char *ctr_span_kind_string(struct ctrace_span *span);
 /* events */
 struct ctrace_span_event *ctr_span_event_add(struct ctrace_span *span, char *name);
 struct ctrace_span_event *ctr_span_event_add_ts(struct ctrace_span *span, char *name, uint64_t ts);
+int ctr_span_event_set_attributes(struct ctrace_span_event *event, struct ctrace_attributes *attr);
 void ctr_span_event_set_dropped_attributes_count(struct ctrace_span_event *event, uint32_t count);
 void ctr_span_event_delete(struct ctrace_span_event *event);
 

--- a/lib/ctraces/src/ctr_decode_msgpack.c
+++ b/lib/ctraces/src/ctr_decode_msgpack.c
@@ -522,6 +522,20 @@ static int unpack_span_dropped_attributes_count(mpack_reader_t *reader, size_t i
     return ctr_mpack_consume_uint32_tag(reader, &context->span->dropped_attr_count);
 }
 
+static int unpack_span_dropped_events_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(reader, &context->span->dropped_events_count);
+}
+
+static int unpack_span_dropped_links_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(reader, &context->span->dropped_links_count);
+}
+
 static int unpack_span_events(mpack_reader_t *reader, size_t index, void *ctx)
 {
     return ctr_mpack_unpack_array(reader, unpack_event, ctx);
@@ -559,6 +573,13 @@ static int unpack_span_status(mpack_reader_t *reader, size_t index, void *ctx)
     return ctr_mpack_unpack_map(reader, callbacks, ctx);
 }
 
+static int unpack_span_schema_url(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->span->schema_url);
+}
+
 static int unpack_span(mpack_reader_t *reader, size_t index, void *ctx)
 {
     int result;
@@ -575,9 +596,12 @@ static int unpack_span(mpack_reader_t *reader, size_t index, void *ctx)
             {"end_time_unix_nano",       unpack_span_end_time_unix_nano},
             {"attributes",               unpack_span_attributes},
             {"dropped_attributes_count", unpack_span_dropped_attributes_count},
+            {"dropped_events_count",     unpack_span_dropped_events_count},
+            {"dropped_links_count",      unpack_span_dropped_links_count},
             {"events",                   unpack_span_events},
             {"links",                    unpack_span_links},
             {"status",                   unpack_span_status},
+            {"schema_url",               unpack_span_schema_url},
             {NULL,                       NULL}
         };
 

--- a/lib/ctraces/src/ctr_decode_opentelemetry.c
+++ b/lib/ctraces/src/ctr_decode_opentelemetry.c
@@ -350,7 +350,16 @@ static struct ctrace_attributes *convert_otel_attrs(size_t n_attributes,
     Opentelemetry__Proto__Common__V1__AnyValue *val;
 
     ctr_decoded_attributes = malloc(sizeof(struct opentelemetry_decode_value));
+    if (!ctr_decoded_attributes) {
+        ctr_errno();
+        return NULL;
+    }
+
     ctr_decoded_attributes->ctr_attr = ctr_attributes_create();
+    if (!ctr_decoded_attributes->ctr_attr) {
+        free(ctr_decoded_attributes);
+        return NULL;
+    }
 
     result = 0;
 
@@ -376,9 +385,9 @@ static struct ctrace_attributes *convert_otel_attrs(size_t n_attributes,
     return attr;
 }
 
-static int ctr_span_set_attributes(struct ctrace_span *span,
-                                   size_t n_attributes,
-                                   Opentelemetry__Proto__Common__V1__KeyValue **attributes)
+static int span_set_attributes(struct ctrace_span *span,
+                               size_t n_attributes,
+                               Opentelemetry__Proto__Common__V1__KeyValue **attributes)
 {
     struct ctrace_attributes *ctr_attributes;
 
@@ -394,9 +403,9 @@ static int ctr_span_set_attributes(struct ctrace_span *span,
     return 0;
 }
 
-static int ctr_span_set_events(struct ctrace_span *span,
-                               size_t n_events,
-                               Opentelemetry__Proto__Trace__V1__Span__Event **events)
+static int span_set_events(struct ctrace_span *span,
+                           size_t n_events,
+                           Opentelemetry__Proto__Trace__V1__Span__Event **events)
 {
     int index_event;
     struct ctrace_span_event *ctr_event;
@@ -409,22 +418,19 @@ static int ctr_span_set_events(struct ctrace_span *span,
         event = events[index_event];
 
         ctr_event = ctr_span_event_add_ts(span, event->name, event->time_unix_nano);
-
         if (ctr_event == NULL) {
             return -1;
         }
 
-        ctr_attributes = convert_otel_attrs(event->n_attributes, event->attributes);
-
-        if (ctr_attributes == NULL) {
-            return -1;
+        if (event->n_attributes > 0 && event->attributes != NULL) {
+            ctr_attributes = convert_otel_attrs(event->n_attributes, event->attributes);
+            if (ctr_attributes == NULL) {
+                return -1;
+            }
+            else {
+                ctr_span_event_set_attributes(ctr_event, ctr_attributes);
+            }
         }
-
-        if (ctr_event->attr) {
-            ctr_attributes_destroy(ctr_event->attr);
-        }
-
-        ctr_event->attr = ctr_attributes;
         ctr_span_event_set_dropped_attributes_count(ctr_event, event->dropped_attributes_count);
     }
 
@@ -544,6 +550,8 @@ int ctr_decode_opentelemetry_create(struct ctrace **out_ctr,
         resource = ctr_resource_span_get_resource(resource_span);
         resource_set_data(resource, otel_resource_span->resource);
 
+        ctr_resource_set_dropped_attr_count(resource, otel_resource_span->resource->dropped_attributes_count);
+
         for (scope_span_index = 0; scope_span_index < otel_resource_span->n_scope_spans; scope_span_index++) {
             otel_scope_span = otel_resource_span->scope_spans[scope_span_index];
             if (otel_scope_span == NULL) {
@@ -571,16 +579,25 @@ int ctr_decode_opentelemetry_create(struct ctrace **out_ctr,
                 ctr_span_set_trace_id(span, otel_span->trace_id.data, otel_span->trace_id.len);
                 ctr_span_set_span_id(span, otel_span->span_id.data, otel_span->span_id.len);
                 ctr_span_set_parent_span_id(span, otel_span->parent_span_id.data, otel_span->parent_span_id.len);
+
+                if (otel_span->trace_state && strlen(otel_span->trace_state) > 0) {
+                    ctr_span_set_trace_state(span, otel_span->trace_state, strlen(otel_span->trace_state));
+                }
+
                 ctr_span_kind_set(span, otel_span->kind);
                 ctr_span_start_ts(ctr, span, otel_span->start_time_unix_nano);
                 ctr_span_end_ts(ctr, span, otel_span->end_time_unix_nano);
                 if (otel_span->status) {
                     ctr_span_set_status(span, otel_span->status->code, otel_span->status->message);
                 }
-                ctr_span_set_attributes(span, otel_span->n_attributes, otel_span->attributes);
-                ctr_span_set_events(span, otel_span->n_events, otel_span->events);
+
+                span_set_attributes(span, otel_span->n_attributes, otel_span->attributes);
+                span_set_events(span, otel_span->n_events, otel_span->events);
+
                 ctr_span_set_dropped_attributes_count(span, otel_span->dropped_attributes_count);
                 ctr_span_set_dropped_events_count(span, otel_span->dropped_events_count);
+                ctr_span_set_dropped_links_count(span, otel_span->dropped_links_count);
+
                 ctr_span_set_links(span, otel_span->n_links, otel_span->links);
             }
         }

--- a/lib/ctraces/src/ctr_encode_msgpack.c
+++ b/lib/ctraces/src/ctr_encode_msgpack.c
@@ -138,7 +138,7 @@ static void pack_instrumentation_scope(mpack_writer_t *writer, struct ctrace_ins
 {
     if (ins_scope == NULL) {
         mpack_write_nil(writer);
-        
+
         return;
     }
 
@@ -307,7 +307,7 @@ static void pack_links(mpack_writer_t *writer, struct cfl_list *links)
 
 static void pack_span(mpack_writer_t *writer, struct ctrace_span *span)
 {
-    mpack_start_map(writer, 13);
+    mpack_start_map(writer, 16);
 
     /* trace_id */
     mpack_write_cstr(writer, "trace_id");
@@ -364,6 +364,14 @@ static void pack_span(mpack_writer_t *writer, struct ctrace_span *span)
     mpack_write_cstr(writer, "dropped_attributes_count");
     mpack_write_u32(writer, span->dropped_attr_count);
 
+    /* dropped_events_count */
+    mpack_write_cstr(writer, "dropped_events_count");
+    mpack_write_u32(writer, span->dropped_events_count);
+
+    /* dropped_links_count */
+    mpack_write_cstr(writer, "dropped_links_count");
+    mpack_write_u32(writer, span->dropped_links_count);
+
     /* events */
     mpack_write_cstr(writer, "events");
     pack_events(writer, &span->events);
@@ -371,6 +379,15 @@ static void pack_span(mpack_writer_t *writer, struct ctrace_span *span)
     /* links */
     mpack_write_cstr(writer, "links");
     pack_links(writer, &span->links);
+
+    /* schema_url */
+    mpack_write_cstr(writer, "schema_url");
+    if (span->schema_url) {
+        mpack_write_str(writer, span->schema_url, cfl_sds_len(span->schema_url));
+    }
+    else {
+        mpack_write_nil(writer);
+    }
 
     /* span_status */
     mpack_write_cstr(writer, "status");

--- a/lib/ctraces/src/ctr_link.c
+++ b/lib/ctraces/src/ctr_link.c
@@ -105,6 +105,11 @@ void ctr_link_set_dropped_attr_count(struct ctrace_link *link, uint32_t count)
     link->dropped_attr_count = count;
 }
 
+void ctr_link_set_flags(struct ctrace_link *link, uint32_t flags)
+{
+    link->flags = flags;
+}
+
 void ctr_link_destroy(struct ctrace_link *link)
 {
     if (link->trace_id) {

--- a/lib/ctraces/src/ctr_span.c
+++ b/lib/ctraces/src/ctr_span.c
@@ -195,6 +195,20 @@ char *ctr_span_kind_string(struct ctrace_span *span)
  * Span attributes
  * ---------------
  */
+int ctr_span_set_attributes(struct ctrace_span *span, struct ctrace_attributes *attr)
+{
+    if (!attr) {
+        return -1;
+    }
+
+    if (span->attr) {
+        ctr_attributes_destroy(span->attr);
+    }
+
+    span->attr = attr;
+    return 0;
+}
+
 int ctr_span_set_attribute_string(struct ctrace_span *span, char *key, char *value)
 {
     return ctr_attributes_set_string(span->attr, key, value);
@@ -278,9 +292,48 @@ int ctr_span_set_status(struct ctrace_span *span, int code, char *message)
     return 0;
 }
 
+int ctr_span_set_trace_state(struct ctrace_span *span, char *state, int len)
+{
+    if (span->trace_state) {
+        cfl_sds_destroy(span->trace_state);
+    }
+
+    span->trace_state = cfl_sds_create_len(state, len);
+    if (!span->trace_state) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int ctr_span_set_flags(struct ctrace_span *span, uint32_t flags)
+{
+    span->flags = flags;
+    return 0;
+}
+
+void ctr_span_set_schema_url(struct ctrace_span *span, char *url)
+{
+    if (span->schema_url) {
+        cfl_sds_destroy(span->schema_url);
+    }
+
+    span->schema_url = cfl_sds_create(url);
+}
+
+void ctr_span_set_dropped_link_count(struct ctrace_span *span, uint32_t count)
+{
+    span->dropped_links_count = count;
+}
+
 void ctr_span_set_dropped_events_count(struct ctrace_span *span, uint32_t count)
 {
     span->dropped_events_count = count;
+}
+
+void ctr_span_set_dropped_links_count(struct ctrace_span *span, uint32_t count)
+{
+    span->dropped_links_count = count;
 }
 
 void ctr_span_set_dropped_attributes_count(struct ctrace_span *span, uint32_t count)
@@ -318,6 +371,10 @@ void ctr_span_destroy(struct ctrace_span *span)
     }
     if (span->trace_state != NULL) {
         cfl_sds_destroy(span->trace_state);
+    }
+
+    if (span->schema_url != NULL) {
+        cfl_sds_destroy(span->schema_url);
     }
 
     /* events */
@@ -416,6 +473,20 @@ int ctr_span_event_set_attribute_kvlist(struct ctrace_span_event *event, char *k
 {
 
     return ctr_attributes_set_kvlist(event->attr, key, value);
+}
+
+int ctr_span_event_set_attributes(struct ctrace_span_event *event, struct ctrace_attributes *attr)
+{
+    if (!attr) {
+        return -1;
+    }
+
+    if (event->attr) {
+        ctr_attributes_destroy(event->attr);
+    }
+
+    event->attr = attr;
+    return 0;
 }
 
 void ctr_span_event_set_dropped_attributes_count(struct ctrace_span_event *event, uint32_t count)

--- a/plugins/in_opentelemetry/CMakeLists.txt
+++ b/plugins/in_opentelemetry/CMakeLists.txt
@@ -6,7 +6,9 @@ set(src
   http_conn.c
   opentelemetry.c
   opentelemetry_prot.c
+  opentelemetry_traces.c
   opentelemetry_config.c
+  opentelemetry_utils.c
   )
 
 FLB_PLUGIN(in_opentelemetry "${src}" "monkey-core-static")

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -27,16 +27,19 @@
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
-#include <monkey/monkey.h>
 #include <fluent-bit/http_server/flb_http_server.h>
 
-#include <monkey/mk_core.h>
 #include <cmetrics/cmt_decode_opentelemetry.h>
 #include <cprofiles/cprof_decode_opentelemetry.h>
 #include <cprofiles/cprof_encode_text.h>
 
 #include <fluent-otel-proto/fluent-otel.h>
+
+
 #include "opentelemetry.h"
+#include "opentelemetry_utils.h"
+#include "opentelemetry_traces.h"
+
 #include "http_conn.h"
 
 #define HTTP_CONTENT_JSON  0
@@ -157,93 +160,6 @@ static int process_payload_metrics(struct flb_opentelemetry *ctx, struct http_co
     }
 
     return 0;
-}
-
-static int process_payload_traces_proto(struct flb_opentelemetry *ctx, struct http_conn *conn,
-                                        flb_sds_t tag,
-                                        size_t tag_len,
-                                        struct mk_http_session *session,
-                                        struct mk_http_request *request)
-{
-    struct ctrace *decoded_context;
-    size_t         offset;
-    int            result;
-
-    offset = 0;
-    result = ctr_decode_opentelemetry_create(&decoded_context,
-                                             request->data.data,
-                                             request->data.len,
-                                             &offset);
-    if (result == 0) {
-        result = flb_input_trace_append(ctx->ins, tag, tag_len, decoded_context);
-        ctr_decode_opentelemetry_destroy(decoded_context);
-    }
-
-    return result;
-}
-
-static int process_payload_raw_traces(struct flb_opentelemetry *ctx, struct http_conn *conn,
-                                      flb_sds_t tag,
-                                      size_t tag_len,
-                                      struct mk_http_session *session,
-                                      struct mk_http_request *request)
-{
-    int ret;
-    int root_type;
-    char *out_buf = NULL;
-    size_t out_size;
-
-    msgpack_packer mp_pck;
-    msgpack_sbuffer mp_sbuf;
-
-    msgpack_sbuffer_init(&mp_sbuf);
-    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
-
-    msgpack_pack_array(&mp_pck, 2);
-    flb_pack_time_now(&mp_pck);
-
-    /* Check if the incoming payload is a valid  message and convert it to msgpack */
-    ret = flb_pack_json(request->data.data, request->data.len,
-                        &out_buf, &out_size, &root_type, NULL);
-
-    if (ret == 0 && root_type == JSMN_OBJECT) {
-        /* JSON found, pack it msgpack representation */
-        msgpack_sbuffer_write(&mp_sbuf, out_buf, out_size);
-    }
-    else {
-        /* the content might be a binary payload or invalid JSON */
-        msgpack_pack_map(&mp_pck, 1);
-        msgpack_pack_str_with_body(&mp_pck, "trace", 5);
-        msgpack_pack_str_with_body(&mp_pck, request->data.data, request->data.len);
-    }
-
-    /* release 'out_buf' if it was allocated */
-    if (out_buf) {
-        flb_free(out_buf);
-    }
-
-    flb_input_log_append(ctx->ins, tag, tag_len, mp_sbuf.data, mp_sbuf.size);
-    msgpack_sbuffer_destroy(&mp_sbuf);
-
-    return 0;
-}
-
-static int process_payload_traces(struct flb_opentelemetry *ctx, struct http_conn *conn,
-                                  flb_sds_t tag,
-                                  size_t tag_len,
-                                  struct mk_http_session *session,
-                                  struct mk_http_request *request)
-{
-    int result;
-
-    if (ctx->raw_traces) {
-        result = process_payload_raw_traces(ctx, conn, tag, tag_len, session, request);
-    }
-    else {
-        result = process_payload_traces_proto(ctx, conn, tag, tag_len, session, request);
-    }
-
-    return result;
 }
 
 static int otel_pack_string(msgpack_packer *mp_pck, char *str)
@@ -772,140 +688,6 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
 
     if (ret != 0) {
         return -1;
-    }
-
-    return 0;
-}
-
-static int find_map_entry_by_key(msgpack_object_map *map,
-                                 char *key,
-                                 size_t match_index,
-                                 int case_insensitive)
-{
-    int     result;
-    int     index;
-    int key_len;
-    size_t  match_count;
-
-    if (!key) {
-        return -1;
-    }
-
-    key_len = strlen(key);
-    match_count = 0;
-
-    for (index = 0 ; index < (int) map->size ; index++) {
-        if (key_len != map->ptr[index].key.via.str.size) {
-            continue;
-        }
-
-        if (map->ptr[index].key.type == MSGPACK_OBJECT_STR) {
-            if (case_insensitive) {
-                result = strncasecmp(map->ptr[index].key.via.str.ptr,
-                                     key,
-                                     map->ptr[index].key.via.str.size);
-            }
-            else {
-                result = strncmp(map->ptr[index].key.via.str.ptr,
-                                 key,
-                                 map->ptr[index].key.via.str.size);
-            }
-
-            if (result == 0) {
-                if (match_count == match_index) {
-                    return index;
-                }
-
-                match_count++;
-            }
-        }
-    }
-
-    return -1;
-}
-
-static int json_payload_get_wrapped_value(msgpack_object *wrapper,
-                                          msgpack_object **value,
-                                          int            *type)
-{
-    int                 internal_type;
-    msgpack_object     *kv_value;
-    msgpack_object_str *kv_key;
-    msgpack_object_map *map;
-
-    if (wrapper->type != MSGPACK_OBJECT_MAP) {
-        return -1;
-    }
-
-    map = &wrapper->via.map;
-    kv_value = NULL;
-    internal_type = -1;
-
-    if (map->size == 1) {
-        if (map->ptr[0].key.type == MSGPACK_OBJECT_STR) {
-            kv_value = &map->ptr[0].val;
-            kv_key = &map->ptr[0].key.via.str;
-
-            if (strncasecmp(kv_key->ptr, "stringValue",  kv_key->size) == 0 ||
-                strncasecmp(kv_key->ptr, "string_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_STR;
-            }
-            else if (strncasecmp(kv_key->ptr, "boolValue",  kv_key->size) == 0 ||
-                     strncasecmp(kv_key->ptr, "bool_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_BOOLEAN;
-            }
-            else if (strncasecmp(kv_key->ptr, "intValue",  kv_key->size) == 0 ||
-                     strncasecmp(kv_key->ptr, "int_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_POSITIVE_INTEGER;
-            }
-            else if (strncasecmp(kv_key->ptr, "doubleValue",  kv_key->size) == 0 ||
-                     strncasecmp(kv_key->ptr, "double_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_FLOAT;
-            }
-            else if (strncasecmp(kv_key->ptr, "bytesValue",  kv_key->size) == 0 ||
-                     strncasecmp(kv_key->ptr, "bytes_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_BIN;
-            }
-            else if (strncasecmp(kv_key->ptr, "arrayValue",  kv_key->size) == 0 ||
-                     strncasecmp(kv_key->ptr, "array_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_ARRAY;
-            }
-            else if (strncasecmp(kv_key->ptr, "kvlistValue",  kv_key->size) == 0 ||
-                     strncasecmp(kv_key->ptr, "kvlist_value", kv_key->size) == 0) {
-                internal_type = MSGPACK_OBJECT_MAP;
-            }
-        }
-    }
-
-    if (internal_type != -1) {
-        if (type != NULL) {
-            *type  = internal_type;
-        }
-
-        if (value != NULL) {
-            *value = kv_value;
-        }
-
-        if (kv_value->type == MSGPACK_OBJECT_MAP) {
-            map = &kv_value->via.map;
-
-            if (map->size == 1) {
-                kv_value = &map->ptr[0].val;
-                kv_key = &map->ptr[0].key.via.str;
-
-                if (strncasecmp(kv_key->ptr, "values", kv_key->size) == 0) {
-                    if (value != NULL) {
-                        *value = kv_value;
-                    }
-                }
-                else {
-                    return -3;
-                }
-            }
-        }
-    }
-    else {
-        return -2;
     }
 
     return 0;
@@ -1464,9 +1246,15 @@ static int process_json_payload_log_records_entry(struct flb_opentelemetry *ctx,
         }
 
         result = json_payload_append_converted_value(
-                    encoder,
-                    FLB_LOG_EVENT_BODY,
-                    body_object);
+                                                    encoder,
+                                                    FLB_LOG_EVENT_BODY,
+                                                    body_object);
+        if (result != FLB_EVENT_ENCODER_SUCCESS) {
+            flb_plg_error(ctx->ins, "could not append body");
+            flb_log_event_encoder_rollback_record(encoder);
+            result = -4;
+            return result;
+        }
     }
 
     result = flb_log_event_encoder_dynamic_field_flush(&encoder->body);
@@ -2011,7 +1799,6 @@ int opentelemetry_prot_uncompress(struct mk_http_session *session,
     return 0;
 }
 
-
 /*
  * Handle an incoming request. It performs extra checks over the request, if
  * everything is OK, it enqueue the incoming payload.
@@ -2026,6 +1813,7 @@ int opentelemetry_prot_handle(struct flb_opentelemetry *ctx, struct http_conn *c
     char *uri;
     char *qs;
     char *out_chunked = NULL;
+    flb_sds_t content_type = NULL;
     size_t out_chunked_size = 0;
     off_t diff;
     size_t tag_len;
@@ -2084,7 +1872,7 @@ int opentelemetry_prot_handle(struct flb_opentelemetry *ctx, struct http_conn *c
         }
 
         /* New tag skipping the URI '/' */
-        flb_sds_cat(tag, uri + 1, len - 1);
+        flb_sds_cat_safe(&tag, uri + 1, len - 1);
 
         /* Sanitize, only allow alphanum chars */
         for (i = 0; i < flb_sds_len(tag); i++) {
@@ -2150,9 +1938,6 @@ int opentelemetry_prot_handle(struct flb_opentelemetry *ctx, struct http_conn *c
             flb_sds_destroy(tag);
             mk_mem_free(uri);
             send_response(conn, 400, "error: invalid chunked data\n");
-            if (uncompressed_data != NULL) {
-                flb_free(uncompressed_data);
-            }
             return -1;
         }
         else {
@@ -2174,7 +1959,14 @@ int opentelemetry_prot_handle(struct flb_opentelemetry *ctx, struct http_conn *c
         ret = process_payload_metrics(ctx, conn, tag, tag_len, session, request);
     }
     else if (strcmp(uri, "/v1/traces") == 0) {
-        ret = process_payload_traces(ctx, conn, tag, tag_len, session, request);
+        if (request->content_type.data != NULL) {
+            content_type = flb_sds_create_len(request->content_type.data,
+                                              request->content_type.len);
+        }
+
+        ret = opentelemetry_process_traces(ctx, content_type, tag, tag_len,
+                                           request->data.data, request->data.len);
+        flb_sds_destroy(content_type);
     }
     else if (strcmp(uri, "/v1/logs") == 0) {
         ret = process_payload_logs(ctx, conn, tag, tag_len, session, request);
@@ -2276,7 +2068,7 @@ static int send_grpc_response_ng(struct flb_http_response *response,
 
     wire_message_length = (uint32_t) message_length;
 
-    cfl_sds_cat(body_buffer, "\x00----", 5);
+    cfl_sds_cat_safe(&body_buffer, "\x00----", 5);
 
     ((uint8_t *) body_buffer)[1] = (wire_message_length & 0xFF000000) >> 24;
     ((uint8_t *) body_buffer)[2] = (wire_message_length & 0x00FF0000) >> 16;
@@ -2284,7 +2076,7 @@ static int send_grpc_response_ng(struct flb_http_response *response,
     ((uint8_t *) body_buffer)[4] = (wire_message_length & 0x000000FF) >> 0;
 
     if (message_buffer != NULL) {
-        cfl_sds_cat(body_buffer, (char *) message_buffer, message_length);
+        cfl_sds_cat_safe(&body_buffer, (char *) message_buffer, message_length);
     }
 
     flb_http_response_set_status(response, 200);
@@ -2495,120 +2287,6 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
     }
 
     return 0;
-}
-
-
-static int process_payload_traces_proto_ng(struct flb_opentelemetry *ctx,
-                                           flb_sds_t tag,
-                                           struct flb_http_request *request,
-                                           struct flb_http_response *response)
-{
-    struct ctrace *decoded_context;
-    size_t         offset;
-    int            result;
-
-    offset = 0;
-
-    if (request->content_type == NULL) {
-        flb_error("[otel] content type missing");
-
-        return -1;
-    }
-
-    if (strcasecmp(request->content_type, "application/grpc") == 0) {
-        if (cfl_sds_len(request->body) < 5) {
-            return -1;
-        }
-
-        result = ctr_decode_opentelemetry_create(&decoded_context,
-                                                 &request->body[5],
-                                                 cfl_sds_len(request->body) - 5,
-                                                 &offset);
-    }
-    else if (strcasecmp(request->content_type, "application/x-protobuf") == 0 ||
-             strcasecmp(request->content_type, "application/json") == 0) {
-        result = ctr_decode_opentelemetry_create(&decoded_context,
-                                                request->body,
-                                                cfl_sds_len(request->body),
-                                                &offset);
-    }
-    else {
-        flb_plg_error(ctx->ins, "Unsupported content type %s", request->content_type);
-
-        return -1;
-    }
-
-    if (result == 0) {
-        result = flb_input_trace_append(ctx->ins, tag, cfl_sds_len(tag), decoded_context);
-        ctr_decode_opentelemetry_destroy(decoded_context);
-    }
-    else {
-        flb_plg_warn(ctx->ins, "non-success ctraces opentelemetry decode result %d", result);
-    }
-
-    return result;
-}
-
-static int process_payload_raw_traces_ng(struct flb_opentelemetry *ctx,
-                                         flb_sds_t tag,
-                                         struct flb_http_request *request,
-                                         struct flb_http_response *response)
-{
-    int ret;
-    int root_type;
-    char *out_buf = NULL;
-    size_t out_size;
-
-    msgpack_packer mp_pck;
-    msgpack_sbuffer mp_sbuf;
-
-    msgpack_sbuffer_init(&mp_sbuf);
-    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
-
-    msgpack_pack_array(&mp_pck, 2);
-    flb_pack_time_now(&mp_pck);
-
-    /* Check if the incoming payload is a valid JSON message and convert it to msgpack */
-    ret = flb_pack_json(request->body, cfl_sds_len(request->body),
-                        &out_buf, &out_size, &root_type, NULL);
-
-    if (ret == 0 && root_type == JSMN_OBJECT) {
-        /* JSON found, pack it msgpack representation */
-        msgpack_sbuffer_write(&mp_sbuf, out_buf, out_size);
-    }
-    else {
-        /* the content might be a binary payload or invalid JSON */
-        msgpack_pack_map(&mp_pck, 1);
-        msgpack_pack_str_with_body(&mp_pck, "trace", 5);
-        msgpack_pack_str_with_body(&mp_pck, request->body, cfl_sds_len(request->body));
-    }
-
-    /* release 'out_buf' if it was allocated */
-    if (out_buf) {
-        flb_free(out_buf);
-    }
-
-    flb_input_log_append(ctx->ins, tag, flb_sds_len(tag), mp_sbuf.data, mp_sbuf.size);
-    msgpack_sbuffer_destroy(&mp_sbuf);
-
-    return 0;
-}
-
-static int process_payload_traces_ng(struct flb_opentelemetry *ctx,
-                                     flb_sds_t tag,
-                                     struct flb_http_request *request,
-                                     struct flb_http_response *response)
-{
-    int result;
-
-    if (ctx->raw_traces) {
-        result = process_payload_raw_traces_ng(ctx, tag, request, response);
-    }
-    else {
-        result = process_payload_traces_proto_ng(ctx, tag, request, response);
-    }
-
-    return result;
 }
 
 static int process_payload_logs_ng(struct flb_opentelemetry *ctx,
@@ -2903,7 +2581,10 @@ int opentelemetry_prot_handle_ng(struct flb_http_request *request,
         else {
             tag = flb_sds_create(context->ins->tag);
         }
-        result = process_payload_traces_ng(context, tag, request, response);
+
+        result = opentelemetry_process_traces(context, request->content_type,
+                                              tag, flb_sds_len(tag),
+                                              request->body, cfl_sds_len(request->body));
     }
     else if (strcmp(request->path, "/v1/logs") == 0 ||
              strcmp(request->path, "/opentelemetry.proto.collector.log.v1.LogService/Export") == 0 ||

--- a/plugins/in_opentelemetry/opentelemetry_traces.c
+++ b/plugins/in_opentelemetry/opentelemetry_traces.c
@@ -1,0 +1,1251 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_pack.h>
+
+#include <ctraces/ctraces.h>
+#include <ctraces/ctr_encode_text.h>
+
+#include "opentelemetry.h"
+#include "opentelemetry_traces.h"
+#include "opentelemetry_utils.h"
+
+int opentelemetry_traces_process_protobuf(struct flb_opentelemetry *ctx,
+                                          flb_sds_t tag,
+                                          size_t tag_len,
+                                          void *data, size_t size)
+{
+    struct ctrace *decoded_context;
+    size_t         offset;
+    int            result;
+
+    offset = 0;
+    result = ctr_decode_opentelemetry_create(&decoded_context,
+                                             data, size,
+                                             &offset);
+    if (result == 0) {
+        result = flb_input_trace_append(ctx->ins, tag, tag_len, decoded_context);
+        ctr_decode_opentelemetry_destroy(decoded_context);
+    }
+
+    return result;
+}
+
+static int process_attribute(struct ctrace_attributes *attr,
+                             msgpack_object *key, msgpack_object *value, int type)
+{
+    int ret;
+    char *key_str;
+    char *value_str;
+    int64_t value_int;
+    double value_double;
+    int value_bool;
+
+    if (key->type != MSGPACK_OBJECT_STR) {
+        return -1;
+    }
+
+    /* temporary buffer for key since it needs to be NULL terminated */
+    key_str = flb_sds_create_len(key->via.str.ptr, key->via.str.size);
+    if (key_str == NULL) {
+        return -1;
+    }
+
+    /*
+     * the value of 'type' is set by the JSON wrapped value, we need to to convert it
+     * since msgpack_object *value is always a string
+     */
+    switch (type) {
+    case MSGPACK_OBJECT_STR:
+        if (value->type != MSGPACK_OBJECT_STR) {
+            flb_sds_destroy(key_str);
+            return -1;
+        }
+
+        value_str = flb_sds_create_len(value->via.str.ptr, value->via.str.size);
+        if (value_str == NULL) {
+            flb_sds_destroy(key_str);
+            return -1;
+        }
+
+        ret = ctr_attributes_set_string(attr, key_str, value_str);
+        flb_sds_destroy(value_str);
+        break;
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        if (value->type != MSGPACK_OBJECT_POSITIVE_INTEGER &&
+            value->type != MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+            flb_sds_destroy(key_str);
+            return -1;
+        }
+
+        value_int = value->via.i64;
+        ret = ctr_attributes_set_int64(attr, key_str, value_int);
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        if (value->type != MSGPACK_OBJECT_FLOAT32 &&
+            value->type != MSGPACK_OBJECT_FLOAT64) {
+            flb_sds_destroy(key_str);
+            return -1;
+        }
+
+        value_double = value->via.f64;
+        ret = ctr_attributes_set_double(attr, key_str, value_double);
+        break;
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (value->type != MSGPACK_OBJECT_BOOLEAN) {
+            flb_sds_destroy(key_str);
+            return -1;
+        }
+
+        value_bool = value->via.boolean;
+        ret = ctr_attributes_set_bool(attr, key_str, value_bool);
+        break;
+    case MSGPACK_OBJECT_ARRAY:
+        /*
+         * The less fun part (OTel JSON encoding), the value can be an array and
+         * only allows values such as string, bool, int64, double. I am glad this
+         * don't support nested arrays or maps.
+         */
+        ret = 0;
+        break;
+    default:
+        flb_sds_destroy(key_str);
+        return -1;
+    }
+
+    flb_sds_destroy(key_str);
+    return ret;
+}
+
+static int process_resource_unwrap_attribute(msgpack_object *attr,
+                                             msgpack_object *out_key,
+                                             msgpack_object *out_value, int *out_value_type)
+{
+    int ret;
+    int type;
+    msgpack_object key;
+    msgpack_object val;
+    msgpack_object *real_value;
+
+    if (attr->type != MSGPACK_OBJECT_MAP) {
+        return -1;
+    }
+
+    ret = find_map_entry_by_key(&attr->via.map, "key", 0, FLB_TRUE);
+    if (ret == -1) {
+        return -1;
+    }
+
+    key = attr->via.map.ptr[ret].val;
+    if (key.type != MSGPACK_OBJECT_STR) {
+        return -1;
+    }
+
+    ret = find_map_entry_by_key(&attr->via.map, "value", 0, FLB_TRUE);
+    if (ret == -1) {
+        return -1;
+    }
+
+    val = attr->via.map.ptr[ret].val;
+
+    ret = json_payload_get_wrapped_value(&val, &real_value, &type);
+    if (ret != 0) {
+        return -1;
+    }
+
+    *out_key = key;
+    *out_value = *real_value;
+    *out_value_type = type;
+
+    return 0;
+}
+
+/*
+ * Convert a list of attributes in msgpack format to a cfl attributes by
+ * unwrapping JSON encoded value types.
+ */
+static struct ctrace_attributes *convert_attributes(struct flb_opentelemetry *ctx,
+                                                    msgpack_object *attributes,
+                                                    char *log_context)
+{
+    int i;
+    int ret;
+    int value_type;
+    msgpack_object key;
+    msgpack_object value;
+    struct ctrace_attributes *attr;
+
+    attr = ctr_attributes_create();
+    if (attr == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < attributes->via.array.size; i++) {
+        ret = process_resource_unwrap_attribute(&attributes->via.array.ptr[i],
+                                                &key, &value, &value_type);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "found invalid %s attribute, skipping",
+                         log_context);
+            continue;
+        }
+
+        /* set attribute */
+        ret = process_attribute(attr, &key, &value, value_type);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to set %s attribute, skipping",
+                         log_context);
+            continue;
+        }
+    }
+
+    return attr;
+}
+
+static int process_resource_attributes(struct flb_opentelemetry *ctx,
+                                       struct ctrace *ctr,
+                                       struct ctrace_resource_span *resource_span,
+                                       msgpack_object *attributes)
+
+{
+    struct ctrace_resource *resource;
+    struct ctrace_attributes *attr;
+
+    attr = convert_attributes(ctx, attributes, "trace resource");
+    if (!attr) {
+        return -1;
+    }
+
+    resource = ctr_resource_span_get_resource(resource_span);
+    ctr_resource_set_attributes(resource, attr);
+
+    return 0;
+}
+
+static int process_scope_attributes(struct flb_opentelemetry *ctx,
+                                    struct ctrace *ctr,
+                                    struct ctrace_scope_span *scope_span,
+                                    msgpack_object *name,
+                                    msgpack_object *version,
+                                    msgpack_object *attributes,
+                                    msgpack_object *dropped_attributes_count)
+
+{
+    int dropped = 0;
+    cfl_sds_t name_str = NULL;
+    cfl_sds_t version_str = NULL;
+    struct ctrace_attributes *attr = NULL;
+    struct ctrace_instrumentation_scope *ins_scope;
+
+    if (attributes) {
+        attr = convert_attributes(ctx, attributes, "trace scope");
+        if (!attr) {
+            return -1;
+        }
+    }
+
+    if (name) {
+        name_str = cfl_sds_create_len(name->via.str.ptr, name->via.str.size);
+    }
+    if (version) {
+        version_str = cfl_sds_create_len(version->via.str.ptr, version->via.str.size);
+    }
+
+    if (dropped_attributes_count) {
+        dropped = dropped_attributes_count->via.u64;
+    }
+
+    ins_scope = ctr_instrumentation_scope_create(name_str, version_str, dropped, attr);
+    if (!ins_scope) {
+        if (name_str) {
+            cfl_sds_destroy(name_str);
+        }
+        if (version_str) {
+            cfl_sds_destroy(version_str);
+        }
+        if (attr) {
+            ctr_attributes_destroy(attr);
+        }
+        return -1;
+    }
+
+    if (name_str) {
+        cfl_sds_destroy(name_str);
+    }
+    if (version_str) {
+        cfl_sds_destroy(version_str);
+    }
+
+    ctr_scope_span_set_instrumentation_scope(scope_span, ins_scope);
+    return 0;
+}
+
+static int process_events(struct flb_opentelemetry *ctx,
+                          struct ctrace *ctr,
+                          struct ctrace_span *span,
+                          msgpack_object *events)
+{
+    int i;
+    int ret;
+    int len;
+    uint64_t ts = 0;
+    char tmp[64];
+    cfl_sds_t name_str = NULL;
+    msgpack_object event;
+    msgpack_object *name = NULL;
+    msgpack_object *attr = NULL;
+    struct ctrace_span_event *ctr_event = NULL;
+    struct ctrace_attributes *ctr_attr = NULL;
+
+    for (i = 0; i < events->via.array.size; i++) {
+        event = events->via.array.ptr[i];
+        if (event.type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "unexpected event type");
+            return -1;
+        }
+
+        name_str = NULL;
+        ts  = 0;
+
+        /* name */
+        ret = find_map_entry_by_key(&event.via.map, "name", 0, FLB_TRUE);
+        if (ret >= 0 && event.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            name = &event.via.map.ptr[ret].val;
+            name_str = cfl_sds_create_len(name->via.str.ptr, name->via.str.size);
+            if (name_str == NULL) {
+                return -1;
+            }
+        }
+
+        if (!name_str) {
+            flb_plg_warn(ctx->ins, "span event name is missing");
+            return -1;
+        }
+
+        /* time_unix_nano */
+        ret = find_map_entry_by_key(&event.via.map, "timeUnixNano", 0, FLB_TRUE);
+        if (ret >= 0 && event.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            /* convert to uint64_t */
+            len = event.via.map.ptr[ret].val.via.str.size;
+            if (len > sizeof(tmp) - 1) {
+                len = sizeof(tmp) - 1;
+                memcpy(tmp, event.via.map.ptr[ret].val.via.str.ptr, len);
+                tmp[len] = '\0';
+
+                flb_plg_error(ctx->ins, "invalid timeUnixNano: '%s'", tmp);
+                if (name_str) {
+                    cfl_sds_destroy(name_str);
+                }
+                return -1;
+            }
+
+            memcpy(tmp, event.via.map.ptr[ret].val.via.str.ptr, len);
+            tmp[len] = '\0';
+
+            ts = strtoull(tmp, NULL, 10);
+        }
+
+        ctr_event = ctr_span_event_add_ts(span, name_str, ts);
+        cfl_sds_destroy(name_str);
+        if (ctr_event == NULL) {
+            return -1;
+        }
+
+        /* attributes */
+        ret = find_map_entry_by_key(&event.via.map, "attributes", 0, FLB_TRUE);
+        if (ret >= 0 && event.via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+            attr = &event.via.map.ptr[ret].val;
+            ctr_attr = convert_attributes(ctx, attr, "span event");
+            if (ctr_attr) {
+                ctr_span_event_set_attributes(ctr_event, ctr_attr);
+            }
+        }
+
+        /* dropped_attributes_count */
+        ret = find_map_entry_by_key(&event.via.map, "droppedAttributesCount", 0, FLB_FALSE);
+        if (ret >= 0 && event.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            ctr_span_event_set_dropped_attributes_count(ctr_event, event.via.map.ptr[ret].val.via.u64);
+        }
+    }
+
+    return 0;
+}
+
+static int process_links(struct flb_opentelemetry *ctx,
+                         struct ctrace *ctr,
+                         struct ctrace_span *span,
+                         msgpack_object *links)
+{
+    int i;
+    int ret;
+    int len;
+    char tmp[64];
+    char trace_id_bin[16];
+    char span_id_bin[8];
+    cfl_sds_t buf;
+    msgpack_object link;
+    msgpack_object *trace_id = NULL;
+    msgpack_object *span_id = NULL;
+    msgpack_object *trace_state = NULL;
+    msgpack_object *dropped_attr_count = NULL;
+    msgpack_object *flags = NULL;
+    msgpack_object *attr = NULL;
+
+    struct ctrace_link *ctr_link = NULL;
+    struct ctrace_attributes *ctr_attr = NULL;
+
+    for (i = 0; i < links->via.array.size; i++) {
+        link = links->via.array.ptr[i];
+        if (link.type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "unexpected link type");
+            return -1;
+        }
+
+        trace_id = NULL;
+        span_id = NULL;
+        trace_state = NULL;
+        dropped_attr_count = NULL;
+        flags = NULL;
+        ctr_attr = NULL;
+
+        /* traceId */
+        ret = find_map_entry_by_key(&link.via.map, "traceId", 0, FLB_TRUE);
+        if (ret >= 0 && link.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            trace_id = &link.via.map.ptr[ret].val;
+
+            /* trace_id is an hex of 32 bytes */
+            if (trace_id->via.str.size != 32) {
+                len = trace_id->via.str.size;
+                if (len > sizeof(tmp) - 1) {
+                    len = sizeof(tmp) - 1;
+                }
+                memcpy(tmp, trace_id->via.str.ptr, len);
+                tmp[len] = '\0';
+
+                flb_plg_error(ctx->ins, "invalid event traceId: '%s'", tmp);
+                return -1;
+            }
+
+            /* decode the hex string (16 bytes) */
+            hex_to_id((char *) trace_id->via.str.ptr, trace_id->via.str.size,
+                      (unsigned char *) trace_id_bin, 16);
+        }
+
+        if (!trace_id) {
+            flb_plg_error(ctx->ins, "link traceId is missing");
+            return -1;
+        }
+
+        /* spanId */
+        ret = find_map_entry_by_key(&link.via.map, "spanId", 0, FLB_TRUE);
+        if (ret >= 0 && link.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            span_id = &link.via.map.ptr[ret].val;
+
+            /* span_id is an hex of 16 bytes */
+            if (span_id->via.str.size != 16) {
+                len = span_id->via.str.size;
+                if (len > sizeof(tmp) - 1) {
+                    len = sizeof(tmp) - 1;
+                }
+                memcpy(tmp, span_id->via.str.ptr, len);
+                tmp[len] = '\0';
+                flb_plg_error(ctx->ins, "invalid spanId: '%s'", tmp);
+                return -1;
+            }
+
+            /* decode the hex string (8 bytes) */
+            memset(tmp, '\0', sizeof(tmp));
+            hex_to_id((char *) span_id->via.str.ptr, span_id->via.str.size,
+                      (unsigned char *) span_id_bin, 8);
+        }
+
+        if (!span_id) {
+            flb_plg_error(ctx->ins, "link spanId is missing");
+            return -1;
+        }
+
+        /* traceState */
+        ret = find_map_entry_by_key(&link.via.map, "traceState", 0, FLB_FALSE);
+        if (ret >= 0 && link.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            trace_state = &link.via.map.ptr[ret].val;
+        }
+
+        /* attributes */
+        ret = find_map_entry_by_key(&link.via.map, "attributes", 0, FLB_FALSE);
+        if (ret >= 0 && link.via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+            attr = &link.via.map.ptr[ret].val;
+            ctr_attr = convert_attributes(ctx, attr, "event link");
+        }
+
+        /* droped_attributes_count */
+        ret = find_map_entry_by_key(&link.via.map, "droppedAttributesCount", 0, FLB_FALSE);
+        if (ret >= 0 && link.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            dropped_attr_count = &link.via.map.ptr[ret].val;
+        }
+
+        /* flags */
+        ret = find_map_entry_by_key(&link.via.map, "flags", 0, FLB_FALSE);
+        if (ret >= 0 && link.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            flags = &link.via.map.ptr[ret].val;
+        }
+
+        ctr_link = ctr_link_create(span,
+                                        trace_id_bin, 16,
+                                        span_id_bin, 8);
+
+        if (ctr_link == NULL) {
+            if (ctr_attr) {
+                ctr_attributes_destroy(ctr_attr);
+            }
+            return -1;
+        }
+
+        if (trace_state) {
+            buf = cfl_sds_create_len(trace_state->via.str.ptr, trace_state->via.str.size);
+            if (buf) {
+                ctr_link_set_trace_state(ctr_link, buf);
+                cfl_sds_destroy(buf);
+            }
+        }
+
+        if (ctr_attr) {
+            ctr_link_set_attributes(ctr_link, ctr_attr);
+        }
+
+        if (dropped_attr_count) {
+            ctr_link_set_dropped_attr_count(ctr_link, dropped_attr_count->via.u64);
+        }
+
+        if (flags) {
+            ctr_link_set_flags(ctr_link, flags->via.u64);
+        }
+    }
+
+    return 0;
+}
+
+static int process_span_status(struct flb_opentelemetry *ctx,
+                               struct ctrace *ctr,
+                               struct ctrace_span *span,
+                               msgpack_object *status)
+{
+    int ret;
+    int code = 0;
+    char *message = NULL;
+
+    if (status->type != MSGPACK_OBJECT_MAP) {
+        flb_plg_error(ctx->ins, "unexpected status type");
+        return -1;
+    }
+
+    /* code */
+    ret = find_map_entry_by_key(&status->via.map, "code", 0, FLB_TRUE);
+    if (ret >= 0 && status->via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        code = status->via.map.ptr[ret].val.via.u64;
+    }
+    else {
+        flb_plg_error(ctx->ins, "status code is missing");
+        return -1;
+    }
+
+    /* message */
+    ret = find_map_entry_by_key(&status->via.map, "message", 0, FLB_FALSE);
+    if (ret >= 0 && status->via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+        message = flb_sds_create_len(status->via.map.ptr[ret].val.via.str.ptr,
+                                     status->via.map.ptr[ret].val.via.str.size);
+    }
+
+    ctr_span_set_status(span, code, message);
+    if (message) {
+        flb_sds_destroy(message);
+    }
+
+    return 0;
+}
+
+static int process_spans(struct flb_opentelemetry *ctx,
+                         struct ctrace *ctr,
+                         struct ctrace_scope_span *scope_span,
+                         msgpack_object *spans)
+{
+    int i;
+    int ret;
+    int len;
+    uint64_t val;
+    char tmp[64];
+    cfl_sds_t val_str = NULL;
+    msgpack_object span;
+    msgpack_object *name = NULL;
+    msgpack_object *attr = NULL;
+    struct ctrace_span *ctr_span = NULL;
+    struct ctrace_attributes *ctr_attr = NULL;
+
+    for (i = 0; i < spans->via.array.size; i++) {
+        span = spans->via.array.ptr[i];
+        if (span.type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "unexpected span type");
+            return -1;
+        }
+
+        val_str = NULL;
+
+        /* name */
+        ret = find_map_entry_by_key(&span.via.map, "name", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            name = &span.via.map.ptr[ret].val;
+            val_str = cfl_sds_create_len(name->via.str.ptr, name->via.str.size);
+        }
+
+        if (!val_str) {
+            flb_plg_error(ctx->ins, "span name is missing");
+            return -1;
+        }
+
+        /* create the span */
+        ctr_span = ctr_span_create(ctr, scope_span, val_str, NULL);
+        cfl_sds_destroy(val_str);
+
+        if (ctr_span == NULL) {
+            return -1;
+        }
+
+        /* traceId */
+        ret = find_map_entry_by_key(&span.via.map, "traceId", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            /* trace_id is an hex of 32 bytes */
+            if (span.via.map.ptr[ret].val.via.str.size != 32) {
+                len = span.via.map.ptr[ret].val.via.str.size;
+                if (len > sizeof(tmp) - 1) {
+                    len = sizeof(tmp) - 1;
+                }
+                memcpy(tmp, span.via.map.ptr[ret].val.via.str.ptr, len);
+                tmp[len] = '\0';
+
+                flb_plg_error(ctx->ins, "invalid traceId: '%s'", tmp);
+                return -1;
+            }
+
+            /* decode the hex string (16 bytes) */
+            memset(tmp, '\0', sizeof(tmp));
+            hex_to_id((char *) span.via.map.ptr[ret].val.via.str.ptr,
+                      span.via.map.ptr[ret].val.via.str.size,
+                      (unsigned char *) tmp, 16);
+            ctr_span_set_trace_id(ctr_span, tmp, 16);
+        }
+
+        /* spanId */
+        ret = find_map_entry_by_key(&span.via.map, "spanId", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            /* span_id is an hex of 16 bytes */
+            if (span.via.map.ptr[ret].val.via.str.size != 16) {
+                len = span.via.map.ptr[ret].val.via.str.size;
+                if (len > sizeof(tmp) - 1) {
+                    len = sizeof(tmp) - 1;
+                }
+                memcpy(tmp, span.via.map.ptr[ret].val.via.str.ptr, len);
+                tmp[len] = '\0';
+                flb_plg_error(ctx->ins, "invalid spanId: '%s'", tmp);
+                return -1;
+            }
+
+            /* decode the hex string (8 bytes) */
+            memset(tmp, '\0', sizeof(tmp));
+            hex_to_id((char *) span.via.map.ptr[ret].val.via.str.ptr,
+                      span.via.map.ptr[ret].val.via.str.size,
+                      (unsigned char *) tmp, 8);
+            ctr_span_set_span_id(ctr_span, tmp, 8);
+        }
+
+        /* traceState */
+        ret = find_map_entry_by_key(&span.via.map, "traceState", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            val_str = cfl_sds_create_len(span.via.map.ptr[ret].val.via.str.ptr,
+                                         span.via.map.ptr[ret].val.via.str.size);
+            ctr_span->trace_state = val_str;
+            val_str = NULL;
+        }
+
+        /* flags */
+        ret = find_map_entry_by_key(&span.via.map, "flags", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            /* unsupported in CTraces */
+        }
+
+        /* parentSpanId */
+        ret = find_map_entry_by_key(&span.via.map, "parentSpanId", 0, FLB_TRUE);
+        if (ret >= 0 &&
+            span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR &&
+            span.via.map.ptr[ret].val.via.str.size > 0) {
+
+            /* parent_span_id is an hex of 16 bytes */
+            if (span.via.map.ptr[ret].val.via.str.size != 16) {
+                len = span.via.map.ptr[ret].val.via.str.size;
+                if (len > sizeof(tmp) - 1) {
+                    len = sizeof(tmp) - 1;
+                }
+                memcpy(tmp, span.via.map.ptr[ret].val.via.str.ptr, len);
+                tmp[len] = '\0';
+                flb_plg_error(ctx->ins, "invalid parentSpanId: '%s'", tmp);
+                return -1;
+            }
+
+            /* decode the hex string (8 bytes) */
+            memset(tmp, '\0', sizeof(tmp));
+            hex_to_id((char *) span.via.map.ptr[ret].val.via.str.ptr,
+                      span.via.map.ptr[ret].val.via.str.size,
+                      (unsigned char *) tmp, 8);
+            ctr_span_set_parent_span_id(ctr_span, tmp, 8);
+        }
+
+        /* flags */
+        ret = find_map_entry_by_key(&span.via.map, "flags", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            ctr_span_set_flags(ctr_span, span.via.map.ptr[ret].val.via.u64);
+        }
+
+        /* start_time_unix_nano */
+        ret = find_map_entry_by_key(&span.via.map, "startTimeUnixNano", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            /* convert string number to integer */
+            val = convert_string_number_to_u64((char *) span.via.map.ptr[ret].val.via.str.ptr,
+                                               span.via.map.ptr[ret].val.via.str.size);
+            ctr_span_start_ts(ctr, ctr_span, val);
+        }
+
+        /* end_time_unix_nano */
+        ret = find_map_entry_by_key(&span.via.map, "endTimeUnixNano", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            /* convert string number to integer */
+            val = convert_string_number_to_u64((char *) span.via.map.ptr[ret].val.via.str.ptr,
+                                               span.via.map.ptr[ret].val.via.str.size);
+            ctr_span_end_ts(ctr, ctr_span, val);
+        }
+
+        /* kind */
+        ret = find_map_entry_by_key(&span.via.map, "kind", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            ctr_span_kind_set(ctr_span, span.via.map.ptr[ret].val.via.u64);
+        }
+
+        /* attributes */
+        ret = find_map_entry_by_key(&span.via.map, "attributes", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+            attr = &span.via.map.ptr[ret].val;
+            ctr_attr = convert_attributes(ctx, attr, "span");
+            if (ctr_attr) {
+                ctr_span_set_attributes(ctr_span, ctr_attr);
+            }
+        }
+
+        /* dropped_attributes_count */
+        ret = find_map_entry_by_key(&span.via.map, "droppedAttributesCount", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            ctr_span_set_dropped_attributes_count(ctr_span, span.via.map.ptr[ret].val.via.u64);
+        }
+
+        /* events */
+        ret = find_map_entry_by_key(&span.via.map, "events", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+            ret = process_events(ctx, ctr, ctr_span, &span.via.map.ptr[ret].val);
+        }
+
+        /* dropped_events_count */
+        ret = find_map_entry_by_key(&span.via.map, "droppedEventsCount", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            ctr_span_set_dropped_events_count(ctr_span, span.via.map.ptr[ret].val.via.u64);
+        }
+
+        /* dropped_links_count */
+        ret = find_map_entry_by_key(&span.via.map, "droppedLinksCount", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            ctr_span_set_dropped_links_count(ctr_span, span.via.map.ptr[ret].val.via.u64);
+        }
+
+        /* links */
+        ret = find_map_entry_by_key(&span.via.map, "links", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+            ret = process_links(ctx, ctr, ctr_span, &span.via.map.ptr[ret].val);
+        }
+
+        /* schema_url */
+        ret = find_map_entry_by_key(&span.via.map, "schemaUrl", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            val_str = cfl_sds_create_len(span.via.map.ptr[ret].val.via.str.ptr,
+                                         span.via.map.ptr[ret].val.via.str.size);
+            ctr_span_set_schema_url(ctr_span, val_str);
+            cfl_sds_destroy(val_str);
+            val_str = NULL;
+        }
+
+        /* status */
+        ret = find_map_entry_by_key(&span.via.map, "status", 0, FLB_TRUE);
+        if (ret >= 0 && span.via.map.ptr[ret].val.type == MSGPACK_OBJECT_MAP) {
+            process_span_status(ctx, ctr, ctr_span, &span.via.map.ptr[ret].val);
+        }
+    }
+
+    return 0;
+}
+
+
+static int process_scope_span(struct flb_opentelemetry *ctx,
+                              struct ctrace *ctr,
+                              struct ctrace_resource_span *resource_span,
+                              msgpack_object *scope_spans)
+{
+    int ret;
+    msgpack_object scope;
+    msgpack_object *name;
+    msgpack_object *attr;
+    msgpack_object *version;
+    msgpack_object *schema_url;
+    msgpack_object *dropped_attr;
+    msgpack_object *spans;
+    cfl_sds_t url = NULL;
+    struct ctrace_scope_span *scope_span;
+
+    /* get 'scope' */
+    ret = find_map_entry_by_key(&scope_spans->via.map, "scope", 0, FLB_TRUE);
+    if (ret >= 0) {
+        scope = scope_spans->via.map.ptr[ret].val;
+        if (scope.type != MSGPACK_OBJECT_MAP) {
+            flb_plg_error(ctx->ins, "unexpected scope type in scope span");
+            return -1;
+        }
+
+        /* create the scope_span */
+        scope_span = ctr_scope_span_create(resource_span);
+        if (scope_span == NULL) {
+            return -1;
+        }
+
+        /* instrumentation scope: name */
+        name = NULL;
+        ret = find_map_entry_by_key(&scope.via.map, "name", 0, FLB_TRUE);
+        if (ret >= 0 && scope.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            name = &scope.via.map.ptr[ret].val;
+        }
+
+        /* instrumentation scope: version */
+        version = NULL;
+        ret = find_map_entry_by_key(&scope.via.map, "version", 0, FLB_TRUE);
+        if (ret >= 0 && scope.via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+            version = &scope.via.map.ptr[ret].val;
+        }
+
+        /* instrumentation scope: attributes */
+        attr = NULL;
+        ret = find_map_entry_by_key(&scope.via.map, "attributes", 0, FLB_TRUE);
+        if (ret >= 0 && scope.via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+            attr = &scope.via.map.ptr[ret].val;
+        }
+
+        /* instrumentation scope: dropped_attributes_count */
+        dropped_attr = NULL;
+        ret = find_map_entry_by_key(&scope.via.map, "droppedAttributesCount", 0, FLB_TRUE);
+        if (ret >= 0 && scope.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+            dropped_attr = &scope.via.map.ptr[ret].val;
+        }
+
+        ret = process_scope_attributes(ctx,
+                                       ctr,
+                                       scope_span,
+                                       name, version, attr, dropped_attr);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to process scope attributes");
+        }
+    }
+
+    /* schema_url */
+    ret = find_map_entry_by_key(&scope_spans->via.map, "schemaUrl", 0, FLB_TRUE);
+    if (ret >= 0) {
+        schema_url = &scope_spans->via.map.ptr[ret].val;
+        if (schema_url->type == MSGPACK_OBJECT_STR) {
+            /* set schema url */
+            url = cfl_sds_create_len(schema_url->via.str.ptr, schema_url->via.str.size);
+            if (url) {
+                ctr_scope_span_set_schema_url(scope_span, url);
+                cfl_sds_destroy(url);
+            }
+        }
+    }
+
+    /* process the scope spans[] */
+    ret = find_map_entry_by_key(&scope_spans->via.map, "spans", 0, FLB_TRUE);
+    if (ret >= 0 && scope_spans->via.map.ptr[ret].val.type == MSGPACK_OBJECT_ARRAY) {
+        spans = &scope_spans->via.map.ptr[ret].val;
+        ret = process_spans(ctx, ctr, scope_span, spans);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to process spans");
+        }
+    }
+
+    return 0;
+}
+
+static int process_resource_span(struct flb_opentelemetry *ctx,
+                                 struct ctrace *ctr,
+                                 msgpack_object *resource_spans)
+{
+    int i;
+    int ret;
+    cfl_sds_t url;
+    struct ctrace_resource *ctr_resource;
+    struct ctrace_resource_span *resource_span;
+    msgpack_object resource;
+    msgpack_object attr;
+    msgpack_object scope_spans;
+    msgpack_object schema_url;
+
+    if (resource_spans->type != MSGPACK_OBJECT_MAP) {
+        return -1;
+    }
+
+    /* get the resource */
+    ret = find_map_entry_by_key(&resource_spans->via.map, "resource", 0, FLB_TRUE);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "resource missing");
+        return -1;
+    }
+
+    resource = resource_spans->via.map.ptr[ret].val;
+    if (resource.type != MSGPACK_OBJECT_MAP) {
+        flb_plg_error(ctx->ins, "unexpected resource type in resource span");
+        return -1;
+    }
+
+
+    resource_span = ctr_resource_span_create(ctr);
+    if (resource_span == NULL) {
+        return -1;
+    }
+
+    ctr_resource = ctr_resource_span_get_resource(resource_span);
+
+    /* droppedAttributesCount */
+    ret = find_map_entry_by_key(&resource.via.map, "droppedAttributesCount", 0, FLB_FALSE);
+    if (ret >= 0 && resource.via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        ctr_resource_set_dropped_attr_count(ctr_resource, resource.via.map.ptr[ret].val.via.u64);
+    }
+
+
+    /* Get resource attributes */
+    ret = find_map_entry_by_key(&resource.via.map, "attributes", 0, FLB_TRUE);
+    if (ret >= 0) {
+        attr = resource.via.map.ptr[ret].val;
+        if (attr.type == MSGPACK_OBJECT_ARRAY) {
+            /* iterate and register attributes */
+            ret = process_resource_attributes(ctx,
+                                              ctr,
+                                              resource_span,
+                                              &attr);
+            if (ret == -1) {
+                flb_plg_warn(ctx->ins, "failed to process resource attributes");
+            }
+        }
+    }
+
+    /* scopeSpans */
+    ret = find_map_entry_by_key(&resource_spans->via.map, "scopeSpans", 0, FLB_TRUE);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "scopeSpans missing");
+        return -1;
+    }
+    scope_spans = resource_spans->via.map.ptr[ret].val;
+
+    if (scope_spans.type != MSGPACK_OBJECT_ARRAY) {
+        flb_plg_error(ctx->ins, "unexpected scopeSpans type");
+        ctr_destroy(ctr);
+        return -1;
+    }
+
+    for (i = 0; i < scope_spans.via.array.size; i++) {
+        ret = process_scope_span(ctx,
+                                 ctr,
+                                 resource_span,
+                                 &scope_spans.via.array.ptr[i]);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to process scope span");
+        }
+    }
+
+    /* schema_url */
+    ret = find_map_entry_by_key(&resource.via.map, "schemaUrl", 0, FLB_TRUE);
+    if (ret >= 0) {
+        schema_url = resource.via.map.ptr[ret].val;
+        if (schema_url.type == MSGPACK_OBJECT_STR) {
+            url = cfl_sds_create_len(schema_url.via.str.ptr, schema_url.via.str.size);
+            if (url) {
+                ctr_resource_span_set_schema_url(resource_span, url);
+                cfl_sds_destroy(url);
+            }
+        }
+    }
+
+    return 0;
+}
+
+static struct ctrace *process_root_msgpack(struct flb_opentelemetry *ctx, msgpack_object *obj)
+{
+    int i;
+    int ret;
+    struct ctrace *ctr;
+    msgpack_object_array *resource_spans;
+
+    if (obj->type != MSGPACK_OBJECT_MAP) {
+        return NULL;
+    }
+
+    ret = find_map_entry_by_key(&obj->via.map, "resourceSpans", 0, FLB_TRUE);
+    if (ret == -1) {
+        ret = find_map_entry_by_key(&obj->via.map, "resource_spans", 0, FLB_TRUE);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "resourceSpans missing");
+            return NULL;
+        }
+    }
+
+    if (obj->via.map.ptr[ret].val.type != MSGPACK_OBJECT_ARRAY) {
+        flb_plg_error(ctx->ins, "unexpected resourceSpans type");
+        return NULL;
+    }
+
+    resource_spans = &obj->via.map.ptr[ret].val.via.array;
+    ret = 0;
+
+    ctr = ctr_create(NULL);
+    if (!ctr) {
+        return NULL;
+    }
+
+    for (i = 0; i < resource_spans->size; i++) {
+        ret = process_resource_span(ctx, ctr,  &resource_spans->ptr[i]);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to process resource span");
+
+            ctr_destroy(ctr);
+            return NULL;
+        }
+    }
+
+    return ctr;
+}
+
+static int process_json(struct flb_opentelemetry *ctx,
+                        char *tag, size_t tag_len,
+                        const char *body, size_t len)
+{
+    int              result = -1;
+    int              root_type;
+    char            *msgpack_body;
+    size_t           msgpack_body_length;
+    size_t           offset = 0;
+    msgpack_unpacked unpacked_root;
+    struct ctrace   *ctr;
+
+    result = flb_pack_json(body, len, &msgpack_body, &msgpack_body_length,
+                           &root_type, NULL);
+
+    if (result != 0) {
+        flb_plg_error(ctx->ins, "invalid JSON: msgpack conversion error");
+        return -1;
+    }
+
+    msgpack_unpacked_init(&unpacked_root);
+
+    result = msgpack_unpack_next(&unpacked_root,
+                                 msgpack_body,
+                                 msgpack_body_length,
+                                 &offset);
+
+    if (result != MSGPACK_UNPACK_SUCCESS) {
+        return -1;
+    }
+
+    /* iterate msgpack and comppose a CTraces context */
+    ctr = process_root_msgpack(ctx, &unpacked_root.data);
+    if (ctr) {
+        result = flb_input_trace_append(ctx->ins, tag, tag_len, ctr);
+        ctr_destroy(ctr);
+    }
+
+    msgpack_unpacked_destroy(&unpacked_root);
+    flb_free(msgpack_body);
+
+    return result;
+}
+
+static int opentelemetry_traces_process_json(struct flb_opentelemetry *ctx,
+                                             flb_sds_t tag, size_t tag_len,
+                                             char *data, size_t size)
+{
+    int ret;
+
+    ret = process_json(ctx, tag, tag_len, data, size);
+
+    return ret;
+}
+
+/*
+ * This interface was the first approach to take traces in JSON and ingest them as logs,
+ * we are not sure if it is still in use, but we are keeping it for now
+ */
+int opentelemetry_traces_process_raw_traces(struct flb_opentelemetry *ctx,
+                                            flb_sds_t tag,
+                                            size_t tag_len,
+                                            void *data, size_t size)
+{
+    int ret;
+    int root_type;
+    char *out_buf = NULL;
+    size_t out_size;
+
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    flb_pack_time_now(&mp_pck);
+
+    /* Check if the incoming payload is a valid  message and convert it to msgpack */
+    ret = flb_pack_json(data, size,
+                        &out_buf, &out_size, &root_type, NULL);
+
+    if (ret == 0 && root_type == JSMN_OBJECT) {
+        /* JSON found, pack it msgpack representation */
+        msgpack_sbuffer_write(&mp_sbuf, out_buf, out_size);
+    }
+    else {
+        /* the content might be a binary payload or invalid JSON */
+        msgpack_pack_map(&mp_pck, 1);
+        msgpack_pack_str_with_body(&mp_pck, "trace", 5);
+        msgpack_pack_str_with_body(&mp_pck, data, size);
+    }
+
+    /* release 'out_buf' if it was allocated */
+    if (out_buf) {
+        flb_free(out_buf);
+    }
+
+    flb_input_log_append(ctx->ins, tag, tag_len, mp_sbuf.data, mp_sbuf.size);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    return 0;
+}
+
+int opentelemetry_process_traces(struct flb_opentelemetry *ctx,
+                                 flb_sds_t content_type,
+                                 flb_sds_t tag,
+                                 size_t tag_len,
+                                 void *data, size_t size)
+{
+    int ret = -1;
+    int is_proto = FLB_FALSE; /* default to JSON */
+    char *buf;
+    char *payload;
+    uint64_t payload_size;
+
+    buf = (char *) data;
+
+    payload = buf;
+    payload_size = size;
+
+    /* Detect the type of payload */
+    if (content_type) {
+        if (strcasecmp(content_type, "application/json") == 0) {
+            if (buf[0] != '{') {
+                flb_plg_error(ctx->ins, "Invalid JSON payload");
+                return -1;
+            }
+
+            is_proto = FLB_FALSE;
+        }
+        else if (strcasecmp(content_type, "application/protobuf") == 0 ||
+                 strcasecmp(content_type, "application/x-protobuf") == 0) {
+            is_proto = FLB_TRUE;
+        }
+        else if (strcasecmp(content_type, "application/grpc") == 0) {
+            if (size < 5) {
+                return -1;
+            }
+
+            /* magic bytes: 0x00 or 0x01 */
+            if (buf[0] != 0 && buf[0] != 1) {
+                flb_plg_error(ctx->ins, "Invalid gRPC magic byte");
+                return -1;
+            }
+
+            if (buf[0] == 1) {
+                flb_plg_error(ctx->ins, "gRPC compression is not supported");
+                return -1;
+            }
+            /* payload size */
+            payload_size = ((uint64_t) (uint8_t) buf[1] << 24) |
+                           ((uint64_t) (uint8_t) buf[2] << 16) |
+                           ((uint64_t) (uint8_t) buf[3] << 8)  |
+                           ((uint64_t) (uint8_t) buf[4]);
+
+            if (size < payload_size + 5) {
+                flb_plg_error(ctx->ins, "Invalid gRPC payload size: received=%zu expected=%zu",
+                              size, payload_size + 5);
+                return -1;
+            }
+
+            /*
+             * FIXME: implement compression support for the gRPC message, leaving on
+             * hold for now.
+             */
+
+            /* skip the gRPC header bytes */
+            payload = buf + 5;
+
+            is_proto = FLB_TRUE;
+        }
+        else {
+            flb_plg_error(ctx->ins, "Unsupported content type %s", content_type);
+            return -1;
+        }
+    }
+
+    if (is_proto == FLB_TRUE) {
+        ret = opentelemetry_traces_process_protobuf(ctx,
+                                                    tag, tag_len,
+                                                    payload, payload_size);
+    }
+    else {
+        if (ctx->raw_traces) {
+            ret = opentelemetry_traces_process_raw_traces(ctx,
+                                                          tag, tag_len,
+                                                          payload, payload_size);
+        }
+        else {
+            /* The content is likely OTel JSON */
+            ret = opentelemetry_traces_process_json(ctx,
+                                                    tag, tag_len,
+                                                    payload, payload_size);
+        }
+    }
+
+    return ret;
+}

--- a/plugins/in_opentelemetry/opentelemetry_traces.h
+++ b/plugins/in_opentelemetry/opentelemetry_traces.h
@@ -1,0 +1,41 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_OPENTELEMETRY_TRACES_H
+#define FLB_IN_OPENTELEMETRY_TRACES_H
+
+#include <fluent-bit/flb_input_plugin.h>
+
+int opentelemetry_traces_process_protobuf(struct flb_opentelemetry *ctx,
+                                          flb_sds_t tag,
+                                          size_t tag_len,
+                                          void *data, size_t size);
+
+int opentelemetry_traces_process_raw_traces(struct flb_opentelemetry *ctx,
+                                            flb_sds_t tag,
+                                            size_t tag_len,
+                                            void *data, size_t size);
+
+int opentelemetry_process_traces(struct flb_opentelemetry *ctx,
+                                 flb_sds_t content_type,
+                                 flb_sds_t tag,
+                                 size_t tag_len,
+                                 void *data, size_t size);
+
+#endif

--- a/plugins/in_opentelemetry/opentelemetry_utils.c
+++ b/plugins/in_opentelemetry/opentelemetry_utils.c
@@ -1,0 +1,217 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <ctype.h>
+
+int find_map_entry_by_key(msgpack_object_map *map,
+                          char *key,
+                          size_t match_index,
+                          int case_insensitive)
+{
+    int     result;
+    int     index;
+    int key_len;
+    size_t  match_count;
+
+    if (!key) {
+        return -1;
+    }
+
+    key_len = strlen(key);
+    match_count = 0;
+
+    for (index = 0 ; index < (int) map->size ; index++) {
+        if (key_len != map->ptr[index].key.via.str.size) {
+            continue;
+        }
+
+        if (map->ptr[index].key.type == MSGPACK_OBJECT_STR) {
+            if (case_insensitive) {
+                result = strncasecmp(map->ptr[index].key.via.str.ptr,
+                                     key,
+                                     map->ptr[index].key.via.str.size);
+            }
+            else {
+                result = strncmp(map->ptr[index].key.via.str.ptr,
+                                 key,
+                                 map->ptr[index].key.via.str.size);
+            }
+
+            if (result == 0) {
+                if (match_count == match_index) {
+                    return index;
+                }
+
+                match_count++;
+            }
+        }
+    }
+
+    return -1;
+}
+
+int json_payload_get_wrapped_value(msgpack_object *wrapper,
+                                   msgpack_object **value,
+                                   int            *type)
+{
+    int                 internal_type;
+    msgpack_object     *kv_value;
+    msgpack_object_str *kv_key;
+    msgpack_object_map *map;
+
+    if (wrapper->type != MSGPACK_OBJECT_MAP) {
+        return -1;
+    }
+
+    map = &wrapper->via.map;
+    kv_value = NULL;
+    internal_type = -1;
+
+    if (map->size == 1) {
+        if (map->ptr[0].key.type == MSGPACK_OBJECT_STR) {
+            kv_value = &map->ptr[0].val;
+            kv_key = &map->ptr[0].key.via.str;
+
+            if (strncasecmp(kv_key->ptr, "stringValue",  kv_key->size) == 0 ||
+                strncasecmp(kv_key->ptr, "string_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_STR;
+            }
+            else if (strncasecmp(kv_key->ptr, "boolValue",  kv_key->size) == 0 ||
+                     strncasecmp(kv_key->ptr, "bool_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_BOOLEAN;
+            }
+            else if (strncasecmp(kv_key->ptr, "intValue",  kv_key->size) == 0 ||
+                     strncasecmp(kv_key->ptr, "int_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_POSITIVE_INTEGER;
+            }
+            else if (strncasecmp(kv_key->ptr, "doubleValue",  kv_key->size) == 0 ||
+                     strncasecmp(kv_key->ptr, "double_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_FLOAT;
+            }
+            else if (strncasecmp(kv_key->ptr, "bytesValue",  kv_key->size) == 0 ||
+                     strncasecmp(kv_key->ptr, "bytes_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_BIN;
+            }
+            else if (strncasecmp(kv_key->ptr, "arrayValue",  kv_key->size) == 0 ||
+                     strncasecmp(kv_key->ptr, "array_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_ARRAY;
+            }
+            else if (strncasecmp(kv_key->ptr, "kvlistValue",  kv_key->size) == 0 ||
+                     strncasecmp(kv_key->ptr, "kvlist_value", kv_key->size) == 0) {
+                internal_type = MSGPACK_OBJECT_MAP;
+            }
+        }
+    }
+
+    if (internal_type != -1) {
+        if (type != NULL) {
+            *type  = internal_type;
+        }
+
+        if (value != NULL) {
+            *value = kv_value;
+        }
+
+        if (kv_value->type == MSGPACK_OBJECT_MAP) {
+            map = &kv_value->via.map;
+
+            if (map->size == 1) {
+                kv_value = &map->ptr[0].val;
+                kv_key = &map->ptr[0].key.via.str;
+
+                if (strncasecmp(kv_key->ptr, "values", kv_key->size) == 0) {
+                    if (value != NULL) {
+                        *value = kv_value;
+                    }
+                }
+                else {
+                    return -3;
+                }
+            }
+        }
+    }
+    else {
+        return -2;
+    }
+
+    return 0;
+}
+
+static int hex_to_int(char ch)
+{
+    if (ch >= '0' && ch <= '9') {
+        return ch - '0';
+    }
+
+    if (ch >= 'a' && ch <= 'f') {
+        return ch - 'a' + 10;
+    }
+
+    if (ch >= 'A' && ch <= 'F') {
+        return ch - 'A' + 10;
+    }
+
+    return -1;
+}
+
+/* convert an hex string to the expected id (16 bytes) */
+int hex_to_id(char *str, int len, unsigned char *out_buf, int out_size)
+{
+    int i;
+    int high;
+    int low;
+
+    if (len % 2 != 0) {
+        return -1;
+    }
+
+    for (i = 0; i < len; i += 2) {
+        if (!isxdigit(str[i]) || !isxdigit(str[i + 1])) {
+            return -1;
+        }
+
+        high = hex_to_int(str[i]);
+        low = hex_to_int(str[i + 1]);
+
+        if (high == -1 || low == -1) {
+            return -1;
+        }
+
+        out_buf[i / 2] = (high << 4) | low;
+    }
+
+    return 0;
+}
+
+uint64_t convert_string_number_to_u64(char *str, size_t len)
+{
+    uint64_t val;
+    char tmp[32];
+
+    if (len > sizeof(tmp) - 1) {
+        return 0;
+    }
+
+    memcpy(tmp, str, len);
+    tmp[len] = '\0';
+
+    val = strtoull(tmp, NULL, 10);
+    return val;
+}

--- a/plugins/in_opentelemetry/opentelemetry_utils.h
+++ b/plugins/in_opentelemetry/opentelemetry_utils.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_OPENTELEMETRY_UTILS_H
+#define FLB_IN_OPENTELEMETRY_UTILS_H
+
+#include <fluent-bit/flb_input_plugin.h>
+
+int find_map_entry_by_key(msgpack_object_map *map,
+                          char *key,
+                          size_t match_index,
+                          int case_insensitive);
+
+int json_payload_get_wrapped_value(msgpack_object *wrapper,
+                                   msgpack_object **value,
+                                   int            *type);
+
+int hex_to_id(char *str, int len, unsigned char *out_buf, int out_size);
+uint64_t convert_string_number_to_u64(char *str, size_t len);
+
+#endif


### PR DESCRIPTION
This PR add support to receive Traces in JSON-Otel schema and also upgrades CTraces to v0.6.0

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
