### PR TITLE
http_server: add new API to configure the maximum buffer size

### DIFF
--- a/include/fluent-bit/http_server/flb_http_server.h
+++ b/include/fluent-bit/http_server/flb_http_server.h
@@ -46,6 +46,7 @@
 #define HTTP_SERVER_SUCCESS                    0
 #define HTTP_SERVER_PROVIDER_ERROR            -1
 #define HTTP_SERVER_ALLOCATION_ERROR          -2
+#define HTTP_SERVER_BUFFER_LIMIT_EXCEEDED     -3
 
 #define HTTP_SERVER_UNINITIALIZED              0
 #define HTTP_SERVER_INITIALIZED                1
@@ -76,6 +77,7 @@ struct flb_http_server {
     flb_http_server_request_processor_callback
                            request_callback;
     void                  *user_data;
+    size_t                 buffer_max_size;
 };
 
 struct flb_http_server_session {
@@ -120,6 +122,10 @@ int flb_http_server_start(struct flb_http_server *session);
 int flb_http_server_stop(struct flb_http_server *session);
 
 int flb_http_server_destroy(struct flb_http_server *session);
+
+void flb_http_server_set_buffer_max_size(struct flb_http_server *server, size_t size);
+
+size_t flb_http_server_get_buffer_max_size(struct flb_http_server *server);
 
 /* HTTP SESSION */
 

--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -172,6 +172,8 @@ static int in_elasticsearch_bulk_init(struct flb_input_instance *ins,
             return -1;
         }
 
+        flb_http_server_set_buffer_max_size(&ctx->http_server, ctx->buffer_max_size);
+
         ctx->http_server.request_callback = in_elasticsearch_bulk_prot_handle_ng;
 
         flb_input_downstream_set(ctx->http_server.downstream, ctx->ins);

--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -129,6 +129,8 @@ static int in_http_init(struct flb_input_instance *ins,
             return -1;
         }
 
+        flb_http_server_set_buffer_max_size(&ctx->http_server, ctx->buffer_max_size);
+
         ctx->http_server.request_callback = http_prot_handle_ng;
 
         flb_input_downstream_set(ctx->http_server.downstream, ctx->ins);

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -129,6 +129,14 @@ static int send_response(struct http_conn *conn, int http_status, char *message)
                        FLB_VERSION_STR,
                        context->success_headers_str);
     }
+    else if (http_status == 413) {
+        flb_sds_printf(&out,
+                       "HTTP/1.1 413 Request Entity Too Large\r\n"
+                       "Server: Fluent Bit v%s\r\n"
+                       "Content-Length: %i\r\n\r\n%s",
+                       FLB_VERSION_STR,
+                       len, message ? message : "");
+    }
     else if (http_status == 400) {
         flb_sds_printf(&out,
                        "HTTP/1.1 400 Bad Request\r\n"
@@ -1006,6 +1014,9 @@ static int send_response_ng(struct flb_http_response *response,
     }
     else if (http_status == 400) {
         flb_http_response_set_message(response, "Bad Request");
+    }
+    else if (http_status == 413) {
+        flb_http_response_set_message(response, "Payload Too Large");
     }
 
     if (http_status == 200 ||

--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -126,6 +126,8 @@ static int in_opentelemetry_init(struct flb_input_instance *ins,
             return -1;
         }
 
+        flb_http_server_set_buffer_max_size(&ctx->http_server, ctx->buffer_max_size);
+
         ctx->http_server.request_callback = opentelemetry_prot_handle_ng;
 
         flb_input_downstream_set(ctx->http_server.downstream, ctx->ins);

--- a/plugins/in_prometheus_remote_write/prom_rw.c
+++ b/plugins/in_prometheus_remote_write/prom_rw.c
@@ -126,6 +126,8 @@ static int prom_rw_init(struct flb_input_instance *ins,
             return -1;
         }
 
+        flb_http_server_set_buffer_max_size(&ctx->http_server, ctx->buffer_max_size);
+
         ctx->http_server.request_callback = prom_rw_prot_handle_ng;
 
         flb_input_downstream_set(ctx->http_server.downstream, ctx->ins);

--- a/plugins/in_splunk/splunk.c
+++ b/plugins/in_splunk/splunk.c
@@ -130,6 +130,8 @@ static int in_splunk_init(struct flb_input_instance *ins,
             return -1;
         }
 
+        flb_http_server_set_buffer_max_size(&ctx->http_server, ctx->buffer_max_size);
+
         ctx->http_server.request_callback = splunk_prot_handle_ng;
 
         flb_input_downstream_set(ctx->http_server.downstream, ctx->ins);


### PR DESCRIPTION
The HTTP Server interface, which supports HTTP/2 with fallback to HTTP/1, now includes an API to configure the maximum buffer size per client during data ingestion. If a client exceeds this limit, a 413 Payload Too Large error is returned.

This PR updates the following input plugins to use the new API:

- in_elasticsearch
- in_http
- in_opentelemetry
- in_prometheus_remote_write
- in_splunk

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
