### PR TITLE
opentelemetry: remove enforcement of timestamp fields for logs (backport v4.0)

### DIFF
--- a/src/opentelemetry/flb_opentelemetry_logs.c
+++ b/src/opentelemetry/flb_opentelemetry_logs.c
@@ -21,6 +21,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_opentelemetry.h>
 #include <ctype.h>
 
@@ -73,13 +74,9 @@ static int process_json_payload_log_records_entry(
         result = flb_otel_utils_find_map_entry_by_key(log_records_entry, "observedTimeUnixNano", 0, FLB_TRUE);
     }
 
-    /* we need a timestamp... */
+    /* fallback to current time if both timestamp fields are missing */
     if (result == -1) {
-        if (error_status) {
-            *error_status = FLB_OTEL_LOGS_ERR_MISSING_TIMESTAMP;
-        }
-        return -FLB_OTEL_LOGS_ERR_MISSING_TIMESTAMP;
-
+        flb_time_get(&timestamp);
     }
     else {
         timestamp_object = &log_records_entry->ptr[result].val;

--- a/tests/internal/data/opentelemetry/README.md
+++ b/tests/internal/data/opentelemetry/README.md
@@ -136,7 +136,7 @@ For error cases, use the `expected_error` field:
   "test_case_name": {
     "input": { ... },
     "expected_error": {
-      "code": "FLB_OTEL_LOGS_ERR_MISSING_TIMESTAMP"
+      "code": "FLB_OTEL_LOGS_ERR_UNEXPECTED_LOGRECORDS_ENTRY_TYPE"
     }
   }
 }

--- a/tests/internal/data/opentelemetry/test_cases.json
+++ b/tests/internal/data/opentelemetry/test_cases.json
@@ -37,9 +37,12 @@
   },
 
   "missing_timestamp": {
-    "input": {"resourceLogs": [{"scopeLogs": [{"logRecords": [{}]}]}]},
-    "expected_error": {
-      "code": "FLB_OTEL_LOGS_ERR_MISSING_TIMESTAMP"
+    "input": {"resourceLogs": [{"scopeLogs": [{"logRecords": [{"body": {"stringValue": "test"}}]}]}]},
+    "expected": {
+      "group_metadata": {"schema":"otlp","resource_id":0,"scope_id":0},
+      "group_body": {"resource":{}},
+      "log_metadata": {"otlp":{}},
+      "log_body": {"log": "test"}
     }
   },
 
@@ -985,49 +988,6 @@
     },
     "expected_error": {
       "code": "FLB_OTEL_LOGS_ERR_SCOPELOGS_MISSING"
-    }
-  },
-
-  "multiple_records_no_timestamp_after_valid_ones": {
-    "input": {
-      "resourceLogs": [{
-        "resource": {
-          "attributes": [
-            {"key": "service.name", "value": {"stringValue": "test-service"}}
-          ]
-        },
-        "scopeLogs": [{
-          "scope": {
-            "name": "test-scope"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1640995200000000000",
-              "severityNumber": 9,
-              "severityText": "INFO",
-              "attributes": [
-                {"key": "user.id", "value": {"stringValue": "user123"}},
-                {"key": "action", "value": {"stringValue": "login"}}
-              ],
-              "body": {"stringValue": "User login successful"}
-            },
-            {
-              "timeUnixNano": "1640995201000000000",
-              "severityNumber": 5,
-              "severityText": "DEBUG",
-              "body": {"stringValue": "Processing user session"}
-            },
-            {
-              "severityNumber": 13,
-              "severityText": "ERROR",
-              "body": {"stringValue": "This log is missing timestamp"}
-            }
-          ]
-        }]
-      }]
-    },
-    "expected_error": {
-      "code": "FLB_OTEL_LOGS_ERR_MISSING_TIMESTAMP"
     }
   },
 


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit/pull/10813 , fixes https://github.com/fluent/fluent-bit/issues/10793

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
