### PR TITLE
Remove export of internal sds_alloc from cfl_sds.h

### DIFF
--- a/lib/cfl/include/cfl/cfl_sds.h
+++ b/lib/cfl/include/cfl/cfl_sds.h
@@ -49,7 +49,6 @@ static inline void cfl_sds_len_set(cfl_sds_t s, size_t len)
 }
 
 size_t cfl_sds_avail(cfl_sds_t s);
-cfl_sds_t sds_alloc(size_t size);
 size_t cfl_sds_alloc(cfl_sds_t s);
 cfl_sds_t cfl_sds_increase(cfl_sds_t s, size_t len);
 size_t cfl_sds_len(cfl_sds_t s);


### PR DESCRIPTION
`cfl_sds.h` exports an `sds_alloc` function. This function appears to be internal, especially since it also exports a `cfl_sds_alloc` function that follows naming conventions.

This export caused problems in another PR (see [this comment](https://github.com/fluent/fluent-bit/pull/10326/files#r2088398735)) when compiling `src/flb_sds.c`, which also declares an `sds_alloc` function.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
