### PR TITLE
out_loki: prevent race conditions when multiple workers use remove_keys

### DIFF
--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -100,6 +100,9 @@ struct flb_loki {
     struct cfl_list dynamic_tenant_list;
     pthread_mutex_t dynamic_tenant_list_lock;
 
+    struct cfl_list remove_mpa_list;
+    pthread_mutex_t remove_mpa_list_lock;
+
     /* Upstream Context */
     struct flb_upstream *u;
 


### PR DESCRIPTION
Fixes #10560

Added per-thread removal contexts in Loki’s configuration to prevent race conditions when multiple workers use the `Remove_Keys` option. The change introduces a thread-local storage for these contexts and created helper functions to manage them safely

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
