### PR TITLE
in_winevtlog: Handle Daylight saving time by using newer functions

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -189,17 +189,17 @@ static int pack_systemtime(struct winevtlog_config *ctx, SYSTEMTIME *st)
     CHAR buf[64];
     size_t len = 0;
     _locale_t locale;
-    TIME_ZONE_INFORMATION tzi;
+    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
     SYSTEMTIME st_local;
 
-    GetTimeZoneInformation(&tzi);
+    GetDynamicTimeZoneInformation(&dtzi);
 
     locale = _get_current_locale();
     if (locale == NULL) {
         return -1;
     }
     if (st != NULL) {
-        SystemTimeToTzSpecificLocalTime(&tzi, st, &st_local);
+        SystemTimeToTzSpecificLocalTimeEx(&dtzi, st, &st_local);
 
         struct tm tm = {st_local.wSecond,
                         st_local.wMinute,

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -207,7 +207,7 @@ static int pack_systemtime(struct winevtlog_config *ctx, SYSTEMTIME *st)
                         st_local.wDay,
                         st_local.wMonth-1,
                         st_local.wYear-1900,
-                        st_local.wDayOfWeek, 0, 0};
+                        st_local.wDayOfWeek, 0, -1};
         len = _strftime_l(buf, 64, FORMAT_ISO8601, &tm, locale);
         if (len == 0) {
             flb_errno();
@@ -243,7 +243,7 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
     ft.dwLowDateTime = timestamp.LowPart;
     FileTimeToLocalFileTime(&ft, &ft_local);
     if (FileTimeToSystemTime(&ft_local, &st)) {
-        struct tm tm = {st.wSecond, st.wMinute, st.wHour, st.wDay, st.wMonth-1, st.wYear-1900, st.wDayOfWeek, 0, 0};
+        struct tm tm = {st.wSecond, st.wMinute, st.wHour, st.wDay, st.wMonth-1, st.wYear-1900, st.wDayOfWeek, 0, -1};
         len = _strftime_l(buf, 64, FORMAT_ISO8601, &tm, locale);
         if (len == 0) {
             flb_errno();

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -192,6 +192,8 @@ static int pack_systemtime(struct winevtlog_config *ctx, SYSTEMTIME *st)
     DYNAMIC_TIME_ZONE_INFORMATION dtzi;
     SYSTEMTIME st_local;
 
+    _tzset();
+
     GetDynamicTimeZoneInformation(&dtzi);
 
     locale = _get_current_locale();
@@ -233,6 +235,8 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
     FILETIME ft, ft_local;
     SYSTEMTIME st;
     _locale_t locale;
+
+    _tzset();
 
     locale = _get_current_locale();
     if (locale == NULL) {


### PR DESCRIPTION
* SystemTimeToTzSpecificLocalTimeEx
* GetDynamicTimeZoneInformation

are able to handle Daylight Saving Time(DST).

FileTimeToLocalFileTime and SystemTimeToTzSpecificLocalTimeEx
automatically convert between ST and DST.
These functions are working well for DST conversions.

Then, we got:

<img width="1327" height="703" alt="image" src="https://github.com/user-attachments/assets/b0eca4be-f10f-47eb-a5db-0979f452e7c3" />

```
[663] winevtlog.0: [[1753251022.125331400, {}], {"ProviderName"=>"Microsoft-Windows-RestartManager", "ProviderGuid"=>"{0888E5EF-9B98-4695-979D-E92CE4247224}", "Qualifiers"=>"", "EventID"=>10001, "Version"=>0, "Level"=>4, "Task"=>0, "Opcode"=>0, "Keywords"=>"0x8000000000000000", "TimeCreated"=>"2025-05-10 05:13:42 -0700", "EventRecordID"=>3959, "ActivityID"=>"", "RelatedActivityID"=>"", "ProcessID"=>34096, "ThreadID"=>61344, "Channel"=>"Application", "Computer"=>"hiro-area51-14", "UserID"=>"NT AUTHORITY\SYSTEM", "Message"=>"Ending session 0 started ΓÇÄ2025ΓÇÄ-ΓÇÄ05ΓÇÄ-ΓÇÄ10T12:13:42.448394200Z.", "StringInserts"=>[0, "2025-05-10 05:13:42 -0700"]}]
[664] winevtlog.0: [[1753251022.125822100, {}], {"ProviderName"=>"Microsoft-Windows-RestartManager", "ProviderGuid"=>"{0888E5EF-9B98-4695-979D-E92CE4247224}", "Qualifiers"=>"", "EventID"=>10000, "Version"=>0, "Level"=>4, "Task"=>0, "Opcode"=>0, "Keywords"=>"0x8000000000000000", "TimeCreated"=>"2025-05-10 05:13:42 -0700", "EventRecordID"=>3960, "ActivityID"=>"", "RelatedActivityID"=>"", "ProcessID"=>34096, "ThreadID"=>61344, "Channel"=>"Application", "Computer"=>"hiro-area51-14", "UserID"=>"NT AUTHORITY\SYSTEM", "Message"=>"Starting session 0 - ΓÇÄ2025ΓÇÄ-ΓÇÄ05ΓÇÄ-ΓÇÄ10T12:13:42.785623300Z.", "StringInserts"=>[0, "2025-05-10 05:13:42 -0700"]}]
```

PST is now under Daylight Saving Time(DST).
So, it's correct behavior for the DST implemented timezone.

<!-- Provide summary of changes -->

This was originally reported in https://github.com/fluent/fluent-bit/pull/8386.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

It's easily testing with the basic winevtlog plugin's parameters.

```powershell
PS> bin/fluent-bit -i winevtlog -p read_existing_events=On -o stdout
```
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
