### PR TITLE
aws: add a 10s response timeout to http client

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -46,6 +46,7 @@
 #define AWS_USER_AGENT_K8S "k8s"
 #define AWS_ECS_METADATA_URI "ECS_CONTAINER_METADATA_URI_V4"
 #define FLB_MAX_AWS_RESP_BUFFER_SIZE 0 /* 0 means unlimited capacity as per requirement */
+#define FLB_MAX_AWS_RESP_TIMEOUT 10 /* 10 seconds */
 
 #ifdef FLB_SYSTEM_WINDOWS
 #define FLB_AWS_BASE_USER_AGENT        "aws-fluent-bit-plugin-windows"
@@ -385,6 +386,9 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
         }
         goto error;
     }
+
+    /* Set a HTTP response timeout */
+    flb_http_set_response_timeout(c, FLB_MAX_AWS_RESP_TIMEOUT);
 
     /* Increase the maximum HTTP response buffer size to fit large responses from AWS services */
     ret = flb_http_buffer_size(c, FLB_MAX_AWS_RESP_BUFFER_SIZE);


### PR DESCRIPTION
Fixes #10051

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 10-second response timeout for outgoing HTTP requests to avoid indefinite waits.
  * Improves stability and predictability by failing faster when remote services are slow or unresponsive.
  * Users will see quicker error feedback under poor network conditions, enabling faster retries or fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->