### PR TITLE
filter_lua: add groups metadata and body support

### DIFF
--- a/include/fluent-bit/flb_processor.h
+++ b/include/fluent-bit/flb_processor.h
@@ -232,6 +232,7 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
                                                      char *unit_name);
 void flb_processor_unit_destroy(struct flb_processor_unit *pu);
 int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k, struct cfl_variant *v);
+int flb_processor_unit_set_property_str(struct flb_processor_unit *pu, const char *k, const char *v);
 
 int flb_processors_load_from_config_format_group(struct flb_processor *proc, struct flb_cf_group *g);
 

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -457,7 +457,7 @@ static int flb_processor_unit_set_condition(struct flb_processor_unit *pu, struc
         value_count = 1;
 
         /* Check that IN and NOT_IN operators only work with array values */
-        if ((rule_op == FLB_RULE_OP_IN || rule_op == FLB_RULE_OP_NOT_IN) && 
+        if ((rule_op == FLB_RULE_OP_IN || rule_op == FLB_RULE_OP_NOT_IN) &&
             rule_val->type != CFL_VARIANT_ARRAY) {
             flb_error("[processor] 'in' and 'not_in' operators require array values, got %d type instead",
                     rule_val->type);
@@ -500,7 +500,7 @@ static int flb_processor_unit_set_condition(struct flb_processor_unit *pu, struc
                 flb_condition_destroy(condition);
                 return -1;
             }
-            
+
             /* Mark that we've allocated an array value */
             is_array_value = 1;
 
@@ -545,9 +545,9 @@ static int flb_processor_unit_set_condition(struct flb_processor_unit *pu, struc
         /* Add rule to the condition */
         ret = flb_condition_add_rule(condition, field, rule_op, value, value_count, context);
 
-        /* 
-         * Free array value if we allocated it. For 'in' and 'not_in' operators, 
-         * flb_condition_add_rule makes its own copy of the strings in the array, 
+        /*
+         * Free array value if we allocated it. For 'in' and 'not_in' operators,
+         * flb_condition_add_rule makes its own copy of the strings in the array,
          * so we need to free our copies whether or not the rule was added successfully.
          */
         if (is_array_value) {
@@ -609,6 +609,26 @@ int flb_processor_unit_set_property(struct flb_processor_unit *pu, const char *k
     return flb_processor_instance_set_property(
             (struct flb_processor_instance *) pu->ctx,
             k, v);
+}
+
+int flb_processor_unit_set_property_str(struct flb_processor_unit *pu, const char *k, const char *v)
+{
+    int ret;
+    struct cfl_variant *val;
+
+    if (!pu || !k || !v) {
+        return -1;
+    }
+
+    val = cfl_variant_create_from_string((char *) v);
+    if (!val) {
+        return -1;
+    }
+
+    ret = flb_processor_unit_set_property(pu, k, val);
+    cfl_variant_destroy(val);
+
+    return ret;
 }
 
 void flb_processor_unit_destroy(struct flb_processor_unit *pu)


### PR DESCRIPTION
Current Lua filter did not process the groups definitions, so when it process data that contains these metadata such as payloads coming from OpenTelemetry the groups definitions were dropped. 

This PR implements groups support allowing to work normally, this is a configuration example:

```yaml
pipeline:
  inputs:
    - name: dummy
      dummy: "{\"message\": \"Hello, Fluent Bit!\"}"
      metadata: "{\"record_meta\": \"ok\"}"

      processors:
        logs:
          - name: opentelemetry_envelope

          - name: content_modifier
            context: otel_resource_attributes
            action: insert
            key: my_res_attr
            value: my_value

          - name: content_modifier
            context: otel_scope_attributes
            action: insert
            key: my_scope_attr
            value: my_value


          - name: lua
            time_as_table: true
            call: noop
            code: |
              function noop(tag, timestamp, record)
                record["new_field"] = "This is a new field from Lua"
                return 1, timestamp, record
              end

  outputs:
    - name: stdout
      match: "*"
```

stdout / output

```bash
GROUP METADATA : 

{"schema"=>"otlp", "resource_id"=>0, "scope_id"=>0}

GROUP ATTRIBUTES : 

{"resource"=>{"attributes"=>{"my_res_attr"=>"my_value"}}, "scope"=>{"attributes"=>{"my_scope_attr"=>"my_value"}}}

[0] dummy.0: [[1749184962.814868525, {"record_meta"=>"ok"}], {"message"=>"Hello, Fluent Bit!", "new_field"=>"This is a new field from Lua"}]
```

In this PR I also added unit tests to check groups checking under different conditions for different return values

- modified (1)
- no modified (0)
- drop (-1)

Note: if the Lua script removed all the records and the group is empty, the group is removed as well.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
