### PR TITLE
output: allow metrics chunks with 0 records. Skip them before flushing

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -655,9 +655,10 @@ static FLB_INLINE void output_pre_cb_flush(void)
 
     co_switch(coro->caller);
 
-    /* Skip flush if type is FLB_EVENT_TYPE_LOGS and event chunk has zero records  */
+    /* Skip flush if type is FLB_EVENT_TYPE_LOGS or FLB_EVENT_TYPE_METRICS and event chunk has zero records  */
     if (persisted_params.event_chunk &&
-        persisted_params.event_chunk->type == FLB_EVENT_TYPE_LOGS &&
+            (persisted_params.event_chunk->type == FLB_EVENT_TYPE_LOGS ||
+             persisted_params.event_chunk->type == FLB_EVENT_TYPE_METRICS) &&
         persisted_params.event_chunk->total_events == 0) {
         flb_debug("[output] skipping flush for event chunk with zero records.");
         FLB_OUTPUT_RETURN(FLB_OK);


### PR DESCRIPTION
Addresses #10313

Skips the flush if the payload is empty.
Empty payload can be the result of filtering the data. See #10313 for details.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change. See #10313 
- [x] Debug log output from testing the change

Relevant message:

```text
[2025/05/29 11:49:52] [debug] [output] skipping flush for event chunk with zero records.
```

```text
fluent-bit -c drop.yml            
Fluent Bit v4.0.3
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/05/29 11:49:49] [ info] Configuration:
[2025/05/29 11:49:49] [ info]  flush time     | 1.000000 seconds
[2025/05/29 11:49:49] [ info]  grace          | 5 seconds
[2025/05/29 11:49:49] [ info]  daemon         | 0
[2025/05/29 11:49:49] [ info] ___________
[2025/05/29 11:49:49] [ info]  inputs:
[2025/05/29 11:49:49] [ info]      event_type
[2025/05/29 11:49:49] [ info] ___________
[2025/05/29 11:49:49] [ info]  filters:
[2025/05/29 11:49:49] [ info] ___________
[2025/05/29 11:49:49] [ info]  outputs:
[2025/05/29 11:49:49] [ info]      splunk.0
[2025/05/29 11:49:49] [ info] ___________
[2025/05/29 11:49:49] [ info]  collectors:
[2025/05/29 11:49:49] [ info] [fluent bit] version=4.0.3, commit=b491682b6d, pid=46548
[2025/05/29 11:49:49] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2025/05/29 11:49:49] [ info] [storage] ver=1.1.6, type=memory+filesystem, sync=normal, checksum=off, max_chunks_up=128
[2025/05/29 11:49:49] [ info] [storage] backlog input plugin: storage_backlog.1
[2025/05/29 11:49:49] [ info] [simd    ] disabled
[2025/05/29 11:49:49] [ info] [cmetrics] version=1.0.3
[2025/05/29 11:49:49] [ info] [ctraces ] version=0.6.6
[2025/05/29 11:49:49] [ info] [input:event_type:event_type.0] initializing
[2025/05/29 11:49:49] [ info] [input:event_type:event_type.0] storage_strategy='filesystem' (memory + filesystem)
[2025/05/29 11:49:49] [debug] [input:event_type:event_type.0] [thread init] initialization OK
[2025/05/29 11:49:49] [ info] [input:event_type:event_type.0] thread instance initialized
[2025/05/29 11:49:49] [debug] [event_type:event_type.0] created event channels: read=39 write=40
[2025/05/29 11:49:49] [ info] [input:storage_backlog:storage_backlog.1] initializing
[2025/05/29 11:49:49] [ info] [input:storage_backlog:storage_backlog.1] storage_strategy='memory' (memory only)
[2025/05/29 11:49:49] [debug] [storage_backlog:storage_backlog.1] created event channels: read=43 write=44
[2025/05/29 11:49:49] [ info] [input:storage_backlog:storage_backlog.1] queue memory limit: 95.4M
[2025/05/29 11:49:49] [debug] [splunk:splunk.0] created event channels: read=45 write=46
[2025/05/29 11:49:49] [ info] [output:splunk:splunk.0] worker #0 started
[2025/05/29 11:49:49] [debug] [processor:metrics_selector:metrics_selector.0] action type EXCLUDE
[2025/05/29 11:49:49] [debug] [router] match rule event_type.0:splunk.0
[2025/05/29 11:49:49] [debug] [router] match rule storage_backlog.1:splunk.0
[2025/05/29 11:49:49] [ info] [sp] stream processor started
[2025/05/29 11:49:49] [ info] [input:storage_backlog:storage_backlog.1] register event_type.0/46419-1748533759.95882000.flb
[2025/05/29 11:49:50] [ info] [input:storage_backlog:storage_backlog.1] queueing event_type.0:46419-1748533759.95882000.flb
[2025/05/29 11:49:51] [debug] [input:event_type:event_type.0] metrics, ret=0
[2025/05/29 11:49:51] [ info] [input:event_type:event_type.0] [OK] collector_time
[2025/05/29 11:49:51] [debug] [task] created task=0x600000968000 id=0 OK
[2025/05/29 11:49:51] [debug] [input coro] destroy coro_id=0
[2025/05/29 11:49:51] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #0
[2025/05/29 11:49:51] [debug] [output] skipping flush for event chunk with zero records.
[2025/05/29 11:49:51] [debug] [out flush] cb_destroy coro_id=0
[2025/05/29 11:49:51] [ info] [engine] flush backlog chunk '46419-1748533759.95882000.flb' succeeded: task_id=0, input=storage_backlog.1 > output=splunk.0 (out_id=0)
[2025/05/29 11:49:51] [debug] [task] destroy task=0x600000968000 (task_id=0)
[2025/05/29 11:49:52] [debug] [task] created task=0x60000096c000 id=0 OK
[2025/05/29 11:49:52] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #0
[2025/05/29 11:49:52] [debug] [output] skipping flush for event chunk with zero records.
[2025/05/29 11:49:52] [debug] [out flush] cb_destroy coro_id=1
[2025/05/29 11:49:52] [debug] [task] destroy task=0x60000096c000 (task_id=0)
[2025/05/29 11:49:53] [debug] [input:event_type:event_type.0] metrics, ret=0
[2025/05/29 11:49:53] [ info] [input:event_type:event_type.0] [OK] collector_time
[2025/05/29 11:49:53] [debug] [input coro] destroy coro_id=1
[2025/05/29 11:49:54] [debug] [task] created task=0x600000970000 id=0 OK
[2025/05/29 11:49:54] [debug] [output:splunk:splunk.0] task_id=0 assigned to thread #0
[2025/05/29 11:49:54] [debug] [output] skipping flush for event chunk with zero records.
[2025/05/29 11:49:54] [debug] [out flush] cb_destroy coro_id=2
[2025/05/29 11:49:54] [debug] [task] destroy task=0x600000970000 (task_id=0)

```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
