### PR TITLE
processor_content_modifier: fix and enhance data type conversion

### DIFF
--- a/plugins/processor_content_modifier/cm_utils.c
+++ b/plugins/processor_content_modifier/cm_utils.c
@@ -162,6 +162,7 @@ int cm_utils_variant_convert(struct cfl_variant *input_value,
     int ret;
     int errno_backup;
     int64_t as_int;
+    uint64_t as_uint;
     double as_double;
     char buf[64];
     char *str = NULL;
@@ -214,20 +215,57 @@ int cm_utils_variant_convert(struct cfl_variant *input_value,
                 str = input_value->data.as_string;
             }
 
-            as_int = strtoimax(str, &converstion_canary, 10);
-            if (errno == ERANGE || errno == EINVAL) {
-                errno = errno_backup;
+            /* signed integer */
+            if (str[0] == '-') {
+                as_int = strtoimax(str, &converstion_canary, 10);
+                if (errno == ERANGE || errno == EINVAL || *converstion_canary != '\0') {
+                    errno = errno_backup;
+                    if (tmp) {
+                        cfl_variant_destroy(tmp);
+                    }
+                    return CFL_FALSE;
+                }
+
                 if (tmp) {
                     cfl_variant_destroy(tmp);
                 }
-                return CFL_FALSE;
-            }
 
-            if (tmp) {
-                cfl_variant_destroy(tmp);
-            }
+                if (as_int < INT_MIN || as_int > INT_MAX) {
+                    return CFL_FALSE;
+                }
 
-            tmp = cfl_variant_create_from_int64(as_int);
+                tmp = cfl_variant_create_from_int64(as_int);
+            }
+            else {
+                /* unsigned integer */
+                as_uint = strtoumax(str, &converstion_canary, 10);
+                if (errno == ERANGE || errno == EINVAL || *converstion_canary != '\0') {
+                    errno = errno_backup;
+                    if (tmp) {
+                        cfl_variant_destroy(tmp);
+                    }
+                    return CFL_FALSE;
+                }
+
+                if (tmp) {
+                    cfl_variant_destroy(tmp);
+                }
+
+                if (as_uint <= INT_MAX) {
+                    as_int = (int64_t) as_uint;
+                    tmp = cfl_variant_create_from_int64(as_int);
+                }
+                else if (as_uint <= UINT_MAX) {
+                    tmp = cfl_variant_create_from_int64((int64_t) as_uint);
+                }
+                else {
+                    /* out of range for both `int` and `unsigned int` */
+                    if (tmp) {
+                        cfl_variant_destroy(tmp);
+                    }
+                    return CFL_FALSE;
+                }
+            }
         }
         else if (output_type == CFL_VARIANT_DOUBLE) {
             errno = 0;
@@ -288,7 +326,34 @@ int cm_utils_variant_convert(struct cfl_variant *input_value,
             tmp = cfl_variant_create_from_bool(as_int);
         }
         else if (output_type == CFL_VARIANT_INT) {
-            /* same type, do nothing */
+            tmp = cfl_variant_create_from_int64(input_value->data.as_int64);
+        }
+        else if (output_type == CFL_VARIANT_DOUBLE) {
+            as_double = (double) input_value->data.as_int64;
+            tmp = cfl_variant_create_from_double(as_double);
+        }
+        else {
+            return CFL_FALSE;
+        }
+    }
+    /* input: uint */
+    else if (input_value->type == CFL_VARIANT_UINT) {
+        if (output_type == CFL_VARIANT_STRING || output_type == CFL_VARIANT_BYTES) {
+            ret = snprintf(buf, sizeof(buf), "%" PRIu64, input_value->data.as_uint64);
+            if (ret < 0 || ret >= sizeof(buf)) {
+                return CFL_FALSE;
+            }
+            tmp = cfl_variant_create_from_string_s(buf, ret, CFL_FALSE);
+        }
+        else if (output_type == CFL_VARIANT_BOOL) {
+            as_int = CFL_FALSE;
+            if (input_value->data.as_uint64 != 0) {
+                as_int = CFL_TRUE;
+            }
+            tmp = cfl_variant_create_from_bool(as_int);
+        }
+        else if (output_type == CFL_VARIANT_INT) {
+            tmp = cfl_variant_create_from_uint64(input_value->data.as_uint64);
         }
         else if (output_type == CFL_VARIANT_DOUBLE) {
             as_double = (double) input_value->data.as_int64;
@@ -322,7 +387,7 @@ int cm_utils_variant_convert(struct cfl_variant *input_value,
             tmp = cfl_variant_create_from_int64(as_int);
         }
         else if (output_type == CFL_VARIANT_DOUBLE) {
-            as_double = input_value->data.as_int64;
+            as_double = input_value->data.as_double;
             tmp = cfl_variant_create_from_double(as_double);
         }
         else {
@@ -343,6 +408,32 @@ int cm_utils_variant_convert(struct cfl_variant *input_value,
         }
         else if (output_type == CFL_VARIANT_DOUBLE) {
             tmp = cfl_variant_create_from_double(0);
+        }
+        else {
+            return CFL_FALSE;
+        }
+    }
+    else if (input_value->type == CFL_VARIANT_BOOL) {
+        if (output_type == CFL_VARIANT_STRING ||
+            output_type == CFL_VARIANT_BYTES) {
+
+            if (input_value->data.as_bool == CFL_TRUE) {
+                tmp = cfl_variant_create_from_string_s("true", 4, CFL_FALSE);
+            }
+            else {
+                tmp = cfl_variant_create_from_string_s("false", 5, CFL_FALSE);
+            }
+        }
+        else if (output_type == CFL_VARIANT_BOOL) {
+            tmp = cfl_variant_create_from_bool(input_value->data.as_bool);
+        }
+        else if (output_type == CFL_VARIANT_INT) {
+            as_int = input_value->data.as_bool;
+            tmp = cfl_variant_create_from_int64(as_int);
+        }
+        else if (output_type == CFL_VARIANT_DOUBLE) {
+            as_double = (double) input_value->data.as_bool;
+            tmp = cfl_variant_create_from_double(as_double);
         }
         else {
             return CFL_FALSE;


### PR DESCRIPTION
As described in #10145, some data types conversion were wrong or just missing. This patch makes the proper fixes and extend to handle unsigned types.

e.g:

```yaml
pipeline:
  inputs:
    - name: dummy
      dummy: |
        {
          "string_to_int": "-1",
          "string_to_uint": "1",
          "string_to_double": "0.2",
          "string_to_boolean": "true",
          "string_to_string": "hello",
          "int_to_string": 1,
          "double_to_double": 0.2,
          "int_to_boolean": 1,
          "int_to_int": -1,
          "uint_to_uint": 1,
          "int_to_double": 1,
          "boolean_to_string": true,
          "boolean_to_boolean": true,
          "boolean_to_int": true,
          "boolean_to_double": true
        }
      processors:
        logs:

          # convert string to int (negative value)
          - name: content_modifier
            action: convert
            key: string_to_int
            converted_type: int

          # convert string to int (positive value)
          - name: content_modifier
            action: convert
            key: string_to_uint
            converted_type: int

          # convert string to double
          - name: content_modifier
            action: convert
            key: string_to_double
            converted_type: double

          # convert string to boolean
          - name: content_modifier
            action: convert
            key: string_to_boolean
            converted_type: boolean

          # convert string to string
          - name: content_modifier
            action: convert
            key: string_to_string
            converted_type: string

          # convert double to double
          - name: content_modifier
            action: convert
            key: double_to_double
            converted_type: double

          # convert int to string
          - name: content_modifier
            action: convert
            key: int_to_string
            converted_type: string

          # convert int to boolean
          - name: content_modifier
            action: convert
            key: int_to_boolean
            converted_type: boolean

          # convert int to int (negative value)
          - name: content_modifier
            action: convert
            key: int_to_int
            converted_type: int

          # convert int to int (negative value)
          - name: content_modifier
            action: convert
            key: int_to_double
            converted_type: double

          # convert boolean to string
          - name: content_modifier
            action: convert
            key: boolean_to_string
            converted_type: string

          # convert boolean to boolean
          - name: content_modifier
            action: convert
            key: boolean_to_boolean
            converted_type: boolean

          # convert boolean to int
          - name: content_modifier
            action: convert
            key: boolean_to_int
            converted_type: int

          # convert boolean to double
          - name: content_modifier
            action: convert
            key: boolean_to_double
            converted_type: double

  outputs:
    - name : stdout
      match: '*'
      format: json_lines
```

Output:

```
bin/fluent-bit -c ../conf/convert.yaml | jq
Fluent Bit v4.0.0
* Copyright (C) 2015-2024 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/03/29 10:34:01] [ info] [fluent bit] version=4.0.0, commit=b0f3a63c87, pid=3947811
[2025/03/29 10:34:01] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/03/29 10:34:01] [ info] [simd    ] disabled
[2025/03/29 10:34:01] [ info] [cmetrics] version=0.9.9
[2025/03/29 10:34:01] [ info] [ctraces ] version=0.6.2
[2025/03/29 10:34:01] [ info] [input:dummy:dummy.0] initializing
[2025/03/29 10:34:01] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/03/29 10:34:01] [ info] [sp] stream processor started
[2025/03/29 10:34:01] [ info] [output:stdout:stdout.0] worker #0 started
{
  "date": 1743266042.566744,
  "uint_to_uint": 1,
  "string_to_int": -1,
  "string_to_uint": 1,
  "string_to_double": 0.2,
  "string_to_boolean": true,
  "string_to_string": "hello",
  "double_to_double": 0.2,
  "int_to_string": "1",
  "int_to_boolean": true,
  "int_to_int": -1,
  "int_to_double": 1.0,
  "boolean_to_string": "true",
  "boolean_to_boolean": true,
  "boolean_to_int": 1,
  "boolean_to_double": 1.0
}
```
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
