### PR TITLE
in_kafka: add enable_auto_commit option for Kafka consumer

### DIFF
--- a/plugins/in_kafka/in_kafka.h
+++ b/plugins/in_kafka/in_kafka.h
@@ -33,6 +33,7 @@
 #define FLB_IN_KAFKA_DEFAULT_FORMAT        "none"
 #define FLB_IN_KAFKA_UNLIMITED             (size_t)-1
 #define FLB_IN_KAFKA_BUFFER_MAX_SIZE       "4M"
+#define FLB_IN_KAFKA_ENABLE_AUTO_COMMIT    "false"
 
 enum {
     FLB_IN_KAFKA_FORMAT_NONE,
@@ -50,7 +51,7 @@ struct flb_in_kafka_config {
     size_t buffer_max_size;          /* Maximum size of chunk allocation */
     size_t polling_threshold;
     int poll_timeout_ms;
-
+    bool enable_auto_commit;
     struct flb_kafka_opaque *opaque;
 
 #ifdef FLB_HAVE_AWS_MSK_IAM


### PR DESCRIPTION
> Note: this is a rebased of PR https://github.com/fluent/fluent-bit/pull/10412 on top of master branch and cleaned up history of commits.

Fixes https://github.com/fluent/fluent-bit/issues/9813

This change introduces a new configuration option 'enable_auto_commit' to control Kafka message commit behavior. When disabled (default), messages are committed only after successful processing, providing better control over message processing guarantees.

The option defaults to false to:
  - Prevent potential message loss in case of failures
  - Give users explicit control over commit behavior
  - Ensure messages are only committed after successful processing

Users can enable auto-commit by setting enable_auto_commit true in their configuration if they prefer automatic batch commits.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
