### PR TITLE
workflows: windows: Add a testing flow with using ARM64 Windows runner

### DIFF
--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -70,7 +70,7 @@ jobs:
           Copy-Item -Path C:\WinFlexBison/win_bison.exe C:\WinFlexBison/bison.exe
           Copy-Item -Path C:\WinFlexBison/win_flex.exe C:\WinFlexBison/flex.exe
           echo "C:\WinFlexBison" | Out-File -FilePath $env:GITHUB_PATH -Append
-          choco install cmake --version "${{ matrix.config.cmake_version }}" --force
+          choco install cmake.portable --version "${{ matrix.config.cmake_version }}" --force
         env:
           WINFLEXBISON: https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip
         shell: pwsh

--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -127,7 +127,7 @@ jobs:
           key: ${{ steps.cache-unit-test-vcpkg-sources.outputs.cache-primary-key }}
           enableCrossOsArchive: false
 
-      - name: Build unit-test for Fluent Bit packages (only for x86 and x64)
+      - name: Build unit-test for Fluent Bit packages (x86, x64, and ARM64)
         run: |
           cmake -G "NMake Makefiles" `
             -D FLB_TESTS_INTERNAL=On `
@@ -170,7 +170,7 @@ jobs:
           dumpbin /dependents .\bin\fluent-bit.exe
         working-directory: build
 
-      - name: Build unit-test for Fluent Bit packages (only for x86 and x64)
+      - name: Run unit tests for Fluent Bit packages (x86, x64, and ARM64)
         run: |
             ctest --build-run-dir "$PWD" --output-on-failure
         shell: pwsh

--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   call-build-windows-unit-test:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.config.os }}
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
@@ -39,11 +39,19 @@ jobs:
             cmake_additional_opt: ""
             vcpkg_triplet: x86-windows-static
             cmake_version: "3.31.6"
+            os: windows-latest
           - name: "Windows 64bit"
             arch: x64
             cmake_additional_opt: ""
             vcpkg_triplet: x64-windows-static
             cmake_version: "3.31.6"
+            os: windows-latest
+          - name: "Windows 64bit (Arm64)"
+            arch: amd64_arm64
+            cmake_additional_opt: "-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64"
+            vcpkg_triplet: arm64-windows-static
+            cmake_version: "3.31.6"
+            os: windows-11-arm
     permissions:
       contents: read
     # Default environment variables can be overridden below. To prevent library pollution - without this other random libraries may be found on the path leading to failures.


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Windows test matrix to run on Windows 32-bit, 64-bit, and Windows 11 on ARM (Arm64), with OS-specific runner selection and updated test steps for ARM64.
* **Chores**
  * Switched to a matrix-driven runner selection for Windows jobs and updated dependency installation to use the portable CMake package for Windows builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->