### PR TITLE
in_blob: validate if db is set on exit

### DIFF
--- a/plugins/in_blob/blob_db.c
+++ b/plugins/in_blob/blob_db.c
@@ -106,12 +106,32 @@ struct flb_sqldb *blob_db_open(struct blob_ctx *ctx, char *db_path)
 
 int blob_db_close(struct blob_ctx *ctx)
 {
-    /* finalize prepared statements */
-    sqlite3_finalize(ctx->stmt_get_file);
-    sqlite3_finalize(ctx->stmt_insert_file);
-    sqlite3_finalize(ctx->stmt_delete_file);
+    int ret;
 
-    return flb_sqldb_close(ctx->db);
+    if (ctx->db == NULL) {
+        return 0;
+    }
+
+    /* finalize prepared statements */
+    if (ctx->stmt_get_file != NULL) {
+        sqlite3_finalize(ctx->stmt_get_file);
+        ctx->stmt_get_file = NULL;
+    }
+
+    if (ctx->stmt_insert_file != NULL) {
+        sqlite3_finalize(ctx->stmt_insert_file);
+        ctx->stmt_insert_file = NULL;
+    }
+
+    if (ctx->stmt_delete_file != NULL) {
+        sqlite3_finalize(ctx->stmt_delete_file);
+        ctx->stmt_delete_file = NULL;
+    }
+
+    ret = flb_sqldb_close(ctx->db);
+    ctx->db = NULL;
+
+    return ret;
 }
 
 int blob_db_file_exists(struct blob_ctx *ctx, char *path, uint64_t *id)


### PR DESCRIPTION
Fixes  #10916 

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
