### PR TITLE
plugin_proxy: fixed memory leak

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -240,6 +240,12 @@ static void flb_proxy_output_cb_destroy(struct flb_output_plugin *plugin)
         cb_unregister(proxy->def);
     }
 
+    if (plugin->name != NULL) {
+        flb_free(plugin->name);
+
+        plugin->name = NULL;
+    }
+
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {
 #ifdef FLB_HAVE_PROXY_GO
         proxy_go_output_unregister(proxy->data);
@@ -284,6 +290,12 @@ static void flb_proxy_input_cb_destroy(struct flb_input_plugin *plugin)
     cb_unregister = flb_plugin_proxy_symbol(proxy, "FLBPluginUnregister");
     if (cb_unregister != NULL) {
         cb_unregister(proxy->def);
+    }
+
+    if (plugin->name != NULL) {
+        flb_free(plugin->name);
+
+        plugin->name = NULL;
     }
 
     if (proxy->def->proxy == FLB_PROXY_GOLANG) {


### PR DESCRIPTION
This PR fixes a memory leak in the plugin proxy, the regular plugin destruction process counts on the name (and description) being constants, however, the plugin proxy makes copies of them when creating both plugin spec instances.

ToDo: I don't really understand why does the plugin proxy create two instances of the `flb_output_plugin` / `flb_input_plugin` structure so I need to check with the code owner to get a better understanding of the reasoning behind it.

Note : This is a backport of PR #10179 