### PR TITLE
in_windows_exporter_metrics: Follow windows_exporter prom names correctly and support connection_state metrics [Backport to 4.0]

### DIFF
--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -25,6 +25,7 @@ set(src
 set(libs
   wbemuuid
   netapi32
+  iphlpapi
 )
 
 FLB_PLUGIN(in_windows_exporter_metrics "${src}" "${libs}")

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -241,10 +241,10 @@ struct we_wmi_tcp_counters {
     struct cmt_counter          *connections_established;
     struct cmt_counter          *connections_passive;
     struct cmt_counter          *connections_reset;
-    struct cmt_gauge            *segments_per_sec;
-    struct cmt_gauge            *segments_received_per_sec;
-    struct cmt_gauge            *segments_retransmitted_per_sec;
-    struct cmt_gauge            *segments_sent_per_sec;
+    struct cmt_gauge            *segments_total;
+    struct cmt_gauge            *segments_received_total;
+    struct cmt_gauge            *segments_retransmitted_total;
+    struct cmt_gauge            *segments_sent_total;
 };
 
 struct we_os_counters {

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -236,6 +236,7 @@ struct we_wmi_tcp_counters {
     struct wmi_query_spec       *v4_info;
     struct wmi_query_spec       *v6_info;
     
+    struct cmt_gauge            *connections_state;
     struct cmt_counter          *connection_failures;
     struct cmt_gauge            *connections_active;
     struct cmt_counter          *connections_established;

--- a/plugins/in_windows_exporter_metrics/we_wmi_tcp.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi_tcp.c
@@ -88,40 +88,40 @@ int we_wmi_tcp_init(struct flb_we *ctx)
     ctx->wmi_tcp->connections_reset = c;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_per_sec",
+                         "segments_total",
                          "Total TCP segments sent or received per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_per_sec = g;
+    ctx->wmi_tcp->segments_total = g;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_received_per_sec",
+                         "segments_total",
                          "TCP segments received per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_received_per_sec = g;
+    ctx->wmi_tcp->segments_received_total = g;
 
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_retransmitted_per_sec",
+                         "segments_retransmitted_total",
                          "TCP segments retransmitted per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_retransmitted_per_sec = g;
+    ctx->wmi_tcp->segments_retransmitted_total = g;
     
     g = cmt_gauge_create(ctx->cmt, "windows", "tcp",
-                         "segments_sent_per_sec",
+                         "segments_sent_total",
                          "TCP segments sent per second.",
                          1, &label);
     if (!g) { 
         return -1; 
     }
-    ctx->wmi_tcp->segments_sent_per_sec = g;
+    ctx->wmi_tcp->segments_sent_total = g;
 
     /* NOTE: Once we tried to use perflib to obtain those of metrics for TCPv4 and TCPv6,
      * there is no way to process the correct metrics.
@@ -200,16 +200,16 @@ int we_wmi_tcp_update(struct flb_we *ctx)
             cmt_counter_set(ctx->wmi_tcp->connections_reset, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_total, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsReceivedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_received_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_received_total, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsRetransmittedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_total, timestamp, val, 1, &ipv4_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsSentPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_sent_per_sec, timestamp, val, 1, &ipv4_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_sent_total, timestamp, val, 1, &ipv4_label);
 
             class_obj->lpVtbl->Release(class_obj);
         }
@@ -235,16 +235,16 @@ int we_wmi_tcp_update(struct flb_we *ctx)
             cmt_counter_set(ctx->wmi_tcp->connections_reset, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_total, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsReceivedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_received_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_received_total, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsRetransmittedPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_retransmitted_total, timestamp, val, 1, &ipv6_label);
 
             val = we_wmi_get_property_value(ctx, "SegmentsSentPersec", class_obj);
-            cmt_gauge_set(ctx->wmi_tcp->segments_sent_per_sec, timestamp, val, 1, &ipv6_label);
+            cmt_gauge_set(ctx->wmi_tcp->segments_sent_total, timestamp, val, 1, &ipv6_label);
 
             class_obj->lpVtbl->Release(class_obj);
         }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is backporting PR for https://github.com/fluent/fluent-bit/pull/10661.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
