### PR TITLE
log: Update log related metrics with a certian interval

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -72,6 +72,8 @@ struct flb_log {
     uint16_t level;            /* level                    */
     char *out;                 /* FLB_LOG_FILE or FLB_LOG_SOCKET */
     pthread_t tid;             /* thread ID   */
+    uint64_t next_hb_ns;       /* next heartbeat (nano sec) */
+    uint64_t hb_interval_ns;   /* heartbeat interval (nano sec) */
     struct flb_worker *worker; /* non-real worker reference */
     struct mk_event_loop *evl;
     struct flb_log_metrics *metrics;

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -470,7 +470,8 @@ static uint64_t monotonic_now_ns(void)
     LARGE_INTEGER cnt, freq;
     uint64_t q = 0;
     uint64_t f = 0;
-    uint64_t us = 0;
+    uint64_t rem = 0;
+    uint64_t sec = 0;
 
     if (s_freq.QuadPart == 0) {
         QueryPerformanceFrequency(&s_freq);
@@ -483,8 +484,10 @@ static uint64_t monotonic_now_ns(void)
     q = (uint64_t)cnt.QuadPart;
     f = (uint64_t)freq.QuadPart;
     /* Use MulDiv-like scaling to reduce precision loss */
-    us = (q * 1000000ULL) / f;
-    return us * 1000ULL;
+    /* Use 128-bit intermediate or chunk the calculation to avoid overflow */
+    sec = q / f;
+    rem = q % f;
+    return (sec * 1000000000ULL) + ((rem * 1000000000ULL) / f);
 }
 
 #else


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes https://github.com/fluent/fluent-bit/issues/11082

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```yaml
---
service:
  flush: 1
  daemon: Off
  log_level: debug
  # Enable/Disable the built-in HTTP Server for metrics
  http_server: Off
  http_listen: 127.0.0.1
  http_port: 2020

pipeline:
  inputs:
    - name: fluentbit_metrics
      tag: metrics_fluentbit
      scrape_interval: 60s

  outputs:
    - name: prometheus_remote_write
      match: 'metrics_*'
      host: localhost
      port: 9090
      uri: /api/v1/write
      retry_limit: 2
      log_response_payload: True
      tls: Off
      add_label: job fluentbit2
```

With the following configuration and Prometheus:

```yaml
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: "prometheus"

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    static_configs:
      - targets: []
```

Launch Prometheus with:

```console
$ prometheus --config.file=/path/to/prometheus.yaml --web.enable-remote-write-receiver  
```

- [x] Debug log output from testing the change

```
Fluent Bit v4.2.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/10/30 18:27:48.943855000] [ info] Configuration:
[2025/10/30 18:27:48.943862000] [ info]  flush time     | 1.000000 seconds
[2025/10/30 18:27:48.943866000] [ info]  grace          | 5 seconds
[2025/10/30 18:27:48.943868000] [ info]  daemon         | 0
[2025/10/30 18:27:48.943870000] [ info] ___________
[2025/10/30 18:27:48.943872000] [ info]  inputs:
[2025/10/30 18:27:48.943874000] [ info]      fluentbit_metrics
[2025/10/30 18:27:48.943876000] [ info] ___________
[2025/10/30 18:27:48.943878000] [ info]  filters:
[2025/10/30 18:27:48.943880000] [ info] ___________
[2025/10/30 18:27:48.943882000] [ info]  outputs:
[2025/10/30 18:27:48.943884000] [ info]      prometheus_remote_write.0
[2025/10/30 18:27:48.943886000] [ info] ___________
[2025/10/30 18:27:48.943888000] [ info]  collectors:
[2025/10/30 18:27:48.945038000] [ info] [fluent bit] version=4.2.0, commit=03dada8a7b, pid=86872
[2025/10/30 18:27:48.945046000] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2025/10/30 18:27:48.945508000] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/10/30 18:27:48.945679000] [ info] [simd    ] NEON
[2025/10/30 18:27:48.945683000] [ info] [cmetrics] version=1.0.5
[2025/10/30 18:27:48.946101000] [ info] [ctraces ] version=0.6.6
[2025/10/30 18:27:48.946227000] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] initializing
[2025/10/30 18:27:48.946233000] [ info] [input:fluentbit_metrics:fluentbit_metrics.0] storage_strategy='memory' (memory only)
[2025/10/30 18:27:48.946240000] [debug] [fluentbit_metrics:fluentbit_metrics.0] created event channels: read=25 write=26
[2025/10/30 18:27:48.946411000] [debug] [prometheus_remote_write:prometheus_remote_write.0] created event channels: read=27 write=28
[2025/10/30 18:27:48.946687000] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] worker #0 started
[2025/10/30 18:27:48.946695000] [ info] [output:prometheus_remote_write:prometheus_remote_write.0] worker #1 started
[2025/10/30 18:27:48.946936000] [ info] [sp] stream processor started
[2025/10/30 18:27:48.947026000] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/10/30 18:28:50.4113000] [debug] [task] created task=0x8c70106c0 id=0 OK
[2025/10/30 18:28:50.4326000] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] task_id=0 assigned to thread #0
[2025/10/30 18:28:50.4480000] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] cmetrics msgpack size: 7550
[2025/10/30 18:28:50.7549000] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] cmetric_id=0 decoded 0-7550 payload_size=4065
[2025/10/30 18:28:50.7608000] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] final payload size: 4065
[2025/10/30 18:28:50.21820000] [debug] [upstream] KA connection #59 to localhost:9090 is connected
[2025/10/30 18:28:50.22244000] [debug] [http_client] not using http_proxy for header
[2025/10/30 18:28:50.24022000] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] localhost:9090, HTTP status=204
[2025/10/30 18:28:50.24054000] [debug] [upstream] KA connection #59 to localhost:9090 is now available
[2025/10/30 18:28:50.24067000] [debug] [output:prometheus_remote_write:prometheus_remote_write.0] http_post result FLB_OK
[2025/10/30 18:28:50.24090000] [debug] [out flush] cb_destroy coro_id=0
[2025/10/30 18:28:50.24144000] [debug] [task] destroy task=0x8c70106c0 (task_id=0)
<snip>
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced heartbeat-based logging metrics that periodically emit per-type log counters for improved observability.
  * Added metrics lifecycle APIs to create and destroy logging metrics, and initialization of heartbeat timing so metrics are emitted at configured intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->