### PR TITLE
tests: increase timeout in core_chunk_trace runtime test

### DIFF
--- a/tests/runtime/core_chunk_trace.c
+++ b/tests/runtime/core_chunk_trace.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include "flb_tests_runtime.h"
 
+#define FLB_TEST_MAX_WAIT 60
 
 struct callback_record {
     void *data;
@@ -101,9 +102,12 @@ void do_test_records_trace(void (*records_cb)(struct callback_records *))
     /* Start test */
     TEST_CHECK(flb_start(ctx) == 0);
 
-    /* 4 sec passed. It must have flushed */
-    sleep(5);
-    
+    /* Wait at most FLB_TEST_MAX_WAIT seconds for the dummy input, and trace callback */
+    for(i = 0; records->num_records == 0 && i < FLB_TEST_MAX_WAIT; i++ ) {
+        sleep(1);
+    }
+    flb_info("[test] collected records, waited %d seconds", i);
+
     records_cb(records);
     
     flb_stop(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Increase wait timeout from 5s to 60s to reduce intermittent failures.

I have noticed, at least locally, that it is frequently required to wait a lot more than the current 5s, as shown in the debug logs.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->

- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

# Debug / Valgrind logs
```
$ valgrind --leak-check=full ./bin/flb-rt-core_chunk_trace 
==1274892== Memcheck, a memory error detector
==1274892== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1274892== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==1274892== Command: ./bin/flb-rt-core_chunk_trace
==1274892== 
Test trace...                                   [2025/11/07 14:13:46.344880856] [ info] [fluent bit] version=4.2.0, commit=f879a93bc7, pid=1274892
[2025/11/07 14:13:46.384589051] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/11/07 14:13:46.385211200] [ info] [simd    ] disabled
[2025/11/07 14:13:46.385578287] [ info] [cmetrics] version=1.0.5
[2025/11/07 14:13:46.385980015] [ info] [ctraces ] version=0.6.6
[2025/11/07 14:13:46.399130338] [ info] [input:emitter:trace-emitter] initializing
[2025/11/07 14:13:46.399790620] [ info] [input:emitter:trace-emitter] storage_strategy='memory' (memory only)
[2025/11/07 14:13:46.435622122] [ info] [input:emitter:trace-emitter] thread instance initialized
[2025/11/07 14:13:46.463921842] [ info] [sp] stream processor started
[2025/11/07 14:13:46.467972372] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2025/11/07 14:13:46.538441225] [ info] [fluent bit] version=4.2.0, commit=f879a93bc7, pid=1274892
[2025/11/07 14:13:46.538894287] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/11/07 14:13:46.539035786] [ info] [simd    ] disabled
[2025/11/07 14:13:46.539141456] [ info] [cmetrics] version=1.0.5
[2025/11/07 14:13:46.539289590] [ info] [ctraces ] version=0.6.6
[2025/11/07 14:13:46.540957336] [ info] [input:dummy:dummy.0] initializing
[2025/11/07 14:13:46.587519012] [ info] [output:stdout:stdout.0] worker #0 started
[2025/11/07 14:13:46.541093806] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/11/07 14:13:46.582230401] [ info] [sp] stream processor started
[2025/11/07 14:13:46.585862300] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[0] dummy.0: [[1762542827.056090136, {}], {"message"=>"dummy"}]
[0] dummy.0: [[1762542828.033435617, {}], {"message"=>"dummy"}]
[0] dummy.0: [[1762542829.033474779, {}], {"message"=>"dummy"}]
[2025/11/07 14:13:50.47970231] [ info] [test] flush record
[0] dummy.0: [[1762542830.033873764, {}], {"message"=>"dummy"}]
[2025/11/07 14:13:50.594354534] [ info] [test] collected records, waited 4 seconds
[2025/11/07 14:13:50.605990204] [ warn] [engine] service will shutdown in max 1 seconds
[2025/11/07 14:13:50.607959037] [ info] [engine] pausing all inputs..
[2025/11/07 14:13:50.610133972] [ info] [input] pausing dummy.0
[2025/11/07 14:13:51.53749179] [ info] [engine] service has stopped (0 pending tasks)
[2025/11/07 14:13:51.54001796] [ info] [input] pausing dummy.0
[2025/11/07 14:13:51.58154295] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/11/07 14:13:51.69416871] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2025/11/07 14:13:51.104944282] [ warn] [engine] service will shutdown in max 1 seconds
[2025/11/07 14:13:51.105167077] [ info] [engine] pausing all inputs..
[2025/11/07 14:13:52.33169863] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
SUCCESS: All unit tests have passed.
==1274892== 
==1274892== HEAP SUMMARY:
==1274892==     in use at exit: 0 bytes in 0 blocks
==1274892==   total heap usage: 5,157 allocs, 5,157 frees, 3,897,925 bytes allocated
==1274892== 
==1274892== All heap blocks were freed -- no leaks are possible
==1274892== 
==1274892== For lists of detected and suppressed errors, rerun with: -s
==1274892== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

# Output of delay required by multiple tests (10 executions)
```
$ for i in {1..10}; do ./bin/flb-rt-core_chunk_trace 2>&1 | grep collected; done 
[2025/11/07 14:17:06.980204356] [ info] [test] collected records, waited 10 seconds
[2025/11/07 14:17:19.55182541] [ info] [test] collected records, waited 6 seconds
[2025/11/07 14:17:30.53825194] [ info] [test] collected records, waited 4 seconds
[2025/11/07 14:17:40.56687053] [ info] [test] collected records, waited 3 seconds
[2025/11/07 14:17:55.55847414] [ info] [test] collected records, waited 8 seconds
[2025/11/07 14:18:05.55402091] [ info] [test] collected records, waited 3 seconds
[2025/11/07 14:18:19.55083289] [ info] [test] collected records, waited 7 seconds
[2025/11/07 14:18:43.57154926] [ info] [test] collected records, waited 17 seconds
[2025/11/07 14:18:53.56144980] [ info] [test] collected records, waited 3 seconds
[2025/11/07 14:19:03.55392549] [ info] [test] collected records, waited 3 seconds
```

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability with an adaptive wait mechanism that polls for results over a configurable duration instead of using fixed timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->