### PR TITLE
in_tail: fix disposal order to prevent use after free

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1305,14 +1305,13 @@ void flb_tail_file_remove(struct flb_tail_file *file)
         flb_log_event_encoder_destroy(file->sl_log_event_encoder);
     }
 
-    if (file->ml_log_event_encoder != NULL) {
-        flb_log_event_encoder_destroy(file->ml_log_event_encoder);
-    }
-
     /* remove the multiline.core stream */
     if (ctx->ml_ctx && file->ml_stream_id > 0) {
-        /* destroy ml stream */
         flb_ml_stream_id_destroy_all(ctx->ml_ctx, file->ml_stream_id);
+    }
+
+    if (file->ml_log_event_encoder != NULL) {
+        flb_log_event_encoder_destroy(file->ml_log_event_encoder);
     }
 
     if (file->rotated > 0) {


### PR DESCRIPTION
This PR inverts the disposal of the multiline encoder and multiline contexts when removing a file in the tail input plugin in order to prevent a use after free.