### PR TITLE
in_splunk: continue with the next token if length of auth header vs token doesn't match

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -1043,7 +1043,7 @@ static int validate_auth_header_ng(struct flb_splunk *ctx, struct flb_http_reque
         mk_list_foreach_safe(head, tmp, &ctx->auth_tokens) {
             splunk_token = mk_list_entry(head, struct flb_splunk_tokens, _head);
             if (strlen(auth_header) != splunk_token->length) {
-                return SPLUNK_AUTH_UNAUTHORIZED;
+                continue;
             }
 
             if (strncasecmp(splunk_token->header,


### PR DESCRIPTION
if the length of token v/s auth header are different, it must skip the token instead of immediately return unauthorized

fixes #10483

----

- [x] Example configuration file for the change (see #10483)
- [x] Debug log output from testing the change

<details><summary>Details</summary>

```text 

$FBIT_HOME/fluent-bit -c files/fluent-bit.yml
Fluent Bit v4.0.4
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/06/17 09:26:54] [ info] Configuration:
[2025/06/17 09:26:54] [ info]  flush time     | 1.000000 seconds
[2025/06/17 09:26:54] [ info]  grace          | 5 seconds
[2025/06/17 09:26:54] [ info]  daemon         | 0
[2025/06/17 09:26:54] [ info] ___________
[2025/06/17 09:26:54] [ info]  inputs:
[2025/06/17 09:26:54] [ info]      splunk
[2025/06/17 09:26:54] [ info] ___________
[2025/06/17 09:26:54] [ info]  filters:
[2025/06/17 09:26:54] [ info] ___________
[2025/06/17 09:26:54] [ info]  outputs:
[2025/06/17 09:26:54] [ info]      stdout.0
[2025/06/17 09:26:54] [ info] ___________
[2025/06/17 09:26:54] [ info]  collectors:
[2025/06/17 09:26:54] [ info] [fluent bit] version=4.0.4, commit=067c0642fe, pid=22977
[2025/06/17 09:26:54] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2025/06/17 09:26:54] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/06/17 09:26:54] [ info] [simd    ] disabled
[2025/06/17 09:26:54] [ info] [cmetrics] version=1.0.3
[2025/06/17 09:26:54] [ info] [ctraces ] version=0.6.6
[2025/06/17 09:26:54] [ info] [input:splunk:splunk_hec] initializing
[2025/06/17 09:26:54] [ info] [input:splunk:splunk_hec] storage_strategy='memory' (memory only)
[2025/06/17 09:26:54] [debug] [downstream] listening on 0.0.0.0:7443
[2025/06/17 09:26:54] [debug] [input:splunk:splunk_hec] [thread init] initialization OK
[2025/06/17 09:26:54] [ info] [input:splunk:splunk_hec] thread instance initialized
[2025/06/17 09:26:54] [debug] [splunk:splunk_hec] created event channels: read=39 write=40
[2025/06/17 09:26:54] [debug] [stdout:stdout.0] created event channels: read=43 write=44
[2025/06/17 09:26:54] [ info] [output:stdout:stdout.0] worker #0 started
[2025/06/17 09:26:54] [ info] [sp] stream processor started
[2025/06/17 09:26:54] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/06/17 09:27:00] [debug] [input:splunk:splunk_hec] header 'Content-Type' is not set
[2025/06/17 09:27:00] [debug] [input:splunk:splunk_hec] Mark as unknown type for ingested payloads
[2025/06/17 09:27:00] [debug] [task] created task=0x6000021e0000 id=0 OK
[2025/06/17 09:27:00] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] hec: [[1750166820.611091000, {}], {"time"=>1750166819.593208, "event"=>{"message"=>"dummy"}, "SPLUNK_HEC_TOKEN"=>"Splunk anotherToken"}]
[2025/06/17 09:27:00] [debug] [out flush] cb_destroy coro_id=0
[2025/06/17 09:27:00] [debug] [task] destroy task=0x6000021e0000 (task_id=0)
[2025/06/17 09:27:01] [debug] [input:splunk:splunk_hec] header 'Content-Type' is not set
[2025/06/17 09:27:01] [debug] [input:splunk:splunk_hec] Mark as unknown type for ingested payloads
[2025/06/17 09:27:02] [debug] [input:splunk:splunk_hec] header 'Content-Type' is not set
[2025/06/17 09:27:02] [debug] [input:splunk:splunk_hec] Mark as unknown type for ingested payloads
[2025/06/17 09:27:02] [debug] [task] created task=0x6000021e4000 id=0 OK
[2025/06/17 09:27:02] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] hec: [[1750166821.600526000, {}], {"time"=>1750166820.593377, "event"=>{"message"=>"dummy"}, "SPLUNK_HEC_TOKEN"=>"Splunk anotherToken"}]
[2025/06/17 09:27:02] [debug] [out flush] cb_destroy coro_id=1
[2025/06/17 09:27:02] [debug] [task] destroy task=0x6000021e4000 (task_id=0)
[2025/06/17 09:27:03] [debug] [input:splunk:splunk_hec] header 'Content-Type' is not set
[2025/06/17 09:27:03] [debug] [input:splunk:splunk_hec] Mark as unknown type for ingested payloads
^C[2025/06/17 09:27:03] [engine] caught signal (SIGINT)
[2025/06/17 09:27:03] [debug] [input:splunk:splunk_hec] thread pause instance
[2025/06/17 09:27:03] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/06/17 09:27:03] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2025/06/17 09:27:03] [debug] [input:splunk:splunk_hec] thread exit instance
```

</details> 

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
