### PR TITLE
in_calyptia_fleet: load configuration on initial startup (backport #10996 to 4.0).

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -2618,8 +2618,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
                                                        config);
         if (ctx->initial_fd == -1) {
             flb_plg_error(ctx->ins, "could not initialize collector for fleet input plugin");
-            flb_upstream_destroy(ctx->u);
-            flb_free(ctx);
+            in_calyptia_fleet_destroy(ctx);
             return -1;
         }
         flb_plg_info(ctx->ins, "updating initial configuration with oneshot interval");

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -2089,6 +2089,8 @@ static int in_calyptia_fleet_collect_once(struct flb_input_instance *ins,
 
         if (ctx->initial_fd == -1) {
             flb_plg_error(ctx->ins, "could not initialize collector for fleet input plugin");
+            /* Resume main collector on retry scheduling failure */
+            flb_input_collector_resume(ctx->collect_fd, ins);
             FLB_INPUT_RETURN(-1);
         }
 

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.h
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.h
@@ -25,6 +25,10 @@
 
 #define FLEET_HEADERS_CONFIG_VERSION "Fleet-Config-Version"
 
+#define FLEET_INITIAL_MAX_TRIES 1
+#define FLEET_INITIAL_RETRY_INTERVAL_SECONDS     10
+#define FLEET_INITIAL_RETRY_INTERVAL_NANOSECONDS 0
+
 struct flb_in_calyptia_fleet_config {
     /* Time interval check */
     int interval_sec;
@@ -63,6 +67,10 @@ struct flb_in_calyptia_fleet_config {
     struct flb_upstream *u;
 
     int collect_fd;
+
+    /* track the initial configuration update */
+    int initial_fd;
+    int initial_retries;
 };
 
 struct reload_ctx {


### PR DESCRIPTION
# Summary

This is a back port of #10996 to the 4.0 stable branch. To avoid slow startups this patch uses a one shot interval to download the initial configuration when registering an agent to a fleet.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Backporting**
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
