### PR TITLE
lib: lwrb: build it as a static lib instead of an interface

### DIFF
--- a/lib/lwrb/lwrb/CMakeLists.txt
+++ b/lib/lwrb/lwrb/CMakeLists.txt
@@ -1,14 +1,12 @@
 #cmake_minimum_required(VERSION 3.22)
 
-# Debug message
-message("Entering ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt")
+# Register core library once and link it statically
+add_library(lwrb STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/src/lwrb/lwrb.c
+)
 
-# Register core library
-add_library(lwrb INTERFACE)
-target_sources(lwrb INTERFACE ${CMAKE_CURRENT_LIST_DIR}/src/lwrb/lwrb.c)
-target_include_directories(lwrb INTERFACE ${CMAKE_CURRENT_LIST_DIR}/src/include)
+target_include_directories(lwrb PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/src/include
+)
 
-# Register other modules
-
-# Debug message
-message("Exiting ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt")
+set_target_properties(lwrb PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This PR fix the build rules for lwrb library to avoid repeated compilation across plugins: every plugin was compiling lwrb over and over.


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
