### PR TITLE
mp: fix `flb_mp_accessor_keys_remove` for sibling keys removal

### DIFF
--- a/tests/internal/mp.c
+++ b/tests/internal/mp.c
@@ -232,6 +232,107 @@ void test_keys_remove_subkey_key()
 
 }
 
+void test_remove_sibling_subkeys()
+{
+    int len;
+    int ret;
+    int type;
+    size_t off = 0;
+    char *buf;
+    size_t size;
+    char *out_buf;
+    size_t out_size;
+    char *json;
+    char final_json[2048] = {0};
+    msgpack_unpacked result;
+    msgpack_unpacked result_final;
+    msgpack_object map;
+    struct flb_mp_accessor *mpa;
+    struct mk_list patterns;
+
+    /* Sample JSON message */
+    json =
+        "{"
+        "\"kubernetes\": {"
+            "\"pod_id\": \"id\","
+            "\"pod_name\": \"name\","
+            "\"host\": \"localhost\","
+            "\"labels\": {"
+                "\"app\": \"myapp\","
+                "\"tier\": \"backend\""
+            "}"
+        "},"
+        "\"msg\": \"kernel panic\""
+        "}";
+
+    /* Convert to msgpack */
+    len = strlen(json);
+    ret = flb_pack_json(json, len, &buf, &size, &type, NULL);
+    TEST_CHECK(ret == 0);
+    if (ret == -1) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Unpack the content */
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, buf, size, &off);
+    map = result.data;
+
+    /* Create list of patterns */
+    flb_slist_create(&patterns);
+
+    /* sub key -> key */
+    flb_slist_add(&patterns, "$kubernetes['pod_name']");
+    flb_slist_add(&patterns, "$kubernetes['foo']");
+    flb_slist_add(&patterns, "$kubernetes['pod_id']");
+    flb_slist_add(&patterns, "$kubernetes['labels']['tier']");
+    flb_slist_add(&patterns, "$time");
+
+
+    /* Create mp accessor */
+    mpa = flb_mp_accessor_create(&patterns);
+    TEST_CHECK(mpa != NULL);
+
+    /* Remove the entry that matches the pattern(s) */
+    ret = flb_mp_accessor_keys_remove(mpa, &map, (void *) &out_buf, &out_size);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    printf("\n=== ORIGINAL  ===\n");
+    flb_pack_print(buf, size);
+    flb_free(buf);
+
+    printf("=== FINAL MAP ===\n");
+    if (ret == FLB_TRUE) {
+        flb_pack_print(out_buf, out_size);
+    }
+    msgpack_unpacked_destroy(&result);
+
+    off = 0;
+    msgpack_unpacked_init(&result_final);
+    msgpack_unpack_next(&result_final, out_buf, out_size, &off);
+    flb_msgpack_to_json(&final_json[0], sizeof(final_json), &result_final.data);
+
+    if (!TEST_CHECK(strstr(&final_json[0] ,"pod_id") == NULL)) {
+        TEST_MSG("pod_id field should be removed");
+    }
+    if (!TEST_CHECK(strstr(&final_json[0] ,"pod_name") == NULL)) {
+        TEST_MSG("pod_name field should be removed");
+    }
+    if (!TEST_CHECK(strstr(&final_json[0] ,"tier") == NULL)) {
+        TEST_MSG("tier field should be removed");
+    }
+    if (!TEST_CHECK(strstr(&final_json[0] ,"app") != NULL)) {
+        TEST_MSG("app field should not be removed");
+    }
+
+    msgpack_unpacked_destroy(&result_final);
+
+    flb_free(out_buf);
+    flb_mp_accessor_destroy(mpa);
+    flb_slist_destroy(&patterns);
+
+}
+
 void remove_subkey_keys(char *list[], int list_size, int index_start)
 {
     int len;
@@ -444,5 +545,6 @@ TEST_LIST = {
     {"accessor_keys_remove_subkey_key" , test_keys_remove_subkey_key},
     {"accessor_keys_remove_subkey_keys" , test_keys_remove_subkey_keys},
     {"object_to_cfl_to_msgpack" , test_object_to_cfl_to_msgpack},
+    {"test_remove_sibling_subkeys" , test_remove_sibling_subkeys},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes #9091

The PR aims to make `flb_mp_accessor_keys_remove` work for sibling subkeys.
The existing versions of the function can only remove one (the first) subkey of a given key. This method is used by several output plugins including `loki` which my team uses. We noticed that not all keys are removed from log records when there are multiple subkeys specified.

A good example is provided in the added unit test, but here is another example of existing behaviour the PR is fixing.

Payload:
```json
{
    "kubernetes": {
        "pod_id": "id",
        "pod_name": "name",
        "host": "localhost"
    },
    "msg": "foo"
}
```

Accessor keys to remove:
```
"$kubernetes['pod_name']"
"$kubernetes['pod_id']"
```

Will result in only `pod_name` being removed. I.e.:

```json
{
    "kubernetes": {
        "pod_id": "id",
        "host": "localhost"
    },
    "msg": "foo"
}
```

With the PR change the output will be:

```json
{
    "kubernetes": {
        "host": "localhost"
    },
    "msg": "foo"
}
```

<details>
<summary>Valgrind output for unit tests</summary>
<pre>
==32115== Memcheck, a memory error detector
==32115== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32115== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==32115== Command: ./bin/flb-it-mp
==32115== Parent PID: 32050
==32115== 
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== Conditional jump or move depends on uninitialised value(s)
==32115==    at 0x483BC98: strlen (vg_replace_strmem.c:459)
==32115==    by 0x4EA3C27: __vfprintf_internal (vfprintf-internal.c:1647)
==32115==    by 0x4E8ED75: fprintf (fprintf.c:32)
==32115==    by 0x330EB6: cfl_variant_print (cfl_variant.c:44)
==32115==    by 0x326272: cfl_kvlist_print (cfl_kvlist.c:451)
==32115==    by 0x331053: cfl_variant_print (cfl_variant.c:81)
==32115==    by 0x326272: cfl_kvlist_print (cfl_kvlist.c:451)
==32115==    by 0x331053: cfl_variant_print (cfl_variant.c:81)
==32115==    by 0x32D91A: cfl_array_print (cfl_array.c:441)
==32115==    by 0x331037: cfl_variant_print (cfl_variant.c:77)
==32115==    by 0x326272: cfl_kvlist_print (cfl_kvlist.c:451)
==32115==    by 0x331053: cfl_variant_print (cfl_variant.c:81)
==32115== 
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== Warning: invalid file descriptor -1 in syscall close()
==32115== 
==32115== HEAP SUMMARY:
==32115==     in use at exit: 0 bytes in 0 blocks
==32115==   total heap usage: 8,107 allocs, 8,107 frees, 2,438,380 bytes allocated
==32115== 
==32115== All heap blocks were freed -- no leaks are possible
==32115== 
==32115== Use --track-origins=yes to see where uninitialised values come from
==32115== For lists of detected and suppressed errors, rerun with: -s
==32115== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
</pre>
</details>

<details>
<summary>Valgrind output for main binary (with config)</summary>

<pre>
[SERVICE]
    flush     1
    log_level info

[INPUT]
    name      dummy
    dummy     {"logType":"UFL","location":"location","runInfo":{},"message":"test","kubernetes":{"container_name":"test","pod_id":"e900ac60-70eb-4f0c-872a-7127884ccf45","host":"ip-10-193-25-96.ec2.internal","pod_name":"b59ce932-f732-49e3-bb89-f15a3908f096-cqktm","annotations":{"connector-schema-name":"schema","connector-detail":"Ft/Group/postgres_rds/schema"}}}
    samples   1

[OUTPUT]
    name                 loki
    match                *
    host                 localhost
    port                 8000
    line_format          json
    labels               source=fluent-bit
    structured_metadata  pod_name=$kubernetes['pod_name'],foo=$kubernetes['foo'],schema=$kubernetes['annotations']['connector-schema-name'],pod_id=$kubernetes['pod_id']
    remove_keys          _p
    drop_single_key      off
</pre>

<pre>
==32110== Memcheck, a memory error detector
==32110== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32110== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==32110== Command: ./bin/fluent-bit -c /home/arkady/simplified-config.conf
==32110== Parent PID: 32050
==32110== 
==32110== 
==32110== HEAP SUMMARY:
==32110==     in use at exit: 0 bytes in 0 blocks
==32110==   total heap usage: 3,679 allocs, 3,679 frees, 1,116,370 bytes allocated
==32110== 
==32110== All heap blocks were freed -- no leaks are possible
==32110== 
==32110== For lists of detected and suppressed errors, rerun with: -s
==32110== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
</pre>
</details>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
