### PR TITLE
workflows: deprecate windows-2019

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -190,8 +190,8 @@ The container images are available here (the tag refers to the branch):
 
 * [ghcr.io/fluent/fluent-bit/unstable:2.1](ghcr.io/fluent/fluent-bit/unstable:2.1)
 * [ghcr.io/fluent/fluent-bit/unstable:master](ghcr.io/fluent/fluent-bit/unstable:master)
-* [ghcr.io/fluent/fluent-bit/unstable:windows-2019-2.1](ghcr.io/fluent/fluent-bit/unstable:windows-2019-2.1)
-* [ghcr.io/fluent/fluent-bit/unstable:windows-2019-master](ghcr.io/fluent/fluent-bit/unstable:windows-2019-master)
+* [ghcr.io/fluent/fluent-bit/unstable:windows-2022-2.1](ghcr.io/fluent/fluent-bit/unstable:windows-2022-2.1)
+* [ghcr.io/fluent/fluent-bit/unstable:windows-2022-master](ghcr.io/fluent/fluent-bit/unstable:windows-2022-master)
 
 The Linux, macOS and Windows packages are available to download from the specific workflow run.
 

--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -390,8 +390,8 @@ jobs:
       fail-fast: true
       matrix:
         windows-base-version:
-          - '2019'
           - '2022'
+          - '2025'
     permissions:
       contents: read
       packages: write
@@ -443,4 +443,4 @@ jobs:
         #   load: false
         #   build-args: |
         #     FLB_NIGHTLY_BUILD=${{ inputs.unstable }}
-        #     WINDOWS_VERSION=ltsc2019
+        #     WINDOWS_VERSION=ltsc2022

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -83,15 +83,15 @@ jobs:
           DOCKER_BUILDKIT: 0
         shell: bash
     pr-image-tests-build-windows-images:
-      name: PR - Docker windows build test, windows 2019 and 2022
+      name: PR - Docker windows build test, windows 2022 and 2025
       runs-on: windows-${{ matrix.windows-base-version }}
       strategy:
         fail-fast: true
         matrix:
           windows-base-version:
             # https://github.com/fluent/fluent-bit/blob/1d366594a889624ec3003819fe18588aac3f17cd/dockerfiles/Dockerfile.windows#L3
-            - '2019'
             - '2022'
+            - '2025'
       permissions:
         contents: read
       steps:

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -575,8 +575,8 @@ jobs:
       fail-fast: false
       matrix:
         tag: [
-          "windows-2019-${{ github.event.inputs.version }}",
-          "windows-2022-${{ github.event.inputs.version }}"
+          "windows-2022-${{ github.event.inputs.version }}",
+          "windows-2025-${{ github.event.inputs.version }}"
         ]
     steps:
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
Github CI has deprecated windows-2019 runner:

https://github.com/actions/runner-images/issues/12045

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
