### PR TITLE
bug-fix: Set correct and unique repo meta data

### DIFF
--- a/packaging/update-apt-repo.sh
+++ b/packaging/update-apt-repo.sh
@@ -32,11 +32,16 @@ APTLY_REPO_NAME="debify-$CODENAME"
 APTLY_ROOTDIR=$(mktemp -d)
 APTLY_CONFIG=$(mktemp)
 
-# The origin and label fields seem to cover the base directory for the repo and codename.
-# The docs seems to suggest these fields are optional and free-form: https://wiki.debian.org/DebianRepository/Format#Origin
+# The origin and label fields are free text fields that should indicate the heritage of the package repository.
+# They are used in an unattend-upgrade scenario and therefore they should be unique for each package source.
+# Further information can be found here https://wiki.debian.org/DebianRepository/Format & https://wiki.debian.org/UnattendedUpgrades
+# For fluent-bit a valid apt config entry for unattended upgrades is
+# Unattended-Upgrade::Origins-Pattern {
+#   "origin=packages.fluentbit.io,codename=${distro_codename},label=fluent-bit"
+# }
 # They are security checks to verify if they have changed so we match the legacy server.
-APTLY_ORIGIN=". $CODENAME"
-APTLY_LABEL=". $CODENAME"
+APTLY_ORIGIN="packages.fluentbit.io"
+APTLY_LABEL="fluent-bit"
 if [[ "$DEB_REPO" == "debian/bullseye" ]]; then
     # For Bullseye, the legacy server had a slightly different setup we try to reproduce here
     APTLY_ORIGIN="bullseye bullseye"


### PR DESCRIPTION
When using unattended-upgrades at least the origin meta data in the release file shoulb be unique across all registered package repos in addition it's also good to set the label to something that clearly identifies the software source.

With this commit the published Release file will look like this:

Origin: packages.fluentbit.io
Label: fluent-bit
Suite: bookworm
Codename: bookworm

<!-- Provide summary of changes -->
Add correct meta data to release file

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
n/a
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
