### PR TITLE
in_calyptia_fleet: backport support for net.* properties for the upstream connection

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1869,6 +1869,7 @@ flb_sds_t fleet_config_get(struct flb_in_calyptia_fleet_config *ctx)
         }
 
         fleet_config_get_properties(&buf, &c_ins->properties, ctx->fleet_config_legacy_format);
+        fleet_config_get_properties(&buf, &c_ins->net_properties, ctx->fleet_config_legacy_format);
 
         if (flb_config_prop_get("fleet_id", &c_ins->properties) == NULL) {
             if (ctx->fleet_id != NULL) {
@@ -2528,6 +2529,9 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
         in_calyptia_fleet_destroy(ctx);
         return -1;
     }
+
+    /* set upstream settings from 'net.*' */
+    flb_input_upstream_set(ctx->u, ctx->ins);
 
     /* Log initial interval values */
     flb_plg_debug(ctx->ins, "initial collector interval: sec=%d nsec=%d",

--- a/tests/runtime/custom_calyptia_input_test.c
+++ b/tests/runtime/custom_calyptia_input_test.c
@@ -58,6 +58,8 @@ static struct test_context *init_test_context()
         return NULL;
     }
 
+    mk_list_init(&t_ctx->ctx->ins->net_properties);
+
     /* Initialize test values in ctx */
     t_ctx->ctx->api_key = flb_strdup("test_api_key");
     t_ctx->ctx->fleet_config_dir = flb_strdup("/test/config/dir");


### PR DESCRIPTION
<!-- Provide summary of changes -->

Copying https://github.com/fluent/fluent-bit/pull/10998 (which went into `master`) into `4.0`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [X] Debug log output from testing the change

### Before
```
matty@ubuntu:~/dev/fluent-bit/build$ ./bin/flb-rt-custom_calyptia_input_test 
Test set_fleet_input_properties...                Test interrupted by SIGSEGV.
Test machine_id_generation...                     Test interrupted by SIGSEGV.
FAILED: 2 of 2 unit tests have failed.
```

### After
```
matty@ubuntu:~/dev/fluent-bit/build$ ./bin/flb-rt-custom_calyptia_input_test 
Test set_fleet_input_properties...              [ OK ]
Test machine_id_generation...                   [ OK ]
SUCCESS: All unit tests have passed.
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
