### PR TITLE
build: only compile simdutf if there is CXX support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,19 @@ include(cmake/platform_feature_checks.cmake)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 
+# Check for CXX support
+include(CheckLanguage)
+check_language(CXX)
+
+# Enable CXX features if CXX is available
+if(CMAKE_CXX_COMPILER)
+  message(STATUS "CXX compiler found, enable simdutf.")
+  set(FLB_USE_SIMDUTF Yes)
+else()
+  message(STATUS "CXX compiler not found, disable simdutf.")
+  set(FLB_USE_SIMDUTF No)
+endif()
+
 # Output paths
 set(FLB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
@@ -139,7 +152,7 @@ option(FLB_COVERAGE            "Build with code-coverage"      No)
 option(FLB_JEMALLOC            "Build with Jemalloc support"   No)
 option(FLB_REGEX               "Build with Regex support"     Yes)
 option(FLB_UTF8_ENCODER        "Build with UTF8 encoding support" Yes)
-option(FLB_UNICODE_ENCODER     "Build with Unicode (UTF-16LE, UTF-16BE) encoding support" Yes)
+option(FLB_UNICODE_ENCODER     "Build with Unicode (UTF-16LE, UTF-16BE) encoding support" ${FLB_USE_SIMDUTF})
 option(FLB_PARSER              "Build with Parser support"    Yes)
 option(FLB_TLS                 "Build with SSL/TLS support"   Yes)
 option(FLB_BINARY              "Build executable binary"      Yes)


### PR DESCRIPTION
Commit 3b04755e99fa500e98dcd1318f9b12f6863d31e4
"build: lib: Bundle simdutf amalgamation v5.5.0",
added support for simdutf, and enforces CXX support if FLB_UNICODE_ENCODER is selected. Which is the default case, fix that now.

As requested by https://github.com/fluent/fluent-bit/pull/9277#discussion_r2068161694.