### PR TITLE
in_exec_wasi: fix config key typo 'bool' to 'oneshot'. Fixes #11232.

### DIFF
--- a/plugins/in_exec_wasi/in_exec_wasi.c
+++ b/plugins/in_exec_wasi/in_exec_wasi.c
@@ -453,7 +453,7 @@ static struct flb_config_map config_map[] = {
       "Set the buffer size"
     },
     {
-      FLB_CONFIG_MAP_BOOL, "bool", "false",
+      FLB_CONFIG_MAP_BOOL, "oneshot", "false",
       0, FLB_TRUE, offsetof(struct flb_exec_wasi, oneshot),
       "execute the command only once"
     },


### PR DESCRIPTION
The config_map entry for the oneshot option was incorrectly using 'bool' as the configuration key instead of 'oneshot'. This made the configuration inconsistent with the regular in_exec plugin and confusing for users.

Fixes #11232.
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [X ] Documentation required for this feature

Doc fix PR: https://github.com/fluent/fluent-bit-docs/pull/2248

**Backporting**
- [N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed the configuration option in the WASI execution plugin from "bool" to "oneshot" for improved clarity and better reflects the parameter's functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->