### PR TITLE
out_kinesis_firehose: introduce port parameter

### DIFF
--- a/plugins/out_kinesis_firehose/firehose.c
+++ b/plugins/out_kinesis_firehose/firehose.c
@@ -120,6 +120,30 @@ static int cb_firehose_init(struct flb_output_instance *ins,
         ctx->sts_endpoint = (char *) tmp;
     }
 
+    /*
+     * Sets the port number for the Kinesis output plugin.
+     *
+     * This function uses the port number already set in the output instance's host structure.
+     * If the port is not set (0), the default HTTPS port is used.
+     *
+     * @param ins The output instance.
+     * @param ctx The Kinesis output plugin context.
+     */
+    flb_plg_debug(ins, "Retrieved port from ins->host.port: %d", ins->host.port);
+
+    if (ins->host.port == 0) {
+        ctx->port = FLB_KINESIS_DEFAULT_HTTPS_PORT;
+        flb_plg_debug(ins, "Port not set. Using default HTTPS port: %d", ctx->port);
+    }
+    else if (ins->host.port == (ctx->port = (uint16_t)ins->host.port)) {
+        flb_plg_debug(ins, "Setting port to: %d", ctx->port);
+    }
+    else {
+        flb_plg_error(ins, "Invalid port number: %d. Must be between %d and %d",
+                      ins->host.port, 1, UINT16_MAX);
+        goto error;
+    }
+
     tmp = flb_output_get_property("compression", ins);
     if (tmp) {
         ret = flb_aws_compression_get_type(tmp);
@@ -259,14 +283,14 @@ static int cb_firehose_init(struct flb_output_instance *ins,
     ctx->firehose_client->region = (char *) ctx->region;
     ctx->firehose_client->retry_requests = ctx->retry_requests;
     ctx->firehose_client->service = "firehose";
-    ctx->firehose_client->port = 443;
+    ctx->firehose_client->port = ctx->port;
     ctx->firehose_client->flags = 0;
     ctx->firehose_client->proxy = NULL;
     ctx->firehose_client->static_headers = &content_type_header;
     ctx->firehose_client->static_headers_len = 1;
 
     struct flb_upstream *upstream = flb_upstream_create(config, ctx->endpoint,
-                                                        443, FLB_IO_TLS,
+                                                        ctx->port, FLB_IO_TLS,
                                                         ctx->client_tls);
     if (!upstream) {
         flb_plg_error(ctx->ins, "Connection initialization error");

--- a/plugins/out_kinesis_firehose/firehose.h
+++ b/plugins/out_kinesis_firehose/firehose.h
@@ -29,6 +29,8 @@
 
 #define DEFAULT_TIME_KEY_FORMAT "%Y-%m-%dT%H:%M:%S"
 
+#define FLB_KINESIS_DEFAULT_HTTPS_PORT    443
+
 /* buffers used for each flush */
 struct flush {
     /* temporary buffer for storing the serialized event messages */
@@ -87,6 +89,7 @@ struct flb_firehose {
     const char *log_key;
     const char *external_id;
     char *sts_endpoint;
+    uint16_t port;
     char *profile;
     int custom_endpoint;
     int retry_requests;

--- a/plugins/out_kinesis_streams/kinesis.c
+++ b/plugins/out_kinesis_streams/kinesis.c
@@ -127,18 +127,17 @@ static int cb_kinesis_init(struct flb_output_instance *ins,
      * @param ctx The Kinesis output plugin context.
      */
     flb_plg_debug(ins, "Retrieved port from ins->host.port: %d", ins->host.port);
-    
-    if (ins->host.port >= FLB_KINESIS_MIN_PORT && ins->host.port <= FLB_KINESIS_MAX_PORT) {
-        ctx->port = ins->host.port;
-        flb_plg_debug(ins, "Setting port to: %d", ctx->port);
-    }
-    else if (ins->host.port == 0) {
+
+    if (ins->host.port == 0) {
         ctx->port = FLB_KINESIS_DEFAULT_HTTPS_PORT;
         flb_plg_debug(ins, "Port not set. Using default HTTPS port: %d", ctx->port);
     }
+    else if (ins->host.port == (ctx->port = (uint16_t)ins->host.port)) {
+        flb_plg_debug(ins, "Setting port to: %d", ctx->port);
+    }
     else {
-        flb_plg_error(ins, "Invalid port number: %d. Must be between %d and %d", 
-                      ins->host.port, FLB_KINESIS_MIN_PORT, FLB_KINESIS_MAX_PORT);
+        flb_plg_error(ins, "Invalid port number: %d. Must be between %d and %d",
+                      ins->host.port, 1, UINT16_MAX);
         goto error;
     }
 

--- a/plugins/out_kinesis_streams/kinesis.h
+++ b/plugins/out_kinesis_streams/kinesis.h
@@ -30,8 +30,6 @@
 #define DEFAULT_TIME_KEY_FORMAT "%Y-%m-%dT%H:%M:%S"
 
 #define FLB_KINESIS_DEFAULT_HTTPS_PORT    443
-#define FLB_KINESIS_MIN_PORT              1
-#define FLB_KINESIS_MAX_PORT              65535
 
 /* buffers used for each flush */
 struct flush {
@@ -96,7 +94,7 @@ struct flb_kinesis {
     int retry_requests;
     char *sts_endpoint;
     int custom_endpoint;
-    int port;
+    uint16_t port;
     char *profile;
 
     /* in this plugin the 'random' partition key is a uuid + fluent tag + timestamp */


### PR DESCRIPTION
<!-- Provide summary of changes -->
This mirrors the same for Kinesis Streams in https://github.com/fluent/fluent-bit/pull/9317

The port parameter is migrated to uint16_t for correctness.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom port numbers for Kinesis Firehose and Kinesis Streams output plugins, ensuring proper validation and assignment of port values.
  * Enhanced error logging for invalid port configurations.

* **Refactor**
  * Updated internal logic to use unsigned 16-bit integers for port values and removed obsolete port range constants.
  * Introduced a default HTTPS port constant for more consistent configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->