### PR TITLE
in_systemd: add basic support for tailing logs from the last N minutes

### DIFF
--- a/plugins/in_systemd/systemd.c
+++ b/plugins/in_systemd/systemd.c
@@ -736,6 +736,11 @@ static struct flb_config_map config_map[] = {
       "Read the journal from the end (tail)"
     },
     {
+      FLB_CONFIG_MAP_INT, "read_since_minutes_ago", "0",
+      0, FLB_TRUE, offsetof(struct flb_systemd_config, read_since_minutes_ago),
+      "Read the journal since minutes ago. 0 means disabled."
+    },
+    {
       FLB_CONFIG_MAP_BOOL, "lowercase", "false",
       0, FLB_TRUE, offsetof(struct flb_systemd_config, lowercase),
       "Lowercase the fields"

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -52,6 +52,7 @@ struct flb_systemd_config {
     struct mk_list *systemd_filters;
     int pending_records;
     int read_from_tail;  /* read_from_tail option */
+    int read_since_minutes_ago;  /* read_since_minutes_ago option */
     int lowercase;
     int strip_underscores;
 


### PR DESCRIPTION
This patch introduces the ability to tail logs from the last N minutes in the systemd input plugin. While the current `read_from_tail` approach works for many use cases, it can result in lost logs when it races with other components that emit logs and bootstrap at the same time.

An alternative solution using a database and cursor approach could help, but it introduces the downside of requiring a state file to be maintained.

Although systemd supports complex values for the "since" parameter, this patch simplifies the implementation by supporting only the specific use case of tailing logs from the last N minutes. This simplified approach is sufficient for many common scenarios.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
