### PR TITLE
in_windows_exporter_metrics: Follow windows_exporter prom names correctly and support connection_state metrics

### DIFF
--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -25,6 +25,7 @@ set(src
 set(libs
   wbemuuid
   netapi32
+  iphlpapi
 )
 
 FLB_PLUGIN(in_windows_exporter_metrics "${src}" "${libs}")

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -241,10 +241,10 @@ struct we_wmi_tcp_counters {
     struct cmt_counter          *connections_established;
     struct cmt_counter          *connections_passive;
     struct cmt_counter          *connections_reset;
-    struct cmt_gauge            *segments_per_sec;
-    struct cmt_gauge            *segments_received_per_sec;
-    struct cmt_gauge            *segments_retransmitted_per_sec;
-    struct cmt_gauge            *segments_sent_per_sec;
+    struct cmt_gauge            *segments_total;
+    struct cmt_gauge            *segments_received_total;
+    struct cmt_gauge            *segments_retransmitted_total;
+    struct cmt_gauge            *segments_sent_total;
 };
 
 struct we_os_counters {

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -236,6 +236,7 @@ struct we_wmi_tcp_counters {
     struct wmi_query_spec       *v4_info;
     struct wmi_query_spec       *v6_info;
     
+    struct cmt_gauge            *connections_state;
     struct cmt_counter          *connection_failures;
     struct cmt_gauge            *connections_active;
     struct cmt_counter          *connections_established;

--- a/plugins/in_windows_exporter_metrics/we_wmi_tcp.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_tcp.c
@@ -88,40 +88,40 @@ int we_wmi_tcp_init(struct flb_we *ctx)
     ctx->wmi_tcp->connections_reset = c;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_per_sec",
+                         "segments_total",
                          "Total TCP segments sent or received per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_per_sec = g;
+    ctx->wmi_tcp->segments_total = g;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_received_per_sec",
+                         "segments_total",
                          "TCP segments received per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_received_per_sec = g;
+    ctx->wmi_tcp->segments_received_total = g;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_retransmitted_per_sec",
+                         "segments_retransmitted_total",
                          "TCP segments retransmitted per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_retransmitted_per_sec = g;
+    ctx->wmi_tcp->segments_retransmitted_total = g;
     
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_sent_per_sec",
+                         "segments_sent_total",
                          "TCP segments sent per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_sent_per_sec = g;
+    ctx->wmi_tcp->segments_sent_total = g;
 
     /* NOTE: Once we tried to use perflib to obtain those of metrics for TCPv4 and TCPv6,
      * there is no way to process the correct metrics.
@@ -200,16 +200,16 @@ int we_wmi_tcp_update(struct flb_we *ctx)
             cmt_counter_set(ctx->wmi_tcp->connections_reset, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_total, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsReceivedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_received_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_received_total, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsRetransmittedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_total, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsSentPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_sent_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_sent_total, timestamp, val, 1, &ipv4_label);
 
             class_obj->lpVtbl->Release(class_obj);
         }
@@ -235,16 +235,16 @@ int we_wmi_tcp_update(struct flb_we *ctx)
             cmt_counter_set(ctx->wmi_tcp->connections_reset, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_total, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsReceivedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_received_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_received_total, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsRetransmittedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_total, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsSentPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_sent_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_sent_total, timestamp, val, 1, &ipv6_label);
 
             class_obj->lpVtbl->Release(class_obj);
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes https://github.com/fluent/fluent-bit/issues/10659.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
````
PS> bin/fluent-bit -i windows_exporter_metrics -p metrics=tcp -o stdout -v
````
- [x] Debug log output from testing the change
```
Fluent Bit v4.1.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/07/29 20:36:10] [ info] Configuration:
[2025/07/29 20:36:10] [ info]  flush time     | 1.000000 seconds
[2025/07/29 20:36:10] [ info]  grace          | 5 seconds
[2025/07/29 20:36:10] [ info]  daemon         | 0
[2025/07/29 20:36:10] [ info] ___________
[2025/07/29 20:36:10] [ info]  inputs:
[2025/07/29 20:36:10] [ info]      windows_exporter_metrics
[2025/07/29 20:36:10] [ info] ___________
[2025/07/29 20:36:10] [ info]  filters:
[2025/07/29 20:36:10] [ info] ___________
[2025/07/29 20:36:10] [ info]  outputs:
[2025/07/29 20:36:10] [ info]      stdout.0
[2025/07/29 20:36:10] [ info] ___________
[2025/07/29 20:36:10] [ info]  collectors:
[2025/07/29 20:36:10] [ info] [fluent bit] version=4.1.0, commit=5a4f268730, pid=17636
[2025/07/29 20:36:10] [debug] [engine] maxstdio set: 512
[2025/07/29 20:36:10] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2025/07/29 20:36:10] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/07/29 20:36:10] [ info] [simd    ] disabled
[2025/07/29 20:36:10] [ info] [cmetrics] version=1.0.5
[2025/07/29 20:36:10] [ info] [ctraces ] version=0.6.6
[2025/07/29 20:36:10] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2025/07/29 20:36:10] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2025/07/29 20:36:10] [debug] [windows_exporter_metrics:windows_exporter_metrics.0] created event channels: read=824 write=828
[2025/07/29 20:36:10] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics tcp
[2025/07/29 20:36:10] [debug] [stdout:stdout.0] created event channels: read=864 write=876
[2025/07/29 20:36:10] [ info] [sp] stream processor started
[2025/07/29 20:36:10] [ info] [output:stdout:stdout.0] worker #0 started
[2025/07/29 20:36:10] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/07/29 20:36:11] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2025/07/29 20:36:17] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2025/07/29 20:36:17] [debug] [task] created task=0000017185103110 id=0 OK
[2025/07/29 20:36:17] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2025-07-29T11:36:11.660836600Z windows_tcp_connection_failures_total{af="ipv4"} = 111
2025-07-29T11:36:11.660836600Z windows_tcp_connection_failures_total{af="ipv6"} = 22
2025-07-29T11:36:11.660836600Z windows_tcp_connections_established_total{af="ipv4"} = 88
2025-07-29T11:36:11.660836600Z windows_tcp_connections_established_total{af="ipv6"} = 6
2025-07-29T11:36:11.660836600Z windows_tcp_connections_passive_total{af="ipv4"} = 257
2025-07-29T11:36:11.660836600Z windows_tcp_connections_passive_total{af="ipv6"} = 6
2025-07-29T11:36:11.660836600Z windows_tcp_connections_reset_total{af="ipv4"} = 398
2025-07-29T11:36:11.660836600Z windows_tcp_connections_reset_total{af="ipv6"} = 0
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="ESTABLISHED"} = 13
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="SYN_RECV"} = 2
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="FIN_WAIT1"} = 1
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="LISTEN"} = 5
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="UNKNOWN"} = 99
2025-07-29T11:36:11.651486700Z windows_tcp_connections_state{af="ipv6",state="UNKNOWN"} = 20
2025-07-29T11:36:11.660836600Z windows_tcp_connections_active{af="ipv4"} = 3393
2025-07-29T11:36:11.660836600Z windows_tcp_connections_active{af="ipv6"} = 28
2025-07-29T11:36:11.660836600Z windows_tcp_segments_total{af="ipv4"} = 0
2025-07-29T11:36:11.660836600Z windows_tcp_segments_total{af="ipv6"} = 45
2025-07-29T11:36:11.660836600Z windows_tcp_segments_total{af="ipv4"} = 0
2025-07-29T11:36:11.660836600Z windows_tcp_segments_total{af="ipv6"} = 22
2025-07-29T11:36:11.660836600Z windows_tcp_segments_retransmitted_total{af="ipv4"} = 0
2025-07-29T11:36:11.660836600Z windows_tcp_segments_retransmitted_total{af="ipv6"} = 0
2025-07-29T11:36:11.660836600Z windows_tcp_segments_sent_total{af="ipv4"} = 0
2025-07-29T11:36:11.660836600Z windows_tcp_segments_sent_total{af="ipv6"} = 22
[2025/07/29 20:36:17] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2025/07/29 20:36:17] [debug] [out flush] cb_destroy coro_id=0
[2025/07/29 20:36:17] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2025/07/29 20:36:17] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2025/07/29 20:36:17] [debug] [task] destroy task=0000017185103110 (task_id=0)
[2025/07/29 20:36:18] [debug] [task] created task=0000017185101BD0 id=0 OK
[2025/07/29 20:36:18] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2025-07-29T11:36:17.427054100Z windows_tcp_connection_failures_total{af="ipv4"} = 111
2025-07-29T11:36:17.427054100Z windows_tcp_connection_failures_total{af="ipv6"} = 22
2025-07-29T11:36:17.427054100Z windows_tcp_connections_established_total{af="ipv4"} = 88
2025-07-29T11:36:17.427054100Z windows_tcp_connections_established_total{af="ipv6"} = 6
2025-07-29T11:36:17.427054100Z windows_tcp_connections_passive_total{af="ipv4"} = 257
2025-07-29T11:36:17.427054100Z windows_tcp_connections_passive_total{af="ipv6"} = 6
2025-07-29T11:36:17.427054100Z windows_tcp_connections_reset_total{af="ipv4"} = 398
2025-07-29T11:36:17.427054100Z windows_tcp_connections_reset_total{af="ipv6"} = 0
2025-07-29T11:36:17.422106100Z windows_tcp_connections_state{af="ipv4",state="ESTABLISHED"} = 13
2025-07-29T11:36:17.422106100Z windows_tcp_connections_state{af="ipv4",state="SYN_RECV"} = 1
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="FIN_WAIT1"} = 1
2025-07-29T11:36:17.422106100Z windows_tcp_connections_state{af="ipv4",state="LISTEN"} = 4
2025-07-29T11:36:17.422106100Z windows_tcp_connections_state{af="ipv4",state="UNKNOWN"} = 101
2025-07-29T11:36:17.422409400Z windows_tcp_connections_state{af="ipv6",state="UNKNOWN"} = 20
2025-07-29T11:36:17.427054100Z windows_tcp_connections_active{af="ipv4"} = 3393
2025-07-29T11:36:17.427054100Z windows_tcp_connections_active{af="ipv6"} = 28
2025-07-29T11:36:17.427054100Z windows_tcp_segments_total{af="ipv4"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_total{af="ipv6"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_total{af="ipv4"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_total{af="ipv6"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_retransmitted_total{af="ipv4"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_retransmitted_total{af="ipv6"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_sent_total{af="ipv4"} = 0
2025-07-29T11:36:17.427054100Z windows_tcp_segments_sent_total{af="ipv6"} = 0
[2025/07/29 20:36:18] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2025/07/29 20:36:18] [debug] [out flush] cb_destroy coro_id=1
[2025/07/29 20:36:18] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2025/07/29 20:36:19] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2025/07/29 20:36:19] [debug] [task] destroy task=0000017185101BD0 (task_id=0)
[2025/07/29 20:36:19] [engine] caught signal (SIGINT)
[2025/07/29 20:36:19] [debug] [task] created task=0000017185102AD0 id=0 OK
[2025/07/29 20:36:19] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2025-07-29T11:36:18.450974000Z windows_tcp_connection_failures_total{af="ipv4"} = 111
2025-07-29T11:36:18.450974000Z windows_tcp_connection_failures_total{af="ipv6"} = 22
2025-07-29T11:36:18.450974000Z windows_tcp_connections_established_total{af="ipv4"} = 89
2025-07-29T11:36:18.450974000Z windows_tcp_connections_established_total{af="ipv6"} = 6
2025-07-29T11:36:18.450974000Z windows_tcp_connections_passive_total{af="ipv4"} = 257
2025-07-29T11:36:18.450974000Z windows_tcp_connections_passive_total{af="ipv6"} = 6
2025-07-29T11:36:18.450974000Z windows_tcp_connections_reset_total{af="ipv4"} = 398
2025-07-29T11:36:18.450974000Z windows_tcp_connections_reset_total{af="ipv6"} = 0
2025-07-29T11:36:18.445644400Z windows_tcp_connections_state{af="ipv4",state="ESTABLISHED"} = 13
2025-07-29T11:36:18.445644400Z windows_tcp_connections_state{af="ipv4",state="SYN_RECV"} = 2
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="FIN_WAIT1"} = 1
2025-07-29T11:36:18.445644400Z windows_tcp_connections_state{af="ipv4",state="LISTEN"} = 5
2025-07-29T11:36:18.445644400Z windows_tcp_connections_state{af="ipv4",state="UNKNOWN"} = 100
2025-07-29T11:36:18.445957700Z windows_tcp_connections_state{af="ipv6",state="UNKNOWN"} = 20
2025-07-29T11:36:18.450974000Z windows_tcp_connections_active{af="ipv4"} = 3394
2025-07-29T11:36:18.450974000Z windows_tcp_connections_active{af="ipv6"} = 28
2025-07-29T11:36:18.450974000Z windows_tcp_segments_total{af="ipv4"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_total{af="ipv6"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_total{af="ipv4"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_total{af="ipv6"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_retransmitted_total{af="ipv4"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_retransmitted_total{af="ipv6"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_sent_total{af="ipv4"} = 0
2025-07-29T11:36:18.450974000Z windows_tcp_segments_sent_total{af="ipv6"} = 0
[2025/07/29 20:36:19] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2025/07/29 20:36:19] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2025/07/29 20:36:19] [debug] [out flush] cb_destroy coro_id=2
[2025/07/29 20:36:19] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2025/07/29 20:36:19] [debug] [task] created task=0000017185101BD0 id=1 OK
[2025/07/29 20:36:19] [debug] [output:stdout:stdout.0] task_id=1 assigned to thread #0
[2025/07/29 20:36:19] [ warn] [engine] service will shutdown in max 5 seconds
2025-07-29T11:36:19.451397000Z windows_tcp_connection_failures_total{af="ipv4"} = 111
2025-07-29T11:36:19.451397000Z windows_tcp_connection_failures_total{af="ipv6"} = 22
2025-07-29T11:36:19.451397000Z windows_tcp_connections_established_total{af="ipv4"} = 89
2025-07-29T11:36:19.451397000Z windows_tcp_connections_established_total{af="ipv6"} = 6
2025-07-29T11:36:19.451397000Z windows_tcp_connections_passive_total{af="ipv4"} = 257
2025-07-29T11:36:19.451397000Z windows_tcp_connections_passive_total{af="ipv6"} = 6
2025-07-29T11:36:19.451397000Z windows_tcp_connections_reset_total{af="ipv4"} = 398
2025-07-29T11:36:19.451397000Z windows_tcp_connections_reset_total{af="ipv6"} = 0
2025-07-29T11:36:19.444124100Z windows_tcp_connections_state{af="ipv4",state="ESTABLISHED"} = 13
2025-07-29T11:36:19.444124100Z windows_tcp_connections_state{af="ipv4",state="SYN_RECV"} = 2
2025-07-29T11:36:11.651158600Z windows_tcp_connections_state{af="ipv4",state="FIN_WAIT1"} = 1
2025-07-29T11:36:19.444124100Z windows_tcp_connections_state{af="ipv4",state="LISTEN"} = 5
2025-07-29T11:36:19.444124100Z windows_tcp_connections_state{af="ipv4",state="UNKNOWN"} = 100
2025-07-29T11:36:19.444522200Z windows_tcp_connections_state{af="ipv6",state="UNKNOWN"} = 20
2025-07-29T11:36:19.451397000Z windows_tcp_connections_active{af="ipv4"} = 3394
2025-07-29T11:36:19.451397000Z windows_tcp_connections_active{af="ipv6"} = 28
2025-07-29T11:36:19.451397000Z windows_tcp_segments_total{af="ipv4"} = 31
2025-07-29T11:36:19.451397000Z windows_tcp_segments_total{af="ipv6"} = 0
2025-07-29T11:36:19.451397000Z windows_tcp_segments_total{af="ipv4"} = 15
2025-07-29T11:36:19.451397000Z windows_tcp_segments_total{af="ipv6"} = 0
2025-07-29T11:36:19.451397000Z windows_tcp_segments_retransmitted_total{af="ipv4"} = 0
2025-07-29T11:36:19.451397000Z windows_tcp_segments_retransmitted_total{af="ipv6"} = 0
2025-07-29T11:36:19.451397000Z windows_tcp_segments_sent_total{af="ipv4"} = 15
2025-07-29T11:36:19.451397000Z windows_tcp_segments_sent_total{af="ipv6"} = 0
[2025/07/29 20:36:19] [debug] [engine] retry=0000000000000000 for task 0 already scheduled to run, not re-scheduling it.
[2025/07/29 20:36:19] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2025/07/29 20:36:19] [debug] [engine] retry=0000000000000000 for task 1 already scheduled to run, not re-scheduling it.
[2025/07/29 20:36:19] [debug] [out flush] cb_destroy coro_id=3
[2025/07/29 20:36:19] [ info] [input] pausing windows_exporter_metrics.0
[2025/07/29 20:36:19] [debug] [task] destroy task=0000017185102AD0 (task_id=0)
[2025/07/29 20:36:19] [debug] [task] destroy task=0000017185101BD0 (task_id=1)
[2025/07/29 20:36:21] [ info] [engine] service has stopped (0 pending tasks)
[2025/07/29 20:36:21] [ info] [input] pausing windows_exporter_metrics.0
[2025/07/29 20:36:21] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/07/29 20:36:21] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
