### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The active development branch (`master`) is currently focused on **v4.1**.
 
 For version-specific maintenance timelines and policies, see our [MAINTENANCE.md](https://github.com/fluent/fluent-bit/blob/master/MAINTENANCE.md).
 
-To track upcoming milestones, visit the [project roadmap](https://github.com/fluent/fluent-bit/wiki/Roadmap).
+To track upcoming milestones, visit the [project roadmap](https://github.com/fluent/fluent-bit/wiki/Fluent-Bit-Roadmap).
 
 ---
 
@@ -66,7 +66,7 @@ make
 bin/fluent-bit -i cpu -o stdout -f 1
 ```
 
-More details: [Build & Install](https://docs.fluentbit.io/manual/installation/sources/build-and-install)
+More details: [Build & Install](https://docs.fluentbit.io/manual/installation/downloads/source/build-and-install)
 
 #### Requirements
 
@@ -78,10 +78,9 @@ More details: [Build & Install](https://docs.fluentbit.io/manual/installation/so
 
 ## Install Fluent Bit
 
-- [Linux packages (Debian, Ubuntu, RHEL, etc.)](https://docs.fluentbit.io/manual/installation/linux)
-- [Docker images](https://docs.fluentbit.io/manual/installation/docker)
-- [Windows binaries](https://docs.fluentbit.io/manual/installation/windows)
-- [IBM Z (s390x)](https://docs.fluentbit.io/manual/installation/linux/s390x)
+- [Linux packages (Debian, Ubuntu, RHEL, etc.)](https://docs.fluentbit.io/manual/installation/downloads/linux)
+- [Docker images](https://docs.fluentbit.io/manual/installation/downloads/docker)
+- [Windows binaries](https://docs.fluentbit.io/manual/installation/downloads/windows)
 
 ---
 


### PR DESCRIPTION
Updated links for roadmap, build-and-install and binaries. The IBM Z page in the documentation does not seem to have existed.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
