### PR TITLE
in_calyptia_fleet: report the configuration version.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -857,6 +857,7 @@ static struct flb_http_client *fleet_http_do(struct flb_in_calyptia_fleet_config
     size_t b_sent;
     struct flb_connection *u_conn;
     struct flb_http_client *client;
+    flb_sds_t config_version;
 
     if (ctx == NULL || url == NULL) {
         return NULL;
@@ -877,6 +878,13 @@ static struct flb_http_client *fleet_http_do(struct flb_in_calyptia_fleet_config
     }
 
     flb_http_buffer_size(client, ctx->max_http_buffer_size);
+
+    config_version = flb_sds_create_size(32);
+    flb_sds_printf(&config_version, "%ld", ctx->config_timestamp);
+    flb_http_add_header(client,
+                         FLEET_HEADERS_CONFIG_VERSION, sizeof(FLEET_HEADERS_CONFIG_VERSION) -1,
+                         config_version, flb_sds_len(config_version));
+    flb_sds_destroy(config_version);
 
     flb_http_add_header(client,
                         CALYPTIA_HEADERS_PROJECT, sizeof(CALYPTIA_HEADERS_PROJECT) - 1,

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.h
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.h
@@ -23,6 +23,8 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_reload.h>
 
+#define FLEET_HEADERS_CONFIG_VERSION "Fleet-Config-Version"
+
 struct flb_in_calyptia_fleet_config {
     /* Time interval check */
     int interval_sec;


### PR DESCRIPTION
# Summary

Report the currently loaded configuration version with each request from the fleet plugin, especially when querying for the latest configuration.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
