### PR TITLE
config_format: yaml: fix state parameter for read_blob in Windows

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -623,7 +623,7 @@ static int read_glob(struct flb_cf *conf, struct local_ctx *ctx,
 
         if (ret == 0 && (st.st_mode & S_IFMT) == S_IFREG) {
 
-            if (read_config(conf, ctx, state, buf) < 0) {
+            if (read_config(conf, ctx, state->file, buf) < 0) {
                 return -1;
             }
         }


### PR DESCRIPTION
Fixes #10905

The config format read_blob() implementation in Windows, was incorrectly receiving a struct parser_state * instead of a struct file_state * to the read_config function. This PR fix the wrong parameter.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of files matched by glob patterns in YAML configuration, ensuring they inherit the correct parent context for path resolution.
  - Improves reliability when loading multiple config fragments via globs, reducing unexpected include/path errors and making behavior more predictable on non-Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->