### PR TITLE
in_calyptia_fleet: Only commit fleet config when successfully reloaded

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -286,6 +286,7 @@ struct flb_config {
     unsigned int hot_reloaded_count;
     int shutdown_by_hot_reloading;
     int hot_reloading;
+    int hot_reload_succeeded;
 
     /* Routing */
     size_t route_mask_size;

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -307,6 +307,7 @@ struct flb_config *flb_config_init()
     config->hot_reloaded_count = 0;
     config->shutdown_by_hot_reloading = FLB_FALSE;
     config->hot_reloading = FLB_FALSE;
+    config->hot_reload_succeeded = FLB_FALSE;
 
 #ifdef FLB_SYSTEM_WINDOWS
     config->win_maxstdio = 512;

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -549,6 +549,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     new_config->hot_reloaded_count = reloaded_count;
     flb_debug("[reload] hot reloaded %d time(s)", reloaded_count);
     new_config->hot_reloading = FLB_FALSE;
+    new_config->hot_reload_succeeded = FLB_TRUE;
 
     return 0;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->

This fixes a fleet bug where fetching an invalid config then shutting down prevented the agent from starting up again.

NB for people who reviewed this as an earlier draft: this is equivalent to the [now-closed PR in my fork repo](https://github.com/alecholmes/fluent-bit/pull/7).

**Problem**
The fleet plugin is buggy today in that it will immediately commit newly received config as the current config, implying the new config is valid. This can notably prevent fluent-bit from restarting correctly after receiving an invalid config.

For example:
* Process starts with a valid config
* Fleet plugin receives a new config. It marks it as current and kicks off a hot reload.
* The hot reload fails. The process will use the old working config.
* Process exits
* Process starts
* Process tries to use the newer invalid config instead of the older valid config.

**Change**

This PR changes how configs received by the fleet plugin are committed as valid.

When a new config is received:
* Any existing new (not current or old) config is deleted, since it is being replaced.
* The received config is saved on disk as new and a hot reload is kicked off.
* Subsequent fleet collect callbacks will check if the hot reload of the new config was successful. If so, the new config is promoted to current.

When a process starts up:
* It deletes new config on disk. By virtue of being marked new, that config was not successfully reloaded in the past.
* It loads up using current or old config, if available.
* It then will attempt to fetch any newer config and reload.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More robust hot-reload with automatic commit/rollback of fleet configs based on reload outcome.
  - Startup now cleans up stale, uncommitted configs for a cleaner state.
  - Added clearer logging around reloading, committing, and cleanup actions.

- Refactor
  - Streamlined fleet configuration management to unify detection and lifecycle handling, improving reliability during reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->