### PR TITLE
in_gpu_metrics: updated config parameters descriptions.

### DIFF
--- a/plugins/in_gpu_metrics/gpu_metrics.c
+++ b/plugins/in_gpu_metrics/gpu_metrics.c
@@ -168,34 +168,36 @@ static int in_gpu_exit(void *data, struct flb_config *config)
 
 static struct flb_config_map config_map[] = {
     {
-     FLB_CONFIG_MAP_TIME, "scrape_interval", "5",
-     0, FLB_TRUE, offsetof(struct in_gpu_metrics, scrape_interval),
-     "Scrape interval for GPU metrics"
-    },
-    {
-     FLB_CONFIG_MAP_STR, "path_sysfs", "/sys",
-     0, FLB_TRUE, offsetof(struct in_gpu_metrics, path_sysfs),
-     "Path to sysfs"
+     FLB_CONFIG_MAP_STR, "cards_exclude", "",
+     0, FLB_TRUE, offsetof(struct in_gpu_metrics, cards_exclude),
+     "Exclude GPU cards by ID. Accepts '*' for all, comma-separated IDs "
+     "(e.g., '0,1,2'), or ranges (e.g., '0-2')."
     },
     {
      FLB_CONFIG_MAP_STR, "cards_include", "*",
      0, FLB_TRUE, offsetof(struct in_gpu_metrics, cards_include),
-     "Cards to include"
-    },
-    {
-     FLB_CONFIG_MAP_STR, "cards_exclude", "",
-     0, FLB_TRUE, offsetof(struct in_gpu_metrics, cards_exclude),
-     "Cards to exclude"
+     "Include GPU cards by ID. Accepts '*' for all, comma-separated IDs "
+     "(e.g., '0,1,2'), or ranges (e.g., '0-2')."
     },
     {
      FLB_CONFIG_MAP_BOOL, "enable_power", "true",
      0, FLB_TRUE, offsetof(struct in_gpu_metrics, enable_power),
-     "Enable power metrics"
+     "Enable collection of GPU power consumption metrics (gpu_power_watts)."
     },
     {
      FLB_CONFIG_MAP_BOOL, "enable_temperature", "true",
      0, FLB_TRUE, offsetof(struct in_gpu_metrics, enable_temperature),
-     "Enable temperature metrics"
+     "Enable collection of GPU temperature metrics (gpu_temperature_celsius)."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "path_sysfs", "/sys",
+     0, FLB_TRUE, offsetof(struct in_gpu_metrics, path_sysfs),
+     "sysfs mount point."
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "scrape_interval", "5",
+     0, FLB_TRUE, offsetof(struct in_gpu_metrics, scrape_interval),
+     "Scrape interval to collect GPU metrics."
     },
     {0}
 };


### PR DESCRIPTION
The following updates help make the config parameter descriptions more informative:

- Sort configuration parameters alphabetically
- Add detailed pattern format info to cards_include and cards_exclude (supports '*' for all, comma-separated IDs, and ranges like '0-2')
- Add specific metric names to enable_power and enable_temperature
- - Standardize path_sysfs description to 'sysfs mount point'
- Add trailing periods to descriptions for consistency

Fixes #11236.

----
**Testing**
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

Doc update PR: https://github.com/fluent/fluent-bit-docs/pull/2259

**Backporting**
- [N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GPU exclusion option (supports wildcards, comma-separated IDs, ranges) and clarified inclusion semantics.
  * Clarified that power and temperature docs refer to GPU-specific metrics.
  * Added configurable sysfs mount point (default "/sys") and configurable scrape interval (default 5s) for GPU metrics collection.
  * Minor phrasing updates across the GPU metrics configuration docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->