### PR TITLE
feat(filter_parser): Enable record accessor for Key_Name

### DIFF
--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_filter.h>
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_record_accessor.h>
 
 struct filter_parser {
     struct flb_parser *parser;

--- a/plugins/filter_parser/filter_parser.h
+++ b/plugins/filter_parser/filter_parser.h
@@ -37,6 +37,7 @@ struct filter_parser_ctx {
     int    preserve_key;
     struct mk_list parsers;
     struct flb_filter_instance *ins;
+    flb_record_accessor_t *ra_key_name;
 };
 
 #endif /* FLB_FILTER_PARSER_H */


### PR DESCRIPTION
This change enhances the Parser filter plugin to allow the 'Key_Name' parameter to use record accessor patterns. This enables you to specify nested fields for parsing, not just top-level keys.

Modifications include:
- Updated `filter_parser.c` to use `flb_ra_create` for `Key_Name` and `flb_ra_get_value_object` to retrieve the data for parsing.
- Adjusted `preserve_key` and `reserve_data` logic to accommodate record accessors, with simplifications for certain edge cases (e.g., `preserve_key` is less effective when `reserve_data` is off).
- Added `flb_record_accessor.h` include and ensured proper cleanup of the record accessor object.
- Introduced comprehensive unit tests in `tests/runtime/filter_parser.c` to validate the new functionality, covering nested keys, top-level keys via RA, `Reserve_Data`/`Preserve_Key` interactions, and non-existent keys.

This addresses the issue where you could not specify a nested key for parsing with the Parser filter.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
