### PR TITLE
in_opentelemetry: added five missing configuration option descriptions. Fixes #11191.

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -200,7 +200,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, enable_http2),
-     NULL
+     "Enable HTTP/2 protocol support for the OpenTelemetry receiver"
     },
 
     {
@@ -219,19 +219,19 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, buffer_max_size),
-     ""
+     "Maximum size of the HTTP request buffer"
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", HTTP_BUFFER_CHUNK_SIZE,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, buffer_chunk_size),
-     ""
+     "Size of each buffer chunk allocated for HTTP requests"
     },
 
     {
      FLB_CONFIG_MAP_STR, "tag_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, tag_key),
-     ""
+     "Record accessor key to use for generating tags from incoming records"
     },
     {
      FLB_CONFIG_MAP_BOOL, "tag_from_uri", "true",
@@ -252,6 +252,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "logs_metadata_key", "otlp",
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, logs_metadata_key),
+     "Key name to store OpenTelemetry logs metadata in the record"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_body_key", NULL,


### PR DESCRIPTION
in_opentelemetry: added five missing configuration option descriptions. Fixes #11191.
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
NA 

- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
N/A

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive help descriptions for OpenTelemetry plugin configuration options. Users will now see helpful guidance for HTTP/2 protocol settings, buffer management parameters (including maximum size and chunk size settings), custom tag key options, and logging metadata configuration. These additions enhance clarity and ease of use during plugin configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->