### PR TITLE
input: private plugins must use global event loop

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -1649,11 +1649,25 @@ static struct flb_input_collector *collector_create(int type,
         coll->evl = thi->evl;
     }
     else {
-        /* We need to obtain the event loop from the TLS when
-         * creating collectors for non threaded plugins running
-         * under a threaded plugin.
+        struct mk_event_loop *tls_evl;
+
+        /*
+         * Collectors for non-threaded plugins normally run on the main
+         * engine event loop. When a private helper input such as the
+         * emitter is instantiated from within a threaded input (e.g. via
+         * an input processor), the input thread stores its own event loop
+         * in TLS.  Those helper inputs must continue to use the main
+         * engine event loop to avoid spinning the input thread.
          */
-        coll->evl = flb_engine_evl_get();
+        tls_evl = flb_engine_evl_get();
+
+        if (tls_evl != NULL && tls_evl != config->evl &&
+            !(ins->p && (ins->p->flags & FLB_INPUT_PRIVATE))) {
+            coll->evl = tls_evl;
+        }
+        else {
+            coll->evl = config->evl;
+        }
     }
 
     /*


### PR DESCRIPTION
Fixes #10529 

Forces the helper that instances private input plugins (emitter)  to bind their collectors back to the main engine loop instead of the thread loop.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects event loop assignment for non-threaded inputs, ensuring private inputs consistently use the main loop. Improves stability and prevents missed events in specific configurations.

* **Tests**
  * Added test coverage to verify private inputs use the main event loop, strengthening reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->