### PR TITLE
log_event_decoder: improved group metadata fields are availability

### DIFF
--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -146,6 +146,11 @@ void flb_log_event_decoder_destroy(struct flb_log_event_decoder *context)
 
     if (context != NULL) {
         if (context->initialized) {
+            if (context->unpacked_group_record.zone ==
+                context->unpacked_event.zone) {
+                msgpack_unpacked_init(&context->unpacked_event);
+            }
+
             msgpack_unpacked_destroy(&context->unpacked_group_record);
             msgpack_unpacked_destroy(&context->unpacked_empty_map);
             msgpack_unpacked_destroy(&context->unpacked_event);
@@ -322,6 +327,11 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
         return context->last_result;
     }
 
+    if (context->unpacked_group_record.zone ==
+        context->unpacked_event.zone) {
+        msgpack_unpacked_init(&context->unpacked_event);
+    }
+
     previous_offset = context->offset;
     result = msgpack_unpack_next(&context->unpacked_event,
                                  context->buffer,
@@ -377,8 +387,6 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
             }
 
             if (context->read_groups != FLB_TRUE) {
-                msgpack_unpacked_init(&context->unpacked_event);
-
                 memset(event, 0, sizeof(struct flb_log_event));
 
                 return flb_log_event_decoder_next(context, event);

--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -361,24 +361,22 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
          * to determine the behavior.
          */
         if (record_type != FLB_LOG_EVENT_NORMAL) {
+            msgpack_unpacked_destroy(&context->unpacked_group_record);
+
+            if (record_type == FLB_LOG_EVENT_GROUP_START) {
+                memcpy(&context->unpacked_group_record,
+                       &context->unpacked_event,
+                       sizeof(msgpack_unpacked));
+
+                context->current_group_metadata = event->metadata;
+                context->current_group_attributes = event->body;
+            }
+            else {
+                context->current_group_metadata = NULL;
+                context->current_group_attributes = NULL;
+            }
+
             if (context->read_groups != FLB_TRUE) {
-                msgpack_unpacked_destroy(&context->unpacked_group_record);
-
-                if (record_type == FLB_LOG_EVENT_GROUP_START) {
-                    memcpy(&context->unpacked_group_record,
-                        &context->unpacked_event,
-                        sizeof(msgpack_unpacked));
-
-                    context->current_group_metadata = event->metadata;
-                    context->current_group_attributes = event->body;
-                }
-                else {
-                    msgpack_unpacked_destroy(&context->unpacked_event);
-
-                    context->current_group_metadata = NULL;
-                    context->current_group_attributes = NULL;
-                }
-
                 msgpack_unpacked_init(&context->unpacked_event);
 
                 memset(event, 0, sizeof(struct flb_log_event));
@@ -387,8 +385,8 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
             }
         }
         else {
-                event->group_metadata = context->current_group_metadata;
-                event->group_attributes = context->current_group_attributes;
+            event->group_metadata = context->current_group_metadata;
+            event->group_attributes = context->current_group_attributes;
         }
     }
 


### PR DESCRIPTION
This PR tweaks the log event decoder logic to ensure that regardless of if the client code chose to receive meta records or not regular records always contain the appropriate group metadata fields to improve the code update process.