### PR TITLE
plugin_proxy: fixed memory leak

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -240,9 +240,15 @@ static void flb_proxy_output_cb_destroy(struct flb_output_plugin *plugin)
         cb_unregister(proxy->def);
     }
 
+    if (plugin->name != NULL) {
+        flb_free(plugin->name);
+
+        plugin->name = NULL;
+    }
+
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {
 #ifdef FLB_HAVE_PROXY_GO
-        proxy_go_output_unregister(proxy->data);
+proxy_go_output_unregister(proxy->data);
 #endif
     }
 
@@ -284,6 +290,12 @@ static void flb_proxy_input_cb_destroy(struct flb_input_plugin *plugin)
     cb_unregister = flb_plugin_proxy_symbol(proxy, "FLBPluginUnregister");
     if (cb_unregister != NULL) {
         cb_unregister(proxy->def);
+    }
+
+    if (plugin->name != NULL) {
+        flb_free(plugin->name);
+
+        plugin->name = NULL;
     }
 
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {
@@ -357,6 +369,7 @@ static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,
     out->proxy = proxy;
     out->flags = def->flags;
     out->name  = flb_strdup(def->name);
+
     out->description = def->description;
     mk_list_add(&out->_head, &config->out_plugins);
 


### PR DESCRIPTION
This PR fixes a memory leak in the plugin proxy, the regular plugin destruction process counts on the name (and description) being constants, however, the plugin proxy makes copies of them when creating both plugin spec instances.

ToDo: I don't really understand why does the plugin proxy create two instances of the `flb_output_plugin` / `flb_input_plugin` structure so I need to check with the code owner to get a better understanding of the reasoning behind it.