### PR TITLE
pipeline: inputs: podman_metrics: use after free fix

### DIFF
--- a/plugins/in_podman_metrics/podman_metrics.c
+++ b/plugins/in_podman_metrics/podman_metrics.c
@@ -231,12 +231,11 @@ static int create_counter(struct flb_in_metrics *ctx, struct cmt_counter **count
 
     }
 
+    labels = (char *[]){id, name, image_name, interface};
     if (interface == NULL) {
-        labels = (char *[]){id, name, image_name};
         label_count = 3;
     }
     else {
-        labels = (char *[]){id, name, image_name, interface};
         label_count = 4;
     }
 


### PR DESCRIPTION
pipeline: inputs: podman_metrics: fixed use after free which was discovered by failed CI build (after migration from GCC 7 to GCC 9 in https://github.com/fluent/fluent-bit/pull/10230 which was merged as part of https://github.com/fluent/fluent-bit/pull/10178) with optimization for size turned on (`cmake -DFLB_SMALL=On ...`).

Refer to https://github.com/fluent/fluent-bit/actions/runs/14581214135/job/40898148724?pr=7608 for the issue which this pull request fixes.

----
**Testing**

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found - refer to [flb_run_code_analysis_10234.log](https://drive.google.com/file/d/1J5J-sLqtAFVs7t62O9ya_-YtcuMtZ2v5/view?usp=sharing) for the output of command
    ```bash
    TEST_PRESET=valgrind SKIP_TESTS='flb-rt-out_td flb-it-network' ./run_code_analysis.sh
    ```
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
