### PR TITLE
in_calyptia_fleet: fix init error mem leaks.

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -63,6 +63,7 @@
 static int fleet_cur_chdir(struct flb_in_calyptia_fleet_config *ctx);
 static int get_calyptia_files(struct flb_in_calyptia_fleet_config *ctx,
                               time_t timestamp);
+static void in_calyptia_fleet_destroy(struct flb_in_calyptia_fleet_config *ctx);
 
 #ifndef FLB_SYSTEM_WINDOWS
 
@@ -632,8 +633,6 @@ static int execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cf
         flb_errno();
         flb_plg_error(ctx->ins, "unable to change to configuration directory");
     }
-
-    fleet_cur_chdir(ctx);
 
     pthread_attr_init(&ptha);
     pthread_attr_setdetachstate(&ptha, PTHREAD_CREATE_DETACHED);
@@ -2214,7 +2213,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
     /* Load the config map */
     ret = flb_input_config_map_set(in, (void *) ctx);
     if (ret == -1) {
-        flb_free(ctx);
+        in_calyptia_fleet_destroy(ctx);
         flb_plg_error(in, "unable to load configuration");
         return -1;
     }
@@ -2225,7 +2224,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
 
         if (tmpdir == NULL) {
             flb_plg_error(in, "unable to find temporary directory (%%TEMP%%).");
-            flb_free(ctx);
+            in_calyptia_fleet_destroy(ctx);
             return -1;
         }
 
@@ -2233,7 +2232,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
 
         if (ctx->config_dir == NULL) {
             flb_plg_error(in, "unable to allocate config-dir.");
-            flb_free(ctx);
+            in_calyptia_fleet_destroy(ctx);
             return -1;
         }
         flb_sds_printf(&ctx->config_dir, "%s" PATH_SEPARATOR "%s", tmpdir, "calyptia-fleet");
@@ -2251,7 +2250,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
 
     if (!ctx->u) {
         flb_plg_error(ctx->ins, "could not initialize upstream");
-        flb_free(ctx);
+        in_calyptia_fleet_destroy(ctx);
         return -1;
     }
 
@@ -2273,6 +2272,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
     /* create fleet directory before creating the fleet header. */
     if (create_fleet_directory(ctx) != 0) {
         flb_plg_error(ctx->ins, "unable to create fleet directories");
+        in_calyptia_fleet_destroy(ctx);
         return -1;
     }
 
@@ -2301,8 +2301,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
 
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not initialize collector for fleet input plugin");
-        flb_upstream_destroy(ctx->u);
-        flb_free(ctx);
+        in_calyptia_fleet_destroy(ctx);
         return -1;
     }
 
@@ -2325,10 +2324,11 @@ static void cb_in_calyptia_fleet_resume(void *data, struct flb_config *config)
     flb_input_collector_resume(ctx->collect_fd, ctx->ins);
 }
 
-static int in_calyptia_fleet_exit(void *data, struct flb_config *config)
+static void in_calyptia_fleet_destroy(struct flb_in_calyptia_fleet_config *ctx)
 {
-    (void) *config;
-    struct flb_in_calyptia_fleet_config *ctx = (struct flb_in_calyptia_fleet_config *)data;
+    if (!ctx) {
+        return;
+    }
 
     if (ctx->fleet_url) {
         flb_sds_destroy(ctx->fleet_url);
@@ -2342,10 +2342,21 @@ static int in_calyptia_fleet_exit(void *data, struct flb_config *config)
         flb_sds_destroy(ctx->fleet_id);
     }
 
-    flb_input_collector_delete(ctx->collect_fd, ctx->ins);
-    flb_upstream_destroy(ctx->u);
-    flb_free(ctx);
+    if (ctx->collect_fd >= 0) {
+        flb_input_collector_delete(ctx->collect_fd, ctx->ins);
+    }
 
+    if (ctx->u) {
+        flb_upstream_destroy(ctx->u);
+    }
+
+    flb_free(ctx);
+}
+
+static int in_calyptia_fleet_exit(void *data, struct flb_config *config)
+{
+    (void) *config;
+    in_calyptia_fleet_destroy((struct flb_in_calyptia_fleet_config *)data);
     return 0;
 }
 


### PR DESCRIPTION
# Summary

Fix memory leaks in `in_calyptia_fleet` and `out_calyptia` that could occur during initialization.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
