### PR TITLE
blob: Plug a sqldb encapsulation leak

### DIFF
--- a/src/flb_blob_db.c
+++ b/src/flb_blob_db.c
@@ -909,7 +909,7 @@ int flb_blob_db_file_part_insert(struct flb_blob_db *context,
     else {
         result = FLB_BLOB_DB_SUCCESS;
 
-        *out_id = sqlite3_last_insert_rowid(context->db);
+        *out_id = flb_sqldb_last_id(context->db);
     }
 
     sqlite3_clear_bindings(statement);


### PR DESCRIPTION
<!-- Provide summary of changes -->

This should be needed for compilation with the recent version of gcc.
gcc-14 or later checks that kind of glitches and make an error.

This is also occurred on my dev box's archlinux WSL2 environment.

> [ 56%] Building C object src/CMakeFiles/fluent-bit-static.dir/config_format/flb_config_format.c.o
/tmp/fluent-bit/src/flb_blob_db.c: In function 'flb_blob_db_file_part_insert':
/tmp/fluent-bit/src/flb_blob_db.c:912:52: error: passing argument 1 of 'sqlite3_last_insert_rowid' from incompatible pointer type [-Wincompatible-pointer-types]
  912 |         *out_id = sqlite3_last_insert_rowid(context->db);
      |                                             ~~~~~~~^~~~
      |                                                    |
      |                                                    __internal_flb_sqldb * {aka struct flb_sqldb *}
In file included from /tmp/fluent-bit/include/fluent-bit/flb_sqldb.h:23,
                 from /tmp/fluent-bit/src/flb_blob_db.c:22:
/tmp/fluent-bit/lib/sqlite-amalgamation-3450200/sqlite3.h:2588:52: note: expected 'sqlite3 *' but argument is of type '__internal_flb_sqldb *' {aka 'struct flb_sqldb *'}
 2588 | SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3*);
      |                                                    ^~~~~~~~
[ 56%] Building C object src/CMakeFiles/fluent-bit-static.dir/config_format/flb_cf_fluentbit.c.o
make[2]: *** [src/CMakeFiles/fluent-bit-static.dir/build.make:1325: src/CMakeFiles/fluent-bit-static.dir/flb_blob_db.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:12446: src/CMakeFiles/fluent-bit-static.dir/all] Error 2
make: *** [Makefile:156: all] Error 2

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

This issue was initially reported in https://github.com/fluent/fluent-bit/pull/10728#issue-3320696105.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving data by ensuring the correct record ID is returned after inserts, reducing rare cases of mismatched IDs and subsequent operation failures.
  * Enhances stability around database write operations without altering existing behavior or workflows.
  * No changes to public interfaces; upgrades are backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->