### PR TITLE
out_chronicle: Fix log_key detection mechanism

### DIFF
--- a/plugins/out_chronicle/chronicle_conf.c
+++ b/plugins/out_chronicle/chronicle_conf.c
@@ -211,55 +211,57 @@ struct flb_chronicle *flb_chronicle_conf_create(struct flb_output_instance *ins,
         }
     }
 
-    if (ctx->credentials_file) {
-        ret = flb_chronicle_read_credentials_file(ctx,
-                                                 ctx->credentials_file,
-                                                 ctx->oauth_credentials);
-        if (ret != 0) {
-            flb_chronicle_conf_destroy(ctx);
-            return NULL;
+    if (ins->test_mode == FLB_FALSE) {
+        if (ctx->credentials_file) {
+            ret = flb_chronicle_read_credentials_file(ctx,
+                                                      ctx->credentials_file,
+                                                      ctx->oauth_credentials);
+            if (ret != 0) {
+                flb_chronicle_conf_destroy(ctx);
+                return NULL;
+            }
         }
-    }
-    else if (!ctx->credentials_file) {
-        /*
-         * If no credentials file has been defined, do manual lookup of the
-         * client email and the private key.
-         */
+        else if (!ctx->credentials_file) {
+            /*
+             * If no credentials file has been defined, do manual lookup of the
+             * client email and the private key.
+             */
 
-        /* Service Account Email */
-        tmp = flb_output_get_property("service_account_email", ins);
-        if (tmp) {
-            creds->client_email = flb_sds_create(tmp);
-        }
-        else {
-            tmp = getenv("SERVICE_ACCOUNT_EMAIL");
+            /* Service Account Email */
+            tmp = flb_output_get_property("service_account_email", ins);
             if (tmp) {
                 creds->client_email = flb_sds_create(tmp);
             }
-        }
+            else {
+                tmp = getenv("SERVICE_ACCOUNT_EMAIL");
+                if (tmp) {
+                    creds->client_email = flb_sds_create(tmp);
+                }
+            }
 
-        /* Service Account Secret */
-        tmp = flb_output_get_property("service_account_secret", ins);
-        if (tmp) {
-            creds->private_key = flb_sds_create(tmp);
-        }
-        else {
-            tmp = getenv("SERVICE_ACCOUNT_SECRET");
+            /* Service Account Secret */
+            tmp = flb_output_get_property("service_account_secret", ins);
             if (tmp) {
                 creds->private_key = flb_sds_create(tmp);
             }
-        }
+            else {
+                tmp = getenv("SERVICE_ACCOUNT_SECRET");
+                if (tmp) {
+                    creds->private_key = flb_sds_create(tmp);
+                }
+            }
 
-        if (!creds->client_email) {
-            flb_plg_error(ctx->ins, "service_account_email/client_email is not defined");
-            flb_chronicle_conf_destroy(ctx);
-            return NULL;
-        }
+            if (!creds->client_email) {
+                flb_plg_error(ctx->ins, "service_account_email/client_email is not defined");
+                flb_chronicle_conf_destroy(ctx);
+                return NULL;
+            }
 
-        if (!creds->private_key) {
-            flb_plg_error(ctx->ins, "service_account_secret/private_key is not defined");
-            flb_chronicle_conf_destroy(ctx);
-            return NULL;
+            if (!creds->private_key) {
+                flb_plg_error(ctx->ins, "service_account_secret/private_key is not defined");
+                flb_chronicle_conf_destroy(ctx);
+                return NULL;
+            }
         }
     }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -236,6 +236,7 @@ if(FLB_IN_LIB)
   FLB_RT_TEST(FLB_OUT_S3                "out_s3.c")
   FLB_RT_TEST(FLB_OUT_TD                "out_td.c")
   FLB_RT_TEST(FLB_OUT_INFLUXDB          "out_influxdb.c")
+  FLB_RT_TEST(FLB_OUT_CHRONICLE         "out_chronicle.c")
 
 endif()
 

--- a/tests/runtime/out_chronicle.c
+++ b/tests/runtime/out_chronicle.c
@@ -111,6 +111,26 @@ static void cb_check_format_multiple_records(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_format_partially_succeeded_records(void *ctx, int ffd,
+                                                        int res_ret, void *res_data,
+                                                        size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p1, *p2;
+
+    set_output_invoked(1);
+
+    p1 = strstr(out_json, "\"log_text\":\"record one\"");
+    if (!TEST_CHECK(p1 != NULL)) {
+        TEST_MSG("Expected log_text with specific value not found. Got: %s", out_json);
+    }
+
+    p2 = strstr(out_json, "\"test\"");
+    TEST_CHECK(p2 == NULL);
+
+    flb_sds_destroy(res_data);
+}
+
 void test_format_no_log_key()
 {
     flb_ctx_t *ctx;
@@ -261,10 +281,53 @@ void test_format_multiple_records()
     flb_destroy(ctx);
 }
 
+void test_format_partially_suceeded_records()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record1[1024];
+    char record2[1024];
+    time_t now = time(NULL);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_key", "message",
+                   "log_type", "TEST_LOG",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter", cb_check_format_partially_succeeded_records, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record1, sizeof(record1) - 1, "[%ld, {\"message\": \"record one\"}]", (long) now);
+    snprintf(record2, sizeof(record2) - 1, "[%ld, {\"test\": \"record two\"}]", (long) now + 1);
+
+    flb_lib_push(ctx, in_ffd, record1, strlen(record1));
+    flb_lib_push(ctx, in_ffd, record2, strlen(record2));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+
 TEST_LIST = {
     { "format_no_log_key",           test_format_no_log_key },
     { "format_with_log_key_found",   test_format_with_log_key_found },
     { "format_with_log_key_not_found", test_format_with_log_key_not_found },
     { "format_multiple_records",     test_format_multiple_records },
+    { "format_partially_suceeded_records", test_format_partially_suceeded_records },
     { NULL, NULL }
 };

--- a/tests/runtime/out_chronicle.c
+++ b/tests/runtime/out_chronicle.c
@@ -1,0 +1,270 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit.h>
+#include "flb_tests_runtime.h"
+
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_invoked = 0;
+static int get_output_invoked()
+{
+    int ret;
+    pthread_mutex_lock(&result_mutex);
+    ret = num_invoked;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void set_output_invoked(int num)
+{
+    pthread_mutex_lock(&result_mutex);
+    num_invoked = num;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void clear_output_invoked()
+{
+    set_output_invoked(0);
+}
+
+static void cb_check_format_no_log_key(void *ctx, int ffd,
+                                       int res_ret, void *res_data,
+                                       size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p;
+
+    set_output_invoked(1);
+
+    p = strstr(out_json, "\"customer_id\":\"test-customer\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected customer_id not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"log_type\":\"TEST_LOG\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected log_type not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"entries\":[");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Entries array not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"log_text\":\"{\\\"message\\\":\\\"hello world\\\"}\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected log_text not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"ts_rfc3339\":");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected ts_rfc3339 key not found. Got: %s", out_json);
+    }
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_format_with_log_key(void *ctx, int ffd,
+                                         int res_ret, void *res_data,
+                                         size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p;
+
+    if (out_json == NULL) {
+        return;
+    }
+
+    set_output_invoked(1);
+
+    p = strstr(out_json, "\"log_text\":\"This is the target message.\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected log_text with specific value not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "other_key");
+    TEST_CHECK(p == NULL);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_format_multiple_records(void *ctx, int ffd,
+                                             int res_ret, void *res_data,
+                                             size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p1, *p2;
+
+    set_output_invoked(1);
+
+    p1 = strstr(out_json, "\"log_text\":\"{\\\"message\\\":\\\"record one\\\"}\"");
+    if (!TEST_CHECK(p1 != NULL)) {
+        TEST_MSG("First record not found. Got: %s", out_json);
+    }
+
+    p2 = strstr(out_json, "\"log_text\":\"{\\\"message\\\":\\\"record two\\\"}\"");
+    if (!TEST_CHECK(p2 != NULL)) {
+        TEST_MSG("Second record not found. Got: %s", out_json);
+    }
+
+    flb_sds_destroy(res_data);
+}
+
+void test_format_no_log_key()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record[1024];
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter", cb_check_format_no_log_key, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record, sizeof(record) - 1, "[%ld, {\"message\": \"hello world\"}]", (long) time(NULL));
+    flb_lib_push(ctx, in_ffd, record, strlen(record));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void test_format_with_log_key_found()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record[1024];
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   "log_key", "message",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter", cb_check_format_with_log_key, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record, sizeof(record) - 1,
+             "[%ld, {\"other_key\": \"some value\", \"message\": \"This is the target message.\"}]",
+             (long) time(NULL));
+    flb_lib_push(ctx, in_ffd, record, strlen(record));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void test_format_with_log_key_not_found()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record[1024];
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   "log_key", "non_existent_key",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter", cb_check_format_with_log_key, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record, sizeof(record) - 1, "[%ld, {\"some_other_key\": \"some_value\"}]", (long) time(NULL));
+    flb_lib_push(ctx, in_ffd, record, strlen(record));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 0);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+
+void test_format_multiple_records()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record1[1024];
+    char record2[1024];
+    time_t now = time(NULL);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter", cb_check_format_multiple_records, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record1, sizeof(record1) - 1, "[%ld, {\"message\": \"record one\"}]", (long) now);
+    snprintf(record2, sizeof(record2) - 1, "[%ld, {\"message\": \"record two\"}]", (long) now + 1);
+
+    flb_lib_push(ctx, in_ffd, record1, strlen(record1));
+    flb_lib_push(ctx, in_ffd, record2, strlen(record2));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+TEST_LIST = {
+    { "format_no_log_key",           test_format_no_log_key },
+    { "format_with_log_key_found",   test_format_with_log_key_found },
+    { "format_with_log_key_not_found", test_format_with_log_key_not_found },
+    { "format_multiple_records",     test_format_multiple_records },
+    { NULL, NULL }
+};


### PR DESCRIPTION
The previous detection mechanism is too tight to handle missing log_key. Instead, we loosen the mechanism that permits to traverse entrie the record. And failing for just missing of anhy of the keys in a record map.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


From leaks command on macOS, there is no reported memory leaks:

```console
Process:         fluent-bit [68263]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x102b74000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [68262]
Target Type:     live task

Date/Time:       2025-07-24 18:39:38.592 +0900
Launch Time:     2025-07-24 18:39:32.789 +0900
OS Version:      macOS 15.5 (24F74)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 16.4 (16F6)

Physical footprint:         10.3M
Physical footprint (peak):  11.1M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 68263: 2457 nodes malloced for 334 KB
Process 68263: 0 leaks for 0 total leaked bytes.

[2025/07/24 18:39:39] [engine] caught signal (SIGCONT)
[2025/07/24 18:39:39] Fluent Bit Dump

```

On Linux platform:

```
==88955== 
==88955== HEAP SUMMARY:
==88955==     in use at exit: 0 bytes in 0 blocks
==88955==   total heap usage: 26,526 allocs, 26,526 frees, 15,438,035 bytes allocated
==88955== 
==88955== All heap blocks were freed -- no leaks are possible
==88955== 
==88955== Use --track-origins=yes to see where uninitialised values come from
==88955== For lists of detected and suppressed errors, rerun with: -s
==88955== ERROR SUMMARY: 17 errors from 5 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
