### PR TITLE
processor: fix missing read_groups flags for log event decoder

### DIFF
--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -1115,6 +1115,7 @@ struct flb_processor_instance *flb_processor_instance_create(struct flb_config *
         flb_processor_instance_destroy(instance);
         instance = NULL;
     }
+    flb_log_event_decoder_read_groups(instance->log_decoder, FLB_TRUE);
 
     return instance;
 }


### PR DESCRIPTION
Fixes #10101

In a recent change, the read_groups flag was set to false to avoid issues with plugins who don't understand groups. This patch fixes the case for processors (logs) making reading groups the default.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
