### PR TITLE
lib: miniz: only require a C compiler

### DIFF
--- a/lib/miniz/CMakeLists.txt
+++ b/lib/miniz/CMakeLists.txt
@@ -7,7 +7,7 @@ if(DEFINED PROJECT_NAME)
 endif()
 
 if(CMAKE_MINOR_VERSION LESS 12)
-  project(miniz)
+  project(miniz C)
   # see issue https://gitlab.kitware.com/cmake/cmake/merge_requests/1799
 else()
   project(miniz C)


### PR DESCRIPTION
Commit https://github.com/richgel999/miniz/commit/05ab4dc05c9d1e1f951f5849b659e2c7e291a620 "Add some catch2 tests" dropped that C flag, but should instead only have added a simple enable_language call for the tests only.

Upstream: https://github.com/richgel999/miniz/commit/383e551cccf41fc2ce1177712d6a37a85d936642
