### PR TITLE
in_udp: Add capability to insert source IP when format none is set

### DIFF
--- a/tests/runtime/in_udp.c
+++ b/tests/runtime/in_udp.c
@@ -431,10 +431,77 @@ void flb_test_format_none_separator()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_format_none_with_source_address()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct sockaddr_in addr;
+    flb_sockfd_t fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+
+    char *buf = "message\n";
+    size_t size = strlen(buf);
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"log\":\"message\",\"source_host\":\"udp://";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "format", "none",
+                        "source_address_key", "source_host",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* use default host/port */
+    fd = init_udp(NULL, -1, &addr);
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+
+    w_size = sendto(fd, buf, size, 0, (const struct sockaddr *)&addr, sizeof(addr));
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        flb_socket_close(fd);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs");
+    }
+
+    flb_socket_close(fd);
+    test_ctx_destroy(ctx);
+}
+
 TEST_LIST = {
     {"udp", flb_test_udp},
     {"udp_with_source_address", flb_test_udp_with_source_address},
     {"format_none", flb_test_format_none},
     {"format_none_separator", flb_test_format_none_separator},
+    {"format_none_with_source_address", flb_test_format_none_with_source_address},
     {NULL, NULL}
 };


### PR DESCRIPTION
This adds support for Source_Address_Key when Format is set to none.

Addresses my earlier comment in this PR: https://github.com/fluent/fluent-bit/pull/7673#issuecomment-3526472205

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
```
[INPUT]
    Name        udp
    Listen      0.0.0.0
    Port        5170
    Format      none
    Source_Address_Key source_host

[OUTPUT]
    Name        stdout
    Match       *
```
- [X] Debug log output from testing the change
```
[2025/11/13 17:20:42.324041892] [ info] Configuration:
[2025/11/13 17:20:42.324070936] [ info]  flush time     | 1.000000 seconds
[2025/11/13 17:20:42.324075966] [ info]  grace          | 5 seconds
[2025/11/13 17:20:42.324079452] [ info]  daemon         | 0
[2025/11/13 17:20:42.324083169] [ info] ___________
[2025/11/13 17:20:42.324086475] [ info]  inputs:
[2025/11/13 17:20:42.324089701] [ info]      udp
[2025/11/13 17:20:42.324093077] [ info] ___________
[2025/11/13 17:20:42.324097255] [ info]  filters:
[2025/11/13 17:20:42.324100441] [ info] ___________
[2025/11/13 17:20:42.324104358] [ info]  outputs:
[2025/11/13 17:20:42.324108055] [ info]      stdout.0
[2025/11/13 17:20:42.324111472] [ info] ___________
[2025/11/13 17:20:42.324114898] [ info]  collectors:
[2025/11/13 17:20:42.324341100] [ info] [fluent bit] version=4.2.1, commit=f1ba23a2e8, pid=1581429
[2025/11/13 17:20:42.324348413] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2025/11/13 17:20:42.324366747] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/11/13 17:20:42.324372628] [ info] [simd    ] disabled
[2025/11/13 17:20:42.324374872] [ info] [cmetrics] version=1.0.5
[2025/11/13 17:20:42.324378890] [ info] [ctraces ] version=0.6.6
[2025/11/13 17:20:42.324420347] [ info] [input:udp:udp.0] initializing
[2025/11/13 17:20:42.324423223] [ info] [input:udp:udp.0] storage_strategy='memory' (memory only)
[2025/11/13 17:20:42.324429644] [debug] [udp:udp.0] created event channels: read=26 write=27
[2025/11/13 17:20:42.324466653] [debug] [downstream] listening on 0.0.0.0:5170
[2025/11/13 17:20:42.324478385] [debug] [stdout:stdout.0] created event channels: read=29 write=30
[2025/11/13 17:20:42.324590003] [ info] [sp] stream processor started
[2025/11/13 17:20:42.324606915] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/11/13 17:20:42.324627814] [ info] [output:stdout:stdout.0] worker #0 started
[2025/11/13 17:21:35.432746309] [debug] [task] created task=0x7feee802aa60 id=0 OK
[2025/11/13 17:21:35.432759764] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] udp.0: [[1763050895.017758118, {}], {"log"=>"test message", "source_host"=>"udp://127.0.0.1:40466"}]
[2025/11/13 17:21:35.445284487] [debug] [out flush] cb_destroy coro_id=0
[2025/11/13 17:21:35.445313711] [debug] [task] destroy task=0x7feee802aa60 (task_id=0)
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Unfortunately Valgrind fails on my Manjaro system, which seems to be expected because Valgrind uses Arch's glibc. But I doubt these simple changes, which were already implemented for the json part, would cause any issues. Maybe someone could test this?

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

Initially added documentation which corresponds to https://github.com/fluent/fluent-bit-docs/pull/1165

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UDP NONE-format logs can optionally include the source (remote) address when enabled in configuration, appending it to log records without changing default behavior.

* **Tests**
  * Added test coverage verifying UDP NONE-format logging includes the configured source address alongside the log payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->