### PR TITLE
in_tail: fix memory leak when using generic unicode conversion (backport #10781)

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -651,12 +651,11 @@ static int process_content(struct flb_tail_file *file, size_t *bytes)
         file->last_processed_bytes += processed_bytes;
     }
 
-#ifdef FLB_HAVE_UNICODE_ENCODER
     if (decoded) {
         flb_free(decoded);
         decoded = NULL;
     }
-#endif
+
     file->parsed = file->buf_len;
 
     if (lines > 0) {


### PR DESCRIPTION
# Summary

Backport of #10781.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Prometheus textfile input.
  - Expanded Node Exporter metrics (sockstat, hwmon, rootfs path) and NGINX scrape_interval.
  - Introduced Windows Exporter cache and TCP metrics.
  - Added Elasticsearch API key auth.
  - Expanded Azure Kusto auth (service principal, managed identity, workload identity).
  - Added CloudWatch Logs entity support.
  - Windows TLS CertStore support for outputs.

- Improvements
  - Output latency histogram; skip emitting empty metrics.
  - Firehose/Kinesis configurable ports; Windows builds updated (ltsc2025).
  - Version bump to 4.0.9.

- Bug Fixes
  - OTEL logs null/type handling; JSON numeric/overflow; histogram bucket and allocation; Kafka commit logic; syslog/tail memory; Windows timezone.

- Tests
  - New runtime and internal tests for Prometheus textfile, Chronicle, OTEL, and JSON packing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->