### PR TITLE
out_datadog: task_arn now correctly mapped to full arn

### DIFF
--- a/plugins/out_datadog/datadog_remap.c
+++ b/plugins/out_datadog/datadog_remap.c
@@ -187,6 +187,7 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
     char *remain;
     char *split;
     char *task_arn;
+    char *task_id;
     int ret;
 
     buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
@@ -198,7 +199,7 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
     * Use the full task ARN for compatibility with Datadog products
     * that expect the complete ARN format
     */
-    ret = dd_remap_append_kv_to_ddtags("task_arn", buf, flb_sds_len(buf), dd_tags_buf);
+    ret = dd_remap_append_kv_to_ddtags(tag_name, buf, flb_sds_len(buf), dd_tags_buf);
     if (ret < 0) {
         flb_sds_destroy(buf);
         return -1;
@@ -220,10 +221,10 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
         }
     }
 
-    task_arn = strstr(buf, ECS_TASK_PREFIX);
-    if (task_arn != NULL) {
-        task_arn += strlen(ECS_TASK_PREFIX);
-        ret = dd_remap_append_kv_to_ddtags("task_id", task_arn, strlen(task_arn), dd_tags_buf);
+    task_id = strstr(buf, ECS_TASK_PREFIX);
+    if (task_id != NULL) {
+        task_id += strlen(ECS_TASK_PREFIX);
+        ret = dd_remap_append_kv_to_ddtags("task_id", task_id, strlen(task_id), dd_tags_buf);
     }
     else {
         // If invalid, preserve the original value under task_id

--- a/plugins/out_datadog/datadog_remap.c
+++ b/plugins/out_datadog/datadog_remap.c
@@ -184,31 +184,6 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
                                   msgpack_object attr_value, flb_sds_t *dd_tags_buf)
 {
     flb_sds_t buf;
-    int ret;
-
-    buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
-    if (!buf) {
-        flb_errno();
-        return -1;
-    }
-
-    /*
-     * Use the full task ARN for compatibility with Datadog products
-     * that expect the complete ARN format
-     */
-    ret = dd_remap_append_kv_to_ddtags(tag_name, buf, flb_sds_len(buf), dd_tags_buf);
-    flb_sds_destroy(buf);
-    if (ret < 0) {
-         return -1;
-    }
-
-    return 0;
-}
-/* remapping function for ecs_task_id */
-static int dd_remap_ecs_task_id(const char *tag_name,
-                                  msgpack_object attr_value, flb_sds_t *dd_tags_buf)
-{
-    flb_sds_t buf;
     char *remain;
     char *split;
     char *task_arn;
@@ -219,11 +194,17 @@ static int dd_remap_ecs_task_id(const char *tag_name,
         flb_errno();
         return -1;
     }
-
     /*
-     * if the input is invalid, not in the form of "arn:aws:ecs:region:XXXX"
-     * then we won't add the "region" in the dd_tags.
-     */
+    * Use the full task ARN for compatibility with Datadog products
+    * that expect the complete ARN format
+    */
+    ret = dd_remap_append_kv_to_ddtags("task_arn", buf, flb_sds_len(buf), dd_tags_buf);
+    if (ret < 0) {
+        flb_sds_destroy(buf);
+        return -1;
+    }
+
+    // --- Begin task_id logic --
     if ((strlen(buf) > strlen(ECS_ARN_PREFIX)) &&
         (strncmp(buf, ECS_ARN_PREFIX, strlen(ECS_ARN_PREFIX)) == 0)) {
 
@@ -241,17 +222,15 @@ static int dd_remap_ecs_task_id(const char *tag_name,
 
     task_arn = strstr(buf, ECS_TASK_PREFIX);
     if (task_arn != NULL) {
-        /* parse out the task_arn */
         task_arn += strlen(ECS_TASK_PREFIX);
-        ret = dd_remap_append_kv_to_ddtags(tag_name, task_arn, strlen(task_arn), dd_tags_buf);
+        ret = dd_remap_append_kv_to_ddtags("task_id", task_arn, strlen(task_arn), dd_tags_buf);
     }
     else {
-        /*
-         * if the input is invalid, not in the form of "XXXXXXXXtask/"task-arn
-         * then we preverse the original value under tag "task_arn".
-         */
-        ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
+        // If invalid, preserve the original value under task_id
+        ret = dd_remap_append_kv_to_ddtags("task_id", buf, strlen(buf), dd_tags_buf);
     }
+    // --- End task_id logic ---
+
     flb_sds_destroy(buf);
     if (ret < 0) {
          return -1;
@@ -259,6 +238,7 @@ static int dd_remap_ecs_task_id(const char *tag_name,
 
     return 0;
 }
+
 /*
  * Statically defines the set of remappings rules in the form of
  * 1) original attr name 2) remapped tag name 3) remapping functions
@@ -271,8 +251,7 @@ const struct dd_attr_tag_remapping remapping[] = {
     {"container_image", "container_image", dd_remap_move_to_tags},
     {"ecs_cluster", "cluster_name", dd_remap_ecs_cluster},
     {"ecs_task_definition", "ecs_task_definition", dd_remap_ecs_task_definition},
-    {"ecs_task_arn", "task_arn", dd_remap_ecs_task_arn},
-    {"ecs_task_arn", "task_id", dd_remap_ecs_task_id}
+    {"ecs_task_arn", "task_arn", dd_remap_ecs_task_arn}
 };
 
 /*

--- a/plugins/out_datadog/datadog_remap.c
+++ b/plugins/out_datadog/datadog_remap.c
@@ -196,7 +196,7 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
      * Use the full task ARN for compatibility with Datadog products
      * that expect the complete ARN format
      */
-    ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
+    ret = dd_remap_append_kv_to_ddtags(tag_name, buf, flb_sds_len(buf), dd_tags_buf);
     flb_sds_destroy(buf);
     if (ret < 0) {
          return -1;

--- a/plugins/out_datadog/datadog_remap.c
+++ b/plugins/out_datadog/datadog_remap.c
@@ -186,7 +186,6 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
     flb_sds_t buf;
     char *remain;
     char *split;
-    char *task_arn;
     int ret;
 
     buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
@@ -214,22 +213,57 @@ static int dd_remap_ecs_task_arn(const char *tag_name,
         }
     }
 
-    task_arn = strstr(buf, ECS_TASK_PREFIX);
-    if (task_arn != NULL) {
-        /* parse out the task_arn */
-        task_arn += strlen(ECS_TASK_PREFIX);
-        ret = dd_remap_append_kv_to_ddtags(tag_name, task_arn, strlen(task_arn), dd_tags_buf);
-    }
-    else {
-        /*
-         * if the input is invalid, not in the form of "XXXXXXXXtask/"task-arn
-         * then we preverse the original value under tag "task_arn".
-         */
-        ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
-    }
+    /*
+     * Use the full task ARN for compatibility with Datadog products
+     * that expect the complete ARN format
+     */
+    ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
     flb_sds_destroy(buf);
     if (ret < 0) {
          return -1;
+    }
+
+    return 0;
+}
+
+/* remapping function for ecs_task_id - extracts just the task ID from the ARN */
+static int dd_remap_ecs_task_id(const char *tag_name,
+                                 msgpack_object attr_value, flb_sds_t *dd_tags_buf)
+{
+    flb_sds_t buf = NULL;
+    char *task_id = NULL;
+    int i;
+    int last_slash = 0;
+    int id_start = 0;
+    int ret;
+
+    buf = flb_sds_create_len(attr_value.via.str.ptr, attr_value.via.str.size);
+    if (!buf) {
+        flb_errno();
+        return -1;
+    }
+
+    /* Find the last slash in the ARN */
+    for (i = 0; i < strlen(buf); i++) {
+        if (buf[i] == '/') {
+            last_slash = i;
+        }
+    }
+
+    if (last_slash == 0 || last_slash >= strlen(buf) - 2) {
+        /* If we can't find a valid slash, use the original value */
+        ret = dd_remap_append_kv_to_ddtags(tag_name, buf, strlen(buf), dd_tags_buf);
+        flb_sds_destroy(buf);
+        return ret;
+    }
+
+    id_start = last_slash + 1;
+    task_id = buf + id_start;
+
+    ret = dd_remap_append_kv_to_ddtags(tag_name, task_id, strlen(task_id), dd_tags_buf);
+    flb_sds_destroy(buf);
+    if (ret < 0) {
+        return -1;
     }
 
     return 0;
@@ -247,7 +281,8 @@ const struct dd_attr_tag_remapping remapping[] = {
     {"container_image", "container_image", dd_remap_move_to_tags},
     {"ecs_cluster", "cluster_name", dd_remap_ecs_cluster},
     {"ecs_task_definition", "ecs_task_definition", dd_remap_ecs_task_definition},
-    {"ecs_task_arn", "task_arn", dd_remap_ecs_task_arn}
+    {"ecs_task_arn", "task_arn", dd_remap_ecs_task_arn},
+    {"ecs_task_arn", "task_id", dd_remap_ecs_task_id}
 };
 
 /*


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #5481 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[SERVICE]
    Flush        1
    Log_Level    trace
    Parsers_File parsers.conf

[INPUT]
    Name        dummy
    Tag         dummy
    Dummy       {"message": "Testing task_arn and task_id remapping", "test": "AGNTLOG-206", "container_id": "abc123def456", "container_name": "/ecs-web-service", "container_image": "nginx:1.24-alpine", "ecs_cluster": "arn:aws:ecs:us-west-2:123456789012:cluster/production-cluster", "ecs_task_definition": "web-service:42", "ecs_task_arn": "arn:aws:ecs:us-west-2:123456789012:task/production-cluster/abc123def456-7890-1234-5678-901234567890"}

[OUTPUT]
    Name        datadog
    Match       *
    apikey      ${DD_API_KEY}
    dd_hostname foobar
    provider    ecs
    dd_source   fluent-bit
    dd_service  test-service
    dd_tags     env:test,version:1.0
    compress    gzip 
```
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
