### PR TITLE
in_tail: New keep_file_handle and fstat_interval_nsec options for tail input

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -78,7 +78,7 @@ static int in_tail_collect_pending(struct flb_input_instance *ins,
         if (file->watch_fd == -1 ||
             (file->offset >= file->size)) {
             /* Gather current file size */
-            ret = fstat(file->fd, &st);
+            ret = flb_tail_file_stat(file, &st);
             if (ret == -1) {
                 flb_errno();
                 flb_tail_file_remove(file);
@@ -340,7 +340,14 @@ static int in_tail_watcher_callback(struct flb_input_instance *ins,
 int in_tail_collect_event(void *file, struct flb_config *config)
 {
     int ret;
+    struct stat st;
     struct flb_tail_file *f = file;
+
+    ret = flb_tail_file_stat(f, &st);
+    if (ret == -1) {
+        flb_tail_file_remove(f);
+        return 0;
+    }
 
     ret = flb_tail_file_chunk(f);
     switch (ret) {
@@ -617,6 +624,13 @@ static struct flb_config_map config_map[] = {
      "nanosecond component of the progress check interval."
     },
     {
+     FLB_CONFIG_MAP_STR, "fstat_interval", "250ms",
+     0, FLB_FALSE, 0,
+     "interval for fstat mode event polling. Controls how often files are checked "
+     "for changes when using stat-based file watching (instead of inotify). "
+     "Default is 250ms. Supports time suffixes: s, ms, us, ns."
+    },
+    {
      FLB_CONFIG_MAP_TIME, "rotate_wait", FLB_TAIL_ROTATE_WAIT,
      0, FLB_TRUE, offsetof(struct flb_tail_config, rotate_wait),
      "specify the number of extra time in seconds to monitor a file once is "
@@ -716,7 +730,14 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_tail_config, skip_empty_lines),
      "Allows to skip empty lines."
     },
-
+    {
+     FLB_CONFIG_MAP_BOOL, "keep_file_handle", "true",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, keep_file_handle),
+     "When set to false, the file handle will be reopened every time we read "
+     "from the source tailed file and closed when done, to avoid keeping it open. "
+     "Useful for SMB shares and network filesystems where keeping handles open "
+     "can cause issues."
+    },
     {
       FLB_CONFIG_MAP_BOOL, "truncate_long_lines", "false",
       0, FLB_TRUE, offsetof(struct flb_tail_config, truncate_long_lines),

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -108,6 +108,10 @@ struct flb_tail_config {
     int progress_check_interval;      /* watcher interval             */
     int progress_check_interval_nsec; /* watcher interval             */
 
+    uint64_t fstat_interval_nsec;     /* fstat mode event polling interval (nanoseconds) */
+
+    int keep_file_handle;      /* keep file handle open during tail (default: true) */
+
 #ifdef FLB_HAVE_INOTIFY
     int   inotify_watcher;     /* enable/disable inotify monitor */
 #endif

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -169,6 +169,65 @@ int flb_tail_file_offset_marker_matches(struct flb_tail_file *file)
     return FLB_TRUE;
 }
 
+/* Ensure file handle is open (opens if closed). Returns 0 on success, FLB_TAIL_ERROR on failure. */
+int flb_tail_file_ensure_open_handle(struct flb_tail_file *file)
+{
+    int fd;
+
+    /* If already open, nothing to do */
+    if (file->fd != -1) {
+        return 0;
+    }
+
+    fd = open(file->name, O_RDONLY);
+    if (fd == -1) {
+        flb_errno();
+        flb_plg_error(file->config->ins, "cannot open %s", file->name);
+        return FLB_TAIL_ERROR;
+    }
+
+    /* Seek to the current offset */
+    if (file->offset > 0) {
+        int64_t ret = lseek(fd, file->offset, SEEK_SET);
+        if (ret == -1) {
+            flb_errno();
+            close(fd);
+            return FLB_TAIL_ERROR;
+        }
+    }
+
+    file->fd = fd;
+    return 0;
+}
+
+/* Get file status using stat() if handle is closed, fstat() if open. Returns 0 on success, -1 on error. */
+int flb_tail_file_stat(struct flb_tail_file *file, struct stat *st)
+{
+    if (file->fd == -1) {
+        return stat(file->name, st);
+    }
+    else {
+        return fstat(file->fd, st);
+    }
+}
+
+/* Close file handle unconditionally */
+void flb_tail_file_close_handle(struct flb_tail_file *file)
+{
+    if (file->fd != -1) {
+        close(file->fd);
+        file->fd = -1;
+    }
+}
+
+/* Close file handle during tail if it's open and keep_file_handle is false */
+void flb_tail_file_close_handle_during_tail(struct flb_tail_file *file)
+{
+    if (file->config->keep_file_handle == FLB_FALSE && file->fd != -1) {
+        flb_tail_file_close_handle(file);
+    }
+}
+
 static uint64_t stat_get_st_dev(struct stat *st)
 {
 #ifdef FLB_SYSTEM_WINDOWS
@@ -1528,6 +1587,12 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     /* Remaining bytes to read */
     file->pending_bytes = file->size - file->offset;
 
+    /* Close file handle if keep_file_handle is false */
+    if (ctx->keep_file_handle == FLB_FALSE) {
+        flb_plg_debug(ctx->ins, "tail_append: file will be read without keeping file handle opened %s", file->name);
+        flb_tail_file_close_handle_during_tail(file);
+    }
+
 #ifdef FLB_HAVE_METRICS
     name = (char *) flb_input_name(ctx->ins);
     ts = cfl_time_now();
@@ -1623,9 +1688,8 @@ void flb_tail_file_remove(struct flb_tail_file *file)
     mk_list_del(&file->_head);
     flb_tail_fs_remove(ctx, file);
 
-    /* avoid deleting file with -1 fd */
     if (file->fd != -1) {
-        close(file->fd);
+        flb_tail_file_close_handle(file);
     }
     if (file->tag_buf) {
         flb_free(file->tag_buf);
@@ -1681,7 +1745,7 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
     int64_t offset;
     struct stat st;
 
-    ret = fstat(file->fd, &st);
+    ret = flb_tail_file_stat(file, &st);
     if (ret == -1) {
         flb_errno();
         return FLB_TAIL_ERROR;
@@ -1694,15 +1758,22 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
 
     /* Check if the file was truncated by comparing current size with previous size */
     if (size_delta < 0) {
-        offset = lseek(file->fd, 0, SEEK_SET);
-        if (offset == -1) {
-            flb_errno();
-            return FLB_TAIL_ERROR;
+        /* If keeping handle open, it's already open but at wrong offset - seek to beginning */
+        if (ctx->keep_file_handle == FLB_TRUE) {
+            offset = lseek(file->fd, 0, SEEK_SET);
+            if (offset == -1) {
+                flb_errno();
+                return FLB_TAIL_ERROR;
+            }
+            file->offset = offset;
+        }
+        else {
+            /* If not keeping handle open, just update offset - handle will be opened/seeks correctly later */
+            file->offset = 0;
         }
 
         flb_plg_debug(ctx->ins, "adjust_counters: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
                       file->inode, file->name, size_delta);
-        file->offset = offset;
         file->buf_len = 0;
 
         /* Update offset in the database file */
@@ -1743,6 +1814,12 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         return FLB_TAIL_BUSY;
     }
 
+    /* Open file handle if it's closed */
+    ret = flb_tail_file_ensure_open_handle(file);
+    if (ret != 0) {
+        return ret;
+    }
+
     file_buffer_capacity = (file->buf_size - file->buf_len) - 1;
     stream_data_length = 0;
 
@@ -1778,6 +1855,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
             if (ctx->skip_long_lines == FLB_FALSE) {
                 flb_plg_error(ctx->ins, "file=%s requires a larger buffer size, "
                           "lines are too long. Skipping file.", file->name);
+                flb_tail_file_close_handle_during_tail(file);
                 return FLB_TAIL_ERROR;
             }
 
@@ -1823,6 +1901,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
                 flb_errno();
                 flb_plg_error(ctx->ins, "cannot increase buffer size for %s, "
                           "skipping file.", file->name);
+                flb_tail_file_close_handle_during_tail(file);
                 return FLB_TAIL_ERROR;
             }
         }
@@ -1872,7 +1951,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
                     flb_plg_error(ctx->ins,
                                   "decompression buffer resize failed for %s.",
                                   file->name);
-
+                    flb_tail_file_close_handle_during_tail(file);
                     return FLB_TAIL_ERROR;
                 }
 
@@ -1911,7 +1990,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
                     flb_plg_error(ctx->ins,
                                   "decompression failed for %s.",
                                   file->name);
-
+                    flb_tail_file_close_handle_during_tail(file);
                     return FLB_TAIL_ERROR;
                 }
 
@@ -1944,6 +2023,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         if (ret < 0) {
             flb_plg_debug(ctx->ins, "inode=%"PRIu64" file=%s process content ERROR",
                           file->inode, file->name);
+            flb_tail_file_close_handle_during_tail(file);
             return FLB_TAIL_ERROR;
         }
 
@@ -1963,12 +2043,19 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         /* adjust file counters, returns FLB_TAIL_OK or FLB_TAIL_ERROR */
         ret = adjust_counters(ctx, file);
 
+        /* Close file handle if keep_file_handle is false */
+        flb_tail_file_close_handle_during_tail(file);
+
         /* Data was consumed but likely some bytes still remain */
         return ret;
     }
     else if (raw_data_length == 0) {
         /* We reached the end of file, let's wait for some incoming data */
         ret = adjust_counters(ctx, file);
+
+        /* Close file handle if keep_file_handle is false */
+        flb_tail_file_close_handle_during_tail(file);
+
         if (ret == FLB_TAIL_OK) {
             return FLB_TAIL_WAIT;
         }
@@ -1980,8 +2067,15 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         /* error */
         flb_errno();
         flb_plg_error(ctx->ins, "error reading %s", file->name);
+
+        /* Close file handle if keep_file_handle is false */
+        flb_tail_file_close_handle_during_tail(file);
+
         return FLB_TAIL_ERROR;
     }
+
+    /* Close file handle if keep_file_handle is false */
+    flb_tail_file_close_handle_during_tail(file);
 
     return FLB_TAIL_ERROR;
 }
@@ -2068,7 +2162,7 @@ int flb_tail_file_to_event(struct flb_tail_file *file)
     struct flb_tail_config *ctx = file->config;
 
     /* Check if the file promoted have pending bytes */
-    ret = fstat(file->fd, &st);
+    ret = flb_tail_file_stat(file, &st);
     if (ret != 0) {
         flb_errno();
         return -1;
@@ -2082,10 +2176,12 @@ int flb_tail_file_to_event(struct flb_tail_file *file)
         file->pending_bytes = 0;
     }
 
-    /* Check if the file has been rotated */
-    ret = flb_tail_file_is_rotated(ctx, file);
-    if (ret == FLB_TRUE) {
-        flb_tail_file_rotated(file);
+    /* Check if the file has been rotated (only when keep_file_handle is enabled) */
+    if (ctx->keep_file_handle == FLB_TRUE) {
+        ret = flb_tail_file_is_rotated(ctx, file);
+        if (ret == FLB_TRUE) {
+            flb_tail_file_rotated(file);
+        }
     }
 
     /* Notify the fs-event handler that we will start monitoring this 'file' */
@@ -2109,10 +2205,13 @@ int flb_tail_file_to_event(struct flb_tail_file *file)
 }
 
 /*
- * Given an open file descriptor, return the filename. This function is a
- * bit slow and it aims to be used only when a file is rotated.
+ * Internal implementation: Given an open file descriptor, return the filename.
+ * This function is a bit slow and it aims to be used only when a file is rotated.
+ * 
+ * This is used to detect the new file path after an open handle has been
+ * rotated/moved. Requires an open file descriptor.
  */
-char *flb_tail_file_name(struct flb_tail_file *file)
+static char *flb_tail_file_name_internal(struct flb_tail_file *file)
 {
     int ret;
     char *buf;
@@ -2203,6 +2302,41 @@ char *flb_tail_file_name(struct flb_tail_file *file)
     free(file_entries);
 #endif
     return buf;
+}
+
+/*
+ * Public wrapper: Get the file name from a file descriptor.
+ * This function handles opening/closing the file handle as needed.
+ * If the handle is closed, opens it temporarily and closes it after getting the name.
+ *
+ * Note: When keep_file_handle is false, this function still needs to work for
+ * resolving symlinks during file initialization, but it should NOT be used for
+ * log rotation detection (which requires persistent open handles).
+ */
+char *flb_tail_file_name(struct flb_tail_file *file)
+{
+    int ret;
+    int fd_was_opened = FLB_FALSE;
+    char *result;
+
+    /* If handle is closed, open it temporarily */
+    if (file->fd == -1) {
+        ret = flb_tail_file_ensure_open_handle(file);
+        if (ret != 0) {
+            return NULL;
+        }
+        fd_was_opened = FLB_TRUE;
+    }
+
+    /* Call the internal implementation */
+    result = flb_tail_file_name_internal(file);
+
+    /* Close handle if we opened it in this function */
+    if (fd_was_opened) {
+        flb_tail_file_close_handle(file);
+    }
+
+    return result;
 }
 
 int flb_tail_file_name_dup(char *path, struct flb_tail_file *file)
@@ -2306,9 +2440,9 @@ static int check_purge_deleted_file(struct flb_tail_config *ctx,
     int64_t mtime;
     struct stat st;
 
-    ret = fstat(file->fd, &st);
+    ret = flb_tail_file_stat(file, &st);
     if (ret == -1) {
-        flb_plg_debug(ctx->ins, "error stat(2) %s, removing", file->name);
+        flb_plg_debug(ctx->ins, "purge: error stat(2) %s, removing", file->name);
         flb_tail_file_remove(file);
         return FLB_TRUE;
     }
@@ -2364,7 +2498,7 @@ int flb_tail_file_purge(struct flb_input_instance *ins,
     mk_list_foreach_safe(head, tmp, &ctx->files_rotated) {
         file = mk_list_entry(head, struct flb_tail_file, _rotate_head);
         if ((file->rotated + ctx->rotate_wait) <= now) {
-            ret = fstat(file->fd, &st);
+            ret = flb_tail_file_stat(file, &st);
             if (ret == 0) {
                 flb_plg_debug(ctx->ins,
                               "inode=%"PRIu64" purge rotated file %s " \

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -118,6 +118,10 @@ static inline int flb_tail_target_file_name_cmp(char *name,
 int flb_tail_file_name_dup(char *path, struct flb_tail_file *file);
 int flb_tail_file_to_event(struct flb_tail_file *file);
 int flb_tail_file_chunk(struct flb_tail_file *file);
+int flb_tail_file_ensure_open_handle(struct flb_tail_file *file);
+int flb_tail_file_stat(struct flb_tail_file *file, struct stat *st);
+void flb_tail_file_close_handle(struct flb_tail_file *file);
+void flb_tail_file_close_handle_during_tail(struct flb_tail_file *file);
 int flb_tail_file_append(char *path, struct stat *st, int mode,
                          ssize_t offset,
                          struct flb_tail_config *ctx);

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -62,7 +62,7 @@ static int tail_fs_event(struct flb_input_instance *ins,
         fst = file->fs_backend;
 
         /* Check current status of the file */
-        ret = fstat(file->fd, &st);
+        ret = flb_tail_file_stat(file, &st);
         if (ret == -1) {
             flb_errno();
             continue;
@@ -99,9 +99,9 @@ static int tail_fs_check(struct flb_input_instance *ins,
         file = mk_list_entry(head, struct flb_tail_file, _head);
         fst = file->fs_backend;
 
-        ret = fstat(file->fd, &st);
+        ret = flb_tail_file_stat(file, &st);
         if (ret == -1) {
-            flb_plg_debug(ctx->ins, "error stat(2) %s, removing", file->name);
+            flb_plg_debug(ctx->ins, "check: error stat(2) %s, removing", file->name);
             flb_tail_file_remove(file);
             continue;
         }
@@ -126,15 +126,22 @@ static int tail_fs_check(struct flb_input_instance *ins,
 
         /* Check if the file was truncated */
         if (size_delta < 0) {
-            offset = lseek(file->fd, 0, SEEK_SET);
-            if (offset == -1) {
-                flb_errno();
-                return -1;
+            /* If keeping handle open, it's already open but at wrong offset - seek to beginning */
+            if (ctx->keep_file_handle == FLB_TRUE) {
+                offset = lseek(file->fd, 0, SEEK_SET);
+                if (offset == -1) {
+                    flb_errno();
+                    return -1;
+                }
+                file->offset = offset;
+            }
+            else {
+                /* If not keeping handle open, just update offset - handle will be opened/seeks correctly later */
+                file->offset = 0;
             }
 
             flb_plg_debug(ctx->ins, "tail_fs_check: file truncated %s (diff: %"PRId64" bytes)", 
                          file->name, size_delta);
-            file->offset = offset;
             file->buf_len = 0;
             memcpy(&fst->st, &st, sizeof(struct stat));
 
@@ -154,6 +161,17 @@ static int tail_fs_check(struct flb_input_instance *ins,
             file->pending_bytes = 0;
         }
 
+        /*
+         * Skip rotation detection when keep_file_handle is false.
+         * Rotation detection requires persistent open handles to work reliably.
+         * Without keeping handles open, calling flb_tail_file_name() would
+         * unnecessarily open and close handles multiple times per check cycle.
+         * Because we are not keeping a handle, a rotation would be interpreted
+         * as a truncation and handled by the truncation management logic.
+         */
+        if (ctx->keep_file_handle == FLB_FALSE) {
+            continue;
+        }
 
         /* Discover the current file name for the open file descriptor */
         name = flb_tail_file_name(file);
@@ -176,7 +194,6 @@ static int tail_fs_check(struct flb_input_instance *ins,
             flb_tail_file_rotated(file);
         }
         flb_free(name);
-
     }
 
     return 0;
@@ -190,9 +207,12 @@ int flb_tail_fs_stat_init(struct flb_input_instance *in,
 
     flb_plg_debug(ctx->ins, "flb_tail_fs_stat_init() initializing stat tail input");
 
-    /* Set a manual timer to collect events every 0.250 seconds */
+    /* Set a manual timer to collect events using configured interval */
+    /* Convert nanoseconds to seconds and nanoseconds for the API */
     ret = flb_input_set_collector_time(in, tail_fs_event,
-                                       0, 250000000, config);
+                                       (int)(ctx->fstat_interval_nsec / 1000000000L),
+                                       (long)(ctx->fstat_interval_nsec % 1000000000L),
+                                       config);
     if (ret < 0) {
         return -1;
     }

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -1385,6 +1385,662 @@ void flb_test_in_tail_multiline_json_and_regex()
     }
 }
 
+void flb_test_keep_file_handle_false()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"keep_file_handle_test.log"};
+    char *msg1 = "first message";
+    char *msg2 = "second message";
+    char *msg3 = "third message";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "false",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Write first message */
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Write second message */
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Write third message */
+    ret = write_msg(ctx, msg3, strlen(msg3));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 3))  {
+        TEST_MSG("output num error. expect=3 got=%d (keep_file_handle=false should read all messages)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
+void flb_test_keep_file_handle_true()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"keep_file_handle_true_test.log"};
+    char *msg1 = "first message";
+    char *msg2 = "second message";
+    char *msg3 = "third message";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "true",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Write first message */
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Write second message */
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Write third message */
+    ret = write_msg(ctx, msg3, strlen(msg3));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 3))  {
+        TEST_MSG("output num error. expect=3 got=%d (keep_file_handle=true should read all messages)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
+void flb_test_keep_file_handle_false_truncation()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"keep_file_handle_truncation_test.log"};
+    char *msg1 = "first message before truncation";
+    char *msg2 = "second message before truncation";
+    char *msg3 = "first message after truncation";
+    char *msg4 = "second message after truncation";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "false",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Write first message before truncation */
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Write second message before truncation */
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Verify we got the first 2 messages */
+    num = get_output_num();
+    if (!TEST_CHECK(num == 2)) {
+        TEST_MSG("output num error before truncation. expect=2 got=%d", num);
+    }
+
+    /* Truncate the file to 0 bytes */
+    ret = ftruncate(ctx->fds[0], 0);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ftruncate failed");
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    fsync(ctx->fds[0]);
+    flb_time_msleep(500);
+
+    /* Write first message after truncation */
+    ret = write_msg(ctx, msg3, strlen(msg3));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Write second message after truncation */
+    ret = write_msg(ctx, msg4, strlen(msg4));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(500);
+
+    /* Verify we got all 4 messages (2 before + 2 after truncation) */
+    num = get_output_num();
+    if (!TEST_CHECK(num == 4)) {
+        TEST_MSG("output num error after truncation. expect=4 got=%d (keep_file_handle=false should detect truncation and read from beginning)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
+/*
+ * Test that fstat_interval with the "ms" suffix is parsed correctly and that
+ * the engine starts and delivers all messages.  Covers the custom suffix
+ * parsing path in flb_tail_config_create().
+ */
+void flb_test_fstat_interval_ms()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"fstat_interval_ms_test.log"};
+    char *msg1 = "fstat interval ms message 1";
+    char *msg2 = "fstat interval ms message 2";
+    char *msg3 = "fstat interval ms message 3";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "false",
+                        "fstat_interval", "100ms",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_start failed: fstat_interval=100ms should be a valid value");
+        test_tail_ctx_destroy(ctx);
+        return;
+    }
+
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg3, strlen(msg3));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 3)) {
+        TEST_MSG("output num error. expect=3 got=%d "
+                 "(fstat_interval=100ms should be accepted and work normally)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
+/*
+ * Symmetric counterpart to flb_test_keep_file_handle_false_truncation.
+ * Verifies that keep_file_handle=true also recovers correctly after a
+ * file truncation: messages written before and after truncation are all
+ * delivered.
+ */
+void flb_test_keep_file_handle_true_truncation()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"keep_file_handle_true_truncation_test.log"};
+    char *msg1 = "first message before truncation";
+    char *msg2 = "second message before truncation";
+    char *msg3 = "first message after truncation";
+    char *msg4 = "second message after truncation";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "true",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 2)) {
+        TEST_MSG("output num error before truncation. expect=2 got=%d", num);
+    }
+
+    /* Truncate the file to 0 bytes */
+    ret = ftruncate(ctx->fds[0], 0);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ftruncate failed");
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    fsync(ctx->fds[0]);
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg3, strlen(msg3));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg4, strlen(msg4));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 4)) {
+        TEST_MSG("output num error after truncation. expect=4 got=%d "
+                 "(keep_file_handle=true should detect truncation and read from beginning)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
+/*
+ * Verify that the engine handles a file being deleted mid-tail gracefully
+ * when keep_file_handle=false.  With keep_file_handle=false the stat check
+ * in in_tail_collect_event uses stat(name) rather than fstat(fd), so an
+ * unlink is detected immediately and the file is removed from tracking
+ * without crashing.
+ */
+void flb_test_keep_file_handle_false_file_deleted()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"keep_file_handle_deleted_test.log"};
+    char *msg1 = "message before deletion 1";
+    char *msg2 = "message before deletion 2";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "false",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 2)) {
+        TEST_MSG("output num error before deletion. expect=2 got=%d", num);
+    }
+
+    /* Delete the file while the engine is still running */
+    unlink(file[0]);
+
+    /* Give the engine time to process the deletion event without crashing */
+    flb_time_msleep(800);
+
+    /* Count must not have changed (no new records from a deleted file) */
+    num = get_output_num();
+    if (!TEST_CHECK(num == 2)) {
+        TEST_MSG("output num changed after deletion. expect=2 got=%d "
+                 "(no records should arrive after the file is unlinked)", num);
+    }
+
+    /*
+     * test_tail_ctx_destroy will close ctx->fds[0] (still valid) and call
+     * unlink(file[0]) which will silently fail since the file is already gone.
+     */
+    test_tail_ctx_destroy(ctx);
+}
+
+/*
+ * Verify that keep_file_handle=false correctly honours read_from_head=false.
+ * Content written to the file before the engine starts must be skipped; only
+ * lines appended after the engine is running should be delivered.
+ *
+ * This exercises the seek-to-offset path in flb_tail_file_ensure_open_handle:
+ * when the handle is re-opened for each read, it must seek to file->offset
+ * to avoid re-reading already-processed bytes.
+ */
+void flb_test_keep_file_handle_false_tail_from_end()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"keep_file_handle_tail_end_test.log"};
+    char *preexisting = "pre-existing content that must be skipped\n";
+    char *msg1 = "new message after engine start 1";
+    char *msg2 = "new message after engine start 2";
+    int ret;
+    int num;
+    int unused;
+    ssize_t w;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Write pre-existing content before the engine starts */
+    w = write(ctx->fds[0], preexisting, strlen(preexisting));
+    if (!TEST_CHECK((size_t) w == strlen(preexisting))) {
+        TEST_MSG("pre-existing write failed");
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    fsync(ctx->fds[0]);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "keep_file_handle", "false",
+                        "read_from_head", "false",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Give the engine time to seek to the end of the pre-existing content */
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num == 2)) {
+        TEST_MSG("output num error. expect=2 got=%d "
+                 "(pre-existing content must be skipped with read_from_head=false "
+                 "even when keep_file_handle=false)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
+/*
+ * Verify that keep_file_handle=false works correctly when tailing multiple
+ * files simultaneously.  Handles are closed and re-opened per-file on every
+ * read cycle; all files must still deliver their records.
+ */
+void flb_test_keep_file_handle_false_multifile()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"kfh_multi_a.log", "kfh_multi_b.log"};
+    char *path = "kfh_multi_a.log, kfh_multi_b.log";
+    char *msg1 = "multifile message 1";
+    char *msg2 = "multifile message 2";
+    int ret;
+    int num;
+    int unused;
+
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], sizeof(file)/sizeof(char*), FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", path,
+                        "keep_file_handle", "false",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* write_msg writes to every fd in the context (both files) */
+    ret = write_msg(ctx, msg1, strlen(msg1));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    ret = write_msg(ctx, msg2, strlen(msg2));
+    if (!TEST_CHECK(ret > 0)) {
+        test_tail_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+    flb_time_msleep(500);
+
+    /* 2 messages × 2 files = 4 records total */
+    num = get_output_num();
+    if (!TEST_CHECK(num == 4)) {
+        TEST_MSG("output num error. expect=4 got=%d "
+                 "(keep_file_handle=false must read all records from all tailed files)", num);
+    }
+
+    test_tail_ctx_destroy(ctx);
+}
+
 void flb_test_path_comma()
 {
     struct flb_lib_out_cb cb_data;
@@ -1407,7 +2063,7 @@ void flb_test_path_comma()
         exit(EXIT_FAILURE);
     }
 
-    ret = flb_input_set(ctx->flb, ctx->o_ffd,
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
                         "path", path,
                         NULL);
     TEST_CHECK(ret == 0);
@@ -2658,6 +3314,14 @@ TEST_LIST = {
     {"skip_long_lines", flb_test_in_tail_skip_long_lines},
     {"truncate_long_lines",          flb_test_in_tail_truncate_long_lines},
     {"truncate_long_lines_utf8",     flb_test_in_tail_truncate_long_lines_utf8},
+    {"keep_file_handle_false", flb_test_keep_file_handle_false},
+    {"keep_file_handle_true", flb_test_keep_file_handle_true},
+    {"keep_file_handle_false_truncation", flb_test_keep_file_handle_false_truncation},
+    {"keep_file_handle_true_truncation", flb_test_keep_file_handle_true_truncation},
+    {"keep_file_handle_false_file_deleted", flb_test_keep_file_handle_false_file_deleted},
+    {"keep_file_handle_false_tail_from_end", flb_test_keep_file_handle_false_tail_from_end},
+    {"keep_file_handle_false_multifile", flb_test_keep_file_handle_false_multifile},
+    {"fstat_interval_ms", flb_test_fstat_interval_ms},
     {"path_comma", flb_test_path_comma},
     {"path_key", flb_test_path_key},
     {"exclude_path", flb_test_exclude_path},


### PR DESCRIPTION
<!-- Provide summary of changes -->

Adds new configuration options *keep_file_handle* and *fstat_interval_nsec* for tail input.

The purpose of this is to prevent file handles from being kept open while files are tailed. The motivation is to support tailing files that have a SMB/SAMBA underlying storage. SMB/SAMBA implementation will prevent tailed files from being deleted if a file handle is open.

Tailing files from SAMBA/SMB shares was fixed in https://github.com/fluent/fluent-bit/pull/10405, but a pre existing file locking issue related to this storage backend was overlooked.

Why fstat_interval_nsec and not only keep_file_handle?

Because cloud storage is very sensitive to IOPS (depending on the storage you might be even billed by this metric), having control on how often fstat is checked has an impact.

**NOTICE**: when keep_file_handle is set to false, log rotation detection does not work as it requires an active handle to figure out where the original file was rotated to.

I tried to honor existing implementation as much as possible so as to not intrudce regresions when keep_file_handle=true (default).

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes #11147

**Links of interest**

https://learn.microsoft.com/en-us/rest/api/storageservices/managing-file-locks

> "If this flag [FILE_SHARE_DELETE] isn't specified, any request to delete the file will fail, until the file is closed."

https://www.samba.org/samba/docs/4.5/man-html/smb.conf.5.html

> When set to yes (default): Samba checks file system permissions directly and denies deletion if permissions don't allow it This aligns with Windows semantics where deletion permissions are verified at the time of the delete request

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

PR for docs: https://github.com/fluent/fluent-bit-docs/pull/2180

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fstat_interval (default 250ms) with unit parsing/validation for stat-based polling.
  * Added keep_file_handle (default enabled) to control whether file handles remain open during tailing.

* **Refactor**
  * Centralized stat and file-handle management; conditional reopen/close semantics adjust rotation, truncation and polling behavior.

* **Tests**
  * Added runtime tests for keep_file_handle true/false and truncation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->