### PR TITLE
out_es: add apikey to available auth types

### DIFF
--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -54,6 +54,7 @@ struct flb_elasticsearch {
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;
+    char *http_api_key;
 
     /* Elastic Cloud Auth */
     char *cloud_user;

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -7,6 +7,21 @@
 #include "data/es/json_es.h" /* JSON_ES */
 
 
+static void cb_check_http_api_key(void *ctx, int ffd,
+                                int res_ret, void *res_data,
+                                size_t res_size, void *data)
+{
+    char *api_key = data;
+
+    TEST_CHECK(api_key != NULL);
+    TEST_CHECK(strlen(api_key) > 0);
+
+    TEST_CHECK(strcmp(api_key, "my-api-key-for-elasticsearch") == 0);
+
+    flb_free(res_data);
+}
+
+
 static void cb_check_write_op_index(void *ctx, int ffd,
                                     int res_ret, void *res_data,
                                     size_t res_size, void *data)
@@ -722,6 +737,51 @@ void flb_test_div0()
     flb_destroy(ctx);
 }
 
+void flb_test_http_api_key()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *api_key = "my-api-key-for-elasticsearch";
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    /* Configure http_api_key */
+    flb_output_set(ctx, out_ffd,
+                   "http_api_key", api_key,
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_api_key,
+                              api_key, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 
 static void cb_check_long_index(void *ctx, int ffd,
                                 int res_ret, void *res_data, size_t res_size,
@@ -1012,6 +1072,7 @@ TEST_LIST = {
     {"tag_key"               , flb_test_tag_key },
     {"replace_dots"          , flb_test_replace_dots },
     {"id_key"                , flb_test_id_key },
+    {"http_api_key"          , flb_test_http_api_key },
     {"logstash_prefix_separator" , flb_test_logstash_prefix_separator },
     {"response_success"      , flb_test_response_success },
     {"response_successes", flb_test_response_successes },


### PR DESCRIPTION
Backport of  #10461

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
