### PR TITLE
in_kmsg: fix typo (it should be strtoull instead of strtoul)

### DIFF
--- a/plugins/in_kmsg/in_kmsg.c
+++ b/plugins/in_kmsg/in_kmsg.c
@@ -114,6 +114,7 @@ static inline int process_line(const char *line,
     struct timeval tv;       /* time value                  */
     int line_len;
     uint64_t val;
+    long pri_val;
     const char *p = line;
     char *end = NULL;
     struct flb_time ts;
@@ -123,14 +124,14 @@ static inline int process_line(const char *line,
     ctx->buffer_id++;
 
     errno = 0;
-    val = strtol(p, &end, 10);
-    if ((errno == ERANGE && (val == INT_MAX || val == INT_MIN))
-        || (errno != 0 && val == 0)) {
+    pri_val = strtol(p, &end, 10);
+    if ((errno == ERANGE && (pri_val == INT_MAX || pri_val == INT_MIN))
+        || (errno != 0 && pri_val == 0)) {
         goto fail;
     }
 
     /* Priority */
-    priority = FLB_KLOG_PRI(val);
+    priority = FLB_KLOG_PRI(pri_val);
 
     if (priority > ctx->prio_level) {
         /* Drop line */
@@ -144,8 +145,9 @@ static inline int process_line(const char *line,
     }
     p++;
 
-    val = strtoul(p, &end, 10);
-    if ((errno == ERANGE && (val == INT_MAX || val == INT_MIN))
+    errno = 0;
+    val = strtoull(p, &end, 10);
+    if ((errno == ERANGE && val == ULLONG_MAX)
         || (errno != 0 && val == 0)) {
         goto fail;
     }
@@ -154,8 +156,8 @@ static inline int process_line(const char *line,
     p = ++end;
 
     /* Timestamp */
-    val = strtoul(p, &end, 10);
-    if ((errno == ERANGE && (val == INT_MAX || val == INT_MIN))
+    val = strtoull(p, &end, 10);
+    if ((errno == ERANGE && val == ULLONG_MAX)
         || (errno != 0 && val == 0)) {
         goto fail;
     }


### PR DESCRIPTION
in 72d9dc8918ca3dad26056c262915908065938882, the intention was to use strtoull, but strtoul was used, so fix that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust parsing of kernel log entries: priority values are parsed reliably to avoid misclassification, and sequence numbers and timestamps fully support 64-bit ranges. Improved error handling prevents overflow and parsing edge-cases, preserving correct event ordering and more accurate time calculations for long-running or high-throughput systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->