### PR TITLE
in_http: validate memory allocation and fix object type on tag key

### DIFF
--- a/plugins/in_http/http_config.c
+++ b/plugins/in_http/http_config.c
@@ -58,6 +58,12 @@ struct flb_http *http_config_create(struct flb_input_instance *ins)
 
     /* HTTP Server specifics */
     ctx->server = flb_calloc(1, sizeof(struct mk_server));
+    if (!ctx->server) {
+        flb_errno();
+        http_config_destroy(ctx);
+        return NULL;
+    }
+
     ctx->server->keep_alive = MK_TRUE;
 
     /* monkey detects server->workers == 0 as the server not being initialized at the

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -187,7 +187,7 @@ static flb_sds_t tag_key(struct flb_http *ctx, msgpack_object *map)
                 val = (kv+j)->val;
                 if (val.type == MSGPACK_OBJECT_BIN) {
                     val_str  = (char *) val.via.bin.ptr;
-                    val_str_size = val.via.str.size;
+                    val_str_size = val.via.bin.size;
                     found = FLB_TRUE;
                     break;
                 }
@@ -1005,7 +1005,7 @@ static int send_response_ng(struct flb_http_response *response,
         flb_http_response_set_message(response, "No Content");
     }
     else if (http_status == 400) {
-        flb_http_response_set_message(response, "Forbidden");
+        flb_http_response_set_message(response, "Bad Request");
     }
 
     if (http_status == 200 ||


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
