### PR TITLE
Dockerfile: optimize layers

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -24,15 +24,14 @@ FROM debian:trixie-slim AS builder-base
 COPY --from=qemu-arm32 /usr/bin/qemu-arm-static /usr/bin/
 COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 
-ARG FLB_NIGHTLY_BUILD
-ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+ARG FLB_NIGHTLY_BUILD \
+    FLB_CHUNK_TRACE=On
 
-ARG FLB_CHUNK_TRACE=On
-ENV FLB_CHUNK_TRACE=${FLB_CHUNK_TRACE}
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD \
+    FLB_CHUNK_TRACE=${FLB_CHUNK_TRACE} \
+    DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
-
-ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -67,8 +66,9 @@ FROM builder-base AS builder
 WORKDIR /src/fluent-bit/build/
 
 # Required to be set to ARMV7 for that target
-ARG WAMR_BUILD_TARGET
-ARG EXTRA_CMAKE_FLAGS
+ARG WAMR_BUILD_TARGET \
+    EXTRA_CMAKE_FLAGS
+
 ENV EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS}
 
 # Optional: jemalloc configure flags (e.g., page size). Leave unset to keep defaults.
@@ -99,8 +99,8 @@ RUN [ -n "${WAMR_BUILD_TARGET:-}" ] && EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DW
 ARG CFLAGS="-v"
 ENV CFLAGS=${CFLAGS}
 
-RUN make -j "$(getconf _NPROCESSORS_ONLN)"
-RUN install bin/fluent-bit /fluent-bit/bin/
+RUN make -j "$(getconf _NPROCESSORS_ONLN)" && \
+    install bin/fluent-bit /fluent-bit/bin/
 
 # Configuration files
 COPY conf/fluent-bit.conf \
@@ -183,6 +183,7 @@ RUN find /dpkg/ -type d -empty -delete && \
 # We want latest at time of build
 # hadolint ignore=DL3006
 FROM gcr.io/distroless/cc-debian13 AS production
+EXPOSE 2020
 ARG RELEASE_VERSION
 ENV FLUENT_BIT_VERSION=${RELEASE_VERSION}
 LABEL description="Fluent Bit multi-architecture container image" \
@@ -198,22 +199,25 @@ LABEL description="Fluent Bit multi-architecture container image" \
     org.opencontainers.image.documentation="https://docs.fluentbit.io/" \
     org.opencontainers.image.authors="Eduardo Silva <eduardo.silva@chronosphere.io>"
 
-# Copy the libraries from the extractor stage into root
-COPY --from=deb-extractor /dpkg /
-
-# Copy certificates
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-
-# Finally the binaries as most likely to change
-COPY --from=builder /fluent-bit /fluent-bit
-
-EXPOSE 2020
-
 # Entry point
 ENTRYPOINT [ "/fluent-bit/bin/fluent-bit" ]
 CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
 
+# Copy certificates
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
+# Copy the libraries from the extractor stage into root
+COPY --from=deb-extractor /dpkg /
+
+# Finally the binaries as most likely to change
+COPY --from=builder /fluent-bit /fluent-bit
+
+
 FROM debian:trixie-slim AS debug
+EXPOSE 2020
+
+# No entry point so we can just shell in
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
 ARG RELEASE_VERSION
 ENV FLUENT_BIT_VERSION=${RELEASE_VERSION}
 LABEL description="Fluent Bit multi-architecture debug container image" \
@@ -269,8 +273,3 @@ RUN apt-get update && \
 
 RUN rm -f /usr/bin/qemu-*-static
 COPY --from=builder /fluent-bit /fluent-bit
-
-EXPOSE 2020
-
-# No entry point so we can just shell in
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized container build to reduce intermediate layers, yielding faster builds and smaller images.
  * Ensured runtime libraries are present in the production image for reliable operation.
  * Exposed service on port 2020 and moved default startup to the production image for improved accessibility.
  * Reordered debug image build without changing its runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->