### PR TITLE
utils: if flb_utils_write_str uses SIMD, add missing highbit_set check() detection

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -830,9 +830,11 @@ int flb_utils_write_str(char *buf, int *off, size_t size, const char *str, size_
              * in a char-by-char basis. Otherwise the do a bulk copy
              */
             if (flb_vector8_has_le(chunk, (unsigned char) 0x1F) ||
-                flb_vector8_has(chunk, (unsigned char)    '"') ||
-                flb_vector8_has(chunk, (unsigned char)    '\\')) {
+                flb_vector8_has(chunk, (unsigned char) '"')    ||
+                flb_vector8_has(chunk, (unsigned char) '\\')  ||
+                flb_vector8_is_highbit_set(chunk)) {
                 break;
+
             }
         }
 

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -369,6 +369,14 @@ void test_write_str_special_bytes()
             "\\u4f60\\u597d\\u4e16\\u754c",
             FLB_TRUE
         },
+        /*
+         * Escaped leading hex (two hex, one valid unicode)
+         */
+        {
+            "你好我来自一个汉字文化影响的地方", 48,
+            "\\u4f60\\u597d\\u6211\\u6765\\u81ea\\u4e00\\u4e2a\\u6c49\\u5b57\\u6587\\u5316\\u5f71\\u54cd\\u7684\\u5730\\u65b9",
+            FLB_TRUE
+        },
         {
             "\xC3\xA1\x0A", 3,  /* UTF-8 encoding of á and newline */
             "\\u00e1\\n",       /* Expected escaped output */


### PR DESCRIPTION
When SIMD is enabled and we do JSON escaping with flb_utils_write_str, we will vectorize the search for special characters that need escaping. The current implementation lacks the highbit check, some issues happens with special Chinese characters.

This PR adds a unit test and proper fix.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
