### PR TITLE
fix: add Google CA to certificate store in fluent-bit Windows image

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -228,8 +228,6 @@ LABEL org.opencontainers.image.title="Fluent Bit" `
 # Copy only the built artifacts from builder stage
 COPY --from=builder /fluent-bit /fluent-bit
 
-RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
-
 # Install Google Root CA certificate to allow communication with Google Cloud services.
 RUN powershell -Command `
     $ErrorActionPreference = 'Stop'; `
@@ -239,6 +237,8 @@ RUN powershell -Command `
     Invoke-WebRequest -Uri $GoogleRootCA -OutFile $CertFile; `
     Import-Certificate -FilePath $CertFile -CertStoreLocation Cert:\LocalMachine\Root\; `
     Remove-Item -Path $CertFile -Force;
+
+RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
 
 ENTRYPOINT [ "fluent-bit.exe" ]
 # Hadolint gets confused by Windows it seems


### PR DESCRIPTION
Windows only ships the Microsoft CA into the base image that is used by fluent-bit to create the Windows Container image.

This means, that all requests to Google signed SSL endpoints - fail.

This PR, adds the Google CA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Windows container images now support communication with Google Cloud services
  * Minor configuration formatting updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->