### PR TITLE
in_node_exporter_metrics: add Linux sockstat collector

### DIFF
--- a/plugins/in_node_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_node_exporter_metrics/CMakeLists.txt
@@ -7,6 +7,7 @@ set(src
   ne_stat.c
   ne_vmstat.c
   ne_netdev.c
+  ne_sockstat.c
   ne_time.c
   ne_loadavg.c
   ne_filefd.c

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -39,6 +39,7 @@
 #include "ne_loadavg.h"
 #include "ne_vmstat.h"
 #include "ne_netdev.h"
+#include "ne_sockstat.h"
 #include "ne_textfile.h"
 #include "ne_systemd.h"
 #include "ne_processes.h"
@@ -192,6 +193,7 @@ static int in_ne_init(struct flb_input_instance *in,
     mk_list_add(&loadavg_collector._head, &ctx->collectors);
     mk_list_add(&vmstat_collector._head, &ctx->collectors);
     mk_list_add(&netdev_collector._head, &ctx->collectors);
+    mk_list_add(&sockstat_collector._head, &ctx->collectors);
     mk_list_add(&filefd_collector._head, &ctx->collectors);
     mk_list_add(&textfile_collector._head, &ctx->collectors);
     mk_list_add(&systemd_collector._head, &ctx->collectors);
@@ -383,6 +385,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "collector.netdev.scrape_interval", "0",
      0, FLB_FALSE, 0,
      "scrape interval to collect netdev metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.sockstat.scrape_interval", "0",
+     0, FLB_FALSE, 0,
+     "scrape interval to collect sockstat metrics from the node."
     },
 
     {

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -33,7 +33,7 @@
 /* Default enabled metrics */
 
 #ifdef __linux__
-#define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,filefd,systemd,nvme,thermal_zone"
+#define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,sockstat,filefd,systemd,nvme,thermal_zone"
 #elif __APPLE__
 #define NE_DEFAULT_ENABLED_METRICS "cpu,loadavg,meminfo,diskstats,uname,netdev"
 #endif
@@ -139,6 +139,28 @@ struct flb_ne {
     struct cmt_gauge *darwin_collisions;
     struct cmt_gauge *darwin_noproto;
 #endif
+
+    /* sockstat_linux */
+    struct cmt_gauge *sockstat_sockets_used;
+    struct cmt_gauge *sockstat_TCP_alloc;
+    struct cmt_gauge *sockstat_TCP_inuse;
+    struct cmt_gauge *sockstat_TCP_mem;
+    struct cmt_gauge *sockstat_TCP_mem_bytes;
+    struct cmt_gauge *sockstat_TCP_orphan;
+    struct cmt_gauge *sockstat_TCP_tw;
+    struct cmt_gauge *sockstat_UDP_inuse;
+    struct cmt_gauge *sockstat_UDP_mem;
+    struct cmt_gauge *sockstat_UDP_mem_bytes;
+    struct cmt_gauge *sockstat_UDPLITE_inuse;
+    struct cmt_gauge *sockstat_RAW_inuse;
+    struct cmt_gauge *sockstat_FRAG_inuse;
+    struct cmt_gauge *sockstat_FRAG_memory;
+    struct cmt_gauge *sockstat_TCP6_inuse;
+    struct cmt_gauge *sockstat_UDP6_inuse;
+    struct cmt_gauge *sockstat_UDPLITE6_inuse;
+    struct cmt_gauge *sockstat_RAW6_inuse;
+    struct cmt_gauge *sockstat_FRAG6_inuse;
+    struct cmt_gauge *sockstat_FRAG6_memory;
 
     /* time */
     struct cmt_gauge *time;

--- a/plugins/in_node_exporter_metrics/ne_sockstat.c
+++ b/plugins/in_node_exporter_metrics/ne_sockstat.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2025 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef __linux__
+#include "ne_sockstat_linux.c"
+#else
+
+#include "ne.h"
+
+struct flb_ne_collector sockstat_collector = {
+    .name = "sockstat",
+    .cb_init = NULL,
+    .cb_update = NULL,
+    .cb_exit = NULL
+};
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_sockstat.h
+++ b/plugins/in_node_exporter_metrics/ne_sockstat.h
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2025 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_SOCKSTAT_H
+#define FLB_IN_NE_SOCKSTAT_H
+
+#include "ne.h"
+
+extern struct flb_ne_collector sockstat_collector;
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_sockstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_sockstat_linux.c
@@ -1,0 +1,400 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2024 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <unistd.h>
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "ne.h"
+#include "ne_utils.h"
+
+static int sockstat_configure(struct flb_ne *ctx)
+{
+    struct cmt_gauge *g;
+
+    /* node_sockstat_sockets_used */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "sockets_used",
+                         "Number of IPv4 sockets in use.",
+                         0, NULL);
+    ctx->sockstat_sockets_used = g;
+
+    /* node_sockstat_TCP_alloc */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP_alloc",
+                         "Number of TCP sockets in state alloc.",
+                         0, NULL);
+    ctx->sockstat_TCP_alloc = g;
+
+    /* node_sockstat_TCP_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP_inuse",
+                         "Number of TCP sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_TCP_inuse = g;
+
+    /* node_sockstat_TCP_mem */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP_mem",
+                         "Number of memory pages used by TCP sockets, in Kernel memory pages.",
+                         0, NULL);
+    ctx->sockstat_TCP_mem = g;
+
+    /* node_sockstat_TCP_mem_bytes */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP_mem_bytes",
+                         "Number of bytes used by TCP sockets.",
+                         0, NULL);
+    ctx->sockstat_TCP_mem_bytes = g;
+
+    /* node_sockstat_TCP_orphan */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP_orphan",
+                         "Number of orphaned TCP sockets in use.",
+                         0, NULL);
+    ctx->sockstat_TCP_orphan = g;
+
+    /* node_sockstat_TCP_tw */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP_tw",
+                         "Number of TCP sockets in state TIME_WAIT.",
+                         0, NULL);
+    ctx->sockstat_TCP_tw = g;
+
+    /* node_sockstat_UDP_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "UDP_inuse",
+                         "Number of UDP sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_UDP_inuse = g;
+
+    /* node_sockstat_UDP_mem */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "UDP_mem",
+                         "Number of memory pages used by UDP sockets, in Kernel memory pages.",
+                         0, NULL);
+    ctx->sockstat_UDP_mem = g;
+
+    /* node_sockstat_UDP_mem_bytes */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "UDP_mem_bytes",
+                         "Number of bytes used by UDP sockets.",
+                         0, NULL);
+    ctx->sockstat_UDP_mem_bytes = g;
+
+    /* node_sockstat_UDPLITE_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "UDPLITE_inuse",
+                         "Number of UDPLITE sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_UDPLITE_inuse = g;
+
+    /* node_sockstat_RAW_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "RAW_inuse",
+                         "Number of RAW sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_RAW_inuse = g;
+
+    /* node_sockstat_FRAG_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "FRAG_inuse",
+                         "Number of FRAG sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_FRAG_inuse = g;
+
+    /* node_sockstat_FRAG_memory */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "FRAG_memory",
+                         "Memory currently used for fragment reassembly in bytes.",
+                         0, NULL);
+    ctx->sockstat_FRAG_memory = g;
+
+    /* node_sockstat_TCP6_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "TCP6_inuse",
+                         "Number of TCP6 sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_TCP6_inuse = g;
+
+    /* node_sockstat_UDP6_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "UDP6_inuse",
+                         "Number of UDP6 sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_UDP6_inuse = g;
+
+    /* node_sockstat_UDPLITE6_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "UDPLITE6_inuse",
+                         "Number of UDPLITE6 sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_UDPLITE6_inuse = g;
+
+    /* node_sockstat_RAW6_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "RAW6_inuse",
+                         "Number of RAW6 sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_RAW6_inuse = g;
+
+    /* node_sockstat_FRAG6_inuse */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "FRAG6_inuse",
+                         "Number of FRAG6 sockets in state inuse.",
+                         0, NULL);
+    ctx->sockstat_FRAG6_inuse = g;
+
+    /* node_sockstat_FRAG6_memory */
+    g = cmt_gauge_create(ctx->cmt, "node", "sockstat", "FRAG6_memory",
+                         "Memory currently used for IPv6 fragment reassembly in bytes.",
+                         0, NULL);
+    ctx->sockstat_FRAG6_memory = g;
+
+    return 0;
+}
+
+static int sockstat_update(struct flb_ne *ctx)
+{
+    int ret;
+    uint64_t ts;
+    size_t page_size;
+    double d_val;
+    struct mk_list list;
+    struct mk_list *head;
+    struct flb_slist_entry *line;
+    struct mk_list tokens;
+    int parts;
+    int i;
+    struct flb_slist_entry *key;
+    struct flb_slist_entry *val;
+
+    mk_list_init(&list);
+    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/sockstat", &list);
+    if (ret == -1) {
+        return -1;
+    }
+
+    ts = cfl_time_now();
+    page_size = sysconf(_SC_PAGESIZE);
+
+    mk_list_foreach(head, &list) {
+        line = mk_list_entry(head, struct flb_slist_entry, _head);
+
+        if (strncmp(line->str, "sockets:", 8) == 0) {
+            mk_list_init(&tokens);
+            ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+            if (ret >= 3) {
+                val = flb_slist_entry_get(&tokens, 2);
+                if (val) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_sockets_used, ts, d_val, 0, NULL);
+                }
+            }
+            flb_slist_destroy(&tokens);
+        }
+        else if (strncmp(line->str, "TCP:", 4) == 0) {
+            mk_list_init(&tokens);
+            ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+            parts = ret;
+            for (i = 1; i + 1 < parts; i += 2) {
+                key = flb_slist_entry_get(&tokens, i);
+                val = flb_slist_entry_get(&tokens, i + 1);
+                if (!key || !val) {
+                    continue;
+                }
+                if (strcmp(key->str, "inuse") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_TCP_inuse, ts, d_val, 0, NULL);
+                }
+                else if (strcmp(key->str, "orphan") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_TCP_orphan, ts, d_val, 0, NULL);
+                }
+                else if (strcmp(key->str, "tw") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_TCP_tw, ts, d_val, 0, NULL);
+                }
+                else if (strcmp(key->str, "alloc") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_TCP_alloc, ts, d_val, 0, NULL);
+                }
+                else if (strcmp(key->str, "mem") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_TCP_mem, ts, d_val, 0, NULL);
+                    cmt_gauge_set(ctx->sockstat_TCP_mem_bytes, ts, d_val * page_size, 0, NULL);
+                }
+            }
+            flb_slist_destroy(&tokens);
+        }
+        else if (strncmp(line->str, "UDP:", 4) == 0) {
+            mk_list_init(&tokens);
+            ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+            parts = ret;
+            for (i = 1; i + 1 < parts; i += 2) {
+                key = flb_slist_entry_get(&tokens, i);
+                val = flb_slist_entry_get(&tokens, i + 1);
+                if (!key || !val) {
+                    continue;
+                }
+                if (strcmp(key->str, "inuse") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_UDP_inuse, ts, d_val, 0, NULL);
+                }
+                else if (strcmp(key->str, "mem") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_UDP_mem, ts, d_val, 0, NULL);
+                    cmt_gauge_set(ctx->sockstat_UDP_mem_bytes, ts, d_val * page_size, 0, NULL);
+                }
+            }
+            flb_slist_destroy(&tokens);
+        }
+        else if (strncmp(line->str, "UDPLITE:", 8) == 0) {
+            mk_list_init(&tokens);
+            ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+            if (ret >= 3) {
+                val = flb_slist_entry_get(&tokens, 2);
+                if (val && ne_utils_str_to_double(val->str, &d_val) == 0) {
+                    cmt_gauge_set(ctx->sockstat_UDPLITE_inuse, ts, d_val, 0, NULL);
+                }
+            }
+            flb_slist_destroy(&tokens);
+        }
+        else if (strncmp(line->str, "RAW:", 4) == 0) {
+            mk_list_init(&tokens);
+            ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+            if (ret >= 3) {
+                val = flb_slist_entry_get(&tokens, 2);
+                if (val && ne_utils_str_to_double(val->str, &d_val) == 0) {
+                    cmt_gauge_set(ctx->sockstat_RAW_inuse, ts, d_val, 0, NULL);
+                }
+            }
+            flb_slist_destroy(&tokens);
+        }
+        else if (strncmp(line->str, "FRAG:", 5) == 0) {
+            mk_list_init(&tokens);
+            ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+            parts = ret;
+            for (i = 1; i + 1 < parts; i += 2) {
+                key = flb_slist_entry_get(&tokens, i);
+                val = flb_slist_entry_get(&tokens, i + 1);
+                if (!key || !val) {
+                    continue;
+                }
+                if (strcmp(key->str, "inuse") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_FRAG_inuse, ts, d_val, 0, NULL);
+                }
+                else if (strcmp(key->str, "memory") == 0) {
+                    ne_utils_str_to_double(val->str, &d_val);
+                    cmt_gauge_set(ctx->sockstat_FRAG_memory, ts, d_val, 0, NULL);
+                }
+            }
+            flb_slist_destroy(&tokens);
+        }
+    }
+
+    flb_slist_destroy(&list);
+
+    /* Parse IPv6 statistics */
+    mk_list_init(&list);
+    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/sockstat6", &list);
+    if (ret != -1) {
+        mk_list_foreach(head, &list) {
+            line = mk_list_entry(head, struct flb_slist_entry, _head);
+
+            if (strncmp(line->str, "TCP6:", 5) == 0) {
+                mk_list_init(&tokens);
+                ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+                if (ret >= 3) {
+                    val = flb_slist_entry_get(&tokens, 2);
+                    if (val && ne_utils_str_to_double(val->str, &d_val) == 0) {
+                        cmt_gauge_set(ctx->sockstat_TCP6_inuse, ts, d_val, 0, NULL);
+                    }
+                }
+                flb_slist_destroy(&tokens);
+            }
+            else if (strncmp(line->str, "UDP6:", 5) == 0) {
+                mk_list_init(&tokens);
+                ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+                if (ret >= 3) {
+                    val = flb_slist_entry_get(&tokens, 2);
+                    if (val && ne_utils_str_to_double(val->str, &d_val) == 0) {
+                        cmt_gauge_set(ctx->sockstat_UDP6_inuse, ts, d_val, 0, NULL);
+                    }
+                }
+                flb_slist_destroy(&tokens);
+            }
+            else if (strncmp(line->str, "UDPLITE6:", 9) == 0) {
+                mk_list_init(&tokens);
+                ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+                if (ret >= 3) {
+                    val = flb_slist_entry_get(&tokens, 2);
+                    if (val && ne_utils_str_to_double(val->str, &d_val) == 0) {
+                        cmt_gauge_set(ctx->sockstat_UDPLITE6_inuse, ts, d_val, 0, NULL);
+                    }
+                }
+                flb_slist_destroy(&tokens);
+            }
+            else if (strncmp(line->str, "RAW6:", 5) == 0) {
+                mk_list_init(&tokens);
+                ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+                if (ret >= 3) {
+                    val = flb_slist_entry_get(&tokens, 2);
+                    if (val && ne_utils_str_to_double(val->str, &d_val) == 0) {
+                        cmt_gauge_set(ctx->sockstat_RAW6_inuse, ts, d_val, 0, NULL);
+                    }
+                }
+                flb_slist_destroy(&tokens);
+            }
+            else if (strncmp(line->str, "FRAG6:", 6) == 0) {
+                mk_list_init(&tokens);
+                ret = flb_slist_split_string(&tokens, line->str, ' ', -1);
+                parts = ret;
+                for (i = 1; i + 1 < parts; i += 2) {
+                    key = flb_slist_entry_get(&tokens, i);
+                    val = flb_slist_entry_get(&tokens, i + 1);
+                    if (!key || !val) {
+                        continue;
+                    }
+                    if (strcmp(key->str, "inuse") == 0) {
+                        if (ne_utils_str_to_double(val->str, &d_val) == 0) {
+                            cmt_gauge_set(ctx->sockstat_FRAG6_inuse, ts, d_val, 0, NULL);
+                        }
+                    }
+                    else if (strcmp(key->str, "memory") == 0) {
+                        if (ne_utils_str_to_double(val->str, &d_val) == 0) {
+                            cmt_gauge_set(ctx->sockstat_FRAG6_memory, ts, d_val, 0, NULL);
+                        }
+                    }
+                }
+                flb_slist_destroy(&tokens);
+            }
+        }
+        flb_slist_destroy(&list);
+    }
+
+    return 0;
+}
+
+static int ne_sockstat_init(struct flb_ne *ctx)
+{
+    sockstat_configure(ctx);
+    return 0;
+}
+
+static int ne_sockstat_update(struct flb_input_instance *ins, struct flb_config *config, void *in_context)
+{
+    struct flb_ne *ctx = (struct flb_ne *) in_context;
+
+    sockstat_update(ctx);
+    return 0;
+}
+
+struct flb_ne_collector sockstat_collector = {
+    .name = "sockstat",
+    .cb_init = ne_sockstat_init,
+    .cb_update = ne_sockstat_update,
+    .cb_exit = NULL
+};
+


### PR DESCRIPTION
as requested in #10698 , fixed.

Implement Linux sockstat collector, same as the original Prometheus node exporter, it collects the data from `/proc/net/sockstat` and `/proc/net/sockstat6`, the following metrics are generated:

## IPv4 Sockstat Metrics

- `node_sockstat_sockets_used`: Total IPv4 sockets in use
- `node_sockstat_TCP_alloc`: TCP sockets allocated
- `node_sockstat_TCP_inuse`: TCP sockets in use
- `node_sockstat_TCP_mem`: TCP memory pages used
- `node_sockstat_TCP_mem_bytes`: TCP memory in bytes
- `node_sockstat_TCP_orphan`: Orphaned TCP sockets
- `node_sockstat_TCP_tw`: TCP sockets in TIME_WAIT state
- `node_sockstat_UDP_inuse`: UDP sockets in use
- `node_sockstat_UDP_mem`: UDP memory pages used
- `node_sockstat_UDP_mem_bytes`: UDP memory in bytes
- `node_sockstat_UDPLITE_inuse`: UDPLITE sockets in use
- `node_sockstat_RAW_inuse`: RAW sockets in use
- `node_sockstat_FRAG_inuse`: Fragment sockets in use
- `node_sockstat_FRAG_memory`: Fragment memory in bytes

## IPv6 Sockstat Metrics

- `node_sockstat_TCP6_inuse`: IPv6 TCP sockets in use
- `node_sockstat_UDP6_inuse`: IPv6 UDP sockets in use
- `node_sockstat_UDPLITE6_inuse`: IPv6 UDPLITE sockets in use
- `node_sockstat_RAW6_inuse`: IPv6 RAW sockets in use
- `node_sockstat_FRAG6_inuse`: IPv6 fragment sockets in use
- `node_sockstat_FRAG6_memory`: IPv6 fragment memory in bytes

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting and exposing detailed Linux socket statistics (sockstat) in the node exporter metrics plugin, including metrics for various socket types and memory usage.
  * Introduced configuration options for the sockstat collector, including customizable scrape intervals.
  * Expanded the default set of enabled metrics to include sockstat on Linux systems.

* **Compatibility**
  * Sockstat metrics are available on Linux platforms; a stub collector is provided for other systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->