### PR TITLE
simd: Detect NEON extension on ARM64 Windows correctly

### DIFF
--- a/include/fluent-bit/flb_simd.h
+++ b/include/fluent-bit/flb_simd.h
@@ -45,7 +45,7 @@
 typedef __m128i flb_vector8;
 typedef __m128i flb_vector32;
 
-#elif defined(__aarch64__) && defined(__ARM_NEON)
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 /*
  * We use the Neon instructions if the compiler provides access to them (as
  * indicated by __ARM_NEON) and we are on aarch64.  While Neon support is
@@ -54,7 +54,16 @@ typedef __m128i flb_vector32;
  * could not realistically use it there without a run-time check, which seems
  * not worth the trouble for now.
  */
-#include <arm_neon.h>
+#ifndef __ARM_NEON
+	#define __ARM_NEON 1
+#endif
+#if __has_include(<arm_neon.h>)
+	#include <arm_neon.h>
+#elif __has_include(<arm64_neon.h>)
+	#include <arm64_neon.h>
+#else
+	#error "NEON intrinsics header not found on this toolchain"
+#endif
 #define FLB_SIMD_NEON
 typedef uint8x16_t flb_vector8;
 typedef uint32x4_t flb_vector32;


### PR DESCRIPTION
<!-- Provide summary of changes -->
With ARM64 Windows environment, we need to this patch to enable NEON extension there.

```console
> systeminfo
<snip>
Processor:                 1  Processor is installed.
                            [01]: ARMv8 (64-bit) Family 8 Model 1 Revision 201 Qualcomm Technologies Inc ~3417 Mhz
<snip>
```
Then, we'll get:

```
Fluent Bit v4.1.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/09/08 19:57:32.551656400] [ info] Configuration:
[2025/09/08 19:57:32.551768800] [ info]  flush time     | 1.000000 seconds
[2025/09/08 19:57:32.551832500] [ info]  grace          | 5 seconds
[2025/09/08 19:57:32.551848000] [ info]  daemon         | 0
<snip>
[2025/09/08 19:57:32.552150800] [ info]  collectors:
[2025/09/08 19:57:32.553900000] [ info] [fluent bit] version=4.1.0, commit=070e761c9f, pid=95924
[2025/09/08 19:57:32.553926800] [debug] [engine] maxstdio set: 512
[2025/09/08 19:57:32.553943900] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2025/09/08 19:57:32.554193000] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/09/08 19:57:32.554213000] [ info] [simd    ] NEON
[2025/09/08 19:57:32.554222300] [ info] [cmetrics] version=1.0.5
[2025/09/08 19:57:32.554233100] [ info] [ctraces ] version=0.6.6
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Expanded ARM64/NEON support, including additional toolchains (e.g., MSVC ARM64/ARM64EC), improving cross-platform compatibility.
  * Preserves consistent SIMD vector types on NEON-enabled builds.

* Bug Fixes
  * More reliable detection and inclusion of NEON intrinsics headers, reducing build issues on varied environments.
  * Adds clear compile-time error when NEON headers are unavailable, preventing ambiguous build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->