### PR TITLE
in_opentelemetry: added five missing configuration option descriptions [backport 4.0]

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry.c
+++ b/plugins/in_opentelemetry/opentelemetry.c
@@ -200,7 +200,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, enable_http2),
-     NULL
+     "Enable HTTP/2 protocol support for the OpenTelemetry receiver"
     },
 
     {
@@ -219,19 +219,19 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, buffer_max_size),
-     ""
+     "Maximum size of the HTTP request buffer"
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", HTTP_BUFFER_CHUNK_SIZE,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, buffer_chunk_size),
-     ""
+     "Size of each buffer chunk allocated for HTTP requests"
     },
 
     {
      FLB_CONFIG_MAP_STR, "tag_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, tag_key),
-     ""
+     "Record accessor key to use for generating tags from incoming records"
     },
     {
      FLB_CONFIG_MAP_BOOL, "tag_from_uri", "true",
@@ -252,6 +252,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "logs_metadata_key", "otlp",
      0, FLB_TRUE, offsetof(struct flb_opentelemetry, logs_metadata_key),
+     "Key name to store OpenTelemetry logs metadata in the record"
     },
     {
      FLB_CONFIG_MAP_STR, "logs_body_key", NULL,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backported fix to Fluent Bit 4.0 for 5 missing config option descriptions in opentelemetry input plugin.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
 Applies to #11191.

----
**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
Docs PR: https://github.com/fluent/fluent-bit-docs/pull/2182

**Backporting**
- [X] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
