### PR TITLE
in_opentelemetry: fix handling of status code in JSON traces (backport 3.2)

### DIFF
--- a/lib/ctraces/.github/workflows/build.yaml
+++ b/lib/ctraces/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
           submodules: true
 
       - name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}
-        uses: uraimo/run-on-arch-action@v2.8.1
+        uses: uraimo/run-on-arch-action@v3.0.0
         with:
           arch: aarch64
           distro: ubuntu_latest

--- a/lib/ctraces/.github/workflows/packages.yaml
+++ b/lib/ctraces/.github/workflows/packages.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
             submodules: true
 
-      - uses: uraimo/run-on-arch-action@v2.8.1
+      - uses: uraimo/run-on-arch-action@v3.0.0
         name: Build the ${{matrix.format}} packages
         with:
           arch: aarch64

--- a/lib/ctraces/CMakeLists.txt
+++ b/lib/ctraces/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # CTraces Version
 set(CTR_VERSION_MAJOR  0)
 set(CTR_VERSION_MINOR  6)
-set(CTR_VERSION_PATCH  0)
+set(CTR_VERSION_PATCH  1)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/lib/ctraces/CODEOWNERS
+++ b/lib/ctraces/CODEOWNERS
@@ -1,0 +1,7 @@
+# Global Owners
+# -------------
+*                        @edsiper @leonardo-albertovich
+
+# CI
+# -------------------------
+/.github/                @niedbalski @patrick-stephens @celalettin1286

--- a/lib/ctraces/include/ctraces/ctr_span.h
+++ b/lib/ctraces/include/ctraces/ctr_span.h
@@ -40,7 +40,7 @@
 /* Status code */
 #define CTRACE_SPAN_STATUS_CODE_UNSET  0
 #define CTRACE_SPAN_STATUS_CODE_OK     1
-#define CTRACE_SPAN_STAUTS_CODE_ERROR  2
+#define CTRACE_SPAN_STATUS_CODE_ERROR  2
 
 struct ctrace_span_status {
     int code;

--- a/plugins/in_opentelemetry/opentelemetry_traces.c
+++ b/plugins/in_opentelemetry/opentelemetry_traces.c
@@ -550,6 +550,7 @@ static int process_span_status(struct flb_opentelemetry *ctx,
 {
     int ret;
     int code = 0;
+    cfl_sds_t tmp = NULL;
     char *message = NULL;
 
     if (status->type != MSGPACK_OBJECT_MAP) {
@@ -559,8 +560,28 @@ static int process_span_status(struct flb_opentelemetry *ctx,
 
     /* code */
     ret = find_map_entry_by_key(&status->via.map, "code", 0, FLB_TRUE);
-    if (ret >= 0 && status->via.map.ptr[ret].val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
-        code = status->via.map.ptr[ret].val.via.u64;
+    if (ret >= 0 && status->via.map.ptr[ret].val.type == MSGPACK_OBJECT_STR) {
+        tmp = cfl_sds_create_len(status->via.map.ptr[ret].val.via.str.ptr,
+                                 status->via.map.ptr[ret].val.via.str.size);
+        if (!tmp) {
+            return -1;
+        }
+
+        if (strcasecmp(tmp, "UNSET") == 0) {
+            code = CTRACE_SPAN_STATUS_CODE_UNSET;
+        }
+        else if (strcasecmp(tmp, "OK") == 0) {
+            code = CTRACE_SPAN_STATUS_CODE_OK;
+        }
+        else if (strcasecmp(tmp, "ERROR") == 0) {
+            code = CTRACE_SPAN_STATUS_CODE_ERROR;
+        }
+        else {
+            flb_plg_error(ctx->ins, "status code value is invalid: %s", tmp);
+            cfl_sds_destroy(tmp);
+            return -1;
+        }
+        cfl_sds_destroy(tmp);
     }
     else {
         flb_plg_error(ctx->ins, "status code is missing");


### PR DESCRIPTION
backport of https://github.com/fluent/fluent-bit/pull/10091

- fix handling of status code in JSON traces
- upgrade to CTraces v0.6.1 (fix typo)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
