### PR TITLE
in_forward: Fix user authentication to align Fluentd's behavior [Backport to 4.0]

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -338,6 +338,7 @@ static int in_fw_init(struct flb_input_instance *ins,
         ctx->shared_key == NULL &&
         ctx->empty_shared_key == FLB_FALSE) {
         flb_plg_error(ctx->ins, "security.users is set but no shared_key or empty_shared_key");
+        delete_users(ctx);
         fw_config_destroy(ctx);
         return -1;
     }

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -333,6 +333,15 @@ static int in_fw_init(struct flb_input_instance *ins,
         return -1;
     }
 
+    /* Users-only configuration must be rejected unless a (possibly empty) shared key is enabled. */
+    if (mk_list_size(&ctx->users) > 0 &&
+        ctx->shared_key == NULL &&
+        ctx->empty_shared_key == FLB_FALSE) {
+        flb_plg_error(ctx->ins, "security.users is set but no shared_key or empty_shared_key");
+        fw_config_destroy(ctx);
+        return -1;
+    }
+
     flb_input_downstream_set(ctx->downstream, ctx->ins);
 
     flb_net_socket_nonblocking(ctx->downstream->server_fd);

--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -60,7 +60,8 @@ struct flb_in_fw_config {
     flb_sds_t unix_perm_str;        /* Permission (config map)     */
 
     /* secure forward */
-    flb_sds_t shared_key;        /* shared key                   */
+    flb_sds_t shared_key;         /* shared key      */
+    int owns_shared_key;          /* own flag of shared key */
     flb_sds_t self_hostname;     /* hostname used in certificate  */
     struct mk_list users;        /* username and password pairs  */
     int empty_shared_key;        /* use an empty string as shared key */

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -26,7 +26,7 @@
 #include "fw_conn.h"
 #include "fw_config.h"
 
-static void fw_destory_shared_key(struct flb_in_fw_config *config)
+static void fw_destroy_shared_key(struct flb_in_fw_config *config)
 {
     if (config->owns_shared_key && config->shared_key) {
         flb_sds_destroy(config->shared_key);
@@ -159,7 +159,7 @@ int fw_config_destroy(struct flb_in_fw_config *config)
         flb_free(config->tcp_port);
     }
 
-    fw_destory_shared_key(config);
+    fw_destroy_shared_key(config);
     flb_sds_destroy(config->self_hostname);
 
     flb_free(config);

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -142,7 +142,18 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     }
 
     conn->handshake_status = FW_HANDSHAKE_ESTABLISHED;
-    if (ctx->shared_key != NULL) {
+    /*
+     * Always force the secure-forward handshake when:
+     *  - a shared key is configured, or
+     *  - empty_shared_key is enabled (empty string shared key), or
+     *  - user authentication is configured (users > 0).
+     *
+     * This closes the gap where "users-only" previously skipped authentication entirely.
+     */
+    conn->handshake_status = FW_HANDSHAKE_ESTABLISHED; /* default */
+    if (ctx->shared_key != NULL ||
+        ctx->empty_shared_key == FLB_TRUE ||
+        mk_list_size(&ctx->users) > 0) {
         conn->handshake_status = FW_HANDSHAKE_HELO;
         helo = flb_calloc(1, sizeof(struct flb_in_fw_helo));
         if (!helo) {

--- a/tests/runtime/in_forward.c
+++ b/tests/runtime/in_forward.c
@@ -678,6 +678,148 @@ void flb_test_threaded_forward_issue_10946()
     flb_destroy(ctx);
 }
 
+static flb_ctx_t *fw_make_ctx_with_forward(int *in_ffd_out, int *out_ffd_out)
+{
+    struct flb_lib_out_cb cb = {0};
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd, ret;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+    if (!ctx) { return NULL; }
+
+    flb_service_set(ctx,
+                    "Flush", "0.200000000",
+                    "Grace", "1",
+                    "Log_Level", "error",
+                    NULL);
+
+    /* forward input */
+    in_ffd = flb_input(ctx, (char *) "forward", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    if (in_ffd < 0) { flb_destroy(ctx); return NULL; }
+
+    /* lib output: count only (no payload check) */
+    cb.cb   = cb_count_only;
+    cb.data = NULL;
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb);
+    TEST_CHECK(out_ffd >= 0);
+    if (out_ffd < 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    if (in_ffd_out)  *in_ffd_out  = in_ffd;
+    if (out_ffd_out) *out_ffd_out = out_ffd;
+    return ctx;
+}
+
+/* 1) users-only => must fail to start (fail-close) */
+void flb_test_fw_auth_users_only_fail_start()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd, ret;
+
+    ctx = fw_make_ctx_with_forward(&in_ffd, &out_ffd);
+    TEST_CHECK(ctx != NULL);
+    if (!ctx) {
+        return;
+    }
+
+    ret = flb_input_set(ctx, in_ffd,
+                        "tag", "test",
+                        "security.users", "alice s3cr3t",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+    if (ret == 0) {
+        TEST_MSG("users-only config unexpectedly started; fail-close not enforced");
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+}
+
+/* 2) empty_shared_key + users => start OK */
+void flb_test_fw_auth_empty_shared_key_plus_users_start_ok()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd, ret;
+
+    ctx = fw_make_ctx_with_forward(&in_ffd, &out_ffd);
+    TEST_CHECK(ctx != NULL);
+    if (!ctx) { return; }
+
+    ret = flb_input_set(ctx, in_ffd,
+                        "tag", "test",
+                        "empty_shared_key", "true",
+                        "security.users", "alice s3cr3t",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+}
+
+/* 3) shared_key only => start OK (backward compatible) */
+void flb_test_fw_auth_shared_key_only_start_ok()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd, ret;
+
+    ctx = fw_make_ctx_with_forward(&in_ffd, &out_ffd);
+    TEST_CHECK(ctx != NULL);
+    if (!ctx) { return; }
+
+    ret = flb_input_set(ctx, in_ffd,
+                        "tag", "test",
+                        "shared_key", "k",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+}
+
+/* 4) shared_key + users => start OK (both checks) */
+void flb_test_fw_auth_shared_key_plus_users_start_ok()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd, ret;
+
+    ctx = fw_make_ctx_with_forward(&in_ffd, &out_ffd);
+    TEST_CHECK(ctx != NULL);
+    if (!ctx) { return; }
+
+    ret = flb_input_set(ctx, in_ffd,
+                        "tag", "test",
+                        "shared_key", "k",
+                        "security.users", "alice s3cr3t",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+}
+
 TEST_LIST = {
     {"forward", flb_test_forward},
     {"forward_port", flb_test_forward_port},
@@ -687,5 +829,9 @@ TEST_LIST = {
     {"unix_perm", flb_test_unix_perm},
 #endif
     {"issue_10946", flb_test_threaded_forward_issue_10946},
+    {"fw_auth_users_only_fail_start", flb_test_fw_auth_users_only_fail_start},
+    {"fw_auth_empty_shared_key_plus_users_start_ok", flb_test_fw_auth_empty_shared_key_plus_users_start_ok},
+    {"fw_auth_shared_key_only_start_ok", flb_test_fw_auth_shared_key_only_start_ok},
+    {"fw_auth_shared_key_plus_users_start_ok", flb_test_fw_auth_shared_key_plus_users_start_ok},
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/10973.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
