### PR TITLE
parser: json: enable optimized JSON backend

### DIFF
--- a/include/fluent-bit/flb_pack_json.h
+++ b/include/fluent-bit/flb_pack_json.h
@@ -39,5 +39,10 @@ int flb_pack_json_ext(const char *json, size_t len,
                       int *out_root_type,
                       struct flb_pack_opts *opts);
 
+int flb_pack_json_recs_ext(const char *json, size_t len,
+                           char **out_buf, size_t *out_size,
+                           int *out_root_type, int *out_records,
+                           size_t *consumed, struct flb_pack_opts *opts);
+
 #endif
 

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -22,6 +22,7 @@
 
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_pack_json.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_parser_decoder.h>
 
@@ -56,12 +57,15 @@ int flb_parser_json_do(struct flb_parser *parser,
     struct flb_tm tm = {0};
     struct flb_time *t;
     size_t consumed;
+    struct flb_pack_opts pack_opts = {0};
 
     consumed = 0;
 
     /* Convert incoming in_buf JSON message to message pack format */
-    ret = flb_pack_json_recs(in_buf, in_size, &mp_buf, &mp_size, &root_type,
-                             &records, &consumed);
+    pack_opts.backend = FLB_PACK_JSON_BACKEND_YYJSON;
+    ret = flb_pack_json_recs_ext(in_buf, in_size, &mp_buf, &mp_size,
+                                 &root_type, &records, &consumed,
+                                 &pack_opts);
     if (ret != 0) {
         return -1;
     }

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -3,6 +3,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_pack_json.h>
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_str.h>
 #include <monkey/mk_core.h>
@@ -60,6 +61,88 @@ void test_json_pack()
     TEST_CHECK(ret == 0);
 
     flb_free(data);
+    flb_free(out_buf);
+}
+
+void test_json_pack_ext_default_backend()
+{
+    int ret;
+    int root_type;
+    char *out_buf = NULL;
+    size_t out_size = 0;
+    const char *json = "{\"k\":\"v\"} {\"k2\":\"v2\"}";
+
+    ret = flb_pack_json_ext(json, strlen(json), &out_buf, &out_size,
+                             &root_type, NULL);
+
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(out_buf != NULL);
+    TEST_CHECK(out_size > 0);
+
+    flb_free(out_buf);
+}
+
+void test_json_pack_ext_jsmn_backend()
+{
+    int ret;
+    int root_type;
+    char *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_pack_opts opts = {0};
+    const char *json = "{\"k\":\"v\"} {\"k2\":\"v2\"}";
+
+    opts.backend = FLB_PACK_JSON_BACKEND_JSMN;
+
+    ret = flb_pack_json_ext(json, strlen(json), &out_buf, &out_size,
+                             &root_type, &opts);
+
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(out_buf != NULL);
+    TEST_CHECK(out_size > 0);
+
+    flb_free(out_buf);
+}
+
+void test_json_pack_recs_ext_default_backend()
+{
+    int ret;
+    int records;
+    int root_type;
+    char *out_buf = NULL;
+    size_t consumed = 0;
+    size_t out_size = 0;
+    const char *json = "{\"k\":\"v\"} {\"k2\":\"v2\"}";
+
+    ret = flb_pack_json_recs_ext(json, strlen(json), &out_buf, &out_size,
+                                  &root_type, &records, &consumed, NULL);
+
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(records == 2);
+    TEST_CHECK(consumed == strlen(json));
+
+    flb_free(out_buf);
+}
+
+void test_json_pack_recs_ext_jsmn_backend()
+{
+    int ret;
+    int records;
+    int root_type;
+    char *out_buf = NULL;
+    size_t consumed = 0;
+    size_t out_size = 0;
+    struct flb_pack_opts opts = {0};
+    const char *json = "{\"k\":\"v\"} {\"k2\":\"v2\"}";
+
+    opts.backend = FLB_PACK_JSON_BACKEND_JSMN;
+
+    ret = flb_pack_json_recs_ext(json, strlen(json), &out_buf, &out_size,
+                                  &root_type, &records, &consumed, &opts);
+
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(records == 2);
+    TEST_CHECK(consumed == strlen(json));
+
     flb_free(out_buf);
 }
 
@@ -1185,6 +1268,10 @@ void test_json_pack_token_count_overflow()
 TEST_LIST = {
     /* JSON maps iteration */
     { "json_pack"          , test_json_pack },
+    { "json_pack_ext_default_backend", test_json_pack_ext_default_backend },
+    { "json_pack_ext_jsmn_backend", test_json_pack_ext_jsmn_backend },
+    { "json_pack_recs_ext_default_backend", test_json_pack_recs_ext_default_backend },
+    { "json_pack_recs_ext_jsmn_backend", test_json_pack_recs_ext_jsmn_backend },
     { "json_pack_iter"     , test_json_pack_iter},
     { "json_pack_mult"     , test_json_pack_mult},
     { "json_pack_mult_iter", test_json_pack_mult_iter},


### PR DESCRIPTION
Now the JSON parser API uses the new optimized backend 

## Summary by CodeRabbit

* **New Features**
  * Added an extended JSON packing interface that can also return the number of records processed and the number of input bytes consumed.
  * Preserves existing behavior when the extended outputs aren’t requested.
  * Parser path updated to prefer the faster JSON backend where available.

* **Tests**
  * Added test coverage for the extended and standard JSON packing flows across both default and JSMN backends.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

