### PR TITLE
install: update install script to handle Rocky/Alma repos now

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ cat /etc/yum.repos.d/fluent-bit.repo
 $INSTALL_CMD_PREFIX yum -y $YUM_PARAMETERS install $INSTALL_PACKAGE_NAME$YUM_VERSION
 SCRIPT
     ;;
-    centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora|rocky|almalinux)
+    centos|centoslinux|rhel|redhatenterpriselinuxserver|fedora)
         # We need variable expansion and non-expansion on the URL line to pick up the base URL.
         # Therefore we combine things with sed to handle it.
         $SUDO sh <<SCRIPT
@@ -83,6 +83,43 @@ cat << EOF > /etc/yum.repos.d/fluent-bit.repo
 name = Fluent Bit
 # Legacy server style
 baseurl = $RELEASE_URL/centos/VERSION_SUBSTR
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=$RELEASE_KEY
+enabled=1
+EOF
+sed -i 's|VERSION_SUBSTR|\$releasever/|g' /etc/yum.repos.d/fluent-bit.repo
+cat /etc/yum.repos.d/fluent-bit.repo
+$INSTALL_CMD_PREFIX yum -y $YUM_PARAMETERS install $INSTALL_PACKAGE_NAME$YUM_VERSION
+SCRIPT
+    ;;
+    # For Rocky and AlmaLinux, we provide new repos now CentOS no longer tracks downstream.
+    almalinux)
+        $SUDO sh <<SCRIPT
+rpm --import $RELEASE_KEY
+cat << EOF > /etc/yum.repos.d/fluent-bit.repo
+[fluent-bit]
+name = Fluent Bit
+# Legacy server style
+baseurl = $RELEASE_URL/$OS/VERSION_SUBSTR
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=$RELEASE_KEY
+enabled=1
+EOF
+sed -i 's|VERSION_SUBSTR|\$releasever/|g' /etc/yum.repos.d/fluent-bit.repo
+cat /etc/yum.repos.d/fluent-bit.repo
+$INSTALL_CMD_PREFIX yum -y $YUM_PARAMETERS install $INSTALL_PACKAGE_NAME$YUM_VERSION
+SCRIPT
+    ;;
+    rocky|rockylinux)
+        $SUDO sh <<SCRIPT
+rpm --import $RELEASE_KEY
+cat << EOF > /etc/yum.repos.d/fluent-bit.repo
+[fluent-bit]
+name = Fluent Bit
+# Legacy server style
+baseurl = $RELEASE_URL/rockylinux/VERSION_SUBSTR
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=$RELEASE_KEY


### PR DESCRIPTION
Resolves #10415 and #10333 by ensuring the one-line install script will automatically use the dedicated repos for AlmaLinux and RockyLinux.

Also see https://github.com/fluent/fluent-bit-docs/pull/1708

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
