### PR TITLE
[WIP] New option for Tail input "truncate_min_threshold"

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -626,6 +626,12 @@ static struct flb_config_map config_map[] = {
      "rotated in case some pending data is flushed."
     },
     {
+     FLB_CONFIG_MAP_SIZE, "truncate_min_threshold", "0",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, truncate_min_threshold),
+     "minimum number of bytes that must be removed from a file to consider it truncated. "
+     "If set to 0, any size reduction will be considered a truncation."
+    },
+    {
      FLB_CONFIG_MAP_BOOL, "docker_mode", "false",
      0, FLB_TRUE, offsetof(struct flb_tail_config, docker_mode),
      "If enabled, the plugin will recombine split Docker log lines before "

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -97,6 +97,7 @@ struct flb_tail_config {
     int   skip_long_lines;     /* skip long lines              */
     int   skip_empty_lines;    /* skip empty lines (off)       */
     int   exit_on_eof;         /* exit fluent-bit on EOF, test */
+    size_t truncate_min_threshold; /* minimum size to detect truncation */
 #ifdef __linux__
     int   file_cache_advise;   /* Use posix_fadvise for file access */
 #endif

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1024,7 +1024,6 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     /* Initialize */
     file->watch_fd  = -1;
     file->fd        = fd;
-    file->last_mtime = st->st_mtime;  /* Initialize last_mtime with current mtime */
 
     /* On non-windows environments check if the original path is a link */
     ret = lstat(path, &lst);
@@ -1399,15 +1398,8 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
         return FLB_TAIL_ERROR;
     }
 
-    /* If file hasn't changed, just return OK */
-    if (st.st_mtime == file->last_mtime) {
-        flb_plg_trace(ctx->ins, "inode=%"PRIu64" file unchanged %s",
-                      file->inode, file->name);
-        return FLB_TAIL_OK;
-    }
-
     /* Check if the file was truncated */
-    if (file->offset > st.st_size) {
+    if (st.st_size < file->offset && (file->offset - st.st_size) >= ctx->truncate_min_threshold) {
         offset = lseek(file->fd, 0, SEEK_SET);
         if (offset == -1) {
             flb_errno();
@@ -1431,7 +1423,6 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
         file->pending_bytes = (st.st_size - file->offset);
     }
 
-    file->last_mtime = st.st_mtime;
     return FLB_TAIL_OK;
 }
 

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -54,6 +54,7 @@ struct flb_tail_file {
     size_t name_len;
     size_t orig_name_len;
     time_t rotated;
+    time_t last_mtime;          /* Last modification time of the file */
     int64_t pending_bytes;
     size_t stream_offset;       /* this represents the logical data offset
                                    which for compressed files could be higher

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -54,7 +54,6 @@ struct flb_tail_file {
     size_t name_len;
     size_t orig_name_len;
     time_t rotated;
-    time_t last_mtime;          /* Last modification time of the file */
     int64_t pending_bytes;
     size_t stream_offset;       /* this represents the logical data offset
                                    which for compressed files could be higher


### PR DESCRIPTION
<!-- Provide summary of changes -->

Add a new option for Tail input "truncate_min_threshold" to adjust the detection algorithm for file truncation to deal with filesystems that have cached metadata and can temporarly report stale file sizes.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #10276
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
