### PR TITLE
utils: handle ipv6 hosts when splitting URLs (4.0 backport)

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -1154,7 +1154,7 @@ static char *flb_utils_copy_host_sds(const char *string, int pos_init, int pos_e
         if (string[pos_end-1] != ']') {
             return NULL;
         }
-        return flb_sds_create_len(string + pos_init + 1, pos_end - 1);
+        return flb_sds_create_len(string + pos_init + 1, pos_end - 2);
     }
     else {
         return flb_sds_create_len(string + pos_init, pos_end);
@@ -1171,6 +1171,7 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
     char *p;
     char *tmp;
     char *sep;
+    char *bracket = NULL;
 
     /* Protocol */
     p = strstr(in_url, "://");
@@ -1192,7 +1193,14 @@ int flb_utils_url_split(const char *in_url, char **out_protocol,
 
     /* Check for first '/' */
     sep = strchr(p, '/');
-    tmp = strchr(p, ':');
+    if (p[0] == '[') {
+        bracket = strchr(p, ']');
+    }
+    if (bracket) {
+        tmp = strchr(bracket, ':');
+    } else {
+        tmp = strchr(p, ':');
+    }
 
     /* Validate port separator is found before the first slash */
     if (sep && tmp) {
@@ -1267,6 +1275,7 @@ int flb_utils_url_split_sds(const flb_sds_t in_url, flb_sds_t *out_protocol,
     char *p = NULL;
     char *tmp = NULL;
     char *sep = NULL;
+    char *bracket = NULL;
 
     /* Protocol */
     p = strstr(in_url, "://");
@@ -1288,7 +1297,14 @@ int flb_utils_url_split_sds(const flb_sds_t in_url, flb_sds_t *out_protocol,
 
     /* Check for first '/' */
     sep = strchr(p, '/');
-    tmp = strchr(p, ':');
+    if (p[0] == '[') {
+        bracket = strchr(p, ']');
+    }
+    if (bracket) {
+        tmp = strchr(bracket, ':');
+    } else {
+        tmp = strchr(p, ':');
+    }
 
     /* Validate port separator is found before the first slash */
     if (sep && tmp) {

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -36,6 +36,8 @@ struct url_check url_checks[] = {
     {0, "https://fluentbit.io:1234/", "https", "fluentbit.io", "1234", "/"},
     {0, "https://fluentbit.io:1234/v", "https", "fluentbit.io", "1234", "/v"},
     {-1, "://", NULL, NULL, NULL, NULL},
+    {0, "http://[fd00:ec2::23]/v1/credentials", "http", "fd00:ec2::23", "80", "/v1/credentials"},
+    {0, "https://[::192.9.5.5]:1234/v", "https", "::192.9.5.5", "1234", "/v"}
 };
 
 void test_url_split_sds()


### PR DESCRIPTION
<!-- Provide summary of changes -->

* Update our URL-splitting utils to check if the host is ipv6, to prevent the `:`s in the host from being interpreted as a port separator
* Add test cases in our utils suite
* Add a test case for an ipv6 URI in the AWS HTTP credentials test suite (my entry-point for finding the bug)

Part of #10699
Backport of #10706 to 4.0.x

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
