### PR TITLE
CODEOWNERS: add alecholmes to fleet.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,7 +92,7 @@
 /.devcontainer                  @patrick-stephens @niedbalski @edsiper
 
 # Calyptia Fleet
-/include/fluent-bit/calyptia/       @pwhelan @patrick-stephens @niedbalski
-/plugins/custom_calyptia/       @pwhelan @patrick-stephens @niedbalski
-/plugins/custom_calyptia/       @pwhelan @patrick-stephens @niedbalski
-/plugins/out_calyptia/     @pwhelan @patrick-stephens @niedbalski
+/include/fluent-bit/calyptia/ @pwhelan @patrick-stephens @niedbalski @alecholmes
+/plugins/custom_calyptia/     @pwhelan @patrick-stephens @niedbalski @alecholmes
+/plugins/custom_calyptia/     @pwhelan @patrick-stephens @niedbalski @alecholmes
+/plugins/out_calyptia/        @pwhelan @patrick-stephens @niedbalski @alecholmes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,3 +96,4 @@
 /plugins/custom_calyptia/     @pwhelan @patrick-stephens @niedbalski @alecholmes
 /plugins/custom_calyptia/     @pwhelan @patrick-stephens @niedbalski @alecholmes
 /plugins/out_calyptia/        @pwhelan @patrick-stephens @niedbalski @alecholmes
+/plugins/in_calyptia_fleet/   @pwhelan @patrick-stephens @niedbalski @alecholmes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,8 +92,8 @@
 /.devcontainer                  @patrick-stephens @niedbalski @edsiper
 
 # Calyptia Fleet
-/include/fluent-bit/calyptia/ @pwhelan @patrick-stephens @niedbalski @alecholmes
-/plugins/custom_calyptia/     @pwhelan @patrick-stephens @niedbalski @alecholmes
-/plugins/custom_calyptia/     @pwhelan @patrick-stephens @niedbalski @alecholmes
-/plugins/out_calyptia/        @pwhelan @patrick-stephens @niedbalski @alecholmes
-/plugins/in_calyptia_fleet/   @pwhelan @patrick-stephens @niedbalski @alecholmes
+/include/fluent-bit/calyptia/ @pwhelan @alecholmes
+/plugins/custom_calyptia/     @pwhelan @alecholmes
+/plugins/custom_calyptia/     @pwhelan @alecholmes
+/plugins/out_calyptia/        @pwhelan @alecholmes
+/plugins/in_calyptia_fleet/   @pwhelan @alecholmes


### PR DESCRIPTION
# Summary

Add Alec Holmes (@alecholmes) as a `CODEOWNERS` for the `in_calyptia_fleet` plugin and the other relevant plugins.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated repository ownership for Calyptia Fleet integrations: replaced two previous owners with pwhelan and alecholmes across relevant Calyptia components and added pwhelan and alecholmes as owners for a new Calyptia Fleet integration area.
  - No changes to product behavior, performance, or user workflows; no action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->