### PR TITLE
reload: Fix hot reload always "in-progress" response after one fail reload

### DIFF
--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -468,6 +468,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
         if (!new_cf) {
             flb_sds_destroy(file);
+            old_config->hot_reloading = FLB_FALSE;
 
             return FLB_RELOAD_HALTED;
         }
@@ -482,6 +483,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
             }
             flb_cf_destroy(new_cf);
             flb_destroy(new_ctx);
+            old_config->hot_reloading = FLB_FALSE;
             flb_error("[reload] reloaded config is invalid. Reloading is halted");
 
             return FLB_RELOAD_HALTED;
@@ -494,6 +496,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
         flb_sds_destroy(file);
         flb_cf_destroy(new_cf);
         flb_destroy(new_ctx);
+        old_config->hot_reloading = FLB_FALSE;
 
         flb_error("[reload] reloaded config format is invalid. Reloading is halted");
 
@@ -506,6 +509,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
         flb_sds_destroy(file);
         flb_cf_destroy(new_cf);
         flb_destroy(new_ctx);
+        old_config->hot_reloading = FLB_FALSE;
 
         flb_error("[reload] reloaded config is invalid. Reloading is halted");
 
@@ -534,6 +538,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
 
     if (ret != 0) {
         flb_destroy(new_ctx);
+        old_config->hot_reloading = FLB_FALSE;
 
         flb_error("[reload] loaded configuration contains error(s). Reloading is aborted");
 


### PR DESCRIPTION
Reset old_config->hot_reloading false after new config load failure, to unblock hot reload next time.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
