### PR TITLE
filter_nest: add wildcard_exclude config

### DIFF
--- a/docker_compose/loki-grafana-structured_metadata_map/config/fluent-bit_loki_out-structured_metadata_map.yaml
+++ b/docker_compose/loki-grafana-structured_metadata_map/config/fluent-bit_loki_out-structured_metadata_map.yaml
@@ -1,5 +1,5 @@
 service:
-  log_level: debug
+  log_level: info
 
 pipeline:
   inputs:
@@ -20,8 +20,22 @@ pipeline:
               "sub_key_1": "hello, world!",
               "sub_key_2": "goodbye, world!"
             }
-          }
+          },
+          "an_unknown_key": "hello, world!",
+          "another_unknown_key": "goodbye, world!"
         }
+
+  filters:
+    - name: nest
+      match: logs
+      nest_under: nested_for_structured_metadata
+      wildcard: '*'
+      wildcard_exclude:
+        - message
+        - logger
+        - hostname
+        - level
+        - 'my_map_of_*'
 
   outputs:
     - name: loki
@@ -31,6 +45,6 @@ pipeline:
       label_keys: $level,$logger
       labels: service_name=test
       structured_metadata: $hostname
-      structured_metadata_map_keys: $my_map_of_attributes_1,$my_map_of_maps_1['root_key']
+      structured_metadata_map_keys: $my_map_of_attributes_1,$my_map_of_maps_1['root_key'],$nested_for_structured_metadata
       line_format: key_value
       drop_single_key: on

--- a/docker_compose/loki-grafana-structured_metadata_map/docker-compose.yml
+++ b/docker_compose/loki-grafana-structured_metadata_map/docker-compose.yml
@@ -6,7 +6,8 @@ services:
 #      context: ../../
 #      dockerfile: dockerfiles/Dockerfile
     depends_on:
-      - loki
+      loki:
+        condition: service_healthy
     container_name: fluentbit
     command: /fluent-bit/bin/fluent-bit -c /etc/fluent-bit_loki_out-structured_metadata_map.yaml
     ports:
@@ -17,7 +18,8 @@ services:
       - ./config/fluent-bit_loki_out-structured_metadata_map.yaml:/etc/fluent-bit_loki_out-structured_metadata_map.yaml
 
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:11.5.2
+    attach: false
     depends_on:
       - loki
       - fluentbit
@@ -28,11 +30,21 @@ services:
     networks:
       - loki-network
     environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_SECURITY_ADMIN=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
 
   loki:
-    image: grafana/loki:2.9.2
+    image: grafana/loki:3.4.2
+    attach: false
     command: -config.file=/etc/loki/loki-config.yaml
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:3100/ready" ]
+      interval: 5s
+      retries: 10
+      start_period: 10s
+      timeout: 10s
     networks:
       - loki-network
     ports:

--- a/docker_compose/node-exporter-dashboard/docker-compose.yml
+++ b/docker_compose/node-exporter-dashboard/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     networks:
       - exporter-network
     environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_SECURITY_ADMIN=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
 
   prometheus:

--- a/plugins/filter_nest/nest.h
+++ b/plugins/filter_nest/nest.h
@@ -38,6 +38,8 @@ struct filter_nest_ctx
     // nest
     struct mk_list wildcards;
     int wildcards_cnt;
+    struct mk_list wildcard_excludes;
+    int wildcard_excludes_cnt;
     bool remove_prefix;
     // lift
     bool add_prefix;

--- a/tests/runtime/filter_nest.c
+++ b/tests/runtime/filter_nest.c
@@ -15,12 +15,18 @@ void flb_test_filter_nest_single(void);
 void flb_test_filter_nest_multi_nest(void);
 void flb_test_filter_nest_multi_lift(void);
 void flb_test_filter_nest_add_prefix(void);
+void flb_test_filter_nest_include_all(void);
+void flb_test_filter_nest_exclude_static(void);
+void flb_test_filter_nest_exclude_wildcard(void);
 /* Test list */
 TEST_LIST = {
     {"single", flb_test_filter_nest_single },
     {"multiple events are not dropped(nest)", flb_test_filter_nest_multi_nest},
     {"multiple events are not dropped(lift)", flb_test_filter_nest_multi_lift},
     {"add_prefix", flb_test_filter_nest_add_prefix},
+    {"include_all", flb_test_filter_nest_include_all},
+    {"exclude_static", flb_test_filter_nest_exclude_static},
+    {"exclude_wildcard", flb_test_filter_nest_exclude_wildcard},
     {NULL, NULL}
 };
 
@@ -366,6 +372,219 @@ void flb_test_filter_nest_add_prefix(void)
 
     if (output != NULL) {
         expected = "\"_nested_key.key\":\"value\"}]";
+        TEST_CHECK_(strstr(output, expected) != NULL, "Expected output to contain '%s', got '%s'", expected, output);
+        free(output);
+    }
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_filter_nest_include_all(void)
+{
+    int ret;
+    int bytes;
+    char *p, *output, *expected;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "1",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "nest", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "Operation", "nest",
+                         "Nest_under", "nested_key",
+                         "Wildcard", "*",
+                         NULL);
+
+    TEST_CHECK(ret == 0);
+
+
+    /* Output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    p = "[1448403340, {\"to_nest\":\"This is some data to nest\", \"extra\":\"Some more data to nest\", \"EXCLUDED_extra_1\":\"Some more data to be excluded\", \"EXCLUDED_extra_2\":\"Some more data to be excluded\", \"EXCLUDED_extra_3\":\"Some more data to be excluded\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    flb_time_msleep(1500); /* waiting flush */
+    output = get_output();
+
+    TEST_CHECK_(output != NULL, "Expected output to not be NULL");
+
+    if (output != NULL) {
+        expected = "{\"nested_key\":{\"to_nest\":\"This is some data to nest\",\"extra\":\"Some more data to nest\",\"EXCLUDED_extra_1\":\"Some more data to be excluded\",\"EXCLUDED_extra_2\":\"Some more data to be excluded\",\"EXCLUDED_extra_3\":\"Some more data to be excluded\"}}]";
+        TEST_CHECK_(strstr(output, expected) != NULL, "Expected output to contain '%s', got '%s'", expected, output);
+        free(output);
+    }
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_filter_nest_exclude_static(void)
+{
+    int ret;
+    int bytes;
+    char *p, *output, *expected;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "1",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "nest", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "Operation", "nest",
+                         "Nest_under", "nested_key",
+                         "Wildcard", "*",
+                         "Wildcard_exclude", "EXCLUDED_extra_1",
+                         "Wildcard_exclude", "EXCLUDED_extra_2",
+                         NULL);
+
+    TEST_CHECK(ret == 0);
+
+
+    /* Output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    p = "[1448403340, {\"to_nest\":\"This is some data to nest\", \"extra\":\"Some more data to nest\", \"EXCLUDED_extra_1\":\"Some more data to be excluded\", \"EXCLUDED_extra_2\":\"Some more data to be excluded\", \"EXCLUDED_NOT\":\"Some more data to be excluded\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    flb_time_msleep(1500); /* waiting flush */
+    output = get_output();
+
+    TEST_CHECK_(output != NULL, "Expected output to not be NULL");
+
+    if (output != NULL) {
+        expected = "\"nested_key\":{\"to_nest\":\"This is some data to nest\",\"extra\":\"Some more data to nest\",\"EXCLUDED_NOT\":\"Some more data to be excluded\"}}";
+        TEST_CHECK_(strstr(output, expected) != NULL, "Expected output to contain '%s', got '%s'", expected, output);
+        free(output);
+    }
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_filter_nest_exclude_wildcard(void)
+{
+    int ret;
+    int bytes;
+    char *p, *output, *expected;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    ctx = flb_create();
+    flb_service_set(ctx,
+                    "Flush", "1",
+                    "Grace", "1",
+                    "Log_Level", "debug",
+                    NULL);
+
+    /* Input */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Prepare output callback context*/
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    /* Filter */
+    filter_ffd = flb_filter(ctx, (char *) "nest", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "Operation", "nest",
+                         "Nest_under", "nested_key",
+                         "Wildcard", "*",
+                         "Wildcard_exclude", "EXCLUDED_*",
+                         NULL);
+
+    TEST_CHECK(ret == 0);
+
+
+    /* Output */
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    p = "[1448403340, {\"to_nest\":\"This is some data to nest\", \"extra\":\"Some more data to nest\", \"EXCLUDED_extra_1\":\"Some more data to be excluded\", \"EXCLUDED_extra_2\":\"Some more data to be excluded\", \"EXCLUDED_extra_3\":\"Some more data to be excluded\"}]";
+    bytes = flb_lib_push(ctx, in_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    flb_time_msleep(1500); /* waiting flush */
+    output = get_output();
+
+    TEST_CHECK_(output != NULL, "Expected output to not be NULL");
+
+    if (output != NULL) {
+        expected = "\"nested_key\":{\"to_nest\":\"This is some data to nest\",\"extra\":\"Some more data to nest\"}}]";
         TEST_CHECK_(strstr(output, expected) != NULL, "Expected output to contain '%s', got '%s'", expected, output);
         free(output);
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Implements #10111 by adding `wildcard_exclude` config to `nest` filter

#10111 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
