### PR TITLE
api: proxy: custom: Implement APIs for custom Go plugins

### DIFF
--- a/include/fluent-bit/flb_api.h
+++ b/include/fluent-bit/flb_api.h
@@ -22,6 +22,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_custom.h>
 
 struct flb_api {
     const char *(*output_get_property) (const char *, struct flb_output_instance *);
@@ -33,6 +34,11 @@ struct flb_api {
     void (*log_print) (int, const char*, int, const char*, ...);
     int (*input_log_check) (struct flb_input_instance *, int);
     int (*output_log_check) (struct flb_output_instance *, int);
+
+    /* To preserve ABI, we need to add these APIs after the
+     * input/output definitions. */
+    const char *(*custom_get_property) (const char *, struct flb_custom_instance *);
+    int (*custom_log_check) (struct flb_custom_instance *, int);
 };
 
 #ifdef FLB_CORE

--- a/include/fluent-bit/flb_custom.h
+++ b/include/fluent-bit/flb_custom.h
@@ -31,9 +31,20 @@
 #define FLB_CUSTOM_NET_CLIENT   1   /* custom may use upstream net.* properties  */
 #define FLB_CUSTOM_NET_SERVER   2   /* custom may use downstream net.* properties  */
 
+/* Custom plugin types */
+#define FLB_CUSTOM_PLUGIN_CORE   0
+#define FLB_CUSTOM_PLUGIN_PROXY  1
+
 struct flb_custom_instance;
 
 struct flb_custom_plugin {
+    /*
+     * The type defines if this is a core-based plugin or it's handled by
+     * some specific proxy.
+     */
+    int type;
+    void *proxy;
+
     int flags;             /* Flags (not available at the moment */
     char *name;            /* Custom plugin short name           */
     char *description;     /* Description                        */
@@ -48,6 +59,9 @@ struct flb_custom_plugin {
                    struct flb_custom_instance *,
                    void *, struct flb_config *);
     int (*cb_exit) (void *, struct flb_config *);
+
+    /* Destroy */
+    void (*cb_destroy) (struct flb_custom_plugin *);
 
     struct mk_list _head;  /* Link to parent list (config->custom) */
 };
@@ -96,5 +110,6 @@ int flb_custom_plugin_property_check(struct flb_custom_instance *ins,
 int flb_custom_init_all(struct flb_config *config);
 void flb_custom_set_context(struct flb_custom_instance *ins, void *context);
 void flb_custom_instance_destroy(struct flb_custom_instance *ins);
+int flb_custom_log_check(struct flb_custom_instance *ins, int l);
 
 #endif

--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -28,6 +28,7 @@
 /* Plugin Types */
 #define FLB_PROXY_INPUT_PLUGIN     1
 #define FLB_PROXY_OUTPUT_PLUGIN    2
+#define FLB_PROXY_CUSTOM_PLUGIN    3
 
 /* Proxies available */
 #define FLB_PROXY_GOLANG          11

--- a/include/fluent-bit/flb_plugins.h.in
+++ b/include/fluent-bit/flb_plugins.h.in
@@ -64,6 +64,9 @@ void flb_plugins_unregister(struct flb_config *config)
 
     mk_list_foreach_safe(head, tmp, &config->custom_plugins) {
         custom = mk_list_entry(head, struct flb_custom_plugin, _head);
+        if(custom->cb_destroy) {
+            custom->cb_destroy(custom);
+        }
         mk_list_del(&custom->_head);
         flb_free(custom);
     }

--- a/src/flb_api.c
+++ b/src/flb_api.c
@@ -24,6 +24,7 @@
 
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_custom.h>
 
 struct flb_api *flb_api_create()
 {
@@ -37,6 +38,7 @@ struct flb_api *flb_api_create()
 
     api->output_get_property = flb_output_get_property;
     api->input_get_property = flb_input_get_property;
+    api->custom_get_property = flb_custom_get_property;
 
 #ifdef FLB_HAVE_METRICS
     api->output_get_cmt_instance = flb_output_get_cmt_instance;
@@ -46,6 +48,7 @@ struct flb_api *flb_api_create()
     api->log_print = flb_log_print;
     api->input_log_check = flb_input_log_check;
     api->output_log_check = flb_output_log_check;
+    api->custom_log_check = flb_custom_log_check;
 
     return api;
 }

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -21,6 +21,7 @@
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_plugin_proxy.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_custom.h>
 #include "./go.h"
 
 /*
@@ -41,7 +42,7 @@
  *
  *      - name: shortname of the plugin.
  *      - description: plugin description.
- *      - type: input, output, filter, whatever.
+ *      - type: input, output, filter, custom, whatever.
  *      - proxy: type of proxy e.g. GOLANG
  *      - flags: optional flags, not used by Go plugins at the moment.
  *
@@ -285,3 +286,87 @@ void proxy_go_input_unregister(void *data) {
     flb_free(plugin->name);
     flb_free(plugin);
 }
+
+int proxy_go_custom_register(struct flb_plugin_proxy *proxy,
+                            struct flb_plugin_proxy_def *def)
+{
+    struct flbgo_custom_plugin *plugin;
+
+    plugin = flb_malloc(sizeof(struct flbgo_custom_plugin));
+    if (!plugin) {
+        flb_errno();
+        return -1;
+    }
+
+    /*
+     * Lookup the entry point function:
+     *
+     * - FLBPluginInit
+     * - FLBPluginExit
+     *
+     * note: registration callback FLBPluginRegister() is resolved by the
+     * parent proxy interface.
+     */
+
+    plugin->cb_init  = flb_plugin_proxy_symbol(proxy, "FLBPluginInit");
+    if (!plugin->cb_init) {
+        flb_error("[go proxy]: could not load FLBPluginInit symbol");
+        flb_free(plugin);
+        return -1;
+    }
+
+    plugin->cb_exit  = flb_plugin_proxy_symbol(proxy, "FLBPluginExit");
+
+    plugin->name = flb_strdup(def->name);
+
+    /* This Go plugin context is an opaque data for the parent proxy */
+    proxy->data = plugin;
+
+    return 0;
+}
+
+int proxy_go_custom_init(struct flb_plugin_proxy *proxy)
+{
+    int ret = 0;
+    struct flbgo_custom_plugin *plugin = proxy->data;
+
+    /* set the API */
+    plugin->api   = proxy->api;
+    plugin->i_ins = proxy->instance;
+    /* In order to avoid having the whole instance as part of the ABI we */
+    /* copy the context pointer into the plugin. */
+    plugin->context = ((struct flb_custom_instance *)proxy->instance)->context;
+
+    ret = plugin->cb_init(plugin);
+    if (ret <= 0) {
+        flb_error("[go proxy]: plugin '%s' failed to initialize",
+                  plugin->name);
+        flb_free(plugin);
+        return -1;
+    }
+
+    return ret;
+}
+
+int proxy_go_custom_destroy(struct flb_plugin_proxy_context *ctx)
+{
+    int ret = 0;
+    struct flbgo_custom_plugin *plugin;
+
+    plugin = (struct flbgo_custom_plugin *) ctx->proxy->data;
+
+    if (plugin->cb_exit) {
+        ret = plugin->cb_exit();
+    }
+
+    return ret;
+}
+
+void proxy_go_custom_unregister(void *data) {
+    struct flbgo_custom_plugin *plugin;
+
+    plugin = (struct flbgo_custom_plugin *) data;
+    flb_free(plugin->name);
+    flb_free(plugin);
+}
+

--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -48,6 +48,16 @@ struct flbgo_input_plugin {
     int (*cb_exit)();
 };
 
+struct flbgo_custom_plugin {
+    char *name;
+    void *api;
+    void *i_ins;
+    struct flb_plugin_proxy_context *context;
+
+    int (*cb_init)();
+    int (*cb_exit)();
+};
+
 int proxy_go_output_register(struct flb_plugin_proxy *proxy,
                              struct flb_plugin_proxy_def *def);
 
@@ -69,4 +79,12 @@ int proxy_go_input_cleanup(struct flb_plugin_proxy *ctx,
                            void *allocated_data);
 int proxy_go_input_destroy(struct flb_plugin_input_proxy_context *ctx);
 void proxy_go_input_unregister(void *data);
+
+int proxy_go_custom_register(struct flb_plugin_proxy *proxy,
+                             struct flb_plugin_proxy_def *def);
+
+int proxy_go_custom_init(struct flb_plugin_proxy *proxy);
+
+int proxy_go_custom_destroy(struct flb_plugin_proxy_context *ctx);
+void proxy_go_custom_unregister(void *data);
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

For some motivations to support custom plugin mechanism in Fluent Bit, we need to implement custom plugins which are built on top of Golang infrastructures.
This PR makes to be able to provide and support Golang custom plugins.
This PR is based on https://github.com/fluent/fluent-bit/pull/9470 but adding modifications with working on calyptia-plugin module which is maintained here:

https://github.com/chronosphereio/calyptia-plugin/pull/101

Plus, we need to implement custom plugin mechanism calyptia-plugin modue.
So, I also implemented custom Golang mechanism in https://github.com/chronosphereio/calyptia-plugin/pull/101.

Note that we might have to maintain ABI for plugin API like logging and obtaining cmetrics instances.
I just adding APIs for custom plugins afterwards of input or output API definitions.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
