### PR TITLE
http input layer: parser realloc fixes (#9970)

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_conn.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_conn.c
@@ -27,13 +27,39 @@
 static void in_elasticsearch_bulk_conn_request_init(struct mk_http_session *session,
                                                     struct mk_http_request *request);
 
+static int elasticsearch_conn_buffer_realloc(struct flb_in_elasticsearch *ctx,
+                                             struct in_elasticsearch_bulk_conn *conn, size_t size)
+{
+    char *tmp;
+
+    /* Perform realloc */
+    tmp = flb_realloc(conn->buf_data, size);
+    if (!tmp) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "could not perform realloc for size %zu", size);
+        return -1;
+    }
+
+    /* Update buffer info */
+    conn->buf_data = tmp;
+    conn->buf_size = size;
+
+    /* Keep NULL termination */
+    conn->buf_data[conn->buf_len] = '\0';
+
+    /* Reset parser state */
+    mk_http_parser_init(&conn->session.parser);
+
+    return 0;
+}
+
 static int in_elasticsearch_bulk_conn_event(void *data)
 {
+    int ret;
     int status;
     size_t size;
     ssize_t available;
     ssize_t bytes;
-    char *tmp;
     size_t request_len;
     struct flb_connection *connection;
     struct in_elasticsearch_bulk_conn *conn;
@@ -60,17 +86,16 @@ static int in_elasticsearch_bulk_conn_event(void *data)
             }
 
             size = conn->buf_size + ctx->buffer_chunk_size;
-            tmp = flb_realloc(conn->buf_data, size);
-            if (!tmp) {
+            ret = elasticsearch_conn_buffer_realloc(ctx, conn, size);
+            if (ret == -1) {
                 flb_errno();
                 in_elasticsearch_bulk_conn_del(conn);
                 return -1;
             }
+
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
-            conn->buf_data = tmp;
-            conn->buf_size = size;
             available = (conn->buf_size - conn->buf_len) - 1;
         }
 

--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -27,62 +27,27 @@
 static void http_conn_request_init(struct mk_http_session *session,
                                    struct mk_http_request *request);
 
-static void check_and_reassign_ptr(char **ptr, const char *old, char *new)
-{
-    if (ptr == NULL) {
-        return;
-    }
-
-    if (*ptr == NULL) {
-        return;
-    }
-
-    *ptr = new + (*ptr - old);
-}
-
-static int http_conn_realloc(struct flb_http *ctx,
-                               struct http_conn *conn,
-                               size_t size)
+static int http_conn_buffer_realloc(struct flb_http *ctx, struct http_conn *conn, size_t size)
 {
     char *tmp;
-    int idx;
-    struct mk_http_header *header;
 
-
+    /* Perform realloc */
     tmp = flb_realloc(conn->buf_data, size);
     if (!tmp) {
         flb_errno();
+        flb_plg_error(ctx->ins, "could not perform realloc for size %zu", size);
         return -1;
     }
-    flb_plg_trace(ctx->ins, "buffer realloc %i -> %zu",
-                    conn->buf_size, size);
 
-    check_and_reassign_ptr(&conn->request.method_p.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.uri.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.uri_processed.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.protocol_p.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.body.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request._content_length.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.content_type.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.connection.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.host.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.host_port.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.if_modified_since.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.last_modified_since.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.range.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.data.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.real_path.data, conn->buf_data, tmp);
-    check_and_reassign_ptr(&conn->request.query_string.data, conn->buf_data, tmp);
-
-    for (idx = conn->session.parser.header_min; idx <= conn->session.parser.header_max && idx >= 0; idx++) {
-        header = &conn->session.parser.headers[idx];
-
-        check_and_reassign_ptr(&header->key.data, conn->buf_data, tmp);
-        check_and_reassign_ptr(&header->val.data, conn->buf_data, tmp);
-    }
-
+    /* Update buffer info */
     conn->buf_data = tmp;
     conn->buf_size = size;
+
+    /* Keep NULL termination */
+    conn->buf_data[conn->buf_len] = '\0';
+
+    /* Reset parser state */
+    mk_http_parser_init(&conn->session.parser);
 
     return 0;
 }
@@ -119,8 +84,9 @@ static int http_conn_event(void *data)
             }
 
             size = conn->buf_size + ctx->buffer_chunk_size;
-            if (http_conn_realloc(ctx, conn, size) == -1) {
+            if (http_conn_buffer_realloc(ctx, conn, size) == -1) {
                 flb_errno();
+                http_conn_del(conn);
                 return -1;
             }
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",

--- a/plugins/in_prometheus_remote_write/prom_rw_conn.c
+++ b/plugins/in_prometheus_remote_write/prom_rw_conn.c
@@ -28,13 +28,40 @@
 static void prom_rw_conn_request_init(struct mk_http_session *session,
                                       struct mk_http_request *request);
 
+
+static int prom_rw_conn_buffer_realloc(struct flb_prom_remote_write *ctx,
+                                       struct prom_remote_write_conn *conn, size_t size)
+{
+    char *tmp;
+
+    /* Perform realloc */
+    tmp = flb_realloc(conn->buf_data, size);
+    if (!tmp) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "could not perform realloc for size %zu", size);
+        return -1;
+    }
+
+    /* Update buffer info */
+    conn->buf_data = tmp;
+    conn->buf_size = size;
+
+    /* Keep NULL termination */
+    conn->buf_data[conn->buf_len] = '\0';
+
+    /* Reset parser state */
+    mk_http_parser_init(&conn->session.parser);
+
+    return 0;
+}
+
 static int prom_rw_conn_event(void *data)
 {
+    int ret;
     int status;
     size_t size;
     ssize_t available;
     ssize_t bytes;
-    char *tmp;
     char *request_end;
     size_t request_len;
     struct prom_remote_write_conn *conn;
@@ -62,16 +89,16 @@ static int prom_rw_conn_event(void *data)
             }
 
             size = conn->buf_size + ctx->buffer_chunk_size;
-            tmp = flb_realloc(conn->buf_data, size);
-            if (!tmp) {
+            ret = prom_rw_conn_buffer_realloc(ctx, conn, size);
+            if (ret == -1) {
                 flb_errno();
+                prom_rw_conn_del(conn);
                 return -1;
             }
+
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
-            conn->buf_data = tmp;
-            conn->buf_size = size;
             available = (conn->buf_size - conn->buf_len) - 1;
         }
 

--- a/plugins/in_splunk/splunk_conn.c
+++ b/plugins/in_splunk/splunk_conn.c
@@ -27,6 +27,41 @@
 static void splunk_conn_request_init(struct mk_http_session *session,
                                      struct mk_http_request *request);
 
+static void splunk_conn_session_init(struct mk_http_session *session,
+                                   struct mk_server *server,
+                                   int client_fd);
+
+static int splunk_conn_buffer_realloc(struct flb_splunk *ctx,
+                                          struct splunk_conn *conn,
+                                          size_t size)
+{
+    char *tmp;
+
+    flb_plg_trace(ctx->ins, "realloc buffer %i -> %zu bytes",
+                  (int)conn->buf_size, size);
+
+    /* Perform realloc */
+    tmp = flb_realloc(conn->buf_data, size);
+    if (!tmp) {
+        flb_errno();
+        flb_plg_error(ctx->ins, "could not perform realloc for size %zu", size);
+        return -1;
+    }
+
+    /* Update buffer info */
+    conn->buf_data = tmp;
+    conn->buf_size = size;
+    /* Keep NULL termination */
+    conn->buf_data[conn->buf_len] = '\0';
+
+    /* Reset parser state */
+    mk_http_parser_init(&conn->session.parser);
+
+    flb_plg_trace(ctx->ins, "realloc completed successfully size=%zu", size);
+    return 0;
+}
+
+
 static int splunk_conn_event(void *data)
 {
     int ret;
@@ -34,7 +69,6 @@ static int splunk_conn_event(void *data)
     size_t size;
     ssize_t available;
     ssize_t bytes;
-    char *tmp;
     size_t request_len;
     struct flb_connection *connection;
     struct splunk_conn *conn;
@@ -42,11 +76,8 @@ static int splunk_conn_event(void *data)
     struct flb_splunk *ctx;
 
     connection = (struct flb_connection *) data;
-
     conn = connection->user_data;
-
     ctx = conn->ctx;
-
     event = &connection->event;
 
     if (event->mask & MK_EVENT_READ) {
@@ -61,16 +92,14 @@ static int splunk_conn_event(void *data)
             }
 
             size = conn->buf_size + ctx->buffer_chunk_size;
-            tmp = flb_realloc(conn->buf_data, size);
-            if (!tmp) {
+            ret = splunk_conn_buffer_realloc(ctx, conn, size);
+            if (ret == -1) {
                 flb_errno();
                 return -1;
             }
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",
                           event->fd, conn->buf_size, size);
 
-            conn->buf_data = tmp;
-            conn->buf_size = size;
             available = (conn->buf_size - conn->buf_len) - 1;
         }
 
@@ -163,8 +192,8 @@ static int splunk_conn_event(void *data)
     }
 
     return 0;
-
 }
+
 
 static void splunk_conn_session_init(struct mk_http_session *session,
                                      struct mk_server *server,

--- a/plugins/in_splunk/splunk_conn.c
+++ b/plugins/in_splunk/splunk_conn.c
@@ -95,6 +95,7 @@ static int splunk_conn_event(void *data)
             ret = splunk_conn_buffer_realloc(ctx, conn, size);
             if (ret == -1) {
                 flb_errno();
+                splunk_conn_del(conn);
                 return -1;
             }
             flb_plg_trace(ctx->ins, "fd=%i buffer realloc %i -> %zu",


### PR DESCRIPTION
backport of #9970

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
