### PR TITLE
in_node_exporter_metrics: Increase buffer size to read /proc/stat correctly

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -153,7 +153,7 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
     int len;
     int ret;
     FILE *f;
-    char line[512];
+    char line[2048];
     char real_path[2048];
 
     mk_list_init(list);


### PR DESCRIPTION
Hello, 

for weeks we've been experiencing an issue with fluent-bit where the CPU metrics provided by node exporter like `node_cpu_seconds_total` would stall, for an unknown reason. Also, after a few days, the metrics would "unfreeze" and resume, and we really didn't understand why.

After recompiling and adding debug into fluent-bit, I managed to trace it down to an issue in the "ne_utils_file_read_lines()" function: https://github.com/fluent/fluent-bit/blob/712b48d7c387c87c922075aa5556afe648e36c4b/plugins/in_node_exporter_metrics/ne_utils.c#L151

This function uses a [512 bytes buffer](https://github.com/fluent/fluent-bit/blob/712b48d7c387c87c922075aa5556afe648e36c4b/plugins/in_node_exporter_metrics/ne_utils.c#L156) to read lines, which is insufficient to read `/proc/stat` entries correctly. Indeed, the "intr" line [can be larger](https://unix.stackexchange.com/questions/556967/why-we-have-so-many-0s-in-intr-field-of-proc-stat).

Most of the time, this isn't an issue, except when the line being read has a length which is  multiple of (buffer size -2), which cause the [fgets() loop](https://github.com/fluent/fluent-bit/blob/c88c5455537868939e977d45334b4650e86adbfa/plugins/in_node_exporter_metrics/ne_utils.c#L175) to produce an empty line, causing an error up in the call stack, and preventing the CPU metrics to be updated. But as soon as some interrupt counter reaches an additional digit (e.g 99 -> 100), the problem disappears since the line length will increase, and there will be a single character to read.

Sample /proc/stat file showing the issue, with intr line of 1020 chars (obtained from an Ubuntu 20.04 LTS):

```
$ cat proc_stat.txt
cpu  644441261 250278 193710764 6839564199 150758 0 21261544 4590423 0 0
cpu0 160903415 60997 48404023 1709556132 38581 0 7668248 1152730 0 0
cpu1 160732678 64155 48446004 1710342339 38188 0 5804330 1145684 0 0
cpu2 161798128 63702 48389798 1709541165 35120 0 4468764 1145420 0 0
cpu3 161007038 61422 48470938 1710124561 38867 0 3320201 1146587 0 0
intr 32324448099 29 9 0 0 0 0 3 0 1 0 9724876 32 15 0 0 19295503 0 0 0 0 0 0 0 0 0 2367 0 0 0 9209232 9791754 9997988 8338376 0 1001160064 916738961 0 410030264 436692148 0 652365018 480804600 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
ctxt 150886032456
btime 1745401938
processes 111586863
procs_running 1
procs_blocked 0
softirq 19224384590 0 1384271522 571488 1539519326 9648544 0 137410393 4010803922 21329 3552203474
```

Sample reproducer script, using a copy of ne_utils_file_read_lines() as main:

```
$ cat test.c
#include <stdio.h>
#include <string.h>


// copy of ne_utils_file_read_lines() in plugins/in_node_exporter_metrics/ne_utils.s
int main (int argc, char **argv) {
    
    int len;
    int ret;
    FILE *f;
    char line[512];
    // char real_path[2048];

    // mk_list_init(list);

    // /* Check the path starts with the mount point to prevent duplication. */
    // if (strncasecmp(path, mount, strlen(mount)) == 0 &&
    //     path[strlen(mount)] == '/') {
    //     mount = "";
    // }


    f = fopen(argv[1], "r");
    if (f == NULL) {
        printf("Cannot open %s\n", argv[1]);
        //flb_errno();
        return -1;
    }

    /* Read the content */
    while (fgets(line, sizeof(line) - 1, f)) {
        len = strlen(line);
        if (line[len - 1] == '\n') {
            line[--len] = 0;
            if (len && line[len - 1] == '\r') {
                line[--len] = 0;
            }
        }
        printf("line of %d bytes: %s \n", len, line);
        if (len == 0) {
            printf("!!!!!!!!! ERROR, line has no len, flb_slist_add will fail!!!!!!!!!!!!\n");
        }

        //ret = flb_slist_add(list, line);
        //if (ret == -1) {
        //    fclose(f);
        //    flb_slist_destroy(list);
        //    return -1;
        //}

    }
}
```

Sample output:
```
$ gcc test.c
$ ./a.out proc_stat.txt
line of 72 bytes: cpu  644441261 250278 193710764 6839564199 150758 0 21261544 4590423 0 0
line of 68 bytes: cpu0 160903415 60997 48404023 1709556132 38581 0 7668248 1152730 0 0
line of 68 bytes: cpu1 160732678 64155 48446004 1710342339 38188 0 5804330 1145684 0 0
line of 68 bytes: cpu2 161798128 63702 48389798 1709541165 35120 0 4468764 1145420 0 0
line of 68 bytes: cpu3 161007038 61422 48470938 1710124561 38867 0 3320201 1146587 0 0
line of 510 bytes: intr 32324448099 29 9 0 0 0 0 3 0 1 0 9724876 32 15 0 0 19295503 0 0 0 0 0 0 0 0 0 2367 0 0 0 9209232 9791754 9997988 8338376 0 1001160064 916738961 0 410030264 436692148 0 652365018 480804600 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
line of 510 bytes:  0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
line of 0 bytes:
!!!!!!!!! ERROR, line has no len, flb_slist_add will fail!!!!!!!!!!!!
line of 17 bytes: ctxt 150886032456
line of 16 bytes: btime 1745401938
line of 19 bytes: processes 111586863
line of 15 bytes: procs_running 1
line of 15 bytes: procs_blocked 0
line of 98 bytes: softirq 19224384590 0 1384271522 571488 1539519326 9648544 0 137410393 4010803922 21329 3552203474
```

Proposed fix is to increase the readline buffer size from 512 to 2048 bytes (1024 seems a bit low given the size of the intr line which is 1020 chars)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found (static buffer)

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum supported line length for file reading, allowing the system to correctly handle longer lines from diverse data sources.
  * Improves compatibility and reduces failures/truncation when processing larger or unexpectedly long input lines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->