### PR TITLE
Add record accessor support in parser filter

### DIFF
--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -24,6 +24,8 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_ra_key.h>
 
 struct filter_parser {
     struct flb_parser *parser;
@@ -33,6 +35,7 @@ struct filter_parser {
 struct filter_parser_ctx {
     flb_sds_t key_name;
     int    key_name_len;
+    struct flb_record_accessor *ra_key;
     int    reserve_data;
     int    preserve_key;
     struct mk_list parsers;


### PR DESCRIPTION
## Summary
- allow Parser filter to parse nested keys using record accessor patterns
- clean up parser context on exit

## Testing
- `cmake .. -DFLB_TESTS_INTERNAL=Off -DFLB_TESTS_RUNTIME=Off`
- `make -j$(nproc)`
- `ctest --output-on-failure`