### PR TITLE
packaging: add -L flag to curl for redirect support 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ SCRIPT
         $SUDO sh <<SCRIPT
 export DEBIAN_FRONTEND=noninteractive
 mkdir -p /usr/share/keyrings/
-curl $RELEASE_KEY | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
+curl -L $RELEASE_KEY | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
 cat > /etc/apt/sources.list.d/fluent-bit.list <<EOF
 deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] $RELEASE_URL/${OS}/${CODENAME} ${CODENAME} main
 EOF


### PR DESCRIPTION
## Problem
The official install.sh script fails on Debian/Ubuntu with:
```
gpg: no valid OpenPGP data found
```

This occurs because `packages.fluentbit.io/fluentbit.key` now returns a 302 redirect to S3. Without the `-L` flag, curl stops at the redirect and returns an empty response, breaking GPG key import.

## Solution
Added `-L` flag to curl command in the Ubuntu/Debian installation section to follow HTTP redirects.

Fixes the installation failure on Debian/Ubuntu platforms.

---

**Testing**

- [ ] Example configuration file for the change
  - [N/A] - This is a change to the installation script, not runtime configuration

- [x] Debug log output from testing the change
```bash
# Before fix (without -L):
$ curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor
gpg: no valid OpenPGP data found.

# After fix (with -L):
$ curl -L https://packages.fluentbit.io/fluentbit.key | gpg --dearmor
# Successfully creates keyring file (3175 bytes)

# Full installation test on Ubuntu 24.04:
$ sudo ./install.sh
...
Installation completed. Happy Logging!
```

- [ ] Attached Valgrind output
  - [N/A] - This change only modifies the installation shell script, not C code

- [ ] Run local packaging test
  - [N/A] - This change only affects the installation script, not package building

- [ ] Set `ok-package-test` label
  - Requires maintainer action

**Documentation**

- [x] Documentation required for this feature
  - Yes, the official documentation at https://docs.fluentbit.io/manual/installation/linux/ubuntu also needs updating with the `-L` flag

**Backporting**

- [x] Backport to latest stable release.
  - Yes, this should be backported to 4.0 and 3.2 branches as the redirect affects all versions

---

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability on Debian/Ubuntu by ensuring the keyring setup process correctly handles URL redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->