### PR TITLE
opentelemetry: allow empty strings for TraceID and SpanID (logs) [Backport to 4.0]

### DIFF
--- a/src/opentelemetry/flb_opentelemetry_logs.c
+++ b/src/opentelemetry/flb_opentelemetry_logs.c
@@ -159,7 +159,7 @@ static int process_json_payload_log_records_entry(
         trace_id = &log_records_entry->ptr[result].val;
     }
 
-    /* trace_id must be a 32 char hex string */
+    /* trace_id must be a 32 char hex string, or empty (skip validation) */
     if (trace_id != NULL) {
         if (trace_id->type != MSGPACK_OBJECT_STR) {
             if (error_status) {
@@ -168,20 +168,25 @@ static int process_json_payload_log_records_entry(
             return -FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
         }
 
-        if (trace_id->via.str.size != 32) {
+        /* Skip validation if trace_id is empty */
+        if (trace_id->via.str.size == 0) {
+            trace_id = NULL; /* Treat as if not present */
+        }
+        else if (trace_id->via.str.size != 32) {
             if (error_status) {
                 *error_status = FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
             }
             return -FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
         }
-
-        /* Validate hex format */
-        for (i = 0; i < 32; i++) {
-            if (!isxdigit(trace_id->via.str.ptr[i])) {
-                if (error_status) {
-                     *error_status = FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
+        else {
+            /* Validate hex format */
+            for (i = 0; i < 32; i++) {
+                if (!isxdigit(trace_id->via.str.ptr[i])) {
+                    if (error_status) {
+                         *error_status = FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
+                    }
+                    return -FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
                 }
-                return -FLB_OTEL_LOGS_ERR_INVALID_TRACE_ID;
             }
         }
     }
@@ -192,6 +197,7 @@ static int process_json_payload_log_records_entry(
         span_id = &log_records_entry->ptr[result].val;
     }
 
+    /* span_id must be a 16 char hex string, or empty (skip validation) */
     if (span_id != NULL) {
         if (span_id->type != MSGPACK_OBJECT_STR) {
             if (error_status) {
@@ -200,20 +206,25 @@ static int process_json_payload_log_records_entry(
             return -FLB_OTEL_LOGS_ERR_INVALID_SPAN_ID;
         }
 
-        if (span_id->via.str.size != 16) {
+        /* Skip validation if span_id is empty */
+        if (span_id->via.str.size == 0) {
+            span_id = NULL; /* Treat as if not present */
+        }
+        else if (span_id->via.str.size != 16) {
             if (error_status) {
                 *error_status = FLB_OTEL_LOGS_ERR_INVALID_SPAN_ID;
             }
             return -FLB_OTEL_LOGS_ERR_INVALID_SPAN_ID;
         }
-
-        /* Validate hex format */
-        for (i = 0; i < 16; i++) {
-            if (!isxdigit(span_id->via.str.ptr[i])) {
-                if (error_status) {
-                    *error_status = FLB_OTEL_LOGS_ERR_INVALID_SPAN_ID;
+        else {
+            /* Validate hex format */
+            for (i = 0; i < 16; i++) {
+                if (!isxdigit(span_id->via.str.ptr[i])) {
+                    if (error_status) {
+                        *error_status = FLB_OTEL_LOGS_ERR_INVALID_SPAN_ID;
+                    }
+                    return -FLB_OTEL_LOGS_ERR_INVALID_SPAN_ID;
                 }
-                return -FLB_OTEL_LOGS_ERR_UNEXPECTED_TIMESTAMP_TYPE;
             }
         }
     }

--- a/tests/internal/data/opentelemetry/test_cases.json
+++ b/tests/internal/data/opentelemetry/test_cases.json
@@ -1305,5 +1305,26 @@
       "log_metadata": {"otlp":{}},
       "log_body": {"plain": {"key1": "v1", "key2": 2}}
     }
+  },
+
+  "empty_trace_span_ids_skipped": {
+    "input": {
+      "resourceLogs": [{
+        "scopeLogs": [{
+          "logRecords": [{
+            "timeUnixNano": "1640995200000000000",
+            "traceId": "",
+            "spanId": "",
+            "body": {"stringValue": "test log with empty trace and span IDs"}
+          }]
+        }]
+      }]
+    },
+    "expected": {
+      "group_metadata": {"schema":"otlp","resource_id":0,"scope_id":0},
+      "group_body": {"resource":{}},
+      "log_metadata": {"otlp":{}},
+      "log_body": {"log": "test log with empty trace and span IDs"}
+    }
   }
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backporting of https://github.com/fluent/fluent-bit/pull/10956.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
