### PR TITLE
in_exec_wasi: change wasm_runtime_call_wasm to wasm_application_execute_main to support latest version of tinygo

### DIFF
--- a/src/wasm/flb_wasm.c
+++ b/src/wasm/flb_wasm.c
@@ -376,14 +376,7 @@ char *flb_wasm_call_function_format_msgpack(struct flb_wasm *fw, const char *fun
 int flb_wasm_call_wasi_main(struct flb_wasm *fw)
 {
 #if WASM_ENABLE_LIBC_WASI != 0
-    wasm_function_inst_t func = NULL;
-
-    if (!(func = wasm_runtime_lookup_wasi_start_function(fw->module_inst))) {
-        flb_error("The wasi mode main function is not found.");
-        return -1;
-    }
-
-    return wasm_runtime_call_wasm(fw->exec_env, func, 0, NULL);
+    return wasm_application_execute_main(fw->module_inst, 0, NULL);
 #else
     return -1;
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #10026
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    HTTP_Server  Off
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name exec_wasi
    Tag  exec.wasi.local
    WASI_Path /config/input/main.wasm

[OUTPUT]
    Name  stdout
    Match *
```
- [ ] Debug log output from testing the change
```

Fluent Bit v4.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/03/02 16:40:40] [ info] Configuration:
[2025/03/02 16:40:40] [ info]  flush time     | 1.000000 seconds
[2025/03/02 16:40:40] [ info]  grace          | 5 seconds
[2025/03/02 16:40:40] [ info]  daemon         | 0
[2025/03/02 16:40:40] [ info] ___________
[2025/03/02 16:40:40] [ info]  inputs:
[2025/03/02 16:40:40] [ info]      exec_wasi
[2025/03/02 16:40:40] [ info] ___________
[2025/03/02 16:40:40] [ info]  filters:
[2025/03/02 16:40:40] [ info] ___________
[2025/03/02 16:40:40] [ info]  outputs:
[2025/03/02 16:40:40] [ info]      stdout.0
[2025/03/02 16:40:40] [ info] ___________
[2025/03/02 16:40:40] [ info]  collectors:
[2025/03/02 16:40:40] [ info] [fluent bit] version=4.0.0, commit=7513b67cbe, pid=161096
[2025/03/02 16:40:40] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/03/02 16:40:40] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/03/02 16:40:40] [ info] [simd    ] disabled
[2025/03/02 16:40:40] [ info] [cmetrics] version=0.9.9
[2025/03/02 16:40:40] [ info] [ctraces ] version=0.6.0
[2025/03/02 16:40:40] [ info] [input:exec_wasi:exec_wasi.0] initializing
[2025/03/02 16:40:40] [ info] [input:exec_wasi:exec_wasi.0] storage_strategy='memory' (memory only)
[2025/03/02 16:40:40] [debug] [exec_wasi:exec_wasi.0] created event channels: read=25 write=26
[2025/03/02 16:40:40] [debug] [input:exec_wasi:exec_wasi.0] interval_sec=1 interval_nsec=0 oneshot=0 buf_size=4096
[2025/03/02 16:40:40] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2025/03/02 16:40:40] [ info] [sp] stream processor started
[2025/03/02 16:40:40] [ info] [output:stdout:stdout.0] worker #0 started
[2025/03/02 16:40:42] [debug] [task] created task=0x7ffff0023d70 id=0 OK
[2025/03/02 16:40:42] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] exec.wasi.local: [[1740919241.699687638, {}], {"wasi_stdout"=>"{"flag": "test", "status": "ok"}"}]
[2025/03/02 16:40:42] [debug] [out flush] cb_destroy coro_id=0
[2025/03/02 16:40:42] [debug] [task] destroy task=0x7ffff0023d70 (task_id=0)
[2025/03/02 16:40:43] [debug] [task] created task=0x7ffff005cd50 id=0 OK
[2025/03/02 16:40:43] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] exec.wasi.local: [[1740919242.701457853, {}], {"wasi_stdout"=>"{"flag": "test", "status": "ok"}"}]
[2025/03/02 16:40:43] [debug] [out flush] cb_destroy coro_id=1
[2025/03/02 16:40:43] [debug] [task] destroy task=0x7ffff005cd50 (task_id=0)
[2025/03/02 16:40:44] [debug] [task] created task=0x7ffff006bd40 id=0 OK
[2025/03/02 16:40:44] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] exec.wasi.local: [[1740919243.700151230, {}], {"wasi_stdout"=>"{"flag": "test", "status": "ok"}"}]
[2025/03/02 16:40:44] [debug] [out flush] cb_destroy coro_id=2
[2025/03/02 16:40:44] [debug] [task] destroy task=0x7ffff006bd40 (task_id=0)
[2025/03/02 16:40:45] [debug] [task] created task=0x7ffff002cb10 id=0 OK
[2025/03/02 16:40:45] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] exec.wasi.local: [[1740919244.700360227, {}], {"wasi_stdout"=>"{"flag": "test", "status": "ok"}"}]
[2025/03/02 16:40:45] [debug] [out flush] cb_destroy coro_id=3
[2025/03/02 16:40:45] [debug] [task] destroy task=0x7ffff002cb10 (task_id=0)
[2025/03/02 16:40:46] [debug] [task] created task=0x7ffff002e560 id=0 OK
[0] exec.wasi.local: [[1740919245.699260535, {}], {"wasi_stdout"=>"{"flag": "test", "status": "ok"}"}]
[2025/03/02 16:40:46] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2025/03/02 16:40:46] [debug] [out flush] cb_destroy coro_id=4
[2025/03/02 16:40:46] [debug] [task] destroy task=0x7ffff002e560 (task_id=0)
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
