### PR TITLE
build: ci: tune MSVC flags, modify ci caching

### DIFF
--- a/.github/workflows/call-build-windows.yaml
+++ b/.github/workflows/call-build-windows.yaml
@@ -82,19 +82,16 @@ jobs:
         config:
           - name: "Windows 32bit"
             arch: x86
-            openssl_dir: C:\vcpkg\packages\openssl_x86-windows-static
             cmake_additional_opt: ""
             vcpkg_triplet: x86-windows-static
             cmake_version: "3.31.6"
           - name: "Windows 64bit"
             arch: x64
-            openssl_dir: C:\vcpkg\packages\openssl_x64-windows-static
             cmake_additional_opt: ""
             vcpkg_triplet: x64-windows-static
             cmake_version: "3.31.6"
           - name: "Windows 64bit (Arm64)"
             arch: amd64_arm64
-            openssl_dir: C:\vcpkg\packages\openssl_arm64-windows-static
             cmake_additional_opt: "-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64"
             vcpkg_triplet: arm64-windows-static
             cmake_version: "3.31.6"
@@ -143,10 +140,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            C:\vcpkg\packages
-          key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-${{ steps.get-date.outputs.date }}
+            C:\vcpkg\installed
+          key: ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-installed-${{ steps.get-date.outputs.date }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-
+            ${{ runner.os }}-${{ matrix.config.arch }}-vcpkg-installed-
           enableCrossOsArchive: false
 
       - name: Build openssl with vcpkg
@@ -159,12 +156,17 @@ jobs:
           C:\vcpkg\vcpkg install --recurse libyaml --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
 
+      - name: Upgrade any outdated vcpkg packages
+        run: |
+          C:\vcpkg\vcpkg upgrade --no-dry-run
+        shell: cmd
+
       - name: Save packages of vcpkg
         id: save-vcpkg-sources
         uses: actions/cache/save@v4
         with:
           path: |
-            C:\vcpkg\packages
+            C:\vcpkg\installed
           key: ${{ steps.cache-vcpkg-sources.outputs.cache-primary-key }}
           enableCrossOsArchive: false
 
@@ -174,7 +176,7 @@ jobs:
         # This is only supposed to be a workaround for now so can be easily removed later.
         if: ${{ matrix.config.arch != 'amd64_arm64' || needs.call-build-windows-get-meta.outputs.armSupported == 'true' }}
         run: |
-          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD='${{ inputs.unstable }}' -DOPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' ${{ matrix.config.cmake_additional_opt }} -DFLB_LIBYAML_DIR=C:\vcpkg\packages\libyaml_${{ matrix.config.vcpkg_triplet }} ../
+          cmake -G "NMake Makefiles" -DFLB_NIGHTLY_BUILD='${{ inputs.unstable }}' -DOPENSSL_ROOT_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' ${{ matrix.config.cmake_additional_opt }} -DFLB_LIBYAML_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' ../
           cmake --build .
           cpack
         working-directory: build

--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -36,13 +36,11 @@ jobs:
         config:
           - name: "Windows 32bit"
             arch: x86
-            openssl_dir: C:\vcpkg\packages\openssl_x86-windows-static
             cmake_additional_opt: ""
             vcpkg_triplet: x86-windows-static
             cmake_version: "3.31.6"
           - name: "Windows 64bit"
             arch: x64
-            openssl_dir: C:\vcpkg\packages\openssl_x64-windows-static
             cmake_additional_opt: ""
             vcpkg_triplet: x64-windows-static
             cmake_version: "3.31.6"
@@ -91,10 +89,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            C:\vcpkg\packages
-          key: ${{ runner.os }}-${{ matrix.config.arch }}-wintest-vcpkg-${{ steps.get-date.outputs.date }}
+            C:\vcpkg\installed
+          key: ${{ runner.os }}-${{ matrix.config.arch }}-wintest-vcpkg-installed-${{ steps.get-date.outputs.date }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.config.arch }}-wintest-vcpkg-
+            ${{ runner.os }}-${{ matrix.config.arch }}-wintest-vcpkg-installed-
           enableCrossOsArchive: false
 
       - name: Build openssl with vcpkg
@@ -107,12 +105,17 @@ jobs:
           C:\vcpkg\vcpkg install --recurse libyaml --triplet ${{ matrix.config.vcpkg_triplet }}
         shell: cmd
 
+      - name: Upgrade any outdated vcpkg packages
+        run: |
+          C:\vcpkg\vcpkg upgrade --no-dry-run
+        shell: cmd
+
       - name: Save packages of vcpkg
         id: save-vcpkg-sources
         uses: actions/cache/save@v4
         with:
           path: |
-            C:\vcpkg\packages
+            C:\vcpkg\installed
           key: ${{ steps.cache-unit-test-vcpkg-sources.outputs.cache-primary-key }}
           enableCrossOsArchive: false
 
@@ -121,9 +124,9 @@ jobs:
           cmake -G "NMake Makefiles" `
             -D FLB_TESTS_INTERNAL=On `
             -D FLB_NIGHTLY_BUILD='${{ inputs.unstable }}' `
-            -D OPENSSL_ROOT_DIR='${{ matrix.config.openssl_dir }}' `
+            -D OPENSSL_ROOT_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' `
             ${{ matrix.config.cmake_additional_opt }} `
-            -D FLB_LIBYAML_DIR=C:\vcpkg\packages\libyaml_${{ matrix.config.vcpkg_triplet }} `
+            -D FLB_LIBYAML_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' `
             -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
             -D FLB_WITHOUT_flb-rt-out_td=On `
             -D FLB_WITHOUT_flb-rt-out_forward=On `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if (MSVC)
   #
   set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /O2 /Zi /wd4100 /wd4711 /wd5045")
   set(CMAKE_EXE_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
+  set(CMAKE_SHARED_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
   set(CMAKE_BUILD_TYPE None)
 
   # Use add_compile_options() to set /MT since Visual Studio
@@ -1029,12 +1030,8 @@ else()
     set(AUTOCONF_HOST_OPT "--host=${GNU_HOST}")
 endif()
 
-if(CMAKE_GENERATOR MATCHES "Ninja")
-  if(FLB_SYSTEM_WINDOWS)
-    MESSAGE(FATAL_ERROR "Building with Ninja is not supported on Windows")
-  else()
-    set(EXTERNAL_BUILD_TOOL "make")
-  endif()
+if(CMAKE_GENERATOR MATCHES "Ninja" AND NOT FLB_SYSTEM_WINDOWS)
+  set(EXTERNAL_BUILD_TOOL "make")
 else()
   set(EXTERNAL_BUILD_TOOL "$(MAKE)")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,16 @@ if (MSVC)
   #   /wd4100 .. C4100 (unreferenced formal parameter)
   #   /wd5045 .. C5045 (Spectre mitigation)
   #
+  # Restore /OPT:REF after setting /Debug, enable /OPT:ICF for 64-bit
+  # builds per Microsoft recommended best practices.
   set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /O2 /Zi /wd4100 /wd4711 /wd5045")
-  set(CMAKE_EXE_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
-  set(CMAKE_SHARED_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
+  set(CMAKE_EXE_LINKER_FLAGS "/DEBUG /OPT:REF /INCREMENTAL:NO")
+  set(CMAKE_SHARED_LINKER_FLAGS "/DEBUG /OPT:REF /INCREMENTAL:NO")
   set(CMAKE_BUILD_TYPE None)
+  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /OPT:ICF")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /OPT:ICF")
+  endif()
 
   # Use add_compile_options() to set /MT since Visual Studio
   # Generator does not notice /MT in CMAKE_C_FLAGS.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -486,8 +486,6 @@ if(FLB_SHARED_LIB)
   if (MSVC)
     set_target_properties(fluent-bit-shared
       PROPERTIES PDB_NAME fluent-bit.dll)
-    target_link_options(fluent-bit-shared
-      PUBLIC /pdb:$<TARGET_PDB_FILE:fluent-bit-shared>)
   endif()
 
   # Library install routines
@@ -521,8 +519,10 @@ if(FLB_BINARY)
   else()
     add_executable(fluent-bit-bin fluent-bit.c flb_dump.c)
   endif()
+  if (MSVC)
+    set_target_properties(fluent-bit-bin PROPERTIES IMPORT_SUFFIX ".exe.lib")
+  endif(MSVC)
   add_sanitizers(fluent-bit-bin)
-
 
   if(FLB_STATIC_CONF)
     add_dependencies(fluent-bit-bin flb-static-conf)


### PR DESCRIPTION
* Change the importlib name for `fluent-bit.exe`, and modify how debug data output is configured for `fluent-bit.dll` so that build outputs are not overwritten by other build outputs.
* Remove code preventing Ninja/MSVC builds.
* Update MSVC linker flags altered by [`/DEBUG`](https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/reference/opt-optimizations.md#arguments) to match Microsoft's [recommendations](https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/optimization-best-practices.md#which-level-of-optimization-to-use).
* Update/fix vcpkg caching

All in all this reduces MSVC CI build times with ~20-25% if there is a cache hit for the vcpkg packages and the size of `fluent-bit.exe` is reduced with about 20 %.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
