### PR TITLE
backport to v.3.2 -- in_tail: make read_from_head after the initial discovery optional

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -396,13 +396,15 @@ static int in_tail_init(struct flb_input_instance *in,
     }
 #endif
 
-    /*
-     * After the first scan (on start time), all new files discovered needs to be
-     * read from head, so we switch the 'read_from_head' flag to true so any
-     * other file discovered after a scan or a rotation are read from the
-     * beginning.
-     */
-    ctx->read_from_head = FLB_TRUE;
+    if (ctx->read_newly_discovered_files_from_head) {
+        /*
+        * After the first scan (on start time), all new files discovered needs to be
+        * read from head, so we switch the 'read_from_head' flag to true so any
+        * other file discovered after a scan or a rotation are read from the
+        * beginning.
+        */
+        ctx->read_from_head = FLB_TRUE;
+    }
 
     /* Set plugin context */
     flb_input_set_context(in, ctx);
@@ -592,6 +594,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "read_from_head", "false",
      0, FLB_TRUE, offsetof(struct flb_tail_config, read_from_head),
      "For new discovered files on start (without a database offset/position), read the "
+     "content from the head of the file, not tail."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "read_newly_discovered_files_from_head", "true",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, read_newly_discovered_files_from_head),
+     "For new discovered files after start (without a database offset/position), read the "
      "content from the head of the file, not tail."
     },
     {

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -235,6 +235,14 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
         return NULL;
     }
 
+    /* hash table for files lookups */
+    ctx->ignored_file_sizes = flb_hash_table_create(FLB_HASH_TABLE_EVICT_NONE, 1000, 0);
+    if (ctx->ignored_file_sizes == NULL) {
+        flb_plg_error(ctx->ins, "could not create ignored file size hash table");
+        flb_tail_config_destroy(ctx);
+        return NULL;
+    }
+
 #ifdef FLB_HAVE_SQLDB
     ctx->db = NULL;
 #endif
@@ -463,10 +471,16 @@ int flb_tail_config_destroy(struct flb_tail_config *config)
     if (config->static_hash) {
         flb_hash_table_destroy(config->static_hash);
     }
+
     if (config->event_hash) {
         flb_hash_table_destroy(config->event_hash);
     }
 
+    if (config->ignored_file_sizes != NULL) {
+        flb_hash_table_destroy(config->ignored_file_sizes);
+    }
+
     flb_free(config);
+
     return 0;
 }

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -82,6 +82,7 @@ struct flb_tail_config {
 #endif
     int refresh_interval_sec;  /* seconds to re-scan           */
     long refresh_interval_nsec;/* nanoseconds to re-scan       */
+    int read_newly_discovered_files_from_head; /* read new files from head after startup */
     int read_from_head;        /* read new files from head     */
     int rotate_wait;           /* sec to wait on rotated files */
     int watcher_interval;      /* watcher interval             */
@@ -161,6 +162,8 @@ struct flb_tail_config {
     /* Hash: hash tables for quick acess to registered files */
     struct flb_hash_table *static_hash;
     struct flb_hash_table *event_hash;
+
+    struct flb_hash_table *ignored_file_sizes;
 
     struct flb_config *config;
 };

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -868,13 +868,24 @@ static int set_file_position(struct flb_tail_config *ctx,
         return 0;
     }
 
-    /* tail... */
-    ret = lseek(file->fd, 0, SEEK_END);
-    if (ret == -1) {
-        flb_errno();
-        return -1;
+    if (file->offset > 0) {
+        ret = lseek(file->fd, file->offset, SEEK_SET);
+
+        if (ret == -1) {
+            flb_errno();
+            return -1;
+        }
     }
-    file->offset = ret;
+    else {
+        ret = lseek(file->fd, 0, SEEK_END);
+
+        if (ret == -1) {
+            flb_errno();
+            return -1;
+        }
+
+        file->offset = ret;
+    }
 
     if (file->decompression_context == NULL) {
         file->stream_offset = ret;
@@ -923,6 +934,7 @@ static int ml_flush_callback(struct flb_ml_parser *parser,
 }
 
 int flb_tail_file_append(char *path, struct stat *st, int mode,
+                         ssize_t offset,
                          struct flb_tail_config *ctx)
 {
     int fd;
@@ -1011,6 +1023,10 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->mult_keys = 0;
     file->mult_flush_timeout = 0;
     file->mult_skipping = FLB_FALSE;
+
+    if (offset != -1) {
+        file->offset = offset;
+    }
 
     if (strlen(path) >= 3 &&
         strcasecmp(&path[strlen(path) - 3], ".gz") == 0) {
@@ -1894,7 +1910,7 @@ int flb_tail_file_rotated(struct flb_tail_file *file)
         ret = stat(tmp, &st);
         if (ret == 0 && st.st_ino != file->inode) {
             if (flb_tail_file_exists(&st, ctx) == FLB_FALSE) {
-                ret = flb_tail_file_append(tmp, &st, FLB_TAIL_STATIC, ctx);
+                ret = flb_tail_file_append(tmp, &st, FLB_TAIL_STATIC, -1, ctx);
                 if (ret == -1) {
                     flb_tail_scan(ctx->path_list, ctx);
                 }

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -119,6 +119,7 @@ int flb_tail_file_name_dup(char *path, struct flb_tail_file *file);
 int flb_tail_file_to_event(struct flb_tail_file *file);
 int flb_tail_file_chunk(struct flb_tail_file *file);
 int flb_tail_file_append(char *path, struct stat *st, int mode,
+                         ssize_t offset,
                          struct flb_tail_config *ctx);
 void flb_tail_file_remove(struct flb_tail_file *file);
 int flb_tail_file_remove_all(struct flb_tail_config *ctx);

--- a/plugins/in_tail/tail_scan.c
+++ b/plugins/in_tail/tail_scan.c
@@ -30,6 +30,30 @@
 #include "tail_scan_glob.c"
 #endif
 
+void flb_tail_scan_register_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length, size_t size)
+{
+    flb_hash_table_add(ctx->ignored_file_sizes, path, path_length, (void *) size, 0);
+
+}
+
+void flb_tail_scan_unregister_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length)
+{
+    flb_hash_table_del(ctx->ignored_file_sizes, path);
+}
+
+ssize_t flb_tail_scan_fetch_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length)
+{
+    ssize_t result;
+
+    result = (ssize_t) flb_hash_table_get_ptr(ctx->ignored_file_sizes, path, path_length);
+
+    if (result == 0) {
+        result = -1;
+    }
+
+    return result;
+}
+
 int flb_tail_scan(struct mk_list *path_list, struct flb_tail_config *ctx)
 {
     int ret;

--- a/plugins/in_tail/tail_scan.h
+++ b/plugins/in_tail/tail_scan.h
@@ -26,4 +26,8 @@ int flb_tail_scan(struct mk_list *path, struct flb_tail_config *ctx);
 int flb_tail_scan_callback(struct flb_input_instance *ins,
                            struct flb_config *config, void *context);
 
+void flb_tail_scan_register_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length, size_t size);
+void flb_tail_scan_unregister_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length);
+ssize_t flb_tail_scan_fetch_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length);
+
 #endif

--- a/plugins/in_tail/tail_scan_win32.c
+++ b/plugins/in_tail/tail_scan_win32.c
@@ -65,6 +65,9 @@ static int tail_register_file(const char *target, struct flb_tail_config *ctx,
     int64_t mtime;
     struct stat st;
     char path[MAX_PATH];
+    ssize_t ignored_file_size;
+
+    ignored_file_size = -1;
 
     if (_fullpath(path, target, MAX_PATH) == NULL) {
         flb_plg_error(ctx->ins, "cannot get absolute path of %s", target);
@@ -81,6 +84,13 @@ static int tail_register_file(const char *target, struct flb_tail_config *ctx,
             if ((ts - ctx->ignore_older) > mtime) {
                 flb_plg_debug(ctx->ins, "excluded=%s (ignore_older)",
                               target);
+
+                flb_tail_scan_register_ignored_file_size(
+                    ctx,
+                    path,
+                    strlen(path),
+                    st.st_size);
+
                 return -1;
             }
         }
@@ -91,7 +101,19 @@ static int tail_register_file(const char *target, struct flb_tail_config *ctx,
         return -1;
     }
 
-    return flb_tail_file_append(path, &st, FLB_TAIL_STATIC, ctx);
+    if (ctx->ignore_older > 0) {
+        ignored_file_size = flb_tail_scan_fetch_ignored_file_size(
+                                ctx,
+                                path,
+                                strlen(path));
+
+        flb_tail_scan_unregister_ignored_file_size(
+            ctx,
+            path,
+            strlen(path));
+    }
+
+    return flb_tail_file_append(path, &st, FLB_TAIL_STATIC, ignored_file_size, ctx);
 }
 
 /*


### PR DESCRIPTION
Additionally, when a file is ignored due to ignore_older its size is stored to ensure that if the file is modified we are able to ingest the data that triggered the timestamp update.


(cherry picked from commit 7d0c4c3ecda5a7682ccda9e40982d3ff92106ae8)

<!-- Provide summary of changes -->
We want to backport #9490 (New in_tail's property: read_newly_discovered_files_from_head)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
- https://github.com/fluent/fluent-bit/issues/9490
   - https://github.com/fluent/fluent-bit/pull/10227
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change

To test that new property 'read_newly_discovered_files_from_head=false' works

Set read_newly_discovered_files_from_head=false to your tail plugin.
```
fluent-bit -i tail -p path="./app*.log" -p path_key=log_path -p Refresh_Interval=3 -p ignore_older=15m -p read_newly_discovered_files_from_head=false -p db=./db.file  -p log_level=debug  -o stdout -l fb.log -v
```
Simulate that files app*.log are updated, timestamp is changed one day back, new file is created as a copy of other, Fluent Bit is stopped, but harvested file is still being updated, after that only records from last known position are read. So far I can confirm that tail plugin configured as above never read the file from head!!
There are some commands, you can use to simulate harvested files changes.

```
#Update the file when FB is running or is down temporarily
cat <<E >>app1.log
[26-Apr-2025 14:57:04] [FluentBit works 11]
E

cp app1.log app8.log

touch -d '-10 hour' app.log
(mac) gtouch -d '-10 hour' app.log

```




<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->


- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
