### PR TITLE
engine: fix endless loop on reload

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1036,11 +1036,6 @@ int flb_engine_start(struct flb_config *config)
                     event->priority = FLB_ENGINE_PRIORITY_SHUTDOWN;
                 }
                 else if (ret == FLB_ENGINE_SHUTDOWN) {
-                    if (config->shutdown_fd > 0) {
-                        mk_event_timeout_destroy(config->evl,
-                                                 &config->event_shutdown);
-                    }
-
                     /* Increase the grace counter */
                     config->grace_count++;
 
@@ -1105,6 +1100,12 @@ int flb_engine_start(struct flb_config *config)
                                  tasks);
                         ret = config->exit_status_code;
                         flb_engine_shutdown(config);
+
+                        if (config->shutdown_fd > 0) {
+                            mk_event_timeout_destroy(config->evl,
+                                                     &config->event_shutdown);
+                        }
+
                         config = NULL;
                         return ret;
                     }


### PR DESCRIPTION
Fix endless loop on fluent-bit reload.

Fixes #10670"

**Testing**
I have reported bug #10670 , it well documented with exact steps to reproduce.
Tested

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
