### PR TITLE
filter_kubernetes: use service account issuer to detect EKS env

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -74,11 +74,10 @@
 #define SERVICE_NAME_SOURCE_MAX_LEN 64
 
 /*
- * Configmap used for verifying whether if FluentBit is
- * on EKS or native Kubernetes
+ * Namespace and token path used for verifying whether FluentBit is
+ * on EKS or native Kubernetes by inspecting serviceaccount token issuer
  */
 #define KUBE_SYSTEM_NAMESPACE "kube-system"
-#define AWS_AUTH_CONFIG_MAP "aws-auth"
 
 /*
  * Possible platform values for Kubernetes plugin


### PR DESCRIPTION
<!-- Provide summary of changes -->

### Background
[Explored Related](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ExploreRelated.html) introduced `filter_kubernetes` to add Kubernetes metadata to logs and metrics. The filter historically relied on the presence of the `aws-auth` ConfigMap to determine if the cluster is running on Amazon EKS. However, with the launch of [EKS access entries](https://docs.aws.amazon.com/eks/latest/eksctl/access-entries.html), the `aws-auth` ConfigMap is no longer guaranteed to be present in EKS clusters.

### Problem
With the launch of [EKS access entries](https://docs.aws.amazon.com/eks/latest/eksctl/access-entries.html), `aws-auth` ConfigMap is no longer guaranteed to be present in EKS clusters. Missing ConfigMap causes two issues:
- **Noisy audit logs**: Generates 404 not found errors in k8s audit logs when the `aws-auth` ConfigMap doesn't exist
- **Incorrect platform tagging**: EKS clusters using access entries (`API `) are falsely tagged as `Generic` or `K8s` platform instead of `AWS::EKS` for "Explore Related" functionality

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" --> NA

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Using an EKS cluster with `authemticationMode` set to `API` to prevent `aws-auth` configmap from being created
```
# eksctl config
accessConfig:
   authenticationMode: API
```
Use CloudWatch LogInsights to search application log entries with metadata. Note the value for `@entity.Attributes.PlatformType`
```
## using public.ecr.aws/aws-observability/aws-for-fluent-bit:2.33.2
Field	Value
@entity.Attributes.K8s.Cluster	 mixed-133
@entity.Attributes.K8s.Namespace	 amazon-cloudwatch
@entity.Attributes.K8s.Node	 ip-192---.us-west-2.compute.internal
@entity.Attributes.K8s.Workload	 cloudwatch-agent
@entity.Attributes.PlatformType	 K8s

## with the new changes
Field	Value
@entity.Attributes.EKS.Cluster	mixed-133
@entity.Attributes.K8s.Namespace	amazon-cloudwatch
@entity.Attributes.K8s.Node	ip-192---.us-west-2.compute.internal
@entity.Attributes.K8s.Workload	cloudwatch-agent
@entity.Attributes.PlatformType	AWS::EKS
```

- [X] Example configuration file for the change
```
application-log.conf: |
          [INPUT]
            Name                tail
            Tag                 application.*
            Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
            Path                /var/log/containers/*.log
            multiline.parser    docker, cri
            DB                  /var/fluent-bit/state/flb_container.db
            Mem_Buf_Limit       50MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Rotate_Wait         30
            storage.type        filesystem
            Read_from_Head      ${READ_FROM_HEAD}
          
          [INPUT]
            Name                tail
            Tag                 application.*
            Path                /var/log/containers/fluent-bit*
            multiline.parser    docker, cri
            DB                  /var/fluent-bit/state/flb_log.db
            Mem_Buf_Limit       5MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Read_from_Head      ${READ_FROM_HEAD}
          
          [INPUT]
            Name                tail
            Tag                 application.*
            Path                /var/log/containers/cloudwatch-agent*
            multiline.parser    docker, cri
            DB                  /var/fluent-bit/state/flb_cwagent.db
            Mem_Buf_Limit       5MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Read_from_Head      ${READ_FROM_HEAD}
          
          [FILTER]
            Name                aws
            Match               application.*
            enable_entity   true
          
          [FILTER]
            Name                kubernetes
            Match               application.*
            Kube_URL            https://kubernetes.default.svc:443
            Kube_Tag_Prefix     application.var.log.containers.
            Merge_Log           On
            Merge_Log_Key       log_processed
            K8S-Logging.Parser  On
            K8S-Logging.Exclude Off
            Labels              Off
            Annotations         Off
            Use_Kubelet         On
            Kubelet_Port        10250
            Buffer_Size         0
          
          [OUTPUT]
            Name                cloudwatch_logs
            Match               application.*
            region              ${AWS_REGION}
            log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
            log_stream_prefix   ${HOST_NAME}-
            auto_create_group   true
            extra_user_agent    container-insights
```
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable EKS detection by inspecting service account token issuer, improving detection in restricted clusters.

* **Bug Fixes**
  * Removed ConfigMap-based checks to reduce required permissions and misdetection.
  * Improved JWT parsing, error handling, and resource cleanup for more robust platform detection.

* **Documentation**
  * Updated internal comments to reflect the issuer-based detection approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->