### PR TITLE
aws_credential_sts: internal: Fix unit test failures

### DIFF
--- a/tests/internal/aws_credentials_sts.c
+++ b/tests/internal/aws_credentials_sts.c
@@ -212,6 +212,9 @@ struct flb_http_client *request_eks_test1(struct flb_aws_client *aws_client,
     mk_list_init(&c->headers);
     payload = build_eks_response_with_ttl_calloc(3600, &payload_len);
     TEST_CHECK(payload != NULL);
+    if (!payload) {
+        return NULL;
+    }
 
     http_test_attach_owned_payload(c, payload, payload_len);
 
@@ -246,6 +249,9 @@ struct flb_http_client *request_eks_flb_sts_session_name(struct flb_aws_client
     mk_list_init(&c->headers);
     payload = build_eks_response_with_ttl_calloc(3600, &payload_len);
     TEST_CHECK(payload != NULL);
+    if (!payload) {
+        return NULL;
+    }
 
     http_test_attach_owned_payload(c, payload, payload_len);
 
@@ -305,6 +311,9 @@ struct flb_http_client *request_sts_test1(struct flb_aws_client *aws_client,
     mk_list_init(&c->headers);
     payload = build_sts_response_with_ttl_calloc(3600, &payload_len);
     TEST_CHECK(payload != NULL);
+    if (!payload) {
+        return NULL;
+    }
 
     http_test_attach_owned_payload(c, payload, payload_len);
 
@@ -469,6 +478,9 @@ static void test_process_sts_response()
     }
     payload = build_eks_response_with_ttl_calloc(3600, &payload_len);
     TEST_CHECK(payload != NULL);
+    if (!payload) {
+        return;
+    }
 
     creds = flb_parse_sts_resp(payload, &expiration);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, one of the AWS STS Credentials test is failed.
So, we need to create the responses dynamically to fit the time constraint.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced hard-coded STS response fixtures with dynamically generated TTL-based XML responses that reflect current time.
  * Added helpers to attach owned payloads to mocked HTTP responses and updated tests to allocate, pass length, and free payloads.
  * Improved in-test memory management and NULL checks while preserving existing test flows and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->