### PR TITLE
http_client: Add required headers that might be missing depending on build

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -55,6 +55,8 @@
 #include <fluent-bit/tls/flb_tls.h>
 #include <time.h>
 #include <fluent-bit/flb_signv4_ng.h>
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_upstream_ha.h>
 
 void flb_http_client_debug(struct flb_http_client *c,
                            struct flb_callback *cb_ctx)


### PR DESCRIPTION
For my local build I used following configuration to build:

```
cmake .. -D FLB_OUT_KAFKA_REST=off -D FLB_OUT_KAFKA=off -D FLB_EXAMPLES=off -D FLB_SHARED_LIB=off -D FLB_SIGNV4=off -DFLB_SIGNV4=Off -DFLB_AWS=Off -DFLB_FILTER_AWS=Off -DFLB_OUT_S3=Off -DFLB_OUT_KINESIS_FIREHOSE=Off -DFLB_OUT_KINESIS_STREAMS=Off -DFLB_OUT_CLOUDWATCH_LOGS=Off -DFLB_OUT_BIGQUERY=Off -DFLB_KAFKA=off -DCMAKE_BUILD_TYPE=Release -DFLB_DEBUG=off -DFLB_RELEASE=on -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib -DFLB_WITHOUT_flb-it-pack=Yes -DFLB_WITHOUT_flb-it-utils=Yes -DFLB_WITHOUT_flb-it-aws_util=Yes -DFLB_WITHOUT_flb-it-aws_credentials_process=Yes -DFLB_TLS=Yes -DFLB_HTTP_SERVER=Yes  -G Ninja -DFLB_CORO_STACK_SIZE=24576 -DFLB_LUAJIT=off -DFLB_OUT_DATADOG=off -DFLB_OUT_AZURE=off -DFLB_OUT_AZURE_KUSTO=off -DFLB_OUT_PGSQL=off -DFLB_OUT_SLACK=off -DFLB_OUT_STACKDRIVER=off -DFLB_OUT_SPLUNK=off -DFLB_OUT_TD=off
```

It seems these headers are added transiently via other headers
I didn't look deeper into it but I found someone reporting similar problems
https://github.com/fluent/fluent-bit/issues/9664

I was building version 4.1.0 on Alpine Linux (due to fluent-bit package still being in edge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Performed minor internal maintenance to align include dependencies with current modules, improving code consistency and future compatibility.
  * Updated internal module references to maintain build reliability across environments.
  * No user-facing impact: functionality, performance, and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->