### PR TITLE
in_storage_backlog: added missing routing mask initialization

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -51,6 +51,7 @@ struct flb_sb {
     struct flb_input_instance *ins; /* input instance */
     struct cio_ctx *cio;            /* chunk i/o instance */
     struct mk_list backlogs;        /* list of all pending chunks segregated by output plugin */
+    flb_route_mask_element *dummy_routes_mask; /* dummy route mask used when segregating events */
 };
 
 
@@ -280,33 +281,24 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
     int                     tag_len;
     const char *            tag_buf;
     int                     result;
-    flb_route_mask_element *dummy_routes_mask;
-
-    dummy_routes_mask = flb_calloc(context->ins->config->route_mask_slots,
-                                   sizeof(flb_route_mask_element));
-
-    if (dummy_routes_mask == NULL) {
-        flb_error("[storage backlog] could not allocate route mask elements %s/%s",
-                  stream->name, target_chunk->name);
-
-        return -1;
-    }
 
     memset(&dummy_input_chunk, 0, sizeof(struct flb_input_chunk));
-    memset(dummy_routes_mask, 0, sizeof(dummy_routes_mask));
+
+    memset(context->dummy_routes_mask,
+           0,
+           context->ins->config->route_mask_slots * sizeof(flb_route_mask_element));
 
     dummy_input_chunk.in    = context->ins;
     dummy_input_chunk.chunk = target_chunk;
-    dummy_input_chunk.routes_mask = dummy_routes_mask;
+    dummy_input_chunk.routes_mask = context->dummy_routes_mask;
 
     chunk_size = cio_chunk_get_real_size(target_chunk);
 
     if (chunk_size < 0) {
         flb_warn("[storage backlog] could not get real size of chunk %s/%s",
                   stream->name, target_chunk->name);
-        flb_free(dummy_routes_mask);
 
-        return -2;
+        return -1;
     }
 
     result = flb_input_chunk_get_tag(&dummy_input_chunk, &tag_buf, &tag_len);
@@ -314,9 +306,8 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
         flb_error("[storage backlog] could not retrieve chunk tag from %s/%s, "
                   "removing it from the queue",
                   stream->name, target_chunk->name);
-        flb_free(dummy_routes_mask);
 
-        return -3;
+        return -2;
     }
 
     flb_routes_mask_set_by_tag(dummy_input_chunk.routes_mask, tag_buf, tag_len,
@@ -330,14 +321,10 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
             result = sb_append_chunk_to_segregated_backlog(target_chunk, stream,
                                                            chunk_size, backlog);
             if (result) {
-                flb_free(dummy_routes_mask);
-
-                return -4;
+                return -3;
             }
         }
     }
-
-    flb_free(dummy_routes_mask);
 
     return 0;
 }
@@ -670,9 +657,22 @@ static int cb_sb_init(struct flb_input_instance *in,
     char mem[32];
     struct flb_sb *ctx;
 
-    ctx = flb_malloc(sizeof(struct flb_sb));
+    ctx = flb_calloc(1, sizeof(struct flb_sb));
+
     if (!ctx) {
         flb_errno();
+        return -1;
+    }
+
+    ctx->dummy_routes_mask = flb_calloc(in->config->route_mask_slots,
+                                        sizeof(flb_route_mask_element));
+
+    if (ctx->dummy_routes_mask == NULL) {
+        flb_errno();
+        flb_free(ctx);
+
+        flb_error("[storage backlog] could not allocate route mask elements");
+
         return -1;
     }
 
@@ -692,6 +692,7 @@ static int cb_sb_init(struct flb_input_instance *in,
     ret = flb_input_set_collector_time(in, cb_queue_chunks, 1, 0, config);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "could not create collector");
+        flb_free(ctx->dummy_routes_mask);
         flb_free(ctx);
         return -1;
     }
@@ -719,6 +720,10 @@ static int cb_sb_exit(void *data, struct flb_config *config)
     flb_input_collector_pause(ctx->coll_fd, ctx->ins);
 
     sb_destroy_backlogs(ctx);
+
+    if (ctx->dummy_routes_mask != NULL) {
+        flb_free(ctx->dummy_routes_mask);
+    }
 
     flb_free(ctx);
 


### PR DESCRIPTION
This PR fixes an issue with the storage backlog input plugin where the flexible routing mask was not initialized causing a NULL dereference.