### PR TITLE
Reduce sampling attribute copies using shared references

### DIFF
--- a/lib/ctraces/include/ctraces/ctr_attributes.h
+++ b/lib/ctraces/include/ctraces/ctr_attributes.h
@@ -27,10 +27,12 @@
 
 struct ctrace_attributes {
     struct cfl_kvlist *kv;
+    unsigned int ref_count;
 };
 
 struct ctrace_attributes *ctr_attributes_create();
 void ctr_attributes_destroy(struct ctrace_attributes *attr);
+struct ctrace_attributes *ctr_attributes_acquire(struct ctrace_attributes *attr);
 int ctr_attributes_count(struct ctrace_attributes *attr);
 int ctr_attributes_set_string(struct ctrace_attributes *attr, char *key, char *value);
 int ctr_attributes_set_bool(struct ctrace_attributes *attr, char *key, int b);

--- a/lib/ctraces/src/ctr_attributes.c
+++ b/lib/ctraces/src/ctr_attributes.c
@@ -35,15 +35,36 @@ struct ctrace_attributes *ctr_attributes_create()
         return NULL;
     }
 
+    attr->ref_count = 1;
+
     return attr;
 }
 
 void ctr_attributes_destroy(struct ctrace_attributes *attr)
 {
+    if (!attr) {
+        return;
+    }
+
+    if (attr->ref_count > 1) {
+        attr->ref_count--;
+        return;
+    }
+
     if (attr->kv) {
         cfl_kvlist_destroy(attr->kv);
     }
     free(attr);
+}
+
+struct ctrace_attributes *ctr_attributes_acquire(struct ctrace_attributes *attr)
+{
+    if (!attr) {
+        return NULL;
+    }
+
+    attr->ref_count++;
+    return attr;
 }
 
 int ctr_attributes_count(struct ctrace_attributes *attr)


### PR DESCRIPTION
## Summary
- add reference counting support to `ctrace_attributes` so attribute lists can be shared safely
- expose a helper to acquire attribute references and update destroy logic to release them correctly
- update the tail sampling processor to reuse resource and instrumentation attributes instead of deep copying them

## Testing
- `cmake --build build --target ctraces-static`
- `/usr/bin/cc ... -o /tmp/sampling_tail.o -c plugins/processor_sampling/sampling_tail.c`


------
https://chatgpt.com/codex/tasks/task_e_68d46a9e0c3c8327ae947a2b45d8c40a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added reference-counted attributes, enabling safe sharing and reuse across components.
  - Exposed an API to acquire/reuse attribute references.
- Bug Fixes
  - Safer attribute teardown with null checks and guarded destruction to prevent premature frees.
- Refactor
  - Sampling processor now reuses existing attribute sets instead of deep-copying, simplifying lifecycle management.
  - Reduced memory allocations and duplication for resource and instrumentation scope attributes, improving performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->