### PR TITLE
simd: Handle older version of gcc such as CentOS 7

### DIFF
--- a/include/fluent-bit/flb_simd.h
+++ b/include/fluent-bit/flb_simd.h
@@ -54,19 +54,31 @@ typedef __m128i flb_vector32;
  * could not realistically use it there without a run-time check, which seems
  * not worth the trouble for now.
  */
-#ifndef __ARM_NEON
-	#define __ARM_NEON 1
-#endif
-#if __has_include(<arm_neon.h>)
-	#include <arm_neon.h>
-#elif __has_include(<arm64_neon.h>)
-	#include <arm64_neon.h>
+/* portable include detection: avoid __has_include on old GCC (CentOS 7) */
+/* Prefer feature macro if present. The latter branch is mainly for MSVC C++ compiler. */
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+  #include <arm_neon.h>
+  #define FLB_SIMD_NEON
 #else
-	#error "NEON intrinsics header not found on this toolchain"
+  /* Use __has_include only if the preprocessor supports it */
+  #if defined(__has_include)
+    #if __has_include(<arm_neon.h>)
+      #include <arm_neon.h>
+      #define FLB_SIMD_NEON
+    #elif __has_include(<arm64_neon.h>)
+      #include <arm64_neon.h>
+      #define FLB_SIMD_NEON
+    #endif
+  #endif
+  /* Fallback for old GCC on aarch64 where arm_neon.h normally exists */
+  #ifndef FLB_SIMD_NEON
+    #include <arm_neon.h>
+    #define FLB_SIMD_NEON
+  #endif
 #endif
-#define FLB_SIMD_NEON
-typedef uint8x16_t flb_vector8;
-typedef uint32x4_t flb_vector32;
+
+typedef uint8x16_t  flb_vector8;
+typedef uint32x4_t  flb_vector32;
 
 #elif defined(__riscv) && (__riscv_v_intrinsic >= 11000)
 /*

--- a/include/fluent-bit/flb_simd.h
+++ b/include/fluent-bit/flb_simd.h
@@ -77,8 +77,13 @@ typedef __m128i flb_vector32;
   #endif
 #endif
 
-typedef uint8x16_t  flb_vector8;
-typedef uint32x4_t  flb_vector32;
+#if defined(FLB_SIMD_NEON)
+  typedef uint8x16_t  flb_vector8;
+  typedef uint32x4_t  flb_vector32;
+#else
+  #define FLB_SIMD_NONE
+  typedef uint64_t flb_vector8;
+#endif
 
 #elif defined(__riscv) && (__riscv_v_intrinsic >= 11000)
 /*


### PR DESCRIPTION
<!-- Provide summary of changes -->
Thanks to failing this workflow https://github.com/fluent/fluent-bit/actions/runs/17607810201/job/50022515193?pr=9600, I noticed that we need to plug older gcc building failure on CentOS7.

This is only affected for master branch. We didn't backport enabling NEON commit on ARM64 Windows.
So, it's only needed merging this PR for master branch.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ARM NEON detection with a multi-path probe and tolerant fallback, reducing build failures on ARM/aarch64 and smoothing varied toolchains.
* **Chores**
  * SIMD public surface now accurately reflects detected NEON support (introduces an explicit “no-NEON” indicator and maps vector types to NEON only when available), with no change to runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->