### PR TITLE
out_s3: Add parquet compression type with pure C

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -52,6 +52,7 @@ jobs:
           - "-DFLB_SANITIZE_THREAD=On"
           - "-DFLB_SIMD=On"
           - "-DFLB_SIMD=Off"
+          - "-DFLB_ARROW=On"
         cmake_version:
           - "3.31.6"
         compiler:
@@ -63,6 +64,10 @@ jobs:
             cxx: clang++
         exclude:
           - flb_option: "-DFLB_COVERAGE=On"
+            compiler:
+              cc: clang
+              cxx: clang++
+          - flb_option: "-DFLB_ARROW=On"
             compiler:
               cc: clang
               cxx: clang++
@@ -86,6 +91,15 @@ jobs:
         with:
           repository: calyptia/fluent-bit-ci
           path: ci
+      - name: Setup Apache Arrow libraries for parquet (-DFLB_ARROW=On Only)
+        if: matrix.flb_option == '-DFLB_ARROW=On'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -V ca-certificates lsb-release wget
+          wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          sudo apt-get update
+          sudo apt-get install -y -V libarrow-glib-dev libparquet-glib-dev
 
       - name: ${{ matrix.compiler.cc }} & ${{ matrix.compiler.cxx }} - ${{ matrix.flb_option }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1237,7 +1237,7 @@ pkg_check_modules(ARROW_GLIB_PARQUET QUIET parquet-glib)
 if(FLB_ARROW AND ARROW_GLIB_PARQUET_FOUND)
   FLB_DEFINITION(FLB_HAVE_ARROW_PARQUET)
 else()
-  message(STATUS "Arrow GLib Parquet not found. Disabling parquet compression for AWS module")
+  message(STATUS "Arrow GLib Parquet not found. Disabling parquet compression")
 endif()
 
 # EBPF Support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1232,6 +1232,14 @@ else()
   set(FLB_ARROW OFF)
 endif()
 
+# Additional prerequisites for Apache Parquet
+pkg_check_modules(ARROW_GLIB_PARQUET QUIET parquet-glib)
+if(FLB_ARROW AND ARROW_GLIB_PARQUET_FOUND)
+  FLB_DEFINITION(FLB_HAVE_ARROW_PARQUET)
+else()
+  message(STATUS "Arrow GLib Parquet not found. Disabling parquet compression for AWS module")
+endif()
+
 # EBPF Support
 # ============
 if (FLB_IN_EBPF)

--- a/include/fluent-bit/aws/flb_aws_compress.h
+++ b/include/fluent-bit/aws/flb_aws_compress.h
@@ -21,9 +21,10 @@
 #define FLB_AWS_COMPRESS
 
 #include <sys/types.h>
-#define FLB_AWS_COMPRESS_NONE  0
-#define FLB_AWS_COMPRESS_GZIP  1
-#define FLB_AWS_COMPRESS_ARROW 2
+#define FLB_AWS_COMPRESS_NONE    0
+#define FLB_AWS_COMPRESS_GZIP    1
+#define FLB_AWS_COMPRESS_ARROW   2
+#define FLB_AWS_COMPRESS_PARQUET 3
 
 /*
  * Get compression type from compression keyword. The return value is used to identify

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -703,9 +703,11 @@ static int cb_s3_init(struct flb_output_instance *ins,
             flb_plg_error(ctx->ins, "unknown compression: %s", tmp);
             return -1;
         }
-        if (ctx->use_put_object == FLB_FALSE && ctx->compression == FLB_AWS_COMPRESS_ARROW) {
+        if (ctx->use_put_object == FLB_FALSE &&
+            (ctx->compression == FLB_AWS_COMPRESS_ARROW ||
+             ctx->compression == FLB_AWS_COMPRESS_PARQUET)) {
             flb_plg_error(ctx->ins,
-                          "use_put_object must be enabled when Apache Arrow is enabled");
+                          "use_put_object must be enabled when Apache Arrow or Parquet is enabled");
             return -1;
         }
         ctx->compression = ret;
@@ -730,7 +732,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
             flb_plg_error(ctx->ins, "upload_chunk_size must be at least 5,242,880 bytes");
             return -1;
         }
-        if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+        if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
             if(ctx->upload_chunk_size > MAX_CHUNKED_UPLOAD_COMPRESS_SIZE) {
                 flb_plg_error(ctx->ins, "upload_chunk_size in compressed multipart upload cannot exceed 5GB");
                 return -1;
@@ -1125,7 +1127,7 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
         file_first_log_time = chunk->first_log_time;
     }
 
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+    if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
         /* Map payload */
         ret = flb_aws_compression_compress(ctx->compression, body, body_size, &payload_buf, &payload_size);
         if (ret == -1) {
@@ -1168,7 +1170,9 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
             goto multipart;
         }
         else {
-            if (ctx->use_put_object == FLB_FALSE && ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+            if (ctx->use_put_object == FLB_FALSE &&
+                (ctx->compression == FLB_AWS_COMPRESS_ARROW ||
+                 ctx->compression == FLB_AWS_COMPRESS_PARQUET)) {
                 flb_plg_info(ctx->ins, "Pre-compression upload_chunk_size= %zu, After compression, chunk is only %zu bytes, "
                                        "the chunk was too small, using PutObject to upload", preCompress_size, body_size);
             }
@@ -1190,7 +1194,7 @@ put_object:
      * remove chunk from buffer list
      */
     ret = s3_put_object(ctx, tag, file_first_log_time, body, body_size);
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+    if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
         flb_free(payload_buf);
     }
     if (ret < 0) {
@@ -1217,7 +1221,7 @@ multipart:
             if (chunk) {
                 s3_store_file_unlock(chunk);
             }
-            if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+            if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
                 flb_free(payload_buf);
             }
             return FLB_RETRY;
@@ -1231,7 +1235,7 @@ multipart:
             if (chunk) {
                 s3_store_file_unlock(chunk);
             }
-            if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+            if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
                 flb_free(payload_buf);
             }
             return FLB_RETRY;
@@ -1241,7 +1245,7 @@ multipart:
 
     ret = upload_part(ctx, m_upload, body, body_size, NULL);
     if (ret < 0) {
-        if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+        if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
             flb_free(payload_buf);
         }
         m_upload->upload_errors += 1;
@@ -1258,7 +1262,7 @@ multipart:
         s3_store_file_delete(ctx, chunk);
         chunk = NULL;
     }
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP) {
+    if (ctx->compression != FLB_AWS_COMPRESS_NONE) {
         flb_free(payload_buf);
     }
     if (m_upload->bytes >= ctx->file_size) {
@@ -3991,8 +3995,8 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "compression", NULL,
      0, FLB_FALSE, 0,
-    "Compression type for S3 objects. 'gzip' and 'arrow' are the supported values. "
-    "'arrow' is only an available if Apache Arrow was enabled at compile time. "
+    "Compression type for S3 objects. 'gzip', 'arrow' and 'parquet' are the supported values. "
+    "'arrow' and 'parquet' are only available if Apache Arrow was enabled at compile time. "
     "Defaults to no compression. "
     "If 'gzip' is selected, the Content-Encoding HTTP Header will be set to 'gzip'."
     },

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1170,9 +1170,7 @@ static int upload_data(struct flb_s3 *ctx, struct s3_file *chunk,
             goto multipart;
         }
         else {
-            if (ctx->use_put_object == FLB_FALSE &&
-                (ctx->compression == FLB_AWS_COMPRESS_ARROW ||
-                 ctx->compression == FLB_AWS_COMPRESS_PARQUET)) {
+            if (ctx->use_put_object == FLB_FALSE && ctx->compression == FLB_AWS_COMPRESS_GZIP) {
                 flb_plg_info(ctx->ins, "Pre-compression upload_chunk_size= %zu, After compression, chunk is only %zu bytes, "
                                        "the chunk was too small, using PutObject to upload", preCompress_size, body_size);
             }

--- a/src/aws/compression/arrow/CMakeLists.txt
+++ b/src/aws/compression/arrow/CMakeLists.txt
@@ -9,3 +9,7 @@ if (ARROW_GLIB_PARQUET_FOUND)
 target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_PARQUET_INCLUDE_DIRS})
 target_link_libraries(flb-aws-arrow ${ARROW_GLIB_PARQUET_LDFLAGS})
 endif()
+
+if(FLB_JEMALLOC)
+  target_link_libraries(flb-aws-arrow ${JEMALLOC_LIBRARIES})
+endif()

--- a/src/aws/compression/arrow/CMakeLists.txt
+++ b/src/aws/compression/arrow/CMakeLists.txt
@@ -4,8 +4,8 @@ set(src
 add_library(flb-aws-arrow STATIC ${src})
 
 target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_INCLUDE_DIRS})
-target_link_libraries(flb-aws-arrow ${ARROW_GLIB_LIBRARIES})
+target_link_libraries(flb-aws-arrow ${ARROW_GLIB_LDFLAGS})
 if (ARROW_GLIB_PARQUET_FOUND)
 target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_PARQUET_INCLUDE_DIRS})
-target_link_libraries(flb-aws-arrow ${ARROW_GLIB_PARQUET_LIBRARIES})
+target_link_libraries(flb-aws-arrow ${ARROW_GLIB_PARQUET_LDFLAGS})
 endif()

--- a/src/aws/compression/arrow/CMakeLists.txt
+++ b/src/aws/compression/arrow/CMakeLists.txt
@@ -5,3 +5,7 @@ add_library(flb-aws-arrow STATIC ${src})
 
 target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_INCLUDE_DIRS})
 target_link_libraries(flb-aws-arrow ${ARROW_GLIB_LDFLAGS})
+if (ARROW_GLIB_PARQUET_FOUND)
+target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_PARQUET_INCLUDE_DIRS})
+target_link_libraries(flb-aws-arrow ${ARROW_GLIB_PARQUET_LDFLAGS})
+endif()

--- a/src/aws/compression/arrow/CMakeLists.txt
+++ b/src/aws/compression/arrow/CMakeLists.txt
@@ -4,8 +4,8 @@ set(src
 add_library(flb-aws-arrow STATIC ${src})
 
 target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_INCLUDE_DIRS})
-target_link_libraries(flb-aws-arrow ${ARROW_GLIB_LDFLAGS})
+target_link_libraries(flb-aws-arrow ${ARROW_GLIB_LIBRARIES})
 if (ARROW_GLIB_PARQUET_FOUND)
 target_include_directories(flb-aws-arrow PRIVATE ${ARROW_GLIB_PARQUET_INCLUDE_DIRS})
-target_link_libraries(flb-aws-arrow ${ARROW_GLIB_PARQUET_LDFLAGS})
+target_link_libraries(flb-aws-arrow ${ARROW_GLIB_PARQUET_LIBRARIES})
 endif()

--- a/src/aws/compression/arrow/compress.c
+++ b/src/aws/compression/arrow/compress.c
@@ -12,6 +12,7 @@
 #include <parquet-glib/parquet-glib.h>
 #endif
 #include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_mem.h>
 #include <inttypes.h>
 
 /*
@@ -258,8 +259,9 @@ int out_s3_compress_parquet(void *json, size_t size, void **out_buf, size_t *out
             return -1;
         }
 
-        buf = malloc(len);
+        buf = flb_malloc(len);
         if (buf == NULL) {
+            flb_errno();
             g_object_unref(buffer);
             g_bytes_unref(bytes);
             return -1;

--- a/src/aws/compression/arrow/compress.c
+++ b/src/aws/compression/arrow/compress.c
@@ -8,6 +8,9 @@
  */
 
 #include <arrow-glib/arrow-glib.h>
+#ifdef FLB_HAVE_ARROW_PARQUET
+#include <parquet-glib/parquet-glib.h>
+#endif
 #include <inttypes.h>
 
 /*
@@ -145,3 +148,123 @@ int out_s3_compress_arrow(void *json, size_t size, void **out_buf, size_t *out_s
         g_bytes_unref(bytes);
         return 0;
 }
+
+#ifdef FLB_HAVE_ARROW_PARQUET
+static GArrowResizableBuffer* table_to_parquet_buffer(GArrowTable *table)
+{
+        GArrowResizableBuffer *buffer;
+        GArrowBufferOutputStream *sink;
+        GParquetArrowFileWriter *writer;
+        GArrowSchema *schema;
+        GError *error = NULL;
+        gboolean success;
+        gint64 n_rows = 0;
+
+        buffer = garrow_resizable_buffer_new(0, &error);
+        if (buffer == NULL) {
+            g_error_free(error);
+            return NULL;
+        }
+
+        sink = garrow_buffer_output_stream_new(buffer);
+        if (sink == NULL) {
+            g_object_unref(buffer);
+            return NULL;
+        }
+
+        schema = garrow_table_get_schema(table);
+        if (schema == NULL) {
+            g_object_unref(buffer);
+            g_object_unref(sink);
+            return NULL;
+        }
+
+        /* Create a new Parquet file writer */
+        writer = gparquet_arrow_file_writer_new_arrow(schema,
+                                                      GARROW_OUTPUT_STREAM(sink),
+                                                      NULL, /* Arrow writer properties */
+                                                      &error);
+        g_object_unref(schema);
+        if (writer == NULL) {
+            g_error_free(error);
+            g_object_unref(buffer);
+            g_object_unref(sink);
+            return NULL;
+        }
+
+        n_rows = garrow_table_get_n_rows(table);
+
+        /* Write the entire table to the Parquet file buffer */
+        success = gparquet_arrow_file_writer_write_table(writer, table, n_rows, &error);
+        if (!success) {
+            g_error_free(error);
+            g_object_unref(buffer);
+            g_object_unref(sink);
+            g_object_unref(writer);
+            return NULL;
+        }
+
+        /* Close the writer to finalize the Parquet file metadata */
+        success = gparquet_arrow_file_writer_close(writer, &error);
+        if (!success) {
+            g_error_free(error);
+            g_object_unref(buffer);
+            g_object_unref(sink);
+            g_object_unref(writer);
+            return NULL;
+        }
+
+        g_object_unref(sink);
+        g_object_unref(writer);
+        return buffer;
+}
+
+
+int out_s3_compress_parquet(void *json, size_t size, void **out_buf, size_t *out_size)
+{
+        GArrowTable *table;
+        GArrowResizableBuffer *buffer;
+        GBytes *bytes;
+        gconstpointer ptr;
+        gsize len;
+        uint8_t *buf;
+
+        table = parse_json((uint8_t *) json, size);
+        if (table == NULL) {
+            return -1;
+        }
+
+        buffer = table_to_parquet_buffer(table);
+        g_object_unref(table);
+        if (buffer == NULL) {
+            return -1;
+        }
+
+        bytes = garrow_buffer_get_data(GARROW_BUFFER(buffer));
+        if (bytes == NULL) {
+            g_object_unref(buffer);
+            return -1;
+        }
+
+        ptr = g_bytes_get_data(bytes, &len);
+        if (ptr == NULL) {
+            g_object_unref(buffer);
+            g_bytes_unref(bytes);
+            return -1;
+        }
+
+        buf = malloc(len);
+        if (buf == NULL) {
+            g_object_unref(buffer);
+            g_bytes_unref(bytes);
+            return -1;
+        }
+        memcpy(buf, ptr, len);
+        *out_buf = (void *) buf;
+        *out_size = len;
+
+        g_object_unref(buffer);
+        g_bytes_unref(bytes);
+        return 0;
+}
+#endif

--- a/src/aws/compression/arrow/compress.h
+++ b/src/aws/compression/arrow/compress.h
@@ -11,3 +11,18 @@
  */
 
 int out_s3_compress_arrow(void *json, size_t size, void **out_buf, size_t *out_size);
+
+#ifdef FLB_HAVE_ARROW_PARQUET
+/*
+ * This function converts out_s3 buffer into Apache Parquet format.
+ *
+ * `json` is a string that contain (concatenated) JSON objects.
+ *
+ * `size` is the length of the json data (excluding the trailing
+ * null-terminator character).
+ *
+ * Return 0 on success (with `out_buf` and `out_size` updated),
+ * and -1 on failure
+ */
+int out_s3_compress_parquet(void *json, size_t size, void **out_buf, size_t *out_size);
+#endif

--- a/src/aws/flb_aws_compress.c
+++ b/src/aws/flb_aws_compress.c
@@ -55,6 +55,13 @@ static const struct compression_option compression_options[] = {
         &out_s3_compress_arrow
     },
 #endif
+#ifdef FLB_HAVE_ARROW_PARQUET
+    {
+        FLB_AWS_COMPRESS_PARQUET,
+        "parquet",
+        &out_s3_compress_parquet
+    },
+#endif
     { 0 }
 };
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
With apache arrow glib parquet library, we're able to support parquet format on out_s3.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush        5
    Daemon       Off
    Log_Level    trace
    HTTP_Server  Off
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name dummy
    Tag  dummy.local
    dummy {"boolean": false, "int": 1, "long": 1, "float": 1.1, "double": 1.1, "bytes": "foo", "string": "foo"}

[OUTPUT]
    Name  s3
    Match dummy*
    Region us-east-2
    bucket fbit-parquet-s3
    Use_Put_object true
    compression parquet
    # No need to specify schema
```

- [x] Debug log output from testing the change

```console
Fluent Bit v4.1.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/08/05 17:27:09] [ info] Configuration:
[2025/08/05 17:27:09] [ info]  flush time     | 5.000000 seconds
[2025/08/05 17:27:09] [ info]  grace          | 5 seconds
[2025/08/05 17:27:09] [ info]  daemon         | 0
[2025/08/05 17:27:09] [ info] ___________
[2025/08/05 17:27:09] [ info]  inputs:
[2025/08/05 17:27:09] [ info]      dummy
[2025/08/05 17:27:09] [ info] ___________
[2025/08/05 17:27:09] [ info]  filters:
[2025/08/05 17:27:09] [ info] ___________
[2025/08/05 17:27:09] [ info]  outputs:
[2025/08/05 17:27:09] [ info]      s3.0
[2025/08/05 17:27:09] [ info] ___________
[2025/08/05 17:27:09] [ info]  collectors:
[2025/08/05 17:27:09] [ info] [fluent bit] version=4.1.0, commit=0afb495f86, pid=81424
[2025/08/05 17:27:09] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2025/08/05 17:27:09] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/08/05 17:27:09] [ info] [simd    ] NEON
[2025/08/05 17:27:09] [ info] [cmetrics] version=1.0.5
[2025/08/05 17:27:09] [ info] [ctraces ] version=0.6.6
[2025/08/05 17:27:09] [ info] [input:dummy:dummy.0] initializing
[2025/08/05 17:27:09] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/08/05 17:27:09] [debug] [dummy:dummy.0] created event channels: read=26 write=27
[2025/08/05 17:27:09] [debug] [s3:s3.0] created event channels: read=28 write=29
[2025/08/05 17:27:09] [debug] [tls] attempting to load certificates from system keychain of macOS
# <snip of loading certificates logs>
[2025/08/05 17:27:09] [debug] [tls] finished loading keychain certificates, total loaded: 153
[2025/08/05 17:27:09] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2025/08/05 17:27:09] [debug] [aws_credentials] creating profile (null) provider
[2025/08/05 17:27:09] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2025/08/05 17:27:09] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2025/08/05 17:27:09] [debug] [aws_credentials] Not initializing ECS/EKS HTTP Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI and AWS_CONTAINER_CREDENTIALS_FULL_URI is not set
[2025/08/05 17:27:09] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2025/08/05 17:27:09] [debug] [aws_credentials] Sync called on the EC2 provider
[2025/08/05 17:27:09] [debug] [aws_credentials] Init called on the env provider
[2025/08/05 17:27:09] [ info] [output:s3:s3.0] Sending locally buffered data from previous executions to S3; buffer=/tmp/fluent-bit/s3/fbit-parquet-s3
[2025/08/05 17:27:09] [ info] [output:s3:s3.0] Pre-compression chunk size is 2394, After compression, chunk is 2384 bytes
[2025/08/05 17:27:10] [debug] [upstream] KA connection #34 to s3.us-east-2.amazonaws.com:443 is connected
[2025/08/05 17:27:10] [debug] [http_client] not using http_proxy for header
[2025/08/05 17:27:10] [debug] [aws_credentials] Requesting credentials from the env provider..
[2025/08/05 17:27:10] [debug] [upstream] KA connection #34 to s3.us-east-2.amazonaws.com:443 is now available
[2025/08/05 17:27:10] [debug] [output:s3:s3.0] PutObject http status=200
[2025/08/05 17:27:10] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/dummy.local/2025/08/05/08/27/09-objectt33OX2sM
[2025/08/05 17:27:10] [debug] [aws_credentials] upstream_set called on the EC2 provider
[2025/08/05 17:27:10] [ info] [output:s3:s3.0] worker #0 started
[2025/08/05 17:27:10] [ info] [sp] stream processor started
[2025/08/05 17:27:10] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/08/05 17:27:15] [debug] [task] created task=0x1137040a0 id=0 OK
[2025/08/05 17:27:15] [debug] [output:s3:s3.0] task_id=0 assigned to thread #0
[2025/08/05 17:27:15] [debug] [output:s3:s3.0] Creating upload timer with frequency 60s
[2025/08/05 17:27:15] [debug] [out flush] cb_destroy coro_id=0
[2025/08/05 17:27:15] [debug] [task] destroy task=0x1137040a0 (task_id=0)
[2025/08/05 17:27:18] [engine] caught signal (SIGTERM)
[2025/08/05 17:27:18] [ info] [input] pausing dummy.0
[2025/08/05 17:27:18] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2025/08/05 17:27:18] [ info] [output:s3:s3.0] thread worker #0 stopped
[2025/08/05 17:27:18] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2025/08/05 17:27:18] [ info] [output:s3:s3.0] Pre-compression chunk size is 504, After compression, chunk is 1904 bytes
[2025/08/05 17:27:18] [debug] [output:s3:s3.0] PutObject http status=200
[2025/08/05 17:27:18] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/dummy.local/2025/08/05/08/27/15-objectkoBRRSAl
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

With leaks on macOS, there's no leaks:

```log
Process:         fluent-bit [81424]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x100f58000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [81423]
Target Type:     live task

Date/Time:       2025-08-05 17:27:19.085 +0900
Launch Time:     2025-08-05 17:27:09.515 +0900
OS Version:      macOS 15.5 (24F74)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         15.6M
Physical footprint (peak):  18.8M
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 81424: 3008 nodes malloced for 428 KB
Process 81424: 0 leaks for 0 total leaked bytes.

[2025/08/05 17:27:19] [engine] caught signal (SIGCONT)
[2025/08/05 17:27:19] Fluent Bit Dump
```

With valgrind:

```console
==361658== LEAK SUMMARY:
==361658==    definitely lost: 0 bytes in 0 blocks
==361658==    indirectly lost: 0 bytes in 0 blocks
==361658==      possibly lost: 0 bytes in 0 blocks
==361658==    still reachable: 68,984 bytes in 677 blocks
==361658==         suppressed: 0 bytes in 0 blocks
==361658== Reachable blocks (those to which a pointer was found) are not shown.
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Parquet as a compression option for the S3 output (now supports gzip, arrow, parquet). Requires Apache Arrow support at build time.

- Improvements
  - Enforced requirement to enable use_put_object when using Arrow or Parquet compression.
  - Clarified upload size handling: compressed uploads (any non-NONE compression) follow the 5GB multipart limit; uncompressed (NONE) follows the 50MB single-part limit.

- Documentation
  - Updated configuration descriptions to include Parquet and build requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->