### PR TITLE
opentelemetry: fix handling of numeric attributes (backport v4.0)

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_traces.c
+++ b/plugins/in_opentelemetry/opentelemetry_traces.c
@@ -93,24 +93,46 @@ static int process_attribute(struct ctrace_attributes *attr,
         break;
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-        if (value->type != MSGPACK_OBJECT_POSITIVE_INTEGER &&
-            value->type != MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+        if (value->type == MSGPACK_OBJECT_STR) {
+            value_str = flb_sds_create_len(value->via.str.ptr, value->via.str.size);
+            if (value_str == NULL) {
+                flb_sds_destroy(key_str);
+                return -1;
+            }
+            value_int = strtoll(value_str, NULL, 10);
+            flb_sds_destroy(value_str);
+        }
+        else if (value->type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
+                 value->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+            value_int = value->via.i64;
+        }
+        else {
             flb_sds_destroy(key_str);
             return -1;
         }
 
-        value_int = value->via.i64;
         ret = ctr_attributes_set_int64(attr, key_str, value_int);
         break;
     case MSGPACK_OBJECT_FLOAT32:
     case MSGPACK_OBJECT_FLOAT64:
-        if (value->type != MSGPACK_OBJECT_FLOAT32 &&
-            value->type != MSGPACK_OBJECT_FLOAT64) {
+        if (value->type == MSGPACK_OBJECT_STR) {
+            value_str = flb_sds_create_len(value->via.str.ptr, value->via.str.size);
+            if (value_str == NULL) {
+                flb_sds_destroy(key_str);
+                return -1;
+            }
+            value_double = strtod(value_str, NULL);
+            flb_sds_destroy(value_str);
+        }
+        else if (value->type == MSGPACK_OBJECT_FLOAT32 ||
+                 value->type == MSGPACK_OBJECT_FLOAT64) {
+            value_double = value->via.f64;
+        }
+        else {
             flb_sds_destroy(key_str);
             return -1;
         }
 
-        value_double = value->via.f64;
         ret = ctr_attributes_set_double(attr, key_str, value_double);
         break;
     case MSGPACK_OBJECT_BOOLEAN:

--- a/src/opentelemetry/flb_opentelemetry_utils.c
+++ b/src/opentelemetry/flb_opentelemetry_utils.c
@@ -113,16 +113,18 @@ int flb_otel_utils_json_payload_get_wrapped_value(msgpack_object *wrapper,
             }
             else if (strncasecmp(kv_key->ptr, "intValue",  kv_key->size) == 0) {
                 if (kv_value->type != MSGPACK_OBJECT_POSITIVE_INTEGER &&
-                    kv_value->type != MSGPACK_OBJECT_NEGATIVE_INTEGER) {
-                    /* If the value is not an integer, we cannot process it */
+                    kv_value->type != MSGPACK_OBJECT_NEGATIVE_INTEGER &&
+                    kv_value->type != MSGPACK_OBJECT_STR) {
+                    /* If the value is not an integer or string, we cannot process it */
                     return -2;
                 }
                 internal_type = MSGPACK_OBJECT_POSITIVE_INTEGER;
             }
             else if (strncasecmp(kv_key->ptr, "doubleValue",  kv_key->size) == 0) {
                 if (kv_value->type != MSGPACK_OBJECT_FLOAT32 &&
-                    kv_value->type != MSGPACK_OBJECT_FLOAT64) {
-                    /* If the value is not a float, we cannot process it */
+                    kv_value->type != MSGPACK_OBJECT_FLOAT64 &&
+                    kv_value->type != MSGPACK_OBJECT_STR) {
+                    /* If the value is not a float or string, we cannot process it */
                     return -2;
                 }
                 internal_type = MSGPACK_OBJECT_FLOAT;

--- a/tests/internal/data/opentelemetry/test_cases.json
+++ b/tests/internal/data/opentelemetry/test_cases.json
@@ -1255,6 +1255,29 @@
       "log_body": {"a":{"d":[{"e":"g"}]}}
     }
   },
+  "resource_attribute_intvalue_string": {
+    "input": {
+      "resourceLogs": [{
+        "resource": {
+          "attributes": [
+            {"key": "resourceVersion", "value": {"intValue": "1"}}
+          ]
+        },
+        "scopeLogs": [{
+          "logRecords": [{
+            "timeUnixNano": "1640995200000000000",
+            "body": {"stringValue": "test log"}
+          }]
+        }]
+      }]
+    },
+    "expected": {
+      "group_metadata": {"schema":"otlp","resource_id":0,"scope_id":0},
+      "group_body": {"resource":{"attributes":{"resourceVersion":1}}},
+      "log_metadata": {"otlp":{}},
+      "log_body": {"log": "test log"}
+    }
+  },
   "unwrapped_plain_map": {
     "input": {
       "resourceLogs": [{

--- a/tests/internal/opentelemetry.c
+++ b/tests/internal/opentelemetry.c
@@ -475,6 +475,27 @@ void test_json_payload_get_wrapped_value()
 
     msgpack_sbuffer_destroy(&sbuf);
     msgpack_unpacked_destroy(&up);
+
+    /* Test integer value provided as a string */
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&pck, 1);
+    msgpack_pack_str(&pck, 8);
+    msgpack_pack_str_body(&pck, "intValue", 8);
+    msgpack_pack_str(&pck, 1);
+    msgpack_pack_str_body(&pck, "1", 1);
+
+    msgpack_unpacked_init(&up);
+    msgpack_unpack_next(&up, sbuf.data, sbuf.size, NULL);
+
+    ret = flb_otel_utils_json_payload_get_wrapped_value(&up.data, &val, &type);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+    TEST_CHECK(val->type == MSGPACK_OBJECT_STR);
+
+    msgpack_sbuffer_destroy(&sbuf);
+    msgpack_unpacked_destroy(&up);
 }
 
 #define OTEL_TEST_CASES_PATH      FLB_TESTS_DATA_PATH "/data/opentelemetry/test_cases.json"


### PR DESCRIPTION
Backport of #10815, fixes https://github.com/fluent/fluent-bit/issues/10796

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
