### PR TITLE
wasm: Enable reference types feature on wasm

### DIFF
--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -93,7 +93,7 @@ endif ()
 if (NOT MSVC)
   set (WAMR_BUILD_LIB_PTHREAD 1)
 endif ()
-set (WAMR_BUILD_REF_TYPES 0)
+set (WAMR_BUILD_REF_TYPES 1)
 
 if (NOT MSVC)
   # linker flags


### PR DESCRIPTION
As of Rustc 1.81, it starts to use reference type on Wasm creations. So, we need to enable it on our bundled runtime.

Closes https://github.com/fluent/fluent-bit/issues/10196.

Rustc

```
% rustc --version
rustc 1.87.0 (17067e9ac 2025-05-09)
```

AOT object is also able to load
```
$ bin/flb-wamrc --target=x86_64 --cpu=skylake -o filter_rust_rustc187.aot filter_rust_rustc187.wasm
Create AoT compiler with:
  target:        x86_64
  target cpu:    skylake
  target triple: x86_64-pc-linux-gnu
  cpu features:  
  opt level:     3
  size level:    3
  output format: AoT file
Compile success, file filter_rust_rustc187.aot was generated.
```


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [x] Debug log output from testing the change

```
Fluent Bit v4.0.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/05/20 15:55:51] [ info] Configuration:
[2025/05/20 15:55:51] [ info]  flush time     | 1.000000 seconds
[2025/05/20 15:55:51] [ info]  grace          | 5 seconds
[2025/05/20 15:55:51] [ info]  daemon         | 0
[2025/05/20 15:55:51] [ info] ___________
[2025/05/20 15:55:51] [ info]  inputs:
[2025/05/20 15:55:51] [ info]      dummy
[2025/05/20 15:55:51] [ info] ___________
[2025/05/20 15:55:51] [ info]  filters:
[2025/05/20 15:55:51] [ info]      wasm.0
[2025/05/20 15:55:51] [ info] ___________
[2025/05/20 15:55:51] [ info]  outputs:
[2025/05/20 15:55:51] [ info]      stdout.0
[2025/05/20 15:55:51] [ info] ___________
[2025/05/20 15:55:51] [ info]  collectors:
[2025/05/20 15:55:51] [ info] [fluent bit] version=4.0.2, commit=0ae7e15fe4, pid=816837
[2025/05/20 15:55:51] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/05/20 15:55:51] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/05/20 15:55:51] [ info] [simd    ] disabled
[2025/05/20 15:55:51] [ info] [cmetrics] version=1.0.2
[2025/05/20 15:55:51] [ info] [ctraces ] version=0.6.6
[2025/05/20 15:55:51] [ info] [input:dummy:dummy.0] initializing
[2025/05/20 15:55:51] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/05/20 15:55:51] [debug] [dummy:dummy.0] created event channels: read=25 write=26
[2025/05/20 15:55:51] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2025/05/20 15:55:51] [ info] [output:stdout:stdout.0] worker #0 started
[2025/05/20 15:55:51] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2025/05/20 15:55:51] [ info] [sp] stream processor started
[2025/05/20 15:55:52] [debug] [task] created task=0x7fcc7fe36640 id=0 OK
[2025/05/20 15:55:52] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.locals: [[1747724151.894320357, {}], {"lang"=>"Rust", "message"=>"dummy", "original"=>"{"message":"dummy","wasm_float1":1.0,"wasm_float2":100.0,"wasm_int1":1,"wasm_int2":100}", "tag"=>"dummy.locals", "time"=>"2025-05-20T06:55:51.894320357 +0000"}]
[2025/05/20 15:55:52] [debug] [out flush] cb_destroy coro_id=0
[2025/05/20 15:55:52] [debug] [task] destroy task=0x7fcc7fe36640 (task_id=0)
^C[2025/05/20 15:55:53] [engine] caught signal (SIGINT)
[2025/05/20 15:55:53] [debug] [task] created task=0x7fcc7fe36640 id=0 OK
[2025/05/20 15:55:53] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2025/05/20 15:55:53] [ warn] [engine] service will shutdown in max 5 seconds
[2025/05/20 15:55:53] [debug] [engine] retry=0x7fcc80bf4500 for task 0 already scheduled to run, not re-scheduling it.
[2025/05/20 15:55:53] [ info] [input] pausing dummy.0
[0] dummy.locals: [[1747724152.894329892, {}], {"lang"=>"Rust", "message"=>"dummy", "original"=>"{"message":"dummy","wasm_float1":1.0,"wasm_float2":100.0,"wasm_int1":1,"wasm_int2":100}", "tag"=>"dummy.locals", "time"=>"2025-05-20T06:55:52.894329892 +0000"}]
[2025/05/20 15:55:53] [debug] [out flush] cb_destroy coro_id=1
[2025/05/20 15:55:53] [debug] [task] destroy task=0x7fcc7fe36640 (task_id=0)
[2025/05/20 15:55:53] [ info] [engine] service has stopped (0 pending tasks)
[2025/05/20 15:55:53] [ info] [input] pausing dummy.0
[2025/05/20 15:55:53] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/05/20 15:55:53] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
