### PR TITLE
out_oracle_log_analytics: fix use-after-free on flush failure

### DIFF
--- a/plugins/out_oracle_log_analytics/oci_logan.c
+++ b/plugins/out_oracle_log_analytics/oci_logan.c
@@ -1199,7 +1199,6 @@ static void cb_oci_logan_flush(struct flb_event_chunk *event_chunk,
                       ins, out_context,
                       config);
     if (ret != FLB_OK) {
-        flb_oci_logan_conf_destroy(ctx);
         FLB_OUTPUT_RETURN(ret);
     }
     flb_plg_debug(ctx->ins, "success");


### PR DESCRIPTION
This pull request includes a small but important change to the `cb_oci_logan_flush` function in the `oci_logan.c` file. The change improves error handling by logging an error message when the flush operation fails instead of destroying the configuration context.

* [`plugins/out_oracle_log_analytics/oci_logan.c`](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L1202-R1202): Modified the `cb_oci_logan_flush` function to log an error message with the failure code instead of destroying the configuration context when the flush operation fails.