### PR TITLE
Pwhelan event reload

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -52,9 +52,21 @@
  * pointers.
  */
 
+#define FLB_CONTEXT_EV_SIGNAL      (1 << 0) /* 1 */
+
+enum ctx_signal_type {
+    FLB_CTX_SIGNAL_RELOAD,
+    FLB_CTX_SIGNAL_SHUTDOWN,
+};
+
 /* Main struct to hold the configuration of the runtime service */
 struct flb_config {
     struct mk_event ch_event;
+
+    /* external communication channel for fluent-bit contexts */
+    struct mk_event_loop *ctx_evl;
+    flb_pipefd_t ch_context_signal[2]; /* channel to recieve context signal events */
+    struct mk_event event_context_signal;
 
     int support_mode;         /* enterprise support mode ?      */
     int is_ingestion_active;  /* date ingestion active/allowed  */

--- a/src/http_server/api/v2/reload.c
+++ b/src/http_server/api/v2/reload.c
@@ -41,6 +41,7 @@ static void handle_reload_request(mk_request_t *request, struct flb_config *conf
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
     int http_status = 200;
+    enum ctx_signal_type ctx_signal;
 
     /* initialize buffers */
     msgpack_sbuffer_init(&mp_sbuf);
@@ -50,7 +51,6 @@ static void handle_reload_request(mk_request_t *request, struct flb_config *conf
     msgpack_pack_str(&mp_pck, 6);
     msgpack_pack_str_body(&mp_pck, "reload", 6);
 
-#ifdef FLB_SYSTEM_WINDOWS
     if (config->enable_hot_reload != FLB_TRUE) {
         msgpack_pack_str(&mp_pck, 11);
         msgpack_pack_str_body(&mp_pck, "not enabled", 11);
@@ -67,37 +67,9 @@ static void handle_reload_request(mk_request_t *request, struct flb_config *conf
         http_status =  400;
     }
     else {
-        ret = GenerateConsoleCtrlEvent(1 /* CTRL_BREAK_EVENT_1 */, 0);
-        if (ret == 0) {
-            mk_http_status(request, 500);
-            mk_http_done(request);
-            return;
-        }
-
-        msgpack_pack_str(&mp_pck, 4);
-        msgpack_pack_str_body(&mp_pck, "done", 4);
-        msgpack_pack_str(&mp_pck, 6);
-        msgpack_pack_str_body(&mp_pck, "status", 6);
-        msgpack_pack_int64(&mp_pck, ret);
-    }
-#else
-    if (config->enable_hot_reload != FLB_TRUE) {
-        msgpack_pack_str(&mp_pck, 11);
-        msgpack_pack_str_body(&mp_pck, "not enabled", 11);
-        msgpack_pack_str(&mp_pck, 6);
-        msgpack_pack_str_body(&mp_pck, "status", 6);
-        msgpack_pack_int64(&mp_pck, -1);
-    }
-    else if (config->hot_reloading == FLB_TRUE) {
-        msgpack_pack_str(&mp_pck, 11);
-        msgpack_pack_str_body(&mp_pck, "in progress", 11);
-        msgpack_pack_str(&mp_pck, 6);
-        msgpack_pack_str_body(&mp_pck, "status", 6);
-        msgpack_pack_int64(&mp_pck, -2);
-        http_status =  400;
-    }
-    else {
-        ret = kill(getpid(), SIGHUP);
+        ctx_signal = FLB_CTX_SIGNAL_RELOAD;
+        ret = flb_pipe_w(config->ch_context_signal[1], &ctx_signal,
+                         sizeof(enum ctx_signal_type));
         if (ret != 0) {
             mk_http_status(request, 500);
             mk_http_done(request);
@@ -110,8 +82,6 @@ static void handle_reload_request(mk_request_t *request, struct flb_config *conf
         msgpack_pack_str_body(&mp_pck, "status", 6);
         msgpack_pack_int64(&mp_pck, ret);
     }
-
-#endif
 
     /* Export to JSON */
     out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size);


### PR DESCRIPTION
# Summary

Add a new event loop for contexts and for signaling context events.

# Description

This event loop has a channel that is used internally for signals, ie: shutdown, reload, etc... The main loop now uses this event loop to receive shutdown and reload signals.

This should solve the issue addressed in #9908 in a cross platform and much more stable and clean manner.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
