### PR TITLE
simd: Use __riscv_vsetvl_eXXm1 function to get the actual width of RVV instructions

### DIFF
--- a/include/fluent-bit/flb_simd.h
+++ b/include/fluent-bit/flb_simd.h
@@ -77,8 +77,27 @@ typedef uint32x4_t flb_vector32;
 typedef vuint8m1_t flb_vector8;
 typedef vuint32m1_t flb_vector32;
 
-#define RVV_VEC8_INST_LEN  (128 / 8)     /* 16 */
-#define RVV_VEC32_INST_LEN (128 / 8 / 4) /*  4 */
+static size_t vec8_vl_cached = 0;
+static size_t vec32_vl_cached = 0;
+
+static inline size_t flb_rvv_get_vec8_vl()
+{
+    if (vec8_vl_cached == 0) {
+        vec8_vl_cached = __riscv_vsetvl_e8m1(16);
+    }
+    return vec8_vl_cached;
+}
+
+static inline size_t flb_rvv_get_vec32_vl()
+{
+    if (vec32_vl_cached == 0) {
+        vec32_vl_cached = __riscv_vsetvl_e32m1(4);
+    }
+    return vec32_vl_cached;
+}
+
+#define RVV_VEC8_INST_LEN  flb_rvv_get_vec8_vl()  /* 16 */
+#define RVV_VEC32_INST_LEN flb_rvv_get_vec32_vl() /*  4 */
 
 #else
 /*


### PR DESCRIPTION
This is because RVV instructions are truely hardware dependent. So, we need to obtain the actual width with the specific instriction of RVV extentions.

We use 1 segment of 8 or 32 elements of RVV or other SIMD instructions.
So, in RVV, we need to obtain the actual size of VLEN on the RISC-V CPU.
This could be enabled with the following instructions:

* __riscv_vsetvl_e8m1
* __riscv_vsetvl_e32m1

Note that the current implementation is also good but it is only effective for VLEN = 128 environments.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
