### PR TITLE
processor_content_modifier: fix leak on JSON conversion and data type

### DIFF
--- a/plugins/processor_content_modifier/cm_utils.c
+++ b/plugins/processor_content_modifier/cm_utils.c
@@ -151,6 +151,7 @@ cfl_sds_t cm_utils_variant_convert_to_json(struct cfl_variant *value)
     mpack_writer_destroy(&writer);
 
     json_result = flb_msgpack_raw_to_json_sds(data, size);
+    MPACK_FREE(data);
 
     return json_result;
 }

--- a/plugins/processor_content_modifier/cm_utils.h
+++ b/plugins/processor_content_modifier/cm_utils.h
@@ -595,7 +595,7 @@ static inline int unpack_cfl_variant(mpack_reader_t *reader,
     if (value_type == mpack_type_str) {
         result = unpack_cfl_variant_string(reader, value);
     }
-    else if (value_type == mpack_type_str) {
+    else if (value_type == mpack_type_bool) {
         result = unpack_cfl_variant_boolean(reader, value);
     }
     else if (value_type == mpack_type_int) {


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
