### PR TITLE
internal: test: conditional: Add Byte-Order-Mark(BOM) for non western Windows environments

### DIFF
--- a/tests/internal/conditionals.c
+++ b/tests/internal/conditionals.c
@@ -1,4 +1,4 @@
-#include <fluent-bit/flb_info.h>
+﻿#include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_sds.h>


### PR DESCRIPTION
In non-Western Windows environment, especially cp932 (Shift-JIS) environment of Windows, cl.exe complains continuous lines but this should be caused character encoding glitches.
This should be fixed by BOM at the top of the source files. This issue should be happened if the files contain non-ASCII characters such as AccsantGrave or other symbols or multibytes characters could cause this type of issue.

<!-- Provide summary of changes -->

```
[ 98%] Building C object tests/internal/CMakeFiles/flb-it-conditionals.dir/conditionals.c.obj
conditionals.c
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(905): warning C4819: ファイルは、現在のコード  ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1384): error C2001: 定数が 2 行目に続いています。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1385): error C2146: 構文エラー: ')' が、識別子 'acutest_check_' の前に必要です。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1511): error C2001: 定数が 2 行目に続いています。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1512): error C2146: 構文エラー: ')' が、識別子 'acutest_check_' の前に必要です。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1799): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1800): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1801): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1802): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1803): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1804): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1805): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1806): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1807): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1808): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1809): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1810): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1811): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1812): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1813): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1814): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1815): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1816): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1817): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(1818): warning C4113: 'void (__cdecl *)()' はパラメーター リストが 'void (__cdecl *)(void)' と異なります。
NMAKE : fatal error U1077: '"C:\Program Files\CMake\bin\cmake.exe" -E cmake_cl_compile_depends --dep-file=CMakeFiles\flb-it-conditionals.dir\conditionals.c.obj.d --working-dir=C:\Users\cosmo\Documents\GitHub\fluent-bit\build\tests\internal --filter-prefix="メモ: インクルード ファイル:  " -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe @C:\Users\cosmo\AppData\Local\Temp\nm1458.tmp' : リターン コード '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\HostX64\x64\nmake.exe" -s -f tests\internal\CMakeFiles\flb-it-conditionals.dir\build.make /nologo -SL                 tests\internal\CMakeFiles\flb-it-conditionals.dir\build' : リターン コード '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\HostX64\x64\nmake.exe" -s -f CMakeFiles\Makefile2 /nologo -LS                 all' : リターン コード '0x2'
Stop.
```

This compiling error is caused by:

https://github.com/fluent/fluent-bit/blob/master/tests/internal/conditionals.c#L1384
```c
    record_data = create_test_record("path", "/api/üser/测试");
```

In addition, cp932 Windows environment does not recognize UTF-8 by default.
With this behavior, the following error which is including the above error log is sometimes happening:

```
C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\internal\conditionals.c(905): warning C4819: ファイルは、現在のコード  ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください。
```

To suppress this type of errors, we need to put BOM at the first bytes of the files which contains non-ASCII characters.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
