### PR TITLE
processor: fix missing read_groups flags for log event decoder (backport for 3.2)

### DIFF
--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -1063,6 +1063,7 @@ struct flb_processor_instance *flb_processor_instance_create(struct flb_config *
         flb_processor_instance_destroy(instance);
         instance = NULL;
     }
+    flb_log_event_decoder_read_groups(instance->log_decoder, FLB_TRUE);
 
     return instance;
 }


### PR DESCRIPTION
backport of #10117

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
