### PR TITLE
out_opentelemetry: switch config property 'http2' default to 'off' (backport 3.2)

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -280,6 +280,7 @@ int opentelemetry_post(struct opentelemetry_context *ctx,
 
     if (request->protocol_version == HTTP_PROTOCOL_VERSION_20 &&
         ctx->enable_grpc_flag) {
+
         grpc_body = cfl_sds_create_size(body_len + 5);
 
         if (grpc_body == NULL) {
@@ -730,7 +731,7 @@ static struct flb_config_map config_map[] = {
      "Adds a custom label to the metrics use format: 'add_label name value'"
     },
     {
-     FLB_CONFIG_MAP_STR, "http2", "on",
+     FLB_CONFIG_MAP_STR, "http2", "off",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, enable_http2),
      "Enable, disable or force HTTP/2 usage. Accepted values : on, off, force"
     },


### PR DESCRIPTION
(backport of #10089 to 3.2 branch)

We have received many reports that Fluent Bit cannot send data to the OpenTelemetry Collector over a plain text communication, this is happening because we enabled http2 by default so when the Otel Collector receives the request (PRI * HTTP/2.0...) it drops the connection.

This PR switches http2 default to off so users don't run into this problem.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
