### PR TITLE
dockerfile: update to Debian Trixie

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -35,8 +35,7 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
-RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/sources.list && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -48,7 +47,7 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/so
     libcurl4-openssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev/trixie-backports \
+    libsystemd-dev \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -122,20 +121,20 @@ COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 # We also include some extra handling for the status files that some tooling uses for scanning, etc.
 WORKDIR /tmp
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/sources.list && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get download \
-    libssl3 \
-    libcurl4 \
+    libssl3t64 \
+    libcurl4t64 \
     libnghttp2-14 \
+    libnghttp3-9 \
     librtmp1 \
-    libssh2-1 \
-    libpsl5 \
+    libssh2-1t64 \
+    libpsl5t64 \
     libbrotli1 \
     libsasl2-2 \
     pkg-config \
     libpq5 \
-    libsystemd0/trixie-backports \
+    libsystemd0 \
     zlib1g \
     ca-certificates \
     libatomic1 \
@@ -149,19 +148,20 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/so
     libk5crypto3 \
     libcom-err2 \
     libkrb5support0 \
-    libgnutls30 \
+    libgnutls30t64 \
     libkeyutils1 \
     libp11-kit0 \
     libidn2-0 \
-    libunistring2 \
+    libunistring5 \
     libtasn1-6 \
-    libnettle8 \
-    libhogweed6 \
+    libnettle8t64 \
+    libhogweed6t64 \
     libgmp10 \
     libffi8 \
     liblzma5 \
     libyaml-0-2 \
     libcap2 \
+    libldap2 \
     && \
     mkdir -p /dpkg/var/lib/dpkg/status.d/ && \
     for deb in *.deb; do \
@@ -229,25 +229,26 @@ COPY --from=qemu-arm64 /usr/bin/qemu-aarch64-static /usr/bin/
 ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
-RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/sources.list && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libssl3 \
-    libcurl4 \
+    libssl3t64 \
+    libcurl4t64 \
     libnghttp2-14 \
+    libnghttp3-9 \
     librtmp1 \
-    libssh2-1 \
-    libpsl5 \
+    libssh2-1t64 \
+    libpsl5t64 \
     libbrotli1 \
     libsasl2-2 \
     pkg-config \
     libpq5 \
-    libsystemd0/trixie-backports \
+    libsystemd0 \
     zlib1g \
     ca-certificates \
     libatomic1 \
     libgcrypt20 \
     libyaml-0-2 \
+    libldap2 \
     bash gdb valgrind build-essential  \
     git bash-completion vim tmux jq \
     dnsutils iputils-ping iputils-arping iputils-tracepath iputils-clockdiff \
@@ -256,7 +257,7 @@ RUN echo "deb http://deb.debian.org/debian trixie-backports main" >> /etc/apt/so
     openssl \
     htop atop strace iotop sysstat ncdu logrotate hdparm pciutils psmisc tree pv \
     make tar flex bison \
-    libssl-dev libsasl2-dev libsystemd-dev/trixie-backports zlib1g-dev libpq-dev libyaml-dev postgresql-server-dev-all \
+    libssl-dev libsasl2-dev libsystemd-dev zlib1g-dev libpq-dev libyaml-dev postgresql-server-dev-all \
     && apt-get satisfy -y cmake "cmake (<< 4.0)" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Distroless containers for Trixie/13 are now available to test: https://github.com/GoogleContainerTools/distroless/issues/1851#issuecomment-3383501287

Most of the work was done downstream with integration testing there as well: https://github.com/FluentDo/agent/pull/139

Note that Debian 13 images are still in preview so should not be merged until GA: https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#debian-13-preview

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded container bases to Debian 13 (Trixie) across builder, extractor, debug, and production stages; production now uses a Debian 13 distroless variant.
  * Replaced backports-specific packages with standard Trixie equivalents and aligned runtime/build library selections across all stages.

* **Impact**
  * Updated system libraries and metadata for improved security, compatibility, and consistency.
  * No user-facing functionality changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->