### PR TITLE
fix: Do not use system proxy when opentelemetry proxy configured

### DIFF
--- a/include/fluent-bit/flb_upstream.h
+++ b/include/fluent-bit/flb_upstream.h
@@ -93,6 +93,9 @@ void flb_upstream_init();
 struct flb_upstream *flb_upstream_create(struct flb_config *config,
                                          const char *host, int port, int flags,
                                          struct flb_tls *tls);
+struct flb_upstream *flb_upstream_create_bypass_proxy(struct flb_config *config,
+                                                      const char *host, int port, int flags,
+                                                      struct flb_tls *tls);
 struct flb_upstream *flb_upstream_create_url(struct flb_config *config,
                                              const char *url, int flags,
                                              struct flb_tls *tls);

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -318,10 +318,10 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
     if (ctx->proxy) {
         flb_plg_trace(ctx->ins, "Upstream Proxy=%s:%i",
                       ctx->proxy_host, ctx->proxy_port);
-        upstream = flb_upstream_create(config,
-                                       ctx->proxy_host,
-                                       ctx->proxy_port,
-                                       io_flags, ins->tls);
+        upstream = flb_upstream_create_bypass_proxy(config,
+                                                    ctx->proxy_host,
+                                                    ctx->proxy_port,
+                                                    io_flags, ins->tls);
     }
     else {
         upstream = flb_upstream_create(config,

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -52,7 +52,8 @@ set(UNIT_TESTS_FILES
   storage_inherit.c
   unicode.c
   opentelemetry.c
-)
+  upstream_proxy.c
+  )
 
 # Config format
 set(UNIT_TESTS_FILES

--- a/tests/internal/upstream_proxy.c
+++ b/tests/internal/upstream_proxy.c
@@ -1,0 +1,70 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_upstream.h>
+#include <fluent-bit/flb_config.h>
+#include "flb_tests_internal.h"
+
+
+void test_upstream_with_proxy() {
+    struct flb_config *config;
+    struct flb_upstream *upstream1, *upstream2;
+    
+    /* Create a config with proxy settings */
+    config = flb_config_init();
+    if (!config) {
+        TEST_CHECK(0);
+        return;
+    }
+    
+    /* Set proxy configuration */
+    config->http_proxy = flb_strdup("http://proxy.example.com:8080");
+    
+    /* Test regular upstream creation - should use proxy */
+    upstream1 = flb_upstream_create(config, "destination.com", 443, 0, NULL);
+    TEST_CHECK(upstream1 != NULL);
+    if (!upstream1) {
+        flb_free(config->http_proxy);
+        flb_config_exit(config);
+        return;
+    }
+    
+    /* Test bypass proxy upstream creation - should skip proxy */
+    upstream2 = flb_upstream_create_bypass_proxy(config, "destination.com", 443, 0, NULL);
+    TEST_CHECK(upstream2 != NULL);
+    if (!upstream2) {
+        flb_upstream_destroy(upstream1);
+        flb_free(config->http_proxy);
+        flb_config_exit(config);
+        return;
+    }
+    
+    /* VERIFY ACTUAL PROXY BEHAVIOR */
+    /* upstream1 should connect to proxy, with destination as proxied target */
+    TEST_CHECK(upstream1->tcp_host != NULL);
+    TEST_CHECK(strcmp(upstream1->tcp_host, "proxy.example.com") == 0);
+    TEST_CHECK(upstream1->tcp_port == 8080);
+    TEST_CHECK(upstream1->proxied_host != NULL);
+    TEST_CHECK(strcmp(upstream1->proxied_host, "destination.com") == 0);
+    TEST_CHECK(upstream1->proxied_port == 443);
+    
+    /* upstream2 should connect directly to destination, no proxy */
+    TEST_CHECK(upstream2->tcp_host != NULL);
+    TEST_CHECK(strcmp(upstream2->tcp_host, "destination.com") == 0);
+    TEST_CHECK(upstream2->tcp_port == 443);
+    TEST_CHECK(upstream2->proxied_host == NULL);  /* No proxying! */
+    
+    /* Cleanup */
+    flb_upstream_destroy(upstream1);
+    flb_upstream_destroy(upstream2);
+    
+    flb_free(config->http_proxy);
+    flb_config_exit(config);
+}
+
+TEST_LIST = {
+    { "upstream_with_proxy", test_upstream_with_proxy },
+    { 0 }
+};


### PR DESCRIPTION
The opentelemetry plugin allows configuring a specific `proxy`. When that `proxy` is configured, it should override any host level proxies like `HTTP_PROXY`. This change bypasses the `HTTP_PROXY` if `proxy` is configured.


Fixes #10561

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
