### PR TITLE
Fix decompressor memset usage

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -628,14 +628,14 @@ static int flb_gzip_decompressor_process_body_chunk(
         return FLB_DECOMPRESSOR_FAILURE;
     }
 
-    processed_bytes  = context->input_buffer_length;;
+    processed_bytes  = context->input_buffer_length;
     processed_bytes -= inner_context->miniz_stream.avail_in;
 
     *output_length  -= inner_context->miniz_stream.avail_out;
 
 #ifdef FLB_DECOMPRESSOR_ERASE_DECOMPRESSED_DATA
     if (processed_bytes > 0) {
-        memset(context->read_buffer, processed_bytes);
+        memset(context->read_buffer, 0, processed_bytes);
     }
 #endif
 


### PR DESCRIPTION
## Summary
- zero-out decompressed bytes correctly

## Testing
- `cmake .. -DFLB_PARSER=Off -DFLB_STREAM_PROCESSOR=Off -DFLB_RECORD_ACCESSOR=Off -DFLB_PROCESSOR_SQL=Off -DFLB_TESTS_INTERNAL=On -DFLB_TESTS_RUNTIME=Off` *(fails: unknown CMake command `flex_target`)*
- `make -j2` *(fails: missing dependencies)*
