### PR TITLE
config: yaml: fix double-free from freeing state before cleanup on exit.

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2849,7 +2849,6 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
         flb_error("[config] file '%s' is already included", cfg_file);
         flb_sds_destroy(include_dir);
         flb_sds_destroy(include_file);
-        state_destroy(state);
         return -1;
     }
 
@@ -2860,7 +2859,6 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
         flb_errno();
         flb_sds_destroy(include_dir);
         flb_sds_destroy(include_file);
-        state_destroy(state);
         return -1;
     }
 
@@ -2872,7 +2870,6 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
         fclose(fh);
         flb_sds_destroy(include_dir);
         flb_sds_destroy(include_file);
-        state_destroy(state);
         return -1;
     }
     ctx->level++;


### PR DESCRIPTION
# Summary

Fix double frees when an error occurs when parsing yaml configuration files, especially with missing include files.

# Description

Remove calls to state_destroy on error when it will be cleaned up at the end of the function that parses the yaml configuration.

This fix is meant to address [CVE-2025-29477](https://nvd.nist.gov/vuln/detail/CVE-2025-29477). This is mostly to just encourage code cleanliness.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
