### PR TITLE
in_http: add configurable health endpoint

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -234,6 +234,11 @@ static struct flb_config_map config_map[] = {
      "Set successful response code. 200, 201 and 204 are supported."
     },
 
+    {
+     FLB_CONFIG_MAP_BOOL, "health_check", "false",
+     0, FLB_TRUE, offsetof(struct flb_http, enable_health_endpoint),
+     "Enable health check endpoint accessible via GET /health"
+    },
 
     /* EOF */
     {0}

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -61,6 +61,9 @@ struct flb_http {
     struct mk_server *server;
 
     int collector_id;
+
+    /* Health endpoint configuration */
+    int enable_health_endpoint;
 };
 
 

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -778,7 +778,7 @@ static int http_prot_uncompress(struct flb_http *ctx,
     return 0;
 }
 
-static int  process_payload(struct flb_http *ctx, struct http_conn *conn,
+static int process_payload(struct flb_http *ctx, struct http_conn *conn,
                            flb_sds_t tag,
                            struct mk_http_session *session,
                            struct mk_http_request *request)
@@ -1003,12 +1003,14 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
 
     if (request->method != MK_METHOD_POST) {
         flb_sds_destroy(tag);
+        mk_mem_free(uri);
         send_response(conn, 400, "error: invalid HTTP method\n");
         return -1;
     }
 
     ret = process_payload(ctx, conn, tag, session, request);
     flb_sds_destroy(tag);
+    mk_mem_free(uri);
 
     if (ret == 0) {
         send_response(conn, ctx->successful_response_code, NULL);

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -34,6 +34,7 @@
 
 #define HTTP_CONTENT_JSON       0
 #define HTTP_CONTENT_URLENCODED 1
+#define HTTP_HEALTH_ENDPOINT    "/health"
 
 static inline char hex2nibble(char c)
 {
@@ -95,7 +96,7 @@ cfl_sds_t get_health_message()
              tm_time.tm_year + 1900, tm_time.tm_mon + 1, tm_time.tm_mday,
              tm_time.tm_hour, tm_time.tm_min, tm_time.tm_sec, tm.tm.tv_nsec);
 
-    msg = cfl_sds_create_size(256);
+    msg = cfl_sds_create_size(512);
     if (!msg) {
         return NULL;
     }
@@ -103,10 +104,11 @@ cfl_sds_t get_health_message()
     cfl_sds_printf(&msg,
                   "{\n"
                   "  \"status\": \"ok\",\n"
-                  "  \"message\": \"I can only show you the door. You're the one that has to walk through it.\",\n"
+                  "  \"version\": \"%s\",\n"
+                  "  \"git_hash\": \"%s\",\n"
                   "  \"timestamp\": \"%s\"\n"
                   "}\n",
-                  time_str);
+                  FLB_VERSION_STR, FLB_GIT_HASH, time_str);
 
     return msg;
 }
@@ -990,7 +992,7 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
         request->_content_length.data = NULL;
     }
 
-    if (request->method == MK_METHOD_GET && strcmp(uri, "/health") == 0) {
+    if (request->method == MK_METHOD_GET && strcmp(uri, HTTP_HEALTH_ENDPOINT) == 0 && ctx->enable_health_endpoint) {
         flb_sds_destroy(tag);
         mk_mem_free(uri);
         health = get_health_message();
@@ -1324,7 +1326,7 @@ int http_prot_handle_ng(struct flb_http_request *request,
         return -1;
     }
 
-    if (request->method == HTTP_METHOD_GET && strcmp(request->path, "/health") == 0) {
+    if (request->method == HTTP_METHOD_GET && strcmp(request->path, HTTP_HEALTH_ENDPOINT) == 0 && ctx->enable_health_endpoint) {
         flb_sds_destroy(tag);
         health = get_health_message();
         send_response_ng(response, 200, health);

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -81,6 +81,36 @@ static int sds_uri_decode(flb_sds_t s)
     return 0;
 }
 
+cfl_sds_t get_health_message()
+{
+    char time_str[128];
+    cfl_sds_t msg = NULL;
+    struct tm tm_time;
+    struct flb_time tm;
+
+    flb_time_get(&tm);
+    gmtime_r(&tm.tm.tv_sec, &tm_time);
+
+    snprintf(time_str, sizeof(time_str) - 1, "%04d-%02d-%02dT%02d:%02d:%02d.%09ldZ",
+             tm_time.tm_year + 1900, tm_time.tm_mon + 1, tm_time.tm_mday,
+             tm_time.tm_hour, tm_time.tm_min, tm_time.tm_sec, tm.tm.tv_nsec);
+
+    msg = cfl_sds_create_size(256);
+    if (!msg) {
+        return NULL;
+    }
+
+    cfl_sds_printf(&msg,
+                  "{\n"
+                  "  \"status\": \"ok\",\n"
+                  "  \"message\": \"I can only show you the door. You're the one that has to walk through it.\",\n"
+                  "  \"timestamp\": \"%s\"\n"
+                  "}\n",
+                  time_str);
+
+    return msg;
+}
+
 static int send_response(struct http_conn *conn, int http_status, char *message)
 {
     struct flb_http *context;
@@ -112,13 +142,25 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
                        context->success_headers_str);
     }
     else if (http_status == 200) {
-        flb_sds_printf(&out,
-                       "HTTP/1.1 200 OK\r\n"
-                       "Server: Fluent Bit v%s\r\n"
-                       "%s"
-                       "Content-Length: 0\r\n\r\n",
-                       FLB_VERSION_STR,
-                       context->success_headers_str);
+        if (len > 0) {
+            flb_sds_printf(&out,
+                "HTTP/1.1 200 OK\r\n"
+                "Server: Fluent Bit v%s\r\n"
+                "%s"
+                "Content-Length: %i\r\n\r\n%s",
+                FLB_VERSION_STR,
+                context->success_headers_str,
+                len, message);
+        }
+        else {
+            flb_sds_printf(&out,
+                        "HTTP/1.1 200 OK\r\n"
+                        "Server: Fluent Bit v%s\r\n"
+                        "%s"
+                        "Content-Length: 0\r\n\r\n",
+                        FLB_VERSION_STR,
+                        context->success_headers_str);
+            }
     }
     else if (http_status == 204) {
         flb_sds_printf(&out,
@@ -734,7 +776,7 @@ static int http_prot_uncompress(struct flb_http *ctx,
     return 0;
 }
 
-static int process_payload(struct flb_http *ctx, struct http_conn *conn,
+static int  process_payload(struct flb_http *ctx, struct http_conn *conn,
                            flb_sds_t tag,
                            struct mk_http_session *session,
                            struct mk_http_request *request)
@@ -868,6 +910,7 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
     int len;
     char *uri;
     char *qs;
+    flb_sds_t health;
     off_t diff;
     flb_sds_t tag;
     struct mk_http_header *header;
@@ -920,8 +963,6 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
         }
     }
 
-    mk_mem_free(uri);
-
     /* Check if we have a Host header: Hostname ; port */
     mk_http_point_header(&request->host, &session->parser, MK_HEADER_HOST);
 
@@ -932,6 +973,7 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
     /* HTTP/1.1 needs Host header */
     if (!request->host.data && request->protocol == MK_HTTP_PROTOCOL_11) {
         flb_sds_destroy(tag);
+        mk_mem_free(uri);
         return -1;
     }
 
@@ -946,6 +988,15 @@ int http_prot_handle(struct flb_http *ctx, struct http_conn *conn,
     }
     else {
         request->_content_length.data = NULL;
+    }
+
+    if (request->method == MK_METHOD_GET && strcmp(uri, "/health") == 0) {
+        flb_sds_destroy(tag);
+        mk_mem_free(uri);
+        health = get_health_message();
+        ret = send_response(conn, 200, health);
+        flb_sds_destroy(health);
+        return ret;
     }
 
     if (request->method != MK_METHOD_POST) {
@@ -1233,7 +1284,9 @@ int http_prot_handle_ng(struct flb_http_request *request,
     int                             ret;
     int                             len;
     flb_sds_t                       tag;
+    flb_sds_t                       health;
     struct flb_http                *ctx;
+
 
     ctx = (struct flb_http *) response->stream->user_data;
     if (request->path[0] != '/') {
@@ -1271,6 +1324,13 @@ int http_prot_handle_ng(struct flb_http_request *request,
         return -1;
     }
 
+    if (request->method == HTTP_METHOD_GET && strcmp(request->path, "/health") == 0) {
+        flb_sds_destroy(tag);
+        health = get_health_message();
+        send_response_ng(response, 200, health);
+        flb_sds_destroy(health);
+        return 0;
+    }
     if (request->method != HTTP_METHOD_POST) {
         send_response_ng(response, 400, "error: invalid HTTP method\n");
         flb_sds_destroy(tag);


### PR DESCRIPTION
Add optional health endpoint accessible via GET /health when enabled.

The endpoint returns JSON with status, version, git hash and timestamp. Please note that this endpoint is disabled by default.

The health_check configuration directive enables the endpoint:
```yaml
inputs:
  - name: http
    port: 9880
    health_check: true
```

When enabled, GET /health returns:
```json
{
  "status": "ok",
  "version": "4.0.0", 
  "git_hash": "9e84b08f0b69bf27d3307c31e08de90b4395f5e1",
  "timestamp": "2025-06-05T15:43:17.398269000Z"
}
```

Fixes #10003
Supersedes PR #10020