### PR TITLE
engine: fix memory leaks with parse error handling in parse_string_map_to_list (backport of #10943).

### DIFF
--- a/src/flb_config_map.c
+++ b/src/flb_config_map.c
@@ -97,6 +97,7 @@ static struct mk_list *parse_string_map_to_list(struct flb_config_map *map, char
 
     if (ret == -1) {
         flb_error("[config map] error reading list of options");
+        flb_slist_destroy(list);
         flb_free(list);
         return NULL;
     }


### PR DESCRIPTION
# Summary

This is a backport of #10943 to the 4.0 series.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
