### PR TITLE
filter_kubernetes: fix compiler warning

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -1332,7 +1332,8 @@ static int merge_pod_meta(struct flb_kube_meta *meta, struct flb_kube *ctx,
     msgpack_object api_map;
     msgpack_object ann_map;
     struct flb_kube_props props = {0};
-    struct service_attributes *tmp_service_attributes = {0};
+    struct service_attributes *tmp_service_attributes = NULL;
+    void *tmp_service_attributes_buf = NULL;
 
     /*
      * - reg_buf: is a msgpack Map containing meta captured using Regex
@@ -1478,8 +1479,9 @@ static int merge_pod_meta(struct flb_kube_meta *meta, struct flb_kube *ctx,
     if (ctx->aws_use_pod_association) {
         pod_service_found = flb_hash_table_get(ctx->aws_pod_service_hash_table,
                                  meta->podname, meta->podname_len,
-                                 &tmp_service_attributes, &tmp_service_attr_size);
-        if (pod_service_found != -1 && tmp_service_attributes != NULL) {
+                                 &tmp_service_attributes_buf, &tmp_service_attr_size);
+        if (pod_service_found != -1 && tmp_service_attributes_buf != NULL) {
+            tmp_service_attributes = (struct service_attributes *) tmp_service_attributes_buf;
             map_size += tmp_service_attributes->fields;
         }
         if (ctx->platform) {
@@ -1820,7 +1822,8 @@ static inline int extract_pod_meta(struct flb_kube *ctx,
     ssize_t n;
     int ret;
     int pod_service_found;
-    struct service_attributes *tmp_service_attributes = {0};
+    struct service_attributes *tmp_service_attributes = NULL;
+    void *tmp_service_attributes_buf = NULL;
 
     /* Reset meta context */
     memset(meta, '\0', sizeof(struct flb_kube_meta));
@@ -1843,9 +1846,10 @@ static inline int extract_pod_meta(struct flb_kube *ctx,
 
         pod_service_found = flb_hash_table_get(ctx->aws_pod_service_hash_table,
                                  meta->podname, meta->podname_len,
-                                 &tmp_service_attributes, &tmp_service_attr_size);
+                                 &tmp_service_attributes_buf, &tmp_service_attr_size);
 
-        if (pod_service_found != -1 && tmp_service_attributes != NULL) {
+        if (pod_service_found != -1 && tmp_service_attributes_buf != NULL) {
+            tmp_service_attributes = (struct service_attributes *) tmp_service_attributes_buf;
             if (tmp_service_attributes->name[0] != '\0') {
                 n += tmp_service_attributes->name_len + 1;
             }

--- a/plugins/filter_kubernetes/kubernetes_aws.c
+++ b/plugins/filter_kubernetes/kubernetes_aws.c
@@ -27,7 +27,7 @@
 #include "kube_conf.h"
 #include "kube_meta.h"
 #include "fluent-bit/flb_http_client.h"
-#include "fluent-bit/flb_output_plugin.h"
+#include "fluent-bit/flb_filter_plugin.h"
 #include "fluent-bit/flb_pack.h"
 #include "fluent-bit/flb_upstream_conn.h"
 /*
@@ -73,7 +73,7 @@ static int get_pod_service_file_info(struct flb_kube *ctx, char **buffer)
         if (payload_size) {
             *buffer=payload;
             packed = payload_size;
-            flb_plg_debug(ctx->ins, "pod to service map content is: %s", buffer);
+            flb_plg_debug(ctx->ins, "pod to service map content is: %s", *buffer);
         }
     }
 
@@ -198,7 +198,7 @@ int fetch_pod_service_map(struct flb_kube *ctx, char *api_server_url,
     int ret;
     struct flb_http_client *c;
     size_t b_sent;
-    struct flb_upstream_conn *u_conn;
+    struct flb_connection *u_conn;
     char *buffer = {0};
 
     flb_plg_debug(ctx->ins, "fetch pod to service map");


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing AWS pod association attributes during Kubernetes metadata processing, reducing errors and potential crashes.
* **Refactor**
  * Hardened metadata extraction with safer memory handling and null checks, improving overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->