### PR TITLE
filter_lua: add support to access groups and metadata

### DIFF
--- a/cmake/plugins_options.cmake
+++ b/cmake/plugins_options.cmake
@@ -85,7 +85,6 @@ DEFINE_OPTION(FLB_FILTER_GREP                 "Enable grep filter"              
 DEFINE_OPTION(FLB_FILTER_KUBERNETES           "Enable kubernetes filter"                     ON)
 DEFINE_OPTION(FLB_FILTER_LOG_TO_METRICS       "Enable log-derived metrics filter"            ON)
 DEFINE_OPTION(FLB_FILTER_LUA                  "Enable Lua scripting filter"                  ON)
-DEFINE_OPTION(FLB_FILTER_LUA_USE_MPACK        "Enable mpack on the lua filter"               OFF)
 DEFINE_OPTION(FLB_FILTER_MODIFY               "Enable modify filter"                         ON)
 DEFINE_OPTION(FLB_FILTER_MULTILINE            "Enable multiline filter"                      ON)
 DEFINE_OPTION(FLB_FILTER_NEST                 "Enable nest filter"                           ON)

--- a/plugins/filter_lua/CMakeLists.txt
+++ b/plugins/filter_lua/CMakeLists.txt
@@ -8,6 +8,3 @@ else()
   FLB_PLUGIN(filter_lua "${src}" "m")
 endif()
 
-if(FLB_FILTER_LUA_USE_MPACK)
-    add_definitions(-DFLB_FILTER_LUA_USE_MPACK)
-endif()

--- a/plugins/filter_lua/lua.c
+++ b/plugins/filter_lua/lua.c
@@ -36,7 +36,6 @@
 #include "fluent-bit/flb_mem.h"
 #include "lua.h"
 #include "lua_config.h"
-#include "mpack/mpack.h"
 
 /* helper to rollback encoder buffer to previous offset */
 static inline void encoder_rollback(struct flb_log_event_encoder *enc,
@@ -826,11 +825,7 @@ struct flb_filter_plugin filter_lua_plugin = {
     .description  = "Lua Scripting Filter",
     .cb_pre_run   = cb_lua_pre_run,
     .cb_init      = cb_lua_init,
-#ifdef FLB_FILTER_LUA_USE_MPACK
-    .cb_filter    = cb_lua_filter_mpack,
-#else
     .cb_filter    = cb_lua_filter,
-#endif
     .cb_exit      = cb_lua_exit,
     .config_map   = config_map,
     .flags        = 0

--- a/plugins/filter_lua/lua_config.h
+++ b/plugins/filter_lua/lua_config.h
@@ -40,6 +40,9 @@ struct lua_filter {
     struct flb_luajit *lua;           /* state context   */
     struct flb_filter_instance *ins;  /* filter instance */
     flb_sds_t packbuf;                /* dynamic buffer used for mpack write */
+    int cb_args;                      /* number of callback arguments */
+    int cb_expected_returns;          /* expected return values from Lua */
+
 };
 
 struct lua_filter *lua_config_create(struct flb_filter_instance *ins,

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_log_event.h>
 #include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_sds.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -133,7 +134,8 @@ int callback_cat(void* data, size_t size, void* cb_data)
 static char *get_group_metadata(void *chunk, size_t size)
 {
     int ret;
-    char *json;
+    flb_sds_t out_buf;
+    size_t out_size = 1024;
     struct flb_log_event log_event;
     struct flb_log_event_decoder log_decoder;
 
@@ -147,15 +149,29 @@ static char *get_group_metadata(void *chunk, size_t size)
         return NULL;
     }
 
-    json = flb_msgpack_to_json_str(1024, log_event.metadata);
+    /* get metadata entry in JSON */
+    out_buf = flb_sds_create_size(out_size);
+    if (!out_buf) {
+        flb_error("failed to allocate out_buf");
+        return NULL;
+    }
+
+    ret = flb_msgpack_to_json(out_buf, out_size, log_event.metadata);
+    if (ret < 0) {
+        flb_sds_destroy(out_buf);
+        flb_log_event_decoder_destroy(&log_decoder);
+        return NULL;
+    }
+
     flb_log_event_decoder_destroy(&log_decoder);
-    return json;
+    return out_buf;
 }
 
 static char *get_group_body(void *chunk, size_t size)
 {
     int ret;
-    char *json;
+    flb_sds_t out_buf;
+    size_t out_size = 1024;
     struct flb_log_event log_event;
     struct flb_log_event_decoder log_decoder;
 
@@ -169,33 +185,87 @@ static char *get_group_body(void *chunk, size_t size)
         return NULL;
     }
 
-    json = flb_msgpack_to_json_str(1024, log_event.body);
+    /* get metadata entry in JSON */
+    out_buf = flb_sds_create_size(out_size);
+    if (!out_buf) {
+        flb_error("failed to allocate out_buf");
+        return NULL;
+    }
+
+    ret = flb_msgpack_to_json(out_buf, out_size, log_event.body);
+    if (ret < 0) {
+        flb_sds_destroy(out_buf);
+        flb_log_event_decoder_destroy(&log_decoder);
+        return NULL;
+    }
+
     flb_log_event_decoder_destroy(&log_decoder);
-    return json;
+    return out_buf;
 }
 
 static char *get_log_body(void *chunk, size_t size)
 {
     int ret;
-    char *json;
+    flb_sds_t out_buf;
+    size_t out_size = 1024;
     struct flb_log_event log_event;
     struct flb_log_event_decoder log_decoder;
 
     ret = flb_log_event_decoder_init(&log_decoder, chunk, size);
     TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
 
-    flb_log_event_decoder_read_groups(&log_decoder, FLB_TRUE);
-
-    /* 0: group header */
     flb_log_event_decoder_next(&log_decoder, &log_event);
 
-    /* 1: record */
-    flb_log_event_decoder_next(&log_decoder, &log_event);
+    /* get metadata entry in JSON */
+    out_buf = flb_sds_create_size(out_size);
+    if (!out_buf) {
+        flb_error("failed to allocate out_buf");
+        return NULL;
+    }
 
-    json = flb_msgpack_to_json_str(1024, log_event.body);
+    ret = flb_msgpack_to_json(out_buf, out_size, log_event.body);
+    if (ret < 0) {
+        flb_sds_destroy(out_buf);
+        flb_log_event_decoder_destroy(&log_decoder);
+        return NULL;
+    }
 
     flb_log_event_decoder_destroy(&log_decoder);
-    return json;
+    return out_buf;
+}
+
+static char *get_record_metadata(void *chunk, size_t size)
+{
+    int ret;
+    size_t out_size = 1024;
+    flb_sds_t out_buf;
+    struct flb_log_event log_event;
+    struct flb_log_event_decoder log_decoder;
+
+    ret = flb_log_event_decoder_init(&log_decoder, chunk, size);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+
+    ret = flb_log_event_decoder_next(&log_decoder, &log_event);
+    if (ret != FLB_EVENT_DECODER_SUCCESS) {
+        return NULL;
+    }
+
+    /* get metadata entry in JSON */
+    out_buf = flb_sds_create_size(out_size);
+    if (!out_buf) {
+        flb_error("failed to allocate out_buf");
+        return NULL;
+    }
+
+    ret = flb_msgpack_to_json(out_buf, out_size, log_event.metadata);
+    if (ret < 0) {
+        flb_sds_destroy(out_buf);
+        flb_log_event_decoder_destroy(&log_decoder);
+        return NULL;
+    }
+
+    flb_log_event_decoder_destroy(&log_decoder);
+    return out_buf;
 }
 
 void delete_script()
@@ -203,6 +273,10 @@ void delete_script()
     unlink(TMP_LUA_PATH);
     flb_debug("remove script\n");
 }
+
+/* callback used by flb_test_five_args */
+static int cb_check_metadata_modified(void *chunk, size_t size, void *data);
+static int cb_check_metadata_array(void *chunk, size_t size, void *data);
 
 
 int create_script(char *script_body, size_t body_size)
@@ -974,7 +1048,7 @@ void flb_test_empty_array(void)
     flb_sds_destroy(outbuf);
 }
 
-void flb_test_invalid_metatable(void)
+void flb_test_invalid_metatable()
 {
     int ret;
     flb_ctx_t *ctx;
@@ -1048,6 +1122,115 @@ void flb_test_invalid_metatable(void)
     flb_destroy(ctx);
 }
 
+void flb_test_metadata_single_record()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    const char *script = "function lua_main(tag, ts, group, metadata, record)\n"\
+                        "  metadata['stream'] = 'custom'\n"\
+                        "  record['extra'] = 'yes'\n"\
+                        "  return 1, ts, metadata, record\n"\
+                        "end";
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_metadata_modified;
+    cb_data.data = NULL;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *)"lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    flb_filter_set(ctx, filter_ffd,
+                   "Match", "*",
+                   "call", "lua_main",
+                   "code", script,
+                   NULL);
+
+    in_ffd = flb_input(ctx, (char *)"dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "dummy", "{\"msg\":\"hi\"}", NULL);
+    flb_input_set(ctx, in_ffd, "metadata", "{\"stream\":\"orig\"}", NULL);
+
+    out_ffd = flb_output(ctx, (char *)"lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "data_mode", "chunk",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2000);
+
+    ret = get_output_num();
+    TEST_CHECK(ret > 0);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_metadata_array(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    struct flb_lib_out_cb cb_data;
+
+    const char *script = "function lua_main(tag, ts, group, metadata, record)\n"\
+                        "  return 1, ts, { {stream='one'}, {stream='two'} }, { {msg='a'}, {msg='b'} }\n"\
+                        "end";
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_metadata_array;
+    cb_data.data = NULL;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
+
+    filter_ffd = flb_filter(ctx, (char *)"lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    flb_filter_set(ctx, filter_ffd,
+                   "Match", "*",
+                   "call", "lua_main",
+                   "code", script,
+                   NULL);
+
+    in_ffd = flb_input(ctx, (char *)"dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "dummy", "{\"foo\":\"bar\"}", NULL);
+
+    out_ffd = flb_output(ctx, (char *)"lib", (void *)&cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "*",
+                   "data_mode", "chunk",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2000);
+
+    ret = get_output_num();
+    TEST_CHECK(ret == 2);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* validate group handling with processors and Lua filter */
 static int cb_check_group(void *chunk, size_t size, void *data)
 {
@@ -1055,10 +1238,11 @@ static int cb_check_group(void *chunk, size_t size, void *data)
     char *json;
 
     json = get_group_metadata(chunk, size);
+
     TEST_CHECK(json != NULL);
     if (json) {
         TEST_CHECK(strcmp(json, "{\"schema\":\"otlp\",\"resource_id\":0,\"scope_id\":0}") == 0);
-        flb_free(json);
+        flb_sds_destroy(json);
     }
 
     json = get_group_body(chunk, size);
@@ -1066,7 +1250,7 @@ static int cb_check_group(void *chunk, size_t size, void *data)
     if (json) {
         TEST_CHECK(strstr(json, "\"my_res_attr\":\"my_value\"") != NULL);
         TEST_CHECK(strstr(json, "\"my_scope_attr\":\"my_value\"") != NULL);
-        flb_free(json);
+        flb_sds_destroy(json);
     }
 
     json = get_log_body(chunk, size);
@@ -1074,7 +1258,7 @@ static int cb_check_group(void *chunk, size_t size, void *data)
     if (json) {
         TEST_CHECK(strstr(json, "Hello, Fluent Bit!") != NULL);
         TEST_CHECK(strstr(json, "This is a new field from Lua") != NULL);
-        flb_free(json);
+        flb_sds_destroy(json);
     }
 
     set_output_num(num + 1);
@@ -1091,7 +1275,7 @@ static int cb_check_group_no_modified(void *chunk, size_t size, void *data)
     TEST_CHECK(json != NULL);
     if (json) {
         TEST_CHECK(strcmp(json, "{\"schema\":\"otlp\",\"resource_id\":0,\"scope_id\":0}") == 0);
-        flb_free(json);
+        flb_sds_destroy(json);
     }
 
     json = get_group_body(chunk, size);
@@ -1099,17 +1283,77 @@ static int cb_check_group_no_modified(void *chunk, size_t size, void *data)
     if (json) {
         TEST_CHECK(strstr(json, "\"my_res_attr\":\"my_value\"") != NULL);
         TEST_CHECK(strstr(json, "\"my_scope_attr\":\"my_value\"") != NULL);
-        flb_free(json);
+        flb_sds_destroy(json);
     }
 
     json = get_log_body(chunk, size);
     TEST_CHECK(json != NULL);
     if (json) {
         TEST_CHECK(strstr(json, "Hello, Fluent Bit!") != NULL);
-        flb_free(json);
+        flb_sds_destroy(json);
     }
 
     set_output_num(num + 1);
+    return 0;
+}
+
+static int cb_check_metadata_modified(void *chunk, size_t size, void *data)
+{
+    int num = get_output_num();
+    char *json;
+
+    json = get_record_metadata(chunk, size);
+    TEST_CHECK(json != NULL);
+    if (json) {
+        TEST_CHECK(strstr(json, "\"stream\":\"custom\"") != NULL);
+        flb_sds_destroy(json);
+    }
+
+    json = get_log_body(chunk, size);
+    TEST_CHECK(json != NULL);
+    if (json) {
+        TEST_CHECK(strstr(json, "\"extra\":\"yes\"") != NULL);
+        flb_sds_destroy(json);
+    }
+
+    set_output_num(num + 1);
+    return 0;
+}
+
+static int cb_check_metadata_array(void *chunk, size_t size, void *data)
+{
+    int num = get_output_num();
+    int idx = 0;
+    struct flb_log_event log_event;
+    struct flb_log_event_decoder dec;
+    int ret;
+
+    ret = flb_log_event_decoder_init(&dec, chunk, size);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+
+    while ((ret = flb_log_event_decoder_next(&dec, &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+        char *meta = flb_msgpack_to_json_str(256, log_event.metadata);
+        char *body = flb_msgpack_to_json_str(256, log_event.body);
+
+        TEST_CHECK(meta != NULL && body != NULL);
+        if (meta && body) {
+            if (idx == 0) {
+                TEST_CHECK(strstr(meta, "\"stream\":\"one\"") != NULL);
+                TEST_CHECK(strstr(body, "\"msg\":\"a\"") != NULL);
+            }
+            else if (idx == 1) {
+                TEST_CHECK(strstr(meta, "\"stream\":\"two\"") != NULL);
+                TEST_CHECK(strstr(body, "\"msg\":\"b\"") != NULL);
+            }
+            flb_free(meta);
+            flb_free(body);
+        }
+        idx++;
+    }
+
+    flb_log_event_decoder_destroy(&dec);
+    set_output_num(num + idx);
+
     return 0;
 }
 
@@ -1347,6 +1591,8 @@ TEST_LIST = {
     {"split_record", flb_test_split_record},
     {"empty_array", flb_test_empty_array},
     {"invalid_metatable", flb_test_invalid_metatable},
+    {"metadata_single_record", flb_test_metadata_single_record},
+    {"metadata_array", flb_test_metadata_array},
     {"group_lua_processor_modified", flb_test_group_lua_processor_modified},
     {"group_lua_processor_no_modified", flb_test_group_lua_processor_no_modified},
     {"group_lua_drop", flb_test_group_lua_drop},


### PR DESCRIPTION
Prior to this change, the Lua filter in Fluent Bit supported processing of individual log records with a function signature that allowed modifying the timestamp and the record only:

```lua
function append_tag(tag, timestamp, record)
    ...
    return 1, timestamp, record
end
```

This PR introduces an optional extended prototype that allows access to group metadata and record metadata, making the function more powerful and better suited for structured formats like OpenTelemetry Logs.

## New function signature

The new supported Lua function prototype is:

```lua
function cb_metadata(tag, timestamp, group, metadata, record)
    ...
    return 1, timestamp, metadata, record
end
```

### Arguments:

- `tag`: the input tag of the log record.
- `timestamp`: the timestamp of the log record.
- `group`: a read-only table that contains group-level metadata (e.g., OpenTelemetry resource or scope info). This will be an empty table if the log is not part of a group.
- `metadata`: a table representing the record-specific metadata. You may modify this if needed.
- `record`: the actual log record table, same as in the original signature.

### Return Values:

The function must return exactly 4 values, in the following order:

- Return Code:
  - `1`: Record was modified.
  - `0`: Record was not modified.
  - `-1`: Record should be dropped.
- Timestamp: The updated timestamp.
- Metadata Table: A new or modified metadata table.
- Record Table: A new or modified log record.

### How Fluent Bit Chooses the Function Signature ?

At load time, the Lua filter analyzes the function signature by checking the number of parameters. If the Lua function accepts:

- 3 arguments: it assumes the classic mode (tag, timestamp, record)
- 5 arguments: it uses the metadata-aware mode (tag, timestamp, group, metadata, record)

This ensures backward compatibility with existing Lua scripts.

Support for Returning Arrays (Multiple Records)
-----------------------------------------------

As with the original Lua callback design, the function may optionally return multiple records
as arrays.

When using the metadata-aware prototype, you must return:

```lua
return 1, timestamp, {metadata_1, metadata_2, ...}, {record_1, record_2, ...}
```

Example:

```lua
function cb_metadata(tag, ts, group, metadata, record)
    -- first record with its metadata
    m1 = {foo = "meta1"}
    r1 = {msg = "first log", old_record = record}

    -- second record with its metadata
    m2 = {foo = "meta2"}
    r2 = {msg = "second log", old_record = record}

    return 1, ts, {m1, m2}, {r1, r2}
end
```

note: The metadata and record arrays must be the same length.

## OpenTelemetry Test

The following is a simple OpenTelemetry Test logs, we ingest a log with Curl, receive it with Fluent Bit OpenTelemetry input plugin, process it with Lua and print the results to stdout:

### JSON log

```json
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          { "key": "service.name", "value": { "stringValue": "my-app" } },
          { "key": "host.name", "value": { "stringValue": "localhost" } }
        ]
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "example-logger",
            "version": "1.0.0"
          },
          "logRecords": [
            {
              "timeUnixNano": "1717920000000000000",
              "severityNumber": 9,
              "severityText": "INFO",
              "body": {
                "stringValue": "User logged in successfully"
              },
              "attributes": [
                { "key": "user.id", "value": { "stringValue": "12345" } },
                { "key": "env", "value": { "stringValue": "prod" } }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```

### Fluent Bit Configuration

The inline Lua script will put the OTLP service name inside the log record (body) and change the severity from 9 to 13 if this has been set as part of the record metadata:

```yaml
pipeline:
  inputs:
    - name: opentelemetry
      port: 4318
      processors:
        logs:
          - name: lua
            call: cb_groups_and_metadata
            code: |
              function cb_groups_and_metadata(tag, timestamp, group, metadata, record)
                -- copy the OTLP metadata 'service.name' to the record
                if group['resource']['attributes']['service.name'] then
                  record['service_name'] = group['resource']['attributes']['service.name']
                end

                -- change OTLP Log severity by modifying the record metadata
                if metadata['otlp']['severity_number'] then
                  if metadata['otlp']['severity_number'] == 9 then
                    -- change severity 9 to 13
                    metadata['otlp']['severity_number'] = 13
                    metadata['otlp']['severity_text '] = 'WARN'
                  end
                end

                return 1, timestamp, metadata, record
              end


  outputs:
    - name : stdout
      match: '*'
```

### Use Curl to send the data to Fluent Bit 

```bash
curl -X POST http://localhost:4318/v1/logs \
  -H "Content-Type: application/json" \
  --data-binary @otel-log.json
```

## Final comments:

- Group metadata is read-only and should not be modified.
- If you don’t need group or metadata support, you can continue using the 3-argument prototype.
- Mixed return types (single record vs array) are supported, but must follow the proper structure.
- This PR __REMOVES__ the MPACK version of the Lua code serializer just to avoid duplicating code and logic.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
