### PR TITLE
out_http: add support for zstd and snappy compression (backport for v3.2)

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -372,6 +372,7 @@ int flb_http_bearer_auth(struct flb_http_client *c,
 int flb_http_set_keepalive(struct flb_http_client *c);
 int flb_http_set_content_encoding_gzip(struct flb_http_client *c);
 int flb_http_set_content_encoding_zstd(struct flb_http_client *c);
+int flb_http_set_content_encoding_snappy(struct flb_http_client *c);
 
 int flb_http_set_callback_context(struct flb_http_client *c,
                                   struct flb_callback *cb_ctx);

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -26,7 +26,11 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_sds.h>
+
 #include <fluent-bit/flb_gzip.h>
+#include <fluent-bit/flb_snappy.h>
+#include <fluent-bit/flb_zstd.h>
+
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <msgpack.h>
@@ -142,13 +146,22 @@ static int http_post(struct flb_out_http *ctx,
     if (ctx->compress_gzip == FLB_TRUE) {
         ret = flb_gzip_compress((void *) body, body_len,
                                 &payload_buf, &payload_size);
-        if (ret == -1) {
-            flb_plg_error(ctx->ins,
-                          "cannot gzip payload, disabling compression");
-        }
-        else {
-            compressed = FLB_TRUE;
-        }
+    }
+    else if (ctx->compress_snappy == FLB_TRUE) {
+        ret = flb_snappy_compress((void *) body, body_len,
+                                  &payload_buf, &payload_size);
+    }
+    else if (ctx->compress_zstd == FLB_TRUE) {
+        ret = flb_zstd_compress((void *) body, body_len,
+                                &payload_buf, &payload_size);
+    }
+
+    if (ret == -1) {
+        flb_plg_warn(ctx->ins, "could not compress payload, sending as it is");
+        compressed = FLB_FALSE;
+    }
+    else {
+        compressed = FLB_TRUE;
     }
 
     /* Create HTTP client context */
@@ -209,7 +222,15 @@ static int http_post(struct flb_out_http *ctx,
 
     /* Content Encoding: gzip */
     if (compressed == FLB_TRUE) {
-        flb_http_set_content_encoding_gzip(c);
+        if (ctx->compress_gzip == FLB_TRUE) {
+            flb_http_set_content_encoding_gzip(c);
+        }
+        else if (ctx->compress_snappy == FLB_TRUE) {
+            flb_http_set_content_encoding_snappy(c);
+        }
+        else if (ctx->compress_zstd == FLB_TRUE) {
+            flb_http_set_content_encoding_zstd(c);
+        }
     }
 
     /* Basic Auth headers */
@@ -697,7 +718,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "compress", NULL,
      0, FLB_FALSE, 0,
-     "Set payload compression mechanism. Option available is 'gzip'"
+     "Set payload compression mechanism. Option available are 'gzip', 'snappy' and 'zstd'"
     },
     {
      FLB_CONFIG_MAP_SLIST_1, "header", NULL,

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -85,6 +85,8 @@ struct flb_out_http {
 
     /* Compression mode (gzip) */
     int compress_gzip;
+    int compress_snappy;
+    int compress_zstd;
 
     /* Allow duplicated headers */
     int allow_dup_headers;

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_record_accessor.h>
+
 #ifdef FLB_HAVE_SIGNV4
 #ifdef FLB_HAVE_AWS
 #include <fluent-bit/flb_aws_credentials.h>
@@ -257,6 +258,17 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
     if (tmp) {
         if (strcasecmp(tmp, "gzip") == 0) {
             ctx->compress_gzip = FLB_TRUE;
+        }
+        else if (strcasecmp(tmp, "snappy") == 0) {
+            ctx->compress_snappy = FLB_TRUE;
+        }
+        else if (strcasecmp(tmp, "zstd") == 0) {
+            ctx->compress_zstd = FLB_TRUE;
+        }
+        else {
+            flb_plg_error(ctx->ins, "invalid compress option '%s'", tmp);
+            flb_free(ctx);
+            return NULL;
         }
     }
 

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1124,6 +1124,17 @@ int flb_http_set_content_encoding_zstd(struct flb_http_client *c)
     return ret;
 }
 
+int flb_http_set_content_encoding_snappy(struct flb_http_client *c)
+{
+    int ret;
+
+    ret = flb_http_add_header(c,
+                              FLB_HTTP_HEADER_CONTENT_ENCODING,
+                              sizeof(FLB_HTTP_HEADER_CONTENT_ENCODING) - 1,
+                              "snappy", 6);
+    return ret;
+}
+
 int flb_http_set_callback_context(struct flb_http_client *c,
                                   struct flb_callback *cb_ctx)
 {


### PR DESCRIPTION
Backport of #9979 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
