### PR TITLE
in_splunk: fix memory corruption by resetting parser after reallocation

### DIFF
--- a/plugins/in_splunk/splunk_conn.c
+++ b/plugins/in_splunk/splunk_conn.c
@@ -27,6 +27,41 @@
 static void splunk_conn_request_init(struct mk_http_session *session,
                                      struct mk_http_request *request);
 
+static void splunk_conn_session_init(struct mk_http_session *session,
+                                   struct mk_server *server,
+                                   int client_fd);
+
+static int splunk_conn_buffer_realloc(struct flb_splunk *ctx,
+                                          struct splunk_conn *conn,
+                                          size_t size)
+{
+    char *tmp;
+
+    flb_plg_trace(ctx->ins, "realloc buffer %i -> %zu bytes",
+                  (int)conn->buf_size, size);
+
+    /* Perform realloc */
+    tmp = flb_realloc(conn->buf_data, size);
+    if (!tmp) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "could not perform realloc for size %zu", size);
+        return -1;
+    }
+
+    /* Update buffer info */
+    conn->buf_data = tmp;
+    conn->buf_size = size;
+    /* Keep NULL termination */
+    conn->buf_data[conn->buf_len] = '\0';
+
+    /* Reset parser state */
+    mk_http_parser_init(&conn->session.parser);
+
+    flb_plg_trace(ctx->ins, "realloc completed successfully size=%zu", size);
+    return 0;
+}
+
+
 static int splunk_conn_event(void *data)
 {
     int ret;
@@ -34,7 +69,6 @@ static int splunk_conn_event(void *data)
     size_t size;
     ssize_t available;
     ssize_t bytes;
-    char *tmp;
     size_t request_len;
     struct flb_connection *connection;
     struct splunk_conn *conn;
@@ -42,11 +76,8 @@ static int splunk_conn_event(void *data)
     struct flb_splunk *ctx;
 
     connection = (struct flb_connection *) data;
-
     conn = connection->user_data;
-
     ctx = conn->ctx;
-
     event = &connection->event;
 
     if (event->mask & MK_EVENT_READ) {
@@ -61,16 +92,14 @@ static int splunk_conn_event(void *data)
             }
 
             size = conn->buf_size + ctx->buffer_chunk_size;
-            tmp = flb_realloc(conn->buf_data, size);
-            if (!tmp) {
+            ret = splunk_conn_buffer_realloc(ctx, conn, size);
+            if (ret == -1) {
                 flb_errno();
                 return -1;
             }
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
-            conn->buf_data = tmp;
-            conn->buf_size = size;
             available = (conn->buf_size - conn->buf_len) - 1;
         }
 
@@ -163,8 +192,8 @@ static int splunk_conn_event(void *data)
     }
 
     return 0;
-
 }
+
 
 static void splunk_conn_session_init(struct mk_http_session *session,
                                      struct mk_server *server,


### PR DESCRIPTION
When buffer reallocation occurs in HTTP/1.1 connections, parsed header references become invalid since they point to locations in the old buffer. This causes memory corruption and crashes when later accessing those headers.

Add splunk_conn_realloc_and_reparse() function that:
- Performs buffer reallocation
- Resets parser state

This ensures no dangling pointers exist after reallocation, preventing crashes at the cost of reparsing. A proper fix using offsets instead of pointers will be implemented in mk_http_parser in a future change.

Fixes #9964 

## Testing
See #9964 

```
[ikslabdein@toolbox repro]$ ./main -payload=payload.json -rps=1 -token=AAAA-AAAA-AAAA-AAAA -endpoint=http://localhost:9393/services/collecto
r/event
Response was 200
Response was 200
```
```
record token before: 	{
  SPLUNK_HEC_TOKEN = "Splunk AAAA-AAAA-AAAA-AAAA",
  bytes = 27294,
  datetime = "06/Feb/2025:17:00:54 -0300",
  host = "68.2.73.0",
  method = "HEAD",
  protocol = "HTTP/2.0",
  referer = "http://www.districtportals.com/e-business/strategize/paradigms",
  request = "/engineer/portals/markets/action-items",
  status = 302,
  ["user-identifier"] = "dach3307",
  <metatable> = {
    type = 2
  }
}
record token before: 	{
  SPLUNK_HEC_TOKEN = "Splunk AAAA-AAAA-AAAA-AAAA",
  bytes = 26694,
  datetime = "06/Feb/2025:17:00:54 -0300",
  host = "120.226.22.46",
  method = "PUT",
  protocol = "HTTP/1.0",
  referer = "http://www.forwardinnovate.org/back-end",
  request = "/platforms/e-business/e-commerce",
  status = 500,
  ["user-identifier"] = "emard6662",
  <metatable> = {
    type = 2
  }
}
record token before: 	{
  SPLUNK_HEC_TOKEN = "Splunk AAAA-AAAA-AAAA-AAAA",
  bytes = 27367,
  datetime = "06/Feb/2025:17:00:54 -0300",
  host = "234.88.165.193",
  method = "POST",
  protocol = "HTTP/2.0",
  referer = "http://www.centralweb-readiness.name/e-commerce",
  request = "/roi/e-business",
  status = 204,
  ["user-identifier"] = "-",
  <metatable> = {
    type = 2
  }
}
```

```
[2025/02/20 11:39:47] [debug] [input:splunk:splunk_hec] realloc buffer 2048000 -> 2560000 bytes
[2025/02/20 11:39:47] [debug] [input:splunk:splunk_hec] realloc completed successfully size=2560000
[2025/02/20 11:39:47] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:105] fd=61 buffer realloc 2560000 -> 2560000
[2025/02/20 11:39:47] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:122] read()=512000 pre_len=2047999 now_len=2559999
[2025/02/20 11:39:47] [debug] [input:splunk:splunk_hec] realloc buffer 2560000 -> 3072000 bytes
[2025/02/20 11:39:47] [debug] [input:splunk:splunk_hec] realloc completed successfully size=3072000
[2025/02/20 11:39:47] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:105] fd=61 buffer realloc 3072000 -> 3072000
[2025/02/20 11:39:47] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:122] read()=204439 pre_len=2559999 now_len=2764438
[2025/02/20 11:39:48] [debug] [task] created task=0x7f2270155330 id=0 without routes, dropping.
[2025/02/20 11:39:48] [debug] [task] destroy task=0x7f2270155330 (task_id=0)
[2025/02/20 11:39:48] [debug] [task] created task=0x7f2270155410 id=0 without routes, dropping.
[2025/02/20 11:39:48] [debug] [task] destroy task=0x7f2270155410 (task_id=0)
[2025/02/20 11:39:48] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:117] fd=61 closed connection
[2025/02/20 11:39:48] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:117] fd=60 closed connection
[2025/02/20 11:39:48] [trace] [input:splunk:splunk_hec at /var/home/ikslabdein/code/oss/upstream/plugins/in_splunk/splunk_conn.c:117] fd=59 closed connection

```