### PR TITLE
packaging: add AlmaLinux and RockyLinux builds

### DIFF
--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -113,6 +113,14 @@
           "type": "deb"
         },
         {
+          "target": "raspbian/buster",
+          "type": "deb"
+        },
+        {
+          "target": "raspbian/bullseye",
+          "type": "deb"
+        },
+        {
           "target": "raspbian/bookworm",
           "type": "deb"
         }

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -113,14 +113,6 @@
           "type": "deb"
         },
         {
-          "target": "raspbian/buster",
-          "type": "deb"
-        },
-        {
-          "target": "raspbian/bullseye",
-          "type": "deb"
-        },
-        {
           "target": "raspbian/bookworm",
           "type": "deb"
         }

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -41,6 +41,22 @@
           "type": "rpm"
         },
         {
+          "target": "rockylinux/8",
+          "type": "rpm"
+        },
+        {
+          "target": "rockylinux/8.arm64v8",
+          "type": "rpm"
+        },
+        {
+          "target": "rockylinux/9",
+          "type": "rpm"
+        },
+        {
+          "target": "rockylinux/9.arm64v8",
+          "type": "rpm"
+        },
+        {
           "target": "debian/bookworm",
           "type": "deb"
         },

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -57,6 +57,22 @@
           "type": "rpm"
         },
         {
+          "target": "almalinux/8",
+          "type": "rpm"
+        },
+        {
+          "target": "almalinux/8.arm64v8",
+          "type": "rpm"
+        },
+        {
+          "target": "almalinux/9",
+          "type": "rpm"
+        },
+        {
+          "target": "almalinux/9.arm64v8",
+          "type": "rpm"
+        },
+        {
           "target": "debian/bookworm",
           "type": "deb"
         },

--- a/packaging/distros/almalinux/Dockerfile
+++ b/packaging/distros/almalinux/Dockerfile
@@ -13,7 +13,7 @@ FROM multiarch/qemu-user-static:x86_64-aarch64 as multiarch-aarch64
 FROM almalinux:8 as almalinux-8-base
 
 # Add for the YAML development libraries
-RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-powertools.repo
 
 # hadolint ignore=DL3033
 RUN yum -y update && \
@@ -30,7 +30,7 @@ FROM --platform=arm64 almalinux:8 as almalinux-8.arm64v8-base
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
 # Add for the YAML development libraries
-RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-powertools.repo
 
 # hadolint ignore=DL3033
 RUN yum -y update && \

--- a/packaging/distros/almalinux/Dockerfile
+++ b/packaging/distros/almalinux/Dockerfile
@@ -47,7 +47,7 @@ ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 FROM almalinux:9 as almalinux-9-base
 
 # Add for the YAML development libraries
-RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
 
 # hadolint ignore=DL3033
 RUN yum -y update && \
@@ -64,7 +64,7 @@ FROM --platform=arm64 almalinux:9 as almalinux-9.arm64v8-base
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
 # Add for the YAML development libraries
-RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
 
 # hadolint ignore=DL3033
 RUN yum -y update && \

--- a/packaging/distros/almalinux/Dockerfile
+++ b/packaging/distros/almalinux/Dockerfile
@@ -1,0 +1,125 @@
+# Special Dockerfile to build all targets, the only difference is
+# the packages in the base image.
+# Set this to the base image to use in each case, so if we want to build for almalinux/8
+# we would set BASE_BUILDER=almalinux-8-base.
+ARG BASE_BUILDER
+# Lookup the name to use below but should follow the '<distro>-base' convention with slashes replaced.
+# Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
+
+# Multiarch support
+FROM multiarch/qemu-user-static:x86_64-aarch64 as multiarch-aarch64
+
+# almalinux/8 base image
+FROM almalinux:8 as almalinux-8-base
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# almalinux/8.arm64v8 base image
+# hadolint ignore=DL3029
+FROM --platform=arm64 almalinux:8 as almalinux-8.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
+FROM almalinux:9 as almalinux-9-base
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# almalinux/8.arm64v8 base image
+# hadolint ignore=DL3029
+FROM --platform=arm64 almalinux:9 as almalinux-9.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
+# Common build for all distributions now
+# hadolint ignore=DL3006
+FROM $BASE_BUILDER as builder
+
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
+# Docker context must be the base of the repo
+WORKDIR /source/fluent-bit/
+COPY . ./
+
+WORKDIR /source/fluent-bit/build/
+# CMake configuration variables
+# Unused
+ARG CFLAGS
+ARG CMAKE_INSTALL_PREFIX=/opt/fluent-bit/
+ARG CMAKE_INSTALL_SYSCONFDIR=/etc/
+ARG FLB_RELEASE=On
+ARG FLB_TRACE=On
+ARG FLB_SQLDB=On
+ARG FLB_HTTP_SERVER=On
+ARG FLB_OUT_KAFKA=On
+ARG FLB_JEMALLOC=On
+ARG FLB_CHUNK_TRACE=On
+ARG FLB_UNICODE_ENCODER=On
+ARG FLB_KAFKA=On
+ARG FLB_OUT_PGSQL=On
+
+RUN cmake -DCMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" \
+    -DCMAKE_INSTALL_SYSCONFDIR="$CMAKE_INSTALL_SYSCONFDIR" \
+    -DFLB_RELEASE="$FLB_RELEASE" \
+    -DFLB_TRACE="$FLB_TRACE" \
+    -DFLB_SQLDB="$FLB_SQLDB" \
+    -DFLB_HTTP_SERVER="$FLB_HTTP_SERVER" \
+    -DFLB_KAFKA="$FLB_KAFKA" \
+    -DFLB_OUT_PGSQL="$FLB_OUT_PGSQL" \
+    -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+    -DFLB_JEMALLOC_OPTIONS="$FLB_JEMALLOC_OPTIONS" \
+    -DFLB_JEMALLOC="${FLB_JEMALLOC}" \
+    -DFLB_CHUNK_TRACE="${FLB_CHUNK_TRACE}" \
+    -DFLB_UNICODE_ENCODER="${FLB_UNICODE_ENCODER}" \
+    ../
+
+VOLUME [ "/output" ]
+CMD [ "/bin/bash", "-c", "make --no-print-directory -j 4 && cpack3 -G RPM && cp *.rpm /output/" ]

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -10,16 +10,26 @@ FROM balenalib/rpi-raspbian:buster AS raspbian-buster-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # Builder image so dependencies can be latest, recommended and no need to wipe
-# We pin cmake to a working version (latest 3.16 triggers cmake failures for GNU C compiler detection)
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
-    apt-get install -y cmake=3.13.4-1 cmake-data=3.13.4-1 \
-    curl ca-certificates build-essential \
+    apt-get install -y curl ca-certificates build-essential \
     make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
+
+# We need at least CMake 3.20 or higher to build the project - repos only support up to 3.16 which has a separate issue anyway
+ENV CMAKE_HOME="/opt/cmake"
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+RUN mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
 # raspbian/bullseye base image
 FROM balenalib/rpi-raspbian:bullseye AS raspbian-bullseye-base
@@ -28,11 +38,22 @@ ENV DEBIAN_FRONTEND noninteractive
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential \
-    cmake make bash sudo wget unzip dh-make \
+    make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
+
+ENV CMAKE_HOME="/opt/cmake"
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+RUN mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
 # raspbian/bookworm base image
 FROM balenalib/rpi-raspbian:bookworm AS raspbian-bookworm-base

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -6,36 +6,20 @@ ARG BASE_BUILDER
 # Lookup the name to use below but should follow the '<distro>-base' convention with slashes replaced.
 # Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
 
-# Multiarch support
-FROM multiarch/qemu-user-static:x86_64-aarch64 AS multiarch-aarch64
-
 FROM balenalib/rpi-raspbian:buster AS raspbian-buster-base
 ENV DEBIAN_FRONTEND noninteractive
 
 # Builder image so dependencies can be latest, recommended and no need to wipe
+# We pin cmake to a working version (latest 3.16 triggers cmake failures for GNU C compiler detection)
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
-    apt-get install -y curl ca-certificates build-essential \
+    apt-get install -y cmake=3.13.4-1 cmake-data=3.13.4-1 \
+    curl ca-certificates build-essential \
     make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
-
-# We need at least CMake 3.20 or higher to build the project - repos only support up to 3.16 which has a separate issue anyway
-ENV CMAKE_HOME="/opt/cmake"
-ARG CMAKE_VERSION="3.31.6"
-ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
-# There is no binary version to pull so build from source
-
-# hadolint ignore=DL4006
-RUN mkdir -p "${CMAKE_HOME}" && \
-    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz" && \
-    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1 && \
-    "${CMAKE_HOME}"/configure --prefix=/usr && \
-    make -C "${CMAKE_HOME}" -j 4 && \
-    make -C "${CMAKE_HOME}" install
 
 # raspbian/bullseye base image
 FROM balenalib/rpi-raspbian:bullseye AS raspbian-bullseye-base
@@ -44,24 +28,11 @@ ENV DEBIAN_FRONTEND noninteractive
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    cmake make bash sudo wget unzip dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
     apt-get install -y --reinstall lsb-base lsb-release
-
-ENV CMAKE_HOME="/opt/cmake"
-ARG CMAKE_VERSION="3.31.6"
-ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
-
-# hadolint ignore=DL4006
-RUN mkdir -p "${CMAKE_HOME}" && \
-    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz" && \
-    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1 && \
-    "${CMAKE_HOME}"/configure --prefix=/usr && \
-    make -C "${CMAKE_HOME}" -j 4 && \
-    make -C "${CMAKE_HOME}" install
 
 # raspbian/bookworm base image
 FROM balenalib/rpi-raspbian:bookworm AS raspbian-bookworm-base

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -6,6 +6,9 @@ ARG BASE_BUILDER
 # Lookup the name to use below but should follow the '<distro>-base' convention with slashes replaced.
 # Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
 
+# Multiarch support
+FROM multiarch/qemu-user-static:x86_64-aarch64 AS multiarch-aarch64
+
 FROM balenalib/rpi-raspbian:buster AS raspbian-buster-base
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -23,13 +26,16 @@ RUN apt-get update && \
 ENV CMAKE_HOME="/opt/cmake"
 ARG CMAKE_VERSION="3.31.6"
 ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+# There is no binary version to pull so build from source
 
+# hadolint ignore=DL4006
 RUN mkdir -p "${CMAKE_HOME}" && \
-    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
-
-ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1 && \
+    "${CMAKE_HOME}"/configure --prefix=/usr && \
+    make -C "${CMAKE_HOME}" -j 4 && \
+    make -C "${CMAKE_HOME}" install
 
 # raspbian/bullseye base image
 FROM balenalib/rpi-raspbian:bullseye AS raspbian-bullseye-base
@@ -48,12 +54,14 @@ ENV CMAKE_HOME="/opt/cmake"
 ARG CMAKE_VERSION="3.31.6"
 ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 
+# hadolint ignore=DL4006
 RUN mkdir -p "${CMAKE_HOME}" && \
-    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
-    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
-
-ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1 && \
+    "${CMAKE_HOME}"/configure --prefix=/usr && \
+    make -C "${CMAKE_HOME}" -j 4 && \
+    make -C "${CMAKE_HOME}" install
 
 # raspbian/bookworm base image
 FROM balenalib/rpi-raspbian:bookworm AS raspbian-bookworm-base

--- a/packaging/distros/rockylinux/Dockerfile
+++ b/packaging/distros/rockylinux/Dockerfile
@@ -1,0 +1,125 @@
+# Special Dockerfile to build all targets, the only difference is
+# the packages in the base image.
+# Set this to the base image to use in each case, so if we want to build for rockylinux/8
+# we would set BASE_BUILDER=rockylinux-8-base.
+ARG BASE_BUILDER
+# Lookup the name to use below but should follow the '<distro>-base' convention with slashes replaced.
+# Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
+
+# Multiarch support
+FROM multiarch/qemu-user-static:x86_64-aarch64 as multiarch-aarch64
+
+# rockylinux/8 base image
+FROM rockylinux:8 as rockylinux-8-base
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# rockylinux/8.arm64v8 base image
+# hadolint ignore=DL3029
+FROM --platform=arm64 rockylinux:8 as rockylinux-8.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
+FROM rockylinux:9 as rockylinux-9-base
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# rockylinux/8.arm64v8 base image
+# hadolint ignore=DL3029
+FROM --platform=arm64 rockylinux:9 as rockylinux-9.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel && \
+    yum clean all
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
+# Common build for all distributions now
+# hadolint ignore=DL3006
+FROM $BASE_BUILDER as builder
+
+ARG FLB_NIGHTLY_BUILD
+ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD
+
+# Docker context must be the base of the repo
+WORKDIR /source/fluent-bit/
+COPY . ./
+
+WORKDIR /source/fluent-bit/build/
+# CMake configuration variables
+# Unused
+ARG CFLAGS
+ARG CMAKE_INSTALL_PREFIX=/opt/fluent-bit/
+ARG CMAKE_INSTALL_SYSCONFDIR=/etc/
+ARG FLB_RELEASE=On
+ARG FLB_TRACE=On
+ARG FLB_SQLDB=On
+ARG FLB_HTTP_SERVER=On
+ARG FLB_OUT_KAFKA=On
+ARG FLB_JEMALLOC=On
+ARG FLB_CHUNK_TRACE=On
+ARG FLB_UNICODE_ENCODER=On
+ARG FLB_KAFKA=On
+ARG FLB_OUT_PGSQL=On
+
+RUN cmake -DCMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" \
+    -DCMAKE_INSTALL_SYSCONFDIR="$CMAKE_INSTALL_SYSCONFDIR" \
+    -DFLB_RELEASE="$FLB_RELEASE" \
+    -DFLB_TRACE="$FLB_TRACE" \
+    -DFLB_SQLDB="$FLB_SQLDB" \
+    -DFLB_HTTP_SERVER="$FLB_HTTP_SERVER" \
+    -DFLB_KAFKA="$FLB_KAFKA" \
+    -DFLB_OUT_PGSQL="$FLB_OUT_PGSQL" \
+    -DFLB_NIGHTLY_BUILD="$FLB_NIGHTLY_BUILD" \
+    -DFLB_JEMALLOC_OPTIONS="$FLB_JEMALLOC_OPTIONS" \
+    -DFLB_JEMALLOC="${FLB_JEMALLOC}" \
+    -DFLB_CHUNK_TRACE="${FLB_CHUNK_TRACE}" \
+    -DFLB_UNICODE_ENCODER="${FLB_UNICODE_ENCODER}" \
+    ../
+
+VOLUME [ "/output" ]
+CMD [ "/bin/bash", "-c", "make --no-print-directory -j 4 && cpack3 -G RPM && cp *.rpm /output/" ]

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -42,6 +42,8 @@ APT_TARGETS=("ubuntu:22.04"
     "debian:11")
 
 YUM_TARGETS=("centos:7"
+    "almalinux:8"
+    "almalinux:9"
     "rockylinux:8"
     "rockylinux:9"
     "quay.io/centos/centos:stream9"

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -43,6 +43,7 @@ APT_TARGETS=("ubuntu:22.04"
 
 YUM_TARGETS=("centos:7"
     "rockylinux:8"
+    "rockylinux:9"
     "quay.io/centos/centos:stream9"
     "amazonlinux:2"
     "amazonlinux:2023")

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -31,7 +31,7 @@ fi
 # AWS_S3_BUCKET_STAGING=fluentbit-staging
 export AWS_REGION=${AWS_REGION:-us-east-1}
 
-RPM_REPO_PATHS=("amazonlinux/2" "amazonlinux/2023" "centos/7" "centos/8" "centos/9")
+RPM_REPO_PATHS=("amazonlinux/2" "amazonlinux/2023" "centos/7" "centos/8" "centos/9" "rockylinux/8" "rockylinux/9" )
 
 if [[ "${AWS_SYNC:-false}" != "false" ]]; then
     aws s3 sync s3://"${AWS_S3_BUCKET_RELEASE:?}" "${BASE_PATH:?}"

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -31,7 +31,7 @@ fi
 # AWS_S3_BUCKET_STAGING=fluentbit-staging
 export AWS_REGION=${AWS_REGION:-us-east-1}
 
-RPM_REPO_PATHS=("amazonlinux/2" "amazonlinux/2023" "centos/7" "centos/8" "centos/9" "rockylinux/8" "rockylinux/9" )
+RPM_REPO_PATHS=("amazonlinux/2" "amazonlinux/2023" "centos/7" "centos/8" "centos/9" "rockylinux/8" "rockylinux/9" "almalinux/8" "almalinux/9" )
 
 if [[ "${AWS_SYNC:-false}" != "false" ]]; then
     aws s3 sync s3://"${AWS_S3_BUCKET_RELEASE:?}" "${BASE_PATH:?}"

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -52,6 +52,7 @@ DEB_REPO_PATHS=( "debian/bookworm"
                  "debian/buster"
                  "ubuntu/jammy"
                  "ubuntu/noble"
+                 "raspbian/bookworm"
                 )
 
 for DEB_REPO in "${DEB_REPO_PATHS[@]}"; do


### PR DESCRIPTION
Resolves #10333 by providing Alma Linux & Rocky Linux builds directly rather than relying on CentOS stream dependencies which are now deviating significantly.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
