### PR TITLE
out_http: Allow disabling http 2xx logs

### DIFF
--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -338,16 +338,18 @@ static int http_request(struct flb_out_http *ctx,
             }
         }
         else {
-            if (ctx->log_response_payload &&
-                c->resp.payload && c->resp.payload_size > 0) {
-                flb_plg_info(ctx->ins, "%s:%i, HTTP status=%i\n%s",
-                             ctx->host, ctx->port,
-                             c->resp.status, c->resp.payload);
-            }
-            else {
-                flb_plg_info(ctx->ins, "%s:%i, HTTP status=%i",
-                             ctx->host, ctx->port,
-                             c->resp.status);
+            if (ctx->log_2xx_successes) {
+                if (ctx->log_response_payload &&
+                    c->resp.payload && c->resp.payload_size > 0) {
+                    flb_plg_info(ctx->ins, "%s:%i, HTTP status=%i\n%s",
+                                ctx->host, ctx->port,
+                                c->resp.status, c->resp.payload);
+                }
+                else {
+                    flb_plg_info(ctx->ins, "%s:%i, HTTP status=%i",
+                                ctx->host, ctx->port,
+                                c->resp.status);
+                }
             }
         }
     }
@@ -705,6 +707,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "log_response_payload", "true",
      0, FLB_TRUE, offsetof(struct flb_out_http, log_response_payload),
      "Specify if the response paylod should be logged or not"
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "log_2xx_successes", "true",
+     0, FLB_TRUE, offsetof(struct flb_out_http, log_2xx_successes),
+     "Specify if HTTP 2xx responses should be logged or not"
     },
     {
      FLB_CONFIG_MAP_TIME, "http.response_timeout", "60s",

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -645,6 +645,8 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
     (void) i_ins;
 
     if (ctx->body_key) {
+        /* If the HTTP body is pulled out of the record via a key, one request
+           must be done per record */
         ret = send_all_requests(ctx, event_chunk->data, event_chunk->size,
                                 ctx->body_key, ctx->headers_key, event_chunk);
         if (ret < 0) {
@@ -653,6 +655,7 @@ static void cb_http_flush(struct flb_event_chunk *event_chunk,
         }
     }
     else {
+        /* Otherwise, the whole chunk can be sent */
         ret = compose_payload(ctx, event_chunk->data, event_chunk->size,
                               &out_body, &out_size, config);
         if (ret != FLB_OK) {

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -100,6 +100,9 @@ struct flb_out_http {
     /* Log the response paylod */
     int log_response_payload;
 
+    /* Whether 200 OK etc results should be logged or not */
+    int log_2xx_successes;
+
     /* Response timeout */
     int response_timeout;
 

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -113,6 +113,10 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
         }
     }
 
+    if (ctx->log_response_payload && !ctx->log_2xx_successes) {
+        flb_plg_warn(ctx->ins, "log_response_payload is enabled but log_2xx_successes is disabled - response payloads from 2xx reponses won't be logged");
+    }
+
     /*
      * Check if a Proxy have been set, if so the Upstream manager will use
      * the Proxy end-point and then we let the HTTP client know about it, so


### PR DESCRIPTION
Adds an option to disable log messages for HTTP 2xx responses

As a point of comparison, Fluent Forward egress doesn't log every time it egresses something - but in a busy system using http outputs, fluentbit ends up logging a huge amount because of this 2xx log line during normal operation.
The default has been set such that the logging is still on by default, which should make this a backwards-compatible change.

**Testing**

Will try update the PR with these things soon:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

I imagine this will need a docs update. Happy to raise one after getting an initial review on this PR to indicate it's a change you're happy to merge.
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.
Can probably afford for this not to be backported unless others really want it

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable/disable logging of HTTP 2xx success responses (defaults to enabled).
  * Updated logging behavior: 2xx responses are recorded only when the new option is enabled.
  * Added a runtime warning when payload-logging is enabled but 2xx success logging is disabled, clarifying that 2xx response payloads will not be recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->