### PR TITLE
plugins: fix compilation if FLB_SQLDB (sqlite3) is disabled

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -55,6 +55,8 @@ jobs:
           - "-DFLB_SANITIZE_THREAD=On"
           - "-DFLB_SIMD=On"
           - "-DFLB_SIMD=Off"
+          - "-DFLB_SQLDB=On"
+          - "-DFLB_SQLDB=Off"
           - "-DFLB_ARROW=On"
           - "-DFLB_COMPILER_STRICT_POINTER_TYPES=On"
           - "-DFLB_AVRO_ENCODER=On -DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/plugins/filter_checklist/checklist.c
+++ b/plugins/filter_checklist/checklist.c
@@ -21,13 +21,13 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_ra_key.h>
-#include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
 #include "checklist.h"
 #include <ctype.h>
 
+#ifdef FLB_HAVE_SQLDB
 static int db_init(struct checklist *ctx)
 {
     int ret;
@@ -124,6 +124,7 @@ static int db_check(struct checklist *ctx, char *buf, size_t size)
 
     return match;
 }
+#endif
 
 static int load_file_patterns(struct checklist *ctx)
 {
@@ -175,9 +176,11 @@ static int load_file_patterns(struct checklist *ctx)
         if (ctx->mode == CHECK_EXACT_MATCH) {
             ret = flb_hash_table_add(ctx->ht, buf, len, "", 0);
         }
+#ifdef FLB_HAVE_SQLDB
         else if (ctx->mode == CHECK_PARTIAL_MATCH) {
             ret = db_insert(ctx, buf, len);
         }
+#endif
 
         if (ret >= 0) {
             flb_plg_debug(ctx->ins, "file list: line=%i adds value='%s'", line, buf);
@@ -210,7 +213,13 @@ static int init_config(struct checklist *ctx)
             ctx->mode = CHECK_EXACT_MATCH;
         }
         else if (strcasecmp(tmp, "partial") == 0) {
+#ifdef FLB_HAVE_SQLDB
             ctx->mode = CHECK_PARTIAL_MATCH;
+#else
+            flb_plg_error(ctx->ins,
+                          "'mode=partial' requires FLB_HAVE_SQLDB enabled at build time");
+            return -1;
+#endif
         }
     }
 
@@ -223,12 +232,14 @@ static int init_config(struct checklist *ctx)
             return -1;
         }
     }
+#ifdef FLB_HAVE_SQLDB
     else if (ctx->mode == CHECK_PARTIAL_MATCH) {
         ret = db_init(ctx);
         if (ret < 0) {
             return -1;
         }
     }
+#endif
 
     /* record accessor pattern / key name */
     ctx->ra_lookup_key = flb_ra_create(ctx->lookup_key, FLB_TRUE);
@@ -284,6 +295,11 @@ static int cb_checklist_init(struct flb_filter_instance *ins,
     }
 
     ret = init_config(ctx);
+    if (ret == -1) {
+        flb_filter_set_context(ins, NULL);
+        flb_free(ctx);
+        return -1;
+    }
 
     return 0;
 }
@@ -504,9 +520,11 @@ static int cb_checklist_filter(const void *data, size_t bytes,
                         found = FLB_TRUE;
                     }
                 }
+#ifdef FLB_HAVE_SQLDB
                 else if (ctx->mode == CHECK_PARTIAL_MATCH) {
                     found = db_check(ctx, cmp_buf, cmp_size);
                 }
+#endif
 
                 if (cmp_buf && cmp_buf != (char *) rval->o.via.str.ptr) {
                     flb_free(cmp_buf);
@@ -592,11 +610,13 @@ static int cb_exit(void *data, struct flb_config *config)
         flb_hash_table_destroy(ctx->ht);
     }
 
+#ifdef FLB_HAVE_SQLDB
     if (ctx->db) {
         sqlite3_finalize(ctx->stmt_insert);
         sqlite3_finalize(ctx->stmt_check);
         flb_sqldb_close(ctx->db);
     }
+#endif
 
     flb_free(ctx);
     return 0;

--- a/plugins/filter_checklist/checklist.h
+++ b/plugins/filter_checklist/checklist.h
@@ -21,14 +21,19 @@
 #define FLB_FILTER_CHECK_H
 
 #include <fluent-bit/flb_info.h>
-#include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_hash_table.h>
 #include <fluent-bit/flb_record_accessor.h>
+
+#ifdef FLB_HAVE_SQLDB
+#include <fluent-bit/flb_sqldb.h>
+#endif
 
 #define LINE_SIZE   2048
 #define CHECK_HASH_TABLE_SIZE 100000
 #define CHECK_EXACT_MATCH     0  /* exact string match */
+#ifdef FLB_HAVE_SQLDB
 #define CHECK_PARTIAL_MATCH   1  /* partial match */
+#endif
 
 /* plugin context */
 struct checklist {
@@ -41,9 +46,11 @@ struct checklist {
     struct mk_list *records;
 
     /* internal */
+#ifdef FLB_HAVE_SQLDB
     struct flb_sqldb *db;
     sqlite3_stmt *stmt_insert;
     sqlite3_stmt *stmt_check;
+#endif
     struct flb_hash_table *ht;
     struct flb_record_accessor *ra_lookup_key;
     struct flb_filter_instance *ins;

--- a/plugins/in_blob/blob.c
+++ b/plugins/in_blob/blob.c
@@ -40,8 +40,11 @@
 #include <stdio.h>
 
 #include "blob.h"
-#include "blob_db.h"
 #include "blob_file.h"
+
+#ifdef FLB_HAVE_SQLDB
+#include "blob_db.h"
+#endif
 
 #include "win32_glob.c"
 
@@ -739,7 +742,10 @@ static int in_blob_exit(void *in_context, struct flb_config *config)
         return 0;
     }
 
+#ifdef FLB_HAVE_SQLDB
     blob_db_close(ctx);
+#endif
+
     blob_file_list_remove_all(ctx);
     flb_log_event_encoder_destroy(ctx->log_encoder);
     flb_free(ctx);

--- a/plugins/in_blob/blob.h
+++ b/plugins/in_blob/blob.h
@@ -21,9 +21,12 @@
 #define FLB_IN_BLOB_H
 
 #include <fluent-bit/flb_input_plugin.h>
-#include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+
+#ifdef FLB_HAVE_SQLDB
+#include <fluent-bit/flb_sqldb.h>
+#endif
 
 #define POST_UPLOAD_ACTION_NONE       0
 #define POST_UPLOAD_ACTION_DELETE     1

--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -27,7 +27,6 @@
 #include <fluent-bit/flb_compression.h>
 #include <fluent-bit/flb_zstd.h>
 #include <fluent-bit/flb_base64.h>
-#include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_input_blob.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_plugin.h>
@@ -40,13 +39,16 @@
 #include <string.h>
 
 #include "azure_blob.h"
-#include "azure_blob_db.h"
 #include "azure_blob_uri.h"
 #include "azure_blob_conf.h"
 #include "azure_blob_appendblob.h"
 #include "azure_blob_blockblob.h"
 #include "azure_blob_http.h"
 #include "azure_blob_store.h"
+
+#ifdef FLB_HAVE_SQLDB
+#include "azure_blob_db.h"
+#endif
 
 #define CREATE_BLOB  1337
 #define AZB_UUID_PLACEHOLDER "$UUID"
@@ -780,6 +782,7 @@ cleanup_create:
     return status;
 }
 
+#ifdef FLB_HAVE_SQLDB
 static int delete_blob(struct flb_azure_blob *ctx,
                        const char *path_prefix,
                        char *name)
@@ -858,6 +861,7 @@ cleanup_delete:
     }
     return status;
 }
+#endif
 
 int azb_select_compression_strategy(struct flb_azure_blob *ctx,
                                     int *compression_algorithm,
@@ -1126,6 +1130,7 @@ static int send_blob(struct flb_config *config,
             ref_name = flb_sds_printf(&ref_name, "file=%s.%" PRIu64, name, ms);
         }
         else if (event_type == FLB_EVENT_TYPE_BLOBS) {
+#ifdef FLB_HAVE_SQLDB
             block_id = azb_block_blob_id_blob(ctx, name, part_id);
             if (!block_id) {
                 flb_plg_error(ctx->ins, "could not generate block id");
@@ -1140,6 +1145,16 @@ static int send_blob(struct flb_config *config,
             uri = azb_block_blob_uri(ctx, path_prefix, name,
                                      block_id, 0, generated_random_string);
             ref_name = flb_sds_printf(&ref_name, "file=%s:%" PRIu64, name, part_id);
+#else
+            flb_plg_error(ctx->ins, "FLB_EVENT_TYPE_BLOBS requires FLB_HAVE_SQLDB enabled at build time");
+            flb_free(generated_random_string);
+            generated_random_string = NULL;
+            flb_sds_destroy(ref_name);
+            if (tmp_path_prefix) {
+                flb_sds_destroy(tmp_path_prefix);
+            }
+            return FLB_ERROR;
+#endif
         }
     }
     else {
@@ -1431,6 +1446,7 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
     return 0;
 }
 
+#ifdef FLB_HAVE_SQLDB
 static int blob_chunk_register_parts(struct flb_azure_blob *ctx, uint64_t file_id, size_t total_size)
 {
     int ret;
@@ -1900,6 +1916,7 @@ static int azb_timer_create(struct flb_azure_blob *ctx)
 
     return 0;
 }
+#endif
 
 /**
  * Azure Blob Storage ingestion callback function
@@ -2357,6 +2374,7 @@ static void cb_azure_blob_flush(struct flb_event_chunk *event_chunk,
         }
     }
     else if (event_chunk->type == FLB_EVENT_TYPE_BLOBS) {
+#ifdef FLB_HAVE_SQLDB
         /*
          * For Blob types, we use the flush callback to enqueue the file, then cb_azb_blob_file_upload()
          * takes care of the rest like reading the file and uploading it to Azure.
@@ -2365,6 +2383,9 @@ static void cb_azure_blob_flush(struct flb_event_chunk *event_chunk,
         if (ret == -1) {
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
+#else
+        ret = FLB_ERROR;
+#endif
     }
 
     if (json){
@@ -2425,6 +2446,7 @@ static int cb_worker_init(void *data, struct flb_config *config)
         FLB_TLS_SET(worker_info, info);
     }
 
+#ifdef FLB_HAVE_SQLDB
     ret = azb_timer_create(ctx);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "failed to create upload timer");
@@ -2432,6 +2454,11 @@ static int cb_worker_init(void *data, struct flb_config *config)
     }
 
     return 0;
+#else
+    flb_plg_error(ctx->ins, "creating upload timer skipped because "
+                            "FLB_HAVE_SQLDB is not enabled at build time");
+    return -1;
+#endif
 }
 
 /* worker teardown */

--- a/plugins/out_azure_blob/azure_blob.h
+++ b/plugins/out_azure_blob/azure_blob.h
@@ -23,8 +23,11 @@
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_sds.h>
-#include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_time.h>
+
+#ifdef FLB_HAVE_SQLDB
+#include <fluent-bit/flb_sqldb.h>
+#endif
 
 /* Content-Type */
 #define AZURE_BLOB_CT          "Content-Type"

--- a/plugins/out_azure_blob/azure_blob_blockblob.c
+++ b/plugins/out_azure_blob/azure_blob_blockblob.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_crypto_constants.h>
 #include <fluent-bit/flb_compression.h>
 

--- a/plugins/out_azure_blob/azure_blob_conf.c
+++ b/plugins/out_azure_blob/azure_blob_conf.c
@@ -21,10 +21,14 @@
 #include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_compression.h>
+#include <fluent-bit/flb_utils.h>
 
 #include "azure_blob.h"
 #include "azure_blob_conf.h"
+
+#ifdef FLB_HAVE_SQLDB
 #include "azure_blob_db.h"
+#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -779,6 +783,7 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
         flb_sds_printf(&ctx->shared_key_prefix, "SharedKey %s:", ctx->account_name);
     }
 
+#ifdef FLB_HAVE_SQLDB
     /* database file for blob signal handling */
     if (ctx->database_file) {
         ctx->db = azb_db_open(ctx, ctx->database_file);
@@ -788,6 +793,7 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
     }
 
     pthread_mutex_init(&ctx->file_upload_commit_file_parts, NULL);
+#endif
 
     flb_plg_info(ctx->ins,
                  "account_name=%s, container_name=%s, blob_type=%s, emulator_mode=%s, endpoint=%s, auth_type=%s",
@@ -844,7 +850,9 @@ void flb_azure_blob_conf_destroy(struct flb_azure_blob *ctx)
         flb_upstream_destroy(ctx->u);
     }
 
-
+#ifdef FLB_HAVE_SQLDB
     azb_db_close(ctx);
+#endif
+
     flb_free(ctx);
 }

--- a/src/flb_blob_db.c
+++ b/src/flb_blob_db.c
@@ -17,10 +17,11 @@
  *  limitations under the License.
  */
 
-#ifdef FLB_HAVE_SQLDB
-
-#include <fluent-bit/flb_sqldb.h>
+#include <fluent-bit.h>
 #include <fluent-bit/flb_blob_db.h>
+
+#ifdef FLB_HAVE_SQLDB
+#include <fluent-bit/flb_sqldb.h>
 
 static int prepare_stmts(struct flb_blob_db *context)
 {
@@ -1411,6 +1412,16 @@ int flb_blob_db_close(struct flb_blob_db *context)
     return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
 }
 
+int flb_blob_db_lock(struct flb_blob_db *context)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_unlock(struct flb_blob_db *context)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
 int flb_blob_db_file_exists(struct flb_blob_db *context,
                             char *path,
                             uint64_t *id)
@@ -1455,6 +1466,13 @@ int flb_blob_db_file_delivery_attempts(struct flb_blob_db *context,
     return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
 }
 
+int flb_blob_file_update_remote_id(struct flb_blob_db *context,
+                                   uint64_t id,
+                                   cfl_sds_t remote_id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
 int flb_blob_db_file_get_next_aborted(struct flb_blob_db *context,
                                       uint64_t *id,
                                       uint64_t *delivery_attempts,
@@ -1463,6 +1481,13 @@ int flb_blob_db_file_get_next_aborted(struct flb_blob_db *context,
                                       cfl_sds_t *remote_id,
                                       cfl_sds_t *file_tag,
                                       int *part_count)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_part_update_remote_id(struct flb_blob_db *context,
+                                           uint64_t id,
+                                           cfl_sds_t remote_id)
 {
     return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
 }
@@ -1512,11 +1537,11 @@ int flb_blob_db_file_part_get_next(struct flb_blob_db *context,
                                    cfl_sds_t *file_path,
                                    cfl_sds_t *destination,
                                    cfl_sds_t *remote_file_id,
-                                   cfl_sds_t *tag)
+                                   cfl_sds_t *tag,
+                                   int *part_count)
 {
     return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
 }
-
 
 int flb_blob_db_file_part_uploaded(struct flb_blob_db *context, uint64_t id)
 {

--- a/tests/runtime/filter_checklist.c
+++ b/tests/runtime/filter_checklist.c
@@ -348,6 +348,7 @@ void flb_test_ignore_case(void)
     test_ctx_destroy(ctx);
 }
 
+#ifdef FLB_HAVE_SQLDB
 void flb_test_mode_partial(void)
 {
     int ret;
@@ -394,12 +395,15 @@ void flb_test_mode_partial(void)
 
     test_ctx_destroy(ctx);
 }
+#endif
 
 TEST_LIST = {
     {"lookup_key", flb_test_lookup_key},
     {"lookup_keys", flb_test_lookup_keys},
     {"records", flb_test_records},
     {"ignore_case", flb_test_ignore_case},
+#ifdef FLB_HAVE_SQLDB
     {"mode_partial", flb_test_mode_partial},
+#endif
     {NULL, NULL}
 };

--- a/tests/runtime_shell/CMakeLists.txt
+++ b/tests/runtime_shell/CMakeLists.txt
@@ -12,10 +12,13 @@ if(WIN32)
   if(POWERSHELL_EXECUTABLE)
     set(UNIT_TESTS_PS
       in_dummy_expect.ps1
-      in_tail_expect.ps1
       in_syslog_tcp_plaintext_expect.ps1
       in_syslog_udp_plaintext_expect.ps1
       )
+
+    if(FLB_SQLDB)
+      list(APPEND UNIT_TESTS_PS in_tail_expect.ps1)
+    endif()
 
     if(FLB_TLS)
       list(APPEND UNIT_TESTS_PS
@@ -74,7 +77,6 @@ else()
     custom_calyptia.sh
     dry_run_invalid_property.sh
     in_dummy_expect.sh
-    in_tail_expect.sh
     in_http_tls_expect.sh
     in_syslog_tcp_tls_expect.sh
     in_syslog_tcp_plaintext_expect.sh
@@ -84,6 +86,10 @@ else()
     processor_conditional.sh
     processor_invalid.sh
     )
+
+  if(FLB_SQLDB)
+    list(APPEND UNIT_TESTS_SH in_tail_expect.sh)
+  endif()
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64)")


### PR DESCRIPTION
Fixes:
- https://github.com/fluent/fluent-bit/issues/9757.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SQLDB support is now optional; enabling it restores partial-match checklist behavior and improved blob upload tracking.
  - Added a new post-upload action: "Add Suffix".

- **Bug Fixes**
  - Non-database builds now fail fast for DB-only modes/events to avoid unexpected behavior.
  - Improved initialization and cleanup to prevent leftover state on failures.

- **Tests**
  - CI and unit tests now run with DB-enabled and DB-disabled variants; DB-only tests are conditional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->