### PR TITLE
fix: Make TLS initialization thread-safe and idempotent using pthread_once

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -35,7 +35,11 @@
 #include <stdarg.h>
 
 /* FIXME: this extern should be auto-populated from flb_thread_storage.h */
-extern FLB_TLS_DEFINE(struct flb_log, flb_log_ctx)
+#ifndef FLB_HAVE_C_TLS
+FLB_TLS_DECLARE(struct flb_log, flb_log_ctx);
+#else
+extern FLB_TLS_DEFINE(struct flb_log, flb_log_ctx);
+#endif
 
 /* Message types */
 #define FLB_LOG_OFF     0

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -592,7 +592,11 @@ struct flb_out_flush_params {
     struct flb_coro *coro;                      /* coroutine context     */
 };
 
+#ifndef FLB_HAVE_C_TLS
+FLB_TLS_DECLARE(struct flb_out_flush_params, out_flush_params);
+#else
 extern FLB_TLS_DEFINE(struct flb_out_flush_params, out_flush_params);
+#endif
 
 #define FLB_OUTPUT_RETURN(x)                                            \
     flb_output_return_do(x);                                            \

--- a/include/fluent-bit/flb_scheduler.h
+++ b/include/fluent-bit/flb_scheduler.h
@@ -200,7 +200,11 @@ struct flb_sched_timer_coro_cb_params {
     struct flb_coro *coro;
 };
 
+#ifndef FLB_HAVE_C_TLS
+FLB_TLS_DECLARE(struct flb_sched_timer_coro_cb_params, sched_timer_coro_cb_params);
+#else
 extern FLB_TLS_DEFINE(struct flb_sched_timer_coro_cb_params, sched_timer_coro_cb_params);
+#endif
 
 
 struct flb_timer_cb_coro_params {

--- a/include/fluent-bit/flb_thread_storage.h
+++ b/include/fluent-bit/flb_thread_storage.h
@@ -40,13 +40,41 @@
 /* Fallback mode using pthread_*() for Thread-Local-Storage usage */
 #define FLB_TLS_SET(key, val)      pthread_setspecific(key, (void *) val)
 #define FLB_TLS_GET(key)           pthread_getspecific(key)
-#define FLB_TLS_INIT(key)          pthread_key_create(&key, NULL)
-#define FLB_TLS_DEFINE(type, name) pthread_key_t name;
+
+/*
+ * Thread-safe idempotent initialization using pthread_once.
+ * This ensures pthread_key_create is only called once even if FLB_TLS_INIT
+ * is called from multiple locations (different compilation units, hot reload, etc).
+ */
+#define FLB_TLS_INIT(key) \
+    do { \
+        extern pthread_once_t key##_once; \
+        void key##_init_func(void); \
+        pthread_once(&key##_once, key##_init_func); \
+    } while(0)
+
+/* Define a TLS key with its pthread_once control and init function */
+#define FLB_TLS_DEFINE(type, name) \
+    pthread_key_t name; \
+    pthread_once_t name##_once = PTHREAD_ONCE_INIT; \
+    void name##_init_func(void) { \
+        pthread_key_create(&name, NULL); \
+    }
+
+/* Declare a TLS key that's defined elsewhere */
+#define FLB_TLS_DECLARE(type, name) \
+    extern pthread_key_t name; \
+    extern pthread_once_t name##_once; \
+    void name##_init_func(void);
 #endif
 
 
 /* FIXME: this extern should be auto-populated from flb_thread_storage.h */
-extern FLB_TLS_DEFINE(struct flb_worker, flb_worker_ctx)
+#ifndef FLB_HAVE_C_TLS
+FLB_TLS_DECLARE(struct flb_worker, flb_worker_ctx);
+#else
+extern FLB_TLS_DEFINE(struct flb_worker, flb_worker_ctx);
+#endif
 
 
 #endif /* !FLB_THREAD_STORAGE_H */


### PR DESCRIPTION
Upstreaming [as requested by](https://github.com/chronosphereio/calyptia-fluent-bit/pull/756) @cosmo0920. 

# Background:

`flb_reload()` calls `flb_create()` to create a new context for validation. `flb_create()` calls `flb_log_create()` which calls `FLB_TLS_INIT(flb_worker_ctx)`. On platforms without `FLB_HAVE_C_TLS` defined (e.g. Windows), `FLB_TLS_INIT` directly calls `pthread_key_create`. `FLB_TLS_INIT` is also called from multiple other locations (`flb_lib.c`, `flb_worker.c`, etc.). Each call to `pthread_key_create` with the same key is undefined behavior per POSIX, causing issues like fluentbit logs not being output after a halted reload.

# Summary of changes 

This patch makes FLB_TLS_INIT(key) idempotent using pthread_once:
Before: Each FLB_TLS_INIT call directly executed pthread_key_create, causing multiple key creations
After: Each FLB_TLS_INIT uses pthread_once to ensure the key is created exactly once, regardless of how many times or from where it's called

* Modified FLB_TLS_INIT macro to use pthread_once for one-time initialization
* Updated FLB_TLS_DEFINE to include pthread_once control and initialization function
* Added FLB_TLS_DECLARE macro for proper external declarations
* Fixed headers (`flb_log.h`, `flb_output.h`, `flb_scheduler.h`) to use correct declaration pattern

This ensures thread-safe, idempotent TLS initialization across all compilation units and during hot reload, eliminating the undefined behavior.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved thread-local storage initialization to be safer and idempotent across threads.
  * Standardized conditional declarations for per-thread storage so thread-specific data is reliably allocated and linked based on platform capabilities.
  * Reduced risk of race conditions during TLS setup and clarified initialization semantics without changing external behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->