### PR TITLE
config_format: yaml: add detailed error message on bad format

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2881,7 +2881,29 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
         status = yaml_parser_parse(&parser, &event);
 
         if (status == YAML_FAILURE) {
-            flb_error("[config] invalid YAML format in file %s", cfg_file);
+            if (parser.problem) {
+                flb_error("[config] invalid YAML in file %s at line %zu, column %zu: %s",
+                          cfg_file,
+                          parser.problem_mark.line + 1,
+                          parser.problem_mark.column + 1,
+                          parser.problem);
+
+                /* Provide contextual hint if the error is not on the first line */
+                if (parser.problem_mark.line > 0) {
+                    flb_error("[config] hint: check line %zu (above) for missing ':' or incorrect indentation",
+                              parser.problem_mark.line);
+                }
+            }
+            else {
+                flb_error("[config] invalid YAML format in file %s at line %zu, column %zu",
+                          cfg_file,
+                          parser.problem_mark.line + 1,
+                          parser.problem_mark.column + 1);
+
+                if (parser.problem_mark.line > 0) {
+                    flb_error("[config] hint: check line %zu for syntax issues", parser.problem_mark.line);
+                }
+            }
             code = -1;
             goto done;
         }


### PR DESCRIPTION
Before this patch if a Yaml file contained a format error, it only show:

```
[2025/06/19 16:13:59] [error] [config] invalid YAML format in file mybadfile.yaml
[2025/06/19 16:13:59] [error] configuration file contains errors, aborting.
```
now it prints useful information about the problem:

```
[2025/06/19 16:34:14] [error] [config] invalid YAML in file mybadfile.yaml at line 4, column 1: could not find expected ':'
[2025/06/19 16:34:14] [error] [config] hint: check line 3 (above) for missing ':' or incorrect indentation
[2025/06/19 16:34:14] [error] configuration file contains errors, aborting.
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
