### PR TITLE
in_windows_exporter_metrics: Handle DST more precisely with dynamic timezone verison of functions [Backport to 4.0]

### DIFF
--- a/plugins/in_windows_exporter_metrics/we_os.c
+++ b/plugins/in_windows_exporter_metrics/we_os.c
@@ -170,7 +170,7 @@ int we_os_update(struct flb_we *ctx)
     DWORD caption_len = sizeof(caption), build_len = sizeof(build_number);
     uint64_t timestamp = 0;
     char label_caption[90];
-    TIME_ZONE_INFORMATION tzi;
+    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
     DWORD tztype = 0;
     char *displaytz;
 
@@ -223,21 +223,23 @@ int we_os_update(struct flb_we *ctx)
 
     cmt_gauge_set(ctx->os->time, timestamp, (double)timestamp/1000000000L, 0, NULL);
 
-    tztype = GetTimeZoneInformation(&tzi);
+    _tzset();
+
+    tztype = GetDynamicTimeZoneInformation(&dtzi);
     switch (tztype) {
     case TIME_ZONE_ID_STANDARD:
-        displaytz = we_convert_wstr(tzi.StandardName, CP_UTF8);
+        displaytz = we_convert_wstr(dtzi.StandardName, CP_UTF8);
         cmt_gauge_set(ctx->os->tz, timestamp, 1.0, 1, (char *[]) {displaytz});
         flb_free(displaytz);
         break;
     case TIME_ZONE_ID_DAYLIGHT:
-        displaytz = we_convert_wstr(tzi.DaylightName, CP_UTF8);
+        displaytz = we_convert_wstr(dtzi.DaylightName, CP_UTF8);
         cmt_gauge_set(ctx->os->tz, timestamp, 1.0, 1, (char *[]) {displaytz});
         flb_free(displaytz);
         break;
     case TIME_ZONE_ID_UNKNOWN:
         /* The current timezone does not use daylight saving time. */
-        displaytz = we_convert_wstr(tzi.StandardName, CP_UTF8);
+        displaytz = we_convert_wstr(dtzi.StandardName, CP_UTF8);
         cmt_gauge_set(ctx->os->tz, timestamp, 1.0, 1, (char *[]) {displaytz});
         flb_free(displaytz);
         break;


### PR DESCRIPTION
Backporting from https://github.com/fluent/fluent-bit/pull/10676.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
