### PR TITLE
build: remove buster, replace with bullseye when necessary

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -35,8 +35,6 @@ The [`distros`](./distros/) directory contains OCI container definitions used to
 | Debian        |   12                      | arm64v8 | debian/bookworm.arm64v8  |
 | Debian        |   11                      | x86_64  | debian/bullseye          |
 | Debian        |   11                      | arm64v8 | debian/bullseye.arm64v8  |
-| Debian        |   10                      | x86_64  | debian/buster            |
-| Debian        |   10                      | arm64v8 | debian/buster.arm64v8    |
 | Ubuntu        |   24.04 / Noble Numbat    | x86_64  | ubuntu/24.04             |
 | Ubuntu        |   24.04 / Noble Numbat    | arm64v8 | ubuntu/24.04.arm64v8     |
 | Ubuntu        |   22.04 / Jammy Jellyfish | x86_64  | ubuntu/22.04             |
@@ -48,7 +46,6 @@ The [`distros`](./distros/) directory contains OCI container definitions used to
 | Ubuntu        |   16.04 / Xenial Xerus    | x86_64  | ubuntu/16.04             |
 | Raspbian      |   12 / Bookworm           | arm32v7 | raspbian/bookworm        |
 | Raspbian      |   11 / Bullseye           | arm32v7 | raspbian/bullseye        |
-| Raspbian      |   10 / Buster             | arm32v7 | raspbian/buster          |
 | Rocky Linux   |   10                      | x86_64  | rockylinux/10            |
 | Rocky Linux   |   10                      | arm64v8 | rockylinux/10.arm64v8    |
 | Rocky Linux   |   9                       | x86_64  | rockylinux/9             |

--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -105,14 +105,6 @@
           "type": "deb"
         },
         {
-          "target": "debian/buster",
-          "type": "deb"
-        },
-        {
-          "target": "debian/buster.arm64v8",
-          "type": "deb"
-        },
-        {
           "target": "debian/bullseye",
           "type": "deb"
         },

--- a/packaging/update-apt-repo.sh
+++ b/packaging/update-apt-repo.sh
@@ -10,7 +10,7 @@ if [[ ! -d "$BASE_PATH" ]]; then
     exit 1
 fi
 
-# "debian/bookworm" "debian/bullseye" "debian/buster" "debian/trixie" "ubuntu/xenial" "ubuntu/bionic" "ubuntu/focal" "ubuntu/jammy" "raspbian/buster" "raspbian/bullseye"
+# "debian/bookworm" "debian/bullseye" "debian/trixie" "ubuntu/xenial" "ubuntu/bionic" "ubuntu/focal" "ubuntu/jammy" "raspbian/bullseye"
 DEB_REPO=${DEB_REPO:?}
 
 # Set true to prevent signing

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -61,7 +61,6 @@ done
 
 DEB_REPO_PATHS=( "debian/bookworm"
                  "debian/bullseye"
-                 "debian/buster"
                  "debian/trixie"
                  "ubuntu/jammy"
                  "ubuntu/noble"


### PR DESCRIPTION
It's been three years since buster does not gets updated from Debian Security Team and it's been a year since Debian LTS Team does not support that either.

Now that `trixie` has been added as well to this repository, I've removed all `buster` tests.

There were also some tests which only were tested on `buster`, I've changed them to `bullseye` for now to expect minimum changes, and I'm going to change them to `trixie` with is Debian `stable` now.

----
Enter `` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/2068

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched build pipelines from Debian Buster to Debian Bullseye across releases.
  * Removed Debian Buster build targets and repository entries.

* **Documentation**
  * Updated packaging documentation and comments to reflect removal of Debian Buster (and Raspbian Buster) targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->