### PR TITLE
input: update mem buf limit logging to include size info

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1336,8 +1336,10 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
         in->mem_buf_status = FLB_INPUT_RUNNING;
         if (in->p->cb_resume) {
             flb_input_resume(in);
-            flb_info("[input] %s resume (mem buf overlimit)",
-                      flb_input_name(in));
+            flb_info("[input] %s resume (mem buf overlimit - buf size %zuB now below limit %zuB)",
+                      flb_input_name(in),
+                      in->mem_chunks_size,
+                      in->mem_buf_limit);
         }
     }
     if (flb_input_chunk_is_storage_overlimit(in) == FLB_FALSE &&
@@ -1361,7 +1363,7 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
  * If the number of bytes in use by the chunks are over the imposed limit
  * by configuration, pause the instance.
  */
-static inline int flb_input_chunk_protect(struct flb_input_instance *i)
+static inline int flb_input_chunk_protect(struct flb_input_instance *i, size_t just_written_size)
 {
     struct flb_storage_input *storage = i->storage;
 
@@ -1393,8 +1395,12 @@ static inline int flb_input_chunk_protect(struct flb_input_instance *i)
          * The plugin is using 'memory' buffering only and already reached
          * it limit, just pause the ingestion.
          */
-        flb_warn("[input] %s paused (mem buf overlimit)",
-                 flb_input_name(i));
+        flb_warn("[input] %s paused (mem buf overlimit - event of size %zuB exceeded limit %zu to %zuB)",
+                 flb_input_name(i),
+                 just_written_size,
+                 i->mem_buf_limit,
+                 i->mem_chunks_size
+                );
         flb_input_pause(i);
         i->mem_buf_status = FLB_INPUT_PAUSED;
         return FLB_TRUE;
@@ -1830,7 +1836,7 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     }
 #endif /* FLB_HAVE_CHUNK_TRACE */
 
-    flb_input_chunk_protect(in);
+    flb_input_chunk_protect(in, final_data_size);
     return 0;
 }
 


### PR DESCRIPTION
Addresses https://github.com/fluent/fluent-bit/issues/10384

## Example of new output

```
> bin/fluent-bit -i tail -p path=./logslurp -p mem_buf_limit=1m -o file -m '*' -H
Fluent Bit v4.0.4
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/07/11 08:47:05] [ info] [fluent bit] version=4.0.4, commit=a4e3d2b20d, pid=71384
[2025/07/11 08:47:05] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/07/11 08:47:05] [ info] [simd    ] disabled
[2025/07/11 08:47:05] [ info] [cmetrics] version=1.0.3
[2025/07/11 08:47:05] [ info] [ctraces ] version=0.6.6
[2025/07/11 08:47:05] [ info] [input:tail:tail.0] initializing
[2025/07/11 08:47:05] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2025/07/11 08:47:05] [ info] [output:file:file.0] worker #0 started
[2025/07/11 08:47:05] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2025/07/11 08:47:05] [ info] [sp] stream processor started
[2025/07/11 08:47:05] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/07/11 08:47:05] [ info] [input:tail:tail.0] inotify_fs_add(): inode=8005407 watch_fd=1 name=./logslurp
```
Dump some contents into `./logslurp` by running this a few times:
```
cat /dev/random | xxd | dd of=./logslurp bs=1M count=1024
```
and we see this:
```
[2025/07/11 08:47:47] [ warn] [input] tail.0 paused (mem buf overlimit - event of size 49543B exceeded limit 1000000 to 1040403B)
[2025/07/11 08:47:47] [ info] [input] pausing tail.0
[2025/07/11 08:47:47] [ info] [input] resume tail.0
[2025/07/11 08:47:47] [ info] [input] tail.0 resume (mem buf overlimit - buf size 0B now below limit 1000000B)
[2025/07/11 08:47:47] [ warn] [input] tail.0 paused (mem buf overlimit - event of size 49543B exceeded limit 1000000 to 1040403B)
[2025/07/11 08:47:47] [ info] [input] pausing tail.0
[2025/07/11 08:47:48] [ info] [input] resume tail.0
[2025/07/11 08:47:48] [ info] [input] tail.0 resume (mem buf overlimit - buf size 0B now below limit 1000000B)
[2025/07/11 08:47:48] [ warn] [input] tail.0 paused (mem buf overlimit - event of size 49543B exceeded limit 1000000 to 1040403B)
[2025/07/11 08:47:48] [ info] [input] pausing tail.0
[2025/07/11 08:47:49] [ info] [input] resume tail.0
[2025/07/11 08:47:49] [ info] [input] tail.0 resume (mem buf overlimit - buf size 0B now below limit 1000000B)
[2025/07/11 08:47:49] [ warn] [input] tail.0 paused (mem buf overlimit - event of size 49543B exceeded limit 1000000 to 1040403B)
[2025/07/11 08:47:49] [ info] [input] pausing tail.0
[2025/07/11 08:47:50] [ info] [input] resume tail.0
[2025/07/11 08:47:50] [ info] [input] tail.0 resume (mem buf overlimit - buf size 0B now below limit 1000000B)
[2025/07/11 08:47:50] [ warn] [input] tail.0 paused (mem buf overlimit - event of size 49543B exceeded limit 1000000 to 1040403B)
[2025/07/11 08:47:50] [ info] [input] pausing tail.0
[2025/07/11 08:47:51] [ info] [input] resume tail.0
[2025/07/11 08:47:51] [ info] [input] tail.0 resume (mem buf overlimit - buf size 0B now below limit 1000000B)
[2025/07/11 08:47:51] [ warn] [input] tail.0 paused (mem buf overlimit - event of size 49543B exceeded limit 1000000 to 1040403B)
[2025/07/11 08:47:51] [ info] [input] pausing tail.0
[2025/07/11 08:47:52] [ info] [input] resume tail.0
[2025/07/11 08:47:52] [ info] [input] tail.0 resume (mem buf overlimit - buf size 0B now below limit 1000000B)
```

**Backporting**
It would be nice to backport this to latest stable release if it's not too major a change.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
