### PR TITLE
fix: Add libsasl2-modules-gssapi-mit to Dockerfile

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -132,6 +132,7 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     libpsl5 \
     libbrotli1 \
     libsasl2-2 \
+    libsasl2-modules-gssapi-mit \
     pkg-config \
     libpq5 \
     libsystemd0/bookworm-backports \
@@ -239,6 +240,8 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     libpsl5 \
     libbrotli1 \
     libsasl2-2 \
+    libsasl2-modules-gssapi-mit \
+    krb5-user \
     pkg-config \
     libpq5 \
     libsystemd0/bookworm-backports \


### PR DESCRIPTION
<!-- Provide summary of changes -->
This shared library is needed for users of the kafka plugin + kerberos+gssapi. 

Without they get the error 

```
sasl_[ssl://xxxxxxxxnet:6668/bootstrap](ssl://xxxxxxxxnet:6668/bootstrap): Cyrus/libsasl2 is missing a GSSAPI module: make sure the libsasl2-modules-gssapi-mit or cyrus-sasl-gssapi packages are installed
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes https://github.com/fluent/fluent-bit/issues/10240

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
