### PR TITLE
go: plugin_proxy: error on plugin initialization errors

### DIFF
--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -620,9 +620,11 @@ int flb_input_thread_instance_init(struct flb_config *config, struct flb_input_i
     ret = input_thread_instance_get_status(ins);
     if (ret == -1) {
         flb_plg_error(ins, "unexpected error loading plugin instance");
+        return -1;
     }
     else if (ret == FLB_FALSE) {
         flb_plg_error(ins, "could not initialize threaded plugin instance");
+        return -1;
     }
     else if (ret == FLB_TRUE) {
         flb_plg_info(ins, "thread instance initialized");

--- a/src/proxy/go/go.c
+++ b/src/proxy/go/go.c
@@ -224,7 +224,6 @@ int proxy_go_input_init(struct flb_plugin_proxy *proxy)
     if (ret <= 0) {
         flb_error("[go proxy]: plugin '%s' failed to initialize",
                   plugin->name);
-        flb_free(plugin);
         return -1;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
When a Go plugin fails in initialization, with this change, it crashes fluentbit instead of only printing an error log. Also, `proxy_go_input_init` no longer frees memory that is also cleaned up on flb exit (e.g., a return from `flb_input_thread.c:flb_input_thread_instance_init:610` sees a double free, even before this change).

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
