### PR TITLE
in_kmsg: use strtoull to fix timestamp parsing on 32-bit systems

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -36,6 +36,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <inttypes.h>
+#include <time.h>
 
 #include "in_kmsg.h"
 
@@ -143,7 +144,7 @@ static inline int process_line(const char *line,
     }
     p++;
 
-    val = strtol(p, &end, 10);
+    val = strtoul(p, &end, 10);
     if ((errno == ERANGE && (val == INT_MAX || val == INT_MIN))
         || (errno != 0 && val == 0)) {
         goto fail;
@@ -153,7 +154,7 @@ static inline int process_line(const char *line,
     p = ++end;
 
     /* Timestamp */
-    val = strtol(p, &end, 10);
+    val = strtoul(p, &end, 10);
     if ((errno == ERANGE && (val == INT_MAX || val == INT_MIN))
         || (errno != 0 && val == 0)) {
         goto fail;


### PR DESCRIPTION
On 32-bit systems, kmsg stops producing logs after some time. This is because of ERANGE error. The ERANGE error occurs when processing timestamp, because although val is of type uint64_t, strtol cannot process the value because of long being only 4 bytes, which is not sufficient to hold the timestamp values. It would be better to use strtoull instead, to make sure we have 8 bytes to store the value on all systems.

Fixes #10373.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
