### PR TITLE
out_s3: ensure uploads are not completed when a chunk upload is in progress

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1511,6 +1511,38 @@ static struct multipart_upload *get_upload(struct flb_s3 *ctx,
     return m_upload;
 }
 
+/*
+ * Check if there is a locked chunk for the provided tag. A locked chunk
+ * indicates that an UploadPart request is currently in progress and the
+ * multipart upload should not be completed yet.
+ */
+static int has_locked_chunk(struct flb_s3 *ctx, const char *tag, int tag_len)
+{
+    struct mk_list       *head;
+    struct mk_list       *tmp;
+    struct flb_fstore_file *fsf;
+    struct s3_file       *chunk;
+
+    mk_list_foreach_safe(head, tmp, &ctx->stream_active->files) {
+        fsf = mk_list_entry(head, struct flb_fstore_file, _head);
+        chunk = fsf->data;
+
+        if (fsf->meta_size != tag_len) {
+            continue;
+        }
+
+        if (strncmp((char *) fsf->meta_buf, tag, tag_len) != 0) {
+            continue;
+        }
+
+        if (chunk->locked == FLB_TRUE) {
+            return FLB_TRUE;
+        }
+    }
+
+    return FLB_FALSE;
+}
+
 static struct multipart_upload *create_upload(struct flb_s3 *ctx, const char *tag,
                                               int tag_len, time_t file_first_log_time)
 {
@@ -1827,6 +1859,10 @@ static void cb_s3_upload(struct flb_config *config, void *data)
             complete = FLB_TRUE;
         }
         if (time(NULL) > (m_upload->init_time + ctx->upload_timeout + ctx->retry_time)) {
+            /* Avoid completing the upload while a part is still being uploaded */
+            if (has_locked_chunk(ctx, m_upload->tag, flb_sds_len(m_upload->tag))) {
+                continue;
+            }
             flb_plg_info(ctx->ins, "Completing upload for %s because upload_timeout"
                          " has passed", m_upload->s3_key);
             complete = FLB_TRUE;


### PR DESCRIPTION
Introduce has_locked_chunk to detect active part uploads and skip completion when a chunk is locked. This ensures only one CompleteMultipartUpload happens after all parts finish uploading, avoiding multipart failures due to prematurely completing the upload.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
