### PR TITLE
in_node_exporter_metrics: add new option 'path.rootfs'

### DIFF
--- a/conf/fluent-bit-metrics.conf
+++ b/conf/fluent-bit-metrics.conf
@@ -15,6 +15,8 @@
     name            node_exporter_metrics
     tag             node_metrics
     scrape_interval 2
+    # use host root path when running in containers
+    # path.rootfs     /host
 
 [OUTPUT]
     name            prometheus_exporter

--- a/docker_compose/node-exporter-dashboard/docker-compose.yml
+++ b/docker_compose/node-exporter-dashboard/docker-compose.yml
@@ -4,14 +4,13 @@ services:
   fluentbit:
     image: fluent/fluent-bit:latest
     container_name: fluentbit
-    command: /fluent-bit/bin/fluent-bit -i node_exporter_metrics -p path.procfs=/host/proc -p path.sysfs=/host/sys -o prometheus_exporter -p "add_label=host fluentbit" -f 1
+    command: /fluent-bit/bin/fluent-bit -i node_exporter_metrics -p path.rootfs=/host -o prometheus_exporter -p "add_label=host fluentbit" -f 1
     ports:
       - 2021:2021
     networks:
       - exporter-network
     volumes:
-      - /proc:/host/proc
-      - /sys:/host/sys
+      - /:/host:ro
 
   grafana:
     image: grafana/grafana:latest

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -434,6 +434,12 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_STR, "path.rootfs", "/",
+     0, FLB_TRUE, offsetof(struct flb_ne, path_rootfs),
+     "rootfs mount point"
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "path.procfs", "/proc",
      0, FLB_TRUE, offsetof(struct flb_ne, path_procfs),
      "procfs mount point"

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -48,6 +48,7 @@
 
 struct flb_ne {
     /* configuration */
+    flb_sds_t path_rootfs;
     flb_sds_t path_procfs;
     flb_sds_t path_sysfs;
     flb_sds_t path_textfile;

--- a/plugins/in_node_exporter_metrics/ne_stat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_stat_linux.c
@@ -85,6 +85,7 @@ static int stat_update(struct flb_ne *ctx)
     mk_list_init(&list);
     ret = ne_utils_file_read_lines(ctx->path_procfs, "/stat", &list);
     if (ret == -1) {
+        flb_plg_error(ctx->ins, "failed to read %s/stat", ctx->path_procfs);
         return -1;
     }
 

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -196,9 +196,9 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
 /*
  * Read a file and store the first line as a string.
  */
-int ne_utils_file_read_sds(const char *mount, 
-                           const char *path, 
-                           const char *join_a, 
+int ne_utils_file_read_sds(const char *mount,
+                           const char *path,
+                           const char *join_a,
                            const char *join_b,
                            flb_sds_t *str)
 {

--- a/plugins/in_node_exporter_metrics/ne_utils.h
+++ b/plugins/in_node_exporter_metrics/ne_utils.h
@@ -35,8 +35,8 @@ int ne_utils_file_read_uint64(const char *mount,
 
 int ne_utils_file_read_sds(const char *mount,
                            const char *path,
-                           const char *join_a, 
-                           const char *join_b, 
+                           const char *join_a,
+                           const char *join_b,
                            flb_sds_t *str);
 
 int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list);


### PR DESCRIPTION
This PR fixes #10650

This PR introduces a new `path.rootfs` configuration parameter to the `node_exporter_metrics` input plugin, simplifying containerized deployments by allowing users to specify a single root filesystem mount point instead of mounting /proc and /sys separately.

__Changes Made__

Plugin Configuration:

- Added path.rootfs config option with default value /
- When path.rootfs is set to a non-root path, the plugin automatically composes full paths for:

e.g:

- path.procfs → {rootfs}/proc
- path.sysfs → {rootfs}/sys
- path.textfile → {rootfs}/{textfile_path} (if specified)

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a rootfs path configuration for Node Exporter Metrics, automatically prefixing procfs/sysfs/textfile paths to simplify containerized setups.
- Documentation
  - Added comments guiding how to use host root paths when running in containers.
- Chores
  - Updated the node-exporter dashboard container to mount the host root as read-only and use the new rootfs configuration, reducing multiple bind mounts to a single one.
- Bug Fixes
  - Improved error logging when reading system stats fails, aiding troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->