### PR TITLE
log: increase precision in log's timestamp to nanoseconds

### DIFF
--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -32,6 +32,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_worker.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_time.h>
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
 
@@ -673,13 +674,13 @@ int flb_log_construct(struct log_message *msg, int *ret_len,
     int ret;
     int len;
     int total;
-    time_t now;
     const char *header_color = NULL;
     const char *header_title;
     const char *bold_color = ANSI_BOLD;
     const char *reset_color = ANSI_RESET;
     struct tm result;
     struct tm *current;
+    struct flb_time now;
 
     switch (type) {
     case FLB_LOG_HELP:
@@ -718,8 +719,8 @@ int flb_log_construct(struct log_message *msg, int *ret_len,
     }
     #endif // FLB_LOG_NO_CONTROL_CHARS
 
-    now = time(NULL);
-    current = localtime_r(&now, &result);
+    flb_time_get(&now);
+    current = localtime_r(&now.tm.tv_sec, &result);
 
     if (current == NULL) {
         return -1;
@@ -727,7 +728,7 @@ int flb_log_construct(struct log_message *msg, int *ret_len,
 
     header_title = flb_log_message_type_str(type);
     len = snprintf(msg->msg, sizeof(msg->msg) - 1,
-                   "%s[%s%i/%02i/%02i %02i:%02i:%02i%s]%s [%s%5s%s] ",
+                   "%s[%s%i/%02i/%02i %02i:%02i:%02i.%03ld%s]%s [%s%5s%s] ",
                    /*      time     */                    /* type */
 
                    /* time variables */
@@ -738,6 +739,7 @@ int flb_log_construct(struct log_message *msg, int *ret_len,
                    current->tm_hour,
                    current->tm_min,
                    current->tm_sec,
+                   now.tm.tv_nsec,
                    bold_color, reset_color,
 
                    /* type format */


### PR DESCRIPTION
Adds nanoseconds precision to the logs Fluent Bit writes.

It's possible in some cases that the underlying implementation of the time functions won't provide nanoseconds precision. In those cases, the precision will be to microseconds, which is still better than to the second. (see [here](https://github.com/fluent/fluent-bit/pull/9985#issuecomment-2859018751))

Addresses #9983


<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
