### PR TITLE
http_client_http2: fixed request body overwrite issue

### DIFF
--- a/src/flb_http_client_http2.c
+++ b/src/flb_http_client_http2.c
@@ -366,7 +366,8 @@ static ssize_t http2_data_source_read_callback(nghttp2_session *session,
     }
     else {
         if (content_length > 0) {
-            memcpy(buf, stream->request.body, content_length);
+            memcpy(buf,
+                   &stream->request.body[body_offset], length);
 
             stream->request.body_read_offset += content_length;
         }


### PR DESCRIPTION
This PR fixes an issue that occurred when a request body exceeded the provided buffer size where the last chunk of the body overwrote the first one.

Note: This is a backport of PR #9818