### PR TITLE
internal: add NOT_REGEX operator to conditional processing

### DIFF
--- a/include/fluent-bit/flb_conditionals.h
+++ b/include/fluent-bit/flb_conditionals.h
@@ -47,6 +47,7 @@ enum flb_rule_operator {
     FLB_RULE_OP_GT,
     FLB_RULE_OP_LT,
     FLB_RULE_OP_REGEX,
+    FLB_RULE_OP_NOT_REGEX,
     FLB_RULE_OP_IN,
     FLB_RULE_OP_NOT_IN
 };

--- a/src/flb_conditionals.c
+++ b/src/flb_conditionals.c
@@ -67,6 +67,7 @@ static struct flb_condition_rule *rule_create(const char *field,
     case FLB_RULE_OP_EQ:
     case FLB_RULE_OP_NEQ:
     case FLB_RULE_OP_REGEX:
+    case FLB_RULE_OP_NOT_REGEX:
         if (!value || !((char *)value)[0]) {
             return NULL;
         }
@@ -126,6 +127,7 @@ static struct flb_condition_rule *rule_create(const char *field,
         break;
 
     case FLB_RULE_OP_REGEX:
+    case FLB_RULE_OP_NOT_REGEX:
         rule->regex = flb_regex_create((char *)value);
         if (!rule->regex) {
             flb_cfl_ra_destroy(rule->ra);
@@ -183,6 +185,7 @@ static void rule_destroy(struct flb_condition_rule *rule)
         break;
 
     case FLB_RULE_OP_REGEX:
+    case FLB_RULE_OP_NOT_REGEX:
         if (rule->regex) {
             flb_regex_destroy(rule->regex);
         }
@@ -304,6 +307,12 @@ static int evaluate_rule(struct flb_condition_rule *rule,
         result = (flb_regex_match(rule->regex,
                                   (unsigned char *)str_val,
                                   flb_sds_len(str_val)) > 0);
+        break;
+
+    case FLB_RULE_OP_NOT_REGEX:
+        result = (flb_regex_match(rule->regex,
+                                  (unsigned char *)str_val,
+                                  flb_sds_len(str_val)) <= 0);
         break;
 
     case FLB_RULE_OP_IN:

--- a/tests/internal/conditionals.c
+++ b/tests/internal/conditionals.c
@@ -1166,6 +1166,364 @@ void test_condition_numeric_edge_cases()
     destroy_test_record(record_data);
 }
 
+void test_condition_not_regex()
+{
+    struct test_record *record_data;
+    struct flb_condition *cond;
+    int result;
+
+    /* Test non-matching regex (should return true) */
+    record_data = create_test_record("path", "/other/endpoint");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test matching regex (should return false) */
+    record_data = create_test_record("path", "/api/v1/users");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_FALSE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test empty string (should return true since it doesn't match) */
+    record_data = create_test_record("path", "");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test complex pattern with metacharacters */
+    record_data = create_test_record("path", "/static/image.jpg");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/api/v[0-9]+/.*\\.(json|xml)$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test invalid regex pattern (should fail at rule creation) */
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "[invalid", 0, RECORD_CONTEXT_BODY) == FLB_FALSE);
+
+    flb_condition_destroy(cond);
+}
+
+void test_condition_not_regex_multiple()
+{
+    struct test_record *record_data;
+    struct flb_condition *cond;
+    int result;
+
+    /* Test multiple NOT_REGEX with AND */
+    record_data = create_test_record_with_meta("path", "/static/image.jpg",
+                                             "user_agent", "Mozilla/5.0");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    /* Should NOT match /api/ paths AND NOT match bot user agents */
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$user_agent", FLB_RULE_OP_NOT_REGEX,
+                                    ".*[Bb]ot.*", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* Both conditions should be true */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test NOT_REGEX with OR and other operators */
+    record_data = create_test_record_with_meta("path", "/user/123",
+                                             "method", "POST");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_OR);
+    TEST_CHECK(cond != NULL);
+
+    /* Should match if either:
+     * - path does NOT match admin pattern, OR
+     * - method equals GET
+     */
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/admin/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$method", FLB_RULE_OP_EQ,
+                                    "GET", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* First condition is true */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test complex combination of rules */
+    record_data = create_test_record_with_meta("url", "/api/users/123",
+                                             "status", "404");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    /* Match ALL of:
+     * - url is an API call (does not NOT match /api/)
+     * - status is an error (not 2xx or 3xx)
+     * - url does NOT match static content
+     */
+    TEST_CHECK(flb_condition_add_rule(cond, "$url", FLB_RULE_OP_NOT_REGEX,
+                                    "^/(?!api/).*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$status", FLB_RULE_OP_NOT_REGEX,
+                                    "^[23]\\d{2}$", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$url", FLB_RULE_OP_NOT_REGEX,
+                                    "\\.(jpg|png|gif|css|js)$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* All conditions should be true */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test NOT_REGEX with different contexts */
+    record_data = create_test_record_with_meta("message", "Error occurred",
+                                             "log_level", "ERROR");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    /* Match when:
+     * - Message contains "Error" in body
+     * - Log level in metadata is NOT debug or info
+     */
+    TEST_CHECK(flb_condition_add_rule(cond, "$message", FLB_RULE_OP_REGEX,
+                                    "Error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$log_level", FLB_RULE_OP_NOT_REGEX,
+                                    "^(DEBUG|INFO)$", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test NOT_REGEX with IN and numeric comparisons */
+    record_data = create_test_record_with_meta("path", "/user/profile",
+                                             "response_time", "150");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    const char *paths[] = {"/admin", "/internal", "/system"};
+    double threshold = 200.0;
+
+    /* Match when:
+     * - Path is NOT in restricted list
+     * - Path does NOT match metrics pattern
+     * - Response time is under threshold
+     */
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_IN,
+                                    (void *)paths, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/metrics/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+    TEST_CHECK(flb_condition_add_rule(cond, "$response_time", FLB_RULE_OP_LT,
+                                    &threshold, 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+}
+
+void test_condition_not_regex_border_cases()
+{
+    struct test_record *record_data;
+    struct flb_condition *cond;
+    int result;
+
+    /* Test with Unicode characters */
+    record_data = create_test_record("path", "/api/üser/测试");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^/api/[a-z]+/[a-z]+$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* Should be true since Unicode chars don't match [a-z] */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test with very long input string */
+    char *long_string = flb_malloc(1024);
+    TEST_CHECK(long_string != NULL);
+    memset(long_string, 'a', 1023);
+    long_string[1023] = '\0';
+
+    record_data = create_test_record("path", long_string);
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^a{1024}$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* Should be true since string is 1023 'a's, not 1024 */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+    flb_free(long_string);
+
+    /* Test with only whitespace characters */
+    record_data = create_test_record("path", "   \t   \n   ");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^\\s+$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_FALSE);  /* Should be false since pattern matches whitespace */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test anchored pattern with longer string */
+    record_data = create_test_record("path", "beforeafter");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^before$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* Should be true since "beforeafter" doesn't match "^before$" */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test with backslash characters */
+    record_data = create_test_record("path", "C:\\Windows\\System32\\");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^[A-Z]:\\\\.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_FALSE);  /* Should be false since pattern matches Windows path */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test with repeated pattern */
+    record_data = create_test_record("path", "aaaaa");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "a{4}b", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* Should be true since pattern doesn't match */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test with empty pattern - should fail at creation */
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "", 0, RECORD_CONTEXT_BODY) == FLB_FALSE);
+
+    flb_condition_destroy(cond);
+
+    /* Test with pattern containing only anchors */
+    record_data = create_test_record("path", "");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_FALSE);  /* Should be false since empty string matches ^$ */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Test with non-ASCII pattern */
+    record_data = create_test_record("path", "测试");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+
+    TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
+                                    "^[a-zA-Z]+$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk);
+    TEST_CHECK(result == FLB_TRUE);  /* Should be true since non-ASCII doesn't match [a-zA-Z] */
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+}
+
 TEST_LIST = {
     {"equals", test_condition_equals},
     {"not_equals", test_condition_not_equals},
@@ -1174,6 +1532,9 @@ TEST_LIST = {
     {"in", test_condition_in},
     {"not_in", test_condition_not_in},
     {"regex", test_condition_regex},
+    {"not_regex", test_condition_not_regex},
+    {"not_regex_border_cases", test_condition_not_regex_border_cases},
+    {"not_regex_multiple", test_condition_not_regex_multiple},  /* Added new test */
     {"and", test_condition_and},
     {"or", test_condition_or},
     {"empty", test_condition_empty},


### PR DESCRIPTION
# Description of the change

Fix for #9959 

Implement the NOT_REGEX operator in the conditional evaluation API to support pattern exclusion operations. 

This PR:
- Adds NOT_REGEX to the supported rule operators
- Implements pattern negation functionality
- Add unit tests for NOT_REGEX operator
- Maintains backward compatibility

## Changes to the API

Added NOT_REGEX to the supported rule operators:

```c
enum flb_rule_operator {
    FLB_RULE_OP_EQ,
    FLB_RULE_OP_NEQ,
    FLB_RULE_OP_GT,
    FLB_RULE_OP_LT,
    FLB_RULE_OP_REGEX,
    FLB_RULE_OP_NOT_REGEX,  /* New operator */
    FLB_RULE_OP_IN,
    FLB_RULE_OP_NOT_IN
};
```

## Test Coverage

Added test cases covering:
- Basic NOT_REGEX operations
- Unicode/non-ASCII handling
- Pattern boundary conditions
- Special characters handling
- Empty strings and patterns
- Long string edge cases
- Multiple rules combination
- Border cases

All tests are passing with no memory leaks:
```
Test not_regex...                               [ OK ]
Test not_regex_border_cases...                  [ OK ]
Test not_regex_multiple...                      [ OK ]
```

## Usage Example

```yaml
- type: filter
  condition:
    operator: AND
    rules:
      - field: "$request.path"
        operator: not_regex
        value: "^/api/.*$"
      - field: "$user_agent"
        operator: not_regex
        value: ".*[Bb]ot.*"
```

This filter would match records where:
1. The request path does NOT start with "/api/"
2. The user agent does NOT contain "bot" or "Bot"

## Backward Compatibility

This change:
- Maintains full backward compatibility
- Doesn't modify existing operator behavior
- Adds new functionality without impacting existing configurations
