### PR TITLE
in_splunk: return correct error response for http/1 handler.

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -887,10 +887,12 @@ int splunk_prot_handle(struct flb_splunk *ctx, struct splunk_conn *conn,
                 return -1;
             }
 
-            if (!ret) {
+            if (ret < 0) {
                 send_json_message_response(conn, 400, "{\"text\":\"Invalid data format\",\"code\":6}");
             }
-            send_json_message_response(conn, 200, "{\"text\":\"Success\",\"code\":0}");
+            else {
+                send_json_message_response(conn, 200, "{\"text\":\"Success\",\"code\":0}");
+            }
         }
         else if (strcasecmp(uri, "/services/collector/event/1.0") == 0 ||
                  strcasecmp(uri, "/services/collector/event") == 0 ||
@@ -910,10 +912,12 @@ int splunk_prot_handle(struct flb_splunk *ctx, struct splunk_conn *conn,
                 return -1;
             }
 
-            if (!ret) {
+            if (ret < 0) {
                 send_json_message_response(conn, 400, "{\"text\":\"Invalid data format\",\"code\":6}");
             }
-            send_json_message_response(conn, 200, "{\"text\":\"Success\",\"code\":0}");
+            else {
+                send_json_message_response(conn, 200, "{\"text\":\"Success\",\"code\":0}");
+            }
         }
         else {
             send_response(conn, 400, "error: invalid HTTP endpoint\n");


### PR DESCRIPTION
# Summary

The `in_splunk` plugin is responding with `{"text": "Invalid data format"}` even when submitting valid payloads.

This is a port of the 4.0 patch #10939.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
