### PR TITLE
log_to_metrics: fix improper handling of record accessor context

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.h
+++ b/plugins/filter_log_to_metrics/log_to_metrics.h
@@ -70,6 +70,7 @@ struct log_to_metrics_ctx {
     struct cmt_gauge *g;
     struct cmt_histogram *h;
     struct cmt_histogram_buckets *histogram_buckets;
+    struct flb_record_accessor *value_ra;
 
     /* config options */
     int mode;


### PR DESCRIPTION
"Potentially" fixes #10917

Previously, when value_field was used, a new record accessor context was created for every record during the filtering phase. This was unintended, as record accessor patterns are immutable and expensive to create. Additionally, when the pattern did not match and raised an exception, memory leaks could occur.

This patch simplifies the logic by moving the creation and destruction of the record accessor context to the plugin’s initialization and exit callbacks. It also cleans up the filtering logic to avoid memory leaks and ensure correct usage.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
