### PR TITLE
in_docker: add helper for container name parsing

### DIFF
--- a/plugins/in_docker/cgroup_v1.c
+++ b/plugins/in_docker/cgroup_v1.c
@@ -213,36 +213,6 @@ static char *get_config_file(struct flb_docker *ctx, char *id)
     return path;
 }
 
-static char *extract_name(char *line, char *start)
-{
-    int skip = 9;
-    int len = 0;
-    char *name;
-    char buff[256];
-    char *curr;
-
-    if (start != NULL) {
-        curr = start + skip;
-        while (*curr != '"') {
-            buff[len++] = *curr;
-            curr++;
-        }
-
-        if (len > 0) {
-            name = (char *) flb_calloc(len + 1, sizeof(char));
-            if (!name) {
-                flb_errno();
-                return NULL;
-            }
-            memcpy(name, buff, len);
-
-            return name;
-        }
-    }
-
-    return NULL;
-}
-
 static char *get_container_name(struct flb_docker *ctx, char *id)
 {
     char *container_name = NULL;
@@ -266,7 +236,7 @@ static char *get_container_name(struct flb_docker *ctx, char *id)
     while ((line = read_line(f))) {
         char *index = strstr(line, DOCKER_NAME_ARG);
         if (index != NULL) {
-            container_name = extract_name(line, index);
+            container_name = docker_extract_name(line, index);
             flb_free(line);
             break;
         }

--- a/plugins/in_docker/cgroup_v2.c
+++ b/plugins/in_docker/cgroup_v2.c
@@ -230,36 +230,6 @@ static char *get_config_file(struct flb_docker *ctx, char *id)
     return path;
 }
 
-static char *extract_name(char *line, char *start)
-{
-    int skip = 9;
-    int len = 0;
-    char *name;
-    char buff[256];
-    char *curr;
-
-    if (start != NULL) {
-        curr = start + skip;
-        while (*curr != '"') {
-            buff[len++] = *curr;
-            curr++;
-        }
-
-        if (len > 0) {
-            name = (char *) flb_calloc(len + 1, sizeof(char));
-            if (!name) {
-                flb_errno();
-                return NULL;
-            }
-            memcpy(name, buff, len);
-
-            return name;
-        }
-    }
-
-    return NULL;
-}
-
 static char *get_container_name(struct flb_docker *ctx, char *id)
 {
     char *container_name = NULL;
@@ -283,7 +253,7 @@ static char *get_container_name(struct flb_docker *ctx, char *id)
     while ((line = read_line(f))) {
         char *index = strstr(line, DOCKER_NAME_ARG);
         if (index != NULL) {
-            container_name = extract_name(line, index);
+            container_name = docker_extract_name(line, index);
             flb_free(line);
             break;
         }

--- a/plugins/in_docker/docker.c
+++ b/plugins/in_docker/docker.c
@@ -29,8 +29,56 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <ctype.h>
 
 #include "docker.h"
+
+char *docker_extract_name(const char *line, const char *start)
+{
+    const char *curr;
+    const char *end;
+    size_t len;
+    char *name;
+
+    if (line == NULL || start == NULL) {
+        return NULL;
+    }
+
+    curr = start + strlen(DOCKER_NAME_ARG);
+    if (*curr != ':') {
+        curr = strchr(curr, ':');
+        if (curr == NULL) {
+            return NULL;
+        }
+    }
+
+    curr++;
+    while (*curr != '\0' && isspace((unsigned char) *curr)) {
+        curr++;
+    }
+
+    if (*curr != '"') {
+        return NULL;
+    }
+
+    curr++;
+    end = strchr(curr, '"');
+    if (end == NULL || end <= curr) {
+        return NULL;
+    }
+
+    len = end - curr;
+    name = flb_malloc(len + 1);
+    if (name == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    memcpy(name, curr, len);
+    name[len] = '\0';
+
+    return name;
+}
 
 static int cb_docker_collect(struct flb_input_instance *i_ins,
                              struct flb_config *config, void *in_context);

--- a/plugins/in_docker/docker.h
+++ b/plugins/in_docker/docker.h
@@ -119,4 +119,6 @@ struct flb_docker {
 int in_docker_collect(struct flb_input_instance *i_ins,
                       struct flb_config *config, void *in_context);
 docker_info *in_docker_init_docker_info(char *id);
+char *docker_extract_name(const char *line, const char *start);
+
 #endif


### PR DESCRIPTION
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Docker container name detection across cgroup v1 and v2, reducing parsing errors and inconsistencies in various environments.

* **Refactor**
  * Consolidated container name parsing into a shared implementation to ensure consistent behavior and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->