### PR TITLE
network: fix strerror_r detection for musl

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -638,9 +638,9 @@ static int net_connect_async(int fd,
             }
 
             /* Connection is broken, not much to do here */
-#if ((defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) ||    \
-     (defined(_XOPEN_SOURCE) || _XOPEN_SOURCE - 0L >= 600L)) &&     \
-  (!defined(_GNU_SOURCE))
+#ifdef __GLIBC__
+            str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
+#else
             ret = strerror_r(error, so_error_buf, sizeof(so_error_buf));
             if (ret == 0) {
                 str = so_error_buf;
@@ -649,8 +649,6 @@ static int net_connect_async(int fd,
                 flb_errno();
                 return -1;
             }
-#else
-            str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
 #endif
             flb_error("[net] TCP connection failed: %s:%i (%s)",
                       u->tcp_host, u->tcp_port, str);


### PR DESCRIPTION
```
/home/thomas/br-test-pkg/bootlin-armv7-musl/build/fluent-bit-4.0.8/src/flb_network.c: In function ‘net_connect_async’: /home/thomas/br-test-pkg/bootlin-armv7-musl/build/fluent-bit-4.0.8/src/flb_network.c:653:17: error: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  653 |             str = strerror_r(error, so_error_buf, sizeof(so_error_buf));
      |                 ^
```
This fix should work perfectly for:

- glibc systems: Uses str = strerror_r(...) (GNU version)
- musl systems: Uses ret = strerror_r(...); if (ret == 0) str = so_error_buf; (POSIX version)
- Other libc implementations: Defaults to POSIX behavior

Fix is similar to https://github.com/janet-lang/janet/commit/a5d6b2283834422a9fa9e79b5c7ad9b932b52568.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - More reliable and accurate error messages when a TCP connection fails.
  - Improved cross-platform behavior for error reporting on Linux (glibc) and other environments.
  - Prevents rare failures when retrieving error text during connection errors.

- Refactor
  - Streamlined error-handling path for asynchronous network connections to improve robustness without changing external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->