### PR TITLE
router_condition: Fix unconditional route check in routing

### DIFF
--- a/src/flb_router_condition.c
+++ b/src/flb_router_condition.c
@@ -265,6 +265,10 @@ int flb_router_path_should_route(struct flb_event_chunk *chunk,
         return FLB_FALSE;
     }
 
+    if (!path->route) {
+        return FLB_TRUE;
+    }
+
     if (chunk && chunk->type == FLB_EVENT_TYPE_LOGS) {
         if (!context) {
             return FLB_FALSE;
@@ -273,10 +277,6 @@ int flb_router_path_should_route(struct flb_event_chunk *chunk,
         if (flb_router_chunk_context_prepare_logs(context, chunk) != 0) {
             return FLB_FALSE;
         }
-    }
-
-    if (!path->route) {
-        return FLB_TRUE;
     }
 
     return flb_route_condition_eval(chunk, context, path->route);


### PR DESCRIPTION
The PR https://github.com/fluent/fluent-bit/pull/11055 removed the routes_mask guard, which exposed a design flaw in the previous logic. Unconditional routes were being forced through prepare_logs() first. The proper fix is to allow unconditional routes to short-circuit early, so that chunk_trace routes are wired correctly.
With this change, the core_chunk_trace unit test will no longer fail.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved routing condition evaluation logic with optimized control flow to handle edge cases more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->