### PR TITLE
chore: update yylex() signatures in lexer definition files

### DIFF
--- a/plugins/processor_sql/parser/sql-parser.y
+++ b/plugins/processor_sql/parser/sql-parser.y
@@ -19,7 +19,7 @@
 #include "sql_expression.h"
 #include "parser/sql_parser.h"
 
-extern int yylex();
+extern int yylex(YYSTYPE * yylval_param , yyscan_t yyscanner);
 
 void yyerror (struct sql_query *query, void *scanner, const char *str)
 {

--- a/src/record_accessor/ra.y
+++ b/src/record_accessor/ra.y
@@ -19,7 +19,7 @@
 #include "ra_parser.h"
 #include "ra_lex.h"
 
-extern int flb_ra_lex();
+extern int flb_ra_lex(YYSTYPE * yylval_param , yyscan_t yyscanner);
 
 void flb_ra_error(struct flb_ra_parser *rp, const char *query, void *scanner,
                   const char *str)

--- a/src/stream_processor/parser/sql.y
+++ b/src/stream_processor/parser/sql.y
@@ -18,7 +18,7 @@
 #include "sql_parser.h"
 #include "sql_lex.h"
 
-extern int yylex();
+extern int yylex(YYSTYPE * yylval_param , yyscan_t yyscanner);
 
 void yyerror(struct flb_sp_cmd *cmd, const char *query, void *scanner, const char *str)
 {


### PR DESCRIPTION
Fixes GCC 15 compilation issues reported in #10471 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
