### PR TITLE
Support vhost-style S3 URLs

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -4037,6 +4037,12 @@ static struct flb_config_map config_map[] = {
     "A standard MIME type for the S3 object; this will be set "
     "as the Content-Type HTTP header."
     },
+    {
+     FLB_CONFIG_MAP_BOOL, "vhost_style_urls", "false",
+     0, FLB_TRUE, offsetof(struct flb_s3, vhost_style_urls),
+     "Force the use of vhost-style S3 urls. "
+     "https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html"
+    },
 
     {
      FLB_CONFIG_MAP_STR, "store_dir", "/tmp/fluent-bit/s3",

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -122,6 +122,7 @@ struct flb_s3 {
     int compression;
     int port;
     int insecure;
+    int vhost_style_urls;
     size_t store_dir_limit_size;
 
     struct flb_blob_db blob_db;

--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -429,8 +429,10 @@ int complete_multipart_upload(struct flb_s3 *ctx,
 
     if (pre_signed_url != NULL) {
         tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
-    }
-    else {
+    } else if (ctx->vhost_style_urls == FLB_TRUE) {
+        tmp = flb_sds_printf(&uri, "%s?uploadId=%s",
+                            m_upload->s3_key, m_upload->upload_id);
+    } else {
         tmp = flb_sds_printf(&uri, "/%s%s?uploadId=%s", ctx->bucket,
                             m_upload->s3_key, m_upload->upload_id);
     }
@@ -575,8 +577,9 @@ int create_multipart_upload(struct flb_s3 *ctx,
 
     if (pre_signed_url != NULL) {
         tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
-    }
-    else {
+    } else if (ctx->vhost_style_urls == FLB_TRUE) {
+        tmp = flb_sds_printf(&uri, "%s?uploads=", m_upload->s3_key);
+    } else {
         tmp = flb_sds_printf(&uri, "/%s%s?uploads=", ctx->bucket, m_upload->s3_key);
     }
 
@@ -702,8 +705,11 @@ int upload_part(struct flb_s3 *ctx, struct multipart_upload *m_upload,
 
     if (pre_signed_url != NULL) {
         tmp = flb_sds_copy(uri, pre_signed_url, strlen(pre_signed_url));
-    }
-    else {
+    } else if (ctx->vhost_style_urls == FLB_TRUE) {
+        tmp = flb_sds_printf(&uri, "%s?partNumber=%d&uploadId=%s",
+                            m_upload->s3_key, m_upload->part_number,
+                            m_upload->upload_id);
+    } else {
         tmp = flb_sds_printf(&uri, "/%s%s?partNumber=%d&uploadId=%s",
                             ctx->bucket, m_upload->s3_key, m_upload->part_number,
                             m_upload->upload_id);


### PR DESCRIPTION
[Vhost-style URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html) for S3 have been an option for a while, yet fluent-bit exclusively supports path-style URL's, which forbids it to work with the S3 FIPS endpoints according to [the documentation](https://aws.amazon.com/compliance/fips/).

This PR adds optional, opt-in support for vhost-style URLs on a per-output basis.

Fixes #10390.

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
---
pipeline:
  inputs:
    - name: random
      samples: -1
      interval_sec: 1
      interval_nsec: 0
  outputs:
    - name:  s3
      bucket: my-bucket
      region: us-east-1
      vhost_style_urls: true
```
- [x] Debug log output from testing the change
```
$ bin/fluent-bit -c ../xxx.yml 
Fluent Bit v4.1.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/09/15 16:43:00.869367668] [ info] Configuration:
[2025/09/15 16:43:00.869414328] [ info]  flush time     | 1.000000 seconds
[2025/09/15 16:43:00.869418469] [ info]  grace          | 5 seconds
[2025/09/15 16:43:00.869420256] [ info]  daemon         | 0
[2025/09/15 16:43:00.869421794] [ info] ___________
[2025/09/15 16:43:00.869423521] [ info]  inputs:
[2025/09/15 16:43:00.869425073] [ info]      random
[2025/09/15 16:43:00.869429109] [ info] ___________
[2025/09/15 16:43:00.869431436] [ info]  filters:
[2025/09/15 16:43:00.869432929] [ info] ___________
[2025/09/15 16:43:00.869434451] [ info]  outputs:
[2025/09/15 16:43:00.869436621] [ info]      s3.0
[2025/09/15 16:43:00.869440437] [ info] ___________
[2025/09/15 16:43:00.869445062] [ info]  collectors:
[2025/09/15 16:43:00.870114445] [ info] [fluent bit] version=4.1.0, commit=7e50f95925, pid=52890
[2025/09/15 16:43:00.870128032] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/09/15 16:43:00.870276627] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/09/15 16:43:00.870341901] [ info] [simd    ] disabled
[2025/09/15 16:43:00.870344645] [ info] [cmetrics] version=1.0.5
[2025/09/15 16:43:00.870430418] [ info] [ctraces ] version=0.6.6
[2025/09/15 16:43:00.870518607] [ info] [input:random:random.0] initializing
[2025/09/15 16:43:00.870526738] [ info] [input:random:random.0] storage_strategy='memory' (memory only)
[2025/09/15 16:43:00.870535728] [debug] [random:random.0] created event channels: read=28 write=29
[2025/09/15 16:43:00.870672091] [debug] [input:random:random.0] interval_sec=1 interval_nsec=0
[2025/09/15 16:43:00.870685605] [debug] [s3:s3.0] created event channels: read=30 write=31
[2025/09/15 16:43:00.872993013] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2025/09/15 16:43:00.873193355] [ info] [output:s3:s3.0] New endpoint: mruiz-potato.s3.us-east-1.amazonaws.com
[2025/09/15 16:43:00.873630262] [debug] [aws_credentials] Initialized Env Provider in standard chain
[2025/09/15 16:43:00.873637981] [debug] [aws_credentials] creating profile (null) provider
[2025/09/15 16:43:00.873715397] [debug] [aws_credentials] Initialized AWS Profile Provider in standard chain
[2025/09/15 16:43:00.873731598] [debug] [aws_credentials] Not initializing EKS provider because AWS_ROLE_ARN was not set
[2025/09/15 16:43:00.873740706] [debug] [aws_credentials] Not initializing ECS/EKS HTTP Provider because AWS_CONTAINER_CREDENTIALS_RELATIVE_URI and AWS_CONTAINER_CREDENTIALS_FULL_URI is not set
[2025/09/15 16:43:00.873747298] [debug] [aws_credentials] Initialized EC2 Provider in standard chain
[2025/09/15 16:43:00.873755650] [debug] [aws_credentials] Sync called on the EC2 provider
[2025/09/15 16:43:00.873761670] [debug] [aws_credentials] Init called on the env provider
[2025/09/15 16:43:00.873764884] [debug] [aws_credentials] upstream_set called on the EC2 provider
[2025/09/15 16:43:00.873968619] [ info] [output:s3:s3.0] initializing worker
[2025/09/15 16:43:00.874005387] [ info] [output:s3:s3.0] worker #0 started
[2025/09/15 16:43:00.874028270] [ info] [sp] stream processor started
[2025/09/15 16:43:00.874178029] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/09/15 16:43:01.899689407] [debug] [task] created task=0x7f10f40846b0 id=0 OK
[2025/09/15 16:43:01.899705102] [debug] [output:s3:s3.0] task_id=0 assigned to thread #0
[2025/09/15 16:43:01.899817574] [debug] [output:s3:s3.0] Creating upload timer with frequency 60s
[2025/09/15 16:43:01.900269435] [debug] [out flush] cb_destroy coro_id=0
[2025/09/15 16:43:01.900293789] [debug] [task] destroy task=0x7f10f40846b0 (task_id=0)
[2025/09/15 16:43:02.899711067] [debug] [task] created task=0x7f10f4084b30 id=0 OK
[2025/09/15 16:43:02.899731669] [debug] [output:s3:s3.0] task_id=0 assigned to thread #0
...
[2025/09/15 16:43:37.902558535] [debug] [out flush] cb_destroy coro_id=36
[2025/09/15 16:43:37.902663702] [debug] [task] destroy task=0x7f10f4084e70 (task_id=0)
^C[2025/09/15 16:43:38] [engine] caught signal (SIGINT)
[2025/09/15 16:43:38.155642726] [debug] [task] created task=0x7f10f4084e70 id=0 OK
[2025/09/15 16:43:38.155660279] [debug] [output:s3:s3.0] task_id=0 assigned to thread #0
[2025/09/15 16:43:38.155670487] [ warn] [engine] service will shutdown in max 5 seconds
[2025/09/15 16:43:38.155673830] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2025/09/15 16:43:38.155676494] [ info] [engine] pausing all inputs..
[2025/09/15 16:43:38.155680470] [ info] [input] pausing random.0
[2025/09/15 16:43:38.155708970] [debug] [out flush] cb_destroy coro_id=37
[2025/09/15 16:43:38.155739343] [debug] [task] destroy task=0x7f10f4084e70 (task_id=0)
[2025/09/15 16:43:38.902090586] [ info] [engine] service has stopped (0 pending tasks)
[2025/09/15 16:43:38.902108353] [ info] [input] pausing random.0
[2025/09/15 16:43:38.902146810] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2025/09/15 16:43:38.902164540] [ info] [output:s3:s3.0] initializing worker
[2025/09/15 16:43:38.902217528] [ info] [output:s3:s3.0] thread worker #0 stopped
[2025/09/15 16:43:38.903099452] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2025/09/15 16:43:39.292732905] [debug] [upstream] KA connection #32 to mruiz-potato.s3.us-east-1.amazonaws.com:443 is connected
[2025/09/15 16:43:39.292756712] [debug] [http_client] not using http_proxy for header
[2025/09/15 16:43:39.292773712] [debug] [aws_credentials] Requesting credentials from the env provider..
[2025/09/15 16:43:39.367545633] [debug] [upstream] KA connection #32 to mruiz-potato.s3.us-east-1.amazonaws.com:443 is now available
[2025/09/15 16:43:39.367561000] [debug] [output:s3:s3.0] PutObject http status=200
[2025/09/15 16:43:39.367564798] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/random.0/2025/09/15/16/43/01-objectZjc9DKdy
```
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
$ valgrind --leak-check=full ./bin/fluent-bit -c ../xxx.yml 
==53526== Memcheck, a memory error detector
==53526== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==53526== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==53526== Command: ./bin/fluent-bit -c ../xxx.yml
==53526== 
<regular logs, like the ones attached above>
==53526== 
==53526== HEAP SUMMARY:
==53526==     in use at exit: 0 bytes in 0 blocks
==53526==   total heap usage: 18,923 allocs, 18,923 frees, 3,608,422 bytes allocated
==53526== 
==53526== All heap blocks were freed -- no leaks are possible
==53526== 
==53526== For lists of detected and suppressed errors, rerun with: -s
==53526== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Documentation**
- [x] Documentation required for this feature

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional support for virtual-hosted–style S3 URLs via the vhost_style_urls configuration (default: false). Applies to both single-part (PutObject) and multipart uploads, adjusting request paths and object key handling accordingly. Includes clearer logging of the final endpoint and object key when enabled.
- Tests
  - Added runtime test to validate successful uploads using vhost_style_urls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->