### PR TITLE
in_forward: improve configuration parameter descriptions

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -481,12 +481,12 @@ static struct flb_config_map config_map[] = {
    {
     FLB_CONFIG_MAP_STR, "shared_key", NULL,
     0, FLB_TRUE, offsetof(struct flb_in_fw_config, shared_key),
-    "Shared key for authentication"
+    "Shared key for secure forward authentication."
    },
    {
     FLB_CONFIG_MAP_STR, "self_hostname", NULL,
     0, FLB_FALSE, 0,
-    "Hostname"
+    "Hostname used in the handshake process for secure forward authentication."
    },
    {
     FLB_CONFIG_MAP_STR, "security.users", NULL,
@@ -501,7 +501,7 @@ static struct flb_config_map config_map[] = {
    {
     FLB_CONFIG_MAP_STR, "unix_perm", (char *)NULL,
     0, FLB_TRUE, offsetof(struct flb_in_fw_config, unix_perm_str),
-    "Set the permissions for the UNIX socket"
+    "Set the permissions for the UNIX socket."
    },
    {
     FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", FLB_IN_FW_CHUNK_SIZE,
@@ -516,7 +516,7 @@ static struct flb_config_map config_map[] = {
    {
     FLB_CONFIG_MAP_BOOL, "empty_shared_key", "false",
     0, FLB_TRUE, offsetof(struct flb_in_fw_config, empty_shared_key),
-    "Set an empty shared key for authentication"
+    "Enable an empty string as the shared key for authentication."
    },
    {0}
 };


### PR DESCRIPTION
Fixing config parameters for forward input plugin:

- shared_key: clarify it's for secure forward authentication
- self_hostname: explain it's used in handshake for secure forward auth
- unix_perm: add trailing period for consistency
- empty_shared_key: clarify it enables empty string as shared key

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes issue #11234 
----
**Testing**
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [X ] Documentation required for this feature

Fix docs  PR: https://github.com/fluent/fluent-bit-docs/pull/2257

**Backporting**
- [N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fluent Bit in_forward plugin configuration option descriptions to provide clearer and more specific guidance. Enhanced help text for shared key authentication, hostname configuration, file permissions, and empty shared key handling settings. These changes make the forward input plugin's configuration options easier to understand and configure correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->