### PR TITLE
config: implement storage inheritance option

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -247,6 +247,8 @@ struct flb_config {
     int   storage_bl_flush_on_shutdown; /* enable/disable backlog chunks flush on shutdown */
     struct flb_storage_metrics *storage_metrics_ctx; /* storage metrics context */
     int   storage_trim_files;       /* enable/disable file trimming */
+    char *storage_type;             /* global storage type */
+    int   storage_inherit;          /* apply storage type to inputs */
 
     /* Embedded SQL Database support (SQLite3) */
 #ifdef FLB_HAVE_SQLDB
@@ -400,6 +402,8 @@ enum conf_type {
 #define FLB_CONF_STORAGE_DELETE_IRRECOVERABLE_CHUNKS \
                                        "storage.delete_irrecoverable_chunks"
 #define FLB_CONF_STORAGE_TRIM_FILES    "storage.trim_files"
+#define FLB_CONF_STORAGE_TYPE          "storage.type"
+#define FLB_CONF_STORAGE_INHERIT       "storage.inherit"
 
 /* Coroutines */
 #define FLB_CONF_STR_CORO_STACK_SIZE "Coro_Stack_Size"

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -157,6 +157,12 @@ struct flb_service_config service_configs[] = {
     {FLB_CONF_STORAGE_TRIM_FILES,
      FLB_CONF_TYPE_BOOL,
      offsetof(struct flb_config, storage_trim_files)},
+    {FLB_CONF_STORAGE_TYPE,
+     FLB_CONF_TYPE_STR,
+     offsetof(struct flb_config, storage_type)},
+    {FLB_CONF_STORAGE_INHERIT,
+     FLB_CONF_TYPE_BOOL,
+     offsetof(struct flb_config, storage_inherit)},
 
     /* Coroutines */
     {FLB_CONF_STR_CORO_STACK_SIZE,
@@ -290,8 +296,9 @@ struct flb_config *flb_config_init()
     config->storage_path = NULL;
     config->storage_input_plugin = NULL;
     config->storage_metrics = FLB_TRUE;
+    config->storage_type = NULL;
+    config->storage_inherit = FLB_FALSE;
     config->storage_bl_flush_on_shutdown = FLB_FALSE;
-
     config->sched_cap  = FLB_SCHED_CAP;
     config->sched_base = FLB_SCHED_BASE;
 
@@ -526,6 +533,9 @@ void flb_config_exit(struct flb_config *config)
         flb_free(config->dns_resolver);
     }
 
+    if (config->storage_type) {
+        flb_free(config->storage_type);
+    }
     if (config->storage_path) {
         flb_free(config->storage_path);
     }

--- a/src/flb_storage.c
+++ b/src/flb_storage.c
@@ -502,7 +502,34 @@ int flb_storage_input_create(struct cio_ctx *cio,
 
     /* storage config: get stream type */
     if (in->storage_type == -1) {
-        in->storage_type = FLB_STORAGE_MEM;
+        /* Check if storage inheritance is enabled and configured */
+        if (in->config->storage_inherit == FLB_TRUE && in->config->storage_type != NULL) {
+            if (strcasecmp(in->config->storage_type, "filesystem") == 0) {
+                in->storage_type = FLB_STORAGE_FS;
+            }
+            else if (strcasecmp(in->config->storage_type, "memory") == 0) {
+                in->storage_type = FLB_STORAGE_MEM;
+            }
+            else if (strcasecmp(in->config->storage_type, "memrb") == 0) {
+                in->storage_type = FLB_STORAGE_MEMRB;
+            }
+            else {
+                /* Invalid global storage type, fall back to default */
+                flb_warn("[storage] input '%s': invalid global storage type '%s', using default 'memory'",
+                         flb_input_name(in), in->config->storage_type);
+                in->storage_type = FLB_STORAGE_MEM;
+            }
+        }
+        else if (in->config->storage_inherit == FLB_TRUE && in->config->storage_type == NULL) {
+            /* Storage inheritance enabled but no global storage type configured */
+            flb_warn("[storage] input '%s': storage inheritance enabled but no global storage type configured, using default 'memory'",
+                     flb_input_name(in));
+            in->storage_type = FLB_STORAGE_MEM;
+        }
+        else {
+            /* Use default storage type */
+            in->storage_type = FLB_STORAGE_MEM;
+        }
     }
 
     if (in->storage_type == FLB_STORAGE_FS && cio->options.root_path == NULL) {

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -49,7 +49,8 @@ set(UNIT_TESTS_FILES
   endianness.c
   task_map.c
   strptime.c
-  )
+  storage_inherit.c
+)
 
 # Config format
 set(UNIT_TESTS_FILES

--- a/tests/internal/storage_inherit.c
+++ b/tests/internal/storage_inherit.c
@@ -1,0 +1,202 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_storage.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_kv.h>
+#include "chunkio/chunkio.h"
+
+#include "flb_tests_internal.h"
+
+static void test_storage_inherit_enabled()
+{
+    struct flb_config *config;
+    struct flb_input_instance *in;
+    struct cio_ctx *cio;
+    struct cio_options opts = {0};
+    int ret;
+
+    /* Create config */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    /* Set global storage configuration */
+    config->storage_type = flb_strdup("filesystem");
+    config->storage_inherit = FLB_TRUE;
+    config->storage_path = flb_strdup("/tmp/flb-test");
+
+    /* Create CIO context */
+    cio_options_init(&opts);
+    opts.root_path = "/tmp/flb-test";
+    opts.flags = CIO_OPEN;
+    cio = cio_create(&opts);
+    TEST_CHECK(cio != NULL);
+    config->cio = cio;
+
+    /* Create an input instance without explicit storage.type */
+    in = flb_input_new(config, "dummy", NULL, FLB_FALSE);
+    TEST_CHECK(in != NULL);
+
+    /* Initialize storage - this should inherit filesystem from config */
+    ret = flb_storage_input_create(config->cio, in);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify storage type was inherited */
+    TEST_CHECK(in->storage_type == FLB_STORAGE_FS);
+
+    /* Cleanup */
+    flb_input_exit_all(config);
+    if (cio) {
+        cio_destroy(cio);
+    }
+    flb_config_exit(config);
+}
+
+static void test_storage_inherit_disabled()
+{
+    struct flb_config *config;
+    struct flb_input_instance *in;
+    struct cio_ctx *cio;
+    struct cio_options opts = {0};
+    int ret;
+
+    /* Create config */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    /* Set storage type but disable inheritance */
+    config->storage_type = flb_strdup("filesystem");
+    config->storage_inherit = FLB_FALSE;
+    config->storage_path = flb_strdup("/tmp/flb-test");
+
+    /* Create CIO context */
+    cio_options_init(&opts);
+    opts.root_path = "/tmp/flb-test";
+    opts.flags = CIO_OPEN;
+    cio = cio_create(&opts);
+    TEST_CHECK(cio != NULL);
+    config->cio = cio;
+
+    /* Create an input instance without explicit storage.type */
+    in = flb_input_new(config, "dummy", NULL, FLB_FALSE);
+    TEST_CHECK(in != NULL);
+
+    /* Initialize storage - this should use default memory */
+    ret = flb_storage_input_create(config->cio, in);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify storage type defaults to memory */
+    TEST_CHECK(in->storage_type == FLB_STORAGE_MEM);
+
+    /* Cleanup */
+    flb_input_exit_all(config);
+    if (cio) {
+        cio_destroy(cio);
+    }
+    flb_config_exit(config);
+}
+
+static void test_storage_explicit_override()
+{
+    struct flb_config *config;
+    struct flb_input_instance *in;
+    struct cio_ctx *cio;
+    struct cio_options opts = {0};
+    int ret;
+
+    /* Create config */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    /* Set global storage configuration */
+    config->storage_type = flb_strdup("filesystem");
+    config->storage_inherit = FLB_TRUE;
+    config->storage_path = flb_strdup("/tmp/flb-test");
+
+    /* Create CIO context */
+    cio_options_init(&opts);
+    opts.root_path = "/tmp/flb-test";
+    opts.flags = CIO_OPEN;
+    cio = cio_create(&opts);
+    TEST_CHECK(cio != NULL);
+    config->cio = cio;
+
+    /* Create an input instance with explicit storage.type */
+    in = flb_input_new(config, "dummy", NULL, FLB_FALSE);
+    TEST_CHECK(in != NULL);
+
+    /* Add explicit storage.type property */
+    flb_kv_item_create(&in->properties, "storage.type", "memory");
+
+    /* Process the property to set storage_type */
+    ret = flb_input_set_property(in, "storage.type", "memory");
+    TEST_CHECK(ret == 0);
+
+    /* Initialize storage - this should use explicit memory type */
+    ret = flb_storage_input_create(config->cio, in);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify explicit storage type overrides inheritance */
+    TEST_CHECK(in->storage_type == FLB_STORAGE_MEM);
+
+    /* Cleanup */
+    flb_input_exit_all(config);
+    if (cio) {
+        cio_destroy(cio);
+    }
+    flb_config_exit(config);
+}
+
+static void test_storage_inherit_invalid_type()
+{
+    struct flb_config *config;
+    struct flb_input_instance *in;
+    struct cio_ctx *cio;
+    struct cio_options opts = {0};
+    int ret;
+
+    /* Create config */
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    /* Set invalid global storage type */
+    config->storage_type = flb_strdup("invalid_type");
+    config->storage_inherit = FLB_TRUE;
+    config->storage_path = flb_strdup("/tmp/flb-test");
+
+    /* Create CIO context */
+    cio_options_init(&opts);
+    opts.root_path = "/tmp/flb-test";
+    opts.flags = CIO_OPEN;
+    cio = cio_create(&opts);
+    TEST_CHECK(cio != NULL);
+    config->cio = cio;
+
+    /* Create an input instance without explicit storage.type */
+    in = flb_input_new(config, "dummy", NULL, FLB_FALSE);
+    TEST_CHECK(in != NULL);
+
+    /* Initialize storage - should fallback to memory for invalid type */
+    ret = flb_storage_input_create(config->cio, in);
+    TEST_CHECK(ret == 0);
+    
+    /* Verify invalid type falls back to memory */
+    TEST_CHECK(in->storage_type == FLB_STORAGE_MEM);
+
+    /* Cleanup */
+    flb_input_exit_all(config);
+    if (cio) {
+        cio_destroy(cio);
+    }
+    flb_config_exit(config);
+}
+
+TEST_LIST = {
+    {"storage_inherit_enabled",      test_storage_inherit_enabled},
+    {"storage_inherit_disabled",     test_storage_inherit_disabled},
+    {"storage_explicit_override",    test_storage_explicit_override},
+    {"storage_inherit_invalid_type", test_storage_inherit_invalid_type},
+    {0}
+};


### PR DESCRIPTION
Adds storage inheritance logic allowing input instances to inherit global storage configuration.

Example configuration with global storage inheritance:
```ini
[SERVICE]
    storage.type filesystem
    storage.inherit on
    storage.path /tmp/fluent-bit-test
    flush 1
    daemon off

[INPUT]
    name dummy
    tag test.inherit
    # This input inherits filesystem storage from service

[INPUT] 
    name dummy
    tag test.override
    storage.type memory
    # This input overrides with explicit memory storage

[OUTPUT]
    name stdout
    match *
```

Expected behavior:
- First input uses filesystem storage (inherited from service)
- Second input uses memory storage (explicit override)
- Input instances without explicit storage.type inherit from global config when storage.inherit=on

Example configuration without global storage:
```ini
[SERVICE]
    storage.path /tmp/fluent-bit-test
    flush 1
    daemon off

[INPUT]
    name dummy
    tag test.default
    # Uses default memory storage (no inheritance)

[INPUT] 
    name dummy
    tag test.explicit
    storage.type filesystem
    # Uses explicit filesystem storage

[OUTPUT]
    name stdout
    match *
```

Expected behavior:
- First input defaults to memory storage
- Second input uses filesystem storage (explicit configuration)
- No inheritance occurs when storage.inherit is not enabled