### PR TITLE
in_calyptia_fleet: fix memory leak in get_fleet_id_from_header.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1617,10 +1617,17 @@ static flb_sds_t get_fleet_id_from_header(struct flb_in_calyptia_fleet_config *c
     flb_sds_t fleet_id;
     flb_sds_t name;
     struct flb_cf *cf_hdr;
+    flb_sds_t cfgheadername;
 
 
     if (exists_header_fleet_config(ctx)) {
-        cf_hdr = flb_cf_create_from_file(NULL, hdr_fleet_config_filename(ctx));
+        cfgheadername = hdr_fleet_config_filename(ctx);
+        if (cfgheadername == NULL) {
+            return NULL;
+        }
+
+        cf_hdr = flb_cf_create_from_file(NULL, cfgheadername);
+        flb_sds_destroy(cfgheadername);
 
         if (cf_hdr == NULL) {
             return NULL;


### PR DESCRIPTION
# Summary

Fix a memory leak in the startup of the `in_calyptia_fleet` plugin in the `get_fleet_id_from_header` function found during testing done by @alecholmes. (👍)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
