### PR TITLE
lib: zstd: only require a C compiler

### DIFF
--- a/.github/workflows/pr-compile-check.yaml
+++ b/.github/workflows/pr-compile-check.yaml
@@ -138,7 +138,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y bison cmake flex gcc libssl-dev libyaml-dev
-          sudo apt-get install -y libzstd-dev librdkafka-dev
+          sudo apt-get install -y librdkafka-dev
 
       - name: Install cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
@@ -152,6 +152,6 @@ jobs:
         run: |
           export CXX=/bin/false
           export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
-          cmake -DFLB_PREFER_SYSTEM_LIB_ZSTD=ON -DFLB_PREFER_SYSTEM_LIB_KAFKA=ON ../
+          cmake -DFLB_PREFER_SYSTEM_LIB_KAFKA=ON ../
           make -j $nparallel
         working-directory: build

--- a/lib/zstd-1.5.7/build/cmake/CMakeLists.txt
+++ b/lib/zstd-1.5.7/build/cmake/CMakeLists.txt
@@ -37,7 +37,6 @@ project(zstd
   VERSION "${ZSTD_FULL_VERSION}"
   LANGUAGES C   # Main library is in C
             ASM # And ASM
-            CXX # Testing contributed code also utilizes CXX
   )
 
 message(STATUS "ZSTD VERSION: ${zstd_VERSION}")
@@ -53,12 +52,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 include(GNUInstallDirs)
-
-#-----------------------------------------------------------------------------
-# Add extra compilation flags
-#-----------------------------------------------------------------------------
-include(AddZstdCompilationFlags)
-ADD_ZSTD_COMPILATION_FLAGS()
 
 # Always hide XXHash symbols
 add_definitions(-DXXH_NAMESPACE=ZSTD_)
@@ -122,6 +115,19 @@ option(ZSTD_BUILD_TESTS "BUILD TESTS" ${ZSTD_BUILD_TESTS_default})
 if (MSVC)
     option(ZSTD_USE_STATIC_RUNTIME "LINK TO STATIC RUN-TIME LIBRARIES" OFF)
 endif ()
+
+# Enable C++ support for testing.
+set(ZSTD_ENABLE_CXX ${ZSTD_BUILD_TESTS})
+
+if(ZSTD_ENABLE_CXX)
+    enable_language(CXX)
+endif()
+
+#-----------------------------------------------------------------------------
+# Add extra compilation flags
+#-----------------------------------------------------------------------------
+include(AddZstdCompilationFlags)
+ADD_ZSTD_COMPILATION_FLAGS(ON ZSTD_ENABLE_CXX ON) # C CXX LD
 
 #-----------------------------------------------------------------------------
 # External dependencies

--- a/lib/zstd-1.5.7/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+++ b/lib/zstd-1.5.7/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
@@ -49,7 +49,7 @@ function(EnableCompilerFlag _flag _C _CXX _LD)
     endif ()
 endfunction()
 
-macro(ADD_ZSTD_COMPILATION_FLAGS)
+macro(ADD_ZSTD_COMPILATION_FLAGS _C _CXX _LD)
     # We set ZSTD_HAS_NOEXECSTACK if we are certain we've set all the required
     # compiler flags to mark the stack as non-executable.
     set(ZSTD_HAS_NOEXECSTACK false)
@@ -63,26 +63,26 @@ macro(ADD_ZSTD_COMPILATION_FLAGS)
         # EnableCompilerFlag("-std=c99" true false)   # Set C compilation to c99 standard
         if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND MSVC)
             # clang-cl normally maps -Wall to -Weverything.
-            EnableCompilerFlag("/clang:-Wall" true true false)
+            EnableCompilerFlag("/clang:-Wall" _C _CXX false)
         else ()
-            EnableCompilerFlag("-Wall" true true false)
+            EnableCompilerFlag("-Wall" _C _CXX false)
         endif ()
-        EnableCompilerFlag("-Wextra" true true false)
-        EnableCompilerFlag("-Wundef" true true false)
-        EnableCompilerFlag("-Wshadow" true true false)
-        EnableCompilerFlag("-Wcast-align" true true false)
-        EnableCompilerFlag("-Wcast-qual" true true false)
-        EnableCompilerFlag("-Wstrict-prototypes" true false false)
+        EnableCompilerFlag("-Wextra" _C _CXX false)
+        EnableCompilerFlag("-Wundef" _C _CXX false)
+        EnableCompilerFlag("-Wshadow" _C _CXX false)
+        EnableCompilerFlag("-Wcast-align" _C _CXX false)
+        EnableCompilerFlag("-Wcast-qual" _C _CXX false)
+        EnableCompilerFlag("-Wstrict-prototypes" _C false false)
         # Enable asserts in Debug mode
         if (CMAKE_BUILD_TYPE MATCHES "Debug")
-            EnableCompilerFlag("-DDEBUGLEVEL=1" true true false)
+            EnableCompilerFlag("-DDEBUGLEVEL=1" _C _CXX false)
         endif ()
         # Add noexecstack flags
         # LDFLAGS
-        EnableCompilerFlag("-Wl,-z,noexecstack" false false true)
+        EnableCompilerFlag("-Wl,-z,noexecstack" false false _LD)
         # CFLAGS & CXXFLAGS
-        EnableCompilerFlag("-Qunused-arguments" true true false)
-        EnableCompilerFlag("-Wa,--noexecstack" true true false)
+        EnableCompilerFlag("-Qunused-arguments" _C _CXX false)
+        EnableCompilerFlag("-Wa,--noexecstack" _C _CXX false)
         # NOTE: Using 3 nested ifs because the variables are sometimes
         # empty if the condition is false, and sometimes equal to false.
         # This implicitly converts them to truthy values. There may be
@@ -99,15 +99,15 @@ macro(ADD_ZSTD_COMPILATION_FLAGS)
 
         set(ACTIVATE_MULTITHREADED_COMPILATION "ON" CACHE BOOL "activate multi-threaded compilation (/MP flag)")
         if (CMAKE_GENERATOR MATCHES "Visual Studio" AND ACTIVATE_MULTITHREADED_COMPILATION)
-            EnableCompilerFlag("/MP" true true false)
+            EnableCompilerFlag("/MP" _C _CXX false)
         endif ()
 
         # UNICODE SUPPORT
-        EnableCompilerFlag("/D_UNICODE" true true false)
-        EnableCompilerFlag("/DUNICODE" true true false)
+        EnableCompilerFlag("/D_UNICODE" _C _CXX false)
+        EnableCompilerFlag("/DUNICODE" _C _CXX false)
         # Enable asserts in Debug mode
         if (CMAKE_BUILD_TYPE MATCHES "Debug")
-            EnableCompilerFlag("/DDEBUGLEVEL=1" true true false)
+            EnableCompilerFlag("/DDEBUGLEVEL=1" _C _CXX false)
         endif ()
     endif ()
 


### PR DESCRIPTION
Upstream: https://github.com/facebook/zstd/commit/769723aee2540aaff8951ac432a1babed358aa71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI build setup by removing an unnecessary system package while retaining required native dependencies.
  * Kept external Kafka support configuration intact.

* **Refactor**
  * Improved build configuration so C++ support is enabled only when needed.
  * Made compiler and linker settings apply more selectively across build types.

* **Tests**
  * Updated build pathways to better isolate test-related components.

* **No user-facing functionality changed.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->