### PR TITLE
input: remove second close on collector timer during destruction to avoid double-closing

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1979,7 +1979,6 @@ int flb_input_collector_destroy(struct flb_input_collector *coll)
     if (coll->type == FLB_COLLECT_TIME) {
         if (coll->fd_timer > 0) {
             mk_event_timeout_destroy(config->evl, &coll->event);
-            mk_event_closesocket(coll->fd_timer);
         }
     }
     else {
@@ -1994,7 +1993,6 @@ int flb_input_collector_destroy(struct flb_input_collector *coll)
 int flb_input_collector_pause(int coll_id, struct flb_input_instance *in)
 {
     int ret;
-    flb_pipefd_t fd;
     struct flb_input_collector *coll;
 
     coll = get_collector(coll_id, in);
@@ -2015,10 +2013,8 @@ int flb_input_collector_pause(int coll_id, struct flb_input_instance *in)
          * Note: Invalidate fd_timer first in case closing a socket
          * invokes another event.
          */
-        fd = coll->fd_timer;
         coll->fd_timer = -1;
         mk_event_timeout_destroy(coll->evl, &coll->event);
-        mk_event_closesocket(fd);
     }
     else if (coll->type & (FLB_COLLECT_FD_SERVER | FLB_COLLECT_FD_EVENT)) {
         ret = mk_event_del(coll->evl, &coll->event);


### PR DESCRIPTION
- Removed the second close on the collector timer during destruction to avoid double-closing of the fd
- Updated the pause logic so the timer file descriptor is only invalidated and its event destroyed without an extra close call

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of input collector lifecycle by adjusting socket management. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->