### PR TITLE
output: add Histogram Metric for end-to-end chunk latency

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -78,6 +78,7 @@ struct flb_input_chunk {
 #ifdef FLB_HAVE_CHUNK_TRACE
     struct flb_chunk_trace *trace;
 #endif /* FLB_HAVE_CHUNK_TRACE */
+    double create_time;           /* chunk creation time in seconds with fractional precision) */
     flb_route_mask_element *routes_mask; /* track the output plugins the chunk routes to */
     struct mk_list _head;
 };

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -52,6 +52,7 @@
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 
@@ -454,6 +455,8 @@ struct flb_output_instance {
     struct cmt_gauge   *cmt_upstream_busy_connections;
     /* m: output_chunk_available_capacity_percent */
     struct cmt_gauge   *cmt_chunk_available_capacity_percent;
+    /* m: output_latency_seconds */
+    struct cmt_histogram *cmt_latency;
 
     /* OLD Metrics API */
 #ifdef FLB_HAVE_METRICS

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -30,6 +30,7 @@
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_lib.h>
 #include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_task.h>
 #include <fluent-bit/flb_routes_mask.h>
@@ -938,6 +939,7 @@ struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in, in
     ic->in = in;
     ic->stream_off = 0;
     ic->task = NULL;
+    ic->create_time = flb_time_now();
 #ifdef FLB_HAVE_METRICS
     ic->total_records = 0;
 #endif


### PR DESCRIPTION
This PR introduces a new Fluent Bit internal histogram metric:

- `fluentbit_output_latency_seconds`

This metric captures the end-to-end latency (in seconds) from the time a chunk is created by an input plugin until it is successfully delivered by an output plugin. It provides observability into chunk-level pipeline performance and helps identify slowdowns or bottlenecks in the output path.

__Metric Details__
- Metric name: `fluentbit_output_latency_seconds`
- Type: histogram
- Unit: seconds
- Labels:
  - input: name of the input plugin instance (e.g., random.0)
  - output: name of the output plugin instance (e.g., stdout.0)
  
__Example Output__

```
# HELP fluentbit_output_latency_seconds End-to-end latency in seconds
# TYPE fluentbit_output_latency_seconds histogram
fluentbit_output_latency_seconds_bucket{le="0.5",input="random.0",output="stdout.0"} 0
fluentbit_output_latency_seconds_bucket{le="1.0",input="random.0",output="stdout.0"} 1
fluentbit_output_latency_seconds_bucket{le="1.5",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_bucket{le="2.5",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_bucket{le="5.0",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_bucket{le="10.0",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_bucket{le="20.0",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_bucket{le="30.0",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_bucket{le="+Inf",input="random.0",output="stdout.0"} 6
fluentbit_output_latency_seconds_sum{input="random.0",output="stdout.0"} 6.0015411376953125
fluentbit_output_latency_seconds_count{input="random.0",output="stdout.0"} 6
```

⸻

__Bucket Configuration__

The following default bucket boundaries were selected based on Fluent Bit’s typical flush interval (Flush 1 second), which represents the best-case delivery cycle. These boundaries are intended to capture expected latency ranges under normal and degraded conditions:

`0.5, 1.0, 1.5, 2.5, 5.0, 10.0, 20.0, 30.0, +Inf`

This allows for:
- High resolution around the expected 1s latency target
- Coverage for small backpressure delays
- Detection of retry cycles, network stalls, or plugin bottlenecks

⸻

Notes
- The metric can be exposed via the Prometheus exporter on /api/v2/metrics/prometheus.
- This complements existing per-plugin metrics by offering a pipeline-level view.
- This PR depends on https://github.com/fluent/fluent-bit/pull/10643


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
