### PR TITLE
in_tail: only rely on fstat() to detect file rotation

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1406,16 +1406,21 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
         return FLB_TAIL_ERROR;
     }
 
-    /* Check if the file was truncated */
-    if (file->offset > st.st_size) {
+    int64_t size_delta = st.st_size - file->size;
+    if (size_delta != 0) {
+        file->size = st.st_size;
+    }
+
+    /* Check if the file was truncated by comparing current size with previous size */
+    if (size_delta < 0) {
         offset = lseek(file->fd, 0, SEEK_SET);
         if (offset == -1) {
             flb_errno();
             return FLB_TAIL_ERROR;
         }
 
-        flb_plg_debug(ctx->ins, "inode=%"PRIu64" file truncated %s",
-                      file->inode, file->name);
+        flb_plg_debug(ctx->ins, "adjust_counters: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
+                      file->inode, file->name, size_delta);
         file->offset = offset;
         file->buf_len = 0;
 
@@ -1427,8 +1432,8 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
 #endif
     }
     else {
-        file->size = st.st_size;
-        file->pending_bytes = (st.st_size - file->offset);
+        // Avoid negative pending_bytes when fstat() has stale data and size < offset
+        file->pending_bytes = (st.st_size > file->offset) ? (st.st_size - file->offset) : 0;
     }
 
     return FLB_TAIL_OK;

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -222,8 +222,14 @@ static int tail_fs_event(struct flb_input_instance *ins,
         flb_tail_file_remove(file);
         return 0;
     }
-    file->size = st.st_size;
-    file->pending_bytes = (file->size - file->offset);
+
+    /* Check if the file was truncated */
+    int64_t size_delta = st.st_size - file->size;
+    if (size_delta != 0) {
+        file->size = st.st_size;
+    }
+
+    file->pending_bytes = (st.st_size > file->offset) ? (st.st_size - file->offset) : 0;
 
     /* File was removed ? */
     if (ev.mask & IN_ATTRIB) {
@@ -250,16 +256,15 @@ static int tail_fs_event(struct flb_input_instance *ins,
          * we have.
          */
 
-        /* Check if the file was truncated */
-        if (file->offset > st.st_size) {
+        if (size_delta < 0) {
             offset = lseek(file->fd, 0, SEEK_SET);
             if (offset == -1) {
                 flb_errno();
                 return -1;
             }
 
-            flb_plg_debug(ctx->ins, "inode=%"PRIu64" file truncated %s",
-                          file->inode, file->name);
+            flb_plg_debug(ctx->ins, "tail_fs_event: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
+                          file->inode, file->name, size_delta);
             file->offset = offset;
             file->buf_len = 0;
 

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -119,15 +119,21 @@ static int tail_fs_check(struct flb_input_instance *ins,
             continue;
         }
 
+        int64_t size_delta = st.st_size - file->size;
+        if (size_delta != 0) {
+            file->size = st.st_size;
+        }
+
         /* Check if the file was truncated */
-        if (file->offset > st.st_size) {
+        if (size_delta < 0) {
             offset = lseek(file->fd, 0, SEEK_SET);
             if (offset == -1) {
                 flb_errno();
                 return -1;
             }
 
-            flb_plg_debug(ctx->ins, "file truncated %s", file->name);
+            flb_plg_debug(ctx->ins, "tail_fs_check: file truncated %s (diff: %"PRId64" bytes)", 
+                         file->name, size_delta);
             file->offset = offset;
             file->buf_len = 0;
             memcpy(&fst->st, &st, sizeof(struct stat));


### PR DESCRIPTION
Only rely on filestat() to assume a file is rotated. 

Currently the stream position is compared with the file size. In file systems with metadata cache, the filestat() results might be out of sync with the actual file.

https://techcommunity.microsoft.com/blog/azurestorageblog/announcing-the-public-preview-of-metadata-caching-for-azure-premium-smb-file-sha/4046390

This results in fluentbit thinking the file is truncated over and over again, reingesting the log files almost endlessly.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
