### PR TITLE
in_opentelemetry: Configurable logs_body_key

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -251,6 +251,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "logs_metadata_key", "otlp",
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, logs_metadata_key),
     },
+    {
+     FLB_CONFIG_MAP_STR, "logs_body_key", NULL,
+     0, FLB_TRUE, offsetof(struct flb_opentelemetry, logs_body_key),
+     "Key to use for the logs body. If unset, body key-value pairs will be " \
+     "used as the log record, and other types will be nested under a key."
+    },
 
     /* EOF */
     {0}

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -38,6 +38,7 @@ struct flb_opentelemetry {
     int raw_traces;
     int  tag_from_uri;
     flb_sds_t logs_metadata_key;
+    flb_sds_t logs_body_key;
     int profile_support_enabled;
     int encode_profiles_as_log;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Currently, the logs body is added to the record in multiple ways
 * If it's a MAP, then the key-value pairs are added to the record at the top-level.
 * For other types, it's added under the key "message" for OTLP Proto and "log" for OTLP JSON.

Support a way to always nest the logs body under a specific key for consistency, and to avoid possible clashes with other top-level keys in the record (e.g., `__internal__`).

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
