### PR TITLE
input: make input threads ring_buffer capacity and window flush configurable

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -379,6 +379,8 @@ struct flb_input_instance {
      * in the ring buffer.
      */
     struct flb_ring_buffer *rb;
+    size_t ring_buffer_size;           /* ring buffer size */
+    uint8_t ring_buffer_window;        /* ring buffer window percentage */
 
     /* List of upstreams */
     struct mk_list upstreams;

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -128,12 +128,12 @@ struct flb_config_map input_global_properties[] = {
         "Enable threading on an input"
     },
     {
-        FLB_CONFIG_MAP_INT, "thread.ring_buffer.capacity", "0",
+        FLB_CONFIG_MAP_INT, "thread.ring_buffer.capacity", STR(FLB_INPUT_RING_BUFFER_CAPACITY),
         0, FLB_FALSE, 0,
         "Set custom ring buffer capacity when the input runs in threaded mode"
     },
     {
-        FLB_CONFIG_MAP_INT, "thread.ring_buffer.window", "0",
+        FLB_CONFIG_MAP_INT, "thread.ring_buffer.window", STR(FLB_INPUT_RING_BUFFER_WINDOW),
         0, FLB_FALSE, 0,
         "Set custom ring buffer window percentage for threaded inputs"
     },

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -742,6 +742,7 @@ int flb_input_set_property(struct flb_input_instance *ins,
         ret = atoi(tmp);
         flb_sds_destroy(tmp);
         if (ret <= 0 || ret > 100) {
+            flb_error("[input] thread.ring_buffer.window must be between 1 and 100");
             return -1;
         }
         ins->ring_buffer_window = (uint8_t) ret;


### PR DESCRIPTION
Input plugins running in threaded mode use a per-instance ring buffer to enqueue records into the pipeline, which are then consumed by the engine. By default, each ring buffer is sized for 1024 entries.

In high-throughput scenarios, the default capacity may not be sufficient. This patch introduces two new configuration options to allow fine-tuning of the ring buffer behavior per input plugin:

- thread.ring_buffer.capacity: Sets the maximum number of entries the ring buffer can hold (default: 1024).

- thread.ring_buffer.window: Sets the flush window as a percentage of capacity, used to trigger a flush
                              request when the threshold is reached (default: 5).

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
