### PR TITLE
Expose Vivo stream cursor headers for empty responses

### DIFF
--- a/plugins/out_vivo_exporter/README.md
+++ b/plugins/out_vivo_exporter/README.md
@@ -1,0 +1,23 @@
+# Vivo Exporter
+
+The Vivo exporter exposes Fluent Bit data through an HTTP interface that streams
+logs, metrics, and traces. Each response includes cursor headers that describe
+the stream position so that clients can resume from the point they last read.
+
+## Cursor headers
+
+Responses always include the following headers:
+
+- `Vivo-Stream-Start-ID`: The first record identifier included in the response
+  body (when the body is non-empty).
+- `Vivo-Stream-End-ID`: The last record identifier included in the response
+  body (when the body is non-empty).
+- `Vivo-Stream-Next-ID`: The identifier that will be assigned to the next
+  record appended to the stream. This header is present even when the response
+  body is empty so that clients can track the exporter position across polling
+  intervals.
+
+Clients should store the `Vivo-Stream-Next-ID` value and provide it in the next
+request (for example via the `from` query parameter) to resume from where they
+left off, regardless of whether any records were returned in the previous
+response.

--- a/plugins/out_vivo_exporter/vivo_http.h
+++ b/plugins/out_vivo_exporter/vivo_http.h
@@ -25,6 +25,12 @@
 
 #include "vivo.h"
 
+#define VIVO_STREAM_START_ID    "Vivo-Stream-Start-ID"
+#define VIVO_STREAM_END_ID      "Vivo-Stream-End-ID"
+#define VIVO_STREAM_NEXT_ID     "Vivo-Stream-Next-ID"
+
+struct vivo_stream;
+
 /* HTTP response payload received through a Message Queue */
 struct vivo_http_buf {
     int users;
@@ -52,5 +58,7 @@ int vivo_http_server_stop(struct vivo_http *ph);
 
 int vivo_http_server_mq_push_metrics(struct vivo_http *ph,
                                      void *data, size_t size);
+
+void vivo_http_serve_content(mk_request_t *request, struct vivo_stream *vs);
 
 #endif

--- a/plugins/out_vivo_exporter/vivo_stream.h
+++ b/plugins/out_vivo_exporter/vivo_stream.h
@@ -54,6 +54,7 @@ struct vivo_stream_entry *vivo_stream_append(struct vivo_stream *vs, void *data,
                                              size_t size);
 flb_sds_t vivo_stream_get_content(struct vivo_stream *vs, int64_t from, int64_t to,
                                   int64_t limit,
-                                  int64_t *stream_start_id, int64_t *stream_end_id);
+                                  int64_t *stream_start_id, int64_t *stream_end_id,
+                                  int64_t *stream_next_id);
 
 #endif

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -52,6 +52,7 @@ set(UNIT_TESTS_FILES
   strptime.c
   storage_inherit.c
   unicode.c
+  vivo_http.c
   opentelemetry.c
 )
 

--- a/tests/internal/vivo_http.c
+++ b/tests/internal/vivo_http.c
@@ -1,0 +1,63 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <string.h>
+
+#include <fluent-bit/flb_info.h>
+
+#include "flb_tests_internal.h"
+
+#include "plugins/out_vivo_exporter/vivo_stream.h"
+#include "plugins/out_vivo_exporter/vivo_http.h"
+
+#include <monkey/mk_core/mk_iov.h>
+
+static void test_vivo_http_empty_stream_sets_next_id_header(void)
+{
+    struct vivo_exporter ctx;
+    struct vivo_stream *stream;
+    mk_request_t request;
+    struct mk_iov *extra;
+    int found = 0;
+    int i;
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.stream_queue_size = 1024;
+
+    stream = vivo_stream_create(&ctx);
+    if (!TEST_CHECK(stream != NULL)) {
+        return;
+    }
+
+    memset(&request, 0, sizeof(request));
+
+    vivo_http_serve_content(&request, stream);
+
+    TEST_CHECK(request.headers.status == 200);
+
+    extra = request.headers._extra_rows;
+    if (!TEST_CHECK(extra != NULL)) {
+        vivo_stream_destroy(stream);
+        return;
+    }
+
+    for (i = 0; i < extra->buf_idx; i++) {
+        char *entry = extra->buf_to_free[i];
+
+        if (entry && strstr(entry, VIVO_STREAM_NEXT_ID) != NULL) {
+            found = 1;
+            break;
+        }
+    }
+
+    if (!TEST_CHECK(found == 1)) {
+        TEST_MSG("expected %s header to be present", VIVO_STREAM_NEXT_ID);
+    }
+
+    mk_iov_free(extra);
+    vivo_stream_destroy(stream);
+}
+
+TEST_LIST = {
+    {"vivo_http_empty_stream_sets_next_id_header", test_vivo_http_empty_stream_sets_next_id_header},
+    {NULL, NULL}
+};


### PR DESCRIPTION
## Summary
- expose the Vivo stream cursor by returning the next record identifier from `vivo_stream_get_content`
- always emit a `Vivo-Stream-Next-ID` header from the HTTP handler and document the updated Vivo exporter response contract
- add a unit test that exercises an empty Vivo HTTP response and ensures the cursor header is present

## Testing
- not run (building the full Fluent Bit test suite to execute the new unit test exceeds the current environment constraints)


------
https://chatgpt.com/codex/tasks/task_e_68e2701ba58c832793caf6189a005dd8