### PR TITLE
processor_sampling: fix handling of dropped spans

### DIFF
--- a/plugins/processor_sampling/sampling_conf.c
+++ b/plugins/processor_sampling/sampling_conf.c
@@ -235,14 +235,14 @@ void sampling_config_destroy(struct flb_config *config, struct sampling *ctx)
         return;
     }
 
-    if (ctx->sampling_conditions) {
-        sampling_conditions_destroy(ctx->sampling_conditions);
-    }
-
     if (ctx->plugin) {
         if (ctx->plugin->cb_exit) {
             ctx->plugin->cb_exit(config, ctx->plugin_context);
         }
+    }
+
+    if (ctx->sampling_conditions) {
+        sampling_conditions_destroy(ctx->sampling_conditions);
     }
 
     flb_kv_release(&ctx->plugin_settings_properties);


### PR DESCRIPTION
When discarding spans within a wait period due to shutdown, or discarding spans that are not intended to be sampled, some stale references remain in the registry. This patch corrects that behavior.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
