### PR TITLE
out_opentelemetry: add AWS authentication support

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -24,6 +24,12 @@
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_ra_key.h>
 #include <fluent-bit/flb_http_client.h>
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+#include <fluent-bit/flb_aws_credentials.h>
+#define FLB_OPENTELEMETRY_AWS_CREDENTIAL_PREFIX "aws_"
+#endif
+#endif
 
 #define FLB_OPENTELEMETRY_CONTENT_TYPE_HEADER_NAME "Content-Type"
 #define FLB_OPENTELEMETRY_MIME_PROTOBUF_LITERAL    "application/x-protobuf"
@@ -51,6 +57,16 @@ struct opentelemetry_context {
     /* HTTP Auth */
     char *http_user;
     char *http_passwd;
+
+    /* AWS Auth */
+#ifdef FLB_HAVE_SIGNV4
+#ifdef FLB_HAVE_AWS
+    int has_aws_auth;
+    struct flb_aws_provider *aws_provider;
+    const char *aws_region;
+    const char *aws_service;
+#endif
+#endif
 
     /* Proxy */
     const char *proxy;


### PR DESCRIPTION
WIP: AWS auth support for OpenTelemetry output

```
aws_auth                                 Enable AWS SigV4 authentication
                                         > default: false, type: boolean

aws_service                              AWS destination service code, used by SigV4
                                         authentication
                                         > default: logs, type: string

aws_region                               AWS region of your service
                                         > default: default, type: string

aws_sts_endpoint                         Custom endpoint for the AWS STS API, used with
                                         the `aws_role_arn` option
                                         > default: default, type: string

aws_role_arn                             ARN of an IAM role to assume (ex. for cross
                                         account access)
                                         > default: default, type: string

aws_external_id                          Specify an external ID for the STS API, can be
                                         used with the `aws_role_arn` parameter if your
                                         role requires an external ID.
                                         > default: default, type: string

aws_profile                              AWS Profile name. AWS Profiles can be configured
                                         with AWS CLI and are usuallystored in $HOME/.aws/
                                         directory.
                                         > default: default, type: string
```

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
