### PR TITLE
output: add Histogram Metric for end-to-end chunk latency [Backport to 4.0]

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -78,6 +78,7 @@ struct flb_input_chunk {
 #ifdef FLB_HAVE_CHUNK_TRACE
     struct flb_chunk_trace *trace;
 #endif /* FLB_HAVE_CHUNK_TRACE */
+    double create_time;           /* chunk creation time in seconds with fractional precision) */
     flb_route_mask_element *routes_mask; /* track the output plugins the chunk routes to */
     struct mk_list _head;
 };

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -52,6 +52,7 @@
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 
@@ -454,6 +455,8 @@ struct flb_output_instance {
     struct cmt_gauge   *cmt_upstream_busy_connections;
     /* m: output_chunk_available_capacity_percent */
     struct cmt_gauge   *cmt_chunk_available_capacity_percent;
+    /* m: output_latency_seconds */
+    struct cmt_histogram *cmt_latency;
 
     /* OLD Metrics API */
 #ifdef FLB_HAVE_METRICS

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -30,6 +30,7 @@
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_lib.h>
 #include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_task.h>
 #include <fluent-bit/flb_routes_mask.h>
@@ -938,6 +939,7 @@ struct flb_input_chunk *flb_input_chunk_create(struct flb_input_instance *in, in
     ic->in = in;
     ic->stream_off = 0;
     ic->task = NULL;
+    ic->create_time = flb_time_now();
 #ifdef FLB_HAVE_METRICS
     ic->total_records = 0;
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting from https://github.com/fluent/fluent-bit/pull/10644.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
