### PR TITLE
out_azure_kusto: support for otel log schema

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -1035,7 +1035,7 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
         msgpack_pack_str(&mp_pck, flb_sds_len(ctx->log_key));
         msgpack_pack_str_body(&mp_pck, ctx->log_key, flb_sds_len(ctx->log_key));
 
-        if (log_event.group_attributes != NULL) {
+        if (log_event.group_attributes != NULL && log_event.body != NULL) {
             msgpack_pack_map(&mp_pck,
                                  log_event.group_attributes->via.map.size +
                                  log_event.metadata->via.map.size +

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -1041,7 +1041,7 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
                                  log_event.metadata->via.map.size +
                                  log_event.body->via.map.size);
 
-            for (index = 0; index < log_event.group_attributes->via.map.size; index++) {
+            for (index = 0; index < log_event.group_attributes->via.map.size; index++) { 
                 msgpack_pack_object(&mp_pck, log_event.group_attributes->via.map.ptr[index].key);
                 msgpack_pack_object(&mp_pck, log_event.group_attributes->via.map.ptr[index].val);
             }

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -1038,7 +1038,8 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
         if (log_event.group_attributes != NULL) {
             msgpack_pack_map(&mp_pck,
                                  log_event.group_attributes->via.map.size +
-                                 log_event.metadata->via.map.size);
+                                 log_event.metadata->via.map.size +
+                                 log_event.body->via.map.size);
 
             for (index = 0; index < log_event.group_attributes->via.map.size; index++)
             {
@@ -1050,6 +1051,12 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
             {
                 msgpack_pack_object(&mp_pck, log_event.metadata->via.map.ptr[index].key);
                 msgpack_pack_object(&mp_pck, log_event.metadata->via.map.ptr[index].val);
+            }
+
+            for (index = 0; index < log_event.body->via.map.size; index++)
+            {
+                msgpack_pack_object(&mp_pck, log_event.body->via.map.ptr[index].key);
+                msgpack_pack_object(&mp_pck, log_event.body->via.map.ptr[index].val);
             }
         }
         else if (log_event.body != NULL) {

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -1041,20 +1041,17 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
                                  log_event.metadata->via.map.size +
                                  log_event.body->via.map.size);
 
-            for (index = 0; index < log_event.group_attributes->via.map.size; index++)
-            {
+            for (index = 0; index < log_event.group_attributes->via.map.size; index++) {
                 msgpack_pack_object(&mp_pck, log_event.group_attributes->via.map.ptr[index].key);
                 msgpack_pack_object(&mp_pck, log_event.group_attributes->via.map.ptr[index].val);
             }
 
-            for (index = 0; index < log_event.metadata->via.map.size; index++)
-            {
+            for (index = 0; index < log_event.metadata->via.map.size; index++) {
                 msgpack_pack_object(&mp_pck, log_event.metadata->via.map.ptr[index].key);
                 msgpack_pack_object(&mp_pck, log_event.metadata->via.map.ptr[index].val);
             }
 
-            for (index = 0; index < log_event.body->via.map.size; index++)
-            {
+            for (index = 0; index < log_event.body->via.map.size; index++) {
                 msgpack_pack_object(&mp_pck, log_event.body->via.map.ptr[index].key);
                 msgpack_pack_object(&mp_pck, log_event.body->via.map.ptr[index].val);
             }

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -959,6 +959,7 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
                               const void *data, size_t bytes, void **out_data,
                               size_t *out_size)
 {
+    int index;
     int records = 0;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
@@ -1034,7 +1035,24 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
         msgpack_pack_str(&mp_pck, flb_sds_len(ctx->log_key));
         msgpack_pack_str_body(&mp_pck, ctx->log_key, flb_sds_len(ctx->log_key));
 
-        if (log_event.body != NULL) {
+        if (log_event.group_attributes != NULL) {
+            msgpack_pack_map(&mp_pck,
+                                 log_event.group_attributes->via.map.size +
+                                 log_event.metadata->via.map.size);
+
+            for (index = 0; index < log_event.group_attributes->via.map.size; index++)
+            {
+                msgpack_pack_object(&mp_pck, log_event.group_attributes->via.map.ptr[index].key);
+                msgpack_pack_object(&mp_pck, log_event.group_attributes->via.map.ptr[index].val);
+            }
+
+            for (index = 0; index < log_event.metadata->via.map.size; index++)
+            {
+                msgpack_pack_object(&mp_pck, log_event.metadata->via.map.ptr[index].key);
+                msgpack_pack_object(&mp_pck, log_event.metadata->via.map.ptr[index].val);
+            }
+        }
+        else if (log_event.body != NULL) {
             msgpack_pack_object(&mp_pck, *log_event.body);
         }
         else {


### PR DESCRIPTION
As outlined in the issue below, when the out_azure_kusto plugin was used alongside the in_opentelemetry plugin, it previously generated multiple logs for each incoming OTEL log. For instance: 

    [62] v1_logs: [[-1.000000000, {"schema"=>"otlp", "resource_id"=>0, "scope_id"=>11}], {"resource"=>{"attributes"=>{"telemetry.sdk.name"=>"opentelemetry", "telemetry.sdk.language"=>"dotnet", "telemetry.sdk.version"=>"1.8.1", "service.name"=>"unknown_service:dotnet"}}, "schema_url"=>"", "scope"=>{"name"=>"Microsoft.Extensions.HttpClient.Logging.Internal.HttpLoggingHandler"}}]
    [63] v1_logs: [[1741372257.966227535, {"otlp"=>{"observed_timestamp"=>1741372257825108400, "timestamp"=>1741372257825108400, "severity_number"=>17, "severity_text"=>"Error", "attributes"=>{"resolved_host"=>"<some url>.com", "httpMethod"=>"GET", "httpHost"=>"<removed>", "httpPath"=>"<removed>", "duration"=>274, "{OriginalFormat}"=>"{httpMethod} {httpHost}/{httpPath}", "httpStatusCode"=>401}, "trace_flags"=>0}}], {"message"=>"GET <removed>"}]
    [64] v1_logs: [[-2.000000000, {}], {}]

Fixes:
https://github.com/fluent/fluent-bit/issues/10065

The fix implemented in this PR is take from similar fix done in out_splunk plugin: https://github.com/fluent/fluent-bit/issues/10002

Output log after this change:

    {
      "resource": {
        "attributes": {
          "telemetry.sdk.name": "opentelemetry",
          "telemetry.sdk.language": "dotnet",
          "telemetry.sdk.version": "1.8.1",
          "service.name": "unknown_service:dotnet",
        }
      },
      "schema_url": "",
      "scope": {
        "name": "Microsoft.Extensions.HttpClient.Logging.Internal.HttpLoggingHandler"
      },
      "otlp": {
        "observed_timestamp": 1743791176558409200,
        "timestamp": 1743791176558409200,
        "severity_number": 17,
        "severity_text": "Error",
        "attributes": {
          "resolved_host": "<removed>",
          "httpMethod": "GET",
          "httpHost": "<removed>",
          "httpPath": "<removed>",
          "duration": 36,
          "{OriginalFormat}": "<removed>",
          "httpStatusCode": 403
        },
        "trace_flags": 0
      }
    }


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
