### PR TITLE
in_nginx_exporter_metrics: add scrape_interval option (default: 5s)

### DIFF
--- a/plugins/in_nginx_exporter_metrics/nginx.c
+++ b/plugins/in_nginx_exporter_metrics/nginx.c
@@ -2271,7 +2271,7 @@ static int nginx_init(struct flb_input_instance *ins,
     }
     ctx->coll_id = flb_input_set_collector_time(ins,
                                                 nginx_collect,
-                                                1,
+                                                ctx->scrape_interval,
                                                 0, config);
     ret = 0;
  nginx_init_end:
@@ -2339,6 +2339,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "status_url", DEFAULT_STATUS_URL,
      0, FLB_TRUE, offsetof(struct nginx_ctx, status_url),
      "Define URL of stub status handler"
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "scrape_interval", "5s",
+     0, FLB_TRUE, offsetof(struct nginx_ctx, scrape_interval),
+     "Scrape interval to collect metrics from NGINX."
     },
     {
      FLB_CONFIG_MAP_BOOL, "nginx_plus", "true",

--- a/plugins/in_nginx_exporter_metrics/nginx.h
+++ b/plugins/in_nginx_exporter_metrics/nginx.h
@@ -30,6 +30,7 @@
 struct nginx_ctx
 {
     int coll_id;                    /* collector id */
+    int scrape_interval;            /* collection interval */
     flb_sds_t status_url;
     struct flb_parser *parser;
     struct flb_input_instance *ins; /* Input plugin instace */


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
