### PR TITLE
in_tcp: fix parsed bytes to include separator length

### DIFF
--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -228,7 +228,7 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
                 break;
             }
 
-            consumed += len + 1;
+            consumed += len + sep_len;
             buf += len + sep_len;
         }
         else {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixed malfunction when using a seperator longer than 1 charactor in tcp INPUT none format log.
Consumed length does not include the length of the separator.

I use `$endlog$\r\n` as a separator. As shown below, however part of the separator is included in the split logs, or some content from the previous log is replayed in the next one.

```json
{"log":"Hello, fluent-bit! 1"}
{"log":"Hello, fluent-bit! 2"}
{"log":"Hello, fluent-bit! 3"}
{"log":"lo, fluent-bit! 3"}
{"log":"endlog$\r\nHello, fluent-bit! 4"}
{"log":"endlog$\r\nHello, fluent-bit! 5"}
{"log":"endlog$\r\nHello, fluent-bit! 6"}
{"log":"endlog$\r\nHello, fluent-bit! 7"}
{"log":"Hello, fluent-bit! 8"}
{"log":"t-bit! 8"}
{"log":"endlog$\r\nHello, fluent-bit! 9"}
{"log":"endlog$\r\nHello, fluent-bit! 10"}
{"log":"endlog$\r\nHello, fluent-bit! 11"}
{"log":"Hello, fluent-bit! 12"}
{"log":"-bit! 12"}
{"log":"endlog$\r\nHello, fluent-bit! 13"}
{"log":"Hello, fluent-bit! 14"}
{"log":"-bit! 14"}
{"log":"Hello, fluent-bit! 15"}
{"log":"-bit! 15"}
{"log":"endlog$\r\nHello, fluent-bit! 16"}
{"log":"Hello, fluent-bit! 17"}
{"log":"-bit! 17"}
{"log":"endlog$\r\nHello, fluent-bit! 18"}
{"log":"endlog$\r\nHello, fluent-bit! 19"}
{"log":"Hello, fluent-bit! 20"}
```

After checking the code for parsing the "none" format of the TCP INPUT, I found that the length of the parsed data did not include the length of the separator. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
