### PR TITLE
packaging: remove older Ubuntu targets from smoke test

### DIFF
--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -37,9 +37,7 @@ function check_version() {
     fi
 }
 
-APT_TARGETS=("ubuntu:18.04"
-    "ubuntu:20.04"
-    "ubuntu:22.04"
+APT_TARGETS=("ubuntu:22.04"
     "debian:10"
     "debian:11")
 


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
