### PR TITLE
go: plugin_proxy: update function pointer signatures with correct args for C23

### DIFF
--- a/src/proxy/go/go.h
+++ b/src/proxy/go/go.h
@@ -29,7 +29,7 @@ struct flbgo_output_plugin {
     void *o_ins;
     struct flb_plugin_proxy_context *context;
 
-    int (*cb_init)();
+    int (*cb_init)(struct flbgo_output_plugin *);
     int (*cb_flush)(const void *, size_t, const char *);
     int (*cb_flush_ctx)(void *, const void *, size_t, char *);
     int (*cb_exit)();
@@ -42,7 +42,7 @@ struct flbgo_input_plugin {
     void *i_ins;
     struct flb_plugin_proxy_context *context;
 
-    int (*cb_init)();
+    int (*cb_init)(struct flbgo_input_plugin *);
     int (*cb_collect)(void **, size_t *);
     int (*cb_cleanup)(void *);
     int (*cb_exit)();
@@ -54,7 +54,7 @@ struct flbgo_custom_plugin {
     void *i_ins;
     struct flb_plugin_proxy_context *context;
 
-    int (*cb_init)();
+    int (*cb_init)(struct flbgo_custom_plugin *);
     int (*cb_exit)();
 };
 


### PR DESCRIPTION
see: https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

Fixes another GCC15 build error that's similar to #10471:

```
Building C object src/proxy/go/CMakeFiles/flb-plugin-proxy-go.dir/go.c.o
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c: In function ‘proxy_go_output_init’:
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c:110:11: error: too many arguments to function ‘plugin->cb_init’; expected 0, have 1
  110 |     ret = plugin->cb_init(plugin);
      |           ^~~~~~          ~~~~~~
In file included from /home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c:25:
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/./go.h:32:11: note: declared here
   32 |     int (*cb_init)();
      |           ^~~~~~~
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c: In function ‘proxy_go_input_init’:
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c:224:11: error: too many arguments to function ‘plugin->cb_init’; expected 0, have 1
  224 |     ret = plugin->cb_init(plugin);
      |           ^~~~~~          ~~~~~~
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/./go.h:45:11: note: declared here
   45 |     int (*cb_init)();
      |           ^~~~~~~
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c: In function ‘proxy_go_custom_init’:
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/go.c:340:11: error: too many arguments to function ‘plugin->cb_init’; expected 0, have 1
  340 |     ret = plugin->cb_init(plugin);
      |           ^~~~~~          ~~~~~~
/home/stewart/Projects/OSS/fluentbit-4/src/proxy/go/./go.h:57:11: note: declared here
   57 |     int (*cb_init)();
      |           ^~~~~~~
```

Go plugin split from #10476

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license