### PR TITLE
input_chunk: restrict appending chunks greater than size limit

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -230,7 +230,8 @@ struct flb_config {
     int   storage_del_bad_chunks;   /* delete irrecoverable chunks */
     char *storage_bl_mem_limit;     /* storage backlog memory limit */
     struct flb_storage_metrics *storage_metrics_ctx; /* storage metrics context */
-    int   storage_trim_files;       /* enable/disable file trimming */
+    int    storage_trim_files;       /* enable/disable file trimming */
+    size_t storage_chunk_max_size;   /* The max size for a chunk in bytes */
 
     /* Embedded SQL Database support (SQLite3) */
 #ifdef FLB_HAVE_SQLDB
@@ -358,15 +359,16 @@ enum conf_type {
 #define FLB_CONF_DNS_PREFER_IPV6       "dns.prefer_ipv6"
 
 /* Storage / Chunk I/O */
-#define FLB_CONF_STORAGE_PATH          "storage.path"
-#define FLB_CONF_STORAGE_SYNC          "storage.sync"
-#define FLB_CONF_STORAGE_METRICS       "storage.metrics"
-#define FLB_CONF_STORAGE_CHECKSUM      "storage.checksum"
-#define FLB_CONF_STORAGE_BL_MEM_LIMIT  "storage.backlog.mem_limit"
-#define FLB_CONF_STORAGE_MAX_CHUNKS_UP "storage.max_chunks_up"
+#define FLB_CONF_STORAGE_PATH           "storage.path"
+#define FLB_CONF_STORAGE_SYNC           "storage.sync"
+#define FLB_CONF_STORAGE_METRICS        "storage.metrics"
+#define FLB_CONF_STORAGE_CHECKSUM       "storage.checksum"
+#define FLB_CONF_STORAGE_BL_MEM_LIMIT   "storage.backlog.mem_limit"
+#define FLB_CONF_STORAGE_MAX_CHUNKS_UP  "storage.max_chunks_up"
 #define FLB_CONF_STORAGE_DELETE_IRRECOVERABLE_CHUNKS \
                                        "storage.delete_irrecoverable_chunks"
-#define FLB_CONF_STORAGE_TRIM_FILES    "storage.trim_files"
+#define FLB_CONF_STORAGE_TRIM_FILES     "storage.trim_files"
+#define FLB_CONF_STORAGE_CHUNK_MAX_SIZE "storage.chunk_max_size"
 
 /* Coroutines */
 #define FLB_CONF_STR_CORO_STACK_SIZE "Coro_Stack_Size"

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -154,6 +154,9 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STORAGE_TRIM_FILES,
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, storage_trim_files)},
+    {FLB_CONF_STORAGE_CHUNK_MAX_SIZE,
+     FLB_CONF_TYPE_INT,
+     offsetof(struct flb_config, storage_chunk_max_size)},
 
     /* Coroutines */
     {FLB_CONF_STR_CORO_STACK_SIZE,
@@ -278,6 +281,7 @@ struct flb_config *flb_config_init()
     config->storage_path = NULL;
     config->storage_input_plugin = NULL;
     config->storage_metrics = FLB_TRUE;
+    config->storage_chunk_max_size = FLB_INPUT_CHUNK_FS_MAX_SIZE;
 
     config->sched_cap  = FLB_SCHED_CAP;
     config->sched_base = FLB_SCHED_BASE;

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1142,7 +1142,13 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
     }
 
     if (id >= 0) {
-        if (ic->busy == FLB_TRUE || cio_chunk_is_locked(ic->chunk)) {
+        /*
+         * If the chunk is busy, locked, or does not have room for the new
+         * data, force the creation of a new chunk.
+         */
+        if (ic->busy == FLB_TRUE || cio_chunk_is_locked(ic->chunk) ||
+            (flb_input_chunk_get_real_size(ic) + chunk_size) > \
+                in->config->storage_chunk_max_size) {
             ic = NULL;
         }
         else if (cio_chunk_is_up(ic->chunk) == CIO_FALSE) {
@@ -1679,8 +1685,8 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
         real_diff = 0;
     }
 
-    /* Lock buffers where size > 2MB */
-    if (content_size > FLB_INPUT_CHUNK_FS_MAX_SIZE) {
+    /* Lock buffers where size > chunk max size */
+    if (content_size > in->config->storage_chunk_max_size) {
         cio_chunk_lock(ic->chunk);
     }
 
@@ -1747,8 +1753,8 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
             content_size = cio_chunk_get_content_size(ic->chunk);
 
             /* Do we have less than 1% available ? */
-            min = (FLB_INPUT_CHUNK_FS_MAX_SIZE * 0.01);
-            if (FLB_INPUT_CHUNK_FS_MAX_SIZE - content_size < min) {
+            min = (in->config->storage_chunk_max_size * 0.01);
+            if (in->config->storage_chunk_max_size - content_size < min) {
                 cio_chunk_down(ic->chunk);
             }
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR is a second attempt at restricting input chunk sizes by splitting up input buffers in `input_log_append` based on the chunk max size. It also adds a companion configuration option `storage.chunk_max_size` to configure the max chunk size.

Detailed information can be found in the companion gist I wrote, which contains explanations of this solution, the other solutions I tried that failed, and testing methodology. https://gist.github.com/braydonk/f32256488e989c4e807b0f9ba69bebbb

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Issues: #9374, #1938

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
