### PR TITLE
in_forward: Fix incorrect user auth sequence

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -775,11 +775,10 @@ static int send_pong(struct flb_input_instance *in,
     if (bytes == -1) {
         flb_plg_error(in, "cannot send PONG");
 
-        result = -1;
-    }
-    else if (userauth == FLB_FALSE)  {
-        flb_plg_error(in, "cannot send PONG");
-
+        /*
+         * The 'userauth == FLB_FALSE' case is not an error; it's a successful
+         * transmission of a failure notification. We only fail if the write fails.
+         */
         result = -1;
     }
     else {
@@ -1186,35 +1185,45 @@ int fw_prot_secure_forward_handshake_start(struct flb_input_instance *ins,
 int fw_prot_secure_forward_handshake(struct flb_input_instance *ins,
                                      struct fw_conn *conn)
 {
-    int ret;
     char *shared_key_salt = NULL;
     int userauth = FLB_TRUE;
     flb_sds_t reason = NULL;
+    int ping_ret;
+    int pong_ret;
 
     reason = flb_sds_create_size(32);
     flb_plg_debug(ins, "protocol: checking PING");
-    ret = check_ping(ins, conn, &shared_key_salt);
-    if (ret == -1) {
+    ping_ret = check_ping(ins, conn, &shared_key_salt);
+    if (ping_ret == -1) {
         flb_plg_error(ins, "handshake error checking PING");
 
         goto error;
     }
-    else if (ret == -2) {
+    else if (ping_ret == -2) {
         flb_plg_warn(ins, "user authentication is failed");
         userauth = FLB_FALSE;
         reason = flb_sds_cat(reason, "username/password mismatch", 26);
     }
 
     flb_plg_debug(ins, "protocol: sending PONG");
-    ret = send_pong(ins, conn, shared_key_salt, userauth, reason);
-    if (ret == -1) {
-        flb_plg_error(ins, "handshake error sending PONG");
+    pong_ret = send_pong(ins, conn, shared_key_salt, userauth, reason);
+    if (pong_ret == -1) {
+        flb_plg_error(ins, "handshake error: could not send PONG to client");
 
         goto error;
     }
 
     flb_sds_destroy(shared_key_salt);
     flb_sds_destroy(reason);
+
+    /*
+     * If the initial authentication check failed (either shared_key or user),
+     * we have successfully notified the client with a PONG failure message,
+     * so we must now terminate the handshake by returning an error.
+     */
+    if (ping_ret < 0) {
+        return -1;
+    }
 
     return 0;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
The previous pingpong handshaking is not enough for failing handshake case.
We need to distinguish where the error happens on pingpong handshaking.
This could be made rigid approach to handle this.

Follows up https://github.com/fluent/fluent-bit/pull/11026.

This PR is tested with Fluent Bit (receiver)/Fluent Bit (sender) and  Fluent Bit (receiver)/Fluentd (sender) cases. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

### Fluent Bit (Server Configs)

```ini
[SERVICE]
    Log_Level    debug

[INPUT]
    Name           forward
    Listen         0.0.0.0
    Port           9999
    Empty_Shared_Key     On
    security.users user pass

[OUTPUT]
    Name           stdout
    Match          *
```

```
[SERVICE]
    Log_Level    debug

[INPUT]
    Name           forward
    Listen         0.0.0.0
    Port           9999
    Shared_Key     key
    security.users user pass

[OUTPUT]
    Name           stdout
    Match          *
```

### Fluent Bit (Client Configs)

```ini
[SERVICE]
    Log_Level    debug

[INPUT]
    Name           dummy

[OUTPUT]
    Name           forward
    Match          *
    Host           127.0.0.1
    Port           9999
    Shared_Key     key
    Username       user
    Password       pass
```

```ini
[SERVICE]
    Log_Level    debug

[INPUT]
    Name           dummy

[OUTPUT]
    Name           forward
    Match          *
    Host           127.0.0.1
    Port           9999
    Shared_Key     key
    Username       user
    Password       pass
```

### Fluentd Sender configs

```aconf
<system>
  log_level debug
</system>

<source>
  @type dummy
  tag dummy.events
</source>

<match **>
  @type forward
  <server>
    host 127.0.0.1
    port 9999
    username   user
    password   pass
  </server>

  <security>
    shared_key key
    self_hostname fluentd-sender.local
  </security>

  <buffer>
    @type memory
    flush_interval 1s
  </buffer>
</match>
```

```aconf
<system>
  log_level debug
</system>

<source>
  @type dummy
  tag dummy.events
</source>

<match **>
  @type forward
  <server>
    host 127.0.0.1
    port 9999
    username   user
    password   pass
  </server>

  <security>
    shared_key ""
    self_hostname fluentd-sender.local
  </security>

  <buffer>
    @type memory
    flush_interval 1s
  </buffer>
</match>
```

#### Both of Fluent Bit case

Shared_Key -> OK
Empty_Shared_Key -> OK

#### Fluent Bit (receiver)/Fluentd (sender) case

Shared_Key -> OK
Empty_Shared_Key -> OK

- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication failures during the secure forward handshake to avoid treating non-errors as failures.
  * Clarified and enhanced logging when reply messages fail to send, making troubleshooting more straightforward.
  * Ensured proper cleanup and connection termination on handshake failures to prevent resource leaks.

* **Refactor**
  * Streamlined handshake control flow with clearer success/failure paths for more consistent outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->