### PR TITLE
out_azure_kusto: Added workload identity support (backport v4.0)

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -52,12 +52,27 @@ static int azure_kusto_get_msi_token(struct flb_azure_kusto *ctx)
     return 0;
 }
 
-/* Create a new oauth2 context and get a oauth2 token */
-static int azure_kusto_get_oauth2_token(struct flb_azure_kusto *ctx)
+static int azure_kusto_get_workload_identity_token(struct flb_azure_kusto *ctx)
 {
     int ret;
-    char *token;
+    
+    ret = flb_azure_workload_identity_token_get(ctx->o, 
+                                               ctx->workload_identity_token_file,
+                                               ctx->client_id, 
+                                               ctx->tenant_id);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "error retrieving workload identity token");
+        return -1;
+    }
+    
+    flb_plg_debug(ctx->ins, "Workload identity token retrieved successfully");
+    return 0;
+}
 
+static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
+{
+    int ret;
+    
     /* Clear any previous oauth2 payload content */
     flb_oauth2_payload_clear(ctx->o);
 
@@ -86,7 +101,7 @@ static int azure_kusto_get_oauth2_token(struct flb_azure_kusto *ctx)
     }
 
     /* Retrieve access token */
-    token = flb_oauth2_token_get(ctx->o);
+    char *token = flb_oauth2_token_get(ctx->o);
     if (!token) {
         flb_plg_error(ctx->ins, "error retrieving oauth2 access token");
         return -1;
@@ -107,11 +122,18 @@ flb_sds_t get_azure_kusto_token(struct flb_azure_kusto *ctx)
     }
 
     if (flb_oauth2_token_expired(ctx->o) == FLB_TRUE) {
-        if (ctx->managed_identity_client_id != NULL) {
-            ret = azure_kusto_get_msi_token(ctx);
-        }
-        else {
-            ret = azure_kusto_get_oauth2_token(ctx);
+        switch (ctx->auth_type) {
+            case FLB_AZURE_KUSTO_AUTH_WORKLOAD_IDENTITY:
+                ret = azure_kusto_get_workload_identity_token(ctx);
+                break;
+            case FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_SYSTEM:
+            case FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_USER:
+                ret = azure_kusto_get_msi_token(ctx);
+                break;
+            case FLB_AZURE_KUSTO_AUTH_SERVICE_PRINCIPAL:
+            default:
+                ret = azure_kusto_get_service_principal_token(ctx);
+                break;
         }
     }
 
@@ -205,7 +227,7 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
                             ctx->ins,
                             "Kusto ingestion command request http_do=%i, HTTP Status: %i",
                             ret, c->resp.status);
-                    flb_plg_debug(ctx->ins, "Kusto ingestion command HTTP request payload: %.*s", (int)c->resp.payload_size, c->resp.payload);
+                    flb_plg_debug(ctx->ins, "Kusto ingestion command HTTP response payload: %.*s", (int)c->resp.payload_size, c->resp.payload);
 
                     if (ret == 0) {
                         if (c->resp.status == 200) {
@@ -1413,7 +1435,7 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
     /* Error handling and cleanup */
     if (json) {
         flb_sds_destroy(json);
-    }
+    } 
     if (is_compressed && final_payload) {
         flb_free(final_payload);
     }
@@ -1494,16 +1516,18 @@ static struct flb_config_map config_map[] = {
      "Set the tenant ID of the AAD application used for authentication"},
     {FLB_CONFIG_MAP_STR, "client_id", (char *)NULL, 0, FLB_TRUE,
      offsetof(struct flb_azure_kusto, client_id),
-     "Set the client ID (Application ID) of the AAD application used for authentication"},
+     "Set the client ID (Application ID) of the AAD application or the user-assigned managed identity's client ID when using managed identity authentication"},
     {FLB_CONFIG_MAP_STR, "client_secret", (char *)NULL, 0, FLB_TRUE,
      offsetof(struct flb_azure_kusto, client_secret),
      "Set the client secret (Application Password) of the AAD application used for "
      "authentication"},
-    {FLB_CONFIG_MAP_STR, "managed_identity_client_id", (char *)NULL, 0, FLB_TRUE,
-     offsetof(struct flb_azure_kusto, managed_identity_client_id),
-     "A managed identity client id to authenticate with. "
-     "Set to 'system' for system-assigned managed identity. "
-     "Set the MI client ID (GUID) for user-assigned managed identity."},
+    {FLB_CONFIG_MAP_STR, "workload_identity_token_file", (char *)NULL, 0, FLB_TRUE,
+     offsetof(struct flb_azure_kusto, workload_identity_token_file),
+     "Set the token file path for workload identity authentication"},
+    {FLB_CONFIG_MAP_STR, "auth_type", "service_principal", 0, FLB_TRUE,
+     offsetof(struct flb_azure_kusto, auth_type_str),
+     "Set the authentication type: 'service_principal', 'managed_identity', or 'workload_identity'. "
+     "For managed_identity, use 'system' as client_id for system-assigned identity, or specify the managed identity's client ID"},
     {FLB_CONFIG_MAP_STR, "ingestion_endpoint", (char *)NULL, 0, FLB_TRUE,
      offsetof(struct flb_azure_kusto, ingestion_endpoint),
      "Set the Kusto cluster's ingestion endpoint URL (e.g. "

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -35,6 +35,14 @@
 /* refresh token every 50 minutes */
 #define FLB_AZURE_KUSTO_TOKEN_REFRESH 3000
 
+/* Authentication types */
+typedef enum {
+    FLB_AZURE_KUSTO_AUTH_SERVICE_PRINCIPAL = 0,   /* Client ID + Client Secret */
+    FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_SYSTEM, /* System-assigned managed identity */
+    FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_USER,   /* User-assigned managed identity */
+    FLB_AZURE_KUSTO_AUTH_WORKLOAD_IDENTITY        /* Workload Identity */
+} flb_azure_kusto_auth_type;
+
 /* Kusto streaming inserts oauth scope */
 #define FLB_AZURE_KUSTO_SCOPE "https://help.kusto.windows.net/.default"
 
@@ -91,6 +99,11 @@ struct flb_azure_kusto {
 
     int ingestion_endpoint_connect_timeout;
     int io_timeout;
+
+    /* Authentication */
+    int auth_type;
+    char *auth_type_str;
+    char *workload_identity_token_file;
 
     /* compress payload */
     int compression_enabled;

--- a/plugins/out_azure_kusto/azure_msiauth.c
+++ b/plugins/out_azure_kusto/azure_msiauth.c
@@ -102,3 +102,173 @@ char *flb_azure_msiauth_token_get(struct flb_oauth2 *ctx)
  
      return NULL;
  }
+
+/** Read token from file */
+static flb_sds_t read_token_from_file(const char *token_file)
+{
+    FILE *fp;
+    flb_sds_t token = NULL;
+    char buf[4096]; /* Assuming token won't be larger than 4KB */
+    size_t bytes_read;
+
+    if (!token_file) {
+        flb_error("[azure workload identity] token file path is NULL");
+        return NULL;
+    }
+
+    fp = fopen(token_file, "r");
+    if (!fp) {
+        flb_error("[azure workload identity] could not open token file: %s", token_file);
+        return NULL;
+    }
+
+    bytes_read = fread(buf, 1, sizeof(buf) - 1, fp);
+    fclose(fp);
+
+    if (bytes_read <= 0) {
+        flb_error("[azure workload identity] could not read token from file: %s", token_file);
+        return NULL;
+    }
+
+    buf[bytes_read] = '\0';
+    token = flb_sds_create(buf);
+
+    return token;
+}
+
+int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *token_file, const char *client_id, const char *tenant_id)
+{
+    int ret;
+    size_t b_sent;
+    struct flb_connection *u_conn;
+    struct flb_http_client *c;
+    flb_sds_t federated_token;
+    flb_sds_t body = NULL;
+
+    flb_info("[azure workload identity] inside flb_azure_workload_identity_token_get");
+
+    /* Default token file location if not specified */
+    if (!token_file) {
+        token_file = "/var/run/secrets/azure/tokens/azure-identity-token";
+    }
+
+    /* Read the federated token from file */
+    federated_token = read_token_from_file(token_file);
+    if (!federated_token) {
+        flb_error("[azure workload identity] failed to read federated token");
+        return -1;
+    }
+
+    flb_info("[azure workload identity] after read token from file %s", federated_token);
+
+    /* Build the form data for token exchange *before* creating the client */
+    body = flb_sds_create_size(4096);
+    if (!body) {
+        flb_error("[azure workload identity] failed to allocate memory for request body");
+        flb_sds_destroy(federated_token);
+        return -1;
+    }
+
+    body = flb_sds_cat(body, "client_id=", 10);
+    body = flb_sds_cat(body, client_id, strlen(client_id));
+    /* Use the correct grant_type and length for workload identity */
+    body = flb_sds_cat(body, "&grant_type=client_credentials", 30);
+    body = flb_sds_cat(body, "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer", 77);
+    body = flb_sds_cat(body, "&client_assertion=", 18);
+    body = flb_sds_cat(body, federated_token, flb_sds_len(federated_token));
+    /* Use the correct scope and length for Kusto */
+    body = flb_sds_cat(body, "&scope=https://help.kusto.windows.net/.default", 46);
+
+    if (!body) {
+        /* This check might be redundant if flb_sds_cat handles errors, but safe */
+        flb_error("[azure workload identity] failed to build request body");
+        flb_sds_destroy(federated_token);
+        return -1;
+    }
+
+    /* Get upstream connection to Azure AD token endpoint */
+    u_conn = flb_upstream_conn_get(ctx->u);
+    if (!u_conn) {
+        flb_error("[azure workload identity] could not get an upstream connection");
+        flb_sds_destroy(federated_token);
+        flb_sds_destroy(body); /* Clean up allocated body */
+        return -1;
+    }
+
+    /* Create HTTP client context, passing the body directly */
+    c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
+                        body, flb_sds_len(body), /* Pass body buffer and length here */
+                        ctx->host, atoi(ctx->port), NULL, 0);
+    if (!c) {
+        flb_error("[azure workload identity] error creating HTTP client context");
+        flb_upstream_conn_release(u_conn);
+        flb_sds_destroy(federated_token);
+        flb_sds_destroy(body); /* Clean up allocated body */
+        return -1;
+    }
+
+    /* Prepare token exchange request headers */
+    flb_http_add_header(c, "Content-Type", 12, "application/x-www-form-urlencoded", 33);
+
+    /* Remove the direct assignment as body is passed during creation */
+    /* c->body_buf = body; */
+    /* c->body_len = flb_sds_len(body); */
+
+    /* Add a debug log to verify the body content just before sending */
+    flb_debug("[azure workload identity] Sending request body (len=%zu): %s", flb_sds_len(body), body);
+
+    /* Issue request */
+    ret = flb_http_do(c, &b_sent);
+
+    /* Clean up the body sds now that the request is done or client creation failed */
+    flb_sds_destroy(body);
+    body = NULL;
+
+    if (ret != 0) {
+        flb_warn("[azure workload identity] error in HTTP request, http_do=%i", ret);
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        flb_sds_destroy(federated_token);
+        /* body already destroyed */
+        return -1;
+    }
+
+    flb_debug("[azure workload identity] HTTP Status=%i", c->resp.status);
+    if (c->resp.payload_size > 0) {
+        if (c->resp.status == 200) {
+            flb_debug("[azure workload identity] token exchange successful");
+        }
+        else {
+            flb_warn("[azure workload identity] token exchange failed: %s", c->resp.payload);
+            flb_http_client_destroy(c);
+            flb_upstream_conn_release(u_conn);
+            flb_sds_destroy(federated_token);
+            /* body already destroyed */
+            return -1;
+        }
+    }
+
+    /* Parse the response and extract the token */
+    if (c->resp.payload_size > 0 && c->resp.status == 200) {
+        ret = flb_oauth2_parse_json_response(c->resp.payload,
+                                             c->resp.payload_size, ctx);
+        if (ret == 0) {
+            flb_info("[azure workload identity] access token retrieved successfully");
+            flb_http_client_destroy(c);
+            flb_upstream_conn_release(u_conn);
+            flb_sds_destroy(federated_token);
+            /* body already destroyed */
+            ctx->issued = time(NULL);
+            ctx->expires = ctx->issued + ctx->expires_in;
+            return 0;
+        }
+    }
+
+    flb_error("[azure workload identity] failed to parse token response");
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
+    flb_sds_destroy(federated_token);
+    /* body already destroyed */
+
+    return -1;
+}

--- a/plugins/out_azure_kusto/azure_msiauth.h
+++ b/plugins/out_azure_kusto/azure_msiauth.h
@@ -24,4 +24,5 @@
     "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01%s%s&resource=https://api.kusto.windows.net"
 
 char *flb_azure_msiauth_token_get(struct flb_oauth2 *ctx);
+int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *token_file, const char *client_id, const char *tenant_id);
 


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit/pull/10283

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
