### PR TITLE
strptime: Support some of abbriviated timezone strings for GNU extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,6 +882,18 @@ if(FLB_HAVE_GMTOFF)
   FLB_DEFINITION(FLB_HAVE_GMTOFF)
 endif()
 
+# tm_zone support
+check_c_source_compiles("
+  #include <time.h>
+  int main() {
+     struct tm tm;
+     tm.tm_zone = \"GMT\";
+     return 0;
+  }" FLB_HAVE_TIME_ZONE)
+if(FLB_HAVE_TIME_ZONE)
+  FLB_DEFINITION(FLB_HAVE_TIME_ZONE)
+endif()
+
 # clock_get_time() support for macOS.
 check_c_source_compiles("
   #include <mach/clock.h>

--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -32,6 +32,9 @@ struct flb_time {
 
 struct flb_tm {
     struct tm tm;
+#ifdef FLB_HAVE_TIME_ZONE
+    char *tm_zone;
+#endif
 #ifndef FLB_HAVE_GMTOFF
     long int tm_gmtoff;
 #endif

--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -32,7 +32,7 @@ struct flb_time {
 
 struct flb_tm {
     struct tm tm;
-#ifdef FLB_HAVE_TIME_ZONE
+#ifndef FLB_HAVE_TIME_ZONE
     char *tm_zone;
 #endif
 #ifndef FLB_HAVE_GMTOFF
@@ -44,6 +44,12 @@ struct flb_tm {
 #define flb_tm_gmtoff(x) (x)->tm_gmtoff
 #else
 #define flb_tm_gmtoff(x) (x)->tm.tm_gmtoff
+#endif
+
+#ifndef FLB_HAVE_TIME_ZONE
+#define flb_tm_zone(x) (x)->tm_zone
+#else
+#define flb_tm_zone(x) (x)->tm.tm_zone
 #endif
 
 /*

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -591,7 +591,7 @@ literal:
 		case 'Z':
 		{
 			const flb_tz_abbr_info_t *tz_info;
-			int found_in_known = 0;
+			int found_in_known = FLB_FALSE;
 			size_t abbr_len;
 
 			for (tz_info = flb_known_timezones; tz_info->abbr != NULL; ++tz_info) {
@@ -602,7 +602,7 @@ literal:
 						flb_tm_gmtoff(tm) = tz_info->offset_sec;
 						flb_tm_zone(tm) = tz_info->abbr;
 						bp += abbr_len;
-						found_in_known = 1;
+						found_in_known = FLB_TRUE;
 						break;
 					}
 				}

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -519,15 +519,13 @@ literal:
 					return (NULL);
 				flb_tm_gmtoff(tm) = 0;
 				tm->tm.tm_isdst = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-				tm->tm_zone = "UTC";
+				flb_tm_zone(tm) = "UTC";
 				for(i=0; flb_known_timezones[i].abbr != NULL; ++i) { /* Prefer "UTC" from list if available */
 					if (strcmp(flb_known_timezones[i].abbr, "UTC") == 0) {
-						tm->tm_zone = flb_known_timezones[i].abbr;
+						flb_tm_zone(tm) = flb_known_timezones[i].abbr;
 						break;
 					}
 				}
-#endif
 				fields = 0xffff;         /* everything */
 			}
 			break;
@@ -606,9 +604,7 @@ literal:
 					if (!isalnum((unsigned char)bp[abbr_len])) {
 						tm->tm.tm_isdst = tz_info->is_dst;
 						flb_tm_gmtoff(tm) = tz_info->offset_sec;
-#ifdef FLB_HAVE_TIME_ZONE
-						tm->tm_zone = tz_info->abbr;
-#endif
+						flb_tm_zone(tm) = tz_info->abbr;
 						bp += abbr_len;
 						found_in_known = 1;
 						break;
@@ -627,16 +623,12 @@ literal:
 				if (strncmp((const char *)bp, gmt, 3) == 0) {
 					tm->tm.tm_isdst = 0;
 					flb_tm_gmtoff(tm) = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-					tm->tm_zone = gmt;
-#endif
+					flb_tm_zone(tm) = gmt;
 					bp += 3;
 				} else if (strncmp((const char *)bp, utc, 3) == 0) {
 					tm->tm.tm_isdst = 0;
 					flb_tm_gmtoff(tm) = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-					tm->tm_zone = utc;
-#endif
+					flb_tm_zone(tm) = utc;
 					bp += 3;
 				} else {
 					ep = _find_string(bp, &i, (const char * const *)tzname, NULL, 2);
@@ -661,9 +653,7 @@ literal:
 #else
 					flb_tm_gmtoff(tm) = -(timezone);
 #endif
-#ifdef FLB_HAVE_TIME_ZONE
-					tm->tm_zone = tzname[i];
-#endif
+					flb_tm_zone(tm) = tzname[i];
 					bp = ep;
 				}
 			}
@@ -697,9 +687,7 @@ literal:
 					return NULL;
 				tm->tm.tm_isdst = 0;
 				flb_tm_gmtoff(tm) = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-				tm->tm_zone = "GMT"; /* Original had global gmt array */
-#endif
+				flb_tm_zone(tm) = "GMT"; /* Original had global gmt array */
 				continue;
 			case 'U':
 				if (*bp++ != 'T')
@@ -709,16 +697,12 @@ literal:
 					bp++; /* Allow "UTC" */
 				tm->tm.tm_isdst = 0;
 				flb_tm_gmtoff(tm) = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-				tm->tm_zone = "UTC"; /* Original had global utc array */
-#endif
+				flb_tm_zone(tm) = "UTC"; /* Original had global utc array */
 				continue;
 			case 'Z':
 				tm->tm.tm_isdst = 0;
 				flb_tm_gmtoff(tm) = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-				tm->tm_zone = utc;
-#endif
+				flb_tm_zone(tm) = utc;
 				continue;
 			case '+':
 				neg = 0;
@@ -732,9 +716,7 @@ literal:
 				if (ep != NULL) {
 					flb_tm_gmtoff(tm) = (-5 - i) * SECSPERHOUR;
 					tm->tm.tm_isdst = 0;
-#ifdef FLB_HAVE_TIME_ZONE
-					tm->tm_zone = (char *)nast[i];
-#endif
+					flb_tm_zone(tm)  = (char *)nast[i];
 					bp = ep;
 					continue;
 				}
@@ -742,9 +724,7 @@ literal:
 				if (ep != NULL) {
 					tm->tm.tm_isdst = 1;
 					flb_tm_gmtoff(tm) = (-4 - i) * SECSPERHOUR;
-#ifdef FLB_HAVE_TIME_ZONE
-					tm->tm_zone = (char *)nadt[i];
-#endif
+					flb_tm_zone(tm)  = (char *)nadt[i];
 					bp = ep;
 					continue;
 				}
@@ -766,9 +746,7 @@ literal:
 				offs = -offs;
 			tm->tm.tm_isdst = 0;	/* XXX */
 			flb_tm_gmtoff(tm) = offs;
-#ifdef FLB_HAVE_TIME_ZONE
-			tm->tm_zone = NULL;	/* XXX */
-#endif
+			flb_tm_zone(tm) = NULL;	/* XXX */
 			continue;
 
 		/*

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -588,7 +588,8 @@ literal:
 				return (NULL);
 			break;
 
-		case 'Z': {
+		case 'Z':
+		{
 			const flb_tz_abbr_info_t *tz_info;
 			int found_in_known = 0;
 			size_t abbr_len;
@@ -652,9 +653,8 @@ literal:
 					bp = ep;
 				}
 			}
-			}
 			continue;
-
+		}
 		case 'z':
 			/*
 			 * We recognize all ISO 8601 formats:

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -95,31 +95,107 @@ typedef struct {
 	int is_dst;
 } flb_tz_abbr_info_t;
 
-/* New list of known timezone abbreviations */
+/* Comprehensive list of known timezone abbreviations */
 static const flb_tz_abbr_info_t flb_known_timezones[] = {
-	{"GMT", 0, 0}, {"UTC", 0, 0}, {"Z", 0, 0}, {"UT", 0, 0},
-	{"EST", -5*SECSPERHOUR, 0}, {"EDT", -4*SECSPERHOUR, 1},
-	{"CST", -6*SECSPERHOUR, 0}, {"CDT", -5*SECSPERHOUR, 1},
-	{"MST", -7*SECSPERHOUR, 0}, {"MDT", -6*SECSPERHOUR, 1},
-	{"PST", -8*SECSPERHOUR, 0}, {"PDT", -7*SECSPERHOUR, 1},
-	{"AKST", -9*SECSPERHOUR, 0}, {"AKDT", -8*SECSPERHOUR, 1},
-	{"HST", -10*SECSPERHOUR, 0},
-	{"WET",   0*SECSPERHOUR, 0}, {"WEST",  1*SECSPERHOUR, 1},
-	{"CET",   1*SECSPERHOUR, 0}, {"CEST",  2*SECSPERHOUR, 1},
-	{"EET",   2*SECSPERHOUR, 0}, {"EEST",  3*SECSPERHOUR, 1},
-	{"AEST", 10*SECSPERHOUR, 0}, {"AEDT", 11*SECSPERHOUR, 1},
-	{"ACST", (long)(9.5*SECSPERHOUR), 0}, {"ACDT", (long)(10.5*SECSPERHOUR), 1},
-	{"AWST",  8*SECSPERHOUR, 0},
-	{"JST",   9*SECSPERHOUR, 0},
-	{"A",   1*SECSPERHOUR, 0}, {"B",   2*SECSPERHOUR, 0}, {"C",   3*SECSPERHOUR, 0},
-	{"D",   4*SECSPERHOUR, 0}, {"E",   5*SECSPERHOUR, 0}, {"F",   6*SECSPERHOUR, 0},
-	{"G",   7*SECSPERHOUR, 0}, {"H",   8*SECSPERHOUR, 0}, {"I",   9*SECSPERHOUR, 0},
-	{"K",  10*SECSPERHOUR, 0}, {"L",  11*SECSPERHOUR, 0}, {"M",  12*SECSPERHOUR, 0},
-	{"N",  -1*SECSPERHOUR, 0}, {"O",  -2*SECSPERHOUR, 0}, {"P",  -3*SECSPERHOUR, 0},
-	{"Q",  -4*SECSPERHOUR, 0}, {"R",  -5*SECSPERHOUR, 0}, {"S",  -6*SECSPERHOUR, 0},
-	{"T",  -7*SECSPERHOUR, 0}, {"U",  -8*SECSPERHOUR, 0}, {"V",  -9*SECSPERHOUR, 0},
-	{"W", -10*SECSPERHOUR, 0}, {"X", -11*SECSPERHOUR, 0}, {"Y", -12*SECSPERHOUR, 0},
-	{NULL, 0, 0}
+    /* UTC/GMT and Zulu */
+    {"GMT", 0, 0},
+    {"UTC", 0, 0},
+    {"Z", 0, 0}, /* Zulu Time (UTC) */
+    {"UT", 0, 0},
+
+    /* North American Timezones */
+    {"EST", -5*SECSPERHOUR, 0}, /* Eastern Standard Time */
+    {"EDT", -4*SECSPERHOUR, 1}, /* Eastern Daylight Time */
+    {"CST", -6*SECSPERHOUR, 0}, /* Central Standard Time (North America) */
+    {"CDT", -5*SECSPERHOUR, 1}, /* Central Daylight Time (North America) */
+    {"MST", -7*SECSPERHOUR, 0}, /* Mountain Standard Time */
+    {"MDT", -6*SECSPERHOUR, 1}, /* Mountain Daylight Time */
+    {"PST", -8*SECSPERHOUR, 0}, /* Pacific Standard Time */
+    {"PDT", -7*SECSPERHOUR, 1}, /* Pacific Daylight Time */
+    {"AKST", -9*SECSPERHOUR, 0}, /* Alaska Standard Time */
+    {"AKDT", -8*SECSPERHOUR, 1}, /* Alaska Daylight Time */
+    {"HST", -10*SECSPERHOUR, 0}, /* Hawaii Standard Time */
+    {"HADT", -9*SECSPERHOUR, 1}, /* Hawaii-Aleutian Daylight Time (rarely used for Hawaii proper) */
+    {"AST", -4*SECSPERHOUR, 0}, /* Atlantic Standard Time (e.g., Canada, Caribbean) */
+    {"ADT", -3*SECSPERHOUR, 1}, /* Atlantic Daylight Time */
+    {"NST", (long)(-3.5*SECSPERHOUR), 0}, /* Newfoundland Standard Time */
+    {"NDT", (long)(-2.5*SECSPERHOUR), 1}, /* Newfoundland Daylight Time */
+
+    /* European Timezones */
+    {"WET",   0*SECSPERHOUR, 0}, /* Western European Time */
+    {"WEST",  1*SECSPERHOUR, 1}, /* Western European Summer Time */
+    {"CET",   1*SECSPERHOUR, 0}, /* Central European Time */
+    {"CEST",  2*SECSPERHOUR, 1}, /* Central European Summer Time */
+    {"EET",   2*SECSPERHOUR, 0}, /* Eastern European Time */
+    {"EEST",  3*SECSPERHOUR, 1}, /* Eastern European Summer Time */
+    {"MSK",   3*SECSPERHOUR, 0}, /* Moscow Standard Time */
+    /* {"MSD",   4*SECSPERHOUR, 1}, */ /* Moscow Summer Time (historical) */
+
+    /* South American Timezones */
+    {"ART", -3*SECSPERHOUR, 0}, /* Argentina Time */
+    {"BRT", -3*SECSPERHOUR, 0}, /* Brazil Time (main population areas, can vary by region/DST) */
+    {"BRST", -2*SECSPERHOUR, 1}, /* Brazil Summer Time (historical, not currently observed by all) */
+    {"CLT", -4*SECSPERHOUR, 0}, /* Chile Standard Time */
+    {"CLST", -3*SECSPERHOUR, 1}, /* Chile Summer Time */
+
+    /* Australasian / Oceanian Timezones */
+    {"AEST", 10*SECSPERHOUR, 0}, /* Australian Eastern Standard Time */
+    {"AEDT", 11*SECSPERHOUR, 1}, /* Australian Eastern Daylight Time */
+    {"ACST", (long)(9.5*SECSPERHOUR), 0}, /* Australian Central Standard Time */
+    {"ACDT", (long)(10.5*SECSPERHOUR), 1}, /* Australian Central Daylight Time */
+    {"AWST",  8*SECSPERHOUR, 0}, /* Australian Western Standard Time */
+    {"NZST", 12*SECSPERHOUR, 0}, /* New Zealand Standard Time */
+    {"NZDT", 13*SECSPERHOUR, 1}, /* New Zealand Daylight Time */
+
+    /* Asian Timezones */
+    {"JST",   9*SECSPERHOUR, 0}, /* Japan Standard Time */
+    {"KST",   9*SECSPERHOUR, 0}, /* Korea Standard Time */
+    {"SGT",   8*SECSPERHOUR, 0}, /* Singapore Time */
+    {"IST", (long)(5.5*SECSPERHOUR), 0}, /* India Standard Time */
+    {"GST",   4*SECSPERHOUR, 0}, /* Gulf Standard Time (e.g., UAE, Oman) */
+    {"ICT",   7*SECSPERHOUR, 0}, /* Indochina Time (Thailand, Vietnam, Laos, Cambodia) */
+    {"WIB",   7*SECSPERHOUR, 0}, /* Western Indonesian Time */
+    {"WITA",  8*SECSPERHOUR, 0}, /* Central Indonesian Time */
+    {"WIT",   9*SECSPERHOUR, 0}, /* Eastern Indonesian Time */
+    {"MYT",   8*SECSPERHOUR, 0}, /* Malaysia Time */
+    {"BDT",   6*SECSPERHOUR, 0}, /* Bangladesh Standard Time */
+    {"NPT", (long)(5.75*SECSPERHOUR), 0}, /* Nepal Time */
+
+    /* African Timezones */
+    {"WAT",   1*SECSPERHOUR, 0}, /* West Africa Time */
+    {"CAT",   2*SECSPERHOUR, 0}, /* Central Africa Time */
+    {"EAT",   3*SECSPERHOUR, 0}, /* East Africa Time */
+    {"SAST",  2*SECSPERHOUR, 0}, /* South Africa Standard Time */
+
+    /* Military Timezones */
+    /* These are single letters. 'J' (Juliett) is local time of the observer and not included. */
+    /* 'Z' (Zulu) is UTC, already listed. */
+    {"A",   1*SECSPERHOUR, 0}, /* Alpha Time Zone */
+    {"B",   2*SECSPERHOUR, 0}, /* Bravo Time Zone */
+    {"C",   3*SECSPERHOUR, 0}, /* Charlie Time Zone */
+    {"D",   4*SECSPERHOUR, 0}, /* Delta Time Zone */
+    {"E",   5*SECSPERHOUR, 0}, /* Echo Time Zone */
+    {"F",   6*SECSPERHOUR, 0}, /* Foxtrot Time Zone */
+    {"G",   7*SECSPERHOUR, 0}, /* Golf Time Zone */
+    {"H",   8*SECSPERHOUR, 0}, /* Hotel Time Zone */
+    {"I",   9*SECSPERHOUR, 0}, /* India Time Zone (Military, not India Standard Time) */
+    {"K",  10*SECSPERHOUR, 0}, /* Kilo Time Zone */
+    {"L",  11*SECSPERHOUR, 0}, /* Lima Time Zone */
+    {"M",  12*SECSPERHOUR, 0}, /* Mike Time Zone */
+    {"N",  -1*SECSPERHOUR, 0}, /* November Time Zone */
+    {"O",  -2*SECSPERHOUR, 0}, /* Oscar Time Zone */
+    {"P",  -3*SECSPERHOUR, 0}, /* Papa Time Zone */
+    {"Q",  -4*SECSPERHOUR, 0}, /* Quebec Time Zone */
+    {"R",  -5*SECSPERHOUR, 0}, /* Romeo Time Zone */
+    {"S",  -6*SECSPERHOUR, 0}, /* Sierra Time Zone */
+    {"T",  -7*SECSPERHOUR, 0}, /* Tango Time Zone */
+    {"U",  -8*SECSPERHOUR, 0}, /* Uniform Time Zone */
+    {"V",  -9*SECSPERHOUR, 0}, /* Victor Time Zone */
+    {"W", -10*SECSPERHOUR, 0}, /* Whiskey Time Zone */
+    {"X", -11*SECSPERHOUR, 0}, /* X-ray Time Zone */
+    {"Y", -12*SECSPERHOUR, 0}, /* Yankee Time Zone */
+
+    {NULL, 0, 0}
 };
 
 static const int mon_lengths[2][MONSPERYEAR] = {

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -519,7 +519,7 @@ literal:
 					return (NULL);
 				flb_tm_gmtoff(tm) = 0;
 				tm->tm.tm_isdst = 0;
-				flb_tm_zone(tm) = "UTC";
+				flb_tm_zone(tm) = utc;
 				/* %s format does not handle timezone */
 				fields = 0xffff;         /* everything */
 			}
@@ -682,7 +682,7 @@ literal:
 					return NULL;
 				tm->tm.tm_isdst = 0;
 				flb_tm_gmtoff(tm) = 0;
-				flb_tm_zone(tm) = "GMT"; /* Original had global gmt array */
+				flb_tm_zone(tm) = gmt; /* Original had global gmt array */
 				continue;
 			case 'U':
 				if (*bp++ != 'T')
@@ -692,7 +692,7 @@ literal:
 					bp++; /* Allow "UTC" */
 				tm->tm.tm_isdst = 0;
 				flb_tm_gmtoff(tm) = 0;
-				flb_tm_zone(tm) = "UTC"; /* Original had global utc array */
+				flb_tm_zone(tm) = utc; /* Original had global utc array */
 				continue;
 			case 'Z':
 				tm->tm.tm_isdst = 0;

--- a/src/flb_strptime.c
+++ b/src/flb_strptime.c
@@ -520,12 +520,7 @@ literal:
 				flb_tm_gmtoff(tm) = 0;
 				tm->tm.tm_isdst = 0;
 				flb_tm_zone(tm) = "UTC";
-				for(i=0; flb_known_timezones[i].abbr != NULL; ++i) { /* Prefer "UTC" from list if available */
-					if (strcmp(flb_known_timezones[i].abbr, "UTC") == 0) {
-						flb_tm_zone(tm) = flb_known_timezones[i].abbr;
-						break;
-					}
-				}
+				/* %s format does not handle timezone */
 				fields = 0xffff;         /* everything */
 			}
 			break;

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -48,6 +48,7 @@ set(UNIT_TESTS_FILES
   conditionals.c
   endianness.c
   task_map.c
+  strptime.c
   )
 
 # Config format

--- a/tests/internal/strptime.c
+++ b/tests/internal/strptime.c
@@ -1,0 +1,426 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <stdio.h>
+#include <string.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_strptime.h>
+#include "flb_tests_internal.h"
+
+void check_tm_datetime(const struct tm *ptm, int year, int mon, int mday, int hour, int min, int sec) {
+    TEST_CHECK((year - 1900 ) == ptm->tm_year);
+    TEST_CHECK((mon - 1) == ptm->tm_mon);
+    TEST_CHECK(mday == ptm->tm_mday);
+    TEST_CHECK(hour == ptm->tm_hour);
+    TEST_CHECK(min == ptm->tm_min);
+    TEST_CHECK(sec == ptm->tm_sec);
+}
+
+void check_tm_datetime_wday_yday(const struct tm *ptm, int year, int mon, int mday, int hour, int min, int sec, int wday, int yday) {
+    check_tm_datetime(ptm, year, mon, mday, hour, min, sec);
+    if (wday != -1) 
+        TEST_CHECK(wday == ptm->tm_wday);
+    if (yday != -1) 
+        TEST_CHECK(yday == ptm->tm_yday);
+}
+
+void test_basic_date_time(void) {
+    struct flb_tm my_tm;
+    char *ret;
+    const char *buf = "2023-05-12 10:30:45";
+    const char *fmt = "%Y-%m-%d %H:%M:%S";
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime(buf, fmt, &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK('\0' == *ret);
+        check_tm_datetime(&my_tm.tm, 2023, 5, 12, 10, 30, 45);
+        TEST_CHECK(0 == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(-1 == my_tm.tm.tm_isdst);
+    }
+}
+
+void test_textual_month_day(void) {
+    struct flb_tm my_tm;
+    char *ret;
+    const char *buf = "May 12 2023 Friday";
+    const char *fmt = "%b %d %Y %A";
+
+    memset(&my_tm, 0, sizeof(my_tm));
+
+    ret = flb_strptime(buf, fmt, &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK('\0' == *ret);
+        TEST_CHECK((2023 - 1900) == my_tm.tm.tm_year);
+        TEST_CHECK((5 - 1) == my_tm.tm.tm_mon);
+        TEST_CHECK(12 == my_tm.tm.tm_mday);
+        TEST_CHECK(5 == my_tm.tm.tm_wday);
+    }
+}
+
+void test_year_variations(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("15", "%y", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) 
+        TEST_CHECK((2015 - 1900) == my_tm.tm.tm_year);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("99", "%y", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) 
+        TEST_CHECK((1999 - 1900) == my_tm.tm.tm_year);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("20 15", "%C %y", &my_tm); /* Century 20, year 15 -> 2015 */
+    TEST_CHECK(ret != NULL);
+    if (ret) 
+        TEST_CHECK((2015 - 1900) == my_tm.tm.tm_year);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("19 99", "%C %y", &my_tm); /* Century 19, year 99 -> 1999 */
+    TEST_CHECK(ret != NULL);
+    if (ret) 
+        TEST_CHECK((1999 - 1900) == my_tm.tm.tm_year);
+}
+
+void test_am_pm(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("01:00:00 AM", "%I:%M:%S %p", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) 
+        TEST_CHECK(1 == my_tm.tm.tm_hour);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("12:00:00 AM", "%I:%M:%S %p", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret)
+        TEST_CHECK(0 == my_tm.tm.tm_hour);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("01:00:00 PM", "%I:%M:%S %p", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret)
+        TEST_CHECK(13 == my_tm.tm.tm_hour);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("12:00:00 PM", "%I:%M:%S %p", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret)
+        TEST_CHECK(12 == my_tm.tm.tm_hour);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    my_tm.tm.tm_hour = 13;
+    ret = flb_strptime("AM", "%p", &my_tm);
+    TEST_CHECK(ret == NULL);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    my_tm.tm.tm_hour = 13;
+    ret = flb_strptime("PM", "%p", &my_tm);
+    TEST_CHECK(ret == NULL);
+}
+
+void test_seconds_since_epoch(void) {
+    struct flb_tm my_tm;
+    char *ret;
+    const char *buf = "0";
+    
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime(buf, "%s", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        check_tm_datetime_wday_yday(&my_tm.tm, 1970, 1, 1, 0, 0, 0, 4, 0);
+        TEST_CHECK(0 == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+        TEST_CHECK(strncmp("UTC", flb_tm_zone(&my_tm), 3) == 0);
+    }
+
+    const char *buf2 = "1678608000"; /* Corresponds to 2023-03-12 08:00:00 UTC */
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime(buf2, "%s", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        check_tm_datetime_wday_yday(&my_tm.tm, 2023, 3, 12, 8, 0, 0, 0 /* Sunday */, 70);
+        TEST_CHECK(0 == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+}
+
+void test_recursive_formats(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2024-01-20", "%F", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((2024 - 1900) == my_tm.tm.tm_year);
+        TEST_CHECK(0 == my_tm.tm.tm_mon); /* Jan */
+        TEST_CHECK(20 == my_tm.tm.tm_mday);
+    }
+}
+
+void test_timezone_z_numeric(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023-05-12 10:30:00Z", "%Y-%m-%d %H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        check_tm_datetime(&my_tm.tm, 2023, 5, 12, 10, 30, 0);
+        TEST_CHECK(0 == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+        TEST_CHECK(flb_tm_zone(&my_tm) != NULL &&
+            (strcmp(flb_tm_zone(&my_tm), "UTC") == 0 ||
+             strcmp(flb_tm_zone(&my_tm), "Z") == 0 ||
+             strcmp(flb_tm_zone(&my_tm), "utc") == 0));
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00+0530", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK(10 == my_tm.tm.tm_hour);
+        TEST_CHECK((long)(5.5 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00-0800", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK(10 == my_tm.tm.tm_hour);
+        TEST_CHECK((-8 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+    
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00+05:30", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK(10 == my_tm.tm.tm_hour);
+        TEST_CHECK((long)(5.5 * 3600) == flb_tm_gmtoff(&my_tm));
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00+05", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK(10 == my_tm.tm.tm_hour);
+        TEST_CHECK((5 * 3600) == flb_tm_gmtoff(&my_tm));
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("14:00:00 +01", "%H:%M:%S %z", &my_tm); /* TZ=Africa/Casablanca */
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((1 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+}
+
+void test_timezone_z_named_rfc822(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00GMT", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK(0 == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+        TEST_CHECK(strncmp("GMT", flb_tm_zone(&my_tm), 3) == 0);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00EST", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((-5 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+        TEST_CHECK(strncmp("EST", flb_tm_zone(&my_tm), 3) == 0);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("10:30:00EDT", "%H:%M:%S%z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((-4 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(1 == my_tm.tm.tm_isdst);
+        TEST_CHECK(strncmp("EDT", flb_tm_zone(&my_tm), 3) == 0);
+    }
+}
+
+
+void test_timezone_Z_known_list(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023-01-10 10:00:00 PST", "%Y-%m-%d %H:%M:%S %Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((-8 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst); /* PST is standard */
+        TEST_CHECK(strncmp("PST", flb_tm_zone(&my_tm), 3) == 0);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("14:00:00 cest", "%H:%M:%S %Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((2 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(1 == my_tm.tm.tm_isdst); /* CEST is daylight */
+        TEST_CHECK(strncmp("CEST", flb_tm_zone(&my_tm), 3) == 0);
+    }
+    
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("JST", "%Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((9 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("ICT", "%Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((7 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("WIB", "%Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((7 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("K", "%Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((10 * 3600) == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("PSTX", "%Z", &my_tm);
+    TEST_CHECK(ret == NULL);
+}
+
+void test_timezone_Z_fallback_gmt_utc(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("GMT", "%Z", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if(ret) {
+        TEST_CHECK(0 == flb_tm_gmtoff(&my_tm));
+        TEST_CHECK(0 == my_tm.tm.tm_isdst);
+        TEST_CHECK(strncmp("GMT", flb_tm_zone(&my_tm), 3) == 0);
+    }
+}
+
+void test_invalid_inputs(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("", "%Y", &my_tm);
+    TEST_CHECK(ret == NULL);
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023", "", &my_tm);
+    TEST_CHECK(ret != NULL);
+    TEST_CHECK(strncmp(ret, "2023", 4) == 0);
+
+    /* Mismatch */
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("abc", "%Y", &my_tm);
+    TEST_CHECK(ret == NULL);
+
+    /* Invalid month number */
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023-13-01", "%Y-%m-%d", &my_tm);
+    TEST_CHECK(ret == NULL);
+}
+
+void test_whitespace_handling(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("  2023-05-12  10:30:45  ", " %Y-%m-%d %H:%M:%S ", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if(ret) {
+        check_tm_datetime(&my_tm.tm, 2023, 5, 12, 10, 30, 45);
+
+        TEST_CHECK('\0' == *ret);
+    }
+
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023-05-12T10:30:45", "%Y-%m-%dT%H:%M:%S", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if(ret) {
+        check_tm_datetime(&my_tm.tm, 2023, 5, 12, 10, 30, 45);
+    }
+}
+
+void test_fill_yday_wday(void) {
+    struct flb_tm my_tm;
+    char *ret;
+
+    /* 2023-01-01 is a Sunday (wday=0), yday=0 */
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023-01-01", "%Y-%m-%d", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((2023 - 1900) == my_tm.tm.tm_year);
+        TEST_CHECK(0 == my_tm.tm.tm_mon);
+        TEST_CHECK(1 == my_tm.tm.tm_mday);
+        TEST_CHECK(0 == my_tm.tm.tm_yday); /* yday is 0-indexed */
+        TEST_CHECK(0 == my_tm.tm.tm_wday); /* Sunday */
+    }
+
+    /* 2023-12-31 is a Sunday (wday=0), yday=364 */
+    memset(&my_tm, 0, sizeof(my_tm));
+    ret = flb_strptime("2023-12-31", "%Y-%m-%d", &my_tm);
+    TEST_CHECK(ret != NULL);
+    if (ret) {
+        TEST_CHECK((2023 - 1900) == my_tm.tm.tm_year);
+        TEST_CHECK(11 == my_tm.tm.tm_mon);
+        TEST_CHECK(31 == my_tm.tm.tm_mday);
+        TEST_CHECK(364 == my_tm.tm.tm_yday);
+        TEST_CHECK(0 == my_tm.tm.tm_wday); /* Sunday */
+    }
+}
+
+
+TEST_LIST = {
+    { "basic_date_time", test_basic_date_time },
+    { "textual_month_day", test_textual_month_day },
+    { "year_variations", test_year_variations },
+    { "am_pm", test_am_pm },
+    { "seconds_since_epoch", test_seconds_since_epoch },
+    { "recursive_formats", test_recursive_formats },
+    { "timezone_z_numeric", test_timezone_z_numeric },
+    { "timezone_z_named_rfc822", test_timezone_z_named_rfc822 },
+    { "timezone_Z_known_list", test_timezone_Z_known_list },
+    { "timezone_Z_fallback_gmt_utc", test_timezone_Z_fallback_gmt_utc },
+    { "invalid_inputs", test_invalid_inputs },
+    { "whitespace_handling", test_whitespace_handling },
+    { "fill_yday_wday", test_fill_yday_wday },
+    { NULL, NULL }
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
I implemented a capability to process TimeZone strings.
Plus, `FLB_HAVE_ZONE` is currently nothing effective. This is a vestigial macro that was used or copied from the original BSD's strptime.c code.
Instead, we're able to use a detector which tries to compile the tm_zone member existence in `struct tm` to enable the conditional macro for tm_zone.
Also, I added basic scenarios to run assertions for time zone strings and other functionalities on flb_strptime. 

The corresponding issue is: https://github.com/fluent/fluent-bit/issues/10331

This is because internally, we use `flb_strptime` as a time format parser on flb_parser.c.
So, this change is effective for fluent-bit's parser.

---

The current supported time zone labels of 3-4 letter abbreviated strings:

# Supported Timezone Abbreviations

## UTC/GMT and Zulu

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                |
| :----------- | :----------------- | :--------------- | :----- | :------------------------- |
| `GMT`        | +00:00             | 0                | 0      | Greenwich Mean Time        |
| `UTC`        | +00:00             | 0                | 0      | Coordinated Universal Time |
| `Z`          | +00:00             | 0                | 0      | Zulu Time (UTC)            |
| `UT`         | +00:00             | 0                | 0      | Universal Time             |

## North American Timezones

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                                              |
| :----------- | :----------------- | :--------------- | :----- | :------------------------------------------------------- |
| `EST`        | -05:00             | -18000           | 0      | Eastern Standard Time                                    |
| `EDT`        | -04:00             | -14400           | 1      | Eastern Daylight Time                                    |
| `CST`        | -06:00             | -21600           | 0      | Central Standard Time (North America)                    |
| `CDT`        | -05:00             | -18000           | 1      | Central Daylight Time (North America)                    |
| `MST`        | -07:00             | -25200           | 0      | Mountain Standard Time                                   |
| `MDT`        | -06:00             | -21600           | 1      | Mountain Daylight Time                                   |
| `PST`        | -08:00             | -28800           | 0      | Pacific Standard Time                                    |
| `PDT`        | -07:00             | -25200           | 1      | Pacific Daylight Time                                    |
| `AKST`       | -09:00             | -32400           | 0      | Alaska Standard Time                                     |
| `AKDT`       | -08:00             | -28800           | 1      | Alaska Daylight Time                                     |
| `HST`        | -10:00             | -36000           | 0      | Hawaii Standard Time                                     |
| `HADT`       | -09:00             | -32400           | 1      | Hawaii-Aleutian Daylight Time (rarely used for Hawaii) |
| `AST`        | -04:00             | -14400           | 0      | Atlantic Standard Time (e.g., Canada, Caribbean)         |
| `ADT`        | -03:00             | -10800           | 1      | Atlantic Daylight Time                                   |
| `NST`        | -03:30             | -12600           | 0      | Newfoundland Standard Time                               |
| `NDT`        | -02:30             | -9000            | 1      | Newfoundland Daylight Time                               |

## European Timezones

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                      |
| :----------- | :----------------- | :--------------- | :----- | :------------------------------- |
| `WET`        | +00:00             | 0                | 0      | Western European Time            |
| `WEST`       | +01:00             | 3600             | 1      | Western European Summer Time     |
| `CET`        | +01:00             | 3600             | 0      | Central European Time            |
| `CEST`       | +02:00             | 7200             | 1      | Central European Summer Time     |
| `EET`        | +02:00             | 7200             | 0      | Eastern European Time            |
| `EEST`       | +03:00             | 10800            | 1      | Eastern European Summer Time     |
| `MSK`        | +03:00             | 10800            | 0      | Moscow Standard Time             |

## South American Timezones

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                                                              |
| :----------- | :----------------- | :--------------- | :----- | :----------------------------------------------------------------------- |
| `ART`        | -03:00             | -10800           | 0      | Argentina Time                                                           |
| `BRT`        | -03:00             | -10800           | 0      | Brazil Time (main population areas, can vary by region/DST)              |
| `BRST`       | -02:00             | -7200            | 1      | Brazil Summer Time (historical, not currently observed by all)           |
| `CLT`        | -04:00             | -14400           | 0      | Chile Standard Time                                                      |
| `CLST`       | -03:00             | -10800           | 1      | Chile Summer Time                                                        |

## Australasian / Oceanian Timezones

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                        |
| :----------- | :----------------- | :--------------- | :----- | :--------------------------------- |
| `AEST`       | +10:00             | 36000            | 0      | Australian Eastern Standard Time   |
| `AEDT`       | +11:00             | 39600            | 1      | Australian Eastern Daylight Time   |
| `ACST`       | +09:30             | 34200            | 0      | Australian Central Standard Time   |
| `ACDT`       | +10:30             | 37800            | 1      | Australian Central Daylight Time |
| `AWST`       | +08:00             | 28800            | 0      | Australian Western Standard Time   |
| `NZST`       | +12:00             | 43200            | 0      | New Zealand Standard Time          |
| `NZDT`       | +13:00             | 46800            | 1      | New Zealand Daylight Time          |

## Asian Timezones

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                                               |
| :----------- | :----------------- | :--------------- | :----- | :-------------------------------------------------------- |
| `JST`        | +09:00             | 32400            | 0      | Japan Standard Time                                       |
| `KST`        | +09:00             | 32400            | 0      | Korea Standard Time                                       |
| `SGT`        | +08:00             | 28800            | 0      | Singapore Time                                            |
| `IST`        | +05:30             | 19800            | 0      | India Standard Time                                       |
| `GST`        | +04:00             | 14400            | 0      | Gulf Standard Time (e.g., UAE, Oman)                    |
| `ICT`        | +07:00             | 25200            | 0      | Indochina Time (Thailand, Vietnam, Laos, Cambodia)        |
| `WIB`        | +07:00             | 25200            | 0      | Western Indonesian Time                                   |
| `WITA`       | +08:00             | 28800            | 0      | Central Indonesian Time                                   |
| `WIT`        | +09:00             | 32400            | 0      | Eastern Indonesian Time                                   |
| `MYT`        | +08:00             | 28800            | 0      | Malaysia Time                                             |
| `BDT`        | +06:00             | 21600            | 0      | Bangladesh Standard Time                                  |
| `NPT`        | +05:45             | 20700            | 0      | Nepal Time                                                |

## African Timezones

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                 |
| :----------- | :----------------- | :--------------- | :----- | :-------------------------- |
| `WAT`        | +01:00             | 3600             | 0      | West Africa Time            |
| `CAT`        | +02:00             | 7200             | 0      | Central Africa Time         |
| `EAT`        | +03:00             | 10800            | 0      | East Africa Time            |
| `SAST`       | +02:00             | 7200             | 0      | South Africa Standard Time  |

## Military Timezones

*These are single-letter UTC offset designators. 'J' (Juliett) represents local time and is not included. 'Z' (Zulu) is UTC and listed above.*

| Abbreviation | UTC Offset (HH:MM) | Offset (Seconds) | Is DST | Description                                             |
| :----------- | :----------------- | :--------------- | :----- | :------------------------------------------------------ |
| `A`          | +01:00             | 3600             | 0      | Alpha Time Zone                                         |
| `B`          | +02:00             | 7200             | 0      | Bravo Time Zone                                         |
| `C`          | +03:00             | 10800            | 0      | Charlie Time Zone                                       |
| `D`          | +04:00             | 14400            | 0      | Delta Time Zone                                         |
| `E`          | +05:00             | 18000            | 0      | Echo Time Zone                                          |
| `F`          | +06:00             | 21600            | 0      | Foxtrot Time Zone                                       |
| `G`          | +07:00             | 25200            | 0      | Golf Time Zone                                          |
| `H`          | +08:00             | 28800            | 0      | Hotel Time Zone                                         |
| `I`          | +09:00             | 32400            | 0      | India Time Zone (Military, not India Standard Time)     |
| `K`          | +10:00             | 36000            | 0      | Kilo Time Zone                                          |
| `L`          | +11:00             | 39600            | 0      | Lima Time Zone                                          |
| `M`          | +12:00             | 43200            | 0      | Mike Time Zone                                          |
| `N`          | -01:00             | -3600            | 0      | November Time Zone                                      |
| `O`          | -02:00             | -7200            | 0      | Oscar Time Zone                                         |
| `P`          | -03:00             | -10800           | 0      | Papa Time Zone                                          |
| `Q`          | -04:00             | -14400           | 0      | Quebec Time Zone                                        |
| `R`          | -05:00             | -18000           | 0      | Romeo Time Zone                                         |
| `S`          | -06:00             | -21600           | 0      | Sierra Time Zone                                        |
| `T`          | -07:00             | -25200           | 0      | Tango Time Zone                                         |
| `U`          | -08:00             | -28800           | 0      | Uniform Time Zone                                       |
| `V`          | -09:00             | -32400           | 0      | Victor Time Zone                                        |
| `W`          | -10:00             | -36000           | 0      | Whiskey Time Zone                                       |
| `X`          | -11:00             | -43200           | 0      | X-ray Time Zone                                         |
| `Y`          | -12:00             | -46800           | 0      | Yankee Time Zone                                        |

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/1687

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
