### PR TITLE
in_docker: add helper for container name parsing [Backport to 4.0]

### DIFF
--- a/plugins/in_docker/cgroup_v1.c
+++ b/plugins/in_docker/cgroup_v1.c
@@ -213,36 +213,6 @@ static char *get_config_file(struct flb_docker *ctx, char *id)
     return path;
 }
 
-static char *extract_name(char *line, char *start)
-{
-    int skip = 9;
-    int len = 0;
-    char *name;
-    char buff[256];
-    char *curr;
-
-    if (start != NULL) {
-        curr = start + skip;
-        while (*curr != '"') {
-            buff[len++] = *curr;
-            curr++;
-        }
-
-        if (len > 0) {
-            name = (char *) flb_calloc(len + 1, sizeof(char));
-            if (!name) {
-                flb_errno();
-                return NULL;
-            }
-            memcpy(name, buff, len);
-
-            return name;
-        }
-    }
-
-    return NULL;
-}
-
 static char *get_container_name(struct flb_docker *ctx, char *id)
 {
     char *container_name = NULL;
@@ -266,7 +236,7 @@ static char *get_container_name(struct flb_docker *ctx, char *id)
     while ((line = read_line(f))) {
         char *index = strstr(line, DOCKER_NAME_ARG);
         if (index != NULL) {
-            container_name = extract_name(line, index);
+            container_name = docker_extract_name(line, index);
             flb_free(line);
             break;
         }

--- a/plugins/in_docker/cgroup_v2.c
+++ b/plugins/in_docker/cgroup_v2.c
@@ -230,36 +230,6 @@ static char *get_config_file(struct flb_docker *ctx, char *id)
     return path;
 }
 
-static char *extract_name(char *line, char *start)
-{
-    int skip = 9;
-    int len = 0;
-    char *name;
-    char buff[256];
-    char *curr;
-
-    if (start != NULL) {
-        curr = start + skip;
-        while (*curr != '"') {
-            buff[len++] = *curr;
-            curr++;
-        }
-
-        if (len > 0) {
-            name = (char *) flb_calloc(len + 1, sizeof(char));
-            if (!name) {
-                flb_errno();
-                return NULL;
-            }
-            memcpy(name, buff, len);
-
-            return name;
-        }
-    }
-
-    return NULL;
-}
-
 static char *get_container_name(struct flb_docker *ctx, char *id)
 {
     char *container_name = NULL;
@@ -283,7 +253,7 @@ static char *get_container_name(struct flb_docker *ctx, char *id)
     while ((line = read_line(f))) {
         char *index = strstr(line, DOCKER_NAME_ARG);
         if (index != NULL) {
-            container_name = extract_name(line, index);
+            container_name = docker_extract_name(line, index);
             flb_free(line);
             break;
         }

--- a/plugins/in_docker/docker.c
+++ b/plugins/in_docker/docker.c
@@ -29,8 +29,56 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <ctype.h>
 
 #include "docker.h"
+
+char *docker_extract_name(const char *line, const char *start)
+{
+    const char *curr;
+    const char *end;
+    size_t len;
+    char *name;
+
+    if (line == NULL || start == NULL) {
+        return NULL;
+    }
+
+    curr = start + strlen(DOCKER_NAME_ARG);
+    if (*curr != ':') {
+        curr = strchr(curr, ':');
+        if (curr == NULL) {
+            return NULL;
+        }
+    }
+
+    curr++;
+    while (*curr != '\0' && isspace((unsigned char) *curr)) {
+        curr++;
+    }
+
+    if (*curr != '"') {
+        return NULL;
+    }
+
+    curr++;
+    end = strchr(curr, '"');
+    if (end == NULL || end <= curr) {
+        return NULL;
+    }
+
+    len = end - curr;
+    name = flb_malloc(len + 1);
+    if (name == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    memcpy(name, curr, len);
+    name[len] = '\0';
+
+    return name;
+}
 
 static int cb_docker_collect(struct flb_input_instance *i_ins,
                              struct flb_config *config, void *in_context);

--- a/plugins/in_docker/docker.h
+++ b/plugins/in_docker/docker.h
@@ -119,4 +119,6 @@ struct flb_docker {
 int in_docker_collect(struct flb_input_instance *i_ins,
                       struct flb_config *config, void *in_context);
 docker_info *in_docker_init_docker_info(char *id);
+char *docker_extract_name(const char *line, const char *start);
+
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/10972.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
