### PR TITLE
crash on hot reload hangs

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1082,6 +1082,13 @@ int flb_engine_start(struct flb_config *config)
                     }
 
                     ret = tasks + mem_chunks + fs_chunks;
+                    /* Hot reload safety timeout: prevent infinite hangs even with grace = -1 */
+                    if (ret > 0 && config->shutdown_by_hot_reloading && config->grace == -1 && config->grace_count >= 10) {
+                        flb_error("[engine] hot reload timeout exceeded (10s), crashing to prevent "
+                                  "indefinite hang");
+                        flb_task_running_print(config);
+                        return -1;
+                    }
                     if (ret > 0 && (config->grace_count < config->grace || config->grace == -1)) {
                         if (config->grace_count == 1) {
                             /*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a hard safety timeout for hot-reloads to abort after extended grace when work remains.
  * Recounts pending work during shutdown and improves diagnostics with backlog, memory and filesystem chunk details.
  * When configured, pending data is segregated or flushed during shutdown to ensure data handling.

* Bug Fixes
  * Prevents rare stalls by aborting hot-reloads after repeated grace timeouts.
  * Preserves clean, graceful shutdown when no backlog exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->