### PR TITLE
tests: fix tests that call pthread_join on stopped contexts and crash on macos.

### DIFF
--- a/tests/runtime/filter_grep.c
+++ b/tests/runtime/filter_grep.c
@@ -181,7 +181,9 @@ void flb_test_filter_grep_invalid(void)
         TEST_CHECK(bytes == -1);
     }
 
-    flb_stop(ctx);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
     flb_destroy(ctx);
 }
 
@@ -484,7 +486,9 @@ void flb_test_error_AND_regex_exclude(void)
     ret = flb_start(ctx);
     TEST_CHECK(ret != 0);
 
-    flb_stop(ctx);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
     flb_destroy(ctx);
 }
 
@@ -520,7 +524,9 @@ void flb_test_error_OR_regex_exclude(void)
     ret = flb_start(ctx);
     TEST_CHECK(ret != 0);
 
-    flb_stop(ctx);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
     flb_destroy(ctx);
 }
 

--- a/tests/runtime/filter_modify.c
+++ b/tests/runtime/filter_modify.c
@@ -1620,7 +1620,13 @@ static void flb_test_issue_7368()
     ret = flb_start(ctx->flb);
     TEST_CHECK(ret != 0);
 
-    filter_test_destroy(ctx);
+    if (ret == 0) {
+        filter_test_destroy(ctx);
+    }
+    else {
+        flb_destroy(ctx->flb);
+        flb_free(ctx);
+    }
 }
 
 TEST_LIST = {

--- a/tests/runtime/filter_record_modifier.c
+++ b/tests/runtime/filter_record_modifier.c
@@ -470,7 +470,9 @@ void flb_exclusive_setting()
     /* It should be error since "allowlist_key" and "remove_key" are exclusive */
     TEST_CHECK(ret != 0);
 
-    flb_stop(ctx);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
     flb_destroy(ctx);
 }
 

--- a/tests/runtime/in_syslog.c
+++ b/tests/runtime/in_syslog.c
@@ -540,7 +540,9 @@ void flb_test_syslog_unknown_mode()
         exit(EXIT_FAILURE);
     }
 
-    test_ctx_destroy(ctx);
+    /* free ctx directly to avoid calling flb_stop */
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
 }
 
 void flb_test_syslog_unix_perm()

--- a/tests/runtime/out_kinesis.c
+++ b/tests/runtime/out_kinesis.c
@@ -289,7 +289,9 @@ void flb_test_kinesis_invalid_port(void)
     ret = flb_start(ctx);
     TEST_CHECK(ret != 0);  // Expect failure
 
-    flb_stop(ctx);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
     flb_destroy(ctx);
 }
 


### PR DESCRIPTION
# Summary

When calling `pthread_join(2)` on an invalid or even NULL `tid` the address sanitizer on macOS will raise an issue and crash fluent-bit. This has the effect on causing failures in CI.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
