### PR TITLE
security update: CVE-2024-50608 and CVE-2024-50609 (v3.1)

### DIFF
--- a/plugins/in_prometheus_remote_write/prom_rw_prot.c
+++ b/plugins/in_prometheus_remote_write/prom_rw_prot.c
@@ -345,6 +345,13 @@ int prom_rw_prot_handle(struct flb_prom_remote_write *ctx,
         return -1;
     }
 
+    if (request->data.data == NULL || request->data.len <= 0) {
+        flb_sds_destroy(tag);
+        mk_mem_free(uri);
+        send_response(ctx->ins, conn, 400, "error: no payload found\n");
+        return -1;
+    }
+
     original_data = request->data.data;
     original_data_size = request->data.len;
 
@@ -466,13 +473,22 @@ int prom_rw_prot_handle_ng(struct flb_http_request *request,
     /* HTTP/1.1 needs Host header */
     if (request->protocol_version == HTTP_PROTOCOL_HTTP1 &&
         request->host == NULL) {
-
         return -1;
     }
 
     if (request->method != HTTP_METHOD_POST) {
         send_response_ng(response, 400, "error: invalid HTTP method\n");
+        return -1;
+    }
 
+    /* check content-length */
+    if (request->content_length <= 0) {
+        send_response_ng(response, 400, "error: invalid content-length\n");
+        return -1;
+    }
+
+    if (request->body == NULL) {
+        send_response_ng(response, 400, "error: invalid payload\n");
         return -1;
     }
 


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit/pull/9993

Provides fixes for OpenTelemetry and Prometheus Remote Write inputs associated to:

https://github.com/advisories/GHSA-x9j4-33qm-hgjp
https://github.com/advisories/GHSA-4g89-mg9x-4chc

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
