### PR TITLE
out_s3: implement retry_limit parameter

### DIFF
--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -48,6 +48,8 @@
 
 #define DEFAULT_UPLOAD_TIMEOUT 3600
 
+#define MAX_UPLOAD_ERRORS 5
+
 /*
  * If we see repeated errors on an upload/chunk, we will discard it
  * This saves us from scenarios where something goes wrong and an upload can
@@ -56,8 +58,9 @@
  *
  * The same is done for chunks, just to be safe, even though realistically
  * I can't think of a reason why a chunk could become unsendable.
+ *
+ * The retry limit is now configurable via the retry_limit parameter.
  */
-#define MAX_UPLOAD_ERRORS 5
 
 struct upload_queue {
     struct s3_file *upload_file;
@@ -96,7 +99,7 @@ struct multipart_upload {
 
     struct mk_list _head;
 
-    /* see note for MAX_UPLOAD_ERRORS */
+    /* see note for retry_limit configuration */
     int upload_errors;
     int complete_errors;
 };


### PR DESCRIPTION
retry_limit parameter is not honored and is set to 5. This feature provides dynamic retry_limit based on configuration for out_s3 plugin.

<!-- Provide summary of changes -->

This feature fixes the infinite retry when buffers are cleared and Bucket name does not exist. It also implements retry_limit when users provide it on a out_s3 plugin level.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
```conf

[SERVICE]
    flush        1
    daemon       Off
    log_level    info
    http_server  Off
    http_listen  0.0.0.0
    http_port    2020

[INPUT]
        Name dummy
        Tag dummy.data
        Dummy {"this is":"dummy data"}
        Rate 1
        Samples 1

[OUTPUT]
        Name                         s3
        Match                        dummy.data
        bucket                       NON_EXISTENT_BUCKET
        region                       us-west-2
        retry_limit                  2
        total_file_size              60M
        upload_timeout               20s
        log_level                    info
        net.keepalive_idle_timeout   60
        tls.verify                   False
        compression                  gzip
        use_put_object               True
        store_dir_limit_size         5G
        role_arn                     <ROLE_NAME>
        s3_key_format                /testpath/zstd4/%H%M%S-$UUID.gz
        workers                      1

[OUTPUT]
        Name                         s3
        Match                        dummy.data
        bucket                      NON_EXISTENT_BUCKET
        region                       us-west-2
        total_file_size              60M
        retry_limit                  5
        upload_timeout               20s
        log_level                    info
        net.keepalive_idle_timeout   60
        tls.verify                   False
        compression                  gzip
        use_put_object               True
        store_dir_limit_size         5G
        role_arn                     arn:aws:iam::654907767108:role/oil-publisher-role-irsa
        s3_key_format                /testpath/zstd0/%H%M%S-$UUID.gz
        workers                      1

```


- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
[flb.log](https://github.com/user-attachments/files/22135194/flb.log)


- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

This run is for the scenario where we do not push the records.
[valgrind_report.txt](https://github.com/user-attachments/files/22135703/valgrind_report.txt)

This Report is justified as we dont want to delete the file and use `flb_fstore_file_inactive(ctx->fs, fsf)` instead of `flb_fstore_destroy(ctx->fs)`

It correlates with the current Master version : 
[valgrind_mem_check_4.0.8.txt](https://github.com/user-attachments/files/22138344/valgrind_mem_check_4.0.8.txt)





If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [NA] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [NA] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [NA] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

# Additional Tests Run with Logs : 

[Buffers Cleared Everytime]
BUCKET DOES NOT EXIST
1. 1 s3 output plugin; retry_limit 3 :: Stops after 3 times trying :: SUCCESS -> [NON_EXISTENT_TEST_1s3_3retry.txt](https://github.com/user-attachments/files/22134520/NON_EXISTENT_TEST_1s3_3retry.txt)
2. 1 s3 output plugin; retry_limit 2 :: Stops after 2 times trying :: SUCCESS -> [NON_EXISTENT_TEST_1s3_2retry.txt](https://github.com/user-attachments/files/22134521/NON_EXISTENT_TEST_1s3_2retry.txt)
3. 1 s3 output plugin; No retry_limit :: Stops after 1 time trying :: SUCCESS -> [NON_EXISTENT_TEST_1s3_1retry.txt](https://github.com/user-attachments/files/22134522/NON_EXISTENT_TEST_1s3_1retry.txt)
4. 2 s3 output plugin; 1 correct, 1 incorrect retry_limit 2 :: 1 successfully uploads, 1 stops after 3 times :: SUCCESS -> [NON_EXISTENT_TEST_2s3_1correct_2retry.txt](https://github.com/user-attachments/files/22134519/NON_EXISTENT_TEST_2s3_1correct_2retry.txt)
5. 2 s3 output plugin; 2 incorrect retry_limit 1 and 2 :: 1 stops after 3 retries and other stops after 2 :: SUCCESS -> [NON_EXISTENT_TEST_2s3_2retry_3retry.txt](https://github.com/user-attachments/files/22134518/NON_EXISTENT_TEST_2s3_2retry_3retry.txt)

[Buffers Cleared Everytime]
BUCKET EXISTS
1. 1 s3 output plugin; retry_limit 2 :: successfully uploads :: [NORMAL_BUCKET_1s3_2retry.txt](https://github.com/user-attachments/files/22134516/NORMAL_BUCKET_1s3_2retry.txt)
2. 1 s3 output plugins; retry_limit 0 :: successfully uploads :: [NORMAL_BUCKET_1s3_1retry.txt](https://github.com/user-attachments/files/22134517/NORMAL_BUCKET_1s3_1retry.txt)
3. 2 s3 output plugins; retry_limit 1 :: successfully uploads :: [NORMAL_BUCKET_2s3_2retry.txt](https://github.com/user-attachments/files/22134515/NORMAL_BUCKET_2s3_2retry.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable retry_limit for the S3 output plugin (default: 5), allowing per-instance control of upload retry attempts.
  * Uploads/chunks that exceed the configured retry_limit are discarded/inactivated to avoid endless retries.
  * Log messages now reference the configured retry_limit for clearer diagnostics.

* **Documentation**
  * Added configuration description for retry_limit and its default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes: #10819 