### PR TITLE
log_event_decoder: validate memory allocation

### DIFF
--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -124,6 +124,10 @@ struct flb_log_event_decoder *flb_log_event_decoder_create(
 
     context = (struct flb_log_event_decoder *) \
         flb_calloc(1, sizeof(struct flb_log_event_decoder));
+    if (!context) {
+        flb_errno();
+        return NULL;
+    }
 
     result = flb_log_event_decoder_init(context,
                                         input_buffer,


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
