### PR TITLE
in_winevtlog: Implement trying to reconnect on cancel mechanism

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -161,6 +161,8 @@ static int in_winevtlog_init(struct flb_input_instance *in,
     struct winevtlog_config *ctx;
     struct winevtlog_session *session;
     int status = WINEVTLOG_SESSION_CREATE_OK;
+    double mult = 2.0;
+    DWORD tmp_ms = 0;
 
     /* Initialize context */
     ctx = flb_calloc(1, sizeof(struct winevtlog_config));
@@ -185,6 +187,47 @@ static int in_winevtlog_init(struct flb_input_instance *in,
         flb_log_event_encoder_destroy(ctx->log_encoder);
         flb_free(ctx);
         return -1;
+    }
+
+    if (ctx->backoff_multiplier_str && ctx->backoff_multiplier_str[0] != '\0') {
+        mult = atof(ctx->backoff_multiplier_str);
+        if (mult <= 0.0) {
+            flb_plg_warn(in, "invalid reconnect.multiplier='%s', fallback to 2.0",
+                         ctx->backoff_multiplier_str);
+            mult = 2.0;
+        }
+    }
+    ctx->backoff.multiplier_x1000 = (DWORD)(mult * 1000.0);
+
+    if (ctx->backoff.base_ms == 0) {
+        ctx->backoff.base_ms = 500;
+    }
+
+    if (ctx->backoff.max_ms  == 0) {
+        ctx->backoff.max_ms  = 30000;
+    }
+
+    if (ctx->backoff.jitter_pct == 0) {
+        ctx->backoff.jitter_pct = 20;
+    }
+
+    if (ctx->backoff.max_retries == 0) {
+        ctx->backoff.max_retries = 8;
+    }
+
+    if (ctx->backoff.max_ms < ctx->backoff.base_ms) {
+        flb_plg_warn(in, "reconnect.max_ms < reconnect.base_ms, swapping values");
+        tmp_ms = ctx->backoff.base_ms;
+        ctx->backoff.base_ms = ctx->backoff.max_ms;
+        ctx->backoff.max_ms  = tmp_ms;
+    }
+
+    if (ctx->backoff.multiplier_x1000 < 500)  {
+        ctx->backoff.multiplier_x1000 = 500;
+    }
+
+    if (ctx->backoff.multiplier_x1000 > 10000) {
+        ctx->backoff.multiplier_x1000 = 10000;
     }
 
     /* Initialize session context */
@@ -450,6 +493,32 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "remote.password", (char *)NULL,
       0, FLB_TRUE, offsetof(struct winevtlog_config, remote_password),
       "Specify password of remote access for Windows EventLog"
+    },
+    /* ---- reconnect backoff parameters ---- */
+    {
+      FLB_CONFIG_MAP_INT, "reconnect.base_ms", "500",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, backoff.base_ms),
+      "Initial reconnect backoff in milliseconds"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "reconnect.max_ms", "30000",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, backoff.max_ms),
+      "Maximum reconnect backoff in milliseconds"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "reconnect.multiplier", "2.0",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, backoff_multiplier_str),
+      "Exponential backoff multiplier (float, e.g. 2.0)"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "reconnect.jitter_pct", "20",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, backoff.jitter_pct),
+      "Jitter percentage applied to backoff (e.g. 20 means ±20%)"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "reconnect.max_retries", "8",
+      0, FLB_TRUE, offsetof(struct winevtlog_config, backoff.max_retries),
+      "Max reconnect attempts before giving up"
     },
     /* EOF */
     {0}

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -200,14 +200,20 @@ static int in_winevtlog_init(struct flb_input_instance *in,
     ctx->backoff.multiplier_x1000 = (DWORD)(mult * 1000.0);
 
     /* normalize base/max/jitter/retries to sane ranges */
-    if (ctx->backoff.base_ms == 0) {
+    if (ctx->backoff.base_ms <= 0) {
         ctx->backoff.base_ms = 500;
     }
-    if (ctx->backoff.max_ms  == 0) {
+    if (ctx->backoff.max_ms  <= 0) {
         ctx->backoff.max_ms  = 30000;
+    }
+    if (ctx->backoff.jitter_pct < 0) {
+        ctx->backoff.jitter_pct = 0;
     }
     if (ctx->backoff.jitter_pct == 0) {
         ctx->backoff.jitter_pct = 20;
+    }
+    if (ctx->backoff.max_retries < 0) {
+        ctx->backoff.max_retries = 0;
     }
     if (ctx->backoff.max_retries == 0) {
         ctx->backoff.max_retries = 8;
@@ -222,6 +228,9 @@ static int in_winevtlog_init(struct flb_input_instance *in,
     }
     if (ctx->backoff.jitter_pct > 100U) {  /* jitter as percentage */
         ctx->backoff.jitter_pct = 100U;
+    }
+    if ((unsigned) ctx->backoff.max_retries > 100U) { /* cap retries */
+        ctx->backoff.max_retries = 100;
     }
     /* ensure ordering */
     if (ctx->backoff.max_ms < ctx->backoff.base_ms) {

--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -209,14 +209,8 @@ static int in_winevtlog_init(struct flb_input_instance *in,
     if (ctx->backoff.jitter_pct < 0) {
         ctx->backoff.jitter_pct = 0;
     }
-    if (ctx->backoff.jitter_pct == 0) {
-        ctx->backoff.jitter_pct = 20;
-    }
     if (ctx->backoff.max_retries < 0) {
         ctx->backoff.max_retries = 0;
-    }
-    if (ctx->backoff.max_retries == 0) {
-        ctx->backoff.max_retries = 8;
     }
 
     /* clamp out-of-range values, protecting against negative INT written into DWORD */

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -89,12 +89,58 @@ struct winevtlog_channel *winevtlog_subscribe(const char *channel, struct winevt
     // channel : To wide char
     len = MultiByteToWideChar(CP_UTF8, 0, channel, -1, NULL, 0);
     wide_channel = flb_malloc(sizeof(WCHAR) * len);
-    MultiByteToWideChar(CP_UTF8, 0, channel, -1, wide_channel, len);
+    if (wide_channel == NULL) {
+        if (signal_event) {
+            CloseHandle(signal_event);
+        }
+        flb_free(ch->name);
+        if (ch->query) {
+            flb_free(ch->query);
+        }
+        flb_free(ch);
+        return NULL;
+    }
+    if (0 == MultiByteToWideChar(CP_UTF8, 0, channel, -1, wide_channel, len)) {
+        if (signal_event) {
+            CloseHandle(signal_event);
+        }
+        flb_free(wide_channel);
+        flb_free(ch->name);
+        if (ch->query) {
+            flb_free(ch->query);
+        }
+        flb_free(ch);
+        return NULL;
+    }
     if (query != NULL) {
     // query : To wide char
         len = MultiByteToWideChar(CP_UTF8, 0, query, -1, NULL, 0);
         wide_query = flb_malloc(sizeof(WCHAR) * len);
-        MultiByteToWideChar(CP_UTF8, 0, query, -1, wide_query, len);
+       if (wide_query == NULL) {
+            if (signal_event) {
+                CloseHandle(signal_event);
+            }
+            flb_free(wide_channel);
+            flb_free(ch->name);
+            if (ch->query) {
+                flb_free(ch->query);
+            }
+            flb_free(ch);
+            return NULL;
+        }
+        if (0 == MultiByteToWideChar(CP_UTF8, 0, query, -1, wide_query, len)) {
+            if (signal_event) {
+                CloseHandle(signal_event);
+            }
+            flb_free(wide_query);
+            flb_free(wide_channel);
+            flb_free(ch->name);
+            if (ch->query) {
+                flb_free(ch->query);
+            }
+            flb_free(ch);
+            return NULL;
+        }
         ch->query = flb_strdup(query);
     }
 

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -88,12 +88,12 @@ struct winevtlog_channel *winevtlog_subscribe(const char *channel, struct winevt
 
     // channel : To wide char
     len = MultiByteToWideChar(CP_UTF8, 0, channel, -1, NULL, 0);
-    wide_channel = flb_malloc(sizeof(PWSTR) * len);
+    wide_channel = flb_malloc(sizeof(WCHAR) * len);
     MultiByteToWideChar(CP_UTF8, 0, channel, -1, wide_channel, len);
     if (query != NULL) {
     // query : To wide char
         len = MultiByteToWideChar(CP_UTF8, 0, query, -1, NULL, 0);
-        wide_query = flb_malloc(sizeof(PWSTR) * len);
+        wide_query = flb_malloc(sizeof(WCHAR) * len);
         MultiByteToWideChar(CP_UTF8, 0, query, -1, wide_query, len);
         ch->query = flb_strdup(query);
     }
@@ -1013,7 +1013,7 @@ static wchar_t* convert_str(char *str)
         return NULL;
     }
 
-    buf = flb_malloc(sizeof(PWSTR) * size);
+    buf = flb_malloc(sizeof(WCHAR) * size);
     if (buf == NULL) {
         flb_errno();
         return NULL;

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -734,6 +734,9 @@ static DWORD calc_backoff_ms(struct winevtlog_channel *ch, const struct winevtlo
     span = (LONG)((ms * jitter) / 100);
     delta = (LONG)(prng16(&ch->prng_state) % (2 * span + 1)) - span;
     with_jitter = (LONG)ms + delta;
+    if (with_jitter < 0) {
+        with_jitter = 0;
+    }
     return (DWORD)with_jitter;
 }
 

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -180,12 +180,21 @@ struct winevtlog_channel *winevtlog_subscribe(const char *channel, struct winevt
     err = GetLastError();
     if (!ch->subscription) {
         flb_plg_error(ctx->ins, "cannot subscribe '%s' (%i)", channel, err);
-        flb_free(ch->name);
-        if (ch->query != NULL) {
-            flb_free(ch->query);
+        if (signal_event) {
+            CloseHandle(signal_event);
         }
         if (ch->remote) {
             EvtClose(ch->remote);
+        }
+        if (wide_channel) {
+            flb_free(wide_channel);
+        }
+        if (wide_query) {
+            flb_free(wide_query);
+        }
+        flb_free(ch->name);
+        if (ch->query != NULL) {
+            flb_free(ch->query);
         }
         flb_free(ch);
         return NULL;

--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -27,6 +27,15 @@
 
 struct winevtlog_session;
 
+/* reconnect backoff */
+struct winevtlog_backoff {
+    DWORD base_ms;
+    DWORD max_ms;
+    DWORD multiplier_x1000;
+    DWORD jitter_pct;
+    DWORD max_retries;
+};
+
 struct winevtlog_config {
     unsigned int interval_sec;
     unsigned int interval_nsec;
@@ -48,6 +57,8 @@ struct winevtlog_config {
     flb_pipefd_t coll_fd;
     struct flb_input_instance *ins;
     struct flb_log_event_encoder *log_encoder;
+    struct winevtlog_backoff backoff;
+    flb_sds_t backoff_multiplier_str;
 };
 
 /* Some channels has very heavy contents for 10 events at same time.
@@ -68,6 +79,9 @@ struct winevtlog_channel {
     BOOL   cancelled_by_us;
     BOOL   reconnect_needed;
     DWORD  last_error;
+    DWORD  retry_attempts;
+    ULONGLONG next_retry_deadline;
+    ULONGLONG prng_state;
 
     char *name;
     char *query;
@@ -128,6 +142,11 @@ void winevtlog_pack_event(PEVT_VARIANT system, WCHAR *message,
  */
 int winevtlog_sqlite_load(struct winevtlog_channel *ch, struct winevtlog_config *ctx, struct flb_sqldb *db);
 int winevtlog_sqlite_save(struct winevtlog_channel *ch, struct winevtlog_config *ctx, struct flb_sqldb *db);
+
+/* Non blocking reconnection utilities */
+int   winevtlog_try_reconnect(struct winevtlog_channel *ch, struct winevtlog_config *ctx);
+void  winevtlog_schedule_retry(struct winevtlog_channel *ch, struct winevtlog_config *ctx);
+void  winevtlog_request_cancel(struct winevtlog_channel *ch);
 
 /*
  * SQL templates

--- a/plugins/in_winevtlog/winevtlog.h
+++ b/plugins/in_winevtlog/winevtlog.h
@@ -64,6 +64,11 @@ struct winevtlog_channel {
     int count;
     struct winevtlog_session *session;
 
+    /* reconnect */
+    BOOL   cancelled_by_us;
+    BOOL   reconnect_needed;
+    DWORD  last_error;
+
     char *name;
     char *query;
     unsigned int time_updated;


### PR DESCRIPTION
<!-- Provide summary of changes -->
When migrating to remote accessing feature from the parity feature on Fluentd, I didn't find a way to reconnect stale connections.
Now, I found a way to handle this.
The clue is distinguish an error that is `ERROR_CANCELLED` or `ERROR_INVALID_HANDLE`.
This is one of the key points to handle disconnect on subscriptions.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes https://github.com/fluent/fluent-bit/issues/10937.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [x] Debug log output from testing the change
After applying this patch, retrying to connect mechanism is starting to work:
```
[2025/09/26 18:38:45.838808500] [ warn] [in_winevtlog] EvtNext failed (err=1726), will reconnect
[2025/09/26 18:39:04.992279600] [error] [input:winevtlog:winevtlog.0] reconnect: EvtSubscribe failed on 'Application' (err=1726)
[2025/09/26 18:39:04.992385700] [ warn] [input:winevtlog:winevtlog.0] reconnect attempt 1 failed for 'Application' (err=1726), next at +20002ms
[2025/09/26 18:39:04.992399900] [debug] [input:winevtlog:winevtlog.0] read 205880 bytes from 'Application'
```
Or
```
[ warn] [in_winevtlog] EvtNext failed (err=6), will reconnect
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added automatic, non-blocking reconnection for Windows Event Log input with configurable exponential backoff, jitter and retry scheduling.
  - New user settings: reconnect.base_ms, reconnect.max_ms, reconnect.multiplier, reconnect.jitter_pct, reconnect.max_retries.
  - Added explicit cancel API to request cancellation without triggering reconnect.

- Bug Fixes
  - Corrected wide-character allocation sizing in subscribe/reconnect paths.
  - Enforced safe defaults, bounds and validation for reconnect settings; ensures max_ms ≥ base_ms and caps values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->