### PR TITLE
zstd: aws: compress: fix incompatible pointer glitches

### DIFF
--- a/include/fluent-bit/flb_zstd.h
+++ b/include/fluent-bit/flb_zstd.h
@@ -23,7 +23,7 @@
 #include <fluent-bit/flb_info.h>
 #include <zstd.h>
 
-size_t flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len);
-size_t flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *out_len);
+int flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len);
+int flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *out_len);
 
 #endif

--- a/src/aws/flb_aws_compress.c
+++ b/src/aws/flb_aws_compress.c
@@ -52,7 +52,7 @@ static const struct compression_option compression_options[] = {
     {
         FLB_AWS_COMPRESS_ZSTD,
         "zstd",
-        (int *)&flb_zstd_compress
+        &flb_zstd_compress
     },
 #ifdef FLB_HAVE_ARROW
     {

--- a/src/flb_zstd.c
+++ b/src/flb_zstd.c
@@ -27,7 +27,7 @@
 
 #define FLB_ZSTD_DEFAULT_CHUNK 64 * 1024  /* 64 KB buffer */
 
-size_t flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len)
+int flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len)
 {
     void *buf;
     size_t size;
@@ -127,7 +127,7 @@ static int zstd_uncompress_unknown_size(void *in_data, size_t in_len, void **out
     return 0;
 }
 
-size_t flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *out_len)
+int flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *out_len)
 {
     int ret;
     void *buf;

--- a/tests/internal/aws_compress.c
+++ b/tests/internal/aws_compress.c
@@ -274,7 +274,7 @@ static void flb_aws_compress_truncate_b64_test_cases__zstd_decode(
                                                         size_t max_out_len)
 {
    flb_aws_compress_general_test_cases(FLB_AWS_COMPRESS_TEST_TYPE_B64_TRUNCATE,
-                                      cases, max_out_len, (int *)&flb_zstd_uncompress);
+                                      cases, max_out_len, &flb_zstd_uncompress);
 }
 
 /* General test case loop flb_aws_compress */


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is following up PR for https://github.com/fluent/fluent-bit/pull/10794.
From gcc-14 or above, a check of incompatible pointer types was starting to be quite struct behavior.
And I found that public functions on flb_zstd.c are not needed to use size_t as return types because they just return their status codes.
So, we need to adjust their return types and to remove needless type castings.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Zstandard compression/decompression helpers now return status codes instead of sizes, improving clarity and consistency. Integrations that rely on previous return values may need updates.
- Bug Fixes
  - Improved error signaling during compression/decompression to prevent misinterpreting failures as valid sizes.
- Tests
  - Updated test cases to align with the new status-based return behavior for compression/decompression helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->