### PR TITLE
out_azure_kusto: fix SIGSEGV in nested mk_list_foreach_safe loops

### DIFF
--- a/tests/runtime/out_azure_kusto.c
+++ b/tests/runtime/out_azure_kusto.c
@@ -19,10 +19,109 @@
  */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_utils.h>
+#include <chunkio/cio_utils.h>
 #include "flb_tests_runtime.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#define FLB_KUSTO_GETPID _getpid
+#define FLB_KUSTO_BUFFER_DIR_FORMAT "flb-kusto-test-%d"
+#else
+#include <dirent.h>
+#include <unistd.h>
+#define FLB_KUSTO_GETPID getpid
+#define FLB_KUSTO_BUFFER_DIR_FORMAT "/tmp/flb-kusto-test-%d"
+#endif
 
 /* Test data */
 #include "data/common/json_invalid.h" /* JSON_INVALID */
+
+static int flb_kusto_rm_rf(const char *path)
+{
+    int ret;
+    struct stat st;
+
+    if (stat(path, &st) != 0) {
+        return 0;
+    }
+
+    ret = cio_utils_recursive_delete(path);
+    if (ret != 0) {
+        TEST_MSG("failed to clean buffer directory '%s' errno=%d", path, errno);
+    }
+
+    return ret;
+}
+
+static int flb_kusto_dir_has_entries(const char *path)
+{
+#ifdef _WIN32
+    int ret;
+    int has_entries;
+    char pattern[MAX_PATH];
+    WIN32_FIND_DATAA find_data;
+    HANDLE find_handle;
+
+    ret = snprintf(pattern, sizeof(pattern), "%s\\*", path);
+    if (ret <= 0 || (size_t) ret >= sizeof(pattern)) {
+        return FLB_FALSE;
+    }
+
+    find_handle = FindFirstFileA(pattern, &find_data);
+    if (find_handle == INVALID_HANDLE_VALUE) {
+        return FLB_FALSE;
+    }
+
+    has_entries = FLB_FALSE;
+    do {
+        if (strcmp(find_data.cFileName, ".") != 0 &&
+            strcmp(find_data.cFileName, "..") != 0) {
+            has_entries = FLB_TRUE;
+            break;
+        }
+    } while (FindNextFileA(find_handle, &find_data));
+
+    FindClose(find_handle);
+    return has_entries;
+#else
+    DIR *dir;
+    struct dirent *entry;
+    int has_entries;
+
+    dir = opendir(path);
+    if (!dir) {
+        return FLB_FALSE;
+    }
+
+    has_entries = FLB_FALSE;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") != 0 &&
+            strcmp(entry->d_name, "..") != 0) {
+            has_entries = FLB_TRUE;
+            break;
+        }
+    }
+
+    closedir(dir);
+    return has_entries;
+#endif
+}
+
+static void flb_kusto_sleep_seconds(int seconds)
+{
+#ifdef _WIN32
+    Sleep((DWORD) seconds * 1000);
+#else
+    sleep(seconds);
+#endif
+}
 
 /* Test functions */
 void flb_test_azure_kusto_json_invalid(void);
@@ -30,6 +129,7 @@ void flb_test_azure_kusto_managed_identity_system(void);
 void flb_test_azure_kusto_managed_identity_user(void);
 void flb_test_azure_kusto_service_principal(void);
 void flb_test_azure_kusto_workload_identity(void);
+void flb_test_azure_kusto_buffering_backlog(void);
 
 /* Test list */
 TEST_LIST = {
@@ -38,6 +138,7 @@ TEST_LIST = {
     {"managed_identity_user", flb_test_azure_kusto_managed_identity_user},
     {"service_principal", flb_test_azure_kusto_service_principal},
     {"workload_identity", flb_test_azure_kusto_workload_identity},
+    {"buffering_backlog", flb_test_azure_kusto_buffering_backlog},
     {NULL, NULL}
 };
 
@@ -78,7 +179,7 @@ void flb_test_azure_kusto_json_invalid(void)
         total++;
     }
 
-    sleep(1); /* waiting flush */
+    flb_kusto_sleep_seconds(1); /* waiting flush */
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -210,4 +311,107 @@ void flb_test_azure_kusto_workload_identity(void)
 
     flb_stop(ctx);
     flb_destroy(ctx);
+}
+
+/* Regression: exercise buffering-enabled backlog processing on restart */
+void flb_test_azure_kusto_buffering_backlog(void)
+{
+    int i;
+    int ret;
+    int has_buffered_chunks;
+    char buffer_dir[64];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ret = snprintf(buffer_dir, sizeof(buffer_dir), FLB_KUSTO_BUFFER_DIR_FORMAT,
+                   (int) FLB_KUSTO_GETPID());
+    if (ret <= 0 || (size_t) ret >= sizeof(buffer_dir)) {
+        TEST_MSG("failed to build buffer directory path");
+        TEST_CHECK(ret > 0 && (size_t) ret < sizeof(buffer_dir));
+        return;
+    }
+
+    ret = flb_kusto_rm_rf(buffer_dir);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        return;
+    }
+
+    ret = flb_utils_mkdir(buffer_dir, 0700);
+    if (ret != 0) {
+        TEST_MSG("failed to create buffer directory '%s' errno=%d", buffer_dir, errno);
+        TEST_CHECK(ret == 0);
+        return;
+    }
+
+    /* First run: enable buffering and write data to disk */
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "dummy", "{\"k\":\"v\"}", NULL);
+    flb_input_set(ctx, in_ffd, "samples", "1", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "azure_kusto", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "auth_type", "managed_identity", NULL);
+    flb_output_set(ctx, out_ffd, "client_id", "system", NULL);
+    flb_output_set(ctx, out_ffd, "ingestion_endpoint",
+                   "https://ingest-CLUSTER.kusto.windows.net", NULL);
+    flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
+    flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
+    flb_output_set(ctx, out_ffd, "buffering_enabled", "true", NULL);
+    flb_output_set(ctx, out_ffd, "buffer_dir", buffer_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < 5; i++) {
+        if (flb_kusto_dir_has_entries(buffer_dir) == FLB_TRUE) {
+            break;
+        }
+        flb_kusto_sleep_seconds(1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    has_buffered_chunks = flb_kusto_dir_has_entries(buffer_dir);
+    TEST_CHECK_(has_buffered_chunks == FLB_TRUE,
+                "expected buffered chunks in '%s'", buffer_dir);
+
+    /* Second run: restart to process backlog from buffer_dir */
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "azure_kusto", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "auth_type", "managed_identity", NULL);
+    flb_output_set(ctx, out_ffd, "client_id", "system", NULL);
+    flb_output_set(ctx, out_ffd, "ingestion_endpoint",
+                   "https://ingest-CLUSTER.kusto.windows.net", NULL);
+    flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
+    flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
+    flb_output_set(ctx, out_ffd, "buffering_enabled", "true", NULL);
+    flb_output_set(ctx, out_ffd, "buffer_dir", buffer_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_kusto_sleep_seconds(1); /* ingest_all_chunks runs on startup for buffered backlog */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    ret = flb_kusto_rm_rf(buffer_dir);
+    TEST_CHECK(ret == 0);
 }


### PR DESCRIPTION

**Disclaimer: Used copilot to investigate the crash we faced and took it's help to write this**

## Summary

Fixes a SIGSEGV crash in the Azure Kusto output plugin when processing buffered backlog data on startup.

## Root Cause

The `ingest_all_chunks()` function had nested `mk_list_foreach_safe` loops that both used the same `tmp` variable as the iterator:

```c
mk_list_foreach_safe(head, tmp, &ctx->fs->streams) {     // outer loop
    ...
    mk_list_foreach_safe(f_head, tmp, &fs_stream->files) {  // inner loop - SAME tmp!
```

The `mk_list_foreach_safe` macro stores the "next" pointer in its second argument for safe iteration during list modification. When the inner loop overwrote `tmp`, it corrupted the outer loop's iteration state, causing undefined behavior and eventually a SIGSEGV when the outer loop tried to continue iteration with a corrupted pointer.

## Crash Stack Trace (from production)

```
[engine] caught signal (SIGSEGV)
#0 flush_init() at plugins/out_azure_kusto/azure_kusto.c:1169
#1 cb_azure_kusto_flush() at plugins/out_azure_kusto/azure_kusto.c:1257
#2 co_init() at lib/monkey/deps/flb_libco/amd64.c:117
```

## Fix

Add a dedicated `f_tmp` variable for the inner loop to prevent iterator corruption:

```c
struct mk_list *tmp;
struct mk_list *f_tmp;  // NEW: dedicated inner loop iterator
...
mk_list_foreach_safe(head, tmp, &ctx->fs->streams) {
    ...
    mk_list_foreach_safe(f_head, f_tmp, &fs_stream->files) {  // Use f_tmp
```

## Testing

- Added `flb_test_azure_kusto_buffering_backlog` regression test that exercises the buffering/backlog restart code path
- All existing azure_kusto tests continue to pass
- Verified build compiles without warnings

```
Test json_invalid...                            [ OK ]
Test managed_identity_system...                 [ OK ]
Test managed_identity_user...                   [ OK ]
Test service_principal...                       [ OK ]
Test workload_identity...                       [ OK ]
Test buffering_backlog...                       [ OK ]
SUCCESS: All unit tests have passed.
```

## Changes

- `plugins/out_azure_kusto/azure_kusto.c`: Add `f_tmp` iterator variable for inner loop (+2 lines, -1 line)
- `tests/runtime/out_azure_kusto.c`: Add buffering backlog regression test (+73 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal iteration safety and stability; no public API changes.

* **Tests**
  * Added an end-to-end buffering/backlog regression test that verifies two-phase write-and-restart behavior with cleanup.
  * Added runtime helpers and test scaffolding to support buffered-backlog testing and temporary resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->