### PR TITLE
out_file: Replace SHCreateDirectoryExA to work for recursive directories correctly

### DIFF
--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -45,6 +45,12 @@
 #define NEWLINE "\n"
 #endif
 
+#ifdef FLB_SYSTEM_WINDOWS
+#define FLB_PATH_SEPARATOR "\\"
+#else
+#define FLB_PATH_SEPARATOR "/"
+#endif
+
 struct flb_file_conf {
     const char *out_path;
     const char *out_file;
@@ -368,7 +374,11 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
 #ifdef FLB_SYSTEM_MACOS
     char *parent_dir = NULL;
 #endif
-
+#ifdef FLB_SYSTEM_WINDOWS
+    char parent_path[MAX_PATH];
+    DWORD err;
+    char *p;
+#endif
     int ret;
 
     if (!dir) {
@@ -391,15 +401,40 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
     }
 
 #ifdef FLB_SYSTEM_WINDOWS
-    char path[MAX_PATH];
-
-    if (_fullpath(path, dir, MAX_PATH) == NULL) {
+    if (strncpy_s(parent_path, MAX_PATH, dir, _TRUNCATE) != 0) {
+        flb_plg_error(ins, "path is too long: %s", dir);
         return -1;
     }
 
-    if (SHCreateDirectoryExA(NULL, path, NULL) != ERROR_SUCCESS) {
-        return -1;
+    /* Normalize all forward slashes to backslashes */
+    for (p = parent_path; *p; ++p) {
+        if (*p == '/') {
+            *p = '\\';
+        }
     }
+
+    flb_plg_debug(ins, "starting to create directory %s", parent_path);
+    p = strstr(parent_path, FLB_PATH_SEPARATOR);
+    if (p != NULL && PathRemoveFileSpecA(parent_path)) {
+        flb_plg_debug(ins, "creating directory (recursive) %s", parent_path);
+        ret = mkpath(ins, parent_path);
+        if (ret != 0) {
+            /* If creating the parent failed, we cannot continue. */
+            return -1;
+        }
+    }
+
+    flb_plg_debug(ins, "creating directory %s", dir);
+    if (!CreateDirectoryA(dir, NULL)) {
+        err = GetLastError();
+
+        if (err != ERROR_ALREADY_EXISTS) {
+            flb_plg_error(ins, "could not create directory '%s' (error=%lu)",
+                          dir, err);
+            return -1;
+        }
+    }
+
     return 0;
 #elif FLB_SYSTEM_MACOS
     dup_dir = strdup(dir);
@@ -471,11 +506,11 @@ static void cb_file_flush(struct flb_event_chunk *event_chunk,
     /* Set the right output file */
     if (ctx->out_path) {
         if (ctx->out_file) {
-            snprintf(out_file, PATH_MAX - 1, "%s/%s",
+            snprintf(out_file, PATH_MAX - 1, "%s" FLB_PATH_SEPARATOR "%s",
                      ctx->out_path, ctx->out_file);
         }
         else {
-            snprintf(out_file, PATH_MAX - 1, "%s/%s",
+            snprintf(out_file, PATH_MAX - 1, "%s" FLB_PATH_SEPARATOR "%s",
                      ctx->out_path, event_chunk->tag);
         }
     }

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -406,11 +406,19 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
         return -1;
     }
 
+    p = parent_path;
+
+    /* Skip the drive letter if present (e.g., "C:") */
+    if (p[1] == ':') {
+        p += 2;
+    }
+
     /* Normalize all forward slashes to backslashes */
-    for (p = parent_path; *p; ++p) {
+    while (*p != '\0') {
         if (*p == '/') {
             *p = '\\';
         }
+        p++;
     }
 
     flb_plg_debug(ins, "starting to create directory %s", parent_path);

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -378,6 +378,7 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
     char parent_path[MAX_PATH];
     DWORD err;
     char *p;
+    char *sep;
 #endif
     int ret;
 
@@ -422,8 +423,8 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
     }
 
     flb_plg_debug(ins, "starting to create directory %s", parent_path);
-    p = strstr(parent_path, FLB_PATH_SEPARATOR);
-    if (p != NULL && PathRemoveFileSpecA(parent_path)) {
+    sep = strstr(parent_path, FLB_PATH_SEPARATOR);
+    if (sep != NULL && PathRemoveFileSpecA(parent_path)) {
         flb_plg_debug(ins, "creating directory (recursive) %s", parent_path);
         ret = mkpath(ins, parent_path);
         if (ret != 0) {

--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -422,7 +422,7 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
         p++;
     }
 
-    flb_plg_debug(ins, "starting to create directory %s", parent_path);
+    flb_plg_debug(ins, "processing path '%s'", parent_path);
     sep = strstr(parent_path, FLB_PATH_SEPARATOR);
     if (sep != NULL && PathRemoveFileSpecA(parent_path)) {
         flb_plg_debug(ins, "creating directory (recursive) %s", parent_path);
@@ -433,7 +433,7 @@ static int mkpath(struct flb_output_instance *ins, const char *dir)
         }
     }
 
-    flb_plg_debug(ins, "creating directory %s", dir);
+    flb_plg_debug(ins, "attempting to create final directory '%s'", dir);
     if (!CreateDirectoryA(dir, NULL)) {
         err = GetLastError();
 


### PR DESCRIPTION
It's been a while this issue could be a long standing issue and avoding to use SHCreateDirectoryExA is a removing nonexisting API for Windows Nano Server.
This API is not listed in the supported API list here: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt588480(v=vs.85)

Related to https://github.com/fluent/fluent-bit/issues/10255

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[INPUT]
  Name dummy
  Tag win.dummy

[OUTPUT]
  Name file
  Match *
  Path output_dir/in_dummy/deepened
  Mkdir True
```

- [x] Debug log output from testing the change

```console
Fluent Bit v4.0.5
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/07/11 17:43:43] [ info] Configuration:
[2025/07/11 17:43:43] [ info]  flush time     | 1.000000 seconds
[2025/07/11 17:43:43] [ info]  grace          | 5 seconds
[2025/07/11 17:43:43] [ info]  daemon         | 0
[2025/07/11 17:43:43] [ info] ___________
[2025/07/11 17:43:43] [ info]  inputs:
[2025/07/11 17:43:43] [ info]      dummy
[2025/07/11 17:43:43] [ info] ___________
[2025/07/11 17:43:43] [ info]  filters:
[2025/07/11 17:43:43] [ info] ___________
[2025/07/11 17:43:43] [ info]  outputs:
[2025/07/11 17:43:43] [ info]      file.0
[2025/07/11 17:43:43] [ info] ___________
[2025/07/11 17:43:43] [ info]  collectors:
[2025/07/11 17:43:43] [ info] [fluent bit] version=4.0.5, commit=1af29e72ab, pid=54864
[2025/07/11 17:43:43] [debug] [engine] maxstdio set: 512
[2025/07/11 17:43:43] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2025/07/11 17:43:43] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/07/11 17:43:43] [ info] [simd    ] disabled
[2025/07/11 17:43:43] [ info] [cmetrics] version=1.0.4
[2025/07/11 17:43:43] [ info] [ctraces ] version=0.6.6
[2025/07/11 17:43:43] [ info] [input:dummy:dummy.0] initializing
[2025/07/11 17:43:43] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/07/11 17:43:43] [debug] [dummy:dummy.0] created event channels: read=840 write=844
[2025/07/11 17:43:43] [debug] [file:file.0] created event channels: read=848 write=852
[2025/07/11 17:43:43] [ info] [sp] stream processor started
[2025/07/11 17:43:43] [ info] [output:file:file.0] worker #0 started
[2025/07/11 17:43:43] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/07/11 17:43:45] [debug] [task] created task=000001BDD75D6BC0 id=0 OK
[2025/07/11 17:43:45] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2025/07/11 17:43:45] [debug] [output:file:file.0] processing path 'output_dir\in_dummy\deepened'
[2025/07/11 17:43:45] [debug] [output:file:file.0] creating directory (recursive) output_dir\in_dummy
[2025/07/11 17:43:45] [debug] [output:file:file.0] processing path 'output_dir\in_dummy'
[2025/07/11 17:43:45] [debug] [output:file:file.0] creating directory (recursive) output_dir
[2025/07/11 17:43:45] [debug] [output:file:file.0] processing path 'output_dir'
[2025/07/11 17:43:45] [debug] [output:file:file.0] attempting to create final directory 'output_dir'
[2025/07/11 17:43:45] [debug] [output:file:file.0] attempting to create final directory 'output_dir\in_dummy'
[2025/07/11 17:43:45] [debug] [output:file:file.0] attempting to create final directory 'output_dir/in_dummy/deepened'
[2025/07/11 17:43:45] [debug] [out flush] cb_destroy coro_id=0
[2025/07/11 17:43:45] [debug] [task] destroy task=000001BDD75D6BC0 (task_id=0)
[2025/07/11 17:43:46] [debug] [task] created task=000001BDD75D6EE0 id=0 OK
[2025/07/11 17:43:46] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2025/07/11 17:43:46] [debug] [out flush] cb_destroy coro_id=1
[2025/07/11 17:43:46] [debug] [task] destroy task=000001BDD75D6EE0 (task_id=0)
[2025/07/11 17:43:47] [engine] caught signal (SIGINT)
[2025/07/11 17:43:47] [debug] [task] created task=000001BDD75D7200 id=0 OK
[2025/07/11 17:43:47] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2025/07/11 17:43:47] [debug] [out flush] cb_destroy coro_id=2
[2025/07/11 17:43:47] [debug] [task] destroy task=000001BDD75D7200 (task_id=0)
[2025/07/11 17:43:47] [debug] [task] created task=000001BDD75D6800 id=0 OK
[2025/07/11 17:43:47] [debug] [output:file:file.0] task_id=0 assigned to thread #0
[2025/07/11 17:43:47] [ warn] [engine] service will shutdown in max 5 seconds
[2025/07/11 17:43:47] [debug] [engine] retry=0000000000000000 for task 0 already scheduled to run, not re-scheduling it.
[2025/07/11 17:43:47] [ info] [input] pausing dummy.0
[2025/07/11 17:43:47] [debug] [out flush] cb_destroy coro_id=3
[2025/07/11 17:43:47] [debug] [task] destroy task=000001BDD75D6800 (task_id=0)
[2025/07/11 17:43:48] [ info] [engine] service has stopped (0 pending tasks)
[2025/07/11 17:43:48] [ info] [output:file:file.0] thread worker #0 stopping...
[2025/07/11 17:43:48] [ info] [input] pausing dummy.0
[2025/07/11 17:43:48] [ info] [output:file:file.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
