### PR TITLE
kv: add new flb_kv_item_set() api (upsert)

### DIFF
--- a/include/fluent-bit/flb_kv.h
+++ b/include/fluent-bit/flb_kv.h
@@ -36,6 +36,8 @@ struct flb_kv *flb_kv_item_create_len(struct mk_list *list,
                                       char *v_buf, size_t v_len);
 struct flb_kv *flb_kv_item_create(struct mk_list *list,
                                   char *k_buf, char *v_buf);
+struct flb_kv *flb_kv_item_set(struct mk_list *list,
+                               char *k_buf, char *v_buf);
 void flb_kv_item_destroy(struct flb_kv *kv);
 void flb_kv_release(struct mk_list *list);
 const char *flb_kv_get_key_value(const char *key, struct mk_list *list);

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -167,7 +167,7 @@ static int config_add_labels(struct flb_output_instance *ins,
         k = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);
         v = mk_list_entry_last(mv->val.list, struct flb_slist_entry, _head);
 
-        kv = flb_kv_item_create(&ctx->kv_labels, k->str, v->str);
+        kv = flb_kv_item_set(&ctx->kv_labels, k->str, v->str);
         if (!kv) {
             flb_plg_error(ins, "could not append label %s=%s\n", k->str, v->str);
             return -1;

--- a/src/flb_kv.c
+++ b/src/flb_kv.c
@@ -76,6 +76,36 @@ struct flb_kv *flb_kv_item_create(struct mk_list *list,
     return flb_kv_item_create_len(list, k_buf, k_len, v_buf, v_len);
 }
 
+struct flb_kv *flb_kv_item_set(struct mk_list *list,
+                               char *k_buf, char *v_buf)
+{
+    struct mk_list *head;
+    struct flb_kv *kv;
+
+    if (!k_buf) {
+        return NULL;
+    }
+
+    mk_list_foreach(head, list) {
+        kv = mk_list_entry(head, struct flb_kv, _head);
+        if (strcasecmp(kv->key, k_buf) == 0) {
+            if (kv->val) {
+                flb_sds_destroy(kv->val);
+            }
+            kv->val = flb_sds_create(v_buf);
+            if (!kv->val) {
+                mk_list_del(&kv->_head);
+                flb_sds_destroy(kv->key);
+                flb_free(kv);
+                return NULL;
+            }
+            return kv;
+        }
+    }
+
+    return flb_kv_item_create(list, k_buf, v_buf);
+}
+
 void flb_kv_item_destroy(struct flb_kv *kv)
 {
     if (kv->key) {

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UNIT_TESTS_FILES
   hmac.c
   crypto.c
   hash.c
+  kv.c
   slist.c
   router.c
   network.c

--- a/tests/internal/kv.c
+++ b/tests/internal/kv.c
@@ -1,0 +1,34 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_kv.h>
+#include "flb_tests_internal.h"
+
+static void test_kv_item_set_duplicate()
+{
+    struct mk_list list;
+    struct flb_kv *kv;
+    const char *val;
+
+    flb_kv_init(&list);
+
+    kv = flb_kv_item_set(&list, "color", "blue");
+    TEST_CHECK(kv != NULL);
+
+    kv = flb_kv_item_set(&list, "color", "green");
+    TEST_CHECK(kv != NULL);
+
+    val = flb_kv_get_key_value("color", &list);
+    TEST_CHECK(val != NULL);
+    if (val) {
+        TEST_CHECK(strcmp(val, "green") == 0);
+    }
+
+    TEST_CHECK(mk_list_size(&list) == 1);
+
+    flb_kv_release(&list);
+}
+
+TEST_LIST = {
+    {"kv_item_set_duplicate", test_kv_item_set_duplicate},
+    {0}
+};


### PR DESCRIPTION
Fixes https://github.com/fluent/fluent-bit/issues/10866

This PR introduces a new upsert-style API for the kv interface. In addition we modify OpenTelemetry output plugin to use this new function when adding labels to avoid duplicates.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
