### PR TITLE
out_datadog: added support for site configuration field

### DIFF
--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -581,7 +581,10 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_out_datadog, json_date_key),
      "Date key name for output."
     },
-
+    {
+    FLB_CONFIG_MAP_STR, "site", NULL, 0, FLB_FALSE, offsetof(struct flb_out_datadog, site),
+    "DataDog site for telemetry data (e.g., 'datadoghq.eu', 'datadoghq.com', 'us3.datadoghq.com'). The plugin will construct the full hostname by prepending 'http-intake.logs.' to this value."
+    },
     /* EOF */
     {0}
 };

--- a/plugins/out_datadog/datadog.h
+++ b/plugins/out_datadog/datadog.h
@@ -61,6 +61,7 @@ struct flb_out_datadog {
     flb_sds_t tag_key;
     struct mk_list *headers;
     bool remap;
+    flb_sds_t site;
 
     /* final result */
     flb_sds_t json_date_key;

--- a/plugins/out_datadog/datadog_conf.c
+++ b/plugins/out_datadog/datadog_conf.c
@@ -40,6 +40,7 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     char *host = NULL;
     char *port = NULL;
     char *uri = NULL;
+    char *site = NULL;
 
     /* Start resource creation */
     ctx = flb_calloc(1, sizeof(struct flb_out_datadog));
@@ -98,6 +99,15 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
         return NULL;
     }
 
+    /* Parse site parameter early so it's available for host construction */
+    tmp = flb_output_get_property("site", ins);
+    if (tmp){
+        ctx->site = flb_sds_create(tmp);
+        flb_plg_debug(ctx->ins, "site parameter set to: %s", ctx->site);
+    } else {
+        flb_plg_debug(ctx->ins, "no site parameter found");
+    }
+
     /* Tag Key */
     if (ctx->include_tag_key == FLB_TRUE) {
         ctx->nb_additional_entries++;
@@ -126,7 +136,7 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
     tmp = flb_output_get_property("provider", ins);
     ctx->remap = tmp && (strlen(tmp) == strlen(FLB_DATADOG_REMAP_PROVIDER)) && \
         (strncmp(tmp, FLB_DATADOG_REMAP_PROVIDER, strlen(tmp)) == 0);
-
+    
     ctx->uri = flb_sds_create("/api/v2/logs");
     if (!ctx->uri) {
         flb_plg_error(ctx->ins, "error on uri generation");
@@ -138,18 +148,47 @@ struct flb_out_datadog *flb_datadog_conf_create(struct flb_output_instance *ins,
 
     /* Get network configuration */
     if (!ins->host.name) {
-        tmp_sds = flb_sds_create(FLB_DATADOG_DEFAULT_HOST);
+        /* No explicit Host parameter, check for site */
+        if (ctx->site) {
+            flb_plg_debug(ctx->ins, "using site for host construction: %s", ctx->site);
+            /* Construct hostname from site */
+            tmp_sds = flb_sds_create("http-intake.logs.");
+            if (!tmp_sds) {
+                flb_errno();
+                flb_datadog_conf_destroy(ctx);
+                return NULL;
+            }
+            flb_plg_debug(ctx->ins, "created base hostname: %s", tmp_sds);
+            flb_plg_debug(ctx->ins, "about to concatenate site: %s (length: %zu)", ctx->site, flb_sds_len(ctx->site));
+            tmp_sds = flb_sds_cat(tmp_sds, (const char *)ctx->site, flb_sds_len(ctx->site));
+            flb_plg_debug(ctx->ins, "after concatenation: %s", tmp_sds);
+            ctx->host = tmp_sds;
+            flb_plg_debug(ctx->ins, "host constructed from site: %s", ctx->host);
+        } else {
+            flb_plg_debug(ctx->ins, "no site specified, using default host");
+            /* No site specified, use default */
+            tmp_sds = flb_sds_create(FLB_DATADOG_DEFAULT_HOST);
+            if (!tmp_sds) {
+                flb_errno();
+                flb_datadog_conf_destroy(ctx);
+                return NULL;
+            }
+            ctx->host = tmp_sds;
+            flb_plg_debug(ctx->ins, "host: %s", ctx->host);
+        }
     }
     else {
+        flb_plg_debug(ctx->ins, "explicit Host parameter takes precedence: %s", ins->host.name);
+        /* Explicit Host parameter takes precedence */
         tmp_sds = flb_sds_create(ins->host.name);
+        if (!tmp_sds) {
+            flb_errno();
+            flb_datadog_conf_destroy(ctx);
+            return NULL;
+        }
+        ctx->host = tmp_sds;
+        flb_plg_debug(ctx->ins, "host: %s", ctx->host);
     }
-    if (!tmp_sds) {
-        flb_errno();
-        flb_datadog_conf_destroy(ctx);
-        return NULL;
-    }
-    ctx->host = tmp_sds;
-    flb_plg_debug(ctx->ins, "host: %s", ctx->host);
 
     if (ins->host.port != 0) {
         ctx->port = ins->host.port;
@@ -221,6 +260,9 @@ int flb_datadog_conf_destroy(struct flb_out_datadog *ctx)
     }
     if (ctx->upstream) {
         flb_upstream_destroy(ctx->upstream);
+    }
+    if (ctx->site){
+        flb_sds_destroy(ctx->site);
     }
     flb_free(ctx);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Add `site` Parameter to Fluent Bit Plugin for Regional Data Routing
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
