### PR TITLE
out_loki: add stuctured_metadata_map_keys (3.2.x Backport)

### DIFF
--- a/docker_compose/loki-grafana-structured_metadata_map/README.md
+++ b/docker_compose/loki-grafana-structured_metadata_map/README.md
@@ -1,0 +1,15 @@
+### Description
+
+This directory has a docker-compose file and its
+configuration required to run:
+
+1) A fluentbit installation with a dummy input, and Loki output configured for `structured_metadata_map_keys`
+3) A Loki installation 
+4) A grafana installation with a default Loki datasource
+
+To run this, execute:
+
+$ docker-compose up --force-recreate -d
+
+n.b., the [docker compose file](./docker-compose.yml) contains an `image` and a commented out `build` section. Change
+these to build from local source.

--- a/docker_compose/loki-grafana-structured_metadata_map/config/fluent-bit_loki_out-structured_metadata_map.yaml
+++ b/docker_compose/loki-grafana-structured_metadata_map/config/fluent-bit_loki_out-structured_metadata_map.yaml
@@ -1,0 +1,36 @@
+service:
+  log_level: debug
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: logs
+      dummy: |
+        {
+          "message": "simple log generated",
+          "logger": "my.logger",
+          "level": "INFO",
+          "hostname": "localhost",
+          "my_map_of_attributes_1": {
+            "key_1": "hello, world!",
+            "key_2": "goodbye, world!"
+          },
+          "my_map_of_maps_1": {
+            "root_key": {
+              "sub_key_1": "hello, world!",
+              "sub_key_2": "goodbye, world!"
+            }
+          }
+        }
+
+  outputs:
+    - name: loki
+      match: logs
+      host: loki
+      remove_keys: hostname,my_map_of_attributes_1,my_map_of_maps_1
+      label_keys: $level,$logger
+      labels: service_name=test
+      structured_metadata: $hostname
+      structured_metadata_map_keys: $my_map_of_attributes_1,$my_map_of_maps_1['root_key']
+      line_format: key_value
+      drop_single_key: on

--- a/docker_compose/loki-grafana-structured_metadata_map/config/grafana/provisioning/datasources/datasource.yml
+++ b/docker_compose/loki-grafana-structured_metadata_map/config/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,20 @@
+# config file version
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources:
+  - name: Loki
+    orgId: 1
+
+# list of datasources to insert/update depending
+# whats available in the database
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false

--- a/docker_compose/loki-grafana-structured_metadata_map/config/loki-config.yaml
+++ b/docker_compose/loki-grafana-structured_metadata_map/config/loki-config.yaml
@@ -1,0 +1,53 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true

--- a/docker_compose/loki-grafana-structured_metadata_map/docker-compose.yml
+++ b/docker_compose/loki-grafana-structured_metadata_map/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  fluentbit:
+# Comment out `image` and uncomment `build` to build the fluent-bit image from local source
+    image: fluent/fluent-bit:latest
+#    build:
+#      context: ../../
+#      dockerfile: dockerfiles/Dockerfile
+    depends_on:
+      - loki
+    container_name: fluentbit
+    command: /fluent-bit/bin/fluent-bit -c /etc/fluent-bit_loki_out-structured_metadata_map.yaml
+    ports:
+      - 2021:2021
+    networks:
+      - loki-network
+    volumes:
+      - ./config/fluent-bit_loki_out-structured_metadata_map.yaml:/etc/fluent-bit_loki_out-structured_metadata_map.yaml
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    depends_on:
+      - loki
+      - fluentbit
+    ports:
+      - 3000:3000
+    volumes:
+      - ./config/grafana/provisioning:/etc/grafana/provisioning
+    networks:
+      - loki-network
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+
+  loki:
+    image: grafana/loki:2.9.2
+    command: -config.file=/etc/loki/loki-config.yaml
+    networks:
+      - loki-network
+    ports:
+      - 3100:3100
+    volumes:
+      - ./config/loki-config.yaml:/etc/loki/loki-config.yaml
+
+networks:
+  loki-network:
+    driver: bridge

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -78,6 +78,7 @@ struct flb_loki {
     struct mk_list *labels;
     struct mk_list *label_keys;
     struct mk_list *structured_metadata;
+    struct mk_list *structured_metadata_map_keys;
     struct mk_list *remove_keys;
 
     flb_sds_t label_map_path;
@@ -87,13 +88,14 @@ struct flb_loki {
     char *tcp_host;
     int out_line_format;
     int out_drop_single_key;
-    int ra_used;                             /* number of record accessor label keys */
-    struct flb_record_accessor *ra_k8s;      /* kubernetes record accessor */
-    struct mk_list labels_list;              /* list of flb_loki_kv nodes */
-    struct mk_list structured_metadata_list; /* list of flb_loki_kv nodes */
-    struct mk_list remove_keys_derived;      /* remove_keys with label RAs */
+    int ra_used;                           /* number of record accessor label keys */
+    struct flb_record_accessor *ra_k8s;              /* kubernetes record accessor */
+    struct mk_list labels_list;                       /* list of flb_loki_kv nodes */
+    struct mk_list structured_metadata_list;          /* list of flb_loki_kv nodes */
+    struct mk_list structured_metadata_map_keys_list; /* list of flb_loki_kv nodes */
+    struct mk_list remove_keys_derived;              /* remove_keys with label RAs */
     struct flb_mp_accessor *remove_mpa;      /* remove_keys multi-pattern accessor */
-    struct flb_record_accessor *ra_tenant_id_key; /* dynamic tenant id key */
+    struct flb_record_accessor *ra_tenant_id_key;         /* dynamic tenant id key */
 
     struct cfl_list dynamic_tenant_list;
     pthread_mutex_t dynamic_tenant_list_lock;


### PR DESCRIPTION
Resolves https://github.com/fluent/fluent-bit/issues/9463

* Adds stuctured_metadata_map_keys config to dynamically populate stuctured_metadata from a map

This is a PR to backport #9530 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1527

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
