### PR TITLE
in_kafka: optimize poll timeout handling for threaded and main event loop modes

### DIFF
--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -161,7 +161,25 @@ static int in_kafka_collect(struct flb_input_instance *ins,
     ret = FLB_EVENT_ENCODER_SUCCESS;
 
     while (ret == FLB_EVENT_ENCODER_SUCCESS) {
-        rkm = rd_kafka_consumer_poll(ctx->kafka.rk, 1);
+        /* Set the Kafka poll timeout based on execution mode:
+         *
+         * a) Running in the main event loop (non-threaded):
+         *    - Use a minimal timeout (1ms - 10ms) to avoid blocking other inputs.
+         *
+         * b) Running in a dedicated thread:
+         *    - Optimize for throughput by allowing Kafka's internal batching.
+         *    - Align with 'fetch.wait.max.ms' (default: 500ms) to maximize batch efficiency.
+         *    - Set timeout slightly higher than 'fetch.wait.max.ms' (e.g., 1.5x - 2x) to
+         *      ensure it does not interfere with Kafka’s fetch behavior, while still
+         *      keeping the consumer responsive.
+         */
+        if (ctx->ins->flags & FLB_INPUT_THREADED) {
+            /* Threaded mode: Optimize for batch processing and efficiency */
+            rkm = rd_kafka_consumer_poll(ctx->kafka.rk, ctx->poll_timeout_ms);
+        } else {
+            /* Main event loop: Minimize delay for non-blocking execution */
+            rkm = rd_kafka_consumer_poll(ctx->kafka.rk, 1);
+        }
 
         if (!rkm) {
             break;
@@ -427,6 +445,14 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_SIZE, "buffer_max_size", FLB_IN_KAFKA_BUFFER_MAX_SIZE,
     0, FLB_TRUE, offsetof(struct flb_in_kafka_config, buffer_max_size),
     "Set the maximum size of chunk"
+   },
+   {
+    FLB_CONFIG_MAP_INT, "poll_timeout_ms", "1",
+    0, FLB_TRUE, offsetof(struct flb_in_kafka_config, poll_timeout_ms),
+    "Set the timeout in milliseconds for Kafka consumer poll operations. "
+    "When running in the main event loop, use a low value (e.g., 1-10ms) to minimize blocking. "
+    "When running in a dedicated thread, a higher value (e.g., 1.5x - 2x 'librdkafka.fetch.wait.max.ms') "
+    "can improve efficiency by leveraging Kafka's batching."
    },
    /* EOF */
    {0}

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -164,7 +164,7 @@ static int in_kafka_collect(struct flb_input_instance *ins,
         /* Set the Kafka poll timeout based on execution mode:
          *
          * a) Running in the main event loop (non-threaded):
-         *    - Use a minimal timeout (1ms - 10ms) to avoid blocking other inputs.
+         *    - Use a minimal timeout to avoid blocking other inputs.
          *
          * b) Running in a dedicated thread:
          *    - Optimize for throughput by allowing Kafka's internal batching.
@@ -450,9 +450,9 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_INT, "poll_timeout_ms", "1",
     0, FLB_TRUE, offsetof(struct flb_in_kafka_config, poll_timeout_ms),
     "Set the timeout in milliseconds for Kafka consumer poll operations. "
-    "When running in the main event loop, use a low value (e.g., 1-10ms) to minimize blocking. "
-    "When running in a dedicated thread, a higher value (e.g., 1.5x - 2x 'librdkafka.fetch.wait.max.ms') "
-    "can improve efficiency by leveraging Kafka's batching."
+    "This option only takes effect when running in a dedicated thread (i.e., when 'threaded' is enabled). "
+    "Using a higher timeout (e.g., 1.5x - 2x 'rdkafka.fetch.wait.max.ms') "
+    "can improve efficiency by leveraging Kafka's batching mechanism."
    },
    /* EOF */
    {0}

--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -48,6 +48,7 @@ struct flb_in_kafka_config {
     int coll_fd;
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
+    int poll_timeout_ms;
 };
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
# Summary
Set the Kafka poll timeout based on execution mode:
(Note: The fix is based on what's suggested in #9625)
1. Running in the main event loop (non-threaded):
   - Use a minimal timeout (1ms) to avoid blocking other inputs.

3. Running in a dedicated thread:
    -  Optimize for throughput by allowing Kafka's internal batching.
    -  Align with 'librdkafka.fetch.wait.max.ms' (default: 500ms) to maximize batch efficiency.
    -  Set timeout slightly higher than 'librdkafka.fetch.wait.max.ms' (e.g., 1.5x - 2x) to ensure it does not interfere with Kafka’s fetch behavior, while still keeping the consumer responsive.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #8030.
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Tested locally with the config `poll_timeout_ms` option.
```
[INPUT]
    Name        kafka
    Tag         kafka-test
    Brokers     <broker endpoint>
    Topics      <topic-name>
    poll_ms     100
    poll_timeout_ms 1000
    threaded    true
``` 

Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
