### PR TITLE
out_s3: add Blob handling support (rebase of #9907)

### DIFF
--- a/include/fluent-bit/flb_aws_util.h
+++ b/include/fluent-bit/flb_aws_util.h
@@ -192,9 +192,13 @@ int flb_aws_is_auth_error(char *payload, size_t payload_size);
 
 int flb_read_file(const char *path, char **out_buf, size_t *out_size);
 
-//* Constructs S3 object key as per the format. */
+/* Constructs S3 object key as per the format. */
 flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
                          char *tag_delimiter, uint64_t seq_index);
+
+/* Constructs S3 object key as per the blob format. */
+flb_sds_t flb_get_s3_blob_key(const char *format, const char *tag,
+                              char *tag_delimiter, const char *blob_path);
 
 /*
  * This function is an extension to strftime which can support milliseconds with %3N,

--- a/include/fluent-bit/flb_blob_db.h
+++ b/include/fluent-bit/flb_blob_db.h
@@ -1,0 +1,454 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_BLOB_DB_H
+#define FLB_BLOB_DB_H
+
+#include <fluent-bit/flb_lock.h>
+
+#define SQL_PRAGMA_FOREIGN_KEYS "PRAGMA foreign_keys = ON;"
+
+#define SQL_CREATE_BLOB_FILES                                             \
+    "CREATE TABLE IF NOT EXISTS blob_files ("                             \
+    "  id                    INTEGER PRIMARY KEY,"                        \
+    "  tag                   TEXT NOT NULL DEFAULT '',"                   \
+    "  source                TEXT NOT NULL,"                              \
+    "  destination           TEXT NOT NULL,"                              \
+    "  path                  TEXT NOT NULL,"                              \
+    "  remote_id             TEXT NOT NULL DEFAULT '',"                   \
+    "  size                  INTEGER,"                                    \
+    "  created               INTEGER,"                                    \
+    "  delivery_attempts     INTEGER DEFAULT 0,"                          \
+    "  aborted               INTEGER DEFAULT 0,"                          \
+    "  last_delivery_attempt INTEGER DEFAULT 0"                           \
+    ");"
+
+#define SQL_CREATE_BLOB_PARTS                                             \
+    "CREATE TABLE IF NOT EXISTS blob_parts ("                             \
+    "  id                INTEGER PRIMARY KEY,"                            \
+    "  file_id           INTEGER NOT NULL,"                               \
+    "  part_id           INTEGER NOT NULL,"                               \
+    "  remote_id         TEXT NOT NULL DEFAULT '',"                       \
+    "  uploaded          INTEGER DEFAULT 0,"                              \
+    "  in_progress       INTEGER DEFAULT 0,"                              \
+    "  offset_start      INTEGER,"                                        \
+    "  offset_end        INTEGER,"                                        \
+    "  delivery_attempts INTEGER DEFAULT 0,"                              \
+    "  FOREIGN KEY (file_id) REFERENCES blob_files(id) "                  \
+    "    ON DELETE CASCADE"                                               \
+    ");"
+
+#define SQL_INSERT_FILE                                                   \
+    "INSERT INTO blob_files (tag, source, destination, path, size, created)"   \
+    "  VALUES (@tag, @source, @destination, @path, @size, @created);"
+
+#define SQL_DELETE_FILE                                                   \
+    "DELETE FROM blob_files WHERE id=@id;"
+
+#define SQL_SET_FILE_ABORTED_STATE                                        \
+    "UPDATE blob_files SET aborted=@state WHERE id=@id;"
+
+#define SQL_UPDATE_FILE_REMOTE_ID                                         \
+    "UPDATE blob_files SET remote_id=@remote_id WHERE id=@id;"
+
+#define SQL_UPDATE_FILE_DESTINATION                                       \
+    "UPDATE blob_files SET destination=@destination WHERE id=@id;"
+
+#define SQL_UPDATE_FILE_DELIVERY_ATTEMPT_COUNT                            \
+    "UPDATE blob_files "                                                  \
+    "   SET delivery_attempts=@delivery_attempts, "                       \
+    "       last_delivery_attempt=UNIXEPOCH() "                           \
+    " WHERE id=@id;"
+
+#define SQL_GET_FILE                                                      \
+    "SELECT * FROM blob_files WHERE path=@path ORDER BY id DESC;"
+
+#define SQL_GET_FILE_PART_COUNT                                           \
+    "SELECT count(id) "                                                   \
+    "  FROM blob_parts "                                                  \
+    " WHERE file_id=@id;"
+
+#define SQL_GET_NEXT_ABORTED_FILE                                    \
+    "SELECT id, bf.delivery_attempts, source, path, remote_id, "     \
+    "       tag "                                                    \
+    "  FROM blob_files bf "                                          \
+    " WHERE aborted = 1 "                                            \
+    "   AND (SELECT COUNT(*) "                                       \
+    "          FROM blob_parts bp "                                  \
+    "         WHERE bp.file_id = bf.id "                             \
+    "           AND in_progress = 1) = 0 "                           \
+    "ORDER BY id DESC "                                              \
+    "LIMIT 1;"
+
+#define SQL_GET_NEXT_STALE_FILE                                    \
+    "SELECT id, path, remote_id, tag "                             \
+    "  FROM blob_files "                                           \
+    " WHERE aborted = 0 "                                          \
+    "   AND last_delivery_attempt > 0 "                            \
+    "   AND last_delivery_attempt < @freshness_threshold "         \
+    "ORDER BY id DESC "                                            \
+    "LIMIT 1;"
+
+#define SQL_INSERT_FILE_PART                                              \
+    "INSERT INTO blob_parts (file_id, part_id, offset_start, offset_end)" \
+    "  VALUES (@file_id, @part_id, @offset_start, @offset_end);"
+
+#define SQL_UPDATE_FILE_PART_REMOTE_ID                                    \
+    "UPDATE blob_parts SET remote_id=@remote_id WHERE id=@id;"
+
+#define SQL_GET_FILE_PART_REMOTE_ID                                       \
+    "SELECT remote_id "                                                   \
+    "  FROM blob_parts "                                                  \
+    " WHERE file_id=@id;"
+
+#define SQL_UPDATE_FILE_PART_UPLOADED                                     \
+    "UPDATE blob_parts SET uploaded=1, in_progress=0 WHERE id=@id;"
+
+#define SQL_UPDATE_FILE_PART_IN_PROGRESS                                  \
+    "UPDATE blob_parts SET in_progress=@status WHERE id=@id;"
+
+#define SQL_UPDATE_FILE_PART_DELIVERY_ATTEMPT_COUNT                        \
+    "UPDATE blob_parts "                                                   \
+    "   SET delivery_attempts=@delivery_attempts "                         \
+    " WHERE file_id=@file_id "                                             \
+    "   AND part_id=@part_id;"
+
+#define SQL_RESET_FILE_UPLOAD_STATES                                       \
+    "UPDATE blob_files "                                                   \
+    "   SET last_delivery_attempt=0 "                                      \
+    " WHERE id=@id;"
+
+#define SQL_RESET_FILE_PART_UPLOAD_STATES                                  \
+    "UPDATE blob_parts "                                                   \
+    "   SET delivery_attempts=0, "                                         \
+    "       uploaded=0, "                                                  \
+    "       in_progress=0 "                                                \
+    " WHERE file_id=@id;"
+
+#define SQL_GET_NEXT_FILE_PART                         \
+    "  SELECT p.id, "                                  \
+    "         p.file_id, "                             \
+    "         p.part_id, "                             \
+    "         p.offset_start, "                        \
+    "         p.offset_end, "                          \
+    "         p.delivery_attempts, "                   \
+    "         f.path, "                                \
+    "         f.delivery_attempts, "                   \
+    "         f.last_delivery_attempt, "               \
+    "         f.destination, "                         \
+    "         f.remote_id, "                           \
+    "         f.tag "                                  \
+    "    FROM blob_parts p "                           \
+    "    JOIN blob_files f "                           \
+    "      ON p.file_id = f.id "                       \
+    "   WHERE p.uploaded = 0 "                         \
+    "     AND p.in_progress = 0 "                      \
+    "     AND f.aborted = 0 "                          \
+    "     AND (p.part_id = 0 OR "                      \
+    "          (SELECT sp.uploaded "                   \
+    "             FROM blob_parts sp "                 \
+    "            WHERE sp.part_id = 0 "                \
+    "              AND sp.file_id = p.file_id) = 1) "  \
+    "ORDER BY f.created ASC, "                         \
+    "         p.part_id ASC "                          \
+    "   LIMIT 1;"
+
+
+/*
+ * Query to retrieve the oldest file which all it parts are mark as uploaded, this
+ * query will group the results in a single record, e.g:
+ *
+*  path              part_ids
+ *  ----------------  ----------  ------------------------------------------------------------
+ *  /.../alice29.txt  1726423769  0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,
+ *                                19,20,21,22,23,24,25,26,27,28,29,30
+ *
+ * this query is used to compose
+ */
+#define SQL_GET_OLDEST_FILE_WITH_PARTS_CONCAT                                                     \
+    "SELECT f.id, f.path, GROUP_CONCAT(p.part_id ORDER BY p.part_id ASC) AS part_ids, f.source, " \
+    "       f.remote_id, f.tag "                                                                  \
+    "FROM blob_files f "                                                                          \
+    "JOIN blob_parts p ON f.id = p.file_id "                                                      \
+    "WHERE p.uploaded = 1 "                                                                       \
+    "GROUP BY f.id "                                                                              \
+    "HAVING COUNT(p.id) = (SELECT COUNT(p2.id) FROM blob_parts p2 WHERE p2.file_id = f.id) "      \
+    "ORDER BY f.created ASC "                                                                     \
+    "LIMIT 1;"
+
+
+#define FLB_BLOB_DB_SUCCESS                         0
+#define FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE     -1
+#define FLB_BLOB_DB_ERROR_ALLOCATOR_FAILURE        -2
+#define FLB_BLOB_DB_ERROR_INVALID_BLOB_DB_CONTEXT  -3
+#define FLB_BLOB_DB_ERROR_INVALID_FLB_CONTEXT      -4
+#define FLB_BLOB_DB_ERROR_INVALID_DATABASE_PATH    -5
+#define FLB_BLOB_DB_ERROR_SQLDB_OPEN_FAILURE       -6
+#define FLB_BLOB_DB_ERROR_FILE_TABLE_CREATION      -7
+#define FLB_BLOB_DB_ERROR_PART_TABLE_CREATION      -8
+#define FLB_BLOB_DB_ERROR_SQLDB_FK_INIT_FAILURE    -9
+#define FLB_BLOB_DB_ERROR_LOCK_INIT                -10
+
+#define FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE    -200
+
+#define FLB_BLOB_DB_ERROR_FILE_INSERT                          \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -1
+#define FLB_BLOB_DB_ERROR_FILE_DELETE                          \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -2
+#define FLB_BLOB_DB_ERROR_FILE_ABORT                           \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -3
+#define FLB_BLOB_DB_ERROR_FILE_DESTINATION_CHANGE              \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -4
+#define FLB_BLOB_DB_ERROR_FILE_REMOTE_ID_UPDATE                \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -5
+#define FLB_BLOB_DB_ERROR_FILE_DELIVERY_ATTEMPT_UPDATE         \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -6
+#define FLB_BLOB_DB_ERROR_PART_UPLOAD_STATE_RESET              \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -7
+#define FLB_BLOB_DB_ERROR_FILE_UPLOAD_STATE_RESET              \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -8
+#define FLB_BLOB_DB_ERROR_FILE_PART_INSERT                     \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -9
+#define FLB_BLOB_DB_ERROR_FILE_PART_IN_PROGRESS_UPDATE         \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -10
+#define FLB_BLOB_DB_ERROR_PART_UPLOAD_STATE_UPDATE             \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -11
+#define FLB_BLOB_DB_ERROR_PART_DELIVERY_ATTEMPT_COUNTER_UPDATE \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -12
+#define FLB_BLOB_DB_ERROR_PART_REMOTE_ID_UPDATE                \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -13
+#define FLB_BLOB_DB_ERROR_PART_REMOTE_ID_FETCH                 \
+    FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_BASE -14
+
+#define FLB_BLOB_DB_ERROR_EXECUTING_STATEMENT_TOP              \
+    FLB_BLOB_DB_ERROR_PART_REMOTE_ID_UPDATE
+
+/* These errors are highly speciifc and thus client code should be able to
+ * range check them.
+ */
+
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE -100
+
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_INSERT_FILE                             \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 0
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_DELETE_FILE                             \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 1
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_ABORT_FILE                              \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 2
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_FILE                                \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 3
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_DESTINATION                 \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 4
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_REMOTE_ID                   \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 5
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_DELIVERY_ATTEMPT_COUNT      \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 6
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_SET_FILE_ABORTED_STATE                  \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 7
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_NEXT_ABORTED_FILE                   \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 8
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_NEXT_STALE_FILE                     \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 9
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_RESET_FILE_UPLOAD_STATES                \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 10
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_RESET_FILE_PART_UPLOAD_STATES           \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 11
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_INSERT_FILE_PART                        \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 12
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_UPLOADED               \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 13
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_REMOTE_ID              \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 14
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_FETCH_FILE_PART_REMOTE_ID               \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 15
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_DELIVERY_ATTEMPT_COUNT \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 16
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_NEXT_FILE_PART                      \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 17
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_IN_PROGRESS            \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 18
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_OLDEST_FILE_WITH_PARTS              \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 19
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_FILE_PART_COUNT                     \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_BASE - 20
+
+#define FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_TOP                                     \
+    FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_OLDEST_FILE_WITH_PARTS
+
+#ifdef FLB_HAVE_SQLDB
+#include <fluent-bit/flb_sqldb.h>
+
+typedef struct flb_sqldb __internal_flb_sqldb;
+typedef sqlite3_stmt     __internal_sqlite3_stmt;
+#else
+typedef void __internal_flb_sqldb;
+typedef void __internal_sqlite3_stmt;
+#endif
+
+struct flb_blob_db {
+    /* database context */
+    __internal_flb_sqldb    *db;
+    int                      last_error;
+    flb_lock_t               global_lock;
+
+    /* prepared statements: files  */
+    __internal_sqlite3_stmt *stmt_insert_file;
+    __internal_sqlite3_stmt *stmt_delete_file;
+    __internal_sqlite3_stmt *stmt_abort_file;
+    __internal_sqlite3_stmt *stmt_get_file;
+    __internal_sqlite3_stmt *stmt_get_file_part_count;
+    __internal_sqlite3_stmt *stmt_update_file_remote_id;
+    __internal_sqlite3_stmt *stmt_update_file_destination;
+    __internal_sqlite3_stmt *stmt_update_file_delivery_attempt_count;
+    __internal_sqlite3_stmt *stmt_set_file_aborted_state;
+    __internal_sqlite3_stmt *stmt_get_next_aborted_file;
+    __internal_sqlite3_stmt *stmt_get_next_stale_file;
+    __internal_sqlite3_stmt *stmt_reset_file_upload_states;
+
+    /* prepared statement: file parts */
+    __internal_sqlite3_stmt *stmt_insert_file_part;
+    __internal_sqlite3_stmt *stmt_fetch_file_part_remote_id;
+    __internal_sqlite3_stmt *stmt_update_file_part_remote_id;
+    __internal_sqlite3_stmt *stmt_update_file_part_uploaded;
+    __internal_sqlite3_stmt *stmt_reset_file_part_upload_states;
+    __internal_sqlite3_stmt *stmt_update_file_part_delivery_attempt_count;
+    __internal_sqlite3_stmt *stmt_get_next_file_part;
+    __internal_sqlite3_stmt *stmt_update_file_part_in_progress;
+
+    __internal_sqlite3_stmt *stmt_get_oldest_file_with_parts;
+};
+
+int flb_blob_db_open(struct flb_blob_db *context,
+                     struct flb_config *config,
+                     char *path);
+
+int flb_blob_db_close(struct flb_blob_db *context);
+
+int flb_blob_db_lock(struct flb_blob_db *context);
+
+int flb_blob_db_unlock(struct flb_blob_db *context);
+
+int flb_blob_db_file_exists(struct flb_blob_db *context,
+                            char *path,
+                            uint64_t *id);
+
+int64_t flb_blob_db_file_insert(struct flb_blob_db *context,
+                                char *tag,
+                                char *source,
+                                char *destination,
+                                char *path,
+                                size_t size);
+
+int flb_blob_db_file_delete(struct flb_blob_db *context,
+                            uint64_t id,
+                            char *path);
+
+int flb_blob_db_file_set_aborted_state(struct flb_blob_db *context,
+                                       uint64_t id,
+                                       char *path,
+                                       uint64_t state);
+
+int flb_blob_file_change_destination(struct flb_blob_db *context,
+                                     uint64_t id,
+                                     cfl_sds_t destination);
+
+int flb_blob_db_file_delivery_attempts(struct flb_blob_db *context,
+                                       uint64_t id,
+                                       uint64_t attempts);
+
+int flb_blob_file_update_remote_id(struct flb_blob_db *context,
+                                   uint64_t id,
+                                   cfl_sds_t remote_id);
+
+int flb_blob_db_file_get_next_aborted(struct flb_blob_db *context,
+                                      uint64_t *id,
+                                      uint64_t *delivery_attempts,
+                                      cfl_sds_t *path,
+                                      cfl_sds_t *source,
+                                      cfl_sds_t *remote_id,
+                                      cfl_sds_t *file_tag,
+                                      int *part_count);
+
+int flb_blob_db_file_get_next_stale(struct flb_blob_db *context,
+                                    uint64_t *id,
+                                    cfl_sds_t *path,
+                                    uint64_t upload_parts_freshness_threshold,
+                                    cfl_sds_t *remote_id,
+                                    cfl_sds_t *tag,
+                                    int *part_count);
+
+int flb_blob_db_file_reset_upload_states(struct flb_blob_db *context,
+                                         uint64_t id,
+                                         char *path);
+
+int flb_blob_db_file_part_insert(struct flb_blob_db *context,
+                                 uint64_t file_id,
+                                 uint64_t part_id,
+                                 size_t offset_start,
+                                 size_t offset_end,
+                                 int64_t *out_id);
+
+int flb_blob_db_file_part_in_progress(struct flb_blob_db *context,
+                                      int in_progress,
+                                      uint64_t id);
+
+int flb_blob_db_file_part_get_next(struct flb_blob_db *context,
+                                   uint64_t *id,
+                                   uint64_t *file_id,
+                                   uint64_t *part_id,
+                                   off_t *offset_start,
+                                   off_t *offset_end,
+                                   uint64_t *part_delivery_attempts,
+                                   uint64_t *file_delivery_attempts,
+                                   cfl_sds_t *file_path,
+                                   cfl_sds_t *destination,
+                                   cfl_sds_t *remote_file_id,
+                                   cfl_sds_t *tag,
+                                   int *part_count);
+
+int flb_blob_db_file_part_update_remote_id(struct flb_blob_db *context,
+                                           uint64_t id,
+                                           cfl_sds_t remote_id);
+
+int flb_blob_db_file_part_uploaded(struct flb_blob_db *context, uint64_t id);
+
+int flb_blob_db_file_part_update_delivery_attempt_counter(
+        struct flb_blob_db *context,
+        uint64_t file_id,
+        uint64_t part_id,
+        uint64_t attempts);
+
+int flb_blob_db_file_fetch_oldest_ready(struct flb_blob_db *context,
+                                        uint64_t *file_id,
+                                        cfl_sds_t *path,
+                                        cfl_sds_t *part_ids,
+                                        cfl_sds_t *source,
+                                        cfl_sds_t *file_remote_id,
+                                        cfl_sds_t *file_tag,
+                                        int *part_count);
+
+int flb_blob_db_file_fetch_part_ids(struct flb_blob_db *context,
+                                    uint64_t file_id,
+                                    cfl_sds_t *remote_id_list,
+                                    size_t remote_id_list_size,
+                                    int *remote_id_count);
+
+int flb_blob_db_file_fetch_part_count(struct flb_blob_db *context,
+                                      uint64_t file_id);
+#endif

--- a/include/fluent-bit/flb_blob_db.h
+++ b/include/fluent-bit/flb_blob_db.h
@@ -356,12 +356,10 @@ int64_t flb_blob_db_file_insert(struct flb_blob_db *context,
                                 size_t size);
 
 int flb_blob_db_file_delete(struct flb_blob_db *context,
-                            uint64_t id,
-                            char *path);
+                            uint64_t id);
 
 int flb_blob_db_file_set_aborted_state(struct flb_blob_db *context,
                                        uint64_t id,
-                                       char *path,
                                        uint64_t state);
 
 int flb_blob_file_change_destination(struct flb_blob_db *context,
@@ -394,8 +392,7 @@ int flb_blob_db_file_get_next_stale(struct flb_blob_db *context,
                                     int *part_count);
 
 int flb_blob_db_file_reset_upload_states(struct flb_blob_db *context,
-                                         uint64_t id,
-                                         char *path);
+                                         uint64_t id);
 
 int flb_blob_db_file_part_insert(struct flb_blob_db *context,
                                  uint64_t file_id,

--- a/include/fluent-bit/flb_sqldb.h
+++ b/include/fluent-bit/flb_sqldb.h
@@ -22,6 +22,7 @@
 
 #include <sqlite3.h>
 #include <fluent-bit.h>
+#include <fluent-bit/flb_lock.h>
 
 struct flb_sqldb {
     char *path;               /* physical path of the database */
@@ -30,6 +31,7 @@ struct flb_sqldb {
     int users;                /* number of active users        */
     void *parent;             /* if shared, ref to parent      */
     sqlite3 *handler;         /* SQLite3 handler               */
+    flb_lock_t lock;          /* thread safety mechanism       */
     struct mk_list _head;     /* Link to config->sqldb_list    */
 };
 
@@ -40,6 +42,11 @@ int flb_sqldb_close(struct flb_sqldb *db);
 int flb_sqldb_query(struct flb_sqldb *db, const char *sql,
                     int (*callback) (void *, int, char **, char **),
                     void *data);
+
 int64_t flb_sqldb_last_id(struct flb_sqldb *db);
+
+int flb_sqldb_lock(struct flb_sqldb *db);
+
+int flb_sqldb_unlock(struct flb_sqldb *db);
 
 #endif

--- a/plugins/in_blob/blob_db.c
+++ b/plugins/in_blob/blob_db.c
@@ -2,7 +2,7 @@
 
 /*  Fluent Bit
  *  ==========
- *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *  Copyright (C) 2015-2025 The Fluent Bit Authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -53,6 +53,13 @@ struct worker_info {
 
 FLB_TLS_DEFINE(struct worker_info, s3_worker_info);
 
+#ifdef FLB_SYSTEM_WINDOWS
+static int setenv(const char *name, const char *value, int overwrite)
+{
+    return SetEnvironmentVariableA(name, value);
+}
+#endif
+
 static int s3_timer_create(struct flb_s3 *ctx);
 
 static int construct_request_buffer(struct flb_s3 *ctx, flb_sds_t new_data,

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -2878,7 +2878,7 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
      * delivery attempt counter.
      */
     if (part_id == 0) {
-        ret = flb_blob_db_file_delivery_attempts(&ctx->blob_db, file_id, ++file_delivery_attempts);
+        flb_blob_db_file_delivery_attempts(&ctx->blob_db, file_id, ++file_delivery_attempts);
     }
 
     /* read the file content */

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -2919,6 +2919,8 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
                         out_size);
 
         if (ret != 0) {
+            flb_free(out_buf);
+
             cfl_sds_destroy(file_tag);
             cfl_sds_destroy(file_path);
             cfl_sds_destroy(file_remote_id);
@@ -2931,6 +2933,8 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
         m_upload = create_blob_upload(ctx, file_tag, cfl_sds_len(file_tag), file_path);
 
         if (m_upload == NULL) {
+            flb_free(out_buf);
+
             cfl_sds_destroy(file_tag);
             cfl_sds_destroy(file_path);
             cfl_sds_destroy(file_remote_id);
@@ -2945,6 +2949,8 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
             ret = create_multipart_upload(ctx, m_upload);
 
             if (ret < 0) {
+                flb_free(out_buf);
+
                 cfl_sds_destroy(file_tag);
                 cfl_sds_destroy(file_path);
                 cfl_sds_destroy(file_remote_id);
@@ -2962,6 +2968,8 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
             ret = flb_blob_file_update_remote_id(&ctx->blob_db, file_id, m_upload->upload_id);
 
             if (ret != FLB_BLOB_DB_SUCCESS) {
+                flb_free(out_buf);
+
                 cfl_sds_destroy(file_tag);
                 cfl_sds_destroy(file_path);
                 cfl_sds_destroy(file_remote_id);
@@ -2979,6 +2987,8 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
             m_upload->upload_id = flb_sds_create(file_remote_id);
 
             if (m_upload->upload_id == NULL) {
+                flb_free(out_buf);
+
                 cfl_sds_destroy(file_tag);
                 cfl_sds_destroy(file_path);
                 cfl_sds_destroy(file_remote_id);
@@ -3022,22 +3032,9 @@ static int cb_s3_upload_blob(struct flb_config *config, void *data)
         }
     }
 
-    if (ret == -1) {
-        info->active_upload = FLB_FALSE;
-
-        cfl_sds_destroy(file_tag);
-        cfl_sds_destroy(file_path);
-        cfl_sds_destroy(file_remote_id);
-        cfl_sds_destroy(file_destination);
-
-        return 0;
-    }
-
     info->active_upload = FLB_FALSE;
 
-    if (out_buf) {
-        flb_free(out_buf);
-    }
+    flb_free(out_buf);
 
     cfl_sds_destroy(file_tag);
     cfl_sds_destroy(file_path);

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -996,6 +996,8 @@ static int cb_s3_init(struct flb_output_instance *ins,
     struct mk_list *split;
     int list_size;
 
+    FLB_TLS_INIT(s3_worker_info);
+
     ctx = flb_calloc(1, sizeof(struct flb_s3));
     if (!ctx) {
         flb_errno();

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_aws_credentials.h>
 #include <fluent-bit/flb_aws_util.h>
+#include <fluent-bit/flb_blob_db.h>
 
 /* Upload data to S3 in 5MB chunks */
 #define MIN_CHUNKED_UPLOAD_SIZE 5242880
@@ -43,7 +44,7 @@
 #define MAX_FILE_SIZE_STR     "50,000,000,000"
 
 /* Allowed max file size 1 GB for publishing to S3 */
-#define MAX_FILE_SIZE_PUT_OBJECT        1000000000 
+#define MAX_FILE_SIZE_PUT_OBJECT        1000000000
 
 #define DEFAULT_UPLOAD_TIMEOUT 3600
 
@@ -123,6 +124,18 @@ struct flb_s3 {
     int insecure;
     size_t store_dir_limit_size;
 
+    struct flb_blob_db blob_db;
+    flb_sds_t blob_database_file;
+    size_t part_size;
+    time_t upload_parts_timeout;
+    time_t upload_parts_freshness_threshold;
+    int file_delivery_attempt_limit;
+    int part_delivery_attempt_limit;
+    flb_sds_t configuration_endpoint_url;
+    flb_sds_t configuration_endpoint_username;
+    flb_sds_t configuration_endpoint_password;
+    flb_sds_t configuration_endpoint_bearer_token;
+
     /* track the total amount of buffered data */
     size_t current_buffer_size;
 
@@ -186,6 +199,9 @@ int create_multipart_upload(struct flb_s3 *ctx,
 
 int complete_multipart_upload(struct flb_s3 *ctx,
                               struct multipart_upload *m_upload);
+
+int abort_multipart_upload(struct flb_s3 *ctx,
+                           struct multipart_upload *m_upload);
 
 void multipart_read_uploads_from_fs(struct flb_s3 *ctx);
 

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -131,10 +131,12 @@ struct flb_s3 {
     time_t upload_parts_freshness_threshold;
     int file_delivery_attempt_limit;
     int part_delivery_attempt_limit;
-    flb_sds_t configuration_endpoint_url;
-    flb_sds_t configuration_endpoint_username;
-    flb_sds_t configuration_endpoint_password;
-    flb_sds_t configuration_endpoint_bearer_token;
+    flb_sds_t authorization_endpoint_url;
+    flb_sds_t authorization_endpoint_username;
+    flb_sds_t authorization_endpoint_password;
+    flb_sds_t authorization_endpoint_bearer_token;
+    struct flb_upstream *authorization_endpoint_upstream;
+    struct flb_tls *authorization_endpoint_tls_context;
 
     /* track the total amount of buffered data */
     size_t current_buffer_size;
@@ -192,16 +194,19 @@ struct flb_s3 {
 };
 
 int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
-                char *body, size_t body_size);
+                char *body, size_t body_size, char *pre_signed_url);
 
 int create_multipart_upload(struct flb_s3 *ctx,
-                            struct multipart_upload *m_upload);
+                            struct multipart_upload *m_upload,
+                            char *pre_signed_url);
 
 int complete_multipart_upload(struct flb_s3 *ctx,
-                              struct multipart_upload *m_upload);
+                              struct multipart_upload *m_upload,
+                              char *pre_signed_url);
 
 int abort_multipart_upload(struct flb_s3 *ctx,
-                           struct multipart_upload *m_upload);
+                           struct multipart_upload *m_upload,
+                           char *pre_signed_url);
 
 void multipart_read_uploads_from_fs(struct flb_s3 *ctx);
 

--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -403,7 +403,8 @@ error:
 }
 
 int complete_multipart_upload(struct flb_s3 *ctx,
-                              struct multipart_upload *m_upload)
+                              struct multipart_upload *m_upload,
+                              char *pre_signed_url)
 {
     char *body;
     size_t size;
@@ -426,8 +427,14 @@ int complete_multipart_upload(struct flb_s3 *ctx,
         return -1;
     }
 
-    tmp = flb_sds_printf(&uri, "/%s%s?uploadId=%s", ctx->bucket,
-                         m_upload->s3_key, m_upload->upload_id);
+    if (pre_signed_url != NULL) {
+        tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
+    }
+    else {
+        tmp = flb_sds_printf(&uri, "/%s%s?uploadId=%s", ctx->bucket,
+                            m_upload->s3_key, m_upload->upload_id);
+    }
+
     if (!tmp) {
         flb_sds_destroy(uri);
         return -1;
@@ -477,11 +484,11 @@ int complete_multipart_upload(struct flb_s3 *ctx,
 }
 
 int abort_multipart_upload(struct flb_s3 *ctx,
-                           struct multipart_upload *m_upload)
+                           struct multipart_upload *m_upload,
+                           char *pre_signed_url)
 {
     flb_sds_t uri = NULL;
     flb_sds_t tmp;
-    int ret;
     struct flb_http_client *c = NULL;
     struct flb_aws_client *s3_client;
 
@@ -498,8 +505,14 @@ int abort_multipart_upload(struct flb_s3 *ctx,
         return -1;
     }
 
-    tmp = flb_sds_printf(&uri, "/%s%s?uploadId=%s", ctx->bucket,
-                         m_upload->s3_key, m_upload->upload_id);
+    if (pre_signed_url != NULL) {
+        tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
+    }
+    else {
+        tmp = flb_sds_printf(&uri, "/%s%s?uploadId=%s", ctx->bucket,
+                            m_upload->s3_key, m_upload->upload_id);
+    }
+
     if (!tmp) {
         flb_sds_destroy(uri);
         return -1;
@@ -544,7 +557,8 @@ int abort_multipart_upload(struct flb_s3 *ctx,
 }
 
 int create_multipart_upload(struct flb_s3 *ctx,
-                            struct multipart_upload *m_upload)
+                            struct multipart_upload *m_upload,
+                            char *pre_signed_url)
 {
     flb_sds_t uri = NULL;
     flb_sds_t tmp;
@@ -560,7 +574,13 @@ int create_multipart_upload(struct flb_s3 *ctx,
         return -1;
     }
 
-    tmp = flb_sds_printf(&uri, "/%s%s?uploads=", ctx->bucket, m_upload->s3_key);
+    if (pre_signed_url != NULL) {
+        tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
+    }
+    else {
+        tmp = flb_sds_printf(&uri, "/%s%s?uploads=", ctx->bucket, m_upload->s3_key);
+    }
+
     if (!tmp) {
         flb_sds_destroy(uri);
         return -1;
@@ -664,7 +684,7 @@ flb_sds_t get_etag(char *response, size_t size)
 }
 
 int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
-                char *body, size_t body_size)
+                char *body, size_t body_size, char *pre_signed_url)
 {
     flb_sds_t uri = NULL;
     flb_sds_t tmp;
@@ -681,9 +701,15 @@ int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
         return -1;
     }
 
-    tmp = flb_sds_printf(&uri, "/%s%s?partNumber=%d&uploadId=%s",
-                         ctx->bucket, m_upload->s3_key, m_upload->part_number,
-                         m_upload->upload_id);
+    if (pre_signed_url != NULL) {
+        tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
+    }
+    else {
+        tmp = flb_sds_printf(&uri, "/%s%s?partNumber=%d&uploadId=%s",
+                            ctx->bucket, m_upload->s3_key, m_upload->part_number,
+                            m_upload->upload_id);
+    }
+
     if (!tmp) {
         flb_errno();
         flb_sds_destroy(uri);

--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -521,8 +521,7 @@ int abort_multipart_upload(struct flb_s3 *ctx,
 
     s3_client = ctx->s3_client;
     if (s3_plugin_under_test() == FLB_TRUE) {
-        /* c = mock_s3_call("TEST_ABORT_MULTIPART_UPLOAD_ERROR", "AbortMultipartUpload"); */
-        c = NULL;
+        c = mock_s3_call("TEST_ABORT_MULTIPART_UPLOAD_ERROR", "AbortMultipartUpload");
     }
     else {
         c = s3_client->client_vtable->request(s3_client, FLB_HTTP_DELETE,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ set(src
   flb_cfl_record_accessor.c
   flb_conditionals.c
   flb_mem.c
+  flb_blob_db.c
   )
 
 # Config format

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -987,21 +987,23 @@ flb_sds_t flb_get_s3_blob_key(const char *format,
 
     error:
         flb_errno();
+
         if (tmp_tag){
             flb_sds_destroy(tmp_tag);
         }
+
         if (s3_key){
             flb_sds_destroy(s3_key);
         }
+
         if (buf && buf != tmp){
             flb_sds_destroy(buf);
         }
+
         if (tmp){
             flb_sds_destroy(tmp);
         }
-        if (tmp_key){
-            flb_sds_destroy(tmp_key);
-        }
+
         return NULL;
 }
 

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -810,6 +810,201 @@ char* strtok_concurrent(
 #endif
 }
 
+/* Constructs S3 object key as per the blob format. */
+flb_sds_t flb_get_s3_blob_key(const char *format,
+                              const char *tag,
+                              char *tag_delimiter,
+                              const char *blob_path)
+{
+    int i = 0;
+    int ret = 0;
+    char *tag_token = NULL;
+    char *random_alphanumeric;
+    /* concurrent safe strtok_r requires a tracking ptr */
+    char *strtok_saveptr;
+    flb_sds_t tmp = NULL;
+    flb_sds_t buf = NULL;
+    flb_sds_t s3_key = NULL;
+    flb_sds_t tmp_key = NULL;
+    flb_sds_t tmp_tag = NULL;
+    flb_sds_t sds_result = NULL;
+    char *valid_blob_path = NULL;
+
+    if (strlen(format) > S3_KEY_SIZE){
+        flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
+    }
+
+    tmp_tag = flb_sds_create_len(tag, strlen(tag));
+    if(!tmp_tag){
+        goto error;
+    }
+
+    s3_key = flb_sds_create_len(format, strlen(format));
+    if (!s3_key) {
+        goto error;
+    }
+
+    /* Check if delimiter(s) specifed exists in the tag. */
+    for (i = 0; i < strlen(tag_delimiter); i++){
+        if (strchr(tag, tag_delimiter[i])){
+            ret = 1;
+            break;
+        }
+    }
+
+    tmp = flb_sds_create_len(TAG_PART_DESCRIPTOR, 5);
+    if (!tmp) {
+        goto error;
+    }
+    if (strstr(s3_key, tmp)){
+        if(ret == 0){
+            flb_warn("[s3_key] Invalid Tag delimiter: does not exist in tag. "
+                    "tag=%s, format=%s", tag, format);
+        }
+    }
+
+    flb_sds_destroy(tmp);
+    tmp = NULL;
+
+    /* Split the string on the delimiters */
+    tag_token = strtok_concurrent(tmp_tag, tag_delimiter, &strtok_saveptr);
+
+    /* Find all occurences of $TAG[*] and
+     * replaces it with the right token from tag.
+     */
+    i = 0;
+    while(tag_token != NULL && i < MAX_TAG_PARTS) {
+        buf = flb_sds_create_size(10);
+        if (!buf) {
+            goto error;
+        }
+        tmp = flb_sds_printf(&buf, TAG_PART_DESCRIPTOR, i);
+        if (!tmp) {
+            goto error;
+        }
+
+        tmp_key = replace_uri_tokens(s3_key, tmp, tag_token);
+        if (!tmp_key) {
+            goto error;
+        }
+
+        if(strlen(tmp_key) > S3_KEY_SIZE){
+            flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
+        }
+
+        if (buf != tmp) {
+            flb_sds_destroy(buf);
+        }
+        flb_sds_destroy(tmp);
+        tmp = NULL;
+        buf = NULL;
+        flb_sds_destroy(s3_key);
+        s3_key = tmp_key;
+        tmp_key = NULL;
+
+        tag_token = strtok_concurrent(NULL, tag_delimiter, &strtok_saveptr);
+        i++;
+    }
+
+    tmp = flb_sds_create_len(TAG_PART_DESCRIPTOR, 5);
+    if (!tmp) {
+        goto error;
+    }
+
+    /* A match against "$TAG[" indicates an invalid or out of bounds tag part. */
+    if (strstr(s3_key, tmp)){
+        flb_warn("[s3_key] Invalid / Out of bounds tag part: At most 10 tag parts "
+                 "($TAG[0] - $TAG[9]) can be processed. tag=%s, format=%s, delimiters=%s",
+                 tag, format, tag_delimiter);
+    }
+
+    /* Find all occurences of $TAG and replace with the entire tag. */
+    tmp_key = replace_uri_tokens(s3_key, TAG_DESCRIPTOR, tag);
+    if (!tmp_key) {
+        goto error;
+    }
+
+    if(strlen(tmp_key) > S3_KEY_SIZE){
+        flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
+    }
+
+    flb_sds_destroy(s3_key);
+    s3_key = tmp_key;
+    tmp_key = NULL;
+
+    flb_sds_len_set(s3_key, strlen(s3_key));
+
+    valid_blob_path = (char *) blob_path;
+
+    while (*valid_blob_path == '.' ||
+           *valid_blob_path == '/') {
+            valid_blob_path++;
+    }
+
+    /* Append the blob path. */
+    sds_result = flb_sds_cat(s3_key, valid_blob_path, strlen(valid_blob_path));
+
+    if (!sds_result) {
+        goto error;
+    }
+
+    s3_key = sds_result;
+
+    if(strlen(s3_key) > S3_KEY_SIZE){
+        flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
+    }
+
+    /* Find all occurences of $UUID and replace with a random string. */
+    random_alphanumeric = flb_sts_session_name();
+    if (!random_alphanumeric) {
+        goto error;
+    }
+    /* only use 8 chars of the random string */
+    random_alphanumeric[8] = '\0';
+    tmp_key = replace_uri_tokens(s3_key, RANDOM_STRING, random_alphanumeric);
+    if (!tmp_key) {
+        flb_free(random_alphanumeric);
+        goto error;
+    }
+
+    if(strlen(tmp_key) > S3_KEY_SIZE){
+        flb_warn("[s3_key] Object key length is longer than the 1024 character limit.");
+    }
+
+    flb_sds_destroy(s3_key);
+    s3_key = tmp_key;
+    tmp_key = NULL;
+
+    flb_free(random_alphanumeric);
+
+    flb_sds_destroy(tmp);
+    tmp = NULL;
+
+    flb_sds_destroy(tmp_tag);
+    tmp_tag = NULL;
+
+    return s3_key;
+
+    error:
+        flb_errno();
+        if (tmp_tag){
+            flb_sds_destroy(tmp_tag);
+        }
+        if (s3_key){
+            flb_sds_destroy(s3_key);
+        }
+        if (buf && buf != tmp){
+            flb_sds_destroy(buf);
+        }
+        if (tmp){
+            flb_sds_destroy(tmp);
+        }
+        if (tmp_key){
+            flb_sds_destroy(tmp_key);
+        }
+        return NULL;
+}
+
 /* Constructs S3 object key as per the format. */
 flb_sds_t flb_get_s3_key(const char *format, time_t time, const char *tag,
                          char *tag_delimiter, uint64_t seq_index)

--- a/src/flb_blob_db.c
+++ b/src/flb_blob_db.c
@@ -701,10 +701,10 @@ int flb_blob_db_file_get_next_aborted(struct flb_blob_db *context,
     int           result;
     int           exists;
 
-    path = NULL;
-    source = NULL;
-    remote_id = NULL;
-    file_tag = NULL;
+    *path = NULL;
+    *source = NULL;
+    *remote_id = NULL;
+    *file_tag = NULL;
 
     statement = context->stmt_get_next_aborted_file;
 

--- a/src/flb_blob_db.c
+++ b/src/flb_blob_db.c
@@ -1,0 +1,1550 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef FLB_HAVE_SQLDB
+
+#include <fluent-bit/flb_sqldb.h>
+#include <fluent-bit/flb_blob_db.h>
+
+static int prepare_stmts(struct flb_blob_db *context)
+{
+    int result;
+
+    /* insert */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_INSERT_FILE, -1,
+                                &context->stmt_insert_file,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_INSERT_FILE;
+    }
+
+    /* delete */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_DELETE_FILE, -1,
+                                &context->stmt_delete_file,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_DELETE_FILE;
+    }
+
+    /* abort */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_SET_FILE_ABORTED_STATE, -1,
+                                &context->stmt_set_file_aborted_state,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_ABORT_FILE;
+    }
+
+
+    /* file destination update  */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_REMOTE_ID, -1,
+                                &context->stmt_update_file_remote_id,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_REMOTE_ID;
+    }
+
+    /* file destination update  */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_DESTINATION, -1,
+                                &context->stmt_update_file_destination,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_DESTINATION;
+    }
+
+    /* delivery attempt counter update  */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_DELIVERY_ATTEMPT_COUNT, -1,
+                                &context->stmt_update_file_delivery_attempt_count,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_DELIVERY_ATTEMPT_COUNT;
+    }
+
+    /* get */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_FILE, -1,
+                                &context->stmt_get_file,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_FILE;
+    }
+
+    /* get part count */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_FILE_PART_COUNT, -1,
+                                &context->stmt_get_file_part_count,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_FILE_PART_COUNT;
+    }
+
+    /* get next aborted file */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_NEXT_ABORTED_FILE, -1,
+                                &context->stmt_get_next_aborted_file,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_NEXT_ABORTED_FILE;
+    }
+
+    /* get next stale file */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_NEXT_STALE_FILE, -1,
+                                &context->stmt_get_next_stale_file,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_NEXT_STALE_FILE;
+    }
+
+    /* reset file upload progress */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_RESET_FILE_UPLOAD_STATES, -1,
+                                &context->stmt_reset_file_upload_states,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_RESET_FILE_UPLOAD_STATES;
+    }
+
+    /* reset file part upload progress */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_RESET_FILE_PART_UPLOAD_STATES, -1,
+                                &context->stmt_reset_file_part_upload_states,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_RESET_FILE_PART_UPLOAD_STATES;
+    }
+
+    /* insert blob file part */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_INSERT_FILE_PART, -1,
+                                &context->stmt_insert_file_part,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_INSERT_FILE_PART;
+    }
+
+    /* update blob part remote id */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_PART_REMOTE_ID, -1,
+                                &context->stmt_update_file_part_remote_id,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_REMOTE_ID;
+    }
+
+    /* fetch blob part remote id */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_FILE_PART_REMOTE_ID, -1,
+                                &context->stmt_fetch_file_part_remote_id,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_FETCH_FILE_PART_REMOTE_ID;
+    }
+
+    /* update blob part uploaded */
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_PART_UPLOADED, -1,
+                                &context->stmt_update_file_part_uploaded,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_UPLOADED;
+    }
+
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_NEXT_FILE_PART, -1,
+                                &context->stmt_get_next_file_part,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_NEXT_FILE_PART;
+    }
+
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_PART_IN_PROGRESS, -1,
+                                &context->stmt_update_file_part_in_progress,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_PART_IN_PROGRESS;
+    }
+
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_UPDATE_FILE_PART_DELIVERY_ATTEMPT_COUNT, -1,
+                                &context->stmt_update_file_part_delivery_attempt_count,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_UPDATE_FILE_DELIVERY_ATTEMPT_COUNT;
+    }
+
+    result = sqlite3_prepare_v2(context->db->handler,
+                                SQL_GET_OLDEST_FILE_WITH_PARTS_CONCAT, -1,
+                                &context->stmt_get_oldest_file_with_parts,
+                                NULL);
+    if (result != SQLITE_OK) {
+        return FLB_BLOB_DB_ERROR_PREPARING_STATEMENT_GET_OLDEST_FILE_WITH_PARTS;
+    }
+
+    return FLB_BLOB_DB_SUCCESS;
+}
+
+int flb_blob_db_open(struct flb_blob_db *context,
+                     struct flb_config *config,
+                     char *path)
+{
+    int               result;
+    struct flb_sqldb *db;
+
+    if (context == NULL) {
+        return FLB_BLOB_DB_ERROR_INVALID_BLOB_DB_CONTEXT;
+    }
+
+    if (config == NULL) {
+        return FLB_BLOB_DB_ERROR_INVALID_FLB_CONTEXT;
+    }
+
+    if (path == NULL) {
+        return FLB_BLOB_DB_ERROR_INVALID_DATABASE_PATH;
+    }
+
+    db = flb_sqldb_open(path, "", config);
+
+    if (db == NULL) {
+        return FLB_BLOB_DB_ERROR_SQLDB_OPEN_FAILURE;
+    }
+
+    result = flb_sqldb_query(db, SQL_CREATE_BLOB_FILES, NULL, NULL);
+
+    if (result != FLB_OK) {
+        flb_sqldb_close(db);
+
+        return FLB_BLOB_DB_ERROR_FILE_TABLE_CREATION;
+    }
+
+    result = flb_sqldb_query(db, SQL_CREATE_BLOB_PARTS, NULL, NULL);
+
+    if (result != FLB_OK) {
+        flb_sqldb_close(db);
+
+        return FLB_BLOB_DB_ERROR_PART_TABLE_CREATION;
+    }
+
+    result = flb_sqldb_query(db, SQL_PRAGMA_FOREIGN_KEYS, NULL, NULL);
+
+    if (result != FLB_OK) {
+        flb_sqldb_close(db);
+
+        return FLB_BLOB_DB_ERROR_SQLDB_FK_INIT_FAILURE;
+    }
+
+    result = flb_lock_init(&context->global_lock);
+
+    if (result != 0) {
+        flb_sqldb_close(db);
+
+        return FLB_BLOB_DB_ERROR_LOCK_INIT;
+    }
+
+    context->db = db;
+
+    result = prepare_stmts(context);
+
+    if (result != FLB_BLOB_DB_SUCCESS) {
+        flb_lock_destroy(&context->global_lock);
+        flb_sqldb_close(db);
+
+        context->db = NULL;
+    }
+
+    return result;
+}
+
+int flb_blob_db_close(struct flb_blob_db *context)
+{
+    if (context == NULL) {
+        return FLB_BLOB_DB_ERROR_INVALID_BLOB_DB_CONTEXT;
+    }
+
+    if (context->db == NULL) {
+        return FLB_BLOB_DB_SUCCESS;
+    }
+
+    /* finalize prepared statements */
+    sqlite3_finalize(context->stmt_insert_file);
+    sqlite3_finalize(context->stmt_delete_file);
+    sqlite3_finalize(context->stmt_set_file_aborted_state);
+    sqlite3_finalize(context->stmt_get_file);
+    sqlite3_finalize(context->stmt_get_file_part_count);
+    sqlite3_finalize(context->stmt_update_file_remote_id);
+    sqlite3_finalize(context->stmt_update_file_destination);
+    sqlite3_finalize(context->stmt_update_file_delivery_attempt_count);
+    sqlite3_finalize(context->stmt_get_next_aborted_file);
+    sqlite3_finalize(context->stmt_get_next_stale_file);
+    sqlite3_finalize(context->stmt_reset_file_upload_states);
+    sqlite3_finalize(context->stmt_reset_file_part_upload_states);
+
+    sqlite3_finalize(context->stmt_insert_file_part);
+    sqlite3_finalize(context->stmt_update_file_part_remote_id);
+    sqlite3_finalize(context->stmt_fetch_file_part_remote_id);
+    sqlite3_finalize(context->stmt_update_file_part_uploaded);
+    sqlite3_finalize(context->stmt_update_file_part_in_progress);
+    sqlite3_finalize(context->stmt_update_file_part_delivery_attempt_count);
+
+    sqlite3_finalize(context->stmt_get_next_file_part);
+    sqlite3_finalize(context->stmt_get_oldest_file_with_parts);
+
+    flb_lock_destroy(&context->global_lock);
+
+    return flb_sqldb_close(context->db);
+}
+
+int flb_blob_db_lock(struct flb_blob_db *context)
+{
+    return flb_lock_acquire(&context->global_lock,
+                            FLB_LOCK_INFINITE_RETRY_LIMIT,
+                            FLB_LOCK_DEFAULT_RETRY_DELAY);
+}
+
+int flb_blob_db_unlock(struct flb_blob_db *context)
+{
+    return flb_lock_release(&context->global_lock,
+                            FLB_LOCK_INFINITE_RETRY_LIMIT,
+                            FLB_LOCK_DEFAULT_RETRY_DELAY);
+}
+
+
+int flb_blob_db_file_exists(struct flb_blob_db *context,
+                            char *path,
+                            uint64_t *id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+    int           exists;
+
+    statement = context->stmt_get_file;
+
+    flb_sqldb_lock(context->db);
+
+    /* Bind parameters */
+    sqlite3_bind_text(statement, 1, path, -1, 0);
+
+    result = sqlite3_step(statement);
+
+    if (result == SQLITE_ROW) {
+        exists = FLB_TRUE;
+
+        /* id: column 0 */
+        *id = sqlite3_column_int64(statement, 0);
+    }
+    else if (result == SQLITE_DONE) {
+        exists = FLB_FALSE;
+    }
+    else {
+        exists = -1;
+    }
+
+    sqlite3_clear_bindings(statement);
+
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return exists;
+}
+
+int64_t flb_blob_db_file_insert(struct flb_blob_db *context,
+                                char *tag,
+                                char *source,
+                                char *destination,
+                                char *path,
+                                size_t size)
+{
+    sqlite3_stmt *statement;
+    time_t        created;
+    int           result;
+    int64_t       id;
+
+    statement = context->stmt_insert_file;
+
+    flb_sqldb_lock(context->db);
+
+    created = time(NULL);
+
+    sqlite3_bind_text(statement,  1, tag, -1, 0);
+    sqlite3_bind_text(statement,  2, source, -1, 0);
+    sqlite3_bind_text(statement,  3, destination, -1, 0);
+    sqlite3_bind_text(statement,  4, path, -1, 0);
+    sqlite3_bind_int64(statement, 5, size);
+    sqlite3_bind_int64(statement, 6, created);
+
+    result = sqlite3_step(statement);
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    if (result == SQLITE_DONE) {
+        /* Get the database ID for this file */
+        id = flb_sqldb_last_id(context->db);
+    }
+    else {
+        context->last_error = result;
+
+        id = FLB_BLOB_DB_ERROR_FILE_INSERT;
+    }
+
+    flb_sqldb_unlock(context->db);
+
+    return id;
+}
+
+int flb_blob_db_file_delete(struct flb_blob_db *context,
+                            uint64_t id,
+                            char *path)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_delete_file;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_DELETE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_set_aborted_state(struct flb_blob_db *context,
+                                       uint64_t id,
+                                       char *path,
+                                       uint64_t state)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_set_file_aborted_state;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, state);
+    sqlite3_bind_int64(statement, 2, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_ABORT;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_file_update_remote_id(struct flb_blob_db *context,
+                                   uint64_t id,
+                                   cfl_sds_t remote_id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_remote_id;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_text(statement, 1, remote_id, -1, 0);
+    sqlite3_bind_int64(statement, 2, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_REMOTE_ID_UPDATE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_file_change_destination(struct flb_blob_db *context,
+                                     uint64_t id,
+                                     cfl_sds_t destination)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_destination;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_text(statement, 1, destination, -1, 0);
+    sqlite3_bind_int64(statement, 2, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_DESTINATION_CHANGE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_delivery_attempts(struct flb_blob_db *context,
+                                       uint64_t id,
+                                       uint64_t attempts)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_delivery_attempt_count;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, attempts);
+    sqlite3_bind_int64(statement, 2, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_DELIVERY_ATTEMPT_UPDATE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_get_next_stale(struct flb_blob_db *context,
+                                    uint64_t *id,
+                                    cfl_sds_t *path,
+                                    uint64_t upload_parts_freshness_threshold,
+                                    cfl_sds_t *remote_id,
+                                    cfl_sds_t *tag,
+                                    int *part_count)
+{
+    time_t        freshness_threshold;
+    sqlite3_stmt *statement;
+    char         *tmp_remote_id;
+    char         *tmp_path;
+    char         *tmp_tag;
+    int           exists;
+    int           result;
+
+    statement = context->stmt_get_next_stale_file;
+
+    flb_sqldb_lock(context->db);
+
+    freshness_threshold  = time(NULL) - upload_parts_freshness_threshold;
+
+    sqlite3_bind_int64(statement, 1, freshness_threshold);
+
+    result = sqlite3_step(statement);
+
+    if (result == SQLITE_ROW) {
+        exists = FLB_TRUE;
+
+        *id = sqlite3_column_int64(statement, 0);
+        tmp_path = (char *) sqlite3_column_text(statement, 1);
+        tmp_remote_id = (char *) sqlite3_column_text(statement, 2);
+        tmp_tag = (char *) sqlite3_column_text(statement, 3);
+
+        *path = cfl_sds_create(tmp_path);
+
+        if (*path == NULL) {
+            exists = -1;
+        }
+        else {
+            *remote_id = cfl_sds_create(tmp_remote_id);
+
+            if (*remote_id == NULL) {
+                exists = -1;
+            }
+            else {
+                *tag = cfl_sds_create(tmp_tag);
+
+                if (*tag == NULL) {
+                    exists = -1;
+                }
+                else {
+                    *part_count = flb_blob_db_file_fetch_part_count(context, *id);
+
+                    if (*part_count <= 0) {
+                        exists = -1;
+                    }
+                    else {
+                        exists = 1;
+                    }
+
+                }
+            }
+        }
+    }
+    else if (result == SQLITE_DONE) {
+        exists = FLB_FALSE;
+    }
+    else {
+        context->last_error = result;
+
+        exists = -1;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    if (exists == -1) {
+        if (*path != NULL) {
+            cfl_sds_destroy(*path);
+
+            *path = NULL;
+        }
+
+        if (*remote_id != NULL) {
+            cfl_sds_destroy(*remote_id);
+
+            *remote_id = NULL;
+        }
+
+        if (*tag != NULL) {
+            cfl_sds_destroy(*tag);
+
+            *tag = NULL;
+        }
+
+        *id = 0;
+    }
+
+    flb_sqldb_unlock(context->db);
+
+    return exists;
+}
+
+int flb_blob_db_file_get_next_aborted(struct flb_blob_db *context,
+                                      uint64_t *id,
+                                      uint64_t *delivery_attempts,
+                                      cfl_sds_t *path,
+                                      cfl_sds_t *source,
+                                      cfl_sds_t *remote_id,
+                                      cfl_sds_t *file_tag,
+                                      int *part_count)
+{
+    char         *tmp_remote_id;
+    char         *tmp_source;
+    sqlite3_stmt *statement;
+    char         *tmp_path;
+    char         *tmp_tag;
+    int           result;
+    int           exists;
+
+    path = NULL;
+    source = NULL;
+    remote_id = NULL;
+    file_tag = NULL;
+
+    statement = context->stmt_get_next_aborted_file;
+
+    flb_sqldb_lock(context->db);
+
+    result = sqlite3_step(statement);
+
+    if (result == SQLITE_ROW) {
+        exists = FLB_TRUE;
+
+        *id = sqlite3_column_int64(statement, 0);
+        *delivery_attempts = sqlite3_column_int64(statement, 1);
+        tmp_source = (char *) sqlite3_column_text(statement, 2);
+        tmp_path = (char *) sqlite3_column_text(statement, 3);
+        tmp_remote_id = (char *) sqlite3_column_text(statement, 4);
+        tmp_tag = (char *) sqlite3_column_text(statement, 5);
+
+        *path = cfl_sds_create(tmp_path);
+
+        if (*path == NULL) {
+            exists = -1;
+        }
+        else {
+            *source = cfl_sds_create(tmp_source);
+
+            if (*source == NULL) {
+                exists = -1;
+            }
+            else {
+                *remote_id = cfl_sds_create(tmp_remote_id);
+
+                if (*remote_id == NULL) {
+                    exists = -1;
+                }
+                else {
+                    *file_tag = cfl_sds_create(tmp_tag);
+
+                    if (*file_tag == NULL) {
+                        exists = -1;
+                    }
+                    else {
+                        *part_count = flb_blob_db_file_fetch_part_count(context, *id);
+
+                        if (*part_count <= 0) {
+                            exists = -1;
+                        }
+                        else {
+                            exists = 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    else if (result == SQLITE_DONE) {
+        exists = FLB_FALSE;
+    }
+    else {
+        context->last_error = result;
+
+        exists = -1;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    if (exists == -1) {
+        *id = 0;
+        *delivery_attempts = 0;
+
+        if (*path != NULL) {
+            cfl_sds_destroy(*path);
+            *path = NULL;
+        }
+
+        if (*source != NULL) {
+            cfl_sds_destroy(*source);
+            *source = NULL;
+        }
+
+        if (*remote_id != NULL) {
+            cfl_sds_destroy(*remote_id);
+            *remote_id = NULL;
+        }
+
+        if (*file_tag != NULL) {
+            cfl_sds_destroy(*file_tag);
+            *file_tag = NULL;
+        }
+    }
+
+    return exists;
+}
+
+
+static int flb_blob_db_file_reset_part_upload_states(struct flb_blob_db *context,
+                                                     uint64_t id,
+                                                     char *path)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_reset_file_part_upload_states;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_PART_UPLOAD_STATE_RESET;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_reset_upload_states(struct flb_blob_db *context,
+                                         uint64_t id,
+                                         char *path)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_reset_file_upload_states;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, id);
+
+    result = sqlite3_step(statement);
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_UPLOAD_STATE_RESET;
+    }
+    else {
+        result = flb_blob_db_file_reset_part_upload_states(context, id, path);
+    }
+
+    return result;
+}
+
+int flb_blob_db_file_part_insert(struct flb_blob_db *context,
+                                 uint64_t file_id,
+                                 uint64_t part_id,
+                                 size_t offset_start,
+                                 size_t offset_end,
+                                 int64_t *out_id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_insert_file_part;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, file_id);
+    sqlite3_bind_int64(statement, 2, part_id);
+    sqlite3_bind_int64(statement, 3, offset_start);
+    sqlite3_bind_int64(statement, 4, offset_end);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_PART_INSERT;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_part_in_progress(struct flb_blob_db *context,
+                                      int in_progress,
+                                      uint64_t id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_part_in_progress;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int(statement, 1, in_progress);
+    sqlite3_bind_int64(statement, 2, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_FILE_PART_IN_PROGRESS_UPDATE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_part_get_next(struct flb_blob_db *context,
+                                   uint64_t *id,
+                                   uint64_t *file_id,
+                                   uint64_t *part_id,
+                                   off_t *offset_start,
+                                   off_t *offset_end,
+                                   uint64_t *part_delivery_attempts,
+                                   uint64_t *file_delivery_attempts,
+                                   cfl_sds_t *file_path,
+                                   cfl_sds_t *destination,
+                                   cfl_sds_t *remote_file_id,
+                                   cfl_sds_t *tag,
+                                   int *part_count)
+{
+    cfl_sds_t     local_remote_file_id;
+    char         *tmp_remote_file_id;
+    cfl_sds_t     local_destination;
+    char         *tmp_destination;
+    int           inner_result;
+    sqlite3_stmt *statement;
+    cfl_sds_t     local_tag;
+    cfl_sds_t     tmp_tag;
+    int           result;
+    cfl_sds_t     path;
+    char         *tmp;
+
+    local_remote_file_id = NULL;
+    tmp_remote_file_id = NULL;
+    local_destination = NULL;
+    tmp_destination = NULL;
+    local_tag = NULL;
+    tmp_tag = NULL;
+    path = NULL;
+
+    tmp_destination = NULL;
+    tmp = NULL;
+
+    statement = context->stmt_get_next_file_part;
+
+    flb_sqldb_lock(context->db);
+
+    *file_path = NULL;
+
+    result = sqlite3_step(statement);
+
+    if (result == SQLITE_ROW) {
+        *id = sqlite3_column_int64(statement, 0);
+        *file_id = sqlite3_column_int64(statement, 1);
+        *part_id = sqlite3_column_int64(statement, 2);
+        *offset_start = sqlite3_column_int64(statement, 3);
+        *offset_end = sqlite3_column_int64(statement, 4);
+        *part_delivery_attempts = sqlite3_column_int64(statement, 5);
+        tmp = (char *) sqlite3_column_text(statement, 6);
+        *file_delivery_attempts = sqlite3_column_int64(statement, 7);
+        tmp_destination = (char *) sqlite3_column_text(statement, 9);
+        tmp_remote_file_id = (char *) sqlite3_column_text(statement, 10);
+        tmp_tag = (char *) sqlite3_column_text(statement, 11);
+
+        path = cfl_sds_create(tmp);
+        local_tag = cfl_sds_create(tmp_tag);
+        local_destination = cfl_sds_create(tmp_destination);
+        local_remote_file_id = cfl_sds_create(tmp_remote_file_id);
+
+        *part_count = flb_blob_db_file_fetch_part_count(context, *file_id);
+    }
+    else if (result == SQLITE_DONE) {
+        /* no records */
+        result = 0;
+    }
+    else {
+        context->last_error = result;
+
+        result = -1;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    inner_result = -1;
+
+    if (result == SQLITE_ROW) {
+        if (path == NULL ||
+            local_tag == NULL ||
+            local_destination == NULL ||
+            local_remote_file_id == NULL) {
+            result = FLB_BLOB_DB_ERROR_ALLOCATOR_FAILURE;
+        }
+        else{
+            inner_result = flb_blob_db_file_part_in_progress(context, 1, *id);
+
+            if (inner_result == FLB_BLOB_DB_SUCCESS) {
+                *tag = local_tag;
+                *file_path = path;
+                *destination = local_destination;
+                *remote_file_id = local_remote_file_id;
+            }
+        }
+    }
+
+    if (inner_result != FLB_BLOB_DB_SUCCESS ||
+        result != SQLITE_ROW) {
+        if (path != NULL) {
+            cfl_sds_destroy(path);
+        }
+
+        if (local_tag != NULL) {
+            cfl_sds_destroy(local_tag);
+        }
+
+        if (local_destination != NULL) {
+            cfl_sds_destroy(local_destination);
+        }
+
+        if (local_remote_file_id != NULL) {
+            cfl_sds_destroy(local_remote_file_id);
+        }
+    }
+
+    return result;
+}
+
+int flb_blob_db_file_part_update_remote_id(struct flb_blob_db *context,
+                                           uint64_t id,
+                                           cfl_sds_t remote_id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_part_remote_id;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_text(statement, 1, remote_id, -1, 0);
+    sqlite3_bind_int64(statement, 2, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_PART_REMOTE_ID_UPDATE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_part_uploaded(struct flb_blob_db *context,
+                                   uint64_t id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_part_uploaded;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, id);
+
+    result = sqlite3_step(statement);
+
+    if (result != SQLITE_DONE) {
+        context->last_error = result;
+
+        result = FLB_BLOB_DB_ERROR_PART_UPLOAD_STATE_UPDATE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_part_update_delivery_attempt_counter(
+        struct flb_blob_db *context,
+        uint64_t file_id,
+        uint64_t part_id,
+        uint64_t attempts)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_update_file_part_delivery_attempt_count;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, attempts);
+    sqlite3_bind_int64(statement, 2, file_id);
+    sqlite3_bind_int64(statement, 3, part_id);
+
+    result = sqlite3_step(statement);
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    if (result != SQLITE_DONE) {
+        result = FLB_BLOB_DB_ERROR_PART_DELIVERY_ATTEMPT_COUNTER_UPDATE;
+    }
+    else {
+        result = FLB_BLOB_DB_SUCCESS;
+
+    }
+
+    return result;
+}
+
+int flb_blob_db_file_fetch_oldest_ready(struct flb_blob_db *context,
+                                        uint64_t *file_id,
+                                        cfl_sds_t *path,
+                                        cfl_sds_t *part_ids,
+                                        cfl_sds_t *source,
+                                        cfl_sds_t *file_remote_id,
+                                        cfl_sds_t *file_tag,
+                                        int *part_count)
+{
+    sqlite3_stmt *statement;
+    int           result;
+    int           ret;
+    char         *tmp;
+
+    tmp = NULL;
+    *path = NULL;
+    *part_ids = NULL;
+    *source = NULL;
+    *file_remote_id = NULL;
+    *file_tag = NULL;
+
+    statement = context->stmt_get_oldest_file_with_parts;
+
+    flb_sqldb_lock(context->db);
+
+    ret = sqlite3_step(statement);
+
+    if (ret == SQLITE_ROW) {
+        /* file_id */
+        *file_id = sqlite3_column_int64(statement, 0);
+
+        /* path */
+        tmp = (char *) sqlite3_column_text(statement, 1);
+        *path = cfl_sds_create(tmp);
+
+        /* part_ids */
+        tmp = (char *) sqlite3_column_text(statement, 2);
+        *part_ids = cfl_sds_create(tmp);
+
+        /* source */
+        tmp = (char *) sqlite3_column_text(statement, 3);
+        *source = cfl_sds_create(tmp);
+
+        tmp = (char *) sqlite3_column_text(statement, 4);
+        *file_remote_id = cfl_sds_create(tmp);
+
+        tmp = (char *) sqlite3_column_text(statement, 5);
+        *file_tag = cfl_sds_create(tmp);
+
+        if (*path == NULL ||
+            *part_ids == NULL ||
+            *source == NULL ||
+            *file_remote_id == NULL ||
+            *file_tag == NULL) {
+            result = -1;
+        }
+        else{
+            *part_count = flb_blob_db_file_fetch_part_count(context, *file_id);
+
+            if (*part_count <= 0) {
+                result = -1;
+            }
+            else {
+                result = 1;
+            }
+        }
+    }
+    else if (ret == SQLITE_DONE) {
+        /* no records */
+        result = 0;
+    }
+    else {
+        result = -1;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    if (result == -1) {
+        if (*path != NULL) {
+            cfl_sds_destroy(*path);
+
+            *path = NULL;
+        }
+
+        if (*part_ids != NULL) {
+            cfl_sds_destroy(*part_ids);
+
+            *part_ids = NULL;
+        }
+
+        if (*source != NULL) {
+            cfl_sds_destroy(*source);
+
+            *source = NULL;
+        }
+
+        if (*file_remote_id != NULL) {
+            cfl_sds_destroy(*file_remote_id);
+
+            *file_remote_id = NULL;
+        }
+
+        if (*file_tag != NULL) {
+            cfl_sds_destroy(*file_tag);
+
+            *file_tag = NULL;
+        }
+    }
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_fetch_part_ids(struct flb_blob_db *context,
+                                    uint64_t file_id,
+                                    cfl_sds_t *remote_id_list,
+                                    size_t remote_id_list_size,
+                                    int *remote_id_count)
+{
+    size_t        remote_id_index;
+    sqlite3_stmt *statement;
+    int           result;
+    char         *tmp;
+
+    statement = context->stmt_fetch_file_part_remote_id;
+
+    flb_sqldb_lock(context->db);
+
+    memset(remote_id_list, 0, sizeof(cfl_sds_t) * remote_id_list_size);
+
+    sqlite3_bind_int64(statement, 1, file_id);
+
+    result = -1;
+
+    for (remote_id_index = 0 ; remote_id_index < remote_id_list_size ; remote_id_index++) {
+        result = sqlite3_step(statement);
+
+        if (result == SQLITE_ROW) {
+            tmp = (char *) sqlite3_column_text(statement, 0);
+
+            remote_id_list[remote_id_index] = flb_sds_create(tmp);
+
+            if (remote_id_list[remote_id_index] == NULL) {
+                context->last_error = result;
+
+                result = -1;
+
+                break;
+            }
+        }
+        else if (result == SQLITE_DONE) {
+            break;
+        }
+        else {
+            context->last_error = result;
+
+            result = -1;
+
+            break;
+        }
+    }
+
+    if (result == -1) {
+        while (remote_id_index > 0) {
+            if (remote_id_list[remote_id_index] != NULL) {
+                flb_sds_destroy(remote_id_list[remote_id_index]);
+            }
+
+            remote_id_index--;
+        }
+
+        if (remote_id_list[remote_id_index] != NULL) {
+            flb_sds_destroy(remote_id_list[remote_id_index]);
+        }
+
+        memset(remote_id_list, 0, sizeof(cfl_sds_t) * remote_id_list_size);
+    }
+    else {
+        *remote_id_count = (int) remote_id_index;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+int flb_blob_db_file_fetch_part_count(struct flb_blob_db *context,
+                                      uint64_t file_id)
+{
+    sqlite3_stmt *statement;
+    int           result;
+
+    statement = context->stmt_get_file_part_count;
+
+    flb_sqldb_lock(context->db);
+
+    sqlite3_bind_int64(statement, 1, file_id);
+
+    result = sqlite3_step(statement);
+
+    if (result == SQLITE_ROW) {
+        result = sqlite3_column_int64(statement, 0);
+    }
+    else {
+        context->last_error = result;
+
+        result = -1;
+    }
+
+    sqlite3_clear_bindings(statement);
+    sqlite3_reset(statement);
+
+    flb_sqldb_unlock(context->db);
+
+    return result;
+}
+
+#else
+
+int flb_blob_db_open(struct flb_blob_db *context,
+                     struct flb_config *config,
+                     char *path)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_close(struct flb_blob_db *context)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_exists(struct flb_blob_db *context,
+                            char *path,
+                            uint64_t *id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int64_t flb_blob_db_file_insert(struct flb_blob_db *context,
+                                char *tag,
+                                char *source,
+                                char *destination,
+                                char *path,
+                                size_t size)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_delete(struct flb_blob_db *context,
+                            uint64_t id,
+                            char *path)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_set_aborted_state(struct flb_blob_db *context,
+                                       uint64_t id,
+                                       char *path,
+                                       uint64_t state)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_file_change_destination(struct flb_blob_db *context,
+                                     uint64_t id,
+                                     cfl_sds_t destination)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_delivery_attempts(struct flb_blob_db *context,
+                                       uint64_t id,
+                                       uint64_t attempts)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_get_next_aborted(struct flb_blob_db *context,
+                                      uint64_t *id,
+                                      uint64_t *delivery_attempts,
+                                      cfl_sds_t *path,
+                                      cfl_sds_t *source,
+                                      cfl_sds_t *remote_id,
+                                      cfl_sds_t *file_tag,
+                                      int *part_count)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_get_next_stale(struct flb_blob_db *context,
+                                    uint64_t *id,
+                                    cfl_sds_t *path,
+                                    uint64_t upload_parts_freshness_threshold,
+                                    cfl_sds_t *remote_id,
+                                    cfl_sds_t *tag,
+                                    int *part_count)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_reset_upload_states(struct flb_blob_db *context,
+                                         uint64_t id,
+                                         char *path)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_part_insert(struct flb_blob_db *context,
+                                 uint64_t file_id,
+                                 uint64_t part_id,
+                                 size_t offset_start,
+                                 size_t offset_end,
+                                 int64_t *out_id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_part_in_progress(struct flb_blob_db *context,
+                                      int in_progress,
+                                      uint64_t id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_part_get_next(struct flb_blob_db *context,
+                                   uint64_t *id,
+                                   uint64_t *file_id,
+                                   uint64_t *part_id,
+                                   off_t *offset_start,
+                                   off_t *offset_end,
+                                   uint64_t *part_delivery_attempts,
+                                   uint64_t *file_delivery_attempts,
+                                   cfl_sds_t *file_path,
+                                   cfl_sds_t *destination,
+                                   cfl_sds_t *remote_file_id,
+                                   cfl_sds_t *tag)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+
+int flb_blob_db_file_part_uploaded(struct flb_blob_db *context, uint64_t id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_part_update_delivery_attempt_counter(
+        struct flb_blob_db *context,
+        uint64_t file_id,
+        uint64_t part_id,
+        uint64_t attempts)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_fetch_oldest_ready(struct flb_blob_db *context,
+                                        uint64_t *file_id,
+                                        cfl_sds_t *path,
+                                        cfl_sds_t *part_ids,
+                                        cfl_sds_t *source,
+                                        cfl_sds_t *file_remote_id,
+                                        cfl_sds_t *file_tag,
+                                        int *part_count)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_fetch_part_ids(struct flb_blob_db *context,
+                                    uint64_t file_id,
+                                    cfl_sds_t *remote_id_list,
+                                    size_t remote_id_list_size,
+                                    int *remote_id_count)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_fetch_part_count(struct flb_blob_db *context,
+                                      uint64_t file_id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+#endif

--- a/src/flb_blob_db.c
+++ b/src/flb_blob_db.c
@@ -1366,7 +1366,7 @@ int flb_blob_db_file_fetch_part_count(struct flb_blob_db *context,
     result = sqlite3_step(statement);
 
     if (result == SQLITE_ROW) {
-        result = sqlite3_column_int64(statement, 0);
+        result = (int) sqlite3_column_int64(statement, 0);
     }
     else {
         context->last_error = result;

--- a/src/flb_signv4.c
+++ b/src/flb_signv4.c
@@ -434,7 +434,7 @@ static flb_sds_t url_params_format(char *params)
                 tmp = flb_sds_printf(&buf, "%s=%s&",
                                      kv->key, kv->val);
             }
-        } 
+        }
         else {
             if (kv->val == NULL) {
                 tmp = flb_sds_printf(&buf, "%s=",
@@ -621,6 +621,9 @@ static flb_sds_t flb_signv4_canonical_request(struct flb_http_client *c,
         break;
     case FLB_HTTP_HEAD:
         tmp = flb_sds_cat(cr, "HEAD\n", 5);
+        break;
+    case FLB_HTTP_DELETE:
+        tmp = flb_sds_cat(cr, "DELETE\n", 7);
         break;
     };
 


### PR DESCRIPTION
This is a rebased version of PR #9907

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for blob file uploads to S3, including multipart uploads using pre-signed URLs via an authorization endpoint.
  * Introduced a database-backed mechanism for managing blob files and their parts, improving reliability and upload tracking.
  * Added new configuration options for blob uploads, including database file path, part size, delivery attempt limits, upload timeouts, and authorization credentials.
  * Enhanced S3 output plugin to support both log and blob event types.

* **Improvements**
  * Added thread safety to database operations with locking mechanisms.
  * Improved error handling and resource management for database and upload operations.

* **Bug Fixes**
  * Minor documentation and formatting corrections.
  * Fixed resource cleanup on error paths in S3 uploads.

* **Chores**
  * Updated copyright years.
  * Updated build configuration to include new source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->