### PR TITLE
out_s3: support s3 tagging for uploaded objects

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -155,6 +155,13 @@ static struct flb_aws_header storage_class_header = {
     .val_len = 0,
 };
 
+static struct flb_aws_header object_tagging = {
+    .key = "x-amz-tagging",
+    .key_len = 13,
+    .val = "",
+    .val_len = 0,
+};
+
 static char *mock_error_response(char *error_env_var)
 {
     char *err_val = NULL;
@@ -213,6 +220,9 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
     if (ctx->storage_class != NULL) {
         headers_len++;
     }
+    if (ctx->object_tagging != NULL) {
+        headers_len++;
+    }
     if (headers_len == 0) {
         *num_headers = headers_len;
         *headers = s3_headers;
@@ -254,6 +264,12 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n] = content_md5_header;
         s3_headers[n].val = body_md5;
         s3_headers[n].val_len = strlen(body_md5);
+        n++;
+    }
+    if (ctx->object_tagging != NULL) {
+        s3_headers[n] = object_tagging;
+        s3_headers[n].val = ctx->object_tagging;
+        s3_headers[n].val_len = strlen(ctx->object_tagging);
         n++;
     }
     if (ctx->storage_class != NULL) {
@@ -959,6 +975,11 @@ skip_size_validation:
     tmp = flb_output_get_property("storage_class", ins);
     if (tmp) {
         ctx->storage_class = (char *) tmp;
+    }
+
+    tmp = flb_output_get_property("object_tagging", ins);
+    if (tmp) {
+        ctx->object_tagging = (char *) tmp;
     }
 
     if (ctx->insecure == FLB_FALSE) {
@@ -4419,6 +4440,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "authorization_endpoint_bearer_token", NULL,
      0, FLB_TRUE, offsetof(struct flb_s3, authorization_endpoint_bearer_token),
      "Authorization endpoint bearer token"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "object_tagging", NULL,
+     0, FLB_TRUE, offsetof(struct flb_s3, object_tagging),
+     "Specify a list of tags to apply to the S3 object, url-query encoded: `key1=value1&key2=value2`"
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -35,16 +35,15 @@
 #include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_input_blob.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_uri.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 
 #include <msgpack.h>
 
 #include "s3.h"
-#include "fluent-bit/flb_output.h"
-#include "fluent-bit/flb_sds.h"
-#include "fluent-bit/flb_uri.h"
-#include "mk_core/mk_list.h"
 #include "s3_store.h"
 
 #define DEFAULT_S3_PORT 443
@@ -677,25 +676,39 @@ static flb_sds_t construct_object_tagging(struct flb_output_instance *ctx, struc
         }
 
         val_sds = flb_uri_encode(val->str, flb_sds_len(val->str));
-        if (val_sds == NULL) goto error;
+        if (val_sds == NULL) {
+            goto error;
+        }
 
         if (url_sds == NULL) {
             url_sds = flb_sds_create_size(256);
-        } else {
-            if (NULL == flb_sds_printf(&url_sds, "&"))
+            if (url_sds == NULL) {
                 goto error;
+            }
         }
-        if (NULL == flb_sds_printf(&url_sds, "%s=%s", key_sds, val_sds))
+        else {
+            if (NULL == flb_sds_printf(&url_sds, "&")) {
+                goto error;
+            }
+        }
+        if (NULL == flb_sds_printf(&url_sds, "%s=%s", key_sds, val_sds)) {
             goto error;
+        }
         flb_sds_destroy(key_sds); key_sds = NULL;
         flb_sds_destroy(val_sds); val_sds = NULL;
     }
     return url_sds;
 
 error:
-    if (key_sds != NULL) flb_sds_destroy(key_sds);
-    if (val_sds != NULL) flb_sds_destroy(val_sds);
-    if (url_sds != NULL) flb_sds_destroy(url_sds);
+    if (key_sds != NULL) {
+        flb_sds_destroy(key_sds);
+    }
+    if (val_sds != NULL) {
+        flb_sds_destroy(val_sds);
+    }
+    if (url_sds != NULL) {
+        flb_sds_destroy(url_sds);
+    }
     return NULL;
 }
 

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -224,9 +224,6 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
     if (ctx->storage_class != NULL) {
         headers_len++;
     }
-    if (ctx->object_tagging != NULL) {
-        headers_len++;
-    }
     if (ctx->object_tags_encoded != NULL) {
         headers_len++;
     }
@@ -271,12 +268,6 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n] = content_md5_header;
         s3_headers[n].val = body_md5;
         s3_headers[n].val_len = strlen(body_md5);
-        n++;
-    }
-    if (ctx->object_tagging != NULL) {
-        s3_headers[n] = object_tagging;
-        s3_headers[n].val = ctx->object_tagging;
-        s3_headers[n].val_len = strlen(ctx->object_tagging);
         n++;
     }
     if (ctx->object_tags_encoded != NULL) {
@@ -1042,11 +1033,6 @@ skip_size_validation:
         ctx->storage_class = (char *) tmp;
     }
 
-    tmp = flb_output_get_property("object_tagging", ins);
-    if (tmp) {
-        ctx->object_tagging = (char *) tmp;
-    }
-
     ctx->object_tags_encoded = NULL;
     if ((ctx->object_tags != NULL) && (0 < mk_list_size(ctx->object_tags))) {
         flb_sds_t tags_sds = construct_object_tagging(ctx->ins, ctx->object_tags);
@@ -1278,6 +1264,7 @@ skip_size_validation:
 
     return 0;
 }
+
 
 /* worker initialization, used for our internal timers */
 static int cb_s3_worker_init(void *data, struct flb_config *config)
@@ -4515,12 +4502,6 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "authorization_endpoint_bearer_token", NULL,
      0, FLB_TRUE, offsetof(struct flb_s3, authorization_endpoint_bearer_token),
      "Authorization endpoint bearer token"
-    },
-
-    {
-     FLB_CONFIG_MAP_STR, "object_tagging", NULL,
-     0, FLB_TRUE, offsetof(struct flb_s3, object_tagging),
-     "Specify a list of tags to apply to the S3 object, url-query encoded: `key1=value1&key2=value2`"
     },
 
     {

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -41,6 +41,10 @@
 #include <msgpack.h>
 
 #include "s3.h"
+#include "fluent-bit/flb_output.h"
+#include "fluent-bit/flb_sds.h"
+#include "fluent-bit/flb_uri.h"
+#include "mk_core/mk_list.h"
 #include "s3_store.h"
 
 #define DEFAULT_S3_PORT 443
@@ -223,6 +227,9 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
     if (ctx->object_tagging != NULL) {
         headers_len++;
     }
+    if (ctx->object_tags_encoded != NULL) {
+        headers_len++;
+    }
     if (headers_len == 0) {
         *num_headers = headers_len;
         *headers = s3_headers;
@@ -272,6 +279,13 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n].val_len = strlen(ctx->object_tagging);
         n++;
     }
+    if (ctx->object_tags_encoded != NULL) {
+        s3_headers[n] = object_tagging;
+        s3_headers[n].val = ctx->object_tags_encoded;
+        s3_headers[n].val_len = flb_sds_len(ctx->object_tags_encoded);
+        n++;
+    }
+
     if (ctx->storage_class != NULL) {
         s3_headers[n] = storage_class_header;
         s3_headers[n].val = ctx->storage_class;
@@ -640,7 +654,58 @@ static void s3_context_destroy(struct flb_s3 *ctx)
         remove_from_queue(upload_contents);
     }
 
+    if (ctx->object_tags_encoded) {
+        flb_sds_destroy(ctx->object_tags_encoded);
+        ctx->object_tags_encoded = NULL;
+    }
+
     flb_free(ctx);
+}
+
+static flb_sds_t construct_object_tagging(struct flb_output_instance *ctx, struct mk_list *object_tags) {
+    flb_sds_t url_sds = NULL;
+    struct mk_list *head;
+    struct flb_config_map_val *mv;
+
+    flb_sds_t key_sds = NULL;
+    flb_sds_t val_sds = NULL;
+
+    flb_config_map_foreach(head, mv, object_tags) {
+        struct flb_slist_entry *key;
+        key = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
+        key_sds = flb_uri_encode(key->str, flb_sds_len(key->str));
+        if (key_sds == NULL) {
+            goto error;
+        }
+
+        struct flb_slist_entry *val;
+        val = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
+        if (key == val) {
+            flb_plg_warn(ctx, "`s3_object_tag %s` without value is treated as %s=%s",
+                         key->str, key->str, key->str);
+        }
+
+        val_sds = flb_uri_encode(val->str, flb_sds_len(val->str));
+        if (val_sds == NULL) goto error;
+
+        if (url_sds == NULL) {
+            url_sds = flb_sds_create_size(256);
+        } else {
+            if (NULL == flb_sds_printf(&url_sds, "&"))
+                goto error;
+        }
+        if (NULL == flb_sds_printf(&url_sds, "%s=%s", key_sds, val_sds))
+            goto error;
+        flb_sds_destroy(key_sds); key_sds = NULL;
+        flb_sds_destroy(val_sds); val_sds = NULL;
+    }
+    return url_sds;
+
+error:
+    if (key_sds != NULL) flb_sds_destroy(key_sds);
+    if (val_sds != NULL) flb_sds_destroy(val_sds);
+    if (url_sds != NULL) flb_sds_destroy(url_sds);
+    return NULL;
 }
 
 static int cb_s3_init(struct flb_output_instance *ins,
@@ -980,6 +1045,16 @@ skip_size_validation:
     tmp = flb_output_get_property("object_tagging", ins);
     if (tmp) {
         ctx->object_tagging = (char *) tmp;
+    }
+
+    ctx->object_tags_encoded = NULL;
+    if ((ctx->object_tags != NULL) && (0 < mk_list_size(ctx->object_tags))) {
+        flb_sds_t tags_sds = construct_object_tagging(ctx->ins, ctx->object_tags);
+        if (tags_sds == NULL) {
+            flb_plg_error(ctx->ins, "cannot construct_object_tagging");
+            return -1;
+        }
+        ctx->object_tags_encoded = tags_sds;
     }
 
     if (ctx->insecure == FLB_FALSE) {
@@ -4446,6 +4521,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "object_tagging", NULL,
      0, FLB_TRUE, offsetof(struct flb_s3, object_tagging),
      "Specify a list of tags to apply to the S3 object, url-query encoded: `key1=value1&key2=value2`"
+    },
+
+    {
+     FLB_CONFIG_MAP_SLIST_1, "s3_object_tag", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_s3, object_tags),
+     "key-value pairs to tag the S3 object: `s3_object_tag key1 value1; s3_object_tag key2 value2; ...`"
     },
 
     /* EOF */

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -20,7 +20,6 @@
 #ifndef FLB_OUT_S3
 #define FLB_OUT_S3
 
-#include "mk_core/mk_list.h"
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_info.h>

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -121,7 +121,6 @@ struct flb_s3 {
     char *log_key;
     char *external_id;
     char *profile;
-    char *object_tagging;
     struct mk_list *object_tags;
     flb_sds_t object_tags_encoded;
     int free_endpoint;

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -120,6 +120,7 @@ struct flb_s3 {
     char *log_key;
     char *external_id;
     char *profile;
+    char *object_tagging;
     int free_endpoint;
     int retry_requests;
     int use_put_object;

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -20,6 +20,7 @@
 #ifndef FLB_OUT_S3
 #define FLB_OUT_S3
 
+#include "mk_core/mk_list.h"
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_info.h>
@@ -121,6 +122,8 @@ struct flb_s3 {
     char *external_id;
     char *profile;
     char *object_tagging;
+    struct mk_list *object_tags;
+    flb_sds_t object_tags_encoded;
     int free_endpoint;
     int retry_requests;
     int use_put_object;

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -198,7 +198,6 @@ void flb_test_s3_putobject_success(void)
     flb_output_set(ctx, out_ffd,"use_put_object", "true", NULL);
     flb_output_set(ctx, out_ffd,"total_file_size", "5M", NULL);
     flb_output_set(ctx, out_ffd,"upload_timeout", "6s", NULL);
-    // flb_output_set(ctx, out_ffd,"object_tagging", "key1=value1&key2=value2", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -147,7 +147,8 @@ void flb_test_s3_multipart_success(void)
     flb_output_set(ctx, out_ffd,"bucket", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"upload_timeout", "6s", NULL);
     flb_output_set(ctx, out_ffd,"store_dir", store_dir, NULL);
-    flb_output_set(ctx, out_ffd,"object_tagging", "key1=value1&key2=value2", NULL);
+    flb_output_set(ctx, out_ffd,"s3_object_tag", "key1", "value1", NULL);
+    flb_output_set(ctx, out_ffd,"s3_object_tag", "key2", "value2", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -197,7 +198,7 @@ void flb_test_s3_putobject_success(void)
     flb_output_set(ctx, out_ffd,"use_put_object", "true", NULL);
     flb_output_set(ctx, out_ffd,"total_file_size", "5M", NULL);
     flb_output_set(ctx, out_ffd,"upload_timeout", "6s", NULL);
-    flb_output_set(ctx, out_ffd,"object_tagging", "key1=value1&key2=value2", NULL);
+    // flb_output_set(ctx, out_ffd,"object_tagging", "key1=value1&key2=value2", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -416,6 +417,7 @@ void flb_test_s3_complete_upload_error(void)
     flb_output_set(ctx, out_ffd,"bucket", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"upload_timeout", "6s", NULL);
     flb_output_set(ctx, out_ffd,"store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd,"s3_object_tag", "key", "value with spaces", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -147,6 +147,7 @@ void flb_test_s3_multipart_success(void)
     flb_output_set(ctx, out_ffd,"bucket", "fluent", NULL);
     flb_output_set(ctx, out_ffd,"upload_timeout", "6s", NULL);
     flb_output_set(ctx, out_ffd,"store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd,"object_tagging", "key1=value1&key2=value2", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);
@@ -196,6 +197,7 @@ void flb_test_s3_putobject_success(void)
     flb_output_set(ctx, out_ffd,"use_put_object", "true", NULL);
     flb_output_set(ctx, out_ffd,"total_file_size", "5M", NULL);
     flb_output_set(ctx, out_ffd,"upload_timeout", "6s", NULL);
+    flb_output_set(ctx, out_ffd,"object_tagging", "key1=value1&key2=value2", NULL);
     flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
 
     ret = flb_start(ctx);


### PR DESCRIPTION
This change implements applying S3 tags to uploaded objects. 

It adds a new key to `s3` output configuration, called `s3_object_tag`; its values are key-value pairs of S3 tags to apply to uploaded objects.

A configuration example: 

```ini
[OUTPUT]
    match           *
    name            s3
    region          eu-west-1
    profile         my-aws-profile
    bucket          an-s3-logs-bucket
    s3_key_format   /logs/tmp-dsi-test/$TAG/
    s3_object_tag   key1  value1
    s3_object_tag   key2  value2
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Implements a feature request in https://github.com/fluent/fluent-bit/issues/9685

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3 object tagging via a new s3_object_tag configuration (key/value pairs). Tags are sent with uploads (single PUT and multipart) as a URL-encoded x-amz-tagging header; the encoded tag string is logged when set.
  * Tagging data is initialized on startup and cleaned up on shutdown to avoid leaks.

* **Tests**
  * Updated S3 tests to cover object tagging, multipart flows, and tags with special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->