### PR TITLE
input: private plugins must use global event loop [Backport to 4.0]

### DIFF
--- a/tests/internal/processor.c
+++ b/tests/internal/processor.c
@@ -28,6 +28,7 @@
 #include <fluent-bit/flb_bucket_queue.h>
 #include <fluent-bit/flb_storage.h>
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_compat.h>
 
 #include "flb_tests_internal.h"
 
@@ -136,6 +137,12 @@ static void processor_private_inputs_use_main_loop()
 
     flb_init_env();
 
+#ifdef _WIN32
+    WSADATA wsa;
+    int wret = WSAStartup(MAKEWORD(2,2), &wsa);
+    TEST_CHECK(wret == 0);
+#endif
+
     config = flb_config_init();
     TEST_CHECK(config != NULL);
 
@@ -183,6 +190,10 @@ static void processor_private_inputs_use_main_loop()
 
     flb_storage_destroy(config);
     flb_config_exit(config);
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
 }
 
 TEST_LIST = {


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backport of https://github.com/fluent/fluent-bit/pull/10924 and a subsequent PR https://github.com/fluent/fluent-bit/pull/10930

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
