### PR TITLE
in_elasticsearch: fixing missing config parameter description for http2. Fixes #11221.

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch.c
+++ b/plugins/in_elasticsearch/in_elasticsearch.c
@@ -237,7 +237,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_in_elasticsearch, enable_http2),
-     NULL
+     "Enable HTTP/2 support"
     },
 
     {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added description text field to config option `http2` for elasticsearch input plugin

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes: #11221 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [X] Documentation required for this feature

Fixed in Docs PR: https://github.com/fluent/fluent-bit-docs/pull/2246

**Backporting**
- [N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive text to the HTTP/2 configuration option, making it clearer to users what this setting controls and improves configuration discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->