### PR TITLE
in_tail: fix data loss with buffered data on shutdown and gzip files

### DIFF
--- a/plugins/in_tail/tail.h
+++ b/plugins/in_tail/tail.h
@@ -33,6 +33,9 @@
 #define FLB_TAIL_STATIC  0  /* Data is being consumed through read(2) */
 #define FLB_TAIL_EVENT   1  /* Data is being consumed through inotify */
 
+/* Database */
+#define FLB_TAIL_DB_ID_NONE  0  /* File not in database or deleted */
+
 /* Config */
 #define FLB_TAIL_CHUNK              "32768"   /* buffer chunk = 32KB      */
 #define FLB_TAIL_REFRESH                 60   /* refresh every 60 seconds */

--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -28,12 +28,6 @@
 #include <inttypes.h>
 #include <string.h>
 
-struct query_status {
-    int id;
-    int rows;
-    int64_t offset;
-};
-
 static int db_apply_migration_if_needed(struct flb_tail_config *ctx,
                                         struct flb_sqldb *db,
                                         const char *sql)
@@ -147,6 +141,18 @@ struct flb_sqldb *flb_tail_db_open(const char *path,
         return NULL;
     }
 
+    ret = db_apply_migration_if_needed(ctx, db, SQL_ALTER_FILES_ADD_SKIP);
+    if (ret != FLB_OK) {
+        flb_sqldb_close(db);
+        return NULL;
+    }
+
+    ret = db_apply_migration_if_needed(ctx, db, SQL_ALTER_FILES_ADD_ANCHOR);
+    if (ret != FLB_OK) {
+        flb_sqldb_close(db);
+        return NULL;
+    }
+
     return db;
 }
 
@@ -192,7 +198,8 @@ static int flb_tail_db_file_delete_by_id(struct flb_tail_config *ctx,
 static int db_file_exists(struct flb_tail_file *file,
                           struct flb_tail_config *ctx,
                           uint64_t *id, uint64_t *inode, off_t *offset,
-                          uint64_t *offset_marker, size_t *offset_marker_size)
+                          uint64_t *offset_marker, size_t *offset_marker_size,
+                          uint64_t *skip, int64_t *anchor)
 {
     int ret;
     int exists = FLB_FALSE;
@@ -211,6 +218,8 @@ static int db_file_exists(struct flb_tail_file *file,
         /* name: column 1 */
         name = sqlite3_column_text(ctx->stmt_get_file, 1);
         if (ctx->compare_filename && name == NULL) {
+            sqlite3_clear_bindings(ctx->stmt_get_file);
+            sqlite3_reset(ctx->stmt_get_file);
             flb_plg_error(ctx->ins, "db: error getting name: id=%"PRIu64, *id);
             return -1;
         }
@@ -227,12 +236,18 @@ static int db_file_exists(struct flb_tail_file *file,
         /* offset_marker_size: column 5 */
         *offset_marker_size = sqlite3_column_int64(ctx->stmt_get_file, 5);
 
+        /* skip: column 6 */
+        *skip = sqlite3_column_int64(ctx->stmt_get_file, 6);
+
+        /* anchor: column 7 */
+        *anchor = sqlite3_column_int64(ctx->stmt_get_file, 7);
+
         /* Checking if the file's name and inode match exactly */
         if (ctx->compare_filename) {
             if (flb_tail_target_file_name_cmp((char *) name, file) != 0) {
                 exists = FLB_FALSE;
                 flb_plg_debug(ctx->ins, "db: exists stale file from database:"
-                             " id=%"PRIu64" inode=%"PRIu64" offset=%"PRIu64
+                             " id=%"PRIu64" inode=%"PRIu64" offset=%"PRId64
                              " name=%s file_inode=%"PRIu64" file_name=%s",
                              *id, *inode, *offset, name, file->inode,
                              file->name);
@@ -279,6 +294,8 @@ static int db_file_insert(struct flb_tail_file *file, struct flb_tail_config *ct
     sqlite3_bind_int64(ctx->stmt_insert_file, 4, created);
     sqlite3_bind_int64(ctx->stmt_insert_file, 5, file->db_offset_marker);
     sqlite3_bind_int64(ctx->stmt_insert_file, 6, file->db_offset_marker_size);
+    sqlite3_bind_int64(ctx->stmt_insert_file, 7, file->skip_bytes);
+    sqlite3_bind_int64(ctx->stmt_insert_file, 8, file->anchor_offset);
 
     /* Run the insert */
     ret = sqlite3_step(ctx->stmt_insert_file);
@@ -478,7 +495,9 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
 {
     int ret;
     uint64_t id = 0;
-    off_t offset = 0;
+    int64_t offset = 0;
+    uint64_t skip = 0;
+    int64_t anchor = 0;
     uint64_t inode = 0;
     uint64_t offset_marker = 0;
     size_t offset_marker_size = 0;
@@ -494,7 +513,8 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
 
     /* Check if the file exists */
     ret = db_file_exists(file, ctx, &id, &inode, &offset,
-                         &offset_marker, &offset_marker_size);
+                         &offset_marker, &offset_marker_size,
+                         &skip, &anchor);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "cannot execute query to check inode: %" PRIu64,
                       file->inode);
@@ -516,6 +536,18 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
         file->offset = offset;
         file->db_offset_marker = offset_marker;
         file->db_offset_marker_size = offset_marker_size;
+        file->skip_bytes = skip;
+        file->anchor_offset = anchor;
+
+        /* Initialize skipping mode if needed */
+        if (file->skip_bytes > 0) {
+            file->exclude_bytes = file->skip_bytes;
+            file->skipping_mode = FLB_TRUE;
+        }
+        else {
+            file->exclude_bytes = 0;
+            file->skipping_mode = FLB_FALSE;
+        }
     }
 
     tail_db_unlock(ctx);
@@ -549,7 +581,9 @@ int flb_tail_db_file_offset(struct flb_tail_file *file,
     sqlite3_bind_int64(ctx->stmt_offset, 1, db_offset);
     sqlite3_bind_int64(ctx->stmt_offset, 2, file->db_offset_marker);
     sqlite3_bind_int64(ctx->stmt_offset, 3, file->db_offset_marker_size);
-    sqlite3_bind_int64(ctx->stmt_offset, 4, file->db_id);
+    sqlite3_bind_int64(ctx->stmt_offset, 4, file->skip_bytes);
+    sqlite3_bind_int64(ctx->stmt_offset, 5, file->anchor_offset);
+    sqlite3_bind_int64(ctx->stmt_offset, 6, file->db_id);
 
     ret = sqlite3_step(ctx->stmt_offset);
 

--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -635,6 +635,7 @@ int flb_tail_db_file_delete(struct flb_tail_file *file,
     }
 
     flb_plg_debug(ctx->ins, "db: file deleted from database: %s", file->name);
+    file->db_id = FLB_TAIL_DB_ID_NONE;
     tail_db_unlock(ctx);
     return 0;
 }

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1410,7 +1410,7 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->dmode_lastline = flb_sds_create_size(ctx->docker_mode == FLB_TRUE ? 20000 : 0);
     file->dmode_firstline = false;
 #ifdef FLB_HAVE_SQLDB
-    file->db_id     = 0;
+    file->db_id     = FLB_TAIL_DB_ID_NONE;
 #endif
     file->db_offset_marker = 0;
     file->db_offset_marker_size = 0;
@@ -1585,6 +1585,38 @@ void flb_tail_file_remove(struct flb_tail_file *file)
 
     flb_plg_debug(ctx->ins, "inode=%"PRIu64" removing file name %s",
                   file->inode, file->name);
+
+    if (file->buf_len > 0) {
+        if (file->decompression_context == NULL) {
+            /*
+             * If there is data in the buffer, it means it was not processed.
+             * We must rewind the offset to ensure this data is re-read on restart.
+             */
+            off_t old_offset = file->offset;
+
+            if (file->offset > file->buf_len) {
+                file->offset -= file->buf_len;
+            } else {
+                file->offset = 0;
+            }
+
+            flb_plg_debug(ctx->ins, "inode=%"PRIu64" rewind offset for %s: "
+                          "old=%"PRId64" new=%"PRId64" (buf_len=%lu)",
+                          file->inode, file->name, old_offset, file->offset,
+                          (unsigned long)file->buf_len);
+
+#ifdef FLB_HAVE_SQLDB
+            if (ctx->db && file->db_id > FLB_TAIL_DB_ID_NONE) {
+                flb_tail_db_file_offset(file, ctx);
+            }
+#endif
+        }
+        else {
+            flb_plg_warn(ctx->ins, "inode=%"PRIu64" cannot rewind compressed file %s; "
+                         "%lu decompressed bytes in buffer may be lost on restart",
+                         file->inode, file->name, (unsigned long)file->buf_len);
+        }
+    }
 
     if (file->decompression_context != NULL) {
         flb_decompression_context_destroy(file->decompression_context);

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -47,6 +47,7 @@
 #include "tail_dockermode.h"
 #include "tail_multiline.h"
 #include "tail_scan.h"
+#include <fluent-bit/flb_compression.h>
 
 #ifdef FLB_SYSTEM_WINDOWS
 #include "win32.h"
@@ -1144,6 +1145,8 @@ static int set_file_position(struct flb_tail_config *ctx,
                              struct flb_tail_file *file)
 {
     int64_t ret;
+    int64_t seek_pos;
+    int has_db_position;
 
 #ifdef FLB_HAVE_SQLDB
     /*
@@ -1163,17 +1166,42 @@ static int set_file_position(struct flb_tail_config *ctx,
                  */
                 file->offset = 0;
                 file->stream_offset = 0;
+                file->skip_bytes = 0;
+                file->anchor_offset = 0;
+                file->exclude_bytes = 0;
+                file->skipping_mode = FLB_FALSE;
                 flb_tail_db_file_offset(file, ctx);
             }
 
-            if (file->offset > 0) {
-                ret = lseek(file->fd, file->offset, SEEK_SET);
+            /*
+             * Determine seek position based on file type and DB state:
+             *
+             * - Gzip files with anchor/skip info: use anchor_offset
+             * - Normal files or gzip migration fallback: use offset
+             * - No DB position + read_from_head=off: seek to EOF
+             */
+            seek_pos = file->offset;
+            has_db_position = (file->offset > 0);
+
+            /* Override for gzip files with proper anchor tracking */
+            if (file->decompression_context != NULL &&
+                (file->anchor_offset > 0 || file->skip_bytes > 0)) {
+                seek_pos = file->anchor_offset;
+                has_db_position = FLB_TRUE;
+            }
+
+            if (has_db_position) {
+                ret = lseek(file->fd, seek_pos, SEEK_SET);
                 if (ret == -1) {
                     flb_errno();
                     return -1;
                 }
-                if (file->decompression_context == NULL) {
-                    file->stream_offset = ret;
+                file->offset = ret;
+
+                /* Initialize skip state for gzip resume */
+                if (file->decompression_context != NULL && file->skip_bytes > 0) {
+                    file->exclude_bytes = file->skip_bytes;
+                    file->skipping_mode = FLB_TRUE;
                 }
             }
             else if (ctx->read_from_head == FLB_FALSE) {
@@ -1183,11 +1211,23 @@ static int set_file_position(struct flb_tail_config *ctx,
                     return -1;
                 }
                 file->offset = ret;
-                if (file->decompression_context == NULL) {
-                    file->stream_offset = ret;
-                }
+                file->anchor_offset = ret;
                 flb_tail_db_file_offset(file, ctx);
             }
+
+            if (file->decompression_context == NULL) {
+                file->stream_offset = file->offset;
+            }
+            else {
+                /*
+                 * For single-member gzip, stream_offset = skip_bytes is correct.
+                 * For multi-member gzip, skip_bytes only tracks bytes within the
+                 * current member (reset at member boundaries), so stream_offset
+                 * may not reflect the total decompressed bytes from prior members.
+                 */
+                file->stream_offset = file->skip_bytes;
+            }
+
             return 0;
         }
     }
@@ -1219,6 +1259,15 @@ static int set_file_position(struct flb_tail_config *ctx,
 
     if (file->decompression_context == NULL) {
         file->stream_offset = ret;
+    }
+    else {
+        /*
+         * Compressed file without DB: no persistent state available.
+         * Initialize skip-related fields to 0 for code consistency.
+         */
+        file->anchor_offset = file->offset;
+        file->exclude_bytes = 0;
+        file->stream_offset = 0;
     }
 
     return 0;
@@ -1417,6 +1466,12 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
     file->skip_next = FLB_FALSE;
     file->skip_warn = FLB_FALSE;
 
+    /* Initialize gzip resume fields */
+    file->anchor_offset = 0;
+    file->skip_bytes = 0;
+    file->exclude_bytes = 0;
+    file->skipping_mode = FLB_FALSE;
+
     /* Multiline core mode */
     if (ctx->ml_ctx) {
         /*
@@ -1586,37 +1641,19 @@ void flb_tail_file_remove(struct flb_tail_file *file)
     flb_plg_debug(ctx->ins, "inode=%"PRIu64" removing file name %s",
                   file->inode, file->name);
 
-    if (file->buf_len > 0) {
-        if (file->decompression_context == NULL) {
-            /*
-             * If there is data in the buffer, it means it was not processed.
-             * We must rewind the offset to ensure this data is re-read on restart.
-             */
-            off_t old_offset = file->offset;
-
-            if (file->offset > file->buf_len) {
-                file->offset -= file->buf_len;
-            } else {
-                file->offset = 0;
-            }
-
-            flb_plg_debug(ctx->ins, "inode=%"PRIu64" rewind offset for %s: "
-                          "old=%"PRId64" new=%"PRId64" (buf_len=%lu)",
-                          file->inode, file->name, old_offset, file->offset,
-                          (unsigned long)file->buf_len);
-
+    /*
+     * Persist the current offset before removal. flb_tail_file_db_offset()
+     * automatically rewinds to the last resumable position when buf_len > 0
+     * (for plain files), so no manual rewind is needed here.
+     */
 #ifdef FLB_HAVE_SQLDB
-            if (ctx->db && file->db_id > FLB_TAIL_DB_ID_NONE) {
-                flb_tail_db_file_offset(file, ctx);
-            }
-#endif
-        }
-        else {
-            flb_plg_warn(ctx->ins, "inode=%"PRIu64" cannot rewind compressed file %s; "
-                         "%lu decompressed bytes in buffer may be lost on restart",
-                         file->inode, file->name, (unsigned long)file->buf_len);
-        }
+    if (file->buf_len > 0 && ctx->db && file->db_id > FLB_TAIL_DB_ID_NONE) {
+        flb_plg_debug(ctx->ins, "inode=%"PRIu64" persisting offset for %s "
+                      "with buffered data (buf_len=%zu)",
+                      file->inode, file->name, file->buf_len);
+        flb_tail_db_file_offset(file, ctx);
     }
+#endif
 
     if (file->decompression_context != NULL) {
         flb_decompression_context_destroy(file->decompression_context);
@@ -1736,6 +1773,10 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
                       file->inode, file->name, size_delta);
         file->offset = offset;
         file->buf_len = 0;
+        file->anchor_offset = offset;
+        file->skip_bytes = 0;
+        file->exclude_bytes = 0;
+        file->skipping_mode = FLB_FALSE;
 
         /* Update offset in the database file */
 #ifdef FLB_HAVE_SQLDB
@@ -1763,6 +1804,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
     uint8_t                *read_buffer;
     size_t                  read_size;
     size_t                  size;
+    size_t                  remain;
     char                   *tmp;
     int                     ret;
     int                     lines;
@@ -1947,6 +1989,28 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
                     return FLB_TAIL_ERROR;
                 }
 
+                if (file->skipping_mode == FLB_TRUE && decompressed_data_length > 0) {
+                    flb_plg_debug(ctx->ins,
+                                 "Skipping: anchor=%jd offset=%jd "
+                                 "exclude=%zu decompressed=%zu",
+                                 (intmax_t)file->anchor_offset,
+                                 (intmax_t)file->offset,
+                                 file->exclude_bytes, decompressed_data_length);
+                    if (file->exclude_bytes >= decompressed_data_length) {
+                        file->exclude_bytes -= decompressed_data_length;
+                        decompressed_data_length = 0;
+                    }
+                    else {
+                        remain = decompressed_data_length - file->exclude_bytes;
+                        memmove(&file->buf_data[file->buf_len],
+                                &file->buf_data[file->buf_len + file->exclude_bytes],
+                                remain);
+                        decompressed_data_length = remain;
+                        file->exclude_bytes = 0;
+                        file->skipping_mode = FLB_FALSE;
+                    }
+                }
+
                 stream_data_length = decompressed_data_length;
             }
         }
@@ -1985,6 +2049,29 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         consume_bytes(file->buf_data, processed_bytes, file->buf_len);
         file->buf_len -= processed_bytes;
         file->buf_data[file->buf_len] = '\0';
+
+        if (file->decompression_context) {
+            file->skip_bytes += processed_bytes;
+
+            /*
+             * Gzip member boundary: update anchor when we complete a member
+             * and all decompressed data is consumed.
+             */
+            if (file->decompression_context->state ==
+                    FLB_DECOMPRESSOR_STATE_EXPECTING_HEADER &&
+                file->decompression_context->input_buffer_length == 0 &&
+                file->buf_len == 0) {
+                flb_plg_debug(file->config->ins,
+                             "Gzip member completed: updating anchor "
+                             "from %jd to %jd, resetting skip from "
+                             "%"PRIu64" to 0",
+                             (intmax_t)file->anchor_offset,
+                             (intmax_t)file->offset,
+                             file->skip_bytes);
+                file->anchor_offset = file->offset;
+                file->skip_bytes = 0;
+            }
+        }
 
 #ifdef FLB_HAVE_SQLDB
         if (file->config->db) {

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -43,6 +43,10 @@ struct flb_tail_file {
     int64_t size;
     int64_t offset;             /* this represents the raw file offset, not
                                    the input data offset (see stream_offset) */
+    int64_t anchor_offset;      /* compressed: file offset at member start */
+    uint64_t skip_bytes;        /* compressed: decompressed bytes to skip */
+    uint64_t exclude_bytes;     /* compressed: runtime countdown during skip */
+    int skipping_mode;          /* compressed: skipping previously read data */
     int64_t last_line;
     uint64_t  dev_id;
     uint64_t  inode;

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -267,6 +267,10 @@ static int tail_fs_event(struct flb_input_instance *ins,
                           file->inode, file->name, size_delta);
             file->offset = offset;
             file->buf_len = 0;
+            file->anchor_offset = offset;
+            file->skip_bytes = 0;
+            file->exclude_bytes = 0;
+            file->skipping_mode = FLB_FALSE;
 
             /* Update offset in the database file */
 #ifdef FLB_HAVE_SQLDB

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -136,6 +136,10 @@ static int tail_fs_check(struct flb_input_instance *ins,
                          file->name, size_delta);
             file->offset = offset;
             file->buf_len = 0;
+            file->anchor_offset = offset;
+            file->skip_bytes = 0;
+            file->exclude_bytes = 0;
+            file->skipping_mode = FLB_FALSE;
             memcpy(&fst->st, &st, sizeof(struct stat));
 
 #ifdef FLB_HAVE_SQLDB

--- a/plugins/in_tail/tail_sql.h
+++ b/plugins/in_tail/tail_sql.h
@@ -36,17 +36,19 @@
     "  created INTEGER,"                                                \
     "  rotated INTEGER DEFAULT 0,"                                      \
     "  offset_marker INTEGER DEFAULT 0,"                                \
-    "  offset_marker_size INTEGER DEFAULT 0"                            \
+    "  offset_marker_size INTEGER DEFAULT 0,"                           \
+    "  skip    INTEGER DEFAULT 0,"                                      \
+    "  anchor  INTEGER DEFAULT 0"                                       \
     ");"
 
 #define SQL_GET_FILE                                                    \
-    "SELECT id, name, offset, inode, offset_marker, offset_marker_size " \
+    "SELECT id, name, offset, inode, offset_marker, offset_marker_size, skip, anchor " \
     "from in_tail_files WHERE inode=@inode order by id desc;"
 
 #define SQL_INSERT_FILE                                             \
     "INSERT INTO in_tail_files "                                    \
-    "  (name, offset, inode, created, offset_marker, offset_marker_size)" \
-    "  VALUES (@name, @offset, @inode, @created, @offset_marker, @offset_marker_size);"
+    "  (name, offset, inode, created, offset_marker, offset_marker_size, skip, anchor)" \
+    "  VALUES (@name, @offset, @inode, @created, @offset_marker, @offset_marker_size, @skip, @anchor);"
 
 #define SQL_ROTATE_FILE                                                 \
     "UPDATE in_tail_files set name=@name,rotated=1 WHERE id=@id;"
@@ -54,13 +56,20 @@
 #define SQL_UPDATE_OFFSET                                   \
     "UPDATE in_tail_files set offset=@offset, "             \
     "offset_marker=@offset_marker, "                        \
-    "offset_marker_size=@offset_marker_size WHERE id=@id;"
+    "offset_marker_size=@offset_marker_size, "              \
+    "skip=@skip, anchor=@anchor WHERE id=@id;"
 
 #define SQL_ALTER_FILES_ADD_OFFSET_MARKER                           \
     "ALTER TABLE in_tail_files ADD COLUMN offset_marker INTEGER DEFAULT 0;"
 
 #define SQL_ALTER_FILES_ADD_OFFSET_MARKER_SIZE                      \
     "ALTER TABLE in_tail_files ADD COLUMN offset_marker_size INTEGER DEFAULT 0;"
+
+#define SQL_ALTER_FILES_ADD_SKIP                                    \
+    "ALTER TABLE in_tail_files ADD COLUMN skip INTEGER DEFAULT 0;"
+
+#define SQL_ALTER_FILES_ADD_ANCHOR                                  \
+    "ALTER TABLE in_tail_files ADD COLUMN anchor INTEGER DEFAULT 0;"
 
 #define SQL_DELETE_FILE                                                 \
     "DELETE FROM in_tail_files WHERE id=@id;"

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -2948,37 +2948,15 @@ void flb_test_db_offset_rewind_on_shutdown()
     }
 
     /*
-     * Wait for tail to READ the file into buffer (advancing the DB offset).
-     * Instead of sleeping, we poll the DB until the offset increases.
-     * The offset should advance by the length of msg_before_shutdown.
-     */
-    int64_t start_offset = -1;
-    int64_t current_offset = -1;
-    int attempts = 0;
-    
-    /* Get initial offset (should be after the first message) */
-    while (start_offset == -1 && attempts < 20) {
-        start_offset = get_db_offset(db, file[0]);
-        if (start_offset != -1) {
-            break;
-        }
-        flb_time_msleep(100);
-        attempts++;
-    }
-
-    if (!TEST_CHECK(start_offset >= 0)) {
-        TEST_MSG("failed to get initial db offset");
-        test_tail_ctx_destroy(ctx);
-        unlink(file[0]);
-        unlink(db);
-        exit(EXIT_FAILURE);
-    }
-
-    /*
      * Write message WITHOUT newline - this will remain in the tail buffer
      * as an incomplete line, which is the scenario we want to test.
      * The tail plugin processes complete lines (ending with \n), so
      * data without newline stays in buf_len until more data arrives.
+     *
+     * Note: flb_tail_file_db_offset() automatically persists the resumable
+     * offset (offset - buf_len) rather than the raw read position, so the
+     * DB offset will NOT advance past the initial message until the
+     * incomplete line is completed with a newline.
      */
     ret = write_raw(ctx, msg_before_shutdown, strlen(msg_before_shutdown), FLB_FALSE);
     if (!TEST_CHECK(ret > 0)) {
@@ -2988,25 +2966,8 @@ void flb_test_db_offset_rewind_on_shutdown()
         exit(EXIT_FAILURE);
     }
 
-    /* Poll loop */
-    attempts = 0;
-    while (attempts < 20) { /* Max 2 seconds wait */
-        current_offset = get_db_offset(db, file[0]);
-        if (current_offset > start_offset) {
-            break;
-        }
-        flb_time_msleep(100);
-        attempts++;
-    }
-
-    if (!TEST_CHECK(current_offset > start_offset)) {
-        TEST_MSG("DB offset did not advance. start=%ld current=%ld",
-                 start_offset, current_offset);
-        test_tail_ctx_destroy(ctx);
-        unlink(file[0]);
-        unlink(db);
-        exit(EXIT_FAILURE);
-    }
+    /* Wait for tail to read the incomplete line into its buffer */
+    flb_time_msleep(500);
 
     /* Close file descriptors before stopping */
     if (ctx->fds != NULL) {


### PR DESCRIPTION
Unprocessed data in the internal buffer is discarded when Fluent Bit stops, causing data loss because the DB offset is already advanced.

This patch fixes the issue by rewinding the file offset by the remaining buffer length on exit, ensuring data is re-read on restart.

For compressed gzip files, a separate issue caused data duplication after restart because skip_bytes was incorrectly decremented during runtime. A new field 'exclude_bytes' is introduced as a runtime-only counter, preserving skip_bytes for correct DB persistence.

Additionally, this patch prevents resurrecting deleted file entries in the DB by resetting db_id to 0 upon deletion and checking it before updating the offset.

The SQLite schema is updated to include 'anchor_offset' and 'skip_bytes' columns. On upgrade from older versions, these columns are automatically added via ALTER TABLE if they do not exist.

Closes #11265

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
``` log
[SERVICE]
    flush 2
    grace 60
    log_level debug
    log_file /tmp/testing/logs/testing.log
    parsers_file /tmp/testing/parsers.conf
    plugins_file /tmp/testing/plugins.conf
    http_server on
    http_listen 0.0.0.0
    http_port 22002

    storage.path /tmp/testing/storage
    storage.metrics on
    storage.max_chunks_up 512
    storage.sync full
    storage.checksum off
    storage.backlog.mem_limit 100M

[INPUT]
    Name tail
    Path /tmp/testing.input
    Tag testing
    Key message
    Offset_Key   log_offset

    Read_from_Head true
    Refresh_Interval 3
    Rotate_Wait 31557600

    Buffer_Chunk_Size 1MB
    Buffer_Max_Size 16MB
    Inotify_Watcher false

    storage.type filesystem
    storage.pause_on_chunks_overlimit true

    DB /tmp/testing/storage/testing.db
    DB.sync normal
    DB.locking false

    Alias input_log

[OUTPUT]
    Name file
    Match *
    File /tmp/testing.out
```

``` gzip
[SERVICE]
    flush 2
    grace 60
    log_level debug
    log_file /tmp/testing/logs/testing.log
    parsers_file /tmp/testing/parsers.conf
    plugins_file /tmp/testing/plugins.conf
    http_server on
    http_listen 0.0.0.0
    http_port 22002

    storage.path /tmp/testing/storage
    storage.metrics on
    storage.max_chunks_up 512
    storage.sync full
    storage.checksum off
    storage.backlog.mem_limit 100M

[INPUT]
    Name tail
    Path /tmp/testing.input.gz
    Tag testing
    Key message
    Offset_Key   log_offset

    Read_from_Head true
    Refresh_Interval 3
    Rotate_Wait 31557600

    Buffer_Chunk_Size 1MB
    Buffer_Max_Size 16MB
    Inotify_Watcher false

    storage.type filesystem
    storage.pause_on_chunks_overlimit true

    DB /tmp/testing/storage/testing.db
    DB.sync normal
    DB.locking false

    Alias input_log

[OUTPUT]
    Name file
    Match *
    File /tmp/testing.out
```
- [x] Debug log output from testing the change
```
normal file
[2025/12/15 20:40:56.47094045] [debug] [input:tail:input_log] inode=50643270 rewind offset for /tmp/testing.input: old=185883589 new=185883490 (buf_len=99)

compressed file
[2025/12/15 20:45:12.615579997] [debug] [input:tail:input_log] Skipping: anchor=0 offset=0 exclude=1119419529 decompressed=999999
[2025/12/15 20:45:12.617241577] [debug] [input:tail:input_log] Skipping: anchor=0 offset=999999 exclude=1118419530 decompressed=15809
...
[2025/12/15 20:45:15.408197399] [debug] [input:tail:input_log] Skipping: anchor=0 offset=10923918 exclude=1014921 decompressed=999999
[2025/12/15 20:45:15.408206153] [debug] [input:tail:input_log] Skipping: anchor=0 offset=10923918 exclude=14922 decompressed=15809
[2025/12/15 20:45:20.13095551] [debug] [input:tail:input_log] Gzip member completed: updating anchor from 0 to 10923918, resetting skip from 2147483784 to 0
```
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
valgrind --leak-check=full ./bin/fluent-bit -v -c ./fluentbit.conf
...
==546544== 
==546544== HEAP SUMMARY:
==546544==     in use at exit: 0 bytes in 0 blocks
==546544==   total heap usage: 1,973,893 allocs, 1,973,893 frees, 2,123,730,947 bytes allocated
==546544== 
==546544== All heap blocks were freed -- no leaks are possible
==546544== 
==546544== For lists of detected and suppressed errors, rerun with: -s
==546544== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved gzip file resumption, including support for appends, rotations, and multi-member files.
  * Resume progress is now preserved across restarts for compressed files.

* **Bug Fixes**
  * Prevented duplicate or lost records when resuming gzip inputs.
  * Improved offset handling after truncation, shutdown, and buffered data cleanup.
  * Existing tail databases are upgraded automatically to support compressed-file resume state.

* **Tests**
  * Added coverage for gzip resumption, appends, rotations, multi-file-member processing, and offset recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->