### PR TITLE
input: add new ring buffer metrics

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -426,6 +426,11 @@ struct flb_input_instance {
     struct cmt_counter *cmt_memrb_dropped_chunks;
     struct cmt_counter *cmt_memrb_dropped_bytes;
 
+    /* ring buffer 'write' metrics */
+    struct cmt_counter *cmt_ring_buffer_writes;
+    struct cmt_counter *cmt_ring_buffer_retries;
+    struct cmt_counter *cmt_ring_buffer_retry_failures;
+
     /*
      * Indexes for generated chunks: simple hash tables that keeps the latest
      * available chunks for writing data operations. This optimizes the

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1237,6 +1237,34 @@ int flb_input_instance_init(struct flb_input_instance *ins,
         cmt_counter_set(ins->cmt_memrb_dropped_bytes, ts, 0, 1, (char *[]) {name});
     }
 
+    /* fluentbit_input_ring_buffer_writes_total */
+    ins->cmt_ring_buffer_writes = \
+        cmt_counter_create(ins->cmt,
+                            "fluentbit", "input",
+                            "ring_buffer_writes_total",
+                            "Number of ring buffer writes.",
+                            1, (char *[]) {"name"});
+    cmt_gauge_set(ins->cmt_ring_buffer_writes, ts, 0, 1, (char *[]) {name});
+
+    /* fluentbit_input_ring_buffer_retries_total */
+    ins->cmt_ring_buffer_retries = \
+        cmt_counter_create(ins->cmt,
+                            "fluentbit", "input",
+                            "ring_buffer_retries_total",
+                            "Number of ring buffer retries.",
+                            1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_ring_buffer_retries, ts, 0, 1, (char *[]) {name});
+
+
+    /* fluentbit_input_ring_buffer_retry_failures_total */
+    ins->cmt_ring_buffer_retry_failures = \
+        cmt_counter_create(ins->cmt,
+                            "fluentbit", "input",
+                            "ring_buffer_retry_failures_total",
+                            "Number of ring buffer retry failures.",
+                            1, (char *[]) {"name"});
+    cmt_counter_set(ins->cmt_ring_buffer_retry_failures, ts, 0, 1, (char *[]) {name});
+
     /* OLD Metrics */
     ins->metrics = flb_metrics_create(name);
     if (ins->metrics) {


### PR DESCRIPTION
This patch adds new metrics to track the behavior of the input ring buffer, enabling better observability and troubleshooting in high-load or threaded environments.

The following counters are now registered per input instance:

| Metric Name                                          | Description                                 |
|------------------------------------------------------|---------------------------------------------|
| `fluentbit_input_ring_buffer_writes_total`           | Number of successful ring buffer writes     |
| `fluentbit_input_ring_buffer_retries_total`          | Number of retry attempts due to saturation  |
| `fluentbit_input_ring_buffer_retry_failures_total`   | Number of failed retries (after limit hit)  |

---

### Motivation

In high-throughput scenarios — especially when input plugins run in **threaded mode** — the ring buffer can experience contention or saturation. Without visibility into how often data is retried or dropped, diagnosing bottlenecks or tuning buffer sizes is difficult.

By tracking:
- ✅ **successful writes**  
- 🔁 **retry attempts**  
- ❌ **write failures due to retry limits**  

we now have fine-grained insight into backpressure and plugin-level performance.

---

### Example (from Prometheus endpoint)

```prometheus
# HELP fluentbit_input_ring_buffer_writes_total Number of ring buffer writes.
# TYPE fluentbit_input_ring_buffer_writes_total counter
fluentbit_input_ring_buffer_writes_total{name="syslog.0"} 15000

# HELP fluentbit_input_ring_buffer_retries_total Number of ring buffer retries.
# TYPE fluentbit_input_ring_buffer_retries_total counter
fluentbit_input_ring_buffer_retries_total{name="syslog.0"} 820

# HELP fluentbit_input_ring_buffer_retry_failures_total Number of ring buffer retry failures.
# TYPE fluentbit_input_ring_buffer_retry_failures_total counter
fluentbit_input_ring_buffer_retry_failures_total{name="syslog.0"} 5
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
