### PR TITLE
input_metrics: discard cmetrics with no series (backport v4.0)

### DIFF
--- a/include/fluent-bit/flb_macros.h
+++ b/include/fluent-bit/flb_macros.h
@@ -20,10 +20,11 @@
 #ifndef FLB_MACROS_H
 #define FLB_MACROS_H
 
+#include <stdbool.h>
 #include <monkey/mk_core.h>
 
-#define FLB_FALSE  0
-#define FLB_TRUE   !FLB_FALSE
+#define FLB_FALSE  false
+#define FLB_TRUE   true
 
 /* Return values */
 #define FLB_ERROR   0

--- a/include/fluent-bit/flb_metrics.h
+++ b/include/fluent-bit/flb_metrics.h
@@ -42,6 +42,13 @@
 #include <cmetrics/cmt_decode_statsd.h>
 #include <cmetrics/cmt_filter.h>
 
+/*
+ * v1 HTTP endpoint metrics
+ * ------------------------
+ * These are functions that are not part of the CMetrics library, its' the old interface
+ * to ship internal metrics which is part of the v1 HTTP endpoint.
+ */
+
 /* Metrics IDs for general purpose (used by core and Plugins */
 #define FLB_METRIC_N_RECORDS       0
 #define FLB_METRIC_N_BYTES         1
@@ -85,6 +92,10 @@ int flb_metrics_dump_values(char **out_buf, size_t *out_size,
                             struct flb_metrics *me);
 int flb_metrics_destroy(struct flb_metrics *metrics);
 int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt);
+/* ! end of v1 HTTP endpoint metrics */
+
+/* General metrics utilities */
+bool flb_metrics_is_empty(struct cmt *cmt);
 
 #endif
 #endif /* FLB_HAVE_METRICS */

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -376,3 +376,12 @@ int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt)
 
     return 0;
 }
+
+bool flb_metrics_is_empty(struct cmt *cmt)
+{
+    return cfl_list_is_empty(&cmt->counters) &&
+           cfl_list_is_empty(&cmt->gauges) &&
+           cfl_list_is_empty(&cmt->histograms) &&
+           cfl_list_is_empty(&cmt->summaries) &&
+           cfl_list_is_empty(&cmt->untypeds);
+}


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit/pull/10700/

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
