### PR TITLE
record_accesor: fix return value for flb_ra_get_kv_pair when get_ra_parser fails (Backport) 

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -755,8 +755,8 @@ static struct flb_ra_parser* get_ra_parser(struct flb_record_accessor *ra)
  * If 'record accessor' pattern matches an entry in the 'map', set the
  * reference in 'out_key' and 'out_val' for the entries in question.
  *
- * Returns FLB_TRUE if the pattern matched a kv pair, otherwise it returns
- * FLB_FALSE.
+ * Returns 0 if the pattern matched a kv pair, otherwise it returns
+ * -1.
  */
 int flb_ra_get_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
                        msgpack_object **start_key,
@@ -766,7 +766,7 @@ int flb_ra_get_kv_pair(struct flb_record_accessor *ra, msgpack_object map,
 
     rp = get_ra_parser(ra);
     if (rp == NULL) {
-        return FLB_FALSE;
+        return -1;
     }
 
     return flb_ra_key_value_get(rp->key->name, map, rp->key->subkeys,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backport of `record_accesor: fix return value for flb_ra_get_kv_pair when get_ra_parser fails` #10105 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#10105 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
