### PR TITLE
out_opentelemetry: add configurable log resource limits [Backport to 4.0]

### DIFF
--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -914,6 +914,12 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_INT, "logs_max_scopes", DEFAULT_MAX_SCOPE_EXPORT,
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, max_scopes),
+     "Set the maximum number of OTLP log scopes per resource (0 disables the limit; default: 0)"
+    },
+
+    {
      FLB_CONFIG_MAP_STR, "logs_uri", "/v1/logs",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, logs_uri),
      "Specify an optional HTTP URI for the target OTel endpoint."

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -36,6 +36,7 @@
  */
 #define DEFAULT_LOG_RECORD_BATCH_SIZE "1000"
 #define DEFAULT_MAX_RESOURCE_EXPORT   "0"    /* no resource limits */
+#define DEFAULT_MAX_SCOPE_EXPORT      "0"    /* no scope limits */
 
 struct opentelemetry_body_key {
     flb_sds_t key;
@@ -126,6 +127,9 @@ struct opentelemetry_context {
 
     /* Maximum number of resources per OTLP export */
     int max_resources;
+
+    /* Maximum number of scopes per OTLP resource */
+    int max_scopes;
 
     /* Log the response payload */
     int log_response_payload;

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -282,6 +282,12 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
         return NULL;
     }
 
+    if (ctx->max_scopes < 0) {
+        flb_plg_error(ins, "max_scopes must be greater than or equal to zero");
+        flb_opentelemetry_context_destroy(ctx);
+        return NULL;
+    }
+
     /* Parse 'add_label' */
     ret = config_add_labels(ins, ctx);
     if (ret == -1) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/10955.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
