### PR TITLE
input_chunk: Keep consistent for appending chunks

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1861,6 +1861,11 @@ static int append_to_ring_buffer(struct flb_input_instance *ins,
     int retry_limit = 10;
     struct input_chunk_raw *cr;
 
+    if (buf_size == 0) {
+        flb_plg_debug(ins, "skip ingesting data with 0 bytes");
+        return -1;
+    }
+
     cr = flb_calloc(1, sizeof(struct input_chunk_raw));
     if (!cr) {
         flb_errno();


### PR DESCRIPTION
When 0 byte chunk is occurred, just skipping.

This type of errors are happening to occur high volume log environments.
At flb_input_chunk source lines, we need to block 0 byte of calloc.
This is because 0 bytes of calloc means returning NULL.
So, it'll be recorded as undefined error with 0 there.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
