### PR TITLE
in_http: added missing config parameter descriptions.

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -204,38 +204,38 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_http, enable_http2),
-     NULL
+     "Enable HTTP/2 support."
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_http, buffer_max_size),
-     ""
+     "Set the maximum buffer size to store incoming data."
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", HTTP_BUFFER_CHUNK_SIZE,
      0, FLB_TRUE, offsetof(struct flb_http, buffer_chunk_size),
-     ""
+     "Set the initial buffer size to store incoming data."
     },
 
     {
      FLB_CONFIG_MAP_SLIST_1, "success_header", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_http, success_headers),
-     "Add an HTTP header key/value pair on success. Multiple headers can be set"
+     "Add an HTTP header key/value pair on success. Multiple headers can be set."
     },
 
     {
      FLB_CONFIG_MAP_STR, "tag_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_http, tag_key),
-     ""
+     "Specify a key name for extracting the tag from incoming request data."
     },
+
     {
      FLB_CONFIG_MAP_INT, "successful_response_code", "201",
      0, FLB_TRUE, offsetof(struct flb_http, successful_response_code),
      "Set successful response code. 200, 201 and 204 are supported."
     },
-
 
     /* EOF */
     {0}


### PR DESCRIPTION
- 4 parameters need descriptions: http2, buffer_max_size, buffer_chunk_size, tag_key

Fixes #11239.

----
**Testing**
- [N/A ] Example configuration file for the change
- [N/A ] Debug log output from testing the change
- [N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [X ] Documentation required for this feature

Doc fix PR: https://github.com/fluent/fluent-bit-docs/pull/2267

**Backporting**
- [N/A ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified HTTP plugin configuration descriptions: added clear guidance for enabling HTTP/2, setting buffer maximum and initial sizes, specifying tag extraction keys, and formatting success header instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->