### PR TITLE
tests: internal: fuzzers: extend ctrace fuzzer

### DIFF
--- a/tests/internal/fuzzers/ctrace_fuzzer.c
+++ b/tests/internal/fuzzers/ctrace_fuzzer.c
@@ -6,6 +6,7 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     size_t off = 0;
     struct ctrace *ctr = NULL;
+    struct ctrace *ctr2 = NULL;
     size_t msgpack_text_size;
     char *msgpack_text_buffer = NULL;
 
@@ -20,5 +21,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
 
         ctr_destroy(ctr);
     }
+
+    /* Target opentelemtry decoding */
+    ctr_decode_opentelemetry_create(&ctr2, data, size, &off);
+    if (ctr2 != NULL) {
+        ctr_destroy(ctr2);
+    }
+
     return 0;
 }


### PR DESCRIPTION
Extend OSS-Fuzz set up to add decoding of opentelemtry logic.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
