### PR TITLE
help: add space for outputs and processors when generating schema.

### DIFF
--- a/src/flb_help.c
+++ b/src/flb_help.c
@@ -710,10 +710,11 @@ flb_sds_t flb_help_build_json_schema(struct flb_config *config)
      * - fluent-bit
      * - customs
      * - inputs
+     * - processors
      * - filters
      * - outputs
      */
-    msgpack_pack_map(&mp_pck, 5);
+    msgpack_pack_map(&mp_pck, 6);
 
     /* Fluent Bit */
     msgpack_pack_str(&mp_pck, 10);


### PR DESCRIPTION
# Description

## Problem

The output plugins are not appearing in the JSON output from when generating fluent-bit schema via `./bin/calyptia-fluent-bit -J.`

## Root Cause

In flb/src/flb_help.c:717, the root msgpack map was initialized with size 5:
msgpack_pack_map(&mp_pck, 5);

However, the code was actually adding 6 entries to the root map:

- fluent-bit
- customs
- inputs
- processors (this was missing from the comment)
- filters
- outputs

Because the map was declared with size 5, when msgpack tried to pack 6 entries, the 6th entry ("outputs") was being written to the buffer but wasn't properly included in the map structure, causing it to be silently dropped during JSON conversion.

## Fix

Changed line 717 from msgpack_pack_map(&mp_pck, 5) to msgpack_pack_map(&mp_pck, 6) and updated the comment to reflect all 6 entries including "processors".
Verification
All 46 output plugins now appear in the JSON output
The JSON structure includes all 6 root keys: customs, filters, fluent-bit, inputs, outputs, and processors
No debug output is printed to stderr

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "processors" section in the root JSON schema, enabling configuration of processors with schema-based validation.
  * Improves editor auto-completion and validation feedback for processor-related settings.
  * Enhances help and tooling by recognizing processors at the top level of configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->