### PR TITLE
in_http: add fluentd like add_remote_addr functionality

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -227,6 +227,18 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_BOOL, "add_remote_addr", "false",
+     0, FLB_TRUE, offsetof(struct flb_http, add_remote_addr),
+     "Adds REMOTE_ADDR field to the record. The value of REMOTE_ADDR is the client's address."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "remote_addr_key", REMOTE_ADDR_KEY,
+     0, FLB_TRUE, offsetof(struct flb_http, remote_addr_key),
+     "Key name for the remote address field added to the record."
+    },
+
+    {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_http, buffer_max_size),
      "Set the maximum buffer size to store incoming data."

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -33,6 +33,7 @@
 
 #define HTTP_BUFFER_MAX_SIZE    "4M"
 #define HTTP_BUFFER_CHUNK_SIZE  "512K"
+#define REMOTE_ADDR_KEY         "REMOTE_ADDR"
 
 struct flb_http {
     int successful_response_code;
@@ -47,6 +48,9 @@ struct flb_http {
     struct flb_log_event_encoder log_encoder;
 
     struct flb_input_instance *ins;
+
+    int add_remote_addr;
+    const char *remote_addr_key;
 
     /* New gen HTTP server */
     int enable_http2;

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -941,6 +941,124 @@ void flb_test_http_oauth2_accepts_valid_token()
     jwks_mock_server_stop(&jwks);
 }
 
+void test_http_add_remote_addr(char *input, char *xff_content, char *expected_ip, char *http2_cfg)
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+    char expected_buffer[64];
+
+    char *buf = input;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    ret = snprintf(expected_buffer, sizeof(expected_buffer),"\"test\":\"msg\",\"REMOTE_ADDR\":\"%s\"", expected_ip);
+
+    if(!TEST_CHECK(ret > 0)) {
+        TEST_MSG("snprintf failed");
+        exit(EXIT_FAILURE);
+    }
+    cb_data.data = expected_buffer;
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "add_remote_addr", "true",
+                        "http2", http2_cfg,
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", buf, strlen(buf),
+                        "127.0.0.1", 9880, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Add XFF header (undefined in the flb_http_client) */
+    ret = flb_http_add_header(c, "X-Forwarded-For", strlen("X-Forwarded-For"),
+                              xff_content, strlen(xff_content));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed (XFF header)");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 201)) {
+        TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
+/* Test if remote_addr injection is skipped if remote_addr_key is already present */
+void flb_test_http_remote_addr_skip_colliding_ng()
+{
+    test_http_add_remote_addr("{\"test\":\"msg\",\"REMOTE_ADDR\":\"old\"}", "1.2.3.4, 5.6.7.8", "old", "true");
+}
+
+/* Test flow through next gen http server */
+void flb_test_http_remote_addr_map_ng()
+{
+    test_http_add_remote_addr("{\"test\":\"msg\"}", "1.2.3.4, 5.6.7.8", "1.2.3.4", "true");
+}
+
+void flb_test_http_remote_addr_array_ng()
+{
+    test_http_add_remote_addr("[{\"test\":\"msg\"}]", "1.2.3.4, 5.6.7.8", "1.2.3.4", "true");
+}
+
+/* Test flow through legacy http server (monkey) */
+void flb_test_http_remote_addr_map()
+{
+    test_http_add_remote_addr("{\"test\":\"msg\"}", "1.2.3.4, 5.6.7.8", "1.2.3.4", "false");
+}
+
+void flb_test_http_remote_addr_array()
+{
+    test_http_add_remote_addr("[{\"test\":\"msg\"}]", "1.2.3.4, 5.6.7.8", "1.2.3.4", "false");
+}
+
 TEST_LIST = {
     {"http", flb_test_http},
     {"successful_response_code_200", flb_test_http_successful_response_code_200},
@@ -951,5 +1069,10 @@ TEST_LIST = {
     {"tag_key_with_array_input", flb_test_http_tag_key_with_array_input},
     {"oauth2_requires_token", flb_test_http_oauth2_requires_token},
     {"oauth2_accepts_valid_token", flb_test_http_oauth2_accepts_valid_token},
+    {"add_remote_addr_skip_colliding_ng", flb_test_http_remote_addr_skip_colliding_ng},
+    {"add_remote_addr_map_ng", flb_test_http_remote_addr_map_ng},
+    {"add_remote_addr_array_ng", flb_test_http_remote_addr_array_ng},
+    {"add_remote_addr_map", flb_test_http_remote_addr_map},
+    {"add_remote_addr_array", flb_test_http_remote_addr_array},
     {NULL, NULL}
 };


### PR DESCRIPTION
Fixes #10392

This patch is adding a new option ```add_remote_addr``` which appends a REMOTE_ADDR field to the record. The value of REMOTE_ADDR field is the client's IP address. The client's IP address is extracted from the X-Forwarded-For request header (as it was in fluentd)

For example:

```
X-Forwarded-For: host1, host2
```

The value of ```REMOTE_ADDR``` would be ```host1```

# Known Issues

If multiple X-Forwarded-For headers are specified in the request, which is used (last, or first) will depend on which http server is used (mk or ng):

* mk: ```http2: false```: The first XFF header will be used 
* ng: ```http2: true```: The last XFF header will be used
 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
Doc PR: https://github.com/fluent/fluent-bit-docs/pull/2130

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->

# Configuration
```
service:
  daemon: Off
  flush: 1
  log_level: debug

pipeline:
  inputs:
     - name: http
       listen: 0.0.0.0
       port: 9880
       add_remote_addr: true

  outputs:
    - name: stdout
      match: "*"
```
# Debug / Valgrind logs

curl command
```
curl  http://localhost:9880  -d '{"k":"v"}' -H "Content-Type: application/json" -H "X-Forwarded-For: 1.2.3.4, 5.6.7.8"
```

```"REMOTE_ADDR"=>"1.2.3.4"``` is appended

```[0] http.0: [[1761687337.855967665, {}], {"k"=>"v", "REMOTE_ADDR"=>"1.2.3.4"}]```

```
==4070484== Memcheck, a memory error detector
==4070484== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4070484== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==4070484== Command: ./bin/fluent-bit -c ./fluentbit.yaml
==4070484== 
Fluent Bit v4.2.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/10/28 17:39:54.683440115] [ info] Configuration:
[2025/10/28 17:39:54.698966888] [ info]  flush time     | 1.000000 seconds
[2025/10/28 17:39:54.704256903] [ info]  grace          | 5 seconds
[2025/10/28 17:39:54.704510289] [ info]  daemon         | 0
[2025/10/28 17:39:54.704733293] [ info] ___________
[2025/10/28 17:39:54.704947428] [ info]  inputs:
[2025/10/28 17:39:54.705262274] [ info]      http
[2025/10/28 17:39:54.705523272] [ info] ___________
[2025/10/28 17:39:54.705737267] [ info]  filters:
[2025/10/28 17:39:54.705996728] [ info] ___________
[2025/10/28 17:39:54.706204856] [ info]  outputs:
[2025/10/28 17:39:54.706513417] [ info]      stdout.0
[2025/10/28 17:39:54.706778117] [ info] ___________
[2025/10/28 17:39:54.706997000] [ info]  collectors:
[2025/10/28 17:39:54.782106092] [ info] [fluent bit] version=4.2.0, commit=6345fd16ba, pid=4070484
[2025/10/28 17:39:54.798297478] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/10/28 17:39:54.805791346] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/10/28 17:39:54.897690158] [ info] [output:stdout:stdout.0] worker #0 started
[2025/10/28 17:39:54.806267736] [ info] [simd    ] disabled
[2025/10/28 17:39:54.806625046] [ info] [cmetrics] version=1.0.5
[2025/10/28 17:39:54.806958470] [ info] [ctraces ] version=0.6.6
[2025/10/28 17:39:54.823119196] [ info] [input:http:http.0] initializing
[2025/10/28 17:39:54.823797847] [ info] [input:http:http.0] storage_strategy='memory' (memory only)
[2025/10/28 17:39:54.824941504] [debug] [http:http.0] created event channels: read=25 write=26
[2025/10/28 17:39:54.840517725] [debug] [downstream] listening on 0.0.0.0:9880
[2025/10/28 17:39:54.843567989] [debug] [stdout:stdout.0] created event channels: read=28 write=29
[2025/10/28 17:39:54.876344319] [ info] [sp] stream processor started
[2025/10/28 17:39:54.877986785] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/10/28 17:40:04.887836946] [debug] [task] created task=0x6303550 id=0 OK
[0] http.0: [[1761687604.082926903, {}], {"k"=>"v", "REMOTE_ADDR"=>"1.2.3.4"}]
[2025/10/28 17:40:04.890196685] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2025/10/28 17:40:04.919828745] [debug] [out flush] cb_destroy coro_id=0
[2025/10/28 17:40:04.936131040] [debug] [task] destroy task=0x6303550 (task_id=0)
^C[2025/10/28 17:40:09] [engine] caught signal (SIGINT)
[2025/10/28 17:40:09.475472495] [ warn] [engine] service will shutdown in max 5 seconds
[2025/10/28 17:40:09.477024027] [ info] [engine] pausing all inputs..
[2025/10/28 17:40:09.879831748] [ info] [engine] service has stopped (0 pending tasks)
[2025/10/28 17:40:09.886188874] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/10/28 17:40:09.897929043] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==4070484== 
==4070484== HEAP SUMMARY:
==4070484==     in use at exit: 0 bytes in 0 blocks
==4070484==   total heap usage: 3,385 allocs, 3,385 frees, 1,414,591 bytes allocated
==4070484== 
==4070484== All heap blocks were freed -- no leaks are possible
==4070484== 
==4070484== For lists of detected and suppressed errors, rerun with: -s
==4070484== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

# Valgrind output for tests
```
$ valgrind --leak-check=full ./bin/flb-rt-in_http
==4071595== Memcheck, a memory error detector
==4071595== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4071595== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==4071595== Command: ./bin/flb-rt-in_http
==4071595== 
Test http...                                    ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test successful_response_code_200...            ==4071595== Warning: invalid file descriptor -1 in syscall close()
==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test successful_response_code_204...            ==4071595== Warning: invalid file descriptor -1 in syscall close()
==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test failure_response_code_400_bad_json...      ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test failure_response_code_400_bad_disk_write... [/home/alexandre-local/work/ext/github/fluent-bit/lib/chunkio/src/cio_file_unix.c:410 errno=2] No such file or directory
[2025/10/28 17:43:12.953527805] [error] [input chunk] could not create chunk file: http.0:4071595-1761687792.945368626.flb
[2025/10/28 17:43:12.972434144] [error] [input chunk] no available chunk
[2025/10/28 17:43:12.973184034] [error] [input:http:http.0] Error encoding record : -1
==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test tag_key_with_map_input...                  ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test tag_key_with_array_input...                ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_remote_addr_map_ng...                  ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_remote_addr_array_ng...                ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_remote_addr_map...                     ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test add_remote_addr_array...                   ==4071595== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==4071595== 
==4071595== HEAP SUMMARY:
==4071595==     in use at exit: 0 bytes in 0 blocks
==4071595==   total heap usage: 35,527 allocs, 35,527 frees, 12,927,663 bytes allocated
==4071595== 
==4071595== All heap blocks were freed -- no leaks are possible
==4071595== 
==4071595== For lists of detected and suppressed errors, rerun with: -s
==4071595== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional inclusion of the client's remote address in HTTP input records (disabled by default).
  * Configurable field name for the remote address (default: REMOTE_ADDR_KEY).
  * Extraction, sanitization and trimming of remote address (including X-Forwarded-For) for HTTP/1.x and HTTP/2; applies to map and array payloads.
  * Skips injection when the target field already exists to prevent collisions.

* **Tests**
  * Added tests validating remote-address extraction, propagation and collision handling for map and array payloads across HTTP modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->