### PR TITLE
dockerfiles: windows: Avoid to use recommended components on ltsc2025

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -16,6 +16,8 @@ ARG WINDOWS_VERSION=ltsc2019
 # Builder Image - Windows Server Core
 FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION AS builder-base
 
+ENV WINDOWS_VERSION="$WINDOWS_VERSION"
+
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install Visual Studio Build Tools 2019 (MSVS_VERSION=16) / 2022 (MSVS_VERSION=17, requires WINDOWS_VERSION=ltsc2022)
@@ -29,6 +31,9 @@ RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
     $msvs_build_tools_channel=\"C:\local\VisualStudio.chman\"; `
     $msvs_build_tools_dist_url=\"${env:MSVS_BUILD_TOOLS_DOWNLOAD_URL}/${env:MSVS_BUILD_TOOLS_VERSION}/release/${msvs_build_tools_dist_name}\"; `
     $msvs_build_tools_channel_url=\"${env:MSVS_BUILD_TOOLS_DOWNLOAD_URL}/${env:MSVS_BUILD_TOOLS_VERSION}/release/channel\"; `
+    # Bydefault includeRecommended is absent when using ltsc2025
+    $includeRecommended=\"--includeRecommended\"; `
+    if (\"${env:WINDOWS_VERSION}\" -eq \"ltsc2025\") { $includeRecommended=\"\" }; `
     Write-Host \"Downloading Visual Studio Build Tools...\"; `
     Write-Host \"${msvs_build_tools_dist_url} -> ${msvs_build_tools_dist}\"; `
     Write-Host \"${msvs_build_tools_channel_url} -> ${msvs_build_tools_channel}\"; `
@@ -41,7 +46,10 @@ RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
       \"--channelUri ${msvs_build_tools_channel}\", `
       \"--installChannelUri ${msvs_build_tools_channel}\", `
       '--add Microsoft.VisualStudio.Workload.VCTools', `
-      '--includeRecommended'  -NoNewWindow -Wait; `
+      '--add Microsoft.VisualStudio.Component.Windows10SDK.19041', `
+      '--add Microsoft.VisualStudio.Component.VC.CMake.Project', `
+      $includeRecommended `
+      -NoNewWindow -Wait; `
     Remove-Item -Force \"${msvs_build_tools_dist}\";
 
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Windows container images now expose a WINDOWS_VERSION environment variable for easier scripting and diagnostics.
  - Visual Studio Build Tools now include additional components (Windows 10 SDK and CMake support) by default on applicable base images.

- Chores
  - Build tool installation adapts to the Windows base image: recommended components are skipped on ltsc2025 and retained on earlier versions, reducing install time and image size when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->