### PR TITLE
out_azure_kusto: lower the severity of a noisy diagnostic log

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -194,7 +194,7 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
         }
 
         if (uri) {
-            flb_plg_info(ctx->ins, "azure_kusto: before calling azure storage api :: value of set io_timeout is %d", u_conn->net->io_timeout);
+            flb_plg_debug(ctx->ins, "azure_kusto: before calling azure storage api :: value of set io_timeout is %d", u_conn->net->io_timeout);
             flb_plg_debug(ctx->ins, "uploading payload to blob uri: %s", uri);
             c = flb_http_client(u_conn, FLB_HTTP_PUT, uri, payload, payload_size, NULL, 0,
                                 NULL, 0);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Lower the severity of a noisy diagnostic log in the azure_kusto output plugin from info to debug to reduce log spam after upgrading to Fluent Bit 4.0.10. 

Starting with Fluent-Bit 4.0.10 we noticed this log being generated by the engine and after further investigation it seems to be more a debug log. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

```
[2025/10/03 09:00:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:00:33] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:04] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:13] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:28] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:33] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:43] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:48] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:01:53] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:02:03] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:02:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:02:13] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:02:28] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:02:33] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:02:58] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:03:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:03:13] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:03:18] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:03:23] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:03:28] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:03:33] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:04:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:04:28] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:04:33] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:04:48] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:05:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:05:13] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:05:28] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:05:33] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:05:48] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:06:03] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
[2025/10/03 09:06:08] [ info] [output:azure_kusto:azure_kusto.1] azure_kusto: before calling azure storage api :: value of set io_timeout is 0
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Lowered a diagnostic log message to debug level during Azure storage ingestion to reduce noise in default info logs.
  - Keeps normal operational logs cleaner while retaining detailed diagnostics when debug logging is enabled.
  - No functional or behavioral changes to ingestion workflows.
  - No configuration changes required; existing setups continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->