### PR TITLE
network: general fixes for failure states

### DIFF
--- a/src/aws/flb_aws_credentials.c
+++ b/src/aws/flb_aws_credentials.c
@@ -361,7 +361,7 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
     key_max_len = key_prefix_len + 12; /* max length of
                                               "region", "sts_endpoint", "role_arn",
                                               "external_id" */
-    
+
     /* Evaluate full config keys */
     config_key_region = flb_sds_create_len(config_key_prefix, key_max_len);
     strcpy(config_key_region + key_prefix_len, "region");
@@ -462,10 +462,10 @@ struct flb_aws_provider *flb_managed_chain_provider_create(struct flb_output_ins
     /* initialize credentials in sync mode */
     aws_provider->provider_vtable->sync(aws_provider);
     aws_provider->provider_vtable->init(aws_provider);
-    
+
     /* set back to async */
     aws_provider->provider_vtable->async(aws_provider);
-    
+
     /* store dependencies in aws_provider for managed cleanup */
     aws_provider->base_aws_provider = base_aws_provider;
     aws_provider->cred_tls = cred_tls;
@@ -509,6 +509,9 @@ cleanup:
     }
     if (session_name) {
         flb_free(session_name);
+    }
+    if (config_key_profile) {
+        flb_sds_destroy(config_key_profile);
     }
 
     return aws_provider;
@@ -838,9 +841,9 @@ time_t flb_aws_cred_expiration(const char *timestamp)
 }
 
 /*
- * Fluent Bit is now multi-threaded and asynchonous with coros. 
+ * Fluent Bit is now multi-threaded and asynchonous with coros.
  * The trylock prevents deadlock, and protects the provider
- * when a cred refresh happens. The refresh frees and 
+ * when a cred refresh happens. The refresh frees and
  * sets the shared cred cache, a double free could occur
  * if two threads do it at the same exact time.
  */

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -824,7 +824,11 @@ struct flb_http_client *flb_http_client(struct flb_connection *u_conn,
         c->flags |= FLB_HTTP_11;
     }
 
-    add_host_and_content_length(c);
+    ret = add_host_and_content_length(c);
+    if (ret != 0) {
+        flb_http_client_destroy(c);
+        return NULL;
+    }
 
     /* Check proxy data */
     if (proxy) {

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -477,6 +477,12 @@ static int net_connect_sync(int fd, const struct sockaddr *addr, socklen_t addrl
                       fd, host, port);
             goto exit_error;
         }
+
+        /* check the connection status */
+        socket_errno = flb_socket_error(fd);
+        if (socket_errno != 0) {
+            goto exit_error;
+        }
     }
 
     /*

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -670,6 +670,12 @@ static void flb_net_dns_lookup_context_drop(struct flb_dns_lookup_context *looku
     if (!lookup_context->dropped) {
         lookup_context->dropped = FLB_TRUE;
 
+        if (lookup_context->ares_socket_registered) {
+            mk_event_del(lookup_context->event_loop,
+                         &lookup_context->response_event);
+            lookup_context->ares_socket_registered = FLB_FALSE;
+        }
+
         mk_list_del(&lookup_context->_head);
         mk_list_add(&lookup_context->_head, &lookup_context->dns_ctx->lookups_drop);
 

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -685,6 +685,7 @@ int flb_upstream_conn_recycle(struct flb_connection *conn, int val)
 {
     if (val == FLB_TRUE || val == FLB_FALSE) {
         conn->recycle = val;
+        return 0;
     }
 
     return -1;

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -530,6 +530,7 @@ static int prepare_destroy_conn(struct flb_connection *u_conn)
     /* Add node to destroy queue */
     mk_list_add(&u_conn->_head, &uq->destroy_queue);
 
+
     flb_upstream_decrement_total_connections_count(u);
 
     /*
@@ -555,8 +556,13 @@ static inline int prepare_destroy_conn_safe(struct flb_connection *u_conn)
 
 static int destroy_conn(struct flb_connection *u_conn)
 {
-    /* Delay the destruction of busy connections */
-    if (u_conn->busy_flag) {
+    /*
+     * Delay the destruction if the connection is still marked busy or
+     * if there are pending events referencing it (e.g. queued in the
+     * priority bucket queue).
+     */
+    if (u_conn->busy_flag ||
+        u_conn->event._priority_head.prev != NULL) {
         return 0;
     }
 
@@ -614,8 +620,9 @@ static struct flb_connection *create_conn(struct flb_upstream *u)
         flb_debug("[upstream] connection #%i failed to %s:%i",
                   conn->fd, u->tcp_host, u->tcp_port);
 
-        prepare_destroy_conn_safe(conn);
+        /* allow the connection to be destroyed immediately */
         conn->busy_flag = FLB_FALSE;
+        prepare_destroy_conn_safe(conn);
 
         return NULL;
     }
@@ -647,16 +654,19 @@ int flb_upstream_destroy(struct flb_upstream *u)
 
     mk_list_foreach_safe(head, tmp, &uq->av_queue) {
         u_conn = mk_list_entry(head, struct flb_connection, _head);
+        u_conn->busy_flag = FLB_FALSE;
         prepare_destroy_conn(u_conn);
     }
 
     mk_list_foreach_safe(head, tmp, &uq->busy_queue) {
         u_conn = mk_list_entry(head, struct flb_connection, _head);
+        u_conn->busy_flag = FLB_FALSE;
         prepare_destroy_conn(u_conn);
     }
 
     mk_list_foreach_safe(head, tmp, &uq->destroy_queue) {
         u_conn = mk_list_entry(head, struct flb_connection, _head);
+        u_conn->busy_flag = FLB_FALSE;
         destroy_conn(u_conn);
     }
 
@@ -758,9 +768,14 @@ struct flb_connection *flb_upstream_conn_get(struct flb_upstream *u)
 
             flb_stream_release_lock(&u->base);
 
+            /* mark connection as busy so it won't be freed until released */
+            conn->busy_flag = FLB_TRUE;
+
             err = flb_socket_error(conn->fd);
 
             if (!FLB_EINPROGRESS(err) && err != 0) {
+                /* allow immediate cleanup on failure */
+                conn->busy_flag = FLB_FALSE;
                 flb_debug("[upstream] KA connection #%i is in a failed state "
                           "to: %s:%i, cleaning up",
                           conn->fd, u->tcp_host, u->tcp_port);
@@ -799,6 +814,8 @@ struct flb_connection *flb_upstream_conn_get(struct flb_upstream *u)
     }
 
     if (conn != NULL) {
+        /* newly created connections return in an idle state; mark busy */
+        conn->busy_flag = FLB_TRUE;
         flb_connection_reset_io_timeout(conn);
         flb_upstream_increment_busy_connections_count(u);
     }
@@ -828,6 +845,9 @@ int flb_upstream_conn_release(struct flb_connection *conn)
     struct flb_upstream *u = conn->upstream;
     struct flb_upstream_queue *uq;
 
+    /* allow pending destroy to free this connection once we're done */
+    conn->busy_flag = FLB_FALSE;
+
     flb_upstream_decrement_busy_connections_count(u);
 
     uq = flb_upstream_queue_get(u);
@@ -855,6 +875,18 @@ int flb_upstream_conn_release(struct flb_connection *conn)
          * notified if the 'available keepalive connection' gets disconnected by
          * the remote endpoint we need to add it again.
          */
+        /*
+         * Ensure the event is not registered before we add it back. In some
+         * error paths the previous handler might not have removed the event
+         * from the loop which would cause epoll_ctl(ADD) to fail with
+         * EEXIST.  Remove it here if still registered and then reset the
+         * structure state.
+         */
+        if (MK_EVENT_IS_REGISTERED((&conn->event))) {
+            mk_event_del(conn->evl, &conn->event);
+        }
+
+        MK_EVENT_NEW(&conn->event);
         conn->event.handler = cb_upstream_conn_ka_dropped;
 
         ret = mk_event_add(conn->evl,


### PR DESCRIPTION
fixes: https://github.com/fluent/fluent-bit/issues/10458

In addition, other fixes are part of this PR for async DNS resolution (remove stale fd from the event loop), extra validation of socket status for a synchronous network connection and the busy_flag management in the upstream interface.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
