### PR TITLE
out_s3: Add a NULL check for plugging SEGV on dry_run

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -1112,7 +1112,11 @@ static int cb_s3_worker_exit(void *data, struct flb_config *config)
     struct worker_info *info;
     struct flb_s3 *ctx = data;
 
-    flb_plg_info(ctx->ins, "initializing worker");
+    if (!ctx) {
+        return 0;
+    }
+
+    flb_plg_info(ctx->ins, "terminating worker");
 
     info = FLB_TLS_GET(s3_worker_info);
     if (info != NULL) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes https://github.com/fluent/fluent-bit/issues/11104.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
    flush_interval: 1
    daemon: Off
    log_level: debug

pipeline:
    inputs:
        -   name: tcp
            listen: 0.0.0.0
            port: 24224
            format: json
            tag: input.json_tcp
            buffer_size: 128 #kb

    outputs:
        -   name: s3
            match: 'common_output'
            region: eu-west-1
            bucket: TEST
            store_dir_limit_size: 200M
            compression: gzip
            total_file_size: 50M
            s3_key_format: "/%Y/%m/%d/%H_%M_%S_$UUID.json"
```
- [x] Debug log output from testing the change

```log
% bin/fluent-bit -c out_s3_segv.yaml --dry-run
Fluent Bit v4.2.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/11/06 19:44:26.316110000] [ info] Configuration:
[2025/11/06 19:44:26.316116000] [ info]  flush time     | 1.000000 seconds
[2025/11/06 19:44:26.316120000] [ info]  grace          | 5 seconds
[2025/11/06 19:44:26.316121000] [ info]  daemon         | 0
[2025/11/06 19:44:26.316123000] [ info] ___________
[2025/11/06 19:44:26.316124000] [ info]  inputs:
[2025/11/06 19:44:26.316126000] [ info]      tcp
[2025/11/06 19:44:26.316128000] [ info] ___________
[2025/11/06 19:44:26.316129000] [ info]  filters:
[2025/11/06 19:44:26.316131000] [ info] ___________
[2025/11/06 19:44:26.316132000] [ info]  outputs:
[2025/11/06 19:44:26.316134000] [ info]      s3.0
[2025/11/06 19:44:26.316135000] [ info] ___________
[2025/11/06 19:44:26.316137000] [ info]  collectors:
configuration test is successful
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the S3 output plugin's worker termination process with additional defensive checks to prevent crashes and ensure stable plugin shutdown.
  * Improved logging accuracy during worker lifecycle management to clearly distinguish between initialization and termination phases, enabling better operational visibility and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->