### PR TITLE
engine: fix segfault in flb_config_init error case

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -345,6 +345,11 @@ struct flb_config *flb_config_init()
     mk_list_init(&config->cmetrics);
     mk_list_init(&config->cf_parsers_list);
 
+    /* Initialize multiline-parser list. We need this here, because from now
+     * on we use flb_config_exit to cleanup the config, which requires
+     * the config->multiline_parsers list to be initialized. */
+    mk_list_init(&config->multiline_parsers);
+
     /* Task map */
     ret = flb_config_task_map_resize(config, FLB_CONFIG_DEFAULT_TASK_MAP_SIZE);
 
@@ -353,11 +358,6 @@ struct flb_config *flb_config_init()
         flb_config_exit(config);
         return NULL;
     }
-
-    /* Initialize multiline-parser list. We need this here, because from now
-     * on we use flb_config_exit to cleanup the config, which requires
-     * the config->multiline_parsers list to be initialized. */
-    mk_list_init(&config->multiline_parsers);
 
     /* Environment */
     config->env = flb_env_create();


### PR DESCRIPTION
This fixes a segfault in `flb_config_init` that occurs when the call to `flb_config_task_map_resize` fails and then calls `flb_config_exit`, which subsequently dereferences invalid `config->multiline_parsers`.

This was picked up by the fuzzer in CI and can be reproduced on master with this input:
```shell
echo "DgAAAAAHBy8rLi8vLv8QLi8rLy97AT8P/////////xYHB3sBAQAgPy79JjIxNDc0ODM2NDljATg3AAA=" | base64 -d > /tmp/repro_bin
bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ /tmp/repro_bin
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change (see below)
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

## Test output

Before:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 151106316
bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ: Running 1 inputs 1 time(s) each.
Running: /tmp/repro_bin
[2025/05/19 15:58:53] [error] [/home/alec/dev/fluent-bit/src/flb_config.c:1030 errno=0] Success
[2025/05/19 15:58:53] [error] [config] task map resize failed
AddressSanitizer:DEADLYSIGNAL
=================================================================
==816689==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0xaaaab7c13da4 bp 0xffffdca6b760 sp 0xffffdca6b730 T0)
==816689==The signal is caused by a READ memory access.
==816689==Hint: address points to the zero page.
    #0 0xaaaab7c13da4 in flb_ml_parser_destroy_all /home/alec/dev/fluent-bit/src/multiline/flb_ml_parser.c:343:5
    #1 0xaaaab7ba14dc in flb_ml_exit /home/alec/dev/fluent-bit/src/multiline/flb_ml.c:1561:5
    #2 0xaaaab7ba5c08 in flb_parser_exit /home/alec/dev/fluent-bit/src/flb_parser.c:398:5
    #3 0xaaaab7b7a974 in flb_config_exit /home/alec/dev/fluent-bit/src/flb_config.c:514:5
    #4 0xaaaab7b7a1c8 in flb_config_init /home/alec/dev/fluent-bit/src/flb_config.c:353:9
    #5 0xaaaab7b75300 in LLVMFuzzerTestOneInput /home/alec/dev/fluent-bit/tests/internal/fuzzers/signv4_fuzzer.c:60:19
    #6 0xaaaab7aaf044 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/alec/dev/fluent-bit/build/bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ+0x8f044) (BuildId: c5dec4264846745ff5ec0601ce134a381aca66c3)
    #7 0xaaaab7a9a578 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/alec/dev/fluent-bit/build/bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ+0x7a578) (BuildId: c5dec4264846745ff5ec0601ce134a381aca66c3)
    #8 0xaaaab7a9faf4 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/alec/dev/fluent-bit/build/bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ+0x7faf4) (BuildId: c5dec4264846745ff5ec0601ce134a381aca66c3)
    #9 0xaaaab7ac70ec in main (/home/alec/dev/fluent-bit/build/bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ+0xa70ec) (BuildId: c5dec4264846745ff5ec0601ce134a381aca66c3)
    #10 0xffff8fba73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #11 0xffff8fba74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #12 0xaaaab7a9602c in _start (/home/alec/dev/fluent-bit/build/bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ+0x7602c) (BuildId: c5dec4264846745ff5ec0601ce134a381aca66c3)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/alec/dev/fluent-bit/src/multiline/flb_ml_parser.c:343:5 in flb_ml_parser_destroy_all
==816689==ABORTING
```

After:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 277839252
bin/flb-it-fuzz-signv4_fuzzer_OSSFUZZ: Running 1 inputs 1 time(s) each.
Running: /tmp/repro_bin
[2025/05/19 15:57:49] [error] [/home/alec/dev/fluent-bit/src/flb_config.c:1030 errno=0] Success
[2025/05/19 15:57:49] [error] [config] task map resize failed
[2025/05/19 15:57:49] [error] [/home/alec/dev/fluent-bit/src/flb_config.c:1030 errno=9] Bad file descriptor
[2025/05/19 15:57:49] [error] [config] task map resize failed
Executed /tmp/repro_bin in 2 ms
```