### PR TITLE
packaging: add debian trixie support

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -21,6 +21,8 @@ The [`distros`](./distros/) directory contains OCI container definitions used to
 | CentOS        |   8                       | arm64v8 | centos/8.arm64v8         |
 | CentOS        |   7                       | x86_64  | centos/7                 |
 | CentOS        |   7                       | arm64v8 | centos/7.arm64v8         |
+| Debian        |   13                      | x86_64  | debian/trixie            |
+| Debian        |   13                      | arm64v8 | debian/trixie.arm64v8    |
 | Debian        |   12                      | x86_64  | debian/bookworm          |
 | Debian        |   12                      | arm64v8 | debian/bookworm.arm64v8  |
 | Debian        |   11                      | x86_64  | debian/bullseye          |

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -97,6 +97,14 @@
           "type": "deb"
         },
         {
+          "target": "debian/trixie",
+          "type": "deb"
+        },
+        {
+          "target": "debian/trixie.arm64v8",
+          "type": "deb"
+        },
+        {
           "target": "ubuntu/22.04",
           "type": "deb"
         },

--- a/packaging/distros/debian/Dockerfile
+++ b/packaging/distros/debian/Dockerfile
@@ -169,6 +169,56 @@ RUN apt-get -qq update && \
 
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
+# debian/trixie base image
+FROM debian:trixie-slim AS debian-trixie-base
+ENV DEBIAN_FRONTEND="noninteractive" \
+    CMAKE_HOME="/opt/cmake"
+
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get -qq update && \
+    apt-get install -y curl ca-certificates build-essential \
+    make bash sudo wget unzip dh-make \
+    libsystemd-dev zlib1g-dev flex bison \
+    libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
+    tar gzip && \
+    apt-get install -y --reinstall lsb-base lsb-release && \
+    mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
+# debian/trixie.arm64v8 base image
+FROM arm64v8/debian:trixie-slim AS debian-trixie.arm64v8-base
+ENV DEBIAN_FRONTEND="noninteractive" \
+    CMAKE_HOME="/opt/cmake"
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get -qq update && \
+    apt-get install -y curl ca-certificates build-essential \
+    make bash sudo wget unzip dh-make \
+    libsystemd-dev zlib1g-dev flex bison \
+    libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
+    libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
+    tar gzip && \
+    apt-get install -y --reinstall lsb-base lsb-release && \
+    mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
 # Common build for all distributions now
 # hadolint ignore=DL3006
 FROM $BASE_BUILDER AS builder

--- a/packaging/testing/smoke/packages/Dockerfile.debian13
+++ b/packaging/testing/smoke/packages/Dockerfile.debian13
@@ -1,0 +1,47 @@
+# For staging upgrade we use the 'official-install' as the base
+ARG STAGING_BASE=docker.io/dokken/debian-13
+
+ARG RELEASE_URL=https://packages.fluentbit.io
+ARG RELEASE_KEY=https://packages.fluentbit.io/fluentbit.key
+
+# hadolint ignore=DL3006
+FROM docker.io/dokken/debian-13 as official-install
+
+ARG RELEASE_URL
+ENV FLUENT_BIT_PACKAGES_URL=${RELEASE_URL}
+
+ARG RELEASE_KEY
+ENV FLUENT_BIT_PACKAGES_KEY=${RELEASE_KEY}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+RUN systemctl enable fluent-bit
+
+COPY ./test.sh /test.sh
+RUN chmod a+x /test.sh
+
+FROM official-install as staging-upgrade-prep
+RUN rm -f /etc/apt/sources.list.d/fluent-bit.list
+
+# hadolint ignore=DL3006
+FROM ${STAGING_BASE} as staging-install
+ARG STAGING_VERSION
+ENV STAGING_VERSION=${STAGING_VERSION}
+
+ARG STAGING_URL
+ENV FLUENT_BIT_PACKAGES_URL=${STAGING_URL}
+
+ARG STAGING_KEY=${STAGING_URL}/fluentbit.key
+ENV FLUENT_BIT_PACKAGES_KEY=${STAGING_KEY}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN wget -qO - $FLUENT_BIT_PACKAGES_KEY | apt-key add -
+RUN echo "deb $FLUENT_BIT_PACKAGES_URL/debian/trixie trixie main" >> /etc/apt/sources.list
+# hadolint ignore=DL3015,DL3008,DL3009
+RUN apt-get update && apt-get install -y fluent-bit
+RUN systemctl enable fluent-bit
+
+COPY ./test.sh /test.sh
+RUN chmod a+x /test.sh
+
+FROM staging-install as staging-upgrade

--- a/packaging/update-apt-repo.sh
+++ b/packaging/update-apt-repo.sh
@@ -10,7 +10,7 @@ if [[ ! -d "$BASE_PATH" ]]; then
     exit 1
 fi
 
-# "debian/bookworm" "debian/bullseye" "debian/buster" "ubuntu/xenial" "ubuntu/bionic" "ubuntu/focal" "ubuntu/jammy" "raspbian/buster" "raspbian/bullseye"
+# "debian/bookworm" "debian/bullseye" "debian/buster" "debian/trixie" "ubuntu/xenial" "ubuntu/bionic" "ubuntu/focal" "ubuntu/jammy" "raspbian/buster" "raspbian/bullseye"
 DEB_REPO=${DEB_REPO:?}
 
 # Set true to prevent signing

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -50,6 +50,7 @@ done
 DEB_REPO_PATHS=( "debian/bookworm"
                  "debian/bullseye"
                  "debian/buster"
+                 "debian/trixie"
                  "ubuntu/jammy"
                  "ubuntu/noble"
                  "raspbian/bookworm"


### PR DESCRIPTION
Added packaging for Debian 13 (trixie). No package dependency changes done from Debian 12 (bookworm).

This is not quite working yet, due to this compilation error when running `build.sh -d debian/trixie`:

```
[ 56%] Building C object src/CMakeFiles/fluent-bit-static.dir/config_format/flb_config_format.c.o
/tmp/fluent-bit/src/flb_blob_db.c: In function 'flb_blob_db_file_part_insert':
/tmp/fluent-bit/src/flb_blob_db.c:912:52: error: passing argument 1 of 'sqlite3_last_insert_rowid' from incompatible pointer type [-Wincompatible-pointer-types]
  912 |         *out_id = sqlite3_last_insert_rowid(context->db);
      |                                             ~~~~~~~^~~~
      |                                                    |
      |                                                    __internal_flb_sqldb * {aka struct flb_sqldb *}
In file included from /tmp/fluent-bit/include/fluent-bit/flb_sqldb.h:23,
                 from /tmp/fluent-bit/src/flb_blob_db.c:22:
/tmp/fluent-bit/lib/sqlite-amalgamation-3450200/sqlite3.h:2588:52: note: expected 'sqlite3 *' but argument is of type '__internal_flb_sqldb *' {aka 'struct flb_sqldb *'}
 2588 | SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3*);
      |                                                    ^~~~~~~~
[ 56%] Building C object src/CMakeFiles/fluent-bit-static.dir/config_format/flb_cf_fluentbit.c.o
make[2]: *** [src/CMakeFiles/fluent-bit-static.dir/build.make:1325: src/CMakeFiles/fluent-bit-static.dir/flb_blob_db.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:12446: src/CMakeFiles/fluent-bit-static.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
+ echo 'Could not compile using image flb-debian/trixie'
Could not compile using image flb-debian/trixie
+ exit 1
```

Compiling for Debian 12 works fine.

Fixes #10716

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added official Debian 13 (Trixie) packaging targets and base images for x86_64 and ARM64.

- Tests
  - Added Debian 13 smoke tests covering install and staged-upgrade scenarios to validate packaging.

- Documentation
  - Updated packaging docs to list Debian 13 (Trixie) support.

- Chores
  - Updated packaging config and repository sync to publish and sync Debian 13 (Trixie) artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->