### PR TITLE
windows: disable unused build targets and optimise container

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -401,12 +401,25 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.username }}
           password: ${{ secrets.token }}
+
+      - name: Pull the last release image to speed up the build with a cache
+        continue-on-error: true
+        run: |
+          VERSION=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName | sub("^v"; "")')
+          echo VERSION="$VERSION"
+          docker pull ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-$VERSION
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.token }}
 
       - name: Build the production images
         run: |

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -70,7 +70,15 @@ WORKDIR /src/build
 COPY . /src/
 
 ARG BUILD_PARALLEL=1
-RUN cmake -G "'Visual Studio 16 2019'" -DOPENSSL_ROOT_DIR='C:\dev\vcpkg\packages\openssl_x64-windows-static' -DFLB_LIBYAML_DIR='C:\dev\vcpkg\packages\libyaml_x64-windows-static' -DCMAKE_BUILD_TYPE=Release ../;`
+RUN cmake -G "'Visual Studio 16 2019'" `
+    -DOPENSSL_ROOT_DIR='C:\dev\vcpkg\packages\openssl_x64-windows-static' `
+    -DFLB_LIBYAML_DIR='C:\dev\vcpkg\packages\libyaml_x64-windows-static' `
+    -DCMAKE_BUILD_TYPE=Release `
+    -DFLB_SHARED_LIB=Off `
+    -DFLB_EXAMPLES=Off `
+    -DFLB_DEBUG=Off `
+    -DFLB_RELEASE=On `
+    ../;`
     cmake --build . --config Release -j ${BUILD_PARALLEL};
 
 # Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -14,7 +14,7 @@
 ARG WINDOWS_VERSION=ltsc2019
 
 # Builder Image - Windows Server Core
-FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION AS builder
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION AS builder-base
 
 RUN setx /M PATH "%PATH%;C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\WinFlexBison;C:\dev\vcpkg"
 
@@ -69,6 +69,8 @@ ENV VCPKG_LIBRARY_LINKAGE=static
 RUN vcpkg install --recurse openssl --triplet x64-windows-static; `
     vcpkg install --recurse libyaml --triplet x64-windows-static;
 
+FROM builder-base AS builder
+
 # Build Fluent Bit from source - context must be the root of the Git repo
 WORKDIR /src/build
 COPY . /src/
@@ -95,7 +97,8 @@ RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
     Copy-Item -Path /src/conf/parsers_openstack.conf /fluent-bit/etc/; `
     Copy-Item -Path /src/conf/parsers_cinder.conf /fluent-bit/etc/; `
     Copy-Item -Path /src/conf/plugins.conf /fluent-bit/etc/; `
-    Copy-Item -Path /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/; `
+    Copy-Item -Path /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/;
+
 #
 # Runtime Image - Windows Server Core
 #

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -96,7 +96,6 @@ RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
     Copy-Item -Path /src/conf/parsers_cinder.conf /fluent-bit/etc/; `
     Copy-Item -Path /src/conf/plugins.conf /fluent-bit/etc/; `
     Copy-Item -Path /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/; `
-    Copy-Item -Path /src/build/bin/Release/fluent-bit.dll /fluent-bit/bin/;
 #
 # Runtime Image - Windows Server Core
 #

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -62,6 +62,10 @@ RUN `
     Rename-Item -Path /dev/vcpkg-${ENV:VCPKG_VERSION} -NewName vcpkg; `
     /dev/vcpkg/bootstrap-vcpkg.bat;
 
+# Ensure we only attempt to build release and static linking
+ENV VCPKG_BUILD_TYPE=release
+ENV VCPKG_LIBRARY_LINKAGE=static
+
 RUN vcpkg install --recurse openssl --triplet x64-windows-static; `
     vcpkg install --recurse libyaml --triplet x64-windows-static;
 


### PR DESCRIPTION
Resolves #10110 by optimising the Windows container build to remove unnecessary build targets and ensure we build in release mode.

Previously we were building the shared library and examples, along with debug symbols. None of which are required or done by the Linux builds.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
