### PR TITLE
in_ebpf: add three missing config option descriptions. Fixes #11221.

### DIFF
--- a/plugins/in_ebpf/in_ebpf.c
+++ b/plugins/in_ebpf/in_ebpf.c
@@ -231,11 +231,22 @@ static int in_ebpf_exit(void *in_context, struct flb_config *config) {
 }
 
 static struct flb_config_map config_map[] = {
-    {FLB_CONFIG_MAP_STR, "ringbuf_map_name", FLB_IN_EBPF_DEFAULT_RINGBUF_MAP_NAME, 0, FLB_TRUE,
-     offsetof(struct flb_in_ebpf_context, ringbuf_map_name)},
-    {FLB_CONFIG_MAP_INT, "poll_ms", FLB_IN_EBPF_DEFAULT_POLL_MS, 0, FLB_TRUE,
-     offsetof(struct flb_in_ebpf_context, poll_ms)},
-    {FLB_CONFIG_MAP_STR, "Trace", NULL, FLB_CONFIG_MAP_MULT, FLB_FALSE, 0},
+    {
+     FLB_CONFIG_MAP_STR, "ringbuf_map_name", FLB_IN_EBPF_DEFAULT_RINGBUF_MAP_NAME,
+     0, FLB_TRUE, offsetof(struct flb_in_ebpf_context, ringbuf_map_name),
+     "Set the name of the eBPF ring buffer map to read events from"
+    },
+    {
+     FLB_CONFIG_MAP_INT, "poll_ms", FLB_IN_EBPF_DEFAULT_POLL_MS,
+     0, FLB_TRUE, offsetof(struct flb_in_ebpf_context, poll_ms),
+     "Set the polling interval in milliseconds for collecting events"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "Trace", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
+     "Set the eBPF trace to enable (for example, bind, malloc, signal). Can be set multiple times"
+    },
+    /* EOF */
     {0}
 };
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
in_ebpf: add three missing config option descriptions for:

ringbuf_map_name - should describe the BPF ring buffer map name
poll_ms - should describe the polling interval in milliseconds\
Trace - should describe the trace type to enable (for example, bind, malloc, signal)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #11221 

----
**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
Issue: https://github.com/fluent/fluent-bit-docs/issues/2239
Doc PR: https://github.com/fluent/fluent-bit-docs/pull/2240

**Backporting**
- [N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing descriptions for eBPF plugin configuration options:
    - ring buffer map name: clarifies which ring buffer to read events from.
    - polling interval: clarifies the interval (ms) used to collect events.
    - trace settings: explains how to specify eBPF traces and that the option can be provided multiple times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->