### PR TITLE
filter_modifier: added missing log event encoder and decoder disposal

### DIFF
--- a/plugins/filter_record_modifier/filter_modifier.c
+++ b/plugins/filter_record_modifier/filter_modifier.c
@@ -369,12 +369,20 @@ static int cb_modifier_filter(const void *data, size_t bytes,
             if (map_num > BOOL_MAP_LIMIT) {
                 flb_plg_error(ctx->ins, "The number of elements exceeds limit %d",
                               BOOL_MAP_LIMIT);
+
+                flb_log_event_decoder_destroy(&log_decoder);
+                flb_log_event_encoder_destroy(&log_encoder);
+
                 return -1;
             }
             /* allocate map_num + guard byte */
             bool_map = flb_calloc(map_num+1, sizeof(bool_map_t));
             if (bool_map == NULL) {
                 flb_errno();
+
+                flb_log_event_decoder_destroy(&log_decoder);
+                flb_log_event_encoder_destroy(&log_encoder);
+
                 return -1;
             }
             removed_map_num = make_bool_map(ctx, obj,


### PR DESCRIPTION
This PR fixes a resource leak reported in issue #9954 where the log event encoder and decoder instances are not disposed of if `cb_modifier_filter` returns through one of the error code paths in the record processing loop.