### PR TITLE
out_opentelemetry: restored old group meta record processing mechanism

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_logs.c
+++ b/plugins/out_opentelemetry/opentelemetry_logs.c
@@ -922,6 +922,8 @@ int otel_process_logs(struct flb_event_chunk *event_chunk,
         return -1;
     }
 
+    flb_log_event_decoder_read_groups(decoder, FLB_TRUE);
+
     log_record_count = 0;
     opentelemetry__proto__collector__logs__v1__export_logs_service_request__init(&export_logs);
 


### PR DESCRIPTION
This PR restores the previous group meta record handling behavior in the opentelemetry output plugin by explicitly opting in to receive raw group meta records from the log event decoder (using `flb_log_event_decoder_read_groups`).

It would be better to refactor `otel_process_logs` to use the newly introduced `group_attributes` and `group_metadata` fields instead but considering how close we are to releasing the next major version re-enabling the previously tested code is the safest option.