### PR TITLE
out_splunk: Change attaching priority for HEC token

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -962,14 +962,14 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
     if (ctx->http_user && ctx->http_passwd) {
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }
+    else if (ctx->auth_header) {
+        flb_http_add_header(c, "Authorization", 13,
+                            ctx->auth_header, flb_sds_len(ctx->auth_header));
+    }
     else if (metadata_auth_header) {
         flb_http_add_header(c, "Authorization", 13,
                             metadata_auth_header,
                             flb_sds_len(metadata_auth_header));
-    }
-    else if (ctx->auth_header) {
-        flb_http_add_header(c, "Authorization", 13,
-                            ctx->auth_header, flb_sds_len(ctx->auth_header));
     }
 
     /* Append Channel identifier header */


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes https://github.com/fluent/fluent-bit/issues/10208.

When we had implemented metadata retrieving feature, retrieved HEC token was prioritized for the specified HEC token on out_splunk.

This could be wrong assumptions. So, we need to organize the priorities.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

Posted on https://github.com/fluent/fluent-bit/issues/10208#issue-2989871674

- [x] Debug log output from testing the change

The final destination can receive logs:

```
Fluent Bit v4.0.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/05/13 19:03:03] [ info] Configuration:
[2025/05/13 19:03:03] [ info]  flush time     | 1.000000 seconds
[2025/05/13 19:03:03] [ info]  grace          | 5 seconds
[2025/05/13 19:03:03] [ info]  daemon         | 0
[2025/05/13 19:03:03] [ info] ___________
[2025/05/13 19:03:03] [ info]  inputs:
[2025/05/13 19:03:03] [ info]      splunk
[2025/05/13 19:03:03] [ info] ___________
[2025/05/13 19:03:03] [ info]  filters:
[2025/05/13 19:03:03] [ info] ___________
[2025/05/13 19:03:03] [ info]  outputs:
[2025/05/13 19:03:03] [ info]      stdout.0
[2025/05/13 19:03:03] [ info] ___________
[2025/05/13 19:03:03] [ info]  collectors:
[2025/05/13 19:03:03] [ info] [fluent bit] version=4.0.2, commit=4dc3fcd823, pid=259963
[2025/05/13 19:03:03] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/05/13 19:03:03] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/05/13 19:03:03] [ info] [simd    ] SSE2
[2025/05/13 19:03:03] [ info] [cmetrics] version=1.0.0
[2025/05/13 19:03:03] [ info] [ctraces ] version=0.6.5
[2025/05/13 19:03:03] [ info] [input:splunk:splunk_hec] initializing
[2025/05/13 19:03:03] [ info] [input:splunk:splunk_hec] storage_strategy='memory' (memory only)
[2025/05/13 19:03:03] [debug] [splunk:splunk_hec] created event channels: read=25 write=26
[2025/05/13 19:03:03] [debug] [downstream] listening on 0.0.0.0:9778
[2025/05/13 19:03:03] [debug] [stdout:stdout.0] created event channels: read=28 write=29
[2025/05/13 19:03:03] [ info] [sp] stream processor started
[2025/05/13 19:03:03] [ info] [output:stdout:stdout.0] worker #0 started
[2025/05/13 19:03:04] [debug] [task] created task=0x7ed72c023f20 id=0 OK
[2025/05/13 19:03:04] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[{"date":1747130583.738456,"time":1747130582.73701,"event":{"time":1747130581.73697,"event":{"message":"dummy"},"@splunk_token":"Splunk a_super_power_of_hec_token"}}]
[2025/05/13 19:03:04] [debug] [out flush] cb_destroy coro_id=0
[2025/05/13 19:03:04] [debug] [task] destroy task=0x7ed72c023f20 (task_id=0)
[2025/05/13 19:03:05] [debug] [task] created task=0x7ed72c024310 id=0 OK
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==260282== 
==260282== HEAP SUMMARY:
==260282==     in use at exit: 0 bytes in 0 blocks
==260282==   total heap usage: 3,620 allocs, 3,620 frees, 2,053,529 bytes allocated
==260282== 
==260282== All heap blocks were freed -- no leaks are possible
==260282== 
==260282== For lists of detected and suppressed errors, rerun with: -s
==260282== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
