### PR TITLE
out_opensearch: Prevent a SIGSEGV when ctx->index is NULL

### DIFF
--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -687,6 +687,11 @@ static int cb_opensearch_init(struct flb_output_instance *ins,
         return -1;
     }
 
+    if (ctx->index == NULL && ctx->logstash_format == FLB_FALSE && ctx->generate_id == FLB_FALSE) {
+        flb_plg_error(ins, "cannot initialize plugin, index is not set and logstash_format and generate_id are both off");
+        return -1;
+    }
+
     flb_plg_debug(ctx->ins, "host=%s port=%i uri=%s index=%s type=%s",
                   ins->host.name, ins->host.port, ctx->uri,
                   ctx->index, ctx->type);

--- a/tests/runtime/out_opensearch.c
+++ b/tests/runtime/out_opensearch.c
@@ -420,6 +420,48 @@ void flb_test_write_operation_upsert()
     flb_destroy(ctx);
 }
 
+void flb_test_null_index()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "opensearch", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Override defaults of index and type */
+    flb_output_set(ctx, out_ffd,
+                   "index", "",
+                   "type", "type_test",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_type,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == -1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_index_type()
 {
     int ret;


### PR DESCRIPTION
If `index` field is blank in the configuration, and `Logstash_Format` and `Generate_ID` are both `off`, a SIGSEGV can occur when trying to generate the index for a set of messages.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Port from https://github.com/fluent/fluent-bit/pull/10353 to the opensearch output plugin

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [n/a] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [n/a] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [n/a] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
