### PR TITLE
out_opentelemetry: add option to preserve fields in log body

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -898,6 +898,12 @@ static struct flb_config_map config_map[] = {
      "If logs_body_key is set and it matched a pattern, this option will include the "
      "remaining fields in the record as attributes."
     },
+    
+    {
+     FLB_CONFIG_MAP_BOOL, "logs_body_preserve", "false",
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_body_preserve),
+     "Preserve fields in record when they're used in the log body, rather than removing them."
+    },
 
     {
      FLB_CONFIG_MAP_STR, "traces_uri", "/v1/traces",

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -141,6 +141,9 @@ struct opentelemetry_context {
     /* boolean that defines if remaining keys of logs_body_key are set as attributes */
     int logs_body_key_attributes;
 
+    /* Option to preserve fields in record when they're used in the log body */
+    int logs_body_preserve;
+
     /* internal labels ready to append */
     struct mk_list kv_labels;
 

--- a/plugins/out_opentelemetry/opentelemetry_logs.c
+++ b/plugins/out_opentelemetry/opentelemetry_logs.c
@@ -172,7 +172,12 @@ static inline int log_record_set_body(struct opentelemetry_context *ctx,
 
         ret = flb_ra_get_kv_pair(bk->ra, *event->body, &s_key, &o_key, &o_val);
         if (ret == 0) {
-            log_object = msgpack_object_to_otlp_any_value(o_val);
+            /* If we're preserving fields, use the whole record for OTLP body */
+            if (ctx->logs_body_preserve == FLB_TRUE) {
+                log_object = msgpack_object_to_otlp_any_value(event->body);
+            } else {
+                log_object = msgpack_object_to_otlp_any_value(o_val);
+            }
 
             /* Link the record accessor pattern that matched */
             *out_ra_match = bk->ra;
@@ -228,7 +233,7 @@ static int log_record_set_attributes(struct opentelemetry_context *ctx,
      * buffer. If there are matches, meaning that a new output buffer was created, ret will
      * be FLB_TRUE, if no matches exists it returns FLB_FALSE.
      */
-    if (ctx->logs_body_key_attributes == FLB_TRUE && ctx->mp_accessor && ra_match) {
+    if (ctx->logs_body_key_attributes == FLB_TRUE && ctx->mp_accessor && ra_match && ctx->logs_body_preserve == FLB_FALSE) {
         /*
          * if ra_match is not NULL, it means that the log body was populated with a key from the record
          * and the variable holds a reference to the record accessor that matched the key.
@@ -287,16 +292,27 @@ static int log_record_set_attributes(struct opentelemetry_context *ctx,
         attr_count++;
     }
 
-    /* remaining fields that were not added to log body */
-    if (ctx->logs_body_key_attributes == FLB_TRUE && unpacked) {
-        /* iterate the map and reference each elemento as an OTLP value */
-        for (i = 0; i < result.data.via.map.size; i++) {
-            kv = &result.data.via.map.ptr[i];
-            buf[attr_count] = msgpack_kv_to_otlp_any_value(kv);
-            attr_count++;
+    /* Handle remaining fields based on configuration */
+    if (ctx->logs_body_key_attributes == FLB_TRUE) {
+        if (unpacked) {
+            /* iterate the map and reference each element as an OTLP value */
+            for (i = 0; i < result.data.via.map.size; i++) {
+                kv = &result.data.via.map.ptr[i];
+                buf[attr_count] = msgpack_kv_to_otlp_any_value(kv);
+                attr_count++;
+            }
+            msgpack_unpacked_destroy(&result);
+            flb_free(out_buf);
         }
-        msgpack_unpacked_destroy(&result);
-        flb_free(out_buf);
+        else if (!unpacked && ctx->logs_body_preserve == FLB_TRUE) {
+            /* When logs_body_preserve is true, still add fields to attributes
+             * if logs_body_key_attributes is enabled */
+            for (i = 0; i < event->body->via.map.size; i++) {
+                kv = &event->body->via.map.ptr[i];
+                buf[attr_count] = msgpack_kv_to_otlp_any_value(kv);
+                attr_count++;
+            }
+        }
     }
 
     log_record->attributes = buf;


### PR DESCRIPTION
## Summary

- Add new configuration option `logs_body_preserve` that allows record fields to be retained in the log body when they're used/processed by the OpenTelemetry output plugin

##  Details

1. The OpenTelemetry Protocol (OTLP) format separates data into two main parts:
   - A log record body (typically containing the main message)
   - Attributes (key-value pairs for metadata and other fields)

2. The OpenTelemetry output plugin converts Fluent Bit records to this format by:
   - Setting the log body based on logs_body_key settings
   - Moving remaining fields to attributes when logs_body_key_attributes: true is enabled

3. The key issue is in log_record_set_attributes function (line ~231):
   ```c
   if (ctx->logs_body_key_attributes == FLB_TRUE && ctx->mp_accessor && ra_match) {
       /* Code that removes fields from the record */
       ret = flb_mp_accessor_keys_remove(ctx->mp_accessor, event->body, &out_buf, &out_size);
       /* ... */
   }
   ```

4. When the processor_calyptia adds the field "hello: world", this happens:
   - The field is added to the record
   - When processed by the OpenTelemetry output, this field is:
       - Not matched by any logs_body_key pattern
       - So it gets moved to the attributes section completely
       - The field is removed from the record body

5. In contrast, the stdout output just prints whatever it receives, so you see all fields preserved.

6. The logs_body_preserve option now strictly does what its name suggests - it preserves record fields in the log body without forcing them to be added as attributes.

7. Fields are only added to attributes if:
   - logs_body_key_attributes=true is set
   - AND either:
       - Fields were removed from the record (unpacked is true), OR
       - Fields were preserved (logs_body_preserve=true) and we're still adding them to attributes

With this change:
- If you set only logs_body_preserve=true, fields will remain in the record but won't be added to attributes
- If you set both logs_body_key_attributes=true and logs_body_preserve=true, fields will remain in the record AND be added to attributes

## Configuration Example
```yaml
# Sender configuration with logs_body_preserve enabled
pipeline:
  inputs:
    - name: dummy
      tag: dummy.log
      dummy:
        rate: 1
        samples: |
          {"message":"dummy"}
      processors:
        logs:
          - name: calyptia
            actions:
              - type: put
                opts:
                  key: hello
                  value: world
  outputs:
    - name: stdout
      match: "*"

    - name: opentelemetry
      match: "*"
      host: receiver
      port: 4318
      logs_uri: /v1/logs
      logs_body_preserve: true
```

## Expected Output
When the OpenTelemetry output plugin sends logs to a receiver with `logs_body_preserve: true`, the log body should contain all fields from the original record:

```
[0] v1_logs: [[1744281011.1334685613, {"otlp"=>{"observed_timestamp"=>0, "timestamp"=>1744281011912789344, "trace_flags"=>0}}], {"message"=>"dummy", "hello"=>"world"}]
```

Without this option, the field used to populate the log body would be removed, resulting in only one of the fields being present in the output.