### PR TITLE
out_opentelemetry: fix behavior of record attributes handling

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_utils.c
+++ b/plugins/out_opentelemetry/opentelemetry_utils.c
@@ -167,6 +167,33 @@ void otlp_kvarray_destroy(Opentelemetry__Proto__Common__V1__KeyValue **kvarray, 
     }
 }
 
+int otlp_kvarray_append(Opentelemetry__Proto__Common__V1__KeyValue ***base,
+                        size_t *base_count,
+                        Opentelemetry__Proto__Common__V1__KeyValue **extra,
+                        size_t extra_count)
+{
+    size_t new_count;
+    Opentelemetry__Proto__Common__V1__KeyValue **tmp;
+
+    if (extra == NULL || extra_count == 0) {
+        return 0;
+    }
+
+    new_count = *base_count + extra_count;
+    tmp = flb_realloc(*base, new_count * sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+    if (!tmp) {
+        return -1;
+    }
+
+    *base = tmp;
+    memcpy(*base + *base_count, extra,
+           extra_count * sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+    *base_count = new_count;
+    flb_free(extra);
+
+    return 0;
+}
+
 void otlp_kvpair_destroy(Opentelemetry__Proto__Common__V1__KeyValue *kvpair)
 {
     if (kvpair == NULL) {

--- a/plugins/out_opentelemetry/opentelemetry_utils.h
+++ b/plugins/out_opentelemetry/opentelemetry_utils.h
@@ -26,6 +26,10 @@ Opentelemetry__Proto__Common__V1__KeyValueList *otlp_kvlist_value_initialize(siz
 Opentelemetry__Proto__Common__V1__AnyValue *otlp_any_value_initialize(int data_type, size_t entry_count);
 
 void otlp_kvarray_destroy(Opentelemetry__Proto__Common__V1__KeyValue **kvarray, size_t entry_count);
+int otlp_kvarray_append(Opentelemetry__Proto__Common__V1__KeyValue ***base,
+                        size_t *base_count,
+                        Opentelemetry__Proto__Common__V1__KeyValue **extra,
+                        size_t extra_count);
 void otlp_kvpair_destroy(Opentelemetry__Proto__Common__V1__KeyValue *kvpair);
 void otlp_kvlist_destroy(Opentelemetry__Proto__Common__V1__KeyValueList *kvlist);
 void otlp_array_destroy(Opentelemetry__Proto__Common__V1__ArrayValue *array);


### PR DESCRIPTION
Fixes #10445

The log attribute code now merges additional attributes into the existing array instead of overwriting it by calling otlp_kvarray_append.

A new helper otlp_kvarray_append grows an array of OTLP key/value pairs and copies the new entries into it.

Added a unit test test_kvarray_append validating that two key/value arrays are combined correctly.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
