### PR TITLE
in_winevtlog: Support remote access of winevtlog

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -177,7 +177,7 @@ static int in_winevtlog_init(struct flb_input_instance *in,
         flb_plg_error(in, "could not initialize event encoder");
         flb_free(ctx);
 
-        return NULL;
+        return -1;
     }
 
     /* Load the config map */

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -65,7 +65,7 @@ static wchar_t* convert_to_wide(char *str)
     return buf;
 }
 
-static void in_winevtlog_session_destory(struct winevtlog_session *session);
+static void in_winevtlog_session_destroy(struct winevtlog_session *session);
 
 static struct winevtlog_session *in_winevtlog_session_create(struct winevtlog_config *ctx,
                                                              struct flb_config *config,
@@ -90,7 +90,7 @@ static struct winevtlog_session *in_winevtlog_session_create(struct winevtlog_co
     if (ctx->remote_server != NULL) {
         session->server = convert_to_wide(ctx->remote_server);
         if (session->server == NULL) {
-            in_winevtlog_session_destory(session);
+            in_winevtlog_session_destroy(session);
             *status = WINEVTLOG_SESSION_FAILED_TO_CONVERT_WIDE;
             return NULL;
         }
@@ -99,7 +99,7 @@ static struct winevtlog_session *in_winevtlog_session_create(struct winevtlog_co
     if (ctx->remote_domain != NULL) {
         session->domain = convert_to_wide(ctx->remote_domain);
         if (session->domain == NULL) {
-            in_winevtlog_session_destory(session);
+            in_winevtlog_session_destroy(session);
             *status = WINEVTLOG_SESSION_FAILED_TO_CONVERT_WIDE;
             return NULL;
         }
@@ -108,7 +108,7 @@ static struct winevtlog_session *in_winevtlog_session_create(struct winevtlog_co
     if (ctx->remote_username != NULL) {
         session->username = convert_to_wide(ctx->remote_username);
         if (session->username == NULL) {
-            in_winevtlog_session_destory(session);
+            in_winevtlog_session_destroy(session);
             *status = WINEVTLOG_SESSION_FAILED_TO_CONVERT_WIDE;
             return NULL;
         }
@@ -117,7 +117,7 @@ static struct winevtlog_session *in_winevtlog_session_create(struct winevtlog_co
     if (ctx->remote_password != NULL) {
         session->password = convert_to_wide(ctx->remote_password);
         if (session->password == NULL) {
-            in_winevtlog_session_destory(session);
+            in_winevtlog_session_destroy(session);
             *status = WINEVTLOG_SESSION_FAILED_TO_CONVERT_WIDE;
             return NULL;
         }
@@ -129,7 +129,7 @@ static struct winevtlog_session *in_winevtlog_session_create(struct winevtlog_co
     return session;
 }
 
-static void in_winevtlog_session_destory(struct winevtlog_session *session)
+static void in_winevtlog_session_destroy(struct winevtlog_session *session)
 {
     if (session->server != NULL) {
         flb_free(session->server);
@@ -192,11 +192,11 @@ static int in_winevtlog_init(struct flb_input_instance *in,
     session = in_winevtlog_session_create(ctx, config, &status);
     if (status == WINEVTLOG_SESSION_ALLOC_FAILED ||
         status == WINEVTLOG_SESSION_FAILED_TO_CONVERT_WIDE) {
-        flb_plg_error(in, "session is not created and invalid with %d", status);
+        flb_plg_error(in, "session is not created and invalid with status %d", status);
         return -1;
     }
     else if (session == NULL) {
-        flb_plg_debug(in, "session is not created. Connect to local machine.");
+        flb_plg_debug(in, "connect to local machine");
     }
     ctx->session = session;
 
@@ -364,7 +364,7 @@ static int in_winevtlog_exit(void *data, struct flb_config *config)
         flb_sqldb_close(ctx->db);
     }
     if (ctx->session) {
-        in_winevtlog_session_destory(ctx->session);
+        in_winevtlog_session_destroy(ctx->session);
     }
     flb_free(ctx);
 

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -34,7 +34,7 @@
 
 static int pack_nullstr(struct winevtlog_config *ctx)
 {
-    flb_log_event_encoder_append_body_cstring(ctx->log_encoder, "");
+    return flb_log_event_encoder_append_body_cstring(ctx->log_encoder, "");
 }
 
 static int pack_wstr(struct winevtlog_config *ctx, const wchar_t *wstr)
@@ -313,6 +313,8 @@ static int pack_sid(struct winevtlog_config *ctx, PSID sid, int extract_sid)
             }
 
             _snprintf_s(formatted, result_len, _TRUNCATE, "%s\\%s", domain, account);
+
+            size = strlen(formatted);
 
             if (size > 0) {
                 flb_log_event_encoder_append_body_cstring(ctx->log_encoder, formatted);

--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -23,6 +23,7 @@
 
 #include <winevt.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_input_plugin.h>
 
 struct winevtlog_session;
 
@@ -120,8 +121,8 @@ void winevtlog_pack_event(PEVT_VARIANT system, WCHAR *message,
 /*
  * Save the read offset to disk.
  */
-int winevtlog_sqlite_load(struct winevtlog_channel *ch, struct flb_sqldb *db);
-int winevtlog_sqlite_save(struct winevtlog_channel *ch, struct flb_sqldb *db);
+int winevtlog_sqlite_load(struct winevtlog_channel *ch, struct winevtlog_config *ctx, struct flb_sqldb *db);
+int winevtlog_sqlite_save(struct winevtlog_channel *ch, struct winevtlog_config *ctx, struct flb_sqldb *db);
 
 /*
  * SQL templates

--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -24,6 +24,8 @@
 #include <winevt.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
+struct winevtlog_session;
+
 struct winevtlog_config {
     unsigned int interval_sec;
     unsigned int interval_nsec;
@@ -34,6 +36,11 @@ struct winevtlog_config {
     int use_ansi;
     int ignore_missing_channels;
     flb_sds_t event_query;
+    flb_sds_t remote_server;
+    flb_sds_t remote_domain;
+    flb_sds_t remote_username;
+    flb_sds_t remote_password;
+    struct winevtlog_session *session;
 
     struct mk_list *active_channel;
     struct flb_sqldb *db;
@@ -50,15 +57,30 @@ struct winevtlog_config {
 struct winevtlog_channel {
     EVT_HANDLE subscription;
     EVT_HANDLE bookmark;
+    EVT_HANDLE remote;
     HANDLE signal_event;
     EVT_HANDLE events[SUBSCRIBE_ARRAY_SIZE];
     int count;
+    struct winevtlog_session *session;
 
     char *name;
     char *query;
     unsigned int time_updated;
     unsigned int time_created;
     struct mk_list _head;
+};
+
+#define WINEVTLOG_SESSION_CREATE_OK              0
+#define WINEVTLOG_SESSION_ALLOC_FAILED           1
+#define WINEVTLOG_SESSION_SERVER_EMPTY           2
+#define WINEVTLOG_SESSION_FAILED_TO_CONVERT_WIDE 3
+
+struct winevtlog_session {
+    PWSTR server;
+    PWSTR domain;
+    PWSTR username;
+    PWSTR password;
+    EVT_RPC_LOGIN_FLAGS flags;
 };
 
 struct winevtlog_sqlite_record {


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR is a parity feature for fluent-plugin-windows-eventlog's in_windows_eventlog2.
This PR makes to be able to handle remote access on in_winevtlog plugin.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1683

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
