### PR TITLE
fix:update missing headers for Centos 10 compilation

### DIFF
--- a/lib/nghttp2-1.65.0/lib/nghttp2_hd_huffman.c
+++ b/lib/nghttp2-1.65.0/lib/nghttp2_hd_huffman.c
@@ -30,6 +30,7 @@
 
 #include "nghttp2_hd.h"
 #include "nghttp2_net.h"
+#include <arpa/inet.h>
 
 size_t nghttp2_hd_huff_encode_count(const uint8_t *src, size_t len) {
   size_t i;

--- a/lib/nghttp2-1.65.0/lib/nghttp2_helper.c
+++ b/lib/nghttp2-1.65.0/lib/nghttp2_helper.c
@@ -26,6 +26,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <arpa/inet.h>
 
 #include "nghttp2_net.h"
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added missing headers for compilation on Centos 10.
Reports with errors on the undefined `htons` function in two files

```
[2025-06-12T16:28:19.598Z] /tmp/fluent-bit/lib/nghttp2-1.65.0/lib/nghttp2_helper.c:33:16: error: implicit declaration of function ‘htons’ [-Wimplicit-function-declaration]
[2025-06-12T16:28:19.598Z]    33 |   uint16_t x = htons(n);
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
[N/A]
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [NA] Example configuration file for the change
- [NA] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
