### PR TITLE
tls: add support for setting min/max TLS version and cipher list

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -443,6 +443,9 @@ struct flb_input_instance {
     char *tls_crt_file;                  /* Certificate                  */
     char *tls_key_file;                  /* Cert Key                     */
     char *tls_key_passwd;                /* Cert Key Password            */
+    char *tls_min_version;               /* Minimum protocol version of TLS */
+    char *tls_max_version;               /* Maximum protocol version of TLS */
+    char *tls_ciphers;                   /* TLS ciphers */
 
     struct mk_list *tls_config_map;
 

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -366,6 +366,9 @@ struct flb_output_instance {
     char *tls_crt_file;                  /* Certificate                  */
     char *tls_key_file;                  /* Cert Key                     */
     char *tls_key_passwd;                /* Cert Key Password            */
+    char *tls_min_version;               /* Minimum protocol version of TLS */
+    char *tls_max_version;               /* Maximum protocol version of TLS */
+    char *tls_ciphers;                   /* TLS ciphers */
 #endif
 
     /*

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -77,6 +77,11 @@ struct flb_tls_backend {
     /* Additional settings */
     int (*context_alpn_set) (void *, const char *);
 
+    /* TLS Protocol version */
+    int (*set_minmax_proto) (struct flb_tls *tls, const char *, const char *);
+    /* TLS Ciphers */
+    int (*set_ciphers) (struct flb_tls *tls, const char *);
+
     /* Session management */
     void *(*session_create) (struct flb_tls *, int);
     int (*session_destroy) (void *);
@@ -119,6 +124,9 @@ int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn);
 int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname);
 
 int flb_tls_load_system_certificates(struct flb_tls *tls);
+int flb_tls_set_minmax_proto(struct flb_tls *tls,
+                             const char *min_version, const char *max_version);
+int flb_tls_set_ciphers(struct flb_tls *tls, const char *ciphers);
 
 struct mk_list *flb_tls_get_config_map(struct flb_config *config);
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -595,6 +595,15 @@ int flb_input_set_property(struct flb_input_instance *ins,
     else if (prop_key_check("tls.key_passwd", k, len) == 0) {
         flb_utils_set_plugin_string_property("tls.key_passwd", &ins->tls_key_passwd, tmp);
     }
+    else if (prop_key_check("tls.min_version", k, len) == 0) {
+        flb_utils_set_plugin_string_property("tls.min_version", &ins->tls_min_version, tmp);
+    }
+    else if (prop_key_check("tls.max_version", k, len) == 0) {
+        flb_utils_set_plugin_string_property("tls.max_version", &ins->tls_max_version, tmp);
+    }
+    else if (prop_key_check("tls.ciphers", k, len) == 0) {
+        flb_utils_set_plugin_string_property("tls.ciphers", &ins->tls_ciphers, tmp);
+    }
 #endif
     else if (prop_key_check("storage.type", k, len) == 0 && tmp) {
         /* Set the storage type */
@@ -739,6 +748,18 @@ void flb_input_instance_destroy(struct flb_input_instance *ins)
 
     if (ins->tls_key_passwd) {
         flb_sds_destroy(ins->tls_key_passwd);
+    }
+
+    if (ins->tls_min_version) {
+        flb_sds_destroy(ins->tls_min_version);
+    }
+
+    if (ins->tls_max_version) {
+        flb_sds_destroy(ins->tls_max_version);
+    }
+
+    if (ins->tls_ciphers) {
+        flb_sds_destroy(ins->tls_ciphers);
     }
 
     /* release the tag if any */
@@ -1310,6 +1331,26 @@ int flb_input_init_all(struct flb_config *config)
         if (ret == -1) {
             flb_input_instance_destroy(ins);
             return -1;
+        }
+
+        if (ins->tls_min_version != NULL || ins->tls_max_version != NULL) {
+            ret = flb_tls_set_minmax_proto(ins->tls, ins->tls_min_version, ins->tls_max_version);
+            if (ret != 0) {
+                flb_error("[input %s] error setting up minmax protocol version of TLS",
+                          ins->name);
+                flb_input_instance_destroy(ins);
+                return -1;
+            }
+        }
+
+        if (ins->tls_ciphers != NULL) {
+            ret = flb_tls_set_ciphers(ins->tls, ins->tls_ciphers);
+            if (ret != 0) {
+                flb_error("[input %s] error setting up TLS ciphers up to TLSv1.2",
+                          ins->name);
+                flb_input_instance_destroy(ins);
+                return -1;
+            }
         }
     }
 

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -80,6 +80,24 @@ struct flb_config_map tls_configmap[] = {
      "Enable or disable to verify hostname"
     },
 
+    {
+     FLB_CONFIG_MAP_STR, "tls.min_version", NULL,
+     0, FLB_FALSE, 0,
+     "Specify the minimum version of TLS"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "tls.max_version", NULL,
+     0, FLB_FALSE, 0,
+     "Specify the maximum version of TLS"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "tls.ciphers", NULL,
+     0, FLB_FALSE, 0,
+     "Specify TLS ciphers up to TLSv1.2"
+    },
+
     /* EOF */
     {0}
 };
@@ -207,6 +225,25 @@ struct flb_tls *flb_tls_create(int mode,
     tls->api = &tls_openssl;
 
     return tls;
+}
+
+int flb_tls_set_minmax_proto(struct flb_tls *tls,
+                             const char *min_version, const char *max_version)
+{
+    if (tls->ctx) {
+        return tls->api->set_minmax_proto(tls, min_version, max_version);
+    }
+
+    return 0;
+}
+
+int flb_tls_set_ciphers(struct flb_tls *tls, const char *ciphers)
+{
+    if (tls->ctx) {
+        return tls->api->set_ciphers(tls, ciphers);
+    }
+
+    return 0;
 }
 
 int flb_tls_init()


### PR DESCRIPTION
This PR introduces three new TLS configuration options for both input and output plugins:

- `tls.min_version`: specifies the minimum allowed TLS version (e.g., TLSv1.1, TLSv1.2).
- `tls.max_version`: specifies the maximum allowed TLS version (e.g., TLSv1.2, TLSv1.3).
- `tls.ciphers`: allows users to define a specific set of TLS ciphers (up to TLSv1.2).

The options are added to the input/output configuration map and respected during TLS context initialization. This enhances TLS flexibility and allows better control over security compliance and compatibility with external systems.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
