### PR TITLE
input: fixed threaded input processor initialization

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1206,8 +1206,6 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                 return -1;
             }
 
-            //ins->notification_channel = ins->thi->notification_channels[1];
-
             /* register the ring buffer */
             ret = flb_ring_buffer_add_event_loop(ins->rb, config->evl, FLB_INPUT_RING_BUFFER_WINDOW);
             if (ret) {
@@ -1225,6 +1223,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
             }
 
             ins->notification_channel = config->notification_channels[1];
+            ins->processor->notification_channel = ins->notification_channel;
 
             ret = p->cb_init(ins, config, ins->data);
             if (ret != 0) {
@@ -1232,15 +1231,13 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                           ins->name);
                 return -1;
             }
+
+            /* initialize processors */
+            ret = flb_processor_init(ins->processor);
+            if (ret == -1) {
+                return -1;
+            }
         }
-    }
-
-    ins->processor->notification_channel = ins->notification_channel;
-
-    /* initialize processors */
-    ret = flb_processor_init(ins->processor);
-    if (ret == -1) {
-        return -1;
     }
 
     return 0;
@@ -1447,7 +1444,11 @@ static struct flb_input_collector *collector_create(int type,
         coll->evl = thi->evl;
     }
     else {
-        coll->evl = config->evl;
+        /* We need to obtain the event loop from the TLS when
+         * creating collectors for non threaded plugins running
+         * under a threaded plugin.
+         */
+        coll->evl = flb_engine_evl_get();
     }
 
     /*

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -370,6 +370,16 @@ static void input_thread(void *data)
         return;
     }
 
+    ins->processor->notification_channel = ins->notification_channel;
+
+    ret = flb_processor_init(ins->processor);
+    if (ret == -1) {
+        flb_error("failed initialize processors for input %s",
+                  flb_input_name(ins));
+        input_thread_instance_set_status(ins, FLB_INPUT_THREAD_ERROR);
+        return;
+    }
+
     flb_plg_debug(ins, "[thread init] initialization OK");
     input_thread_instance_set_status(ins, FLB_INPUT_THREAD_OK);
 


### PR DESCRIPTION
This PR moves the processor stack initialization to the actual input plugins thread when appropriate.

Note: This is a backport of PR #10350 10350