### PR TITLE
http_client: add response and read idle timeouts (backport v4.0)

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_http_common.h>
 #include <fluent-bit/flb_http_client_http1.h>
 #include <fluent-bit/flb_http_client_http2.h>
+#include <time.h>
 
 #define HTTP_CLIENT_TEMPORARY_BUFFER_SIZE (1024 * 64)
 
@@ -245,6 +246,13 @@ struct flb_http_client {
     /* Response */
     struct flb_http_client_response resp;
 
+    /* State tracking */
+    time_t ts_start;
+    time_t last_read_ts;
+
+    int response_timeout;
+    int read_idle_timeout;
+
     /* Tests */
     int test_mode;
     struct flb_test_http_response test_response;
@@ -373,6 +381,8 @@ int flb_http_set_keepalive(struct flb_http_client *c);
 int flb_http_set_content_encoding_gzip(struct flb_http_client *c);
 int flb_http_set_content_encoding_zstd(struct flb_http_client *c);
 int flb_http_set_content_encoding_snappy(struct flb_http_client *c);
+int flb_http_set_read_idle_timeout(struct flb_http_client *c, int timeout);
+int flb_http_set_response_timeout(struct flb_http_client *c, int timeout);
 
 int flb_http_set_callback_context(struct flb_http_client *c,
                                   struct flb_callback *cb_ctx);

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -193,6 +193,15 @@ static int http_post(struct flb_out_http *ctx,
      */
     c->cb_ctx = ctx->ins->callback;
 
+    flb_http_set_response_timeout(c, ctx->response_timeout);
+
+    if (ctx->read_idle_timeout > 0) {
+        flb_http_set_read_idle_timeout(c, ctx->read_idle_timeout);
+    }
+    else {
+        flb_http_set_read_idle_timeout(c, ctx->ins->net_setup.io_timeout);
+    }
+
     /* Append headers */
     if (headers) {
         append_headers(c, headers);
@@ -677,6 +686,16 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_BOOL, "log_response_payload", "true",
      0, FLB_TRUE, offsetof(struct flb_out_http, log_response_payload),
      "Specify if the response paylod should be logged or not"
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "http.response_timeout", "60s",
+     0, FLB_TRUE, offsetof(struct flb_out_http, response_timeout),
+     "Set maximum time to wait for a server response"
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "http.read_idle_timeout", "0s",
+     0, FLB_TRUE, offsetof(struct flb_out_http, read_idle_timeout),
+     "Set maximum allowed time between two consecutive reads"
     },
     {
      FLB_CONFIG_MAP_STR, "http_user", NULL,

--- a/plugins/out_http/http.h
+++ b/plugins/out_http/http.h
@@ -94,6 +94,12 @@ struct flb_out_http {
     /* Log the response paylod */
     int log_response_payload;
 
+    /* Response timeout */
+    int response_timeout;
+
+    /* Read idle timeout */
+    int read_idle_timeout;
+
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
 

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1503,15 +1503,17 @@ int flb_http_get_response_data(struct flb_http_client *c, size_t bytes_consumed)
         }
         now = time(NULL);
 
-        if (c->response_timeout > 0 &&
-            (now - c->ts_start) > c->response_timeout) {
-            flb_error("[http_client] response timeout reached");
+        if (c->response_timeout > 0 && (now - c->ts_start) > c->response_timeout) {
+            flb_error("[http_client] response timeout reached (elapsed=%lds, limit=%ds)",
+                      (long)(now - c->ts_start), c->response_timeout);
+            flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
             return FLB_HTTP_ERROR;
         }
 
-        if (c->read_idle_timeout > 0 &&
-            (now - c->last_read_ts) > c->read_idle_timeout) {
-            flb_error("[http_client] read idle timeout reached");
+        if (c->read_idle_timeout > 0 &&  (now - c->last_read_ts) > c->read_idle_timeout) {
+            flb_error("[http_client] read idle timeout reached (idle=%lds, limit=%ds)",
+                      (long)(now - c->last_read_ts), c->read_idle_timeout);
+            flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
             return FLB_HTTP_ERROR;
         }
 


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit/pull/10801

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
