### PR TITLE
out_opentelemetry: fix leaks on exceptions

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -199,6 +199,9 @@ static int check_proxy(struct flb_output_instance *ins,
             return -1;
         }
 
+        if (ctx->proxy_host) {
+            flb_free(ctx->proxy_host);
+        }
         ctx->proxy_host = host;
         ctx->proxy_port = atoi(port);
         ctx->proxy = tmp;
@@ -274,6 +277,7 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
     /* Parse 'add_label' */
     ret = config_add_labels(ins, ctx);
     if (ret == -1) {
+        flb_opentelemetry_context_destroy(ctx);
         return NULL;
     }
 

--- a/plugins/out_opentelemetry/opentelemetry_logs.c
+++ b/plugins/out_opentelemetry/opentelemetry_logs.c
@@ -1172,6 +1172,8 @@ start_resource:
         if (ret == -1) {
             /* the only possible fail path is a problem with a memory allocation, let's suggest a FLB_RETRY */
             ret = FLB_RETRY;
+            flb_free(log_record);
+            log_records[log_record_count] = NULL;
             break;
         }
 
@@ -1180,6 +1182,11 @@ start_resource:
         if (ret == -1) {
             /* as before, it can only fail on a memory allocation */
             ret = FLB_RETRY;
+            if (log_record->body) {
+                otlp_any_value_destroy(log_record->body);
+            }
+            flb_free(log_record);
+            log_records[log_record_count] = NULL;
             break;
         }
 


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
