### PR TITLE
input: add missing options to input_global_properties.

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -108,6 +108,21 @@ struct flb_config_map input_global_properties[] = {
         "pause until the buffer is drained. The value is in bytes. If set to 0, the buffer limit is disabled."\
         "Note that if the plugin has enabled filesystem buffering, this limit will not apply."
     },
+    {
+        FLB_CONFIG_MAP_STR, "storage.type", "memory",
+        0, FLB_FALSE, 0,
+        "Sets the storage type for this input, one of: filesystem, memory or memrb."
+    },
+    {
+        FLB_CONFIG_MAP_BOOL, "storage.pause_on_chunks_overlimit", "false",
+        0, FLB_FALSE, 0,
+        "Enable pausing on an input when they reach their chunks limit"
+    },
+    {
+        FLB_CONFIG_MAP_BOOL, "threaded", "false",
+        0, FLB_FALSE, 0,
+        "Enable threading on an input"
+    },
 
     {0}
 };


### PR DESCRIPTION
# Summary

Add options that were missing to `input_global_properties`.

# Description

add the following missing properties to `input_global_properties`:

- storage.type
- storage.pause_on_chunks_overlimit
- threaded

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
