### PR TITLE
processor: add conditional processing support for logs

### DIFF
--- a/include/fluent-bit/flb_mp_chunk.h
+++ b/include/fluent-bit/flb_mp_chunk.h
@@ -28,6 +28,9 @@
 #define FLB_MP_CHUNK_RECORD_OK     0  /* Content retrieved successfully */
 #define FLB_MP_CHUNK_RECORD_EOF    1  /* No more content to retrieve */
 
+/* Forward declaration to avoid circular dependencies */
+struct flb_condition;
+
 struct flb_mp_chunk_record {
     int modified;
     struct flb_log_event event;
@@ -43,6 +46,9 @@ struct flb_mp_chunk_cobj {
 
     struct flb_mp_chunk_record *record_pos;
     struct cfl_list records;
+
+    /* Condition for filtering records during processing */
+    struct flb_condition *condition;
 };
 
 

--- a/include/fluent-bit/flb_processor.h
+++ b/include/fluent-bit/flb_processor.h
@@ -64,6 +64,7 @@ struct flb_input_instance;
 struct flb_log_event_decoder;
 struct flb_log_event_encoder;
 struct flb_processor_instance;
+struct flb_condition;
 
 struct flb_processor_unit {
     int event_type;
@@ -76,6 +77,11 @@ struct flb_processor_unit {
      * contains the filter instance context.
      */
     void *ctx;
+
+    /* Conditional processing: if set, determines if the processor should
+     * be applied to a specific record
+     */
+    struct flb_condition *condition;
 
     /* This lock is meant to cover the case where two output plugin
      * worker threads flb_output_flush_create calls overlap which

--- a/src/flb_cfl_record_accessor.c
+++ b/src/flb_cfl_record_accessor.c
@@ -673,7 +673,7 @@ static flb_sds_t cfl_ra_translate_keymap(struct flb_ra_parser *rp, flb_sds_t buf
         }
     }
     else if (crv->type == FLB_CFL_RA_STRING) {
-        tmp = flb_sds_cat(buf, crv->val.string, flb_sds_len(crv->val.string));
+        tmp = flb_sds_cat(buf, crv->val.string, crv->v.size);
     }
     else if (crv->type == FLB_CFL_RA_NULL) {
         tmp = flb_sds_cat(buf, "null", 4);

--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -470,8 +470,9 @@ int flb_config_map_properties_check(char *context_name,
             continue;
         }
 
-        if (strcasecmp(kv->key, "active") == 0) {
-            /* Accept 'active' property ... */
+        if (strcasecmp(kv->key, "active") == 0 ||
+            strcasecmp(kv->key, "condition") == 0) {
+            /* Accept special core properties */
             continue;
         }
 
@@ -672,6 +673,12 @@ int flb_config_map_set(struct mk_list *properties, struct mk_list *map, void *co
         kv = mk_list_entry(head, struct flb_kv, _head);
 
         if (kv->val == NULL) {
+            continue;
+        }
+
+        /* Skip special core properties */
+        if (strcasecmp(kv->key, "condition") == 0 ||
+            strcasecmp(kv->key, "active") == 0) {
             continue;
         }
 

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -517,7 +517,11 @@ static int flb_processor_unit_set_condition(struct flb_processor_unit *pu, struc
         /* Add rule to the condition */
         ret = flb_condition_add_rule(condition, field, rule_op, value, value_count, context);
 
-        /* Free array value if we allocated it */
+        /* 
+         * Free array value if we allocated it. For 'in' and 'not_in' operators, 
+         * flb_condition_add_rule makes its own copy of the strings in the array, 
+         * so we need to free our copies whether or not the rule was added successfully.
+         */
         if (rule_val && rule_val->type == CFL_VARIANT_ARRAY) {
             for (j = 0; j < value_count; j++) {
                 flb_sds_destroy(((flb_sds_t *)value)[j]);

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -297,7 +297,9 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
     int value_count;
     enum record_context_type context;
     int i;
+    int j;
     int ret;
+    struct cfl_variant *array_val;
 
     /* Handle the "condition" property for processor units */
     if (strcasecmp(k, "condition") == 0) {
@@ -442,8 +444,8 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
             }
             else if (rule_val->type == CFL_VARIANT_UINT) {
                 value = &rule_val->data.as_uint64;
-                flb_debug("[processor] condition rule value (uint): %llu",
-                         rule_val->data.as_uint64);
+                flb_debug("[processor] condition rule value (uint): %lu",
+                         (unsigned long)rule_val->data.as_uint64);
             }
             else if (rule_val->type == CFL_VARIANT_DOUBLE) {
                 value = &rule_val->data.as_double;
@@ -466,8 +468,8 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
                     return -1;
                 }
 
-                for (int j = 0; j < rule_val->data.as_array->entry_count; j++) {
-                    struct cfl_variant *array_val = rule_val->data.as_array->entries[j];
+                for (j = 0; j < rule_val->data.as_array->entry_count; j++) {
+                    array_val = rule_val->data.as_array->entries[j];
                     if (array_val->type != CFL_VARIANT_STRING) {
                         flb_error("[processor] array values must be strings");
                         flb_free(value);
@@ -509,7 +511,7 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
 
             /* Free array value if we allocated it */
             if (rule_val && rule_val->type == CFL_VARIANT_ARRAY) {
-                for (int j = 0; j < value_count; j++) {
+                for (j = 0; j < value_count; j++) {
                     flb_sds_destroy(((flb_sds_t *)value)[j]);
                 }
                 flb_free(value);

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -904,11 +904,11 @@ int flb_processor_run(struct flb_processor *proc,
 
                     /* Set the processor condition if it exists */
                     if (pu->condition) {
-                        flb_info("[processor] setting condition for chunk processing (pu=%s)", pu->name);
+                        flb_debug("[processor] setting condition for chunk processing (pu=%s)", pu->name);
                         chunk_cobj->condition = pu->condition;
                     }
                     else {
-                        flb_info("[processor] no condition set for processor unit (pu=%s)", pu->name);
+                        flb_debug("[processor] no condition set for processor unit (pu=%s)", pu->name);
                     }
 
                     /* Invoke processor plugin callback */

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -42,6 +42,7 @@ set(UNIT_TESTS_FILES
   log_event_decoder.c
   log_event_encoder.c
   processor.c
+  processor_conditional.c
   uri.c
   msgpack_append_message.c
   conditionals.c

--- a/tests/internal/processor_conditional.c
+++ b/tests/internal/processor_conditional.c
@@ -70,6 +70,8 @@ static struct cfl_variant *create_condition_variant(const char *op, int rules_co
 {
     struct cfl_variant *variant;
     struct cfl_kvlist *kvlist;
+    struct cfl_array *rules;
+    struct cfl_variant *rules_var;
 
     variant = cfl_variant_create();
     if (!variant) {
@@ -90,7 +92,7 @@ static struct cfl_variant *create_condition_variant(const char *op, int rules_co
     }
 
     /* Create empty rules array */
-    struct cfl_array *rules = cfl_array_create(rules_count);
+    rules = cfl_array_create(rules_count);
     if (!rules) {
         cfl_kvlist_destroy(kvlist);
         cfl_variant_destroy(variant);
@@ -98,7 +100,7 @@ static struct cfl_variant *create_condition_variant(const char *op, int rules_co
     }
 
     /* Insert rules array into kvlist */
-    struct cfl_variant *rules_var = cfl_variant_create();
+    rules_var = cfl_variant_create();
     if (!rules_var) {
         cfl_array_destroy(rules);
         cfl_kvlist_destroy(kvlist);
@@ -114,6 +116,10 @@ static struct cfl_variant *create_condition_variant(const char *op, int rules_co
         cfl_variant_destroy(variant);
         return NULL;
     }
+
+    /* The array is now owned by the kvlist, but we need to clean up rules_var */
+    rules_var->data.as_array = NULL; /* Prevent double-free */
+    cfl_variant_destroy(rules_var);
 
     /* Link variant to kvlist */
     variant->type = CFL_VARIANT_KVLIST;

--- a/tests/internal/processor_conditional.c
+++ b/tests/internal/processor_conditional.c
@@ -1,0 +1,1926 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_processor.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_conditionals.h>
+#include <cfl/cfl_array.h>
+#include <cfl/cfl_kvlist.h>
+#include <cfl/cfl_variant.h>
+
+#include "flb_tests_internal.h"
+
+/* Helper functions */
+static void cleanup_test_resources(struct flb_config *config, struct flb_processor_unit *pu,
+                                  struct cfl_variant *condition, struct cfl_variant *rule)
+{
+    /* Free rule if it wasn't successfully added to the condition */
+    if (rule) {
+        cfl_variant_destroy(rule);
+    }
+    
+    if (condition) {
+        cfl_variant_destroy(condition);
+    }
+    
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+static struct cfl_variant *create_condition_variant(const char *op, int rules_count)
+{
+    struct cfl_variant *variant;
+    struct cfl_kvlist *kvlist;
+
+    variant = cfl_variant_create();
+    if (!variant) {
+        return NULL;
+    }
+
+    kvlist = cfl_kvlist_create();
+    if (!kvlist) {
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Set operator */
+    if (cfl_kvlist_insert_string(kvlist, "op", (char *)op) != 0) {
+        cfl_kvlist_destroy(kvlist);
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Create empty rules array */
+    struct cfl_array *rules = cfl_array_create(rules_count);
+    if (!rules) {
+        cfl_kvlist_destroy(kvlist);
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Insert rules array into kvlist */
+    struct cfl_variant *rules_var = cfl_variant_create();
+    if (!rules_var) {
+        cfl_array_destroy(rules);
+        cfl_kvlist_destroy(kvlist);
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+    rules_var->type = CFL_VARIANT_ARRAY;
+    rules_var->data.as_array = rules;
+
+    if (cfl_kvlist_insert_array(kvlist, "rules", rules_var->data.as_array) != 0) {
+        cfl_variant_destroy(rules_var);
+        cfl_kvlist_destroy(kvlist);
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Link variant to kvlist */
+    variant->type = CFL_VARIANT_KVLIST;
+    variant->data.as_kvlist = kvlist;
+
+    return variant;
+}
+
+static struct cfl_variant *create_rule_variant(const char *field, 
+                                              const char *op, 
+                                              void *value, 
+                                              int value_type,
+                                              int is_array,
+                                              const char *context)
+{
+    struct cfl_variant *variant;
+    struct cfl_kvlist *kvlist;
+
+    variant = cfl_variant_create();
+    if (!variant) {
+        return NULL;
+    }
+
+    kvlist = cfl_kvlist_create();
+    if (!kvlist) {
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Set field */
+    if (cfl_kvlist_insert_string(kvlist, "field", (char *)field) != 0) {
+        cfl_kvlist_destroy(kvlist);
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Set operator */
+    if (cfl_kvlist_insert_string(kvlist, "op", (char *)op) != 0) {
+        cfl_kvlist_destroy(kvlist);
+        cfl_variant_destroy(variant);
+        return NULL;
+    }
+
+    /* Set value based on type */
+    if (is_array) {
+        /* Create array for IN and NOT_IN operators */
+        struct cfl_array *array = cfl_array_create(2);
+        if (!array) {
+            cfl_kvlist_destroy(kvlist);
+            cfl_variant_destroy(variant);
+            return NULL;
+        }
+
+        /* Add array values */
+        char **values = (char **)value;
+        for (int i = 0; i < 2; i++) {
+            if (cfl_array_append_string(array, values[i]) != 0) {
+                cfl_array_destroy(array);
+                cfl_kvlist_destroy(kvlist);
+                cfl_variant_destroy(variant);
+                return NULL;
+            }
+        }
+
+        if (cfl_kvlist_insert_array(kvlist, "value", array) != 0) {
+            cfl_array_destroy(array);
+            cfl_kvlist_destroy(kvlist);
+            cfl_variant_destroy(variant);
+            return NULL;
+        }
+    }
+    else {
+        switch (value_type) {
+            case CFL_VARIANT_STRING:
+                if (cfl_kvlist_insert_string(kvlist, "value", (char *)value) != 0) {
+                    cfl_kvlist_destroy(kvlist);
+                    cfl_variant_destroy(variant);
+                    return NULL;
+                }
+                break;
+            case CFL_VARIANT_INT:
+                if (cfl_kvlist_insert_int64(kvlist, "value", (int64_t)*((int *)value)) != 0) {
+                    cfl_kvlist_destroy(kvlist);
+                    cfl_variant_destroy(variant);
+                    return NULL;
+                }
+                break;
+            case CFL_VARIANT_DOUBLE:
+                if (cfl_kvlist_insert_double(kvlist, "value", *((double *)value)) != 0) {
+                    cfl_kvlist_destroy(kvlist);
+                    cfl_variant_destroy(variant);
+                    return NULL;
+                }
+                break;
+            case CFL_VARIANT_BOOL:
+                if (cfl_kvlist_insert_bool(kvlist, "value", *((int *)value)) != 0) {
+                    cfl_kvlist_destroy(kvlist);
+                    cfl_variant_destroy(variant);
+                    return NULL;
+                }
+                break;
+            default:
+                cfl_kvlist_destroy(kvlist);
+                cfl_variant_destroy(variant);
+                return NULL;
+        }
+    }
+
+    /* Set context if provided */
+    if (context != NULL) {
+        if (cfl_kvlist_insert_string(kvlist, "context", (char *)context) != 0) {
+            cfl_kvlist_destroy(kvlist);
+            cfl_variant_destroy(variant);
+            return NULL;
+        }
+    }
+
+    /* Link variant to kvlist */
+    variant->type = CFL_VARIANT_KVLIST;
+    variant->data.as_kvlist = kvlist;
+
+    return variant;
+}
+
+static int add_rule_to_condition(struct cfl_variant *condition, struct cfl_variant *rule)
+{
+    struct cfl_array *rules;
+    
+    if (!condition || !rule || 
+        condition->type != CFL_VARIANT_KVLIST || 
+        rule->type != CFL_VARIANT_KVLIST) {
+        return -1;
+    }
+    
+    /* Get rules array from condition */
+    struct cfl_variant *rules_var = cfl_kvlist_fetch(condition->data.as_kvlist, "rules");
+    if (!rules_var || rules_var->type != CFL_VARIANT_ARRAY) {
+        return -1;
+    }
+    
+    rules = rules_var->data.as_array;
+    
+    /* Append rule to rules array */
+    return cfl_array_append(rules, rule);
+}
+
+static struct flb_processor_unit *create_processor_unit(struct flb_config *config)
+{
+    struct flb_processor *proc;
+    struct flb_processor_unit *pu;
+    
+    /* Create the processor */
+    proc = flb_processor_create(config, "test_processor", NULL, 0);
+    if (!proc) {
+        return NULL;
+    }
+    
+    /* Let's create a mock processor unit directly for testing */
+    pu = flb_calloc(1, sizeof(struct flb_processor_unit));
+    if (!pu) {
+        flb_processor_destroy(proc);
+        return NULL;
+    }
+    
+    pu->parent = proc;
+    pu->event_type = FLB_PROCESSOR_LOGS;
+    pu->name = flb_sds_create("test_unit");
+    pu->condition = NULL;
+    
+    /* Initialize the mutex */
+    pthread_mutex_init(&pu->lock, NULL);
+    
+    /* Initialize the lists */
+    mk_list_init(&pu->unused_list);
+    
+    /* Add to the parent's list */
+    mk_list_add(&pu->_head, &proc->logs);
+    
+    return pu;
+}
+
+void test_basic_condition()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *string_value = "error";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create a simple rule: $level eq "error" */
+    rule = create_rule_variant("$level", "eq", string_value, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        /* If we failed to add the rule, we need to free it manually */
+        if (rule) {
+            cfl_variant_destroy(rule);
+            rule = NULL;
+        }
+        goto cleanup;
+    }
+    /* After successful addition, rule is owned by condition */
+    rule = NULL;
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    /* Free rule if it wasn't successfully added to the condition */
+    if (rule) {
+        cfl_variant_destroy(rule);
+    }
+    if (condition) {
+        cfl_variant_destroy(condition);
+    }
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+void test_condition_operator_validation()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *string_value = "error";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with invalid operator */
+    condition = create_condition_variant("INVALID", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create a simple rule */
+    rule = create_rule_variant("$level", "eq", string_value, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        /* If we failed to add the rule, we need to free it manually */
+        if (rule) {
+            cfl_variant_destroy(rule);
+            rule = NULL;
+        }
+        goto cleanup;
+    }
+    /* After successful addition, rule is owned by condition */
+    rule = NULL;
+    
+    /* Test setting the condition - might fail due to invalid operator */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1); /* Should fail with invalid operator */
+    
+    /* In this test we're expecting it to fail, so we don't verify condition properties */
+    
+cleanup:
+    /* Free rule if it wasn't successfully added to the condition */
+    if (rule) {
+        cfl_variant_destroy(rule);
+    }
+    if (condition) {
+        cfl_variant_destroy(condition);
+    }
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+void test_empty_rules()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator and no rules */
+    condition = create_condition_variant("and", 0);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Test setting the condition - expected to fail with empty rules array */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1); /* Empty rules array should cause failure */
+    
+    /* We're expecting failure, so no condition should be set */
+    
+cleanup:
+    if (condition) {
+        cfl_variant_destroy(condition);
+    }
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+void test_multiple_rules()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule1 = NULL, *rule2 = NULL;
+    int ret;
+    char *string_value1 = "error";
+    double numeric_value = 100.5;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 2);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create first rule: $level eq "error" */
+    rule1 = create_rule_variant("$level", "eq", string_value1, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule1 != NULL);
+    if (!rule1) {
+        goto cleanup;
+    }
+    
+    /* Create second rule: $response_time gt 100.5 */
+    rule2 = create_rule_variant("$response_time", "gt", &numeric_value, CFL_VARIANT_DOUBLE, 0, NULL);
+    TEST_CHECK(rule2 != NULL);
+    if (!rule2) {
+        goto cleanup;
+    }
+    
+    /* Add rules to condition */
+    ret = add_rule_to_condition(condition, rule1);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        /* If we failed to add the rule, we need to free it manually */
+        cfl_variant_destroy(rule1);
+        rule1 = NULL;
+        goto cleanup;
+    }
+    /* rule1 is now owned by condition */
+    rule1 = NULL;
+    
+    ret = add_rule_to_condition(condition, rule2);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        /* If we failed to add the rule, we need to free it manually */
+        cfl_variant_destroy(rule2);
+        rule2 = NULL;
+        goto cleanup;
+    }
+    /* rule2 is now owned by condition */
+    rule2 = NULL;
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored with both rules */
+    if (ret == 0 && pu->condition != NULL) {
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 2);
+    }
+    
+cleanup:
+    /* Free rules if they weren't successfully added to the condition */
+    if (rule1) {
+        cfl_variant_destroy(rule1);
+    }
+    if (rule2) {
+        cfl_variant_destroy(rule2);
+    }
+    if (condition) {
+        cfl_variant_destroy(condition);
+    }
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+void test_context_metadata()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *string_value = "production";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create a rule with metadata context: $namespace eq "production" in metadata */
+    rule = create_rule_variant("$namespace", "eq", string_value, CFL_VARIANT_STRING, 0, "metadata");
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        /* If we failed to add the rule, we need to free it manually */
+        if (rule) {
+            cfl_variant_destroy(rule);
+            rule = NULL;
+        }
+        goto cleanup;
+    }
+    /* After successful addition, rule is owned by condition */
+    rule = NULL;
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_all_comparison_operators()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *string_value = "error";
+    double numeric_value = 100.0;
+    char *array_values[2] = {"warning", "error"};
+    char *regex_pattern = "^error.*$";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with OR operator */
+    condition = create_condition_variant("or", 6);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Test EQ operator */
+    rule = create_rule_variant("$level", "eq", string_value, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test NEQ operator */
+    rule = create_rule_variant("$level", "neq", string_value, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test GT operator */
+    rule = create_rule_variant("$response_time", "gt", &numeric_value, CFL_VARIANT_DOUBLE, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test LT operator */
+    rule = create_rule_variant("$response_time", "lt", &numeric_value, CFL_VARIANT_DOUBLE, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test REGEX operator */
+    rule = create_rule_variant("$message", "regex", regex_pattern, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test IN operator */
+    rule = create_rule_variant("$level", "in", array_values, CFL_VARIANT_STRING, 1, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored with all rules */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_OR);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 6);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_gte_lte_operators() 
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule1 = NULL, *rule2 = NULL;
+    int ret;
+    double value1 = 1024.0;
+    double value2 = 95.5;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 2);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create first rule: $memory gte 1024.0 */
+    rule1 = create_rule_variant("$memory", "gte", &value1, CFL_VARIANT_DOUBLE, 0, NULL);
+    TEST_CHECK(rule1 != NULL);
+    if (!rule1) {
+        goto cleanup;
+    }
+    
+    /* Create second rule: $cpu lte 95.5 */
+    rule2 = create_rule_variant("$cpu", "lte", &value2, CFL_VARIANT_DOUBLE, 0, NULL);
+    TEST_CHECK(rule2 != NULL);
+    if (!rule2) {
+        goto cleanup;
+    }
+    
+    /* Add rules to condition */
+    ret = add_rule_to_condition(condition, rule1);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule1);
+        rule1 = NULL;
+        goto cleanup;
+    }
+    rule1 = NULL; /* Ownership transferred to condition */
+    
+    ret = add_rule_to_condition(condition, rule2);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule2);
+        rule2 = NULL;
+        goto cleanup;
+    }
+    rule2 = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 2);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, NULL);
+    if (rule1) {
+        cfl_variant_destroy(rule1);
+    }
+    if (rule2) {
+        cfl_variant_destroy(rule2);
+    }
+}
+
+void test_not_regex_operator()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *pattern = "error|warning";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create rule: $log not_regex "error|warning" */
+    rule = create_rule_variant("$log", "not_regex", pattern, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_not_in_operator()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *array_values[2] = {"info", "debug"};
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create rule: $level not_in ["info", "debug"] */
+    rule = create_rule_variant("$level", "not_in", array_values, CFL_VARIANT_STRING, 1, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_dollar_prefixed_fields()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *string_value = "GET";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create a rule with complex field path using $ prefix: $request['method'] eq "GET" */
+    rule = create_rule_variant("$request['method']", "eq", string_value, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_deeply_nested_field_access()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *string_value = "Bearer token";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create a rule with deeply nested field path: $request['headers']['Authorization'] eq "Bearer token" */
+    rule = create_rule_variant("$request['headers']['Authorization']", "eq", 
+                              string_value, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_overwrite_existing_condition()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition1 = NULL;
+    struct cfl_variant *condition2 = NULL;
+    struct cfl_variant *rule1 = NULL;
+    struct cfl_variant *rule2 = NULL;
+    int ret;
+    char *string_value1 = "error";
+    char *string_value2 = "warning";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create first condition with AND operator */
+    condition1 = create_condition_variant("and", 1);
+    TEST_CHECK(condition1 != NULL);
+    if (!condition1) {
+        goto cleanup;
+    }
+    
+    /* Create a rule: $level eq "error" */
+    rule1 = create_rule_variant("$level", "eq", string_value1, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule1 != NULL);
+    if (!rule1) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition1, rule1);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule1);
+        rule1 = NULL;
+        goto cleanup;
+    }
+    rule1 = NULL; /* Ownership transferred to condition1 */
+    
+    /* Test setting the first condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition1);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        goto cleanup;
+    }
+    
+    /* Verify first condition was created and stored */
+    TEST_CHECK(pu->condition != NULL);
+    TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+    TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    
+    /* Now create second condition with OR operator */
+    condition2 = create_condition_variant("or", 1);
+    TEST_CHECK(condition2 != NULL);
+    if (!condition2) {
+        goto cleanup;
+    }
+    
+    /* Create a rule: $level eq "warning" */
+    rule2 = create_rule_variant("$level", "eq", string_value2, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule2 != NULL);
+    if (!rule2) {
+        goto cleanup;
+    }
+    
+    /* Add rule to second condition */
+    ret = add_rule_to_condition(condition2, rule2);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule2);
+        rule2 = NULL;
+        goto cleanup;
+    }
+    rule2 = NULL; /* Ownership transferred to condition2 */
+    
+    /* Test setting the second condition (should overwrite the first one) */
+    ret = flb_processor_unit_set_property(pu, "condition", condition2);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify second condition replaced the first one */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_OR);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+    }
+    
+cleanup:
+    /* After first condition is set, it's owned by processor unit, so don't free it separately */
+    /* Only free condition1 if it wasn't successfully set */
+    if (condition1 && (!pu || !pu->condition || pu->condition->op != FLB_COND_OP_AND)) {
+        cfl_variant_destroy(condition1);
+    }
+    /* After the second condition is set, the first one is destroyed, so only free condition2 if it wasn't set successfully */
+    if (condition2 && (!pu || !pu->condition || pu->condition->op != FLB_COND_OP_OR)) {
+        cfl_variant_destroy(condition2);
+    }
+    if (rule1) cfl_variant_destroy(rule1);
+    if (rule2) cfl_variant_destroy(rule2);
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+void test_invalid_rule_missing_field()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create invalid rule variant with missing fields */
+    rule = cfl_variant_create();
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    rule->type = CFL_VARIANT_KVLIST;
+    rule->data.as_kvlist = cfl_kvlist_create();
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition - should fail due to missing field in rule */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_invalid_rule_missing_operator()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create invalid rule variant with missing operator */
+    rule = cfl_variant_create();
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    rule->type = CFL_VARIANT_KVLIST;
+    rule->data.as_kvlist = cfl_kvlist_create();
+    
+    if (!rule->data.as_kvlist) {
+        goto cleanup;
+    }
+    
+    if (cfl_kvlist_insert_string(rule->data.as_kvlist, "field", "$level") != 0) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition - should fail due to missing operator in rule */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_invalid_rule_missing_value()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create invalid rule variant with missing value */
+    rule = cfl_variant_create();
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    rule->type = CFL_VARIANT_KVLIST;
+    rule->data.as_kvlist = cfl_kvlist_create();
+    
+    if (!rule->data.as_kvlist) {
+        goto cleanup;
+    }
+    
+    if (cfl_kvlist_insert_string(rule->data.as_kvlist, "field", "$level") != 0 ||
+        cfl_kvlist_insert_string(rule->data.as_kvlist, "op", "eq") != 0) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition - should fail due to missing value in rule */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_invalid_condition_structure()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *invalid_condition = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create invalid condition (not a kvlist) */
+    invalid_condition = cfl_variant_create();
+    TEST_CHECK(invalid_condition != NULL);
+    if (!invalid_condition) {
+        goto cleanup;
+    }
+    
+    /* Properly allocate the string to avoid memory issues */
+    invalid_condition->type = CFL_VARIANT_STRING;
+    invalid_condition->data.as_string = flb_sds_create("not a valid condition");
+    
+    /* Test setting the condition - should fail due to invalid condition structure */
+    ret = flb_processor_unit_set_property(pu, "condition", invalid_condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    /* Clean up variant manually instead of using the helper */
+    if (invalid_condition) {
+        if (invalid_condition->type == CFL_VARIANT_STRING && 
+            invalid_condition->data.as_string) {
+            flb_sds_destroy(invalid_condition->data.as_string);
+            invalid_condition->data.as_string = NULL;
+        }
+        cfl_variant_destroy(invalid_condition);
+    }
+    
+    if (pu) {
+        if (pu->condition) {
+            flb_condition_destroy(pu->condition);
+        }
+        if (pu->name) {
+            flb_sds_destroy(pu->name);
+        }
+        pthread_mutex_destroy(&pu->lock);
+        
+        if (pu->parent) {
+            /* Remove from parent's list */
+            mk_list_del(&pu->_head);
+            flb_processor_destroy(pu->parent);
+        }
+        
+        flb_free(pu);
+    }
+    
+    if (config) {
+        flb_config_exit(config);
+    }
+}
+
+void test_invalid_rules_array()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition without rules array */
+    condition = cfl_variant_create();
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    condition->type = CFL_VARIANT_KVLIST;
+    condition->data.as_kvlist = cfl_kvlist_create();
+    
+    if (!condition->data.as_kvlist) {
+        goto cleanup;
+    }
+    
+    if (cfl_kvlist_insert_string(condition->data.as_kvlist, "op", "and") != 0) {
+        goto cleanup;
+    }
+    
+    /* Test setting the condition - should fail due to missing rules array */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    /* In this case, we're correctly using cfl_kvlist_insert_string which 
+     * properly handles the memory, so we can use the helper function */
+    cleanup_test_resources(config, pu, condition, NULL);
+}
+
+void test_array_value_for_numeric_operator()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *array_values[2] = {"100", "200"};
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create invalid rule: $response_time gt ["100", "200"] */
+    rule = create_rule_variant("$response_time", "gt", array_values, CFL_VARIANT_STRING, 1, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition - should fail due to array value for numeric operator */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_string_value_for_in_operator()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create our own rule variant directly instead of using create_rule_variant */
+    rule = cfl_variant_create();
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Set up the rule structure manually */
+    rule->type = CFL_VARIANT_KVLIST;
+    rule->data.as_kvlist = cfl_kvlist_create();
+    if (!rule->data.as_kvlist) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    
+    /* Add required fields to the rule */
+    if (cfl_kvlist_insert_string(rule->data.as_kvlist, "field", "$level") != 0 ||
+        cfl_kvlist_insert_string(rule->data.as_kvlist, "op", "in") != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    
+    /* Create a string value instead of an array - this is intentionally incorrect
+     * Now that we've fixed the code, this should be properly validated and rejected
+     * with an error instead of crashing */
+    if (cfl_kvlist_insert_string(rule->data.as_kvlist, "value", "error") != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition - should now fail with a proper validation error
+     * instead of crashing, because we added explicit validation for 'in' operations */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_invalid_regex_pattern()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule = NULL;
+    int ret;
+    char *invalid_pattern = "[invalid";
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create condition with AND operator */
+    condition = create_condition_variant("and", 1);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Create rule with invalid regex pattern: $log regex "[invalid" */
+    rule = create_rule_variant("$log", "regex", invalid_pattern, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule != NULL);
+    if (!rule) {
+        goto cleanup;
+    }
+    
+    /* Add rule to condition */
+    ret = add_rule_to_condition(condition, rule);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule);
+        rule = NULL;
+        goto cleanup;
+    }
+    rule = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition - should fail due to invalid regex pattern */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == -1);
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, rule);
+}
+
+void test_complex_nested_condition()
+{
+    struct flb_config *config = NULL;
+    struct flb_processor_unit *pu = NULL;
+    struct cfl_variant *condition = NULL;
+    struct cfl_variant *rule1 = NULL;
+    struct cfl_variant *rule2 = NULL;
+    struct cfl_variant *rule3 = NULL;
+    int ret;
+    char *string_value1 = "error";
+    double numeric_value = 1000.0;
+    char *array_values[2] = {"production", "staging"};
+    
+    /* Initialize */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        goto cleanup;
+    }
+    
+    pu = create_processor_unit(config);
+    TEST_CHECK(pu != NULL);
+    if (!pu) {
+        goto cleanup;
+    }
+    
+    /* Create complex condition with AND operator */
+    condition = create_condition_variant("and", 3);
+    TEST_CHECK(condition != NULL);
+    if (!condition) {
+        goto cleanup;
+    }
+    
+    /* Rule 1: $level eq "error" */
+    rule1 = create_rule_variant("$level", "eq", string_value1, CFL_VARIANT_STRING, 0, NULL);
+    TEST_CHECK(rule1 != NULL);
+    if (!rule1) {
+        goto cleanup;
+    }
+    
+    /* Rule 2: $response_time gt 1000.0 */
+    rule2 = create_rule_variant("$response_time", "gt", &numeric_value, CFL_VARIANT_DOUBLE, 0, NULL);
+    TEST_CHECK(rule2 != NULL);
+    if (!rule2) {
+        goto cleanup;
+    }
+    
+    /* Rule 3: $env in ["production", "staging"] using metadata context */
+    rule3 = create_rule_variant("$env", "in", array_values, CFL_VARIANT_STRING, 1, "metadata");
+    TEST_CHECK(rule3 != NULL);
+    if (!rule3) {
+        goto cleanup;
+    }
+    
+    /* Add rule1 to condition */
+    ret = add_rule_to_condition(condition, rule1);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule1);
+        rule1 = NULL;
+        goto cleanup;
+    }
+    rule1 = NULL; /* Ownership transferred to condition */
+    
+    /* Add rule2 to condition */
+    ret = add_rule_to_condition(condition, rule2);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule2);
+        rule2 = NULL;
+        goto cleanup;
+    }
+    rule2 = NULL; /* Ownership transferred to condition */
+    
+    /* Add rule3 to condition */
+    ret = add_rule_to_condition(condition, rule3);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        cfl_variant_destroy(rule3);
+        rule3 = NULL;
+        goto cleanup;
+    }
+    rule3 = NULL; /* Ownership transferred to condition */
+    
+    /* Test setting the condition */
+    ret = flb_processor_unit_set_property(pu, "condition", condition);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify condition was created and stored */
+    if (ret == 0) {
+        TEST_CHECK(pu->condition != NULL);
+        TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
+        TEST_CHECK(mk_list_size(&pu->condition->rules) == 3);
+    }
+    
+cleanup:
+    cleanup_test_resources(config, pu, condition, NULL);
+    if (rule1) cfl_variant_destroy(rule1);
+    if (rule2) cfl_variant_destroy(rule2);
+    if (rule3) cfl_variant_destroy(rule3);
+}
+
+TEST_LIST = {
+    {"basic_condition", test_basic_condition},
+    {"condition_operator_validation", test_condition_operator_validation},
+    {"empty_rules", test_empty_rules},
+    {"multiple_rules", test_multiple_rules},
+    {"context_metadata", test_context_metadata},
+    {"all_comparison_operators", test_all_comparison_operators},
+    {"gte_lte_operators", test_gte_lte_operators},
+    {"not_regex_operator", test_not_regex_operator},
+    {"not_in_operator", test_not_in_operator},
+    {"dollar_prefixed_fields", test_dollar_prefixed_fields},
+    {"deeply_nested_field_access", test_deeply_nested_field_access},
+    {"overwrite_existing_condition", test_overwrite_existing_condition},
+    {"invalid_rule_missing_field", test_invalid_rule_missing_field},
+    {"invalid_rule_missing_operator", test_invalid_rule_missing_operator},
+    {"invalid_rule_missing_value", test_invalid_rule_missing_value},
+    {"invalid_condition_structure", test_invalid_condition_structure},
+    {"invalid_rules_array", test_invalid_rules_array},
+    {"array_value_for_numeric_operator", test_array_value_for_numeric_operator},
+    {"string_value_for_in_operator", test_string_value_for_in_operator},
+    {"invalid_regex_pattern", test_invalid_regex_pattern},
+    {"complex_nested_condition", test_complex_nested_condition},
+    {NULL, NULL}
+};

--- a/tests/internal/processor_conditional.c
+++ b/tests/internal/processor_conditional.c
@@ -131,6 +131,9 @@ static struct cfl_variant *create_rule_variant(const char *field,
 {
     struct cfl_variant *variant;
     struct cfl_kvlist *kvlist;
+    struct cfl_array *array;
+    char **values;
+    int i;
 
     variant = cfl_variant_create();
     if (!variant) {
@@ -160,7 +163,7 @@ static struct cfl_variant *create_rule_variant(const char *field,
     /* Set value based on type */
     if (is_array) {
         /* Create array for IN and NOT_IN operators */
-        struct cfl_array *array = cfl_array_create(2);
+        array = cfl_array_create(2);
         if (!array) {
             cfl_kvlist_destroy(kvlist);
             cfl_variant_destroy(variant);
@@ -168,8 +171,8 @@ static struct cfl_variant *create_rule_variant(const char *field,
         }
 
         /* Add array values */
-        char **values = (char **)value;
-        for (int i = 0; i < 2; i++) {
+        values = (char **)value;
+        for (i = 0; i < 2; i++) {
             if (cfl_array_append_string(array, values[i]) != 0) {
                 cfl_array_destroy(array);
                 cfl_kvlist_destroy(kvlist);

--- a/tests/internal/processor_conditional.c
+++ b/tests/internal/processor_conditional.c
@@ -363,6 +363,10 @@ void test_basic_condition()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -615,6 +619,10 @@ void test_multiple_rules()
     if (ret == 0 && pu->condition != NULL) {
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 2);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -709,6 +717,10 @@ void test_context_metadata()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -961,6 +973,10 @@ void test_gte_lte_operators()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 2);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -1028,6 +1044,10 @@ void test_not_regex_operator()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -1089,6 +1109,10 @@ void test_not_in_operator()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -1150,6 +1174,10 @@ void test_dollar_prefixed_fields()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:
@@ -1212,6 +1240,10 @@ void test_deeply_nested_field_access()
         TEST_CHECK(pu->condition != NULL);
         TEST_CHECK(pu->condition->op == FLB_COND_OP_AND);
         TEST_CHECK(mk_list_size(&pu->condition->rules) == 1);
+        
+        /* Condition is now owned by processor unit, destroy our copy */
+        cfl_variant_destroy(condition);
+        condition = NULL;
     }
     
 cleanup:

--- a/tests/runtime_shell/CMakeLists.txt
+++ b/tests/runtime_shell/CMakeLists.txt
@@ -13,6 +13,7 @@ set(UNIT_TESTS_SH
   in_syslog_udp_plaintext_expect.sh
   in_syslog_uds_dgram_plaintext_expect.sh
   in_syslog_uds_stream_plaintext_expect.sh
+  processor_conditional.sh
   )
 
 # Prepare list of unit tests

--- a/tests/runtime_shell/processor_conditional.sh
+++ b/tests/runtime_shell/processor_conditional.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+# Setup environment if not already set
+if [ -z "$FLB_BIN" ]; then
+    FLB_ROOT=${FLB_ROOT:-$(cd $(dirname $0)/../.. && pwd)}
+    FLB_BIN=${FLB_BIN:-$FLB_ROOT/build/bin/fluent-bit}
+fi
+
+echo "Using Fluent Bit at: $FLB_BIN"
+
+# Create a temporary YAML config file
+cat > /tmp/processor_conditional.yaml << EOL
+service:
+  log_level: trace
+  flush: 1
+pipeline:
+  inputs:
+    - name: dummy
+      dummy: '{"request": {"method": "GET", "path": "/api/v1/resource", "headers": {"Authorization": "Bearer valid-token"}, "access": "granted"}}'
+      tag: error.msg
+      processors:
+        logs:
+          - name: content_modifier
+            action: insert
+            key: modified_if_post
+            value: true
+            condition:
+              op: and
+              rules:
+                - field: \$request['method']
+                  op: eq
+                  value: POST
+
+          - name: content_modifier
+            action: insert
+            key: modified_if_get
+            value: true
+            condition:
+              op: and
+              rules:
+                - field: \$request['method']
+                  op: eq
+                  value: GET
+
+  outputs:
+    - name: stdout
+      match: '*'
+EOL
+
+echo "Running Fluent Bit with conditional processor YAML config..."
+echo "YAML Config:"
+cat /tmp/processor_conditional.yaml
+
+# Redirect stdout to a file for analysis
+OUTPUT_FILE="/tmp/processor_conditional_output.txt"
+$FLB_BIN -c /tmp/processor_conditional.yaml -o stdout > $OUTPUT_FILE 2>&1 &
+FLB_PID=$!
+echo "Fluent Bit started with PID: $FLB_PID"
+
+# Wait for output to be generated
+echo "Waiting for processing to complete..."
+sleep 5
+
+# Check for output
+if [ ! -f "$OUTPUT_FILE" ]; then
+    echo "Output file not found"
+    kill -15 $FLB_PID || true
+    exit 1
+fi
+
+echo "Output file content:"
+cat $OUTPUT_FILE
+
+# Verify that the GET condition was applied but not the POST condition
+GET_FIELD=$(grep -c "modified_if_get" $OUTPUT_FILE)
+POST_FIELD=$(grep -c "modified_if_post" $OUTPUT_FILE)
+
+# Clean up
+echo "Cleaning up..."
+kill -15 $FLB_PID || true
+rm -f /tmp/processor_conditional.yaml
+rm -f $OUTPUT_FILE
+
+# Check results
+if [ "$GET_FIELD" -gt 0 ] && [ "$POST_FIELD" -eq 0 ]; then
+    echo "Test passed: GET condition applied, POST condition not applied"
+    exit 0
+else
+    echo "Test failed: GET=$GET_FIELD, POST=$POST_FIELD"
+    exit 1
+fi


### PR DESCRIPTION
## Processor conditional processing for logs

Fix #10127

This PR adds conditional processing support for logs in processors. This feature allows processors to conditionally process logs based on field values.

### Example configurations

1. Simple

```yaml
service:
  log_level: info
pipeline:
  inputs:
    - name: dummy
      dummy: '{"request": {"method": "GET", "path": "/api/v1/resource", "headers": {"Authorization": "Bearer valid-token"}, "access": "granted"}}'
      tag: error.msg
      processors:
        logs:
          - name: content_modifier
            action: insert
            key: modified_if_post
            value: true
            condition:
              op: and
              rules:
                - field: "$request['method']"
                  op: eq
                  value: "POST"

          - name: content_modifier
            action: insert
            key: modified_if_get
            value: true
            condition:
              op: and
              rules:
                - field: "$request['method']"
                  op: eq
                  value: "GET"

  outputs:
    - name: stdout
      match: '*'
```

When this configuration runs, the processor only adds the field `modified_if_get` to records where the request method is GET:

```
[0] error.msg: [[1743160978.853138000, {}], {"request"=>{"method"=>"GET", "path"=>"/api/v1/resource", "headers"=>{"Authorization"=>"Bearer valid-token"}, "access"=>"granted"}, "modified_if_get"=>"true"}]
[0] error.msg: [[1743160979.853940000, {}], {"request"=>{"method"=>"GET", "path"=>"/api/v1/resource", "headers"=>{"Authorization"=>"Bearer valid-token"}, "access"=>"granted"}, "modified_if_get"=>"true"}]
```

2. More complex
```yaml
service:
  log_level: info
pipeline:
  inputs:
    - name: dummy
      dummy: '{"request": {"method": "GET", "path": "/api/v1/resource", "headers": {"Authorization": "Bearer valid-token", "Content-Type": "application/json"}, "status_code": 200, "response_time": 150}}'
      tag: request.log
      processors:
        logs:
          - name: content_modifier
            action: insert
            key: high_priority_method
            value: true
            condition:
              op: and
              rules:
                - field: "$request['method']"
                  op: in
                  value: ["POST", "PUT", "DELETE"]

          - name: content_modifier
            action: insert
            key: requires_performance_check
            value: true
            condition:
              op: or
              rules:
                - field: "$request['response_time']"
                  op: gt
                  value: 100
                - field: "$request['status_code']"
                  op: gte
                  value: 400

  outputs:
    - name: stdout
```

Outputs:

```
  "headers"=>{"Authorization"=>"Bearer valid-token", "Content-Type"=>"application/json"}, "status_code"=>200, "response_time"=>150},
  "requires_performance_check"=>"true"}]
  [0] request.log: [[1743163088.501242000, {}], {"request"=>{"method"=>"GET", "path"=>"/api/v1/resource", "headers"=>{"Authorization"=>"Bearer valid-token",
  "Content-Type"=>"application/json"}, "status_code"=>200, "response_time"=>150}, "requires_performance_check"=>"true"}]
  [0] request.log: [[1743163089.501156000, {}], {"request"=>{"method"=>"GET", "path"=>"/api/v1/resource", "headers"=>{"Authorization"=>"Bearer valid-token",
  "Content-Type"=>"application/json"}, "status_code"=>200, "response_time"=>150}, "requires_performance_check"=>"true"}]
```
1. The high_priority_method field was NOT added to the records because our input has "method":"GET" which isn't in the array ["POST", "PUT", "DELETE"] specified
  in the first condition.
  
2. The requires_performance_check field WAS added with value "true" because the second condition is met:
    - We have an OR condition with two rules
    - The first rule checks if response_time > 100 (our value is 150)
    - Since this rule is true, the whole condition evaluates to true, regardless of the second rule
    - This matches what we expected: when response time > 100, flag the request for performance checking
   
### Added tests

#### Internal unit tests
- Added test suite for processor condition validation in `tests/internal/processor_conditional.c`
- Created tests for condition operators (and, or)
- Added tests for rule operators (eq, neq, gt, lt, gte, lte, regex, not_regex, in, not_in)
- Included tests for fields with $ prefix and record accessors
- Added tests for error cases:
  - Invalid operator validation
  - Empty rules arrays
  - Multiple rules handling
  - Context metadata handling
  - Deeply nested field access
  - Overwriting existing conditions
  - Missing fields/operators/values
  - Invalid rule structures
  - Invalid regex patterns
  - Array values for numeric operators
  - String values for 'in' operator
  - Complex nested conditions

#### Runtime shell tests
- Added runtime shell tests in `tests/runtime_shell/processor_conditional.sh`
- Tests processor condition functionality with actual Fluent Bit instances
