### PR TITLE
upstream: Move clearing TLS session from prepare phase to destroy phase

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -515,13 +515,6 @@ static int prepare_destroy_conn(struct flb_connection *u_conn)
     }
 
     if (u_conn->fd > 0) {
-#ifdef FLB_HAVE_TLS
-        if (u_conn->tls_session != NULL) {
-            flb_tls_session_destroy(u_conn->tls_session);
-
-            u_conn->tls_session = NULL;
-        }
-#endif
         shutdown_connection(u_conn);
 
         flb_socket_close(u_conn->fd);
@@ -571,6 +564,15 @@ static int destroy_conn(struct flb_connection *u_conn)
         u_conn->event._priority_head.prev != NULL) {
         return 0;
     }
+
+    /* Delay to destroy TLS session for safety */
+#ifdef FLB_HAVE_TLS
+        if (u_conn->tls_session != NULL) {
+            flb_tls_session_destroy(u_conn->tls_session);
+
+            u_conn->tls_session = NULL;
+        }
+#endif
 
     mk_list_del(&u_conn->_head);
 


### PR DESCRIPTION
This is because lifecycle of TLS is not synchronized with the current implementation.

Somewhere, we observed:

Our observation “TLS is freed too early in the upstream prepare-destroy phase → UAF risk” case is existing in the current code base.

So, even with Keepalive enabled, our Fluent Bit code base shows multiple conditions where the TLS session is freed during the “prepare destroy” step, which can race with async I/O and cause a use-after-free in ssl_write_internal. Moving TLS freeing to the final destroy_conn() phase mitigates this.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TLS session cleanup during connection teardown, ensuring sessions are destroyed at the final destruction stage. This reduces the risk of resource leaks and improves stability in TLS-enabled environments.
* **Refactor**
  * Streamlined the connection destruction flow for consistency and reliability, without changing external behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->