### PR TITLE
Add warning and metrics for abandoned files

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -479,6 +479,18 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
                                                 "Total number of rotated files",
                                                 1, (char *[]) {"name"});
 
+    ctx->cmt_files_abandoned = cmt_counter_create(ins->cmt,
+                                               "fluentbit", "input",
+                                               "files_abandoned_total",
+                                               "Total number of abandoned files",
+                                               1, (char *[]) {"name"});
+
+    ctx->cmt_bytes_abandoned = cmt_counter_create(ins->cmt,
+                                               "fluentbit", "input",
+                                               "bytes_abandoned_total",
+                                               "Total number of pending bytes in abandoned files",
+                                               1, (char *[]) {"name"});
+
     /* OLD metrics */
     flb_metrics_add(FLB_TAIL_METRIC_F_OPENED,
                     "files_opened", ctx->ins->metrics);

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -167,6 +167,8 @@ struct flb_tail_config {
     struct cmt_counter *cmt_files_opened;
     struct cmt_counter *cmt_files_closed;
     struct cmt_counter *cmt_files_rotated;
+    struct cmt_counter *cmt_files_abandoned;
+    struct cmt_counter *cmt_bytes_abandoned;
 
     /* Hash: hash tables for quick acess to registered files */
     struct flb_hash_table *static_hash;


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
