### PR TITLE
core: zstd: Implement dispatcher methods for zstd decompression

### DIFF
--- a/include/fluent-bit/flb_compression.h
+++ b/include/fluent-bit/flb_compression.h
@@ -26,6 +26,7 @@
 
 #define FLB_COMPRESSION_ALGORITHM_NONE                    0
 #define FLB_COMPRESSION_ALGORITHM_GZIP                    1
+#define FLB_COMPRESSION_ALGORITHM_ZSTD                    2
 
 #define FLB_DECOMPRESSOR_STATE_FAILED                    -1
 #define FLB_DECOMPRESSOR_STATE_EXPECTING_HEADER           0

--- a/include/fluent-bit/flb_zstd.h
+++ b/include/fluent-bit/flb_zstd.h
@@ -23,7 +23,14 @@
 #include <fluent-bit/flb_info.h>
 #include <zstd.h>
 
+struct flb_decompression_context;
+
 size_t flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len);
 size_t flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *out_len);
 
+int flb_zstd_decompressor_dispatch(struct flb_decompression_context *context,
+                                   void *output_buffer,
+                                   size_t *output_length);
+void *flb_zstd_decompression_context_create(void);
+void flb_zstd_decompression_context_destroy(void *context);
 #endif

--- a/include/fluent-bit/flb_zstd.h
+++ b/include/fluent-bit/flb_zstd.h
@@ -22,6 +22,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <zstd.h>
+#include <zstd_errors.h>
 
 struct flb_decompression_context;
 

--- a/src/flb_compression.c
+++ b/src/flb_compression.c
@@ -206,7 +206,7 @@ struct flb_decompression_context *flb_decompression_context_create(int algorithm
     }
 
     context->input_buffer_size = input_buffer_size;
-    context->read_buffer = context->read_buffer;
+    context->read_buffer = context->input_buffer;
     context->algorithm = algorithm;
     if (algorithm == FLB_COMPRESSION_ALGORITHM_GZIP) {
         context->state = FLB_DECOMPRESSOR_STATE_EXPECTING_HEADER;

--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -690,9 +690,11 @@ static int flb_gzip_decompressor_process_header(
 
     /* Minimal length: header + crc32 */
     if (context->input_buffer_length < FLB_GZIP_HEADER_SIZE) {
-        flb_error("[gzip] unexpected content length");
-
-        return FLB_DECOMPRESSOR_FAILURE;
+        /*
+         * This is not a fatal error; it's the expected condition when waiting
+         * for more data. Return INSUFFICIENT_DATA without logging an error.
+         */
+        return FLB_DECOMPRESSOR_INSUFFICIENT_DATA;
     }
 
     memcpy(&inner_context->gzip_header,

--- a/src/flb_zstd.c
+++ b/src/flb_zstd.c
@@ -240,6 +240,7 @@ void *flb_zstd_decompression_context_create(void)
 
     if (context == NULL) {
         flb_errno();
+        return NULL;
     }
 
     context->dctx = ZSTD_createDCtx();


### PR DESCRIPTION
<!-- Provide summary of changes -->
For robust handling of zstd compressed buffers and chunks, we need to implement a dispatch mechanism of zstd decompressions.

This is because decompression of zstd should be easily exceeded the limit of buffers and massive usage of memory.
So, we need to implement streaming decompression for zstd, too.

The motivation why we wanted to implement this feature is implementing zstd compression on input and output forward for forward protocol.
At this time, Fluentd had already implemeneted such feature and the later part of works we need to implement to use this core feature to handle robost zstd decompressions in in_forward plugin.

ref: https://github.com/fluent/fluentd/issues/4758

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Zstandard (ZSTD) streaming decompression for incremental handling of compressed streams.
* **Bug Fixes**
  * Improved detection and handling of corrupted ZSTD-compressed data with checksum validation and clear failure signaling.
  * Treat short/partial gzip headers as non-fatal (await more data) instead of logging an error.
* **Tests**
  * Added tests for multi-chunk ZSTD streaming decompression and checksum-based corruption detection.
* **Chores**
  * Added ZSTD compression identifier and enabled context-based decompression management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->