### PR TITLE
in_calyptia_fleet: add support for net.* properties for the upstream connection [backport #10998 to 4.0]

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1869,6 +1869,7 @@ flb_sds_t fleet_config_get(struct flb_in_calyptia_fleet_config *ctx)
         }
 
         fleet_config_get_properties(&buf, &c_ins->properties, ctx->fleet_config_legacy_format);
+        fleet_config_get_properties(&buf, &c_ins->net_properties, ctx->fleet_config_legacy_format);
 
         if (flb_config_prop_get("fleet_id", &c_ins->properties) == NULL) {
             if (ctx->fleet_id != NULL) {

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -2529,6 +2529,9 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
         return -1;
     }
 
+    /* set upstream settings from 'net.*' */
+    flb_input_upstream_set(ctx->u, ctx->ins);
+
     /* Log initial interval values */
     flb_plg_debug(ctx->ins, "initial collector interval: sec=%d nsec=%d",
                   ctx->interval_sec, ctx->interval_nsec);

--- a/tests/runtime/custom_calyptia_input_test.c
+++ b/tests/runtime/custom_calyptia_input_test.c
@@ -58,6 +58,8 @@ static struct test_context *init_test_context()
         return NULL;
     }
 
+    mk_list_init(&t_ctx->ctx->ins->net_properties);
+
     /* Initialize test values in ctx */
     t_ctx->ctx->api_key = flb_strdup("test_api_key");
     t_ctx->ctx->fleet_config_dir = flb_strdup("/test/config/dir");


### PR DESCRIPTION
# Summary

Add support for net.* properties for `in_calyptia_fleet`, ie: `net.dns.mode` to TCP for some networks or setting the `net.dns.resolver` to use the legacy DNS resolver.

# Description

This PR hooks up the support for net* properties for the upstream connection the `in_calyptia_fleet` plugin uses. Among the main reasons for this is for the support for setting the dns resolver.

This requires a change to the `custom_calyptia` plugin as well. With this PR it is now possible to configure the network settings like so:


```ini
[CUSTOM]
    Name calyptia
    Fleet_Name test-fleet
    net.dns.resolver legacy
    net.connect_timeout 60
    API_KEY ********
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
