### PR TITLE
in_forward: fix username parsing

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -216,7 +216,7 @@ static int setup_users(struct flb_in_fw_config *ctx,
 
         /* Get first value (user's name) */
         sentry = mk_list_entry_first(split, struct flb_split_entry, _head);
-        tmp = flb_sds_create_len(sentry->value, sentry->len + 1);
+        tmp = flb_sds_create_len(sentry->value, sentry->len);
         if (tmp == NULL) {
             delete_users(ctx);
             flb_free(user);
@@ -230,13 +230,14 @@ static int setup_users(struct flb_in_fw_config *ctx,
         tmp = flb_sds_create_len(sentry->value, sentry->len);
         if (tmp == NULL) {
             delete_users(ctx);
+            flb_sds_destroy(user->name);
             flb_free(user);
             flb_utils_split_free(split);
             return -1;
         }
         user->password = tmp;
 
-        /* Release split */
+        /* Release split - only after both allocations succeed */
         flb_utils_split_free(split);
 
         /* Link to parent list */


### PR DESCRIPTION
Fix parsing of username from the config value and ensure consistent error handling.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected username buffer sizing to prevent potential overflows.
  * Ensured proper cleanup on allocation failures to avoid memory leaks.
  * Adjusted control flow so resources are released only after successful setup, improving stability.

* **Refactor**
  * Streamlined resource management during user setup for the forward input plugin, enhancing reliability under error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->