### PR TITLE
tests: internal: fuzzers: split cmetrics decoding

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UNIT_TESTS_FILES
   base64_fuzzer.c
   engine_fuzzer.c
   cmetrics_decode_fuzz.c
+  cmetrics_decode_prometheus.c
   config_fuzzer.c
   config_random_fuzzer.c
   ctrace_fuzzer.c

--- a/tests/internal/fuzzers/cmetrics_decode_prometheus.c
+++ b/tests/internal/fuzzers/cmetrics_decode_prometheus.c
@@ -17,17 +17,13 @@
  *  limitations under the License.
  */
 
-#include <cmetrics/cmt_decode_msgpack.h>
-#include <cmetrics/cmt_decode_opentelemetry.h>
+#include <cmetrics/cmt_decode_prometheus.h>
 
 
 int
 LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
 {
-    struct cfl_list decoded_contexts;
     struct cmt *cmt = NULL;
-    size_t off = 0;
-    uint8_t decider;
     int result;
 
     /* At least one byte is needed for deciding which decoder to use */
@@ -35,25 +31,10 @@ LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
         return 0;
     }
 
-    decider = data[0] % 2;
-
-    /* Adjust data pointer since the first byte is used */
-    data += 1;
-    size -= 1;
-
-    /* Fuzz a given decoder */
-    if (decider == 0) {
-        result = cmt_decode_opentelemetry_create(&decoded_contexts, data, size,
-                                                 &off);
-        if (result == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
-            cmt_decode_opentelemetry_destroy (&decoded_contexts);
-        }
-    }
-    else {
-        result = cmt_decode_msgpack_create(&cmt, (char *) data, size, &off);
-        if (result == 0) {
-            cmt_destroy(cmt);
-        }
+    struct cmt_decode_prometheus_parse_opts opts;
+    result = cmt_decode_prometheus_create(&cmt, data, size, &opts);
+    if (result == CMT_DECODE_PROMETHEUS_SUCCESS) {
+        cmt_decode_prometheus_destroy(cmt);
     }
 
     return 0;


### PR DESCRIPTION
This split is because prometheus has calls to abort https://github.com/fluent/fluent-bit/blob/e8d608b7d7a7c12eae2dfce019f3c263257ed131/lib/cmetrics/src/cmt_decode_prometheus.y#L44 which forces prometheus decoding to cause exits. Consequently, coverage reports are missing for some of the cmetrics decoding files and the aborts also mean fuzzing of the other decoders will be limited.

Coverage report:
https://storage.googleapis.com/oss-fuzz-coverage/fluent-bit/reports/20250422/linux/src/fluent-bit/lib/cmetrics/src/report.html

This the above problems by splitting the decoding harness into two different fuzzers.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
