### PR TITLE
out_opentelemetry: restored old group meta record processing mechanism (backport)

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_logs.c
+++ b/plugins/out_opentelemetry/opentelemetry_logs.c
@@ -922,6 +922,8 @@ int otel_process_logs(struct flb_event_chunk *event_chunk,
         return -1;
     }
 
+    flb_log_event_decoder_read_groups(decoder, FLB_TRUE);
+
     log_record_count = 0;
     opentelemetry__proto__collector__logs__v1__export_logs_service_request__init(&export_logs);
 


### PR DESCRIPTION
backport of https://github.com/fluent/fluent-bit/pull/10080

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
