### PR TITLE
workflows: prepare 4.1 release

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -502,7 +502,9 @@ jobs:
           TAG: ${{ steps.get-tag.outputs.tag }}
 
   staging-release-images-latest-tags:
-    # Only update latest tags for 4.0 releases
+    # NOTE: Before releasing 4.1, we need to change '4.' to '4.1'
+    # Meanwhile, we need to release 4.0 series as stable releases.
+    # Only update latest tags for 4. releases
     if: startsWith(github.event.inputs.version, '4.')
     name: Release latest Linux container images
     runs-on: ubuntu-latest
@@ -829,9 +831,20 @@ jobs:
           target_commitish: '3.2'
           make_latest: false
 
-      - name: Release 4.0 and latest
+      - name: Release 4.0 - not latest
         uses: softprops/action-gh-release@v2
         if: startsWith(inputs.version, '4.0')
+        with:
+          body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
+          draft: false
+          generate_release_notes: true
+          name: "Fluent Bit ${{ inputs.version }}"
+          tag_name: v${{ inputs.version }}
+          make_latest: true
+
+      - name: Release 4.1 and latest
+        uses: softprops/action-gh-release@v2
+        if: startsWith(inputs.version, '4.1')
         with:
           body: "https://fluentbit.io/announcements/v${{ inputs.version }}/"
           draft: false
@@ -948,8 +961,15 @@ jobs:
           token: ${{ secrets.GH_PA_TOKEN }}
           ref: 3.2
 
-      - name: Release 4.0 and latest
+      - name: Release 4.0 - not latest
         if: startsWith(inputs.version, '4.0')
+        uses: actions/checkout@v4
+        with:
+          repository: fluent/fluent-bit-docs
+          token: ${{ secrets.GH_PA_TOKEN }}
+
+      - name: Release 4.1 and latest
+        if: startsWith(inputs.version, '4.1')
         uses: actions/checkout@v4
         with:
           repository: fluent/fluent-bit-docs

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,6 +22,7 @@ on:
       - 'examples/**'
     branches:
       - master
+      - 4.0
       - 3.2
       - 3.1
       - 3.0


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, still left for 4.0 release adopted workflows.
So, we need to change the settings to prepare 4.1 release.
For now, we still need to use latest tag for 4.0 release. So, I didn't touch it.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
