### PR TITLE
packaging: support Alma/Rocky/CentOS 10 [Backport to 4.0]

### DIFF
--- a/.github/workflows/call-build-linux-packages.yaml
+++ b/.github/workflows/call-build-linux-packages.yaml
@@ -60,7 +60,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
           path: source
@@ -87,7 +87,7 @@ jobs:
       # Pick up latest master version
       - name: Checkout code for action
         if: inputs.environment == 'staging'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: action-support
 
@@ -115,7 +115,7 @@ jobs:
     continue-on-error: ${{ inputs.ignore_failing_targets || false }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
@@ -163,7 +163,9 @@ jobs:
         # For ubuntu map to codename using the disto-info list (CSV)
         run: |
           sudo apt-get update
-          sudo apt-get install -y distro-info awscli
+          sudo apt-get install -y distro-info
+          sudo apt-get install -y awscli || sudo snap install aws-cli --classic
+
           TARGET=${DISTRO%*.arm64v8}
           if [[ "$TARGET" == "ubuntu/"* ]]; then
               UBUNTU_CODENAME=$(cut -d ',' -f 1,3 < "/usr/share/distro-info/ubuntu.csv"|grep "${TARGET##*/}"|cut -d ',' -f 2)
@@ -194,7 +196,7 @@ jobs:
       # Pick up latest master version
       - name: Checkout code for action
         if: inputs.environment == 'staging'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: action-support
 
@@ -224,12 +226,14 @@ jobs:
         timeout-minutes: 10
         run: |
           sudo apt-get update
-          sudo apt-get install -y createrepo-c aptly awscli
+          sudo apt-get install -y createrepo-c aptly
+          sudo apt-get install -y awscli || sudo snap install aws-cli --classic
+        shell: bash
         env:
           DEBIAN_FRONTEND: noninteractive
 
       - name: Checkout code for repo metadata construction - always latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Import GPG key for signing
         id: import_gpg

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -41,6 +41,14 @@
           "type": "rpm"
         },
         {
+          "target": "centos/10",
+          "type": "rpm"
+        },
+        {
+          "target": "centos/10.arm64v8",
+          "type": "rpm"
+        },
+        {
           "target": "rockylinux/8",
           "type": "rpm"
         },
@@ -57,6 +65,14 @@
           "type": "rpm"
         },
         {
+          "target": "rockylinux/10",
+          "type": "rpm"
+        },
+        {
+          "target": "rockylinux/10.arm64v8",
+          "type": "rpm"
+        },
+        {
           "target": "almalinux/8",
           "type": "rpm"
         },
@@ -70,6 +86,14 @@
         },
         {
           "target": "almalinux/9.arm64v8",
+          "type": "rpm"
+        },
+        {
+          "target": "almalinux/10",
+          "type": "rpm"
+        },
+        {
+          "target": "almalinux/10.arm64v8",
           "type": "rpm"
         },
         {
@@ -94,6 +118,14 @@
         },
         {
           "target": "debian/bullseye.arm64v8",
+          "type": "deb"
+        },
+        {
+          "target": "debian/trixie",
+          "type": "deb"
+        },
+        {
+          "target": "debian/trixie.arm64v8",
           "type": "deb"
         },
         {

--- a/packaging/distros/almalinux/Dockerfile
+++ b/packaging/distros/almalinux/Dockerfile
@@ -7,10 +7,10 @@ ARG BASE_BUILDER
 # Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
 
 # Multiarch support
-FROM multiarch/qemu-user-static:x86_64-aarch64 as multiarch-aarch64
+FROM multiarch/qemu-user-static:x86_64-aarch64 AS multiarch-aarch64
 
 # almalinux/8 base image
-FROM almalinux:8 as almalinux-8-base
+FROM almalinux:8 AS almalinux-8-base
 
 # Add for the YAML development libraries
 RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-powertools.repo
@@ -25,7 +25,7 @@ RUN yum -y update && \
 
 # almalinux/8.arm64v8 base image
 # hadolint ignore=DL3029
-FROM --platform=arm64 almalinux:8 as almalinux-8.arm64v8-base
+FROM --platform=arm64 almalinux:8 AS almalinux-8.arm64v8-base
 
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
@@ -44,7 +44,7 @@ RUN yum -y update && \
 ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
 ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
-FROM almalinux:9 as almalinux-9-base
+FROM almalinux:9 AS almalinux-9-base
 
 # Add for the YAML development libraries
 RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
@@ -59,7 +59,41 @@ RUN yum -y update && \
 
 # almalinux/8.arm64v8 base image
 # hadolint ignore=DL3029
-FROM --platform=arm64 almalinux:9 as almalinux-9.arm64v8-base
+FROM --platform=arm64 almalinux:9 AS almalinux-9.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
+    yum clean all
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
+FROM almalinux:10 AS almalinux-10-base
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
+    yum clean all
+
+# almalinux/8.arm64v8 base image
+# hadolint ignore=DL3029
+FROM --platform=arm64 almalinux:10 AS almalinux-10.arm64v8-base
 
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
@@ -80,7 +114,7 @@ ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
 # Common build for all distributions now
 # hadolint ignore=DL3006
-FROM $BASE_BUILDER as builder
+FROM $BASE_BUILDER AS builder
 
 ARG FLB_NIGHTLY_BUILD
 ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -225,6 +225,69 @@ ENV FLB_KAFKA=$FLB_KAFKA
 ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
 ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
+FROM quay.io/centos/centos:stream10 AS centos-10-base
+
+ENV CMAKE_HOME="/opt/cmake"
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+# Add for the YAML development libraries
+# hadolint ignore=DL3033,DL3041
+RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-enabled crb && \
+    dnf -y install rpm-build ca-certificates gcc gcc-c++ make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
+    libyaml-devel zlib-devel \
+    tar gzip && \
+    dnf clean all && \
+    mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
+ARG FLB_OUT_PGSQL=On
+ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+
+# hadolint ignore=DL3029
+FROM --platform=arm64 quay.io/centos/centos:stream10 AS centos-10.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ENV CMAKE_HOME="/opt/cmake"
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+# Add for the YAML development libraries
+# hadolint ignore=DL3033,DL3041
+RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-enabled crb && \
+    dnf -y install rpm-build ca-certificates gcc gcc-c++ make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
+    libyaml-devel zlib-devel \
+    tar gzip && \
+    dnf clean all && \
+    mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="${CMAKE_URL}/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
+ARG FLB_OUT_PGSQL=On
+ENV FLB_OUT_PGSQL=$FLB_OUT_PGSQL
+ARG FLB_UNICODE_ENCODER=On
+ENV FLB_UNICODE_ENCODER=$FLB_UNICODE_ENCODER
+ARG FLB_KAFKA=On
+ENV FLB_KAFKA=$FLB_KAFKA
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
 # Common build for all distributions now
 # hadolint ignore=DL3006
 FROM $BASE_BUILDER AS builder

--- a/packaging/distros/rockylinux/Dockerfile
+++ b/packaging/distros/rockylinux/Dockerfile
@@ -7,10 +7,10 @@ ARG BASE_BUILDER
 # Use buildkit to skip unused base images: DOCKER_BUILDKIT=1
 
 # Multiarch support
-FROM multiarch/qemu-user-static:x86_64-aarch64 as multiarch-aarch64
+FROM multiarch/qemu-user-static:x86_64-aarch64 AS multiarch-aarch64
 
 # rockylinux/8 base image
-FROM rockylinux:8 as rockylinux-8-base
+FROM rockylinux/rockylinux:8 AS rockylinux-8-base
 
 # Add for the YAML development libraries
 RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
@@ -25,7 +25,7 @@ RUN yum -y update && \
 
 # rockylinux/8.arm64v8 base image
 # hadolint ignore=DL3029
-FROM --platform=arm64 rockylinux:8 as rockylinux-8.arm64v8-base
+FROM --platform=arm64 rockylinux/rockylinux:8 AS rockylinux-8.arm64v8-base
 
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
@@ -44,7 +44,7 @@ RUN yum -y update && \
 ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
 ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
-FROM rockylinux:9 as rockylinux-9-base
+FROM rockylinux/rockylinux:9 AS rockylinux-9-base
 
 # Add for the YAML development libraries
 RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
@@ -57,9 +57,43 @@ RUN yum -y update && \
     cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
 
-# rockylinux/8.arm64v8 base image
+# rockylinux/9.arm64v8 base image
 # hadolint ignore=DL3029
-FROM --platform=arm64 rockylinux:9 as rockylinux-9.arm64v8-base
+FROM --platform=arm64 rockylinux/rockylinux:9 AS rockylinux-9.arm64v8-base
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
+    yum clean all
+
+# Need larger page size
+ARG FLB_JEMALLOC_OPTIONS="--with-lg-page=16 --with-lg-quantum=3"
+ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
+
+FROM rockylinux/rockylinux:10 AS rockylinux-10-base
+
+# Add for the YAML development libraries
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
+
+# hadolint ignore=DL3033
+RUN yum -y update && \
+    yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+    wget unzip systemd-devel wget flex bison \
+    postgresql-libs postgresql-devel postgresql-server postgresql \
+    cyrus-sasl-lib openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
+    yum clean all
+
+# rockylinux/10.arm64v8 base image
+# hadolint ignore=DL3029
+FROM --platform=arm64 rockylinux/rockylinux:10 AS rockylinux-10.arm64v8-base
 
 COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
@@ -80,7 +114,7 @@ ENV FLB_JEMALLOC_OPTIONS=$FLB_JEMALLOC_OPTIONS
 
 # Common build for all distributions now
 # hadolint ignore=DL3006
-FROM $BASE_BUILDER as builder
+FROM $BASE_BUILDER AS builder
 
 ARG FLB_NIGHTLY_BUILD
 ENV FLB_NIGHTLY_BUILD=$FLB_NIGHTLY_BUILD

--- a/packaging/test-release-packages.sh
+++ b/packaging/test-release-packages.sh
@@ -37,18 +37,28 @@ function check_version() {
     fi
 }
 
-APT_TARGETS=("ubuntu:22.04"
+APT_TARGETS=(
+	"ubuntu:22.04"
+	"ubuntu:24.04"
     "debian:10"
-    "debian:11")
+    "debian:11"
+	"debian:12"
+	"debian:13"
+)
 
-YUM_TARGETS=("centos:7"
+YUM_TARGETS=(
+	"centos:7"
     "almalinux:8"
     "almalinux:9"
+    "almalinux:10"
     "rockylinux:8"
     "rockylinux:9"
+    "rockylinux:10"
     "quay.io/centos/centos:stream9"
+    "quay.io/centos/centos:stream10"
     "amazonlinux:2"
-    "amazonlinux:2023")
+    "amazonlinux:2023"
+)
 
 for IMAGE in "${YUM_TARGETS[@]}"
 do

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -31,7 +31,19 @@ fi
 # AWS_S3_BUCKET_STAGING=fluentbit-staging
 export AWS_REGION=${AWS_REGION:-us-east-1}
 
-RPM_REPO_PATHS=("amazonlinux/2" "amazonlinux/2023" "centos/7" "centos/8" "centos/9" "rockylinux/8" "rockylinux/9" "almalinux/8" "almalinux/9" )
+RPM_REPO_PATHS=( "amazonlinux/2" 
+				 "amazonlinux/2023" 
+				 "centos/7" 
+				 "centos/8" 
+				 "centos/9" 
+				 "centos/10" 
+				 "rockylinux/8" 
+				 "rockylinux/9" 
+				 "rockylinux/10" 
+				 "almalinux/8" 
+				 "almalinux/9" 
+				 "almalinux/10"
+				)
 
 if [[ "${AWS_SYNC:-false}" != "false" ]]; then
     aws s3 sync s3://"${AWS_S3_BUCKET_RELEASE:?}" "${BASE_PATH:?}"
@@ -50,6 +62,7 @@ done
 DEB_REPO_PATHS=( "debian/bookworm"
                  "debian/bullseye"
                  "debian/buster"
+                 "debian/trixie"
                  "ubuntu/jammy"
                  "ubuntu/noble"
                  "raspbian/bookworm"


### PR DESCRIPTION
Backport of #10906

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [X] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [X] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
