### PR TITLE
tests: internal: fuzzers: add cfl_record_accessor harness

### DIFF
--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UNIT_TESTS_FILES
   aws_credentials_fuzzer.c
   base64_fuzzer.c
   engine_fuzzer.c
+  cfl_record_accessor_fuzzer.c
   cmetrics_decode_fuzz.c
   cmetrics_decode_prometheus.c
   config_fuzzer.c

--- a/tests/internal/fuzzers/cfl_record_accessor_fuzzer.c
+++ b/tests/internal/fuzzers/cfl_record_accessor_fuzzer.c
@@ -1,0 +1,73 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2025 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_mem.h>
+#include "flb_fuzz_header.h"
+#include <fluent-bit/flb_cfl_record_accessor.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    struct flb_cfl_record_accessor *updated_cra = NULL;
+    struct cfl_kvlist *kvlist = NULL;
+    struct cfl_variant *vobj = NULL;
+    char *null_terminated = NULL;
+
+    /* Limit size to 32KB */
+    if (size > 32768 || size < 104) {
+        return 0;
+    }
+
+    /* Set flb_malloc_mod to be fuzzer-data dependent */
+    flb_malloc_p = 0;
+    flb_malloc_mod = *(int*)data;
+    data += 4;
+    size -= 4;
+
+    /* Avoid division by zero for modulo operations */
+    if (flb_malloc_mod == 0) {
+        flb_malloc_mod = 1;
+    }
+
+    null_terminated = get_null_terminated(100, &data, &size);
+    if (null_terminated == NULL) {
+        return 0;
+    }
+
+    kvlist = cfl_kvlist_create();
+    if (kvlist == NULL) {
+        flb_free(null_terminated);
+        return 0;
+    }
+    
+    cfl_kvlist_insert_bool(kvlist, "k2", CFL_TRUE);
+    vobj = cfl_variant_create_from_kvlist(kvlist);
+    if (vobj != NULL) {
+        updated_cra = flb_cfl_ra_create(null_terminated, FLB_TRUE);
+    }
+
+    if (updated_cra != NULL) {
+        flb_cfl_ra_destroy(updated_cra);
+    }
+    if (null_terminated != NULL) {
+        flb_free(null_terminated);
+    }
+    if (vobj != NULL) {
+        cfl_variant_destroy(vobj);
+    }
+    return 0;
+}


### PR DESCRIPTION
This isn't currently covered. This gives a start for fuzzing this code.

Code coverage ref:
https://storage.googleapis.com/oss-fuzz-coverage/fluent-bit/reports/20250428/linux/src/fluent-bit/src/flb_cfl_record_accessor.c.html

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
