### PR TITLE
out_gelf: fix not escaping quotes in strings inside arrays, producing invalid JSON

### DIFF
--- a/src/flb_pack_gelf.c
+++ b/src/flb_pack_gelf.c
@@ -136,7 +136,7 @@ static flb_sds_t flb_msgpack_gelf_value(flb_sds_t *s, int quote,
         *s = tmp;
     }
     else {
-        tmp = flb_sds_cat(*s, val, val_len);
+        tmp = flb_sds_cat_utf8(s, val, val_len);
         if (tmp == NULL) {
             return NULL;
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes #9638

For GELF output fixes escaping of string contents inside arrays (See the issue)

Before:

```json
{
  "version": "1.1",
  "_log": "info",
  "_time": "2025-01-07T08:44:05+00:00",
  "short_message": "Example message",
  "_some_list": "{"project":"FluentBit","description":"Great"}, {"project":"Grafana","description":"Great too"}",
  "timestamp": 1736252577.548
}
```

After:

```json
{
    "version": "1.1",
    "_log": "info",
    "_time": "2025-01-07T08:44:05+00:00",
    "short_message": "Example message",
    "_some_list": "{\"project\":\"FluentBit\",\"description\":\"Great\"}, {\"project\":\"Grafana\",\"description\":\"Great too\"}",
    "timestamp": 1752144635.149
}
```

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```yml
services:
  fluent-bit:
    image: fluent/fluent-bit:3.2.4
    volumes:
      - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
```

`fluent-bit.conf`

```
[SERVICE]
    Flush         1
    Daemon        Off
    Log_Level     info
    Parsers_File  parsers.conf
    Plugins_File  plugins.conf
    HTTP_Server   On
    HTTP_Listen   0.0.0.0
    HTTP_Port     2020

[INPUT]
    Name      dummy
    Dummy     {"log":"info","time":"2025-01-07T08:44:05+00:00","description":"Example message","some_list":["{\"project\":\"FluentBit\",\"description\":\"Great\"}","{\"project\":\"Grafana\",\"description\":\"Great too\"}"]}

[OUTPUT]
    Name                    gelf
    Match                   *
    Host                    example.com
    Port                    12201
    Mode                    tcp
    Gelf_Short_Message_Key  description
```

- [x] Debug log output from testing the change

Dump contents sent on GELF TCP port:
```sh
nc -lk -p 12201
```

Then run fluent-bit and check output of `nc`:

```
{"version":"1.1", "_log":"info", "_time":"2025-01-07T08:44:05+00:00", "short_message":"Example message", "_some_list":"{\"project\":\"FluentBit\",\"description\":\"Great\"}, {\"project\":\"Grafana\",\"description\":\"Great too\"}", "timestamp":1752144633.149}
```

---
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A]

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
