### PR TITLE
upstream: net.http_proxy setting for all upstream plugins.

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -379,6 +379,10 @@ enum conf_type {
 #define FLB_CONF_DNS_PREFER_IPV4       "dns.prefer_ipv4"
 #define FLB_CONF_DNS_PREFER_IPV6       "dns.prefer_ipv6"
 
+/* Proxies */
+#define FLB_CONF_HTTP_PROXY            "net.http_proxy"
+#define FLB_CONF_NO_PROXY              "net.no_proxy"
+
 /* Storage / Chunk I/O */
 #define FLB_CONF_STORAGE_PATH          "storage.path"
 #define FLB_CONF_STORAGE_SYNC          "storage.sync"

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -316,6 +316,7 @@ struct flb_config {
 #define FLB_CONFIG_LOG_LEVEL(c) (c->log->level)
 
 struct flb_config *flb_config_init();
+void flb_config_env(struct flb_config *config);
 void flb_config_exit(struct flb_config *config);
 const char *flb_config_prop_get(const char *key, struct mk_list *list);
 int flb_config_set_property(struct flb_config *config,

--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -64,6 +64,15 @@ struct flb_net_setup {
     /* network interface to bind and use to send data */
     flb_sds_t source_address;
 
+    /* proxy to use for http(s) connections, using for non-http connections
+     * can lead to unexpected results.
+     */
+    flb_sds_t http_proxy;
+
+    /* domains which must not be proxied
+     */
+    flb_sds_t no_proxy;
+
     /* maximum of times a keepalive connection can be used */
     int keepalive_max_recycle;
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -129,6 +129,11 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, dns_prefer_ipv6)},
 
+    /* proxy */
+    {FLB_CONF_HTTP_PROXY,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, http_proxy)},
+
     /* Storage */
     {FLB_CONF_STORAGE_PATH,
      FLB_CONF_TYPE_STR,

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -199,6 +199,40 @@ struct flb_service_config service_configs[] = {
     {NULL, FLB_CONF_TYPE_OTHER, 0} /* end of array */
 };
 
+static char *flb_config_getenv(const char *name)
+{
+    char *ret;
+    const char *env;
+    char *ucname = flb_calloc(1, strlen(name)+1);
+    char *lcname = flb_calloc(1, strlen(name)+1);
+    int idx;
+
+
+    for (idx = 0; idx < strlen(name); idx++) {
+        ucname[idx] = toupper(name[idx]);
+    }
+
+    for (idx = 0; idx < strlen(name); idx++) {
+        lcname[idx] = toupper(name[idx]);
+    }
+
+    env = getenv(ucname);
+    if (env == NULL || flb_str_emptyval(env) == FLB_TRUE) {
+        env = getenv(lcname);
+    }
+
+    flb_free(ucname);
+    flb_free(lcname);
+
+    if (flb_str_emptyval(env)) {
+        return NULL;
+    }
+
+    ret = flb_malloc(strlen(env) + 1);
+    memcpy(ret, env, strlen(env)+1);
+
+    return ret;
+}
 
 struct flb_config *flb_config_init()
 {
@@ -261,23 +295,6 @@ struct flb_config *flb_config_init()
     config->hc_retry_failure_count       = HC_RETRY_FAILURE_COUNTS_DEFAULT;
     config->health_check_period          = HEALTH_CHECK_PERIOD;
 #endif
-
-    config->http_proxy = getenv("HTTP_PROXY");
-    if (flb_str_emptyval(config->http_proxy) == FLB_TRUE) {
-        config->http_proxy = getenv("http_proxy");
-        if (flb_str_emptyval(config->http_proxy) == FLB_TRUE) {
-            /* Proxy should not be set when `HTTP_PROXY` or `http_proxy` are set to "" */
-            config->http_proxy = NULL;
-        }
-    }
-    config->no_proxy = getenv("NO_PROXY");
-    if (flb_str_emptyval(config->no_proxy) == FLB_TRUE || config->http_proxy == NULL) {
-        config->no_proxy = getenv("no_proxy");
-        if (flb_str_emptyval(config->no_proxy) == FLB_TRUE || config->http_proxy == NULL) {
-            /* NoProxy  should not be set when `NO_PROXY` or `no_proxy` are set to "" or there is no Proxy. */
-            config->no_proxy = NULL;
-        }
-    }
 
     /* Routing */
     flb_routes_mask_set_size(1, config);
@@ -397,6 +414,12 @@ struct flb_config *flb_config_init()
 #endif
 
     return config;
+}
+
+void flb_config_env(struct flb_config *config)
+{
+    config->http_proxy = flb_config_getenv("HTTP_PROXY");
+    config->no_proxy = flb_config_getenv("NO_PROXY");
 }
 
 void flb_config_exit(struct flb_config *config)

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -2108,6 +2108,15 @@ int flb_input_collector_fd(flb_pipefd_t fd, struct flb_config *config)
 
 int flb_input_upstream_set(struct flb_upstream *u, struct flb_input_instance *ins)
 {
+    int ret;
+    const char *host;
+    int port;
+    char *proxy_protocol = NULL;
+    char *proxy_host = NULL;
+    char *proxy_port = NULL;
+    char *proxy_username = NULL;
+    char *proxy_password = NULL;
+
     if (!u) {
         return -1;
     }
@@ -2123,6 +2132,56 @@ int flb_input_upstream_set(struct flb_upstream *u, struct flb_input_instance *in
 
     /* Set networking options 'net.*' received through instance properties */
     memcpy(&u->base.net, &ins->net_setup, sizeof(struct flb_net_setup));
+
+    if (u->proxied_host) {
+        host = flb_strdup(u->proxied_host);
+        flb_free(u->proxied_host);
+        port = u->proxied_port;
+    }
+    else {
+        host = flb_strdup(u->tcp_host);
+        flb_free(u->tcp_host);
+        port = u->tcp_port;
+    }
+
+    /* Set upstream to the http_proxy if it is specified. */
+    if (flb_upstream_needs_proxy(host, ins->net_setup.http_proxy, ins->net_setup.no_proxy) == FLB_TRUE) {
+        flb_debug("[upstream] net_setup->http_proxy: %s->%s", ins->net_setup.http_proxy, host);
+        ret = flb_utils_proxy_url_split(ins->net_setup.http_proxy, 
+                                        &proxy_protocol,
+                                        &proxy_username, &proxy_password,
+                                        &proxy_host, &proxy_port);
+        if (ret == -1) {
+            flb_errno();
+            return -1;
+        }
+
+        if (u->proxy_username) {
+            flb_free(u->proxy_username);
+            u->proxy_username = NULL;
+        }
+
+        if (u->proxy_password) {
+            flb_free(u->proxy_password);
+            u->proxy_password = NULL;
+        }
+
+        u->tcp_host = flb_strdup(proxy_host);
+        u->tcp_port = atoi(proxy_port);
+        u->proxied_host = host;
+        u->proxied_port = port;
+
+        if (proxy_username && proxy_password) {
+            u->proxy_username = flb_strdup(proxy_username);
+            u->proxy_password = flb_strdup(proxy_password);
+        }
+
+        flb_free(proxy_protocol);
+        flb_free(proxy_host);
+        flb_free(proxy_port);
+        flb_free(proxy_username);
+        flb_free(proxy_password);
+    }
 
     return 0;
 }

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -124,6 +124,18 @@ struct flb_config_map upstream_net[] = {
     },
 
     {
+     FLB_CONFIG_MAP_STR, "net.http_proxy", NULL,
+     0, FLB_TRUE, offsetof(struct flb_net_setup, http_proxy),
+     "Set the http proxy"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "net.no_proxy", NULL,
+     0, FLB_TRUE, offsetof(struct flb_net_setup, no_proxy),
+     "Set no proxy domains (FQDN)"
+    },
+
+    {
      FLB_CONFIG_MAP_INT, "net.keepalive_max_recycle", "2000",
      0, FLB_TRUE, offsetof(struct flb_net_setup, keepalive_max_recycle),
      "Set maximum number of times a keepalive connection can be used "
@@ -201,6 +213,16 @@ struct mk_list *flb_upstream_get_config_map(struct flb_config *config)
             if (strcmp(upstream_net[config_index].name,
                        "net.dns.prefer_ipv6") == 0) {
                 upstream_net[config_index].def_value = "true";
+            }
+        }
+        if (config->http_proxy != NULL) {
+            if (strcmp(upstream_net[config_index].name, "http_proxy") == 0) {
+                upstream_net[config_index].def_value = config->http_proxy;
+            }
+        }
+        if (config->no_proxy != NULL) {
+            if (strcmp(upstream_net[config_index].name, "no_proxy") == 0) {
+                upstream_net[config_index].def_value = config->http_proxy;
             }
         }
     }

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1366,6 +1366,8 @@ int flb_main(int argc, char **argv)
     cf = tmp;
 #endif
 
+    flb_config_env(config);
+
     /* Check co-routine stack size */
     if (config->coro_stack_size < getpagesize()) {
         flb_cf_destroy(cf_opts);


### PR DESCRIPTION
# Summary

Add a new `net.http_proxy` as well as a new `net.no_proxy` setting that can be set both globally as well as individually for any input client or output plugin.


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
