### PR TITLE
chore: change chunks dropped log level.

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -398,7 +398,7 @@ static int flb_input_chunk_release_space(
                  * we need to destroy the task as well.
                  */
                 if (old_input_chunk->task->users == 0) {
-                    flb_debug("[task] drop task_id %d with no active route from input plugin %s",
+                    flb_info("[task] drop task_id %d with no active route from input plugin %s",
                               old_input_chunk->task->id, new_input_chunk->in->name);
                     flb_task_destroy(old_input_chunk->task, FLB_TRUE);
 
@@ -406,7 +406,7 @@ static int flb_input_chunk_release_space(
                 }
             }
             else {
-                flb_debug("[input chunk] drop chunk %s with no output route from input plugin %s",
+                flb_info("[input chunk] drop chunk %s with no output route from input plugin %s",
                           flb_input_chunk_get_name(old_input_chunk), new_input_chunk->in->name);
 
                 flb_input_chunk_destroy(old_input_chunk, FLB_TRUE);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Changing the `log_level` for messages about chunks being dropped, to `'info'`.

Fixes: [N/A]
Doesn't address a particular issue. (at least I did'n find one)
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

**Documentation**
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

Currently, it's difficult to detect when the `storage.total_limit_size` is reached (and react accordingly), as nothing is logged, unless the log level is set to `debug`, which makes the output noisy.

Maybe there is some way to log something, but I didn't manage to find one.

Please write if a `Valgrind` report is still needed.
I would expect the `log_info` to be tested already.

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
