### PR TITLE
chunkio: replace Windows API PathIsDirectoryA for nano server compatibility

### DIFF
--- a/lib/chunkio/src/win32/dirent.c
+++ b/lib/chunkio/src/win32/dirent.c
@@ -23,7 +23,6 @@
  */
 
 #include <Windows.h>
-#include <shlwapi.h>
 
 #include "dirent.h"
 
@@ -79,7 +78,8 @@ struct CIO_WIN32_DIR *cio_win32_opendir(const char *path)
 {
     struct CIO_WIN32_DIR *d;
 
-    if (!PathIsDirectoryA(path)) {
+    DWORD attrs = GetFileAttributesA(path);
+    if (attrs == INVALID_FILE_ATTRIBUTES || !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
         return NULL;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Replace Windows API calls in chunkio dirent.c with Nano Server compatible alternatives. The original APIs are not available in Windows Nano Server, preventing Fluent Bit from running in minimal Windows environments and containers.

This change maintains full functionality while ensuring compatibility across all Windows variants including Nano Server deployments.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening directories on Windows by hardening path validation, reducing false positives/negatives for non-directory paths and preventing unexpected failures.
  * Edge cases such as missing paths or invalid attributes now return errors more consistently.
  * Reduced reliance on optional Windows components, improving portability across different installations.
  * No changes to public APIs; behavior for valid directories remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->