### PR TITLE
out_cloudwatch_logs: fix strcasestr _GNU_SOURCE

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -17,6 +17,9 @@
  *  limitations under the License.
  */
 
+#define _GNU_SOURCE
+#include <string.h>
+
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
@@ -41,7 +44,6 @@
 
 #include <monkey/mk_core.h>
 #include <msgpack.h>
-#include <string.h>
 #include <stdio.h>
 
 #ifndef FLB_SYSTEM_WINDOWS


### PR DESCRIPTION
See https://autobuild.buildroot.org/results/ade/ade1783e6a8a9025a4fc12a8370d479662b84ec4/build-end.log.

```
In file included from /workdir/instance-0/output-1/build/fluent-bit-4.0.2/lib/cfl/lib/xxhash/xxh3.h:55,
                 from /workdir/instance-0/output-1/build/fluent-bit-4.0.2/lib/cfl/include/cfl/cfl_hash.h:26,
                 from /workdir/instance-0/output-1/build/fluent-bit-4.0.2/lib/cfl/include/cfl/cfl.h:33,
                 from /workdir/instance-0/output-1/build/fluent-bit-4.0.2/include/fluent-bit/flb_config_map.h:27,
                 from /workdir/instance-0/output-1/build/fluent-bit-4.0.2/include/fluent-bit/flb_output.h:36,
                 from /workdir/instance-0/output-1/build/fluent-bit-4.0.2/plugins/out_cloudwatch_logs/cloudwatch_api.c:22:
/workdir/instance-0/output-1/build/fluent-bit-4.0.2/lib/cfl/lib/xxhash/xxhash.h:3962:5: warning: #warning "XXH3 is highly inefficient without ARM or Thumb-2." [-Wcpp]
 3962 | #   warning "XXH3 is highly inefficient without ARM or Thumb-2."
      |     ^~~~~~~
/workdir/instance-0/output-1/build/fluent-bit-4.0.2/plugins/out_cloudwatch_logs/cloudwatch_api.c: In function 'put_log_events':
/workdir/instance-0/output-1/build/fluent-bit-4.0.2/plugins/out_cloudwatch_logs/cloudwatch_api.c:1540:66: error: implicit declaration of function 'strcasestr'; did you mean 'strcasecmp'? [-Wimplicit-function-declaration]
 1540 |             if (c->resp.data == NULL || c->resp.data_len == 0 || strcasestr(c->resp.data, AMZN_REQUEST_ID_HEADER) == NULL) {
      |                                                                  ^~~~~~~~~~
      |                                                                  strcasecmp
```