### PR TITLE
workflows: Make not to be the latest release for 4.0 branch

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -961,8 +961,16 @@ jobs:
           token: ${{ secrets.GH_PA_TOKEN }}
           ref: 3.2
 
-      - name: Release 4.0 and latest
+      - name: Release 4.0 - not latest
         if: startsWith(inputs.version, '4.0')
+        uses: actions/checkout@v5
+        with:
+          repository: fluent/fluent-bit-docs
+          token: ${{ secrets.GH_PA_TOKEN }}
+          ref: 4.0
+
+      - name: Release 4.1 and latest
+        if: startsWith(inputs.version, '4.1')
         uses: actions/checkout@v5
         with:
           repository: fluent/fluent-bit-docs


### PR DESCRIPTION
<!-- Provide summary of changes -->
Without this patch, every 4.0 release will be marked as the latest release.
This could be inconvenient for releasing process of 4.0.x.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated release process to publish two distinct channels: 4.0 releases explicitly marked as non-latest and 4.1 releases marked as latest when applicable.
  - Added conditional routing so 4.1 follows the latest release path while 4.0 follows a non-latest path.
  - Aligned documentation release steps to the same dual-path behavior so docs reflect the new latest/non-latest distinction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->