### PR TITLE
test: stream_processor: Plug a SEGV for macOS

### DIFF
--- a/tests/internal/stream_processor.c
+++ b/tests/internal/stream_processor.c
@@ -815,6 +815,7 @@ static void test_conv_from_str_to_num()
 
     config = flb_config_init();
     config->evl = mk_event_loop_create(256);
+    flb_engine_evl_init();
     flb_engine_evl_set(config->evl);
 
     ret = flb_storage_create(config);


### PR DESCRIPTION
Without TLS initialization, we got the following error on macOS:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x0000000100b0defc flb-it-stream_processor`_mk_event_timeout_create(ctx=0x0000000000000000, sec=0, nsec=500000000, data=0x0000600001608460) at mk_event_kqueue.c:222:23
   219         EV_SET(&ke, fd, EVFILT_TIMER, EV_ADD, 0, (sec * 1000) + (nsec / 1000000) , event);
   220     #endif
   221
-> 222         ret = kevent(ctx->kfd, &ke, 1, NULL, 0, NULL);
   223         if (ret < 0) {
   224             close(fd);
   225             mk_libc_error("kevent");
Target 0: (flb-it-stream_processor) stopped.
```

This can be plugged by TLS initialization for eventloop.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
