### PR TITLE
workflows: pin QEMU version for Raspbian only

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -105,8 +105,7 @@ jobs:
   call-build-linux-packages:
     name: ${{ matrix.distro }} package build and stage to S3
     environment: ${{ inputs.environment }}
-    # Ensure for OSS Fluent Bit repo we enable usage of Actuated runners for ARM builds, for forks it should keep existing ubuntu-22.04 usage.
-    runs-on: ${{ ((contains(matrix.distro, 'arm' ) || contains(matrix.distro, 'raspbian')) && (github.repository == 'fluent/fluent-bit') && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
+    runs-on: ${{ ((contains(matrix.distro, 'arm' ) || contains(matrix.distro, 'raspbian')) && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     permissions:
       contents: read
     strategy:
@@ -122,6 +121,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      # Raspbian requires ARMv6 emulation
+      - name: Set up QEMU
+        if: contains(matrix.distro, 'raspbian')
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28 # See: https://github.com/docker/setup-qemu-action/issues/198#issuecomment-2653791775
 
       - name: Replace all special characters with dashes
         id: formatted_distro
@@ -212,6 +218,7 @@ jobs:
     environment: ${{ inputs.environment }}
     needs:
       - call-build-linux-packages
+    continue-on-error: ${{ inputs.ignore_failing_targets || false }}
     steps:
       - name: Install dependencies
         timeout-minutes: 10


### PR DESCRIPTION
Resolves #9941 failures with Raspbian builds missing QEMU due to https://github.com/fluent/fluent-bit/pull/9931

See https://github.com/docker/setup-qemu-action/issues/198 and https://github.com/tonistiigi/binfmt/issues/240 which both suggest we have to pin QEMU version now for all runners from ubuntu 22+ (all of them basically).

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [X] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
