### PR TITLE
router: use memchr() and tag length for matching tags [Backport to 4.0]

### DIFF
--- a/src/flb_router.c
+++ b/src/flb_router.c
@@ -20,7 +20,6 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_str.h>
-#include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_chunk.h>
 #include <fluent-bit/flb_output.h>
@@ -34,13 +33,33 @@
 #include <string.h>
 
 /* wildcard support */
-/* tag and match should be null terminated. */
+/* match should be null terminated; tag length is provided explicitly. */
 static inline int router_match(const char *tag, int tag_len,
                                const char *match,
                                void *match_r)
 {
     int ret = FLB_FALSE;
-    char *pos = NULL;
+    const char *tag_end;
+    const char *tag_cursor;
+    size_t remaining;
+    static const char empty_tag[] = "";
+
+    if (tag_len < 0) {
+        return FLB_FALSE;
+    }
+
+    if (!tag) {
+        if (tag_len == 0) {
+            tag = empty_tag;
+        }
+        else {
+            return FLB_FALSE;
+        }
+    }
+
+    tag_end = tag + tag_len;
+    tag_cursor = tag;
+    remaining = (size_t) tag_len;
 
 #ifdef FLB_HAVE_REGEX
     struct flb_regex *match_regex = match_r;
@@ -59,7 +78,11 @@ static inline int router_match(const char *tag, int tag_len,
     (void) match_r;
 #endif
 
-    while (match) {
+    if (!match) {
+        return ret;
+    }
+
+    while (*match) {
         if (*match == '*') {
             while (*++match == '*'){
                 /* skip successive '*' */
@@ -70,58 +93,53 @@ static inline int router_match(const char *tag, int tag_len,
                 break;
             }
 
-            while ((pos = strchr(tag, (int) *match))) {
+            const char *search = tag_cursor;
+
+            while (search < tag_end) {
+                size_t span = (size_t) (tag_end - search);
+                const char *pos;
+
+                pos = memchr(search, (unsigned char) *match, span);
+                if (!pos) {
+                    break;
+                }
+
 #ifndef FLB_HAVE_REGEX
-                if (router_match(pos, tag_len, match, NULL)) {
+                if (router_match(pos, (int) (tag_end - pos), match, NULL)) {
 #else
                 /* We don't need to pass the regex recursively,
                  * we matched in order above
                  */
-                if (router_match(pos, tag_len, match, NULL)) {
+                if (router_match(pos, (int) (tag_end - pos), match, NULL)) {
 #endif
                     ret = 1;
-                    break;
+                    goto done;
                 }
-                tag = pos+1;
+                search = pos + 1;
             }
             break;
         }
-        else if (*tag != *match) {
+        else if (remaining == 0 || *tag_cursor != *match) {
             /* mismatch! */
             break;
         }
-        else if (*tag == '\0') {
-            /* end of tag. so matched! */
-            ret = 1;
-            break;
-        }
-        tag++;
+        tag_cursor++;
+        remaining--;
         match++;
     }
 
+    if (*match == '\0' && remaining == 0) {
+        ret = 1;
+    }
+
+done:
     return ret;
 }
 
 int flb_router_match(const char *tag, int tag_len, const char *match,
                      void *match_regex)
 {
-    int ret;
-    flb_sds_t t;
-
-    if (tag[tag_len] != '\0') {
-        t = flb_sds_create_len(tag, tag_len);
-        if (!t) {
-            return FLB_FALSE;
-        }
-
-        ret = router_match(t, tag_len, match, match_regex);
-        flb_sds_destroy(t);
-    }
-    else {
-        ret = router_match(tag, tag_len, match, match_regex);
-    }
-
-    return ret;
+    return router_match(tag, tag_len, match, match_regex);
 }
 
 /* Associate and input and output instances due to a previous match */

--- a/tests/internal/router.c
+++ b/tests/internal/router.c
@@ -6,42 +6,45 @@
 #include "flb_tests_internal.h"
 
 struct check {
-    char *tag;
-    char *match;
-    int matched;
+    const char *tag;
+    size_t      tag_len;
+    const char *match;
+    int         matched;
 };
 
-struct check route_checks[] = {
-
-    {"file.apache.log", "file.*.log" , FLB_TRUE},
-    {"cpu.rpi"        , "cpu.rpi"    , FLB_TRUE},
-    {"cpu.rpi"        , "cpu.*"      , FLB_TRUE},
-    {"cpu.rpi"        , "*"          , FLB_TRUE},
-    {"cpu.rpi"        , "*.*"        , FLB_TRUE},
-    {"cpu.rpi"        , "*.rpi"      , FLB_TRUE},
-    {"cpu.rpi"        , "mem.*"      , FLB_FALSE},
-    {"cpu.rpi"        , "*u.r*"      , FLB_TRUE},
-    {"hoge"           , "hogeeeeeee" , FLB_FALSE},
-    {"test"           , "test"       , FLB_TRUE}
+static const struct check wildcard_checks[] = {
+    {"file.apache.log", 0, "file.*.log" , FLB_TRUE},
+    {"cpu.rpi"        , 0, "cpu.rpi"    , FLB_TRUE},
+    {"cpu.rpi"        , 0, "cpu.*"      , FLB_TRUE},
+    {"cpu.rpi"        , 0, "*"          , FLB_TRUE},
+    {"cpu.rpi"        , 0, "*.*"        , FLB_TRUE},
+    {"cpu.rpi"        , 0, "*.rpi"      , FLB_TRUE},
+    {"cpu.rpi"        , 0, "mem.*"      , FLB_FALSE},
+    {"cpu.rpi"        , 0, "*u.r*"      , FLB_TRUE},
+    {"hoge"           , 0, "hogeeeeeee" , FLB_FALSE},
+    {"test"           , 0, "test"       , FLB_TRUE}
 };
 
 void test_router_wildcard()
 {
-    int i;
+    size_t i;
     int ret;
-    int len;
-    int checks = 0;
-    struct check *c;
+    size_t len;
+    size_t checks = 0;
+    const struct check *c;
 
-    checks = sizeof(route_checks) / sizeof(struct check);
+    checks = sizeof(wildcard_checks) / sizeof(wildcard_checks[0]);
     for (i = 0; i < checks; i++) {
-        c = &route_checks[i];
-        len = strlen(c->tag);
+        c = &wildcard_checks[i];
+        len = c->tag_len;
+        if (len == 0 && c->tag) {
+            len = strlen(c->tag);
+        }
         ret = flb_router_match(c->tag, len, c->match, NULL);
         TEST_CHECK(ret == c->matched);
         if (ret != c->matched) {
             fprintf(stderr, "test %i failed: tag=%s match=%s expected_to_match=%s\n",
-                    i, c->tag, c->match, c->matched ? "YES": "NO");
+                    (int) i, c->tag, c->match, c->matched ? "YES": "NO");
         }
     }
 
@@ -49,7 +52,72 @@ void test_router_wildcard()
     TEST_CHECK(ret == FLB_TRUE);
 }
 
+static void print_tag(const char *tag, size_t len)
+{
+    size_t i;
+
+    if (tag == NULL) {
+        fputs("<NULL>", stderr);
+        return;
+    }
+
+    for (i = 0; i < len; i++) {
+        unsigned char c = (unsigned char) tag[i];
+        if (c < 0x20 || c > 0x7e) {
+            fprintf(stderr, "\\x%02x", c);
+        }
+        else {
+            fputc(c, stderr);
+        }
+    }
+}
+
+static const char raw_tag[] = {'m','e','t','r','i','c','s'};
+static const char newline_tag[] = {'s','y','s','t','e','m','\n'};
+static const char repeated_star[] = {'a','b','c','d'};
+static const char truncated[] = {'a','b','c'};
+static const char empty_tag[] = {'\0'};
+
+static const struct check route_checks[] = {
+    {raw_tag,     sizeof(raw_tag),     "metrics",   FLB_TRUE},
+    {raw_tag,     sizeof(raw_tag),     "metrics.*", FLB_FALSE},
+    {newline_tag, sizeof(newline_tag), "system\n",  FLB_TRUE},
+    {newline_tag, sizeof(newline_tag), "system",    FLB_FALSE},
+    {repeated_star, sizeof(repeated_star), "**d",   FLB_TRUE},
+    {repeated_star, sizeof(repeated_star), "*c*",   FLB_TRUE},
+    {repeated_star, sizeof(repeated_star), "*e*",   FLB_FALSE},
+    {NULL,        0,                   "",          FLB_TRUE},
+    {NULL,        0,                   "*",         FLB_TRUE},
+    {empty_tag,   0,                   "",          FLB_TRUE},
+    {empty_tag,   0,                   "*",         FLB_TRUE},
+    {raw_tag,     sizeof(raw_tag),     NULL,        FLB_FALSE},
+    {truncated,   2,                   "ab",        FLB_TRUE},
+    {truncated,   2,                   "abc",       FLB_FALSE}
+};
+
+void test_router_edge_cases()
+{
+    size_t i;
+    int ret;
+    size_t checks = sizeof(route_checks) / sizeof(route_checks[0]);
+
+    for (i = 0; i < checks; i++) {
+        const struct check *c = &route_checks[i];
+
+        ret = flb_router_match(c->tag, (int) c->tag_len, c->match, NULL);
+        TEST_CHECK(ret == c->matched);
+        if (ret != c->matched) {
+            const char *match = c->match ? c->match : "<NULL>";
+            fprintf(stderr, "edge test %zu failed: tag=", i);
+            print_tag(c->tag, c->tag_len);
+            fprintf(stderr, " match=%s expected_to_match=%s\n",
+                    match, c->matched ? "YES" : "NO");
+        }
+    }
+}
+
 TEST_LIST = {
     { "wildcard", test_router_wildcard},
+    { "edge_cases", test_router_edge_cases},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/10976.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
