### PR TITLE
proxy: go: add context for input methods

### DIFF
--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -64,6 +64,8 @@ struct flb_plugin_proxy_context {
 
 struct flb_plugin_input_proxy_context {
     int coll_fd;
+    /* This context is set by the remote init and is passed to remote collect */
+    void *remote_context;
     /* A proxy ptr is needed to store the proxy type/lang (OUTPUT/GOLANG) */
     struct flb_plugin_proxy *proxy;
 };

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -284,9 +284,9 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
             instance->context = NULL;
         }
         else {
-            struct flb_plugin_proxy_context *ctx;
+            struct flb_plugin_input_proxy_context *ctx;
 
-            ctx = flb_calloc(1, sizeof(struct flb_plugin_proxy_context));
+            ctx = flb_calloc(1, sizeof(struct flb_plugin_input_proxy_context));
             if (!ctx) {
                 flb_errno();
                 flb_free(instance);

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -81,7 +81,7 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
 #ifdef FLB_HAVE_PROXY_GO
     if (ctx->proxy->def->proxy == FLB_PROXY_GOLANG) {
         flb_trace("[GO] entering go_collect()");
-        ret = proxy_go_input_collect(ctx->proxy, &data, &len);
+        ret = proxy_go_input_collect(ctx, &data, &len);
 
         if (len == 0) {
             flb_trace("[GO] No logs are ingested");
@@ -95,7 +95,7 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
 
         flb_input_log_append(ins, NULL, 0, data, len);
 
-        ret = proxy_go_input_cleanup(ctx->proxy, data);
+        ret = proxy_go_input_cleanup(ctx, data);
         if (ret == -1) {
             flb_errno();
             return -1;
@@ -110,19 +110,10 @@ static int flb_proxy_input_cb_init(struct flb_input_instance *ins,
                                    struct flb_config *config, void *data)
 {
     int ret = -1;
-    struct flb_plugin_input_proxy_context *ctx;
-    struct flb_plugin_proxy_context *pc;
-
-    /* Allocate space for the configuration context */
-    ctx = flb_malloc(sizeof(struct flb_plugin_input_proxy_context));
-    if (!ctx) {
-        flb_errno();
-        return -1;
-    }
+    struct flb_plugin_input_proxy_context *pc;
 
     /* Before to initialize for proxy, set the proxy instance reference */
-    pc = (struct flb_plugin_proxy_context *)(ins->context);
-    ctx->proxy = pc->proxy;
+    pc = (struct flb_plugin_input_proxy_context *)(ins->context);
 
     /* Before to initialize, set the instance reference */
     pc->proxy->instance = ins;
@@ -147,7 +138,7 @@ static int flb_proxy_input_cb_init(struct flb_input_instance *ins,
     }
 
     /* Set the context */
-    flb_input_set_context(ins, ctx);
+    flb_input_set_context(ins, pc);
 
     /* Collect upon data available on timer */
     ret = flb_input_set_collector_time(ins,
@@ -159,12 +150,12 @@ static int flb_proxy_input_cb_init(struct flb_input_instance *ins,
         flb_error("Could not set collector for threaded proxy input plugin");
         goto init_error;
     }
-    ctx->coll_fd = ret;
+    pc->coll_fd = ret;
 
     return ret;
 
 init_error:
-    flb_free(ctx);
+    flb_free(pc);
 
     return -1;
 }
@@ -311,10 +302,10 @@ static int flb_proxy_input_cb_pre_run(struct flb_input_instance *ins,
                                       struct flb_config *config, void *data)
 {
     int ret = -1;
-    struct flb_plugin_proxy_context *pc;
+    struct flb_plugin_input_proxy_context *pc;
     struct flb_plugin_proxy *proxy;
 
-    pc = (struct flb_plugin_proxy_context *)(ins->context);
+    pc = (struct flb_plugin_input_proxy_context *)(ins->context);
     proxy = pc->proxy;
 
     /* pre_run */

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -184,6 +184,7 @@ int proxy_go_input_register(struct flb_plugin_proxy *proxy,
      *
      * - FLBPluginInit
      * - FLBPluginInputCallback
+     * - FLBPluginInputCallbackCtx
      * - FLBPluginExit
      *
      * note: registration callback FLBPluginRegister() is resolved by the
@@ -198,7 +199,9 @@ int proxy_go_input_register(struct flb_plugin_proxy *proxy,
     }
 
     plugin->cb_collect = flb_plugin_proxy_symbol(proxy, "FLBPluginInputCallback");
+    plugin->cb_collect_ctx = flb_plugin_proxy_symbol(proxy, "FLBPluginInputCallbackCtx");
     plugin->cb_cleanup = flb_plugin_proxy_symbol(proxy, "FLBPluginInputCleanupCallback");
+    plugin->cb_cleanup_ctx = flb_plugin_proxy_symbol(proxy, "FLBPluginInputCleanupCallbackCtx");
     plugin->cb_exit  = flb_plugin_proxy_symbol(proxy, "FLBPluginExit");
     plugin->name     = flb_strdup(def->name);
 
@@ -231,27 +234,35 @@ int proxy_go_input_init(struct flb_plugin_proxy *proxy)
     return ret;
 }
 
-int proxy_go_input_collect(struct flb_plugin_proxy *ctx,
+int proxy_go_input_collect(struct flb_plugin_input_proxy_context *ctx,
                            void **collected_data, size_t *len)
 {
     int ret;
     void *data = NULL;
-    struct flbgo_input_plugin *plugin = ctx->data;
+    struct flbgo_input_plugin *plugin = ctx->proxy->data;
 
-    ret = plugin->cb_collect(&data, len);
+    if (plugin->cb_collect_ctx) {
+        ret = plugin->cb_collect_ctx(ctx->remote_context, &data, len);
+    }
+    else {
+        ret = plugin->cb_collect(&data, len);
+    }
 
     *collected_data = data;
 
     return ret;
 }
 
-int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
+int proxy_go_input_cleanup(struct flb_plugin_input_proxy_context *ctx,
                            void *allocated_data)
 {
     int ret = 0;
-    struct flbgo_input_plugin *plugin = ctx->data;
+    struct flbgo_input_plugin *plugin = ctx->proxy->data;
 
-    if (plugin->cb_cleanup) {
+    if (plugin->cb_cleanup_ctx) {
+        ret = plugin->cb_cleanup_ctx(ctx->remote_context, allocated_data);
+    }
+    else if (plugin->cb_cleanup) {
         ret = plugin->cb_cleanup(allocated_data);
     }
     else {

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -40,11 +40,13 @@ struct flbgo_input_plugin {
     char *name;
     void *api;
     void *i_ins;
-    struct flb_plugin_proxy_context *context;
+    struct flb_plugin_input_proxy_context *context;
 
     int (*cb_init)();
     int (*cb_collect)(void **, size_t *);
+    int (*cb_collect_ctx)(void *, void **, size_t *);
     int (*cb_cleanup)(void *);
+    int (*cb_cleanup_ctx)(void *, void *);
     int (*cb_exit)();
 };
 
@@ -63,9 +65,9 @@ int proxy_go_input_register(struct flb_plugin_proxy *proxy,
                             struct flb_plugin_proxy_def *def);
 
 int proxy_go_input_init(struct flb_plugin_proxy *proxy);
-int proxy_go_input_collect(struct flb_plugin_proxy *ctx,
+int proxy_go_input_collect(struct flb_plugin_input_proxy_context *ctx,
                            void **collected_data, size_t *len);
-int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
+int proxy_go_input_cleanup(struct flb_plugin_input_proxy_context *ctx,
                            void *allocated_data);
 int proxy_go_input_destroy(struct flb_plugin_input_proxy_context *ctx);
 void proxy_go_input_unregister(void *data);


### PR DESCRIPTION
<!-- Provide summary of changes -->

These changes resolve the following issue: [#8464](https://github.com/fluent/fluent-bit/issues/8464)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
  log_level: debug

pipeline:
  inputs:
    - name: go-input-plugin-with-context
      config-key: config-value-1
      tag: one
    - name: go-input-plugin-with-context
      config-key: config-value-1
      tag: one

  outputs:
    - name: stdout
      match: '*'
```
- [x] Go Plugin Example (without .h)
```go
package main

/*
#include <stdlib.h>
*/
import "C"
import (
	"fmt"
	"log"
	"time"
	"unsafe"

	"fluent-bit-input-plugin/input"
)

//export FLBPluginRegister
func FLBPluginRegister(def unsafe.Pointer) int {
	return input.FLBPluginRegister(def, "go-input-plugin-with-context", "Go Input Plugin With Context!")
}

//export FLBPluginInit
func FLBPluginInit(plugin unsafe.Pointer) int {
	// Get config param
	param := input.FLBPluginConfigKey(plugin, "config-key")
	fmt.Printf("[flb-go][FLBPluginInit] Plugin parameter config-key=%s \n", param)

	// Set config param to context
	input.FLBPluginSetContext(plugin, param)

	return input.FLB_OK
}

//export FLBPluginInputCallbackCtx
func FLBPluginInputCallbackCtx(ctx unsafe.Pointer, data *unsafe.Pointer, size *C.size_t) int {
	// Get config param from context
	value := input.FLBPluginGetContext(ctx).(string)
	log.Printf("[flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=%s \n", value)

	now := time.Now()
	flb_time := input.FLBTime{now}
	message := map[string]string{"message": value}

	entry := []interface{}{flb_time, message}

	enc := input.NewEncoder()
	packed, err := enc.Encode(entry)
	if err != nil {
		fmt.Println("Can't convert to msgpack:", message, err)
		return input.FLB_ERROR
	}

	length := len(packed)
	*data = C.CBytes(packed)
	*size = C.size_t(length)
	// For emitting interval adjustment.
	time.Sleep(5000 * time.Millisecond)

	return input.FLB_OK
}

//export FLBPluginInputCleanupCallback
func FLBPluginInputCleanupCallback(data unsafe.Pointer) int {
	return input.FLB_OK
}

//export FLBPluginExit
func FLBPluginExit() int {
	return input.FLB_OK
}

func main() {
}

```
- [x] Debug log output from testing the change
```bash
root@35c092a175d8:/fluent-bit-input-plugin# fluent-bit -e ./input-plugin-with-context.so -c development/fluent-bit.yaml
Fluent Bit v4.0.1
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/04/09 20:14:02] [ info] Configuration:
[2025/04/09 20:14:02] [ info]  flush time     | 1.000000 seconds
[2025/04/09 20:14:02] [ info]  grace          | 5 seconds
[2025/04/09 20:14:02] [ info]  daemon         | 0
[2025/04/09 20:14:02] [ info] ___________
[2025/04/09 20:14:02] [ info]  inputs:
[2025/04/09 20:14:02] [ info]      go-input-plugin-with-context
[2025/04/09 20:14:02] [ info]      go-input-plugin-with-context
[2025/04/09 20:14:02] [ info] ___________
[2025/04/09 20:14:02] [ info]  filters:
[2025/04/09 20:14:02] [ info] ___________
[2025/04/09 20:14:02] [ info]  outputs:
[2025/04/09 20:14:02] [ info]      stdout.0
[2025/04/09 20:14:02] [ info] ___________
[2025/04/09 20:14:02] [ info]  collectors:
[2025/04/09 20:14:02] [ info] [fluent bit] version=4.0.1, commit=7505318ca3, pid=9174
[2025/04/09 20:14:02] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/04/09 20:14:02] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/04/09 20:14:02] [ info] [simd    ] disabled
[2025/04/09 20:14:02] [ info] [cmetrics] version=0.9.9
[2025/04/09 20:14:02] [ info] [ctraces ] version=0.6.2
[2025/04/09 20:14:02] [ info] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] initializing
[2025/04/09 20:14:02] [ info] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] storage_strategy='memory' (memory only)
[flb-go][FLBPluginInit] Plugin parameter config-key=config-value-1 
[2025/04/09 20:14:02] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] [thread init] initialization OK
[2025/04/09 20:14:02] [ info] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] thread instance initialized
[2025/04/09 20:14:02] [debug] [go-input-plugin-with-context:go-input-plugin-with-context.0] created event channels: read=38 write=39
[2025/04/09 20:14:02] [ info] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] initializing
[2025/04/09 20:14:02] [ info] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] storage_strategy='memory' (memory only)
[flb-go][FLBPluginInit] Plugin parameter config-key=config-value-2 
[2025/04/09 20:14:02] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] [thread init] initialization OK
[2025/04/09 20:14:02] [ info] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] thread instance initialized
[2025/04/09 20:14:02] [debug] [go-input-plugin-with-context:go-input-plugin-with-context.1] created event channels: read=55 write=56
[2025/04/09 20:14:02] [debug] [stdout:stdout.0] created event channels: read=59 write=60
[2025/04/09 20:14:02] [debug] [router] match rule go-input-plugin-with-context.0:stdout.0
[2025/04/09 20:14:02] [ info] [output:stdout:stdout.0] worker #0 started
[2025/04/09 20:14:02] [debug] [router] match rule go-input-plugin-with-context.1:stdout.0
[2025/04/09 20:14:02] [ info] [sp] stream processor started
2025/04/09 20:14:03 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
2025/04/09 20:14:03 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-2 
2025/04/09 20:14:08 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-2 
2025/04/09 20:14:08 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
[2025/04/09 20:14:09] [debug] [task] created task=0x7f90b802bed0 id=0 OK
[2025/04/09 20:14:09] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2025/04/09 20:14:09] [debug] [task] created task=0x7f90b802bfa0 id=1 OK
[2025/04/09 20:14:09] [debug] [output:stdout:stdout.0] task_id=1 assigned to thread #0
[0] one: [[1744229643.399235929, {}], {"message"=>"config-value-1"}]
[0] one: [[1744229643.400736182, {}], {"message"=>"config-value-2"}]
[2025/04/09 20:14:09] [debug] [out flush] cb_destroy coro_id=0
[2025/04/09 20:14:09] [debug] [out flush] cb_destroy coro_id=1
[2025/04/09 20:14:09] [debug] [task] destroy task=0x7f90b802bed0 (task_id=0)
[2025/04/09 20:14:09] [debug] [task] destroy task=0x7f90b802bfa0 (task_id=1)
2025/04/09 20:14:13 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-2 
2025/04/09 20:14:13 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
[2025/04/09 20:14:14] [debug] [task] created task=0x7f90b80ac390 id=0 OK
[2025/04/09 20:14:14] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2025/04/09 20:14:14] [debug] [task] created task=0x7f90b80ac460 id=1 OK
[0] one: [[1744229648.404982589, {}], {"message"=>"config-value-1"}]
[2025/04/09 20:14:14] [debug] [output:stdout:stdout.0] task_id=1 assigned to thread #0
[0] one: [[1744229648.404970546, {}], {"message"=>"config-value-2"}]
[2025/04/09 20:14:14] [debug] [out flush] cb_destroy coro_id=2
[2025/04/09 20:14:14] [debug] [out flush] cb_destroy coro_id=3
[2025/04/09 20:14:14] [debug] [task] destroy task=0x7f90b80ac390 (task_id=0)
[2025/04/09 20:14:14] [debug] [task] destroy task=0x7f90b80ac460 (task_id=1)
^C[2025/04/09 20:14:15] [engine] caught signal (SIGINT)
[2025/04/09 20:14:15] [ warn] [engine] service will shutdown in max 5 seconds
[2025/04/09 20:14:15] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] thread pause instance
[2025/04/09 20:14:15] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] thread pause instance
[2025/04/09 20:14:16] [ info] [engine] service has stopped (0 pending tasks)
[2025/04/09 20:14:16] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] thread pause instance
[2025/04/09 20:14:16] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] thread pause instance
[2025/04/09 20:14:16] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/04/09 20:14:16] [ info] [output:stdout:stdout.0] thread worker #0 stopped
2025/04/09 20:14:18 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
2025/04/09 20:14:18 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-2 
2025/04/09 20:14:23 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
[2025/04/09 20:14:23] [debug] [GO] running exit callback
[2025/04/09 20:14:23] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.1] thread exit instance
2025/04/09 20:14:28 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
2025/04/09 20:14:33 [flb-go][multiinstance][FLBPluginInputCallbackCtx] Plugin parameter config-key=config-value-1 
[2025/04/09 20:14:38] [debug] [GO] running exit callback
[2025/04/09 20:14:38] [debug] [input:go-input-plugin-with-context:go-input-plugin-with-context.0] thread exit instance
Segmentation fault
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
