### PR TITLE
cleanup old-style multiline parsers

### DIFF
--- a/conf/parsers_extra.conf
+++ b/conf/parsers_extra.conf
@@ -139,27 +139,6 @@
     Time_Keep    On
 # We cannot parse the time as different formats directly, it could be done downstream and/or left as current time
 
-[PARSER]
-    Name         couchbase_erlang_multiline
-    Format       regex
-    # For some reason this cannot parse an ending close bracket ] followed by a new line immediately
-    #Regex        \[(?<logger>\w+):(?<level>\w+),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),.*\](?<message>.*)$
-    Regex        \[(?<logger>\w+):(?<level>\w+),(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+.\d+Z),(?<message>.*)$
-    Time_Key     timestamp
-    Time_Format  %Y-%m-%dT%H:%M:%S.%L   
-    Time_Keep    On
-
-# 2021-03-09T17:32:25.339+00:00 INFO CBAS.bootstrap.AnalyticsNCApplication [main] ...
-# https://rubular.com/r/9jh1oKtXBN5GEV
-# Can include an exception stack trace or a thread dump as well but ignoring these for now
-[PARSER]
-    Name         couchbase_java_multiline
-    Format       regex
-    Regex        ^(?<timestamp>\d+-\d+-\d+T\d+:\d+:\d+\.\d+(\+|-)\d+:\d+)\s+(?<level>\w+)\s+(?<class>.*)\s+\[(?<thread>.*)\]\s+(?<message>.*)$
-    Time_Key     timestamp
-    Time_Format  %Y-%m-%dT%H:%M:%S.%L%z
-    Time_Keep    On
-
 # A slight modification of the usual Apache/Apache2 parsers
 [PARSER]
     Name         couchbase_http

--- a/conf/parsers_java.conf
+++ b/conf/parsers_java.conf
@@ -1,6 +1,0 @@
-[PARSER]
-    Name        java_multiline
-    Format      regex
-    Regex       /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) \[(?<thread>.*)\] (?<level>[^\s]+)(?<message>.*)/
-    Time_Key    time
-    Time_Format %Y-%m-%d %H:%M:%S


### PR DESCRIPTION
<!-- Provide summary of changes -->
deleted old-style multiline parsers, to remove some confusion.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
fixes part of #10212 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Removed legacy multiline log parsers for Couchbase (Erlang and Java) and generic Java.
  * These log formats are no longer recognized out of the box; existing setups relying on them will stop parsing as before.
  * Other parsing rules remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->