### PR TITLE
out_datadog: Fix formatting issue when setting a static hostname via dd_hostname (backport 3.2)

### DIFF
--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -118,6 +118,11 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
         ctx->nb_additional_entries++;
     }
 
+    tmp = flb_output_get_property("dd_hostname", ins);
+    if (tmp) {
+        ctx->nb_additional_entries++;
+    }
+
     tmp = flb_output_get_property("provider", ins);
     ctx->remap = tmp && (strlen(tmp) == strlen(FLB_DATADOG_REMAP_PROVIDER)) && \
         (strncmp(tmp, FLB_DATADOG_REMAP_PROVIDER, strlen(tmp)) == 0);


### PR DESCRIPTION


<!-- Provide summary of changes -->
Providing a static hostname via the dd_hostname configuration options is currently bugged, with an off-by-one error in the message packing loop causing dropped attributes and/or malformed output json. This PR corrects the issue, incrementing the msgpack map size by one when a dd_hostname property is detected.

This PR is a backport of [!10104](https://github.com/fluent/fluent-bit/pull/10104)
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
