### PR TITLE
out_s3: fix the error message of total_file_size limit when use_put_object is enabled

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -705,7 +705,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
          */
         ctx->upload_chunk_size = ctx->file_size;
         if (ctx->file_size > MAX_FILE_SIZE_PUT_OBJECT) {
-            flb_plg_error(ctx->ins, "Max total_file_size is 50M when use_put_object is enabled");
+            flb_plg_error(ctx->ins, "Max total_file_size is %s bytes when use_put_object is enabled", MAX_FILE_SIZE_STR_PUT_OBJECT);
             return -1;
         }
     }

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -43,7 +43,8 @@
 #define MAX_FILE_SIZE_STR     "50,000,000,000"
 
 /* Allowed max file size 1 GB for publishing to S3 */
-#define MAX_FILE_SIZE_PUT_OBJECT        1000000000 
+#define MAX_FILE_SIZE_PUT_OBJECT        1000000000
+#define MAX_FILE_SIZE_STR_PUT_OBJECT    "1,000,000,000"
 
 #define DEFAULT_UPLOAD_TIMEOUT 3600
 


### PR DESCRIPTION
**Background**

This PR fixes a bug in the S3 Output plugin related to the `total_file_size` error message.

Although the actual limit is 1GB (`MAX_FILE_SIZE_PUT_OBJECT`), the error message still incorrectly states it as "50M".

This PR updates the error message to reflect the current limit, following the same approach used for `MAX_FILE_SIZE` to ensure consistency across the codebase.

**Testing**

Below is an excerpt from the output of `run_code_analysis.sh`:

```
[plugins/out_s3/]
s3.c                                           |39.2%  1155|53.3%  30|    -    0
s3_multipart.c                                 |49.0%   357|78.6%  14|    -    0
s3_store.c                                     |66.7%   231|84.2%  19|    -    0
================================================================================
                                         Total:|32.8%  379k|37.6% 24k|    -    0
::endgroup::
+ rm -f /tmp/tmp.keCsSwAMHq
+ exit 0
```


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
