### PR TITLE
in_winevtlog: Plug possible SEGV occurrence paths [Backport to 4.0]

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -37,45 +37,74 @@ static int pack_nullstr(struct winevtlog_config *ctx)
     return flb_log_event_encoder_append_body_cstring(ctx->log_encoder, "");
 }
 
-static int pack_wstr(struct winevtlog_config *ctx, const wchar_t *wstr)
+static int pack_str_codepage(struct winevtlog_config *ctx, const wchar_t *wstr,
+                             UINT code_page, BOOL use_ansi)
 {
-    int size;
-    char *buf;
-    UINT code_page = CP_UTF8;
-    const char *defaultChar = " ";
+    UINT cp = use_ansi ? CP_ACP : code_page;
+    DWORD flags = (cp == CP_UTF8) ? WC_ERR_INVALID_CHARS : 0;
+    int size = 0;
+    char *buf = NULL;
 
     if (!wstr) {
         return -1;
     }
 
-    if (ctx->use_ansi) {
-        code_page = CP_ACP;
-    }
-
-    /* Compute the buffer size first */
-    size = WideCharToMultiByte(code_page, 0, wstr, -1, NULL, 0, NULL, NULL);
+    size = WideCharToMultiByte(cp, flags, wstr, -1, NULL, 0, NULL, NULL);
     if (size == 0) {
         return -1;
     }
 
     buf = flb_malloc(size);
-    if (buf == NULL) {
+    if (!buf) {
         flb_errno();
+
         return -1;
     }
 
-    /* Convert UTF-16 into UTF-8 */
-    size = WideCharToMultiByte(code_page, 0, wstr, -1, buf, size, defaultChar, NULL);
-    if (size == 0) {
+    if (WideCharToMultiByte(cp, flags, wstr, -1, buf, size, NULL, NULL) == 0) {
         flb_free(buf);
         return -1;
     }
 
-    /* Pack buf except the trailing '\0' */
     flb_log_event_encoder_append_body_string(ctx->log_encoder, buf, size - 1);
-
     flb_free(buf);
     return 0;
+}
+
+static int pack_wstr(struct winevtlog_config *ctx, const wchar_t *wstr)
+{
+    return pack_str_codepage(ctx, wstr, CP_UTF8, ctx->use_ansi);
+}
+
+static int pack_astr(struct winevtlog_config *ctx, const char *astr)
+{
+    wchar_t *wbuf = NULL;
+    int wlen = 0;
+    int ret;
+
+    if (!astr) {
+        return -1;
+    }
+
+    wlen = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, astr, -1, NULL, 0);
+    if (wlen == 0) {
+        return -1;
+    }
+
+    wbuf = flb_malloc(sizeof(wchar_t) * wlen);
+    if (!wbuf) {
+        flb_errno();
+        return -1;
+    }
+
+    if (MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, astr, -1, wbuf, wlen) == 0) {
+        flb_free(wbuf);
+        return -1;
+    }
+
+    ret = pack_wstr(ctx, wbuf);
+    flb_free(wbuf);
+    return ret;
 }
 
 static int pack_binary(struct winevtlog_config *ctx, PBYTE bin, size_t length)
@@ -392,7 +421,7 @@ static void pack_string_inserts(struct winevtlog_config *ctx, PEVT_VARIANT value
             }
             break;
         case EvtVarTypeAnsiString:
-            if (pack_wstr(ctx, values[i].AnsiStringVal)) {
+            if (pack_astr(ctx, values[i].AnsiStringVal)) {
                 pack_nullstr(ctx);
             }
             break;

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -42,7 +42,11 @@ static int pack_wstr(struct winevtlog_config *ctx, const wchar_t *wstr)
     int size;
     char *buf;
     UINT code_page = CP_UTF8;
-    LPCSTR defaultChar = L" ";
+    const char *defaultChar = " ";
+
+    if (!wstr) {
+        return -1;
+    }
 
     if (ctx->use_ansi) {
         code_page = CP_ACP;
@@ -110,6 +114,9 @@ static int pack_binary(struct winevtlog_config *ctx, PBYTE bin, size_t length)
 static int pack_guid(struct winevtlog_config *ctx, const GUID *guid)
 {
     LPOLESTR p = NULL;
+    if (!guid) {
+        return -1;
+    }
 
     if (FAILED(StringFromCLSID(guid, &p))) {
         return -1;
@@ -639,14 +646,24 @@ void winevtlog_pack_event(PEVT_VARIANT system, WCHAR *message,
     /* ActivityID */
     ret = flb_log_event_encoder_append_body_cstring(ctx->log_encoder, "ActivityID");
 
-    if (pack_guid(ctx, system[EvtSystemActivityID].GuidVal)) {
+    if (EvtVarTypeNull != system[EvtSystemActivityID].Type) {
+        if (pack_guid(ctx, system[EvtSystemActivityID].GuidVal)) {
+            pack_nullstr(ctx);
+        }
+    }
+    else {
         pack_nullstr(ctx);
     }
 
     /* Related ActivityID */
     ret = flb_log_event_encoder_append_body_cstring(ctx->log_encoder, "RelatedActivityID");
 
-    if (pack_guid(ctx, system[EvtSystemRelatedActivityID].GuidVal)) {
+    if (EvtVarTypeNull != system[EvtSystemRelatedActivityID].Type) {
+        if (pack_guid(ctx, system[EvtSystemRelatedActivityID].GuidVal)) {
+            pack_nullstr(ctx);
+        }
+    }
+    else {
         pack_nullstr(ctx);
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR is backporting of https://github.com/fluent/fluent-bit/pull/10849.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
