### PR TITLE
input: Fix an incompatible pointer

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1244,7 +1244,7 @@ int flb_input_instance_init(struct flb_input_instance *ins,
                             "ring_buffer_writes_total",
                             "Number of ring buffer writes.",
                             1, (char *[]) {"name"});
-    cmt_gauge_set(ins->cmt_ring_buffer_writes, ts, 0, 1, (char *[]) {name});
+    cmt_counter_set(ins->cmt_ring_buffer_writes, ts, 0, 1, (char *[]) {name});
 
     /* fluentbit_input_ring_buffer_retries_total */
     ins->cmt_ring_buffer_retries = \


### PR DESCRIPTION
This incompatible pointer causes the following error in gcc15:

```log
~/GitHub/fluent-bit/src/flb_input.c: In function 'flb_input_instance_init':
~/GitHub/fluent-bit/src/flb_input.c:1247:22: error: passing argument 1 of 'cmt_gauge_set' from incompatible pointer type [-Wincompatible-pointer-types]
 1247 |     cmt_gauge_set(ins->cmt_ring_buffer_writes, ts, 0, 1, (char *[]) {name});
      |                   ~~~^~~~~~~~~~~~~~~~~~~~~~~~
      |                      |
      |                      struct cmt_counter *
In file included from ~/GitHub/fluent-bit/include/fluent-bit/flb_upstream.h:34,
                 from ~/GitHub/fluent-bit/include/fluent-bit/flb_input.h:29,
                 from ~/GitHub/fluent-bit/src/flb_input.c:29:
~/GitHub/fluent-bit/lib/cmetrics/include/cmetrics/cmt_gauge.h:38:37: note: expected 'struct cmt_gauge *' but argument is of type 'struct cmt_counter *'
   38 | int cmt_gauge_set(struct cmt_gauge *gauge, uint64_t timestamp, double val,
      |                   ~~~~~~~~~~~~~~~~~~^~~~~
~/GitHub/fluent-bit/src/flb_network.c: In function 'flb_net_dns_lookup_context_create':
~/GitHub/fluent-bit/src/flb_network.c:1123:5: warning: 'ares_set_socket_functions' is deprecated: Use ares_set_socket_functions_ex instead [-Wdeprecated-declarations]
 1123 |     ares_set_socket_functions(lookup_context->ares_channel,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
