### PR TITLE
in_http: unstructured logs

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -26,6 +26,9 @@
 #include <fluent-bit/flb_zstd.h>
 #include <fluent-bit/flb_snappy.h>
 
+#include <fluent-bit/flb_log_event.h>
+#include <fluent-bit/flb_log_event_decoder.h>
+
 #include <monkey/monkey.h>
 #include <monkey/mk_core.h>
 
@@ -34,6 +37,7 @@
 
 #define HTTP_CONTENT_JSON       0
 #define HTTP_CONTENT_URLENCODED 1
+#define HTTP_CONTENT_PLAIN      2
 
 static inline char hex2nibble(char c)
 {
@@ -213,6 +217,88 @@ static flb_sds_t tag_key(struct flb_http *ctx, msgpack_object *map)
 
     flb_plg_error(ctx->ins, "Could not find tag_key %s in record", ctx->tag_key);
     return NULL;
+}
+
+static ssize_t parse_payload_plaintext(struct flb_http *ctx, flb_sds_t tag,
+                                       char *payload, size_t size)
+{
+    int              ret = FLB_EVENT_ENCODER_SUCCESS;
+    struct flb_time  tm;
+    size_t           offset = 0;
+    const char       *start;
+    const char       *nl;
+    flb_sds_t        tag_from_record = NULL;
+    msgpack_object   entry_key;
+    msgpack_unpacked record;
+    int              result;
+    void             *out_buf;
+    size_t           out_size;
+    struct flb_time  out_time = {0};
+    struct flb_log_event_encoder *log;
+
+
+    for (start = payload; start < payload+size && start != NULL; start = nl+1) {
+        nl = strchr(start, '\n');
+        if (nl == NULL) {
+            nl = payload + size;
+        }
+
+        if (nl-start <= 0) {
+            break;
+        }
+
+        if (*start == '\0') {
+            break;
+        }
+
+        ret = flb_log_event_encoder_begin_record(&ctx->log_encoder);
+
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            flb_log_event_encoder_reset_record(&ctx->log_encoder);
+            return -1;
+        }
+
+
+        ret = flb_log_event_encoder_set_timestamp(
+            &ctx->log_encoder, NULL);
+
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            flb_log_event_encoder_reset_record(&ctx->log_encoder);
+            return -1;
+        }
+
+        ret = flb_log_event_encoder_append_body_values(
+            &ctx->log_encoder,
+            FLB_LOG_EVENT_CSTRING_VALUE("log"),
+            FLB_LOG_EVENT_STRING_VALUE(start, (nl-start)));
+
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            flb_log_event_encoder_reset_record(&ctx->log_encoder);
+            return -1;
+        }
+
+        ret = flb_log_event_encoder_commit_record(&ctx->log_encoder);
+
+        if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+            flb_log_event_encoder_reset_record(&ctx->log_encoder);
+            return -1;
+        }
+
+        if (tag) {
+            ret = flb_input_log_append(ctx->ins, tag, flb_sds_len(tag),
+                                       ctx->log_encoder.output_buffer,
+                                       ctx->log_encoder.output_length);
+        }
+        else {
+            ret = flb_input_log_append(ctx->ins, NULL, 0,
+                                       ctx->log_encoder.output_buffer,
+                                       ctx->log_encoder.output_length);
+        }
+
+        flb_log_event_encoder_reset(&ctx->log_encoder);
+    }
+
+    return 0;
 }
 
 static int process_pack_record(struct flb_http *ctx, struct flb_time *tm,
@@ -766,6 +852,11 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
         type = HTTP_CONTENT_URLENCODED;
     }
 
+    if (header->val.len == 10 &&
+        strncasecmp(header->val.data, "text/plain", 10) == 0) {
+        type = HTTP_CONTENT_PLAIN;
+    }
+
     if (type == -1) {
         send_response(conn, 400, "error: invalid 'Content-Type'\n");
         return -1;
@@ -816,6 +907,9 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
     }
     else if (type == HTTP_CONTENT_URLENCODED) {
         ret = parse_payload_urlencoded(ctx, tag, request->data.data, request->data.len);
+    }
+    else if (type == HTTP_CONTENT_PLAIN) {
+        ret = parse_payload_plaintext(ctx, tag, request->data.data, request->data.len);
     }
 
     if (uncompressed_data != NULL) {
@@ -1201,6 +1295,10 @@ static int process_payload_ng(flb_sds_t tag,
         type = HTTP_CONTENT_URLENCODED;
     }
 
+    if (strcasecmp(request->content_type, "text/plain") == 0) {
+        type = HTTP_CONTENT_PLAIN;
+    }
+
     if (type == -1) {
         send_response_ng(response, 400, "error: invalid 'Content-Type'\n");
         return -1;
@@ -1222,7 +1320,13 @@ static int process_payload_ng(flb_sds_t tag,
             return parse_payload_urlencoded(ctx, tag, payload, cfl_sds_len(payload));
         }
     }
-
+    else if (type == HTTP_CONTENT_PLAIN) {
+        ctx = (struct flb_http *) request->stream->user_data;
+        payload = (char *) request->body;
+        if (payload) {
+            return parse_payload_plaintext(ctx, tag, payload, cfl_sds_len(payload));
+        }
+    }
     return 0;
 }
 


### PR DESCRIPTION
# Summary

Add support for unstructured logs to `in_http`.

# Description

Add support for handling of unstructured new line delimited logs when using a `content-type: text/plain` header. Each log line is submitted with the `log` key.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
