### PR TITLE
in_emitter: Add backpressure limitation for filesystem storage

### DIFF
--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -298,6 +298,7 @@ static int cb_emitter_init(struct flb_input_instance *in,
 {
     struct flb_sched *scheduler;
     struct flb_emitter *ctx;
+    char *pause_prop = NULL;
     int ret;
 
     scheduler = flb_sched_ctx_get();
@@ -330,16 +331,13 @@ static int cb_emitter_init(struct flb_input_instance *in,
      * filesystem storage is in use so the configured storage.max_chunks_up
      * limit is honored.
      */
-    if (in->storage_type == FLB_STORAGE_FS &&
-        in->storage_pause_on_chunks_overlimit == FLB_FALSE) {
-        in->storage_pause_on_chunks_overlimit = FLB_TRUE;
-        flb_plg_debug(in, "enable pause on storage chunks overlimit for emitter");
-    }
-    else if (in->storage_type != FLB_STORAGE_FS &&
-             in->storage_pause_on_chunks_overlimit == FLB_TRUE) {
-        flb_plg_debug(in,
-                      "storage.pause_on_chunks_overlimit reset: storage.type is not filesystem");
-        in->storage_pause_on_chunks_overlimit = FLB_FALSE;
+    pause_prop = flb_input_get_property("storage.pause_on_chunks_overlimit", in);
+    if (pause_prop == NULL) {
+        if (in->storage_type == FLB_STORAGE_FS &&
+            in->storage_pause_on_chunks_overlimit == FLB_FALSE) {
+            in->storage_pause_on_chunks_overlimit = FLB_TRUE;
+            flb_plg_debug(in, "enable pause on storage chunks overlimit for emitter");
+        }
     }
 
     if (in->is_threaded == FLB_TRUE && ctx->ring_buffer_size == 0) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

Aligned emitter initialization with storage-type semantics by enabling pause on chunk overlimit only for filesystem storage and resetting it when another storage type is in use, keeping behavior consistent with other inputs.

Closes https://github.com/fluent/fluent-bit/issues/11279.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic storage backpressure: pausing is now automatically enabled for filesystem storage when needed, ensuring configured maximum chunk limits are respected and preserving prior behavior for other storage types. Added clearer debug logging for these state transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->