### PR TITLE
opentelemetry: fix support for schema_url in opentelemetry plugins (backport of #10201).

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_logs.c
+++ b/plugins/in_opentelemetry/opentelemetry_logs.c
@@ -1346,6 +1346,16 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
             if (scope && (scope->name || scope->version || scope->n_attributes > 0)) {
                 flb_mp_map_header_init(&mh_tmp, &mp_pck);
 
+                if (scope_log->schema_url && strlen(scope_log->schema_url) > 0) {
+                    flb_mp_map_header_append(&mh_tmp);
+                    msgpack_pack_str(&mp_pck, 10);
+                    msgpack_pack_str_body(&mp_pck, "schema_url", 10);
+
+                    len = strlen(scope_log->schema_url);
+                    msgpack_pack_str(&mp_pck, len);
+                    msgpack_pack_str_body(&mp_pck, scope_log->schema_url, len);
+                }
+
                 if (scope->name && strlen(scope->name) > 0) {
                     flb_mp_map_header_append(&mh_tmp);
                     msgpack_pack_str(&mp_pck, 4);

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -169,6 +169,7 @@ struct opentelemetry_context {
     struct flb_record_accessor *ra_scope_name;
     struct flb_record_accessor *ra_scope_version;
     struct flb_record_accessor *ra_scope_attr;
+    struct flb_record_accessor *ra_scope_schema_url;
 
     /* log: metadata components coming from OTLP */
     struct flb_record_accessor *ra_log_meta_otlp_observed_ts;

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -505,6 +505,11 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         flb_plg_error(ins, "failed to create record accessor for scope attributes");
     }
 
+    ctx->ra_scope_schema_url = flb_ra_create("$scope['schema_url']", FLB_FALSE);
+    if (ctx->ra_scope_schema_url == NULL) {
+        flb_plg_error(ins, "failed to create record accessor for resource schema url");
+    }
+
     /* log metadata under $otlp (set by in_opentelemetry) */
 
     ctx->ra_log_meta_otlp_observed_ts = flb_ra_create("$otlp['observed_timestamp']", FLB_FALSE);
@@ -695,6 +700,9 @@ void flb_opentelemetry_context_destroy(struct opentelemetry_context *ctx)
     }
     if (ctx->ra_scope_attr) {
         flb_ra_destroy(ctx->ra_scope_attr);
+    }
+    if (ctx->ra_scope_schema_url) {
+        flb_ra_destroy(ctx->ra_scope_schema_url);
     }
 
     if (ctx->ra_log_meta_otlp_observed_ts) {

--- a/plugins/out_opentelemetry/opentelemetry_logs.c
+++ b/plugins/out_opentelemetry/opentelemetry_logs.c
@@ -808,6 +808,34 @@ static int set_resource_schema_url(struct flb_record_accessor *ra,
     return 0;
 }
 
+static int set_scope_schema_url(struct flb_record_accessor *ra,
+                                msgpack_object *map,
+                                Opentelemetry__Proto__Logs__V1__ScopeLogs *scope_log)
+{
+
+    struct flb_ra_value *ra_val;
+
+    ra_val = flb_ra_get_value_object(ra, *map);
+    if (ra_val == NULL) {
+        return -1;
+    }
+
+    if (ra_val->o.type != MSGPACK_OBJECT_STR) {
+        flb_ra_key_value_destroy(ra_val);
+        return -1;
+    }
+
+    scope_log->schema_url = flb_sds_create_len(ra_val->o.via.str.ptr,
+                                               ra_val->o.via.str.size);
+    flb_ra_key_value_destroy(ra_val);
+
+    if (!scope_log->schema_url) {
+        return -1;
+    }
+
+    return 0;
+}
+
 static int set_scope_name(struct flb_record_accessor *ra,
                          msgpack_object *map,
                          Opentelemetry__Proto__Common__V1__InstrumentationScope *scope)
@@ -1079,6 +1107,9 @@ start_resource:
 
                 /* group body: $scope['attributes'] */
                 set_scope_attributes(ctx->ra_scope_attr, event.body, scope_log->scope);
+
+                /* group body: $scope['schema_url'] */
+                set_scope_schema_url(ctx->ra_scope_schema_url, event.body, scope_log);
             }
 
             ret = FLB_OK;


### PR DESCRIPTION
# Summary

Add support for `scope_logs.schema_url` for opentelemetry. This is a backport of #10201 to the 3.2 series.

# Description

Encode scope_logs.schema_url inside `scope` for `in_opentelemetry` and then set it again in `out_opentelemetry` using a record accessor that searches for `scope.schema_url` inside the logs group attributes.

This should fix issue #10143 for the 3.2 series.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
