### PR TITLE
out_opensearch: release aws signature a retry or error happens

### DIFF
--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -974,6 +974,10 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {
         flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ctx->uri);
+        if (signature) {
+            flb_sds_destroy(signature);
+            signature = NULL;
+        }
         goto retry;
     }
     else {
@@ -987,6 +991,10 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
             else {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s",
                               c->resp.status, ctx->uri);
+            }
+            if (signature) {
+                flb_sds_destroy(signature);
+                signature = NULL;
             }
             goto retry;
         }
@@ -1021,6 +1029,10 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
                         fflush(stderr);
                     }
                 }
+                if (signature) {
+                    flb_sds_destroy(signature);
+                    signature = NULL;
+                }
                 goto retry;
             }
             else {
@@ -1029,6 +1041,10 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
             }
         }
         else {
+            if (signature) {
+                flb_sds_destroy(signature);
+                signature = NULL;
+            }
             goto retry;
         }
     }


### PR DESCRIPTION
When a retry or error happens, if AWS auth is being used we are leaking the signature buffer, this PR corrects that.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup in the OpenSearch plugin to prevent potential memory leaks during error and retry scenarios, enhancing stability and reliability of OpenSearch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->