### PR TITLE
out_s3: clarify comment about sending chunks

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -928,7 +928,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     /*
      * S3 must ALWAYS use sync mode
-     * In the timer thread we do a mk_list_foreach_safe on the queue of uplaods and chunks
+     * In the timer thread we do a mk_list_foreach_safe on the queue of uploads and chunks
      * Iterating over those lists is not concurrent safe. If a flush call ran at the same time
      * And deleted an item from the list, this could cause a crash/corruption.
      */
@@ -1779,7 +1779,7 @@ static void cb_s3_upload(struct flb_config *config, void *data)
         chunk = fsf->data;
 
         if (now < (chunk->create_time + ctx->upload_timeout + ctx->retry_time)) {
-            continue; /* Only send chunks which have timed out */
+            continue; /* Only send chunks which haven't timed out */
         }
 
         /* Locked chunks are being processed, skip */


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR just updates a comment in the s3 output plugin. It clarifies that the plugin only sends chunks that have NOT timed out.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
