### PR TITLE
out_splunk: Avoid sending empty payloads to splunk

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -910,6 +910,14 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
     payload_buf = buf_data;
     payload_size = buf_size;
 
+    /* If the payload is empty, skip the HTTP request to avoid a 400 error*/
+    if (payload_size == 0) {
+        flb_plg_debug(ctx->ins, "empty payload detected, skipping HTTP request");
+        flb_sds_destroy(buf_data);
+        flb_upstream_conn_release(u_conn);
+        FLB_OUTPUT_RETURN(FLB_OK);
+    }
+
     /* Should we compress the payload ? */
     if (ctx->compress_gzip == FLB_TRUE) {
         ret = flb_gzip_compress((void *) buf_data, buf_size,


### PR DESCRIPTION
<!-- Provide summary of changes -->

This attempts to address #10724, though please let me know if this approach is not suitable.

The linked issue has more context, but in short this avoids sending empty log payloads to Splunk's backend as that results in 400 errors that are propagated out.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [n/a] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Splunk output now skips sending requests when there’s no data, avoiding unnecessary compression and network transmission.
  - Reduces CPU and network overhead, improving performance during idle or low-traffic periods.
  - Lowers log noise by emitting a concise debug message instead of attempting an empty send.
  - Enhances stability by eliminating edge cases associated with empty payload handling, without changing existing behavior for non-empty data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->