### PR TITLE
lib: wasm: avoid executable stack as a result of wasm assembler.

### DIFF
--- a/lib/wasm-micro-runtime-WAMR-1.3.3/core/iwasm/common/arch/invokeNative_em64.s
+++ b/lib/wasm-micro-runtime-WAMR-1.3.3/core/iwasm/common/arch/invokeNative_em64.s
@@ -62,3 +62,6 @@ push_args_end:
     leave
     ret
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Closes: #10513