### PR TITLE
tls: openssl: output: configurable certstore name [Backport 4.0]

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -369,6 +369,10 @@ struct flb_output_instance {
     char *tls_min_version;               /* Minimum protocol version of TLS */
     char *tls_max_version;               /* Maximum protocol version of TLS */
     char *tls_ciphers;                   /* TLS ciphers */
+# if defined(FLB_SYSTEM_WINDOWS)
+    char *tls_win_certstore_name;            /* CertStore Name (Windows) */
+    int tls_win_use_enterprise_certstore;    /* Use enterprise CertStore */
+# endif
 #endif
 
     /*

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -101,6 +101,10 @@ struct flb_tls {
     char *vhost;                      /* Virtual hostname for SNI  */
     int mode;                         /* Client or Server          */
     int verify_hostname;              /* Verify hostname           */
+#if defined(FLB_SYSTEM_WINDOWS)
+    char *certstore_name;             /* Windows CertStore Name    */
+    int use_enterprise_store;         /* Use Enterprise store or not */
+#endif
 
     /* Bakend library for TLS */
     void *ctx;                        /* TLS context created */
@@ -122,6 +126,10 @@ int flb_tls_destroy(struct flb_tls *tls);
 int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn);
 
 int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname);
+#if defined(FLB_SYSTEM_WINDOWS)
+int flb_tls_set_certstore_name(struct flb_tls *tls, const char *certstore_name);
+int flb_tls_set_use_enterprise_store(struct flb_tls *tls, int use_enterprise);
+#endif
 
 int flb_tls_load_system_certificates(struct flb_tls *tls);
 int flb_tls_set_minmax_proto(struct flb_tls *tls,

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -92,6 +92,11 @@ struct flb_tls_backend {
     int (*net_write) (struct flb_tls_session *, const void *data,
                       size_t len);
     int (*net_handshake) (struct flb_tls *, char *, void *);
+
+#if defined(FLB_SYSTEM_WINDOWS)
+    int (*set_certstore_name)(struct flb_tls *tls, const char *certstore_name);
+    int (*set_use_enterprise_store)(struct flb_tls *tls, int use_enterprise);
+#endif
 };
 
 /* Main TLS context */

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -1400,6 +1400,8 @@ int flb_output_init_all(struct flb_config *config)
             }
 
             if (ins->tls_win_certstore_name) {
+                flb_debug("[output %s] starting to load %s certstore in TLS context",
+                          ins->name, ins->tls_win_certstore_name);
                 ret = flb_tls_set_certstore_name(ins->tls, ins->tls_win_certstore_name);
                 if (ret == -1) {
                     flb_error("[output %s] error specify certstore name in TLS context",
@@ -1408,6 +1410,8 @@ int flb_output_init_all(struct flb_config *config)
                     return -1;
                 }
 
+                flb_debug("[output %s] attempting to load %s certstore in TLS context",
+                          ins->name, ins->tls_win_certstore_name);
                 ret = flb_tls_load_system_certificates(ins->tls);
                 if (ret == -1) {
                     flb_error("[output %s] error set up to load certstore with a user-defined name in TLS context",

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -83,6 +83,16 @@ struct flb_config_map output_global_properties[] = {
         "Accepted values: a positive integer, 'no_limits', 'false', or 'off' to disable retry limits, "
         "or 'no_retries' to disable retries entirely."
     },
+    {
+        FLB_CONFIG_MAP_STR, "tls.windows.certstore_name", NULL,
+        0, FLB_FALSE, 0,
+        "Sets the certstore name on an output (Windows)"
+    },
+    {
+        FLB_CONFIG_MAP_STR, "tls.windows.use_enterprise_store", NULL,
+        0, FLB_FALSE, 0,
+        "Sets whether using enterprise certstore or not on an output (Windows)"
+    },
 
     {0}
 };
@@ -174,6 +184,11 @@ static void flb_output_free_properties(struct flb_output_instance *ins)
     if (ins->tls_ciphers) {
         flb_sds_destroy(ins->tls_ciphers);
     }
+# if defined(FLB_SYSTEM_WINDOWS)
+    if (ins->tls_win_certstore_name) {
+        flb_sds_destroy(ins->tls_win_certstore_name);
+    }
+# endif
 #endif
 }
 
@@ -751,6 +766,10 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     instance->tls_crt_file          = NULL;
     instance->tls_key_file          = NULL;
     instance->tls_key_passwd        = NULL;
+# if defined(FLB_SYSTEM_WINDOWS)
+    instance->tls_win_certstore_name = NULL;
+    instance->tls_win_use_enterprise_certstore = FLB_FALSE;
+# endif
 #endif
 
     if (plugin->flags & FLB_OUTPUT_NET) {
@@ -975,6 +994,15 @@ int flb_output_set_property(struct flb_output_instance *ins,
     else if (prop_key_check("tls.ciphers", k, len) == 0) {
         flb_utils_set_plugin_string_property("tls.ciphers", &ins->tls_ciphers, tmp);
     }
+#  if defined(FLB_SYSTEM_WINDOWS)
+    else if (prop_key_check("tls.windows.certstore_name", k, len) == 0 && tmp) {
+        flb_utils_set_plugin_string_property("tls.windows.certstore_name", &ins->tls_win_certstore_name, tmp);
+    }
+    else if (prop_key_check("tls.windows.use_enterprise_store", k, len) == 0 && tmp) {
+        ins->tls_win_use_enterprise_certstore = flb_utils_bool(tmp);
+        flb_sds_destroy(tmp);
+    }
+#  endif
 #endif
     else if (prop_key_check("storage.total_limit_size", k, len) == 0 && tmp) {
         if (strcasecmp(tmp, "off") == 0 ||
@@ -1359,6 +1387,36 @@ int flb_output_init_all(struct flb_config *config)
                     return -1;
                 }
             }
+
+# if defined (FLB_SYSTEM_WINDOWS)
+            if (ins->tls_win_use_enterprise_certstore) {
+                ret = flb_tls_set_use_enterprise_store(ins->tls, ins->tls_win_use_enterprise_certstore);
+                if (ret == -1) {
+                    flb_error("[input %s] error set up to use enterprise certstore in TLS context",
+                              ins->name);
+
+                    return -1;
+                }
+            }
+
+            if (ins->tls_win_certstore_name) {
+                ret = flb_tls_set_certstore_name(ins->tls, ins->tls_win_certstore_name);
+                if (ret == -1) {
+                    flb_error("[output %s] error specify certstore name in TLS context",
+                              ins->name);
+
+                    return -1;
+                }
+
+                ret = flb_tls_load_system_certificates(ins->tls);
+                if (ret == -1) {
+                    flb_error("[output %s] error set up to load certstore with a user-defined name in TLS context",
+                              ins->name);
+
+                    return -1;
+                }
+            }
+# endif
         }
 #endif
         /*

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -299,26 +299,18 @@ int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname)
 #if defined(FLB_SYSTEM_WINDOWS)
 int flb_tls_set_certstore_name(struct flb_tls *tls, const char *certstore_name)
 {
-    if (!tls) {
-        return -1;
+    if (tls) {
+        return tls->api->set_certstore_name(tls, certstore_name);
     }
-
-    if (tls->certstore_name) {
-        flb_free(tls->certstore_name);
-    }
-
-    tls->certstore_name = flb_strdup(certstore_name);
 
     return 0;
 }
 
 int flb_tls_set_use_enterprise_store(struct flb_tls *tls, int use_enterprise)
 {
-    if (!tls) {
-        return -1;
+    if (tls) {
+        return tls->api->set_use_enterprise_store(tls, use_enterprise);
     }
-
-    tls->use_enterprise_store = !!use_enterprise;
 
     return 0;
 }

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -216,6 +216,10 @@ struct flb_tls *flb_tls_create(int mode,
     tls->debug = debug;
     tls->mode = mode;
     tls->verify_hostname = FLB_FALSE;
+#if defined(FLB_SYSTEM_WINDOWS)
+    tls->certstore_name = NULL;
+    tls->use_enterprise_store = FLB_FALSE;
+#endif
 
     if (vhost != NULL) {
         tls->vhost = flb_strdup(vhost);
@@ -261,6 +265,12 @@ int flb_tls_destroy(struct flb_tls *tls)
         flb_free(tls->vhost);
     }
 
+#if defined(FLB_SYSTEM_WINDOWS)
+    if (tls->certstore_name) {
+        flb_free(tls->certstore_name);
+    }
+#endif
+
     flb_free(tls);
 
     return 0;
@@ -285,6 +295,34 @@ int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname)
 
     return 0;
 }
+
+#if defined(FLB_SYSTEM_WINDOWS)
+int flb_tls_set_certstore_name(struct flb_tls *tls, const char *certstore_name)
+{
+    if (!tls) {
+        return -1;
+    }
+
+    if (tls->certstore_name) {
+        flb_free(tls->certstore_name);
+    }
+
+    tls->certstore_name = flb_strdup(certstore_name);
+
+    return 0;
+}
+
+int flb_tls_set_use_enterprise_store(struct flb_tls *tls, int use_enterprise)
+{
+    if (!tls) {
+        return -1;
+    }
+
+    tls->use_enterprise_store = !!use_enterprise;
+
+    return 0;
+}
+#endif
 
 int flb_tls_net_read(struct flb_tls_session *session, void *buf, size_t len)
 {

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -372,7 +372,8 @@ static int windows_load_system_certificates(struct tls_context *ctx)
         return -1;
     }
 
-    flb_debug("[tls] successfully loaded certificates from windows system store.");
+    flb_debug("[tls] successfully loaded certificates from windows system %s store.", 
+              certstore_name);
     return 0;
 }
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is backporting PR for https://github.com/fluent/fluent-bit/pull/10590.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
