### PR TITLE
opentelemetry: fix handling of schemaUrl in resource and scope

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -277,13 +277,19 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         return NULL;
     }
 
+    ret = check_proxy(ins, ctx, host, port, protocol, logs_uri);
+    if (ret == -1) {
+        flb_opentelemetry_context_destroy(ctx);
+        return NULL;
+    }
+
     ret = check_proxy(ins, ctx, host, port, protocol, metrics_uri);
     if (ret == -1) {
         flb_opentelemetry_context_destroy(ctx);
         return NULL;
     }
 
-    ret = check_proxy(ins, ctx, host, port, protocol, logs_uri);
+    ret = check_proxy(ins, ctx, host, port, protocol, traces_uri);
     if (ret == -1) {
         flb_opentelemetry_context_destroy(ctx);
         return NULL;
@@ -496,7 +502,7 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         flb_plg_error(ins, "failed to create record accessor for resource attributes");
     }
 
-    ctx->ra_resource_schema_url = flb_ra_create("$schema_url", FLB_FALSE);
+    ctx->ra_resource_schema_url = flb_ra_create("$resource['schema_url']", FLB_FALSE);
     if (ctx->ra_resource_schema_url == NULL) {
         flb_plg_error(ins, "failed to create record accessor for resource schema url");
     }


### PR DESCRIPTION
the  `schemaURL` is now properly set in the group body when received in Opentelemetry input, for JSON and gRPC, here is an example of the packed content inside the group body:

> pretty printed in JSON for readability

```json    
    {
      "resource": {
        "attributes": {
          "service.name": "my.service"
        },
        "schema_url": "https://example.com/schema2"
      },
      "scope": {
        "schema_url": "https://example.com/schema1",
        "name": "my.library",
        "version": "1.0.0",
        "attributes": {
          "my.scope.attribute": "some scope attribute"
        }
      }
    }
```

in addition, the OpenTelemetry output plugin has been fixed in the record accessor pattern to lookup for this value inside the scope map.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
