### PR TITLE
out_opentelemetry: no longer reallocates the http2 setting string

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -262,6 +262,8 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
     const char *tmp = NULL;
     uint64_t http_client_flags;
     int http_protocol_version;
+    int http2_config_value;
+    int http2_effective_value;
 
     /* Allocate plugin context */
     ctx = flb_calloc(1, sizeof(struct opentelemetry_context));
@@ -615,11 +617,19 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
 
     ctx->enable_http2_flag = FLB_TRUE;
 
+    if (ctx->enable_http2) {
+        http2_config_value = flb_utils_bool(ctx->enable_http2);
+    }
+    else {
+        http2_config_value = FLB_FALSE;
+    }
+
+    http2_effective_value = http2_config_value;
+
     /* if gRPC has been enabled, auto-enable HTTP/2 to make end-user life easier */
-    if (ctx->enable_grpc_flag && !flb_utils_bool(ctx->enable_http2)) {
+    if (ctx->enable_grpc_flag && http2_config_value == FLB_FALSE) {
         flb_plg_info(ctx->ins, "gRPC enabled, HTTP/2 has been auto-enabled");
-        flb_sds_destroy(ctx->enable_http2);
-        ctx->enable_http2 = flb_sds_create("on");
+        http2_effective_value = FLB_TRUE;
     }
 
     /*
@@ -627,10 +637,10 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
      * moving forward it wont be necessary since we are now setting some special defaults
      * in case of gRPC is enabled (which is the only case where HTTP/2 is mandatory).
      */
-    if (strcasecmp(ctx->enable_http2, "force") == 0) {
+    if (ctx->enable_http2 && strcasecmp(ctx->enable_http2, "force") == 0) {
         http_protocol_version = HTTP_PROTOCOL_VERSION_20;
     }
-    else if (flb_utils_bool(ctx->enable_http2)) {
+    else if (http2_effective_value == FLB_TRUE) {
         if (!ins->use_tls) {
             http_protocol_version = HTTP_PROTOCOL_VERSION_20;
         }


### PR DESCRIPTION
Derived the effective HTTP/2 mode from the configured value when gRPC is enabled so the plugin no longer reallocates the http2 setting string, eliminating the auto-enable leak while keeping the existing protocol selection behavior intact.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More predictable HTTP/2 behavior: explicit settings are respected, and gRPC can auto-enable HTTP/2 without altering your configuration.
  * “Force” now applies only when explicitly set, preventing unintended overrides.
  * Improved fallback logic reduces unexpected HTTP/2 activation.

* **Refactor**
  * Separated configured vs. effective HTTP/2 state to clarify activation logic and align behavior when gRPC is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->