### PR TITLE
tests: parallelize acutests.

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -91,9 +91,16 @@ if (FLB_CUSTOM_CALYPTIA)
             ${CALYPTIA_TEST_LINK_LIBS}
         )
 
-        add_test(NAME ${TEST_TARGET}
-                 COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
-                 WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        message(STATUS "Add test: ${TEST_NAME}")
+        if (TEST_NAME STREQUAL "out_stackdriver" OR TEST_NAME STREQUAL "filter_kubernetes")
+          add_test(NAME ${TEST_TARGET}
+                   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET} --exec=always -P
+                   WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        else()
+          add_test(NAME ${TEST_TARGET}
+                   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
+                   WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        endif()
 
         set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
         add_dependencies(${TEST_TARGET} fluent-bit-static)
@@ -134,9 +141,16 @@ if(FLB_IN_EBPF)
         )
 
         # Add test
-        add_test(NAME ${TEST_TARGET}
-                COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
-                WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        message(STATUS "Add test: ${TEST_NAME}")
+        if (TEST_NAME STREQUAL "out_stackdriver" OR TEST_NAME STREQUAL "filter_kubernetes")
+          add_test(NAME ${TEST_TARGET}
+                   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET} --exec=always -P
+                   WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        else()
+          add_test(NAME ${TEST_TARGET}
+                   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
+                   WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+        endif()
 
         # Set test properties
         set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
@@ -285,9 +299,18 @@ foreach(source_file ${CHECK_PROGRAMS})
       if(FLB_AVRO_ENCODER)
         target_link_libraries(${source_file_we} avro-static jansson)
       endif()
-    add_test(NAME ${source_file_we}
-            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${source_file_we}
-            WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+
+    message(STATUS "Add test: ${source_file_we}")
+    if (source_file_we STREQUAL "flb-rt-out_stackdriver" OR TEST_NAME STREQUAL "flb-rt-filter_kubernetes")
+      add_test(NAME ${source_file_we}
+               COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${source_file_we} --exec=always -P
+               WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+    else()
+      add_test(NAME ${source_file_we}
+               COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
+               WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
+    endif()
+
     set_tests_properties(${source_file_we} PROPERTIES LABELS "runtime")
     set_property(TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-D${o_source_file_we}")
   endif()


### PR DESCRIPTION
# Summary

Run specific tests in acutest in parallel using threads.

# Description

This PR adds a new system that can be activated when `--exec=always` and the new `-P` option is passed.

This dramatically lowers the time for tests from 2.5-3 minutes to 60 seconds. This is applying the parallellization to just two tests: `out_stackdriver` and `filter_kubernetes`. I chose to restrict the feature to these two tests for now to make sure the feature can be rolled out incrementally.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
