### PR TITLE
S3 MultipartUploads accepts case insensitive 'ETag' headers

### DIFF
--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -652,7 +652,8 @@ flb_sds_t get_etag(char *response, size_t size)
         return NULL;
     }
 
-    tmp = strstr(response, "ETag:");
+    //tmp = strstr(response, "ETag:");
+    tmp = strcasestr(response, "ETag:");
     if (!tmp) {
         return NULL;
     }

--- a/plugins/out_s3/s3_multipart.c
+++ b/plugins/out_s3/s3_multipart.c
@@ -652,7 +652,7 @@ flb_sds_t get_etag(char *response, size_t size)
         return NULL;
     }
 
-    tmp = strstr(response, "ETag:");
+    tmp = strcasestr(response, "ETag:");
     if (!tmp) {
         return NULL;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Prevents case sensitive ETag header names.
Fixes https://github.com/fluent/fluent-bit/issues/11201

**Testing**
YAML config includes an S3 output stage to an S3 compatible service, and an HTTP input stage which we will use for testing:
```
  inputs:
  - name: http
    listen: "0.0.0.0"
    port: 9880
    tag_key: log_tag_key  # the value of this attribute defines the event tag
  outputs:
  - name: s3
    log_level: trace
    match: '*'
    bucket: logs
    endpoint: REDACTED
    region: US
    json_date_format: iso8601
    json_date_key: ts
    part_size: 1M
    preserve_data_ordering: true
    profile: jcb-tester
    s3_key_format: /fluent-bit-logs/$TAG/%Y/%m/%d/%H
    use_put_object: false
```

To generate a large file to upload use the following script:

```
 for i in $(seq 128) ; do
   JSON="{\"log_tag_key\":\"log_tag\",\"msg\":\"This is my message\", \"ts\": \"$(date --utc --iso-8601=seconds)\", \"data\": \"$(dd if=/dev/random bs=1024 count=16 2> /dev/null | base64 --wrap=0)\" }" ;
   curl  --request POST --header "content-type: application/json" --data "$JSON" http://localhost:9880 ;
  done
```

Before we can approve your change; please submit the following in a comment:

- [x] Debug log output from testing the change

```
[2025/11/25 17:26:14.114997595] [ info] [output:s3:s3.0] UploadPart http status=200
[2025/11/25 17:26:14.115815938] [ info] [output:s3:s3.0] Successfully uploaded part #2 for /fluent-bit-logs/log_tag/2025/11/25/15, UploadId=AQAAAZq7nyPECHRyrbgGQ4S40hGAHSFeUEDbras, ETag=541c2b1cff8aafd05c8bc47144e001b8
[2025/11/25 17:26:14.117334902] [debug] [output:s3:s3.0] Successfully persisted upload data, UploadId=AQAAAZq7nyPECHRyrbgGQ4S40hGAHSFeUEDbras

```
Valgrind report:

```
==551332== 
==551332== HEAP SUMMARY:
==551332==     in use at exit: 0 bytes in 0 blocks
==551332==   total heap usage: 457,215 allocs, 457,215 frees, 695,242,903 bytes allocated
==551332== 
==551332== All heap blocks were freed -- no leaks are possible
==551332== 
==551332== For lists of detected and suppressed errors, rerun with: -s
==551332== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**Backporting**

Not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made detection of the ETag header in S3 multipart responses case-insensitive, improving compatibility with varied header casing and increasing reliability of multipart upload handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->