### PR TITLE
cmake: backport #10778 and #10786 to 4.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,14 @@ if(FLB_SMALL)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -g0 ${strip_flag} -fno-stack-protector -fomit-frame-pointer -DNDEBUG -U_FORTIFY_SOURCE")
 endif()
 
+# simdutf
+if(FLB_UNICODE_ENCODER)
+  if (NOT FLB_USE_SIMDUTF)
+    message(STATUS "FLB_USE_SIMDUTF is disabled. Disabling FLB_UNICODE_ENCODER support.")
+    set(FLB_UNICODE_ENCODER OFF)
+  endif()
+endif()
+
 if(FLB_COVERAGE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
   if (FLB_UNICODE_ENCODER)


### PR DESCRIPTION
# Summary

Allow disabling simdutf support.

# Description

Backport of the patches #10778 and #10786 to make the use of simdutf optional.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Prometheus textfile input plugin.
  - Expanded Node Exporter metrics: sockstat, hwmon, path.rootfs support.
  - Windows Exporter: new cache and TCP metrics.
  - Elasticsearch: API key authentication.
  - Azure Kusto: supports service principal, managed identity, and workload identity auth.

- Improvements
  - NGINX exporter: configurable scrape_interval.
  - Output latency histogram metrics.
  - Syslog input batches and flushes encoded output.
  - Kinesis Firehose/Streams: robust port handling.

- Bug Fixes
  - OpenTelemetry logs: stricter ID validation and safer value handling.
  - cmetrics histogram allocation/off-by-one fixes.

- Chores
  - Version bump to 4.0.9.
  - Debian base images switched to archive mirrors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->