### PR TITLE
in_docker: update function pointer signatures with correct args for C23

### DIFF
--- a/plugins/in_docker/docker.h
+++ b/plugins/in_docker/docker.h
@@ -89,7 +89,7 @@ struct flb_docker;
 
 struct cgroup_api {
     int cgroup_version;
-    struct mk_list* (*get_active_docker_ids) ();
+    struct mk_list* (*get_active_docker_ids) (struct flb_docker *);
     char*           (*get_container_name) (struct flb_docker *, char *);
     cpu_snapshot*   (*get_cpu_snapshot)   (struct flb_docker *, char *);
     mem_snapshot*   (*get_mem_snapshot)   (struct flb_docker *, char *);


### PR DESCRIPTION
see: https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

Fixes the same GCC15 build error as #10489 but for the Docker plugin where it was also a problem.

Docker plugin split from #10476

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license