### PR TITLE
lib: updates for cmetrics and monkey

### DIFF
--- a/lib/cmetrics/.github/workflows/build.yaml
+++ b/lib/cmetrics/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -136,7 +136,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -170,7 +170,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/lib/cmetrics/.github/workflows/lint.yaml
+++ b/lib/cmetrics/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ludeeus/action-shellcheck@master
 
   actionlint:
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/lib/cmetrics/.github/workflows/packages.yaml
+++ b/lib/cmetrics/.github/workflows/packages.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         format: [ rpm, deb ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -54,7 +54,7 @@ jobs:
 
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -81,7 +81,7 @@ jobs:
             ext: pkg
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -109,7 +109,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts/
 

--- a/lib/cmetrics/CMakeLists.txt
+++ b/lib/cmetrics/CMakeLists.txt
@@ -68,11 +68,11 @@ else()
 endif()
 
 # Configuration options
-option(CMT_DEV                       "Enable development mode"                   No)
-option(CMT_DEBUG                     "Enable debug mode"                         No)
-option(CMT_TESTS                     "Enable unit testing"                       No)
+option(CMT_DEV                       "Enable development mode"                    No)
+option(CMT_DEBUG                     "Enable debug mode"                          No)
+option(CMT_TESTS                     "Enable unit testing"                        No)
 option(CMT_INSTALL_TARGETS           "Enable subdirectory library installations" Yes)
-option(CMT_ENABLE_PROMETHEUS_DECODER "Enable prometheus decoder"                 Yes)
+option(CMT_PROMETHEUS_TEXT_DECODER   "Enable prometheus text format decoder (requires Flex/Bison)" Yes)
 
 if(CMT_DEV)
   set(CMT_TESTS   Yes)
@@ -155,7 +155,7 @@ check_c_source_compiles("
      return 0;
   }" CMT_HAVE_MSGPACK)
 
-if(CMT_ENABLE_PROMETHEUS_DECODER)
+if(CMT_PROMETHEUS_TEXT_DECODER)
     # Flex and Bison: check if the variables has not been defined before by
     # a parent project to avoid conflicts.
     if(NOT FLEX_FOUND)
@@ -167,7 +167,8 @@ if(CMT_ENABLE_PROMETHEUS_DECODER)
     endif()
 
     if(FLEX_FOUND AND BISON_FOUND)
-        set(CMT_BUILD_PROMETHEUS_DECODER 1)
+        set(CMT_BUILD_PROMETHEUS_TEXT_DECODER 1)
+        CMT_DEFINITION(CMT_HAVE_PROMETHEUS_TEXT_DECODER)
     endif()
 endif()
 

--- a/lib/cmetrics/include/CMakeLists.txt
+++ b/lib/cmetrics/include/CMakeLists.txt
@@ -1,8 +1,25 @@
+# Install headers conditionally based on Prometheus text decoder availability
 file(GLOB cmetricsHeaders "cmetrics/*.h")
-install(FILES ${cmetricsHeaders}
-    DESTINATION ${CMT_INSTALL_INCLUDEDIR}/cmetrics
-    COMPONENT headers
-    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+if(CMT_BUILD_PROMETHEUS_TEXT_DECODER)
+    # Install all headers when Prometheus text decoder is enabled
+    install(FILES ${cmetricsHeaders}
+        DESTINATION ${CMT_INSTALL_INCLUDEDIR}/cmetrics
+        COMPONENT headers
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+else()
+    # Install headers except Prometheus text decoder header when disabled
+    # (remote write decoder header is always installed)
+    foreach(header ${cmetricsHeaders})
+        get_filename_component(header_name ${header} NAME)
+        if(NOT header_name STREQUAL "cmt_decode_prometheus.h")
+            install(FILES ${header}
+                DESTINATION ${CMT_INSTALL_INCLUDEDIR}/cmetrics
+                COMPONENT headers
+                PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+        endif()
+    endforeach()
+endif()
 
 file(GLOB promHeaders "prometheus_remote_write/*.h")
 install(FILES ${promHeaders}

--- a/lib/cmetrics/include/cmetrics/cmt_decode_prometheus.h
+++ b/lib/cmetrics/include/cmetrics/cmt_decode_prometheus.h
@@ -20,6 +20,10 @@
 #ifndef CMT_DECODE_PROMETHEUS_H
 #define CMT_DECODE_PROMETHEUS_H
 
+#include <cmetrics/cmt_info.h>
+
+#ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
+
 #include <stdbool.h>
 
 #include <cmetrics/cmetrics.h>
@@ -109,5 +113,7 @@ int cmt_decode_prometheus_create(
         size_t in_size,
         struct cmt_decode_prometheus_parse_opts *opts);
 void cmt_decode_prometheus_destroy(struct cmt *cmt);
+
+#endif /* CMT_HAVE_PROMETHEUS_TEXT_DECODER */
 
 #endif

--- a/lib/cmetrics/src/CMakeLists.txt
+++ b/lib/cmetrics/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (CMT_BUILD_PROMETHEUS_DECODER)
+if (CMT_BUILD_PROMETHEUS_TEXT_DECODER)
     flex_target(cmt_decode_prometheus_lexer cmt_decode_prometheus.l
         "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.c"
         DEFINES_FILE "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.h"
@@ -28,7 +28,6 @@ set(src
   cmt_decode_opentelemetry.c
   cmt_encode_prometheus.c
   cmt_encode_prometheus_remote_write.c
-  cmt_decode_prometheus_remote_write.c
   cmt_encode_splunk_hec.c
   cmt_encode_cloudwatch_emf.c
   cmt_encode_text.c
@@ -37,11 +36,15 @@ set(src
   cmt_decode_msgpack.c
   cmt_decode_statsd.c
   cmt_mpack_utils.c
-
-  # Prometheus related protobuf files
-  external/remote.pb-c.c
-  external/types.pb-c.c
   )
+
+# Add Prometheus remote write decoder (always available, only needs protobuf)
+set(src ${src}
+    cmt_decode_prometheus_remote_write.c
+    # Prometheus related protobuf files
+    external/remote.pb-c.c
+    external/types.pb-c.c
+    )
 
 
 if (MSVC)
@@ -63,7 +66,7 @@ set(src
   ${PLATFORM_SPECIFIC_ATOMIC_MODULE}
   )
 
-if (CMT_BUILD_PROMETHEUS_DECODER)
+if (CMT_BUILD_PROMETHEUS_TEXT_DECODER)
     set(src ${src}
         ${FLEX_cmt_decode_prometheus_lexer_OUTPUTS}
         ${BISON_cmt_decode_prometheus_parser_OUTPUTS}

--- a/lib/cmetrics/src/cmt_cat.c
+++ b/lib/cmetrics/src/cmt_cat.c
@@ -108,7 +108,7 @@ static inline int cat_histogram_values(struct cmt_metric *metric_dst, struct cmt
         }
     }
 
-    for (i = 0; i <= histogram->buckets->count; i++) {
+    for (i = 0; i < histogram->buckets->count; i++) {
         /* histogram buckets are always integers, no need to convert them */
         metric_dst->hist_buckets[i] += metric_src->hist_buckets[i];
     }

--- a/lib/cmetrics/src/cmt_decode_prometheus.c
+++ b/lib/cmetrics/src/cmt_decode_prometheus.c
@@ -174,6 +174,7 @@ static int split_metric_name(struct cmt_decode_prometheus_context *context,
     *subsystem = strchr(*ns, '_');
     if (!(*subsystem)) {
         *name = *ns;
+        *subsystem = "";
         *ns = "";
     }
     else {

--- a/lib/cmetrics/src/cmt_histogram.c
+++ b/lib/cmetrics/src/cmt_histogram.c
@@ -36,7 +36,7 @@ struct cmt_histogram_buckets *cmt_histogram_buckets_create_size(double *bkts, si
     }
 
     /* besides buckets set by the user, we add an implicit bucket for +inf */
-    upper_bounds = calloc(1, sizeof(double) * (count + 1));
+    upper_bounds = calloc(1, sizeof(double) * count + 1);
     if (!upper_bounds) {
         cmt_errno();
         return NULL;

--- a/lib/cmetrics/tests/CMakeLists.txt
+++ b/lib/cmetrics/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set(UNIT_TESTS_FILES
   filter.c
   )
 
-if (CMT_BUILD_PROMETHEUS_DECODER)
+if (CMT_BUILD_PROMETHEUS_TEXT_DECODER)
     set(UNIT_TESTS_FILES
         ${UNIT_TESTS_FILES}
         prometheus_lexer.c

--- a/lib/cmetrics/tests/issues.c
+++ b/lib/cmetrics/tests/issues.c
@@ -22,6 +22,8 @@
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_encode_text.h>
+#include <cmetrics/cmt_decode_prometheus.h>
+#include <cmetrics/cmt_encode_prometheus.h>
 
 #include "cmt_tests.h"
 
@@ -89,7 +91,40 @@ void test_issue_54()
     cmt_destroy(cmt1);
 }
 
+#ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
+
+/* issue: https://github.com/fluent/fluent-bit/issues/10761 */
+void test_prometheus_metric_no_subsystem()
+{
+    const char text[] =
+        "# HELP up A simple example metric no subsystem\n"
+        "# TYPE up gauge\n"
+        "up{job=\"42\"} 1\n";
+    struct cmt *cmt;
+    cfl_sds_t result;
+    int ret;
+
+    cmt_initialize();
+
+    ret = cmt_decode_prometheus_create(&cmt, text, strlen(text), NULL);
+    TEST_CHECK(ret == CMT_DECODE_PROMETHEUS_SUCCESS);
+    if (ret == CMT_DECODE_PROMETHEUS_SUCCESS) {
+        result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+        TEST_CHECK(result != NULL);
+        if (result) {
+            TEST_CHECK(strstr(result, "up{job=\"42\"} 1") != NULL);
+            cmt_encode_prometheus_destroy(result);
+        }
+        cmt_decode_prometheus_destroy(cmt);
+    }
+}
+
+#endif
+
 TEST_LIST = {
     {"issue_54", test_issue_54},
+#ifdef CMT_HAVE_PROMETHEUS_TEXT_DECODER
+    {"prometheus_metric_no_subsystem", test_prometheus_metric_no_subsystem},
+#endif
     { 0 }
 };

--- a/lib/monkey/CMakeLists.txt
+++ b/lib/monkey/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 # Monkey Version
 set(MK_VERSION_MAJOR  1)
 set(MK_VERSION_MINOR  8)
-set(MK_VERSION_PATCH  4)
+set(MK_VERSION_PATCH  5)
 set(MK_VERSION_STR "${MK_VERSION_MAJOR}.${MK_VERSION_MINOR}.${MK_VERSION_PATCH}")
 
 # Output paths

--- a/lib/monkey/mk_server/mk_http.c
+++ b/lib/monkey/mk_server/mk_http.c
@@ -94,6 +94,16 @@ void mk_http_request_init(struct mk_http_session *session,
                   session->channel,
                   NULL,
                   NULL, NULL, NULL);
+
+    /* Initialize headers input stream */
+    request->in_headers.type        = MK_STREAM_IOV;
+    request->in_headers.dynamic     = MK_FALSE;
+    request->in_headers.cb_consumed = NULL;
+    request->in_headers.cb_finished = NULL;
+    request->in_headers.buffer      = NULL;
+    request->in_headers.bytes_total = 0;
+    request->in_headers.stream      = &request->stream;
+    mk_list_add(&request->in_headers._head, &request->stream.inputs);
 }
 
 static inline int mk_http_point_header(mk_ptr_t *h,
@@ -721,14 +731,6 @@ int mk_http_init(struct mk_http_session *cs, struct mk_http_request *sr,
     }
 
     ret_file = mk_file_get_info(sr->real_path.data, &sr->file_info, MK_FILE_READ);
-
-    /* Manually set the headers input streams */
-    sr->in_headers.type        = MK_STREAM_IOV;
-    sr->in_headers.dynamic     = MK_FALSE;
-    sr->in_headers.cb_consumed = NULL;
-    sr->in_headers.cb_finished = NULL;
-    sr->in_headers.stream      = &sr->stream;
-    mk_list_add(&sr->in_headers._head, &sr->stream.inputs);
 
     /* Plugin Stage 30: look for handlers for this request */
     if (sr->stage30_blocked == MK_FALSE) {

--- a/src/http_server/flb_http_server_http1.c
+++ b/src/http_server/flb_http_server_http1.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/http_server/flb_http_server.h>
+#include <string.h>
 
 /* PRIVATE */
 
@@ -55,16 +56,6 @@ static void dummy_mk_http_request_init(struct mk_http_session *session,
     memset(request, 0, sizeof(struct mk_http_request));
 
     mk_http_request_init(session, request, session->server);
-
-    request->in_headers.type        = MK_STREAM_IOV;
-    request->in_headers.dynamic     = MK_FALSE;
-    request->in_headers.cb_consumed = NULL;
-    request->in_headers.cb_finished = NULL;
-    request->in_headers.stream      = &request->stream;
-
-    mk_list_add(&request->in_headers._head, &request->stream.inputs);
-
-    request->session = session;
 }
 
 static int http1_evict_request(struct flb_http1_server_session *session)
@@ -464,6 +455,7 @@ int flb_http1_server_session_init(struct flb_http1_server_session *session,
 
     dummy_mk_http_session_init(&session->inner_session, &session->inner_server);
 
+    memset(&session->inner_request, 0, sizeof(struct mk_http_request));
     dummy_mk_http_request_init(&session->inner_session, &session->inner_request);
 
     mk_http_parser_init(&session->inner_parser);


### PR DESCRIPTION
Upgrade the following bundled libraries:

- Monkey v1.8.5
- CMetrics v1.0.5

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Prometheus Remote Write decoder is now included by default; Prometheus text-format decoder remains optional via a renamed build option.

- Bug Fixes
  - Safer handling of Prometheus metrics without a subsystem.
  - Fixed histogram bucket off-by-one.
  - Improved HTTP request header/stream initialization.

- Refactor
  - Prometheus text decoder build option renamed; headers install conditionally based on the decoder flag.

- Tests
  - Added test for Prometheus metric without a subsystem.

- Chores
  - CI workflows upgraded to newer action versions.
  - Monkey library version bumped to 1.8.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->