### PR TITLE
output: add new net.proxy_env_ignore option [v4.0]

### DIFF
--- a/include/fluent-bit/flb_network.h
+++ b/include/fluent-bit/flb_network.h
@@ -99,6 +99,9 @@ struct flb_net_setup {
 
     /* maximum number of allowed active TCP connections */
     int max_worker_connections;
+
+    /* If true, ignore HTTP_PROXY, NO_PROXY, etc. */
+    int proxy_env_ignore;
 };
 
 /* Defines a host service and it properties */

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -152,6 +152,7 @@ void flb_net_setup_init(struct flb_net_setup *net)
     net->io_timeout = 0; /* Infinite time */
     net->source_address = NULL;
     net->backlog = FLB_NETWORK_DEFAULT_BACKLOG_SIZE;
+    net->proxy_env_ignore = FLB_FALSE;
 }
 
 int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const char *address)

--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -136,6 +136,12 @@ struct flb_config_map upstream_net[] = {
      "Set the maximum number of active TCP connections that can be used per worker thread."
     },
 
+    {
+     FLB_CONFIG_MAP_BOOL, "net.proxy_env_ignore", "FALSE",
+     0, FLB_TRUE, offsetof(struct flb_net_setup, proxy_env_ignore),
+     "Ignore the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY when "
+    },
+
     /* EOF */
     {0}
 };


### PR DESCRIPTION
> Backport of #10613

This patch introduces a new configuration option: `net.proxy_env_ignore` (default: false).

By default, the upstream connection layer uses proxy settings from the environment (HTTP_PROXY, HTTPS_PROXY). However, in some scenarios, particularly when running multiple plugins with differing proxy needs, this default can cause unintended routing.

The new option `net.proxy_env_ignore` allows a plugin to explicitly disable the use of environment-based proxy configuration. When set to true, Fluent Bit will skip any proxy settings defined via environment variables, relying solely on plugin-level proxy settings (if provided).

e.g:

setting up an invalid proxy port (8081), however functional proxy runs in port 8080

```bash
export HTTP_PROXY=http://localhost:8081
```

```bash
fluent-bit -i random \
           -o opentelemetry \
              -p host=127.0.0.1 
              -p port=4328 
              -p proxy=http://127.0.0.1:8080 
              -p net.proxy_env_ignore=true
```

This enhancement improves plugin-level control over network behavior when relying on the upstream interface.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
