### PR TITLE
in_forward: fix connection release on pause memory corruption

### DIFF
--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -25,6 +25,12 @@
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
+#define FW_INSTANCE_STATE_RUNNING           0
+#define FW_INSTANCE_STATE_ACCEPTING_CLIENT  1
+#define FW_INSTANCE_STATE_PROCESSING_PACKET 2
+#define FW_INSTANCE_STATE_PAUSED            3
+
+
 enum {
     FW_HANDSHAKE_HELO        = 1,
     FW_HANDSHAKE_PINGPONG    = 2,
@@ -76,6 +82,8 @@ struct flb_in_fw_config {
 
     pthread_mutex_t conn_mutex;
 
+    int state;
+    
     /* Plugin is paused */
     int is_paused;
 };

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -28,8 +28,7 @@
 #include "fw_prot.h"
 #include "fw_conn.h"
 
-/* Callback invoked every time an event is triggered for a connection */
-int fw_conn_event(void *data)
+static int fw_conn_event_internal(struct flb_connection *connection)
 {
     int ret;
     int bytes;
@@ -39,9 +38,6 @@ int fw_conn_event(void *data)
     struct fw_conn *conn;
     struct mk_event *event;
     struct flb_in_fw_config *ctx;
-    struct flb_connection *connection;
-
-    connection = (struct flb_connection *) data;
 
     conn = connection->user_data;
 
@@ -125,6 +121,37 @@ int fw_conn_event(void *data)
         return -1;
     }
     return 0;
+}
+
+/* Callback invoked every time an event is triggered for a connection */
+int fw_conn_event(void *data)
+{
+    struct flb_in_fw_config *ctx;
+    struct fw_conn          *conn;
+    int                      result;
+    struct flb_connection   *connection;
+    int                      state_backup;
+
+    connection = (struct flb_connection *) data;
+
+    conn = connection->user_data;
+
+    ctx = conn->ctx;
+
+    state_backup = ctx->state;
+
+    ctx->state = FW_INSTANCE_STATE_PROCESSING_PACKET;
+
+    result = fw_conn_event_internal(connection);
+
+    if (ctx->state == FW_INSTANCE_STATE_PROCESSING_PACKET) {
+        ctx->state = state_backup;
+    }
+    else if (ctx->state == FW_INSTANCE_STATE_PAUSED) {
+        fw_conn_del_all(ctx);
+    }
+
+    return result;
 }
 
 /* Create a new Forward request instance */


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes #11113 

There were a number of use-after-free and invalid memory access bugs found via the above issue that occur when the forward input pauses due to mem_buf_limit being full. This PR attempts to fix all of those errors to avoid segfaults in the forward input under heavy load. See valgrind output below confirming no errors found after running for 30 minutes at high load.

When using the forward input plugin with a low `Mem_Buf_Limit`, Fluent Bit would crash with a segmentation fault when memory limits were hit and the plugin was paused. The issue was that `fw_conn_del_all()` would free all connections immediately, but event handlers were still running and trying to access that freed memory.

### Summary

This commit solves the problem by tracking what the plugin instance is doing at any moment and delaying connection cleanup if needed. It adds a `state` field to the plugin context with four possible values:

- `FW_INSTANCE_STATE_RUNNING` - normal operation
- `FW_INSTANCE_STATE_ACCEPTING_CLIENT` - currently accepting a new connection
- `FW_INSTANCE_STATE_PROCESSING_PACKET` - event handler is processing data
- `FW_INSTANCE_STATE_PAUSED` - plugin has been paused

When `in_fw_pause()` is called, it checks the current state. If the plugin is currently accepting a client or processing a packet, it skips calling `fw_conn_del_all()` and just sets the state to `PAUSED`.

The `in_fw_collect()` function (which accepts new connections) and `fw_conn_event()` (which processes incoming data) both set their respective states when they start, then check if the state changed to `PAUSED` before they exit. If it did, they call `fw_conn_del_all()` themselves after they're done with the connection.

This ensures that connections are never freed while code is actively using them. The cleanup just gets deferred until the current operation finishes, preventing the use-after-free that was causing the crash.

#### Problem

The plugin could crash when a connection was deleted (e.g., during pause/shutdown) while messages were still being processed.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

see issue report.

- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==150631== 
==150631== HEAP SUMMARY:
==150631==     in use at exit: 0 bytes in 0 blocks
==150631==   total heap usage: 471,017 allocs, 471,017 frees, 5,381,700,270 bytes allocated
==150631== 
==150631== All heap blocks were freed -- no leaks are possible
==150631== 
==150631== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.