### PR TITLE
install: set umask to 022 before writing the GPG key to avoid permission issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ SCRIPT
         $SUDO sh <<SCRIPT
 export DEBIAN_FRONTEND=noninteractive
 mkdir -p /usr/share/keyrings/
-curl $RELEASE_KEY | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
+( umask 022 ; curl $RELEASE_KEY | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg)
 cat > /etc/apt/sources.list.d/fluent-bit.list <<EOF
 deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] $RELEASE_URL/${OS}/${CODENAME} ${CODENAME} main
 EOF


### PR DESCRIPTION
On hosts with a "non-standard" umask (for security), the key file can be created with unexpencted permissions which on some distributions (Ubuntu 24.04 confirmed) causes errors suggesting that NO_PUBKEY is available. Refer to https://github.com/fluent/fluent-bit/issues/10161

Fixes https://github.com/fluent/fluent-bit/issues/10161

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Set umask to `077` and create a test file to demonstrate resulting permissions (`rw-------`):

```
$ umask 077
$ touch test
$ ll test
-rw------- 1 phs phs 0 Jun  3 14:09 test
$ rm test
```

Run the old command, demonstrate same permissions are set:

```
$ curl $RELEASE_KEY | gpg --dearmor > key-with-umask077.gpg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3175  100  3175    0     0   4161      0 --:--:-- --:--:-- --:--:--  4161
$ ll
total 4.0K
drwxr-xr-x  2 phs  phs    80 Jun  3 14:09 .
drwxrwxrwt 14 root root  320 Jun  3 14:08 ..
-rw-------  1 phs  phs  2.3K Jun  3 14:09 key-with-umask077.gpg
```

Wrapped in the subshell + umask gives expected permissions which avoid the apt error on 24.04:

```
$ (umask 022 ; curl $RELEASE_KEY | gpg --dearmor > key-with-umask022.gpg)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3175  100  3175    0     0  10748      0 --:--:-- --:--:-- --:--:-- 10762
$ ll
total 8.0K
drwxr-xr-x  2 phs  phs    80 Jun  3 14:09 .
drwxrwxrwt 14 root root  320 Jun  3 14:08 ..
-rw-r--r--  1 phs  phs  2.3K Jun  3 14:09 key-with-umask022.gpg
-rw-------  1 phs  phs  2.3K Jun  3 14:09 key-with-umask077.gpg
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
