### PR TITLE
in_winevtlog: Launch w/o valid subscription when using ignore_missing_channels parameter [Backport 3.2]

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -110,10 +110,15 @@ static int in_winevtlog_init(struct flb_input_instance *in,
 
     ctx->active_channel = winevtlog_open_all(tmp, ctx);
     if (!ctx->active_channel) {
-        flb_plg_error(ctx->ins, "failed to open channels");
-        flb_log_event_encoder_destroy(ctx->log_encoder);
-        flb_free(ctx);
-        return -1;
+        if (ctx->ignore_missing_channels) {
+            flb_plg_debug(ctx->ins, "failed to open and no subscribed channels");
+        }
+        else {
+            flb_plg_error(ctx->ins, "failed to open and no subscribed channels. Subscribe at least one");
+            flb_log_event_encoder_destroy(ctx->log_encoder);
+            flb_free(ctx);
+            return -1;
+        }
     }
 
     /* Initialize SQLite DB (optional) */


### PR DESCRIPTION
Backporting PR of https://github.com/fluent/fluent-bit/pull/10555

When using small amount of log volume but sometimes absent channels, users are forcibly ought to specify with the defenetely existing channels together.
This causes glitches of log flow controls.
So, we decided to permit absence of valid channel subscriptions when using ignore_missing_channels parameter.
This permits to use sometimes absent but low log volume and needed to consume A-to-Z EventLog channels.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
