### PR TITLE
workflows: Use lld-15 only for riscv64

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -253,11 +253,18 @@ jobs:
             --volume "/var/lib/dbus/machine-id:/var/lib/dbus/machine-id"
             --volume "/etc/machine-id:/etc/machine-id"
           install: |
-            dpkg --add-architecture s390x
-            dpkg --add-architecture riscv64
-
             apt-get update
-            apt-get install -y gcc-12 g++-12 libyaml-dev flex bison libssl-dev libbpf-dev linux-tools-common lld
+            apt-get install -y gcc-12 g++-12 libyaml-dev flex bison libssl-dev libbpf-dev linux-tools-common
+            arch="$(dpkg --print-architecture)"
+            case "$arch" in
+              riscv64)
+                apt-get install -y gcc-12 g++-12 libyaml-dev flex bison libssl-dev \
+                                   libbpf-dev linux-tools-common lld-15
+                update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-15 50
+                ;;
+              *)
+                ;;
+            esac
             apt-get satisfy -y cmake "cmake (<< 4.0)"
 
             update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 90
@@ -265,7 +272,15 @@ jobs:
           run: |
             cd build
             export nparallel=$(( $(getconf _NPROCESSORS_ONLN) > 8 ? 8 : $(getconf _NPROCESSORS_ONLN) ))
-            export CMAKE_LINKER_OPTION="-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld
+            export CMAKE_LINKER_OPTION=""
+            arch="$(dpkg --print-architecture)"
+            case "$arch" in
+              riscv64)
+                export CMAKE_LINKER_OPTION='-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld"'
+                ;;
+              *)
+                ;;
+            esac
             export FLB_OPTION="-DFLB_WITHOUT_flb-it-network=1 -DFLB_WITHOUT_flb-it-fstore=1"
             export FLB_OMIT_OPTION=""
             export GLOBAL_OPTION="-DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off -DFLB_DEBUG=On -DFLB_ALL=On -DFLB_EXAMPLES=Off"


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the previous PR https://github.com/fluent/fluent-bit/pull/10903, we're not considered deeply for CI improvements.
This is because to use lld-15 or later is only way to improve CI speed for riscv64.
So, we need to restrict the usage of lld-15 and restore to the previous behavior for s390x CI task.

CI results are: https://github.com/fluent/fluent-bit/actions/runs/17860247892/job/50788824750

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Made unit-test workflow architecture-aware for more reliable runs across platforms.
  - Improved RISC-V (riscv64) support by using the appropriate linker configuration.
  - Avoided forcing linker settings on non-RISC-V architectures to prevent unintended effects.

- Chores
  - Streamlined CI package installation by removing unnecessary multi-architecture additions.
  - Reduced extraneous dependencies to speed up and stabilize CI execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->