### PR TITLE
upstream: add null check for stream  cleanup

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -680,8 +680,8 @@ int flb_upstream_destroy(struct flb_upstream *u)
     flb_free(u->proxied_host);
     flb_free(u->proxy_username);
     flb_free(u->proxy_password);
-    
-    if (u->base._head.next != NULL && u->base._head.prev != NULL) {
+
+    if (mk_list_is_set(&u->base._head) == 0) {
         mk_list_del(&u->base._head);
     }
     


### PR DESCRIPTION
<!-- Provide summary of changes -->
This fix prevents a segmentation fault in `flb_upstream_destroy()` that occurs when destroying upstreams that failed during creation. The root cause is that `mk_list_del(&u->base._head)` attempts to unlink from a list even when the upstream was never properly linked due to creation failures, causing the function to access NULL pointers in the list structure. 

This is because [this line](https://github.com/fluent/fluent-bit/blob/84c9647bae00ec4de69d422af4c66fe570d5fc13/src/flb_upstream.c#L360) which links in the end but if any error occurs, the function returns NULL before calling the `mk_list_add` function.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a rare crash during upstream cleanup by guarding list removal, improving stability during shutdown and dynamic reconfiguration.
  * Reduced risk of invalid memory access that could cause unexpected exits, resulting in more reliable runtime behavior.
  * No changes to user workflows or configuration required; benefits are automatic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->