### PR TITLE
in_opentelemetry: fix groups encoding by closing headers properly

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_logs.c
+++ b/plugins/in_opentelemetry/opentelemetry_logs.c
@@ -1321,7 +1321,7 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
                 msgpack_pack_uint64(&mp_pck, resource->dropped_attributes_count);
             }
 
-
+            flb_mp_map_header_end(&mh_tmp);
 
             if (resource_log->schema_url) {
                 flb_mp_map_header_append(&mh);
@@ -1396,7 +1396,7 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
                 goto binary_payload_to_msgpack_end;
             }
 
-            flb_log_event_encoder_group_end(encoder);
+            flb_log_event_encoder_group_header_end(encoder);
 
             msgpack_sbuffer_clear(&mp_sbuf);
 


### PR DESCRIPTION
backport of #10018

Groups encoding where not closing the msgpack map header, additionaly once the group header was finished instead of closing it we were appending the group finalization record (-2).

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
