### PR TITLE
lib: Recreate the event loop after daemonizing on BSD platforms.

### DIFF
--- a/include/fluent-bit/flb_error.h
+++ b/include/fluent-bit/flb_error.h
@@ -26,6 +26,7 @@
 #define FLB_ERR_CFG_FLUSH             20
 #define FLB_ERR_CFG_FLUSH_CREATE      21
 #define FLB_ERR_CFG_FLUSH_REGISTER    22
+#define FLB_ERR_EVENT_LOOP_CREATE     30
 #define FLB_ERR_CUSTOM_INVALID        49
 #define FLB_ERR_INPUT_INVALID         50
 #define FLB_ERR_INPUT_UNDEF           51

--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -49,6 +49,8 @@ typedef struct flb_lib_ctx         flb_ctx_t;
 struct flb_processor;
 
 FLB_EXPORT void flb_init_env();
+FLB_EXPORT int flb_event_loop_create(flb_ctx_t *ctx);
+FLB_EXPORT int flb_event_loop_destroy(flb_ctx_t *ctx);
 FLB_EXPORT flb_ctx_t *flb_create();
 FLB_EXPORT void flb_destroy(flb_ctx_t *ctx);
 FLB_EXPORT int flb_input(flb_ctx_t *ctx, const char *input, void *data);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(src
   flb_api.c
   flb_csv.c
   flb_lib.c
+  flb_event_loop.c
   flb_log.c
   flb_env.c
   flb_file.c

--- a/src/flb_event_loop.c
+++ b/src/flb_event_loop.c
@@ -1,0 +1,96 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2025 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_lib.h>
+#include <fluent-bit/flb_mem.h>
+
+int flb_event_loop_create(flb_ctx_t *ctx)
+{
+    int ret;
+    struct flb_config *config;
+
+    if (ctx == NULL || ctx->config == NULL)
+        return FLB_LIB_ERROR;
+
+    config = ctx->config;
+
+    /* Create the event loop to receive notifications */
+    ctx->event_loop = mk_event_loop_create(256);
+    if (!ctx->event_loop)
+        goto error_0;
+
+    config->ch_evl = ctx->event_loop;
+
+    /* Prepare the notification channels */
+    ctx->event_channel = flb_calloc(1, sizeof(struct mk_event));
+    if (!ctx->event_channel) {
+        flb_error("[lib] could not allocate event channel");
+        goto error_1;
+    }
+
+    MK_EVENT_ZERO(ctx->event_channel);
+
+    ret = mk_event_channel_create(config->ch_evl,
+                                  &config->ch_notif[0],
+                                  &config->ch_notif[1],
+                                  ctx->event_channel);
+    if (ret != 0) {
+        flb_error("[lib] could not create notification channels");
+        goto error_2;
+    }
+
+    return 0;
+
+error_2:
+    flb_free(ctx->event_channel);
+    ctx->event_channel = NULL;
+error_1:
+    mk_event_loop_destroy(ctx->event_loop);
+    ctx->event_loop = NULL;
+error_0:
+    config->ch_evl = NULL;
+    return FLB_LIB_ERROR;
+}
+
+int flb_event_loop_destroy(flb_ctx_t *ctx)
+{
+    struct flb_config *config;
+
+    if (ctx == NULL || ctx->config == NULL)
+        return 0;
+
+    config = ctx->config;
+    if (ctx->event_channel != NULL) {
+        mk_event_channel_destroy(config->ch_evl,
+                                 config->ch_notif[0],
+                                 config->ch_notif[1],
+                                 ctx->event_channel);
+        flb_free(ctx->event_channel);
+        ctx->event_channel = NULL;
+    }
+
+    if (ctx->event_loop != NULL) {
+        mk_event_loop_destroy(ctx->event_loop);
+        ctx->event_loop = NULL;
+        config->ch_evl = NULL;
+    }
+
+    return 0;
+}
+

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -184,34 +184,10 @@ flb_ctx_t *flb_create()
         return NULL;
     }
 
-    /* Create the event loop to receive notifications */
-    ctx->event_loop = mk_event_loop_create(256);
-    if (!ctx->event_loop) {
-        flb_config_exit(ctx->config);
-        flb_free(ctx);
-        return NULL;
-    }
-    config->ch_evl = ctx->event_loop;
-
-    /* Prepare the notification channels */
-    ctx->event_channel = flb_calloc(1, sizeof(struct mk_event));
-    if (!ctx->event_channel) {
-        perror("calloc");
-        flb_config_exit(ctx->config);
-        flb_free(ctx);
-        return NULL;
-    }
-
-    MK_EVENT_ZERO(ctx->event_channel);
-
-    ret = mk_event_channel_create(config->ch_evl,
-                                  &config->ch_notif[0],
-                                  &config->ch_notif[1],
-                                  ctx->event_channel);
+    ret = flb_event_loop_create(ctx);
     if (ret != 0) {
-        flb_error("[lib] could not create notification channels");
-        flb_stop(ctx);
-        flb_destroy(ctx);
+        flb_config_exit(ctx->config);
+        flb_free(ctx);
         return NULL;
     }
 

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -89,6 +89,9 @@ void flb_utils_error(int err)
     case FLB_ERR_CFG_FLUSH_REGISTER:
         msg = "could not register timer for flushing";
         break;
+    case FLB_ERR_EVENT_LOOP_CREATE:
+        msg = "could not create event loop";
+        break;
     case FLB_ERR_INPUT_INVALID:
         msg = "invalid input type";
         break;

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1416,7 +1416,18 @@ static int flb_main_run(int argc, char **argv)
 #ifdef FLB_HAVE_FORK
     /* Run in background/daemon mode */
     if (config->daemon == FLB_TRUE) {
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+        flb_event_loop_destroy(ctx);
+#endif
         flb_utils_set_daemon(config);
+#if defined(__FreeBSD__) || defined(__NetBSD__) || \
+    defined(__OpenBSD__) || defined(__DragonFly__)
+        if (flb_event_loop_create(ctx) != 0) {
+            flb_error("[daemon] failed to recreate event loop after daemonizing");
+            flb_utils_error(FLB_ERR_EVENT_LOOP_CREATE);
+        }
+#endif
     }
 #endif
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Recreate the event loop after daemonizing on BSD platforms.
Because kqueue(2) is not inherited by the child process.

Before reopening, we need to close event channel sockets that were initially created, so as not to leak the sockets. However, the libmonkey interface `mk_event_channel_destroy` tries to delete sockets from the kqueue. It will fail after daemonizing. We have to call `mk_event_channel_destroy` before daemonizing.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #11170

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public controls to explicitly create and destroy the event-processing loop.

* **Improvements**
  * More consistent lifecycle management and cleanup of event-processing resources for improved stability.
  * Daemon-mode on BSD-family systems now reinitializes event processing after daemonization to reduce runtime issues.

* **Bug Fixes**
  * Added a dedicated error code and user-facing message for event-loop creation failures to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->