### PR TITLE
build: execute daemon-reload and restart postinst in deb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1543,9 +1543,10 @@ if(DPKG_PROGRAM)
     ${PROJECT_SOURCE_DIR}/cpack/debian/conffiles
     )
 
+  set(LDCONFIG_SCRIPT_CMDS "")
   if(FLB_RUN_LDCONFIG)
     set(LDCONFIG_DIR ${FLB_INSTALL_LIBDIR})
-    file(WRITE ${PROJECT_BINARY_DIR}/scripts/postinst "
+    set(LDCONFIG_SCRIPT_CMDS "
 mkdir -p /etc/ld.so.conf.d
 echo \"${LDCONFIG_DIR}\" > /etc/ld.so.conf.d/libfluent-bit.conf
 ldconfig
@@ -1554,9 +1555,19 @@ ldconfig
 rm -f -- /etc/ld.so.conf.d/libfluent-bit.conf
 ldconfig
     ")
-    set(CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst;${PROJECT_BINARY_DIR}/scripts/prerm")
+    list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst;${PROJECT_BINARY_DIR}/scripts/prerm")
   endif(FLB_RUN_LDCONFIG)
 
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cpack/debian/postinst.in"
+    "${PROJECT_BINARY_DIR}/scripts/postinst"
+  )
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E chmod +x
+            "${PROJECT_BINARY_DIR}/scripts/postinst"
+  )
+
+  list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst")
 endif()
 
 # RPM Generation information

--- a/cpack/debian/postinst.in
+++ b/cpack/debian/postinst.in
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+@LDCONFIG_SCRIPT_CMDS@
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+    if [ -d /run/systemd/system ]; then
+        systemctl --system daemon-reload >/dev/null || true
+        systemctl try-restart @FLB_OUT_NAME@.service >/dev/null || true
+    fi
+fi


### PR DESCRIPTION
Follow up to https://github.com/fluent/fluent-bit/pull/10844 and https://github.com/fluent/fluent-bit/pull/8341 and https://github.com/fluent/fluent-bit/pull/8330.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Debian post-install step that reloads system services and attempts to restart the application after install/upgrade, improving out-of-the-box readiness.
  * Post-install actions run quietly with tolerant failure handling for smoother upgrades.

* Chores
  * Improved Debian package assembly to reliably include maintainer scripts (post-install and pre-remove).
  * Streamlined packaging flow to ensure scripts are generated before building the package, enhancing installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->