### PR TITLE
out_opentelemetry: add configurable log resource limits

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -955,7 +955,7 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-      FLB_CONFIG_MAP_INT, "batch_size", DEFAULT_LOG_RECORD_BATCH_SIZE,
+     FLB_CONFIG_MAP_INT, "batch_size", DEFAULT_LOG_RECORD_BATCH_SIZE,
       0, FLB_TRUE, offsetof(struct opentelemetry_context, batch_size),
       "Set the maximum number of log records to be flushed at a time"
     },
@@ -964,10 +964,17 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Set payload compression mechanism. Options available are 'gzip' and 'zstd'."
     },
+
     /*
      * Logs Properties
      * ---------------
      */
+    {
+     FLB_CONFIG_MAP_INT, "logs_max_resources", DEFAULT_MAX_RESOURCE_EXPORT,
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, max_resources),
+     "Set the maximum number of OTLP log resources per export request (0 disables the limit; default: 0)"
+    },
+
     {
      FLB_CONFIG_MAP_STR, "logs_uri", "/v1/logs",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_uri),

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -976,6 +976,12 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_INT, "logs_max_scopes", DEFAULT_MAX_SCOPE_EXPORT,
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, max_scopes),
+     "Set the maximum number of OTLP log scopes per resource (0 disables the limit; default: 0)"
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "logs_uri", "/v1/logs",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_uri),
      "Specify an optional HTTP URI for the target OTel endpoint."

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -41,6 +41,7 @@
  * including the ones that succeeded. This is not ideal.
  */
 #define DEFAULT_LOG_RECORD_BATCH_SIZE "1000"
+#define DEFAULT_MAX_RESOURCE_EXPORT   "0"    /* no resource limits */
 
 struct opentelemetry_body_key {
     flb_sds_t key;
@@ -138,6 +139,9 @@ struct opentelemetry_context {
 
     /* Number of logs to flush at a time */
     int batch_size;
+
+    /* Maximum number of resources per OTLP export */
+    int max_resources;
 
     /* Log the response payload */
     int log_response_payload;

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -42,6 +42,7 @@
  */
 #define DEFAULT_LOG_RECORD_BATCH_SIZE "1000"
 #define DEFAULT_MAX_RESOURCE_EXPORT   "0"    /* no resource limits */
+#define DEFAULT_MAX_SCOPE_EXPORT      "0"    /* no scope limits */
 
 struct opentelemetry_body_key {
     flb_sds_t key;
@@ -142,6 +143,9 @@ struct opentelemetry_context {
 
     /* Maximum number of resources per OTLP export */
     int max_resources;
+
+    /* Maximum number of scopes per OTLP resource */
+    int max_scopes;
 
     /* Log the response payload */
     int log_response_payload;

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -279,6 +279,12 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         return NULL;
     }
 
+    if (ctx->max_resources < 0) {
+        flb_plg_error(ins, "max_resources must be greater than or equal to zero");
+        flb_opentelemetry_context_destroy(ctx);
+        return NULL;
+    }
+
     /* Parse 'add_label' */
     ret = config_add_labels(ins, ctx);
     if (ret == -1) {

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -285,6 +285,12 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         return NULL;
     }
 
+    if (ctx->max_scopes < 0) {
+        flb_plg_error(ins, "max_scopes must be greater than or equal to zero");
+        flb_opentelemetry_context_destroy(ctx);
+        return NULL;
+    }
+
     /* Parse 'add_label' */
     ret = config_add_labels(ins, ctx);
     if (ret == -1) {


### PR DESCRIPTION
Fixes #10929 

Before this patch we had a hard-coded maximum of 100 log resources per chunk and 100 log scopes per resource. The change in question introduces two new configurable options called `logs_max_resources` and `logs_max_scopes` to control the maximum limit, the default value for both is : `0` (unlimited).

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logs_max_resources and logs_max_scopes configuration options (default 0) to control per-export resource and scope limits; 0 disables the limit and enables dynamic growth.
  * Resource and per-resource scope storage now grow dynamically when limits are disabled, improving large-export handling.

* **Bug Fixes**
  * Invalid (negative) values for the new limits are now rejected early with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->