### PR TITLE
in_winevtlog: Plug glitches of time offset for DST/STD switches

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -276,28 +276,20 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
     int offset_hours;
     int offset_minutes;
     char offset_sign;
-    _locale_t locale;
     DWORD tz_id;
 
     _tzset();
-
-    locale = _get_current_locale();
-    if (locale == NULL) {
-        return -1;
-    }
 
     ft.dwHighDateTime = (DWORD)(filetime >> 32);
     ft.dwLowDateTime  = (DWORD)(filetime & 0xFFFFFFFF);
 
     if (!FileTimeToSystemTime(&ft, &st_utc)) {
-        _free_locale(locale);
         return -1;
     }
 
     tz_id = GetDynamicTimeZoneInformation(&dtzi);
 
     if (!SystemTimeToTzSpecificLocalTimeEx(&dtzi, &st_utc, &st_local)) {
-        _free_locale(locale);
         return -1;
     }
 
@@ -337,11 +329,8 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
                       offset_minutes);
 
     if (len <= 0) {
-        _free_locale(locale);
         return -1;
     }
-
-    _free_locale(locale);
 
     flb_log_event_encoder_append_body_string(ctx->log_encoder, buf, len);
     return 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Closes https://github.com/fluent/fluent-bit/issues/11213.

There's DST/STD offset glitches under "TimeCreated" key's values.
This also should be handled with DynamicTimeZoneInformation related APIs.

This PR fixes this type of glitches.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
PS> bin/fluent-bit -i winevtlog -p Channels=System -o stdout
```

- [x] Debug log output from testing the change
```
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/

             Fluent Bit v4.2 ΓÇô Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2025/12/15 07:55:03.948546100] [ info] Configuration:
[2025/12/15 07:55:03.948799400] [ info]  flush time     | 1.000000 seconds
[2025/12/15 07:55:03.948826000] [ info]  grace          | 5 seconds
[2025/12/15 07:55:03.948842500] [ info]  daemon         | 0
[2025/12/15 07:55:03.948857400] [ info] ___________
[2025/12/15 07:55:03.948872200] [ info]  inputs:
[2025/12/15 07:55:03.948886900] [ info]      winevtlog
[2025/12/15 07:55:03.948901300] [ info] ___________
[2025/12/15 07:55:03.948916300] [ info]  filters:
[2025/12/15 07:55:03.948931200] [ info] ___________
[2025/12/15 07:55:03.948946200] [ info]  outputs:
[2025/12/15 07:55:03.948961000] [ info]      stdout.0
[2025/12/15 07:55:03.948975800] [ info] ___________
[2025/12/15 07:55:03.948990500] [ info]  collectors:
[2025/12/15 07:55:03.950108300] [ info] [fluent bit] version=4.2.1, commit=c06c12449f, pid=26188
[2025/12/15 07:55:03.950126500] [debug] [engine] maxstdio set: 512
[2025/12/15 07:55:03.950138500] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2025/12/15 07:55:03.950355100] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/12/15 07:55:03.950367000] [ info] [simd    ] SSE2
[2025/12/15 07:55:03.950373700] [ info] [cmetrics] version=1.0.5
[2025/12/15 07:55:03.950381900] [ info] [ctraces ] version=0.6.6
[2025/12/15 07:55:03.950609800] [ info] [input:winevtlog:winevtlog.0] initializing
[2025/12/15 07:55:03.950620600] [ info] [input:winevtlog:winevtlog.0] storage_strategy='memory' (memory only)
[2025/12/15 07:55:03.950714700] [debug] [winevtlog:winevtlog.0] created event channels: read=788 write=792
[2025/12/15 07:55:03.950729400] [debug] [input:winevtlog:winevtlog.0] connect to local machine
[2025/12/15 07:55:03.950737000] [debug] [input:winevtlog:winevtlog.0] read limit per cycle is set up as 512.0K
[2025/12/15 07:55:03.951244800] [debug] [stdout:stdout.0] created event channels: read=828 write=832
[2025/12/15 07:55:03.952084300] [ info] [sp] stream processor started
[2025/12/15 07:55:03.952339600] [ info] [output:stdout:stdout.0] worker #0 started
[2025/12/15 07:55:03.952466200] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/12/15 07:55:09.978571000] [debug] [input:winevtlog:winevtlog.0] read 584 bytes from 'System'
[2025/12/15 07:55:10.962507800] [debug] [task] created task=000001FC2BE78CE0 id=0 OK
[2025/12/15 07:55:10.962675200] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] winevtlog.0: [[1765781709.978298100, {}], {"ProviderName"=>"Netwaw18", "ProviderGuid"=>"", "Qualifiers"=>16384, "EventID"=>7021, "Version"=>0, "Level"=>4, "Task"=>0, "Opcode"=>0, "Keywords"=>"0x80000000000000", "TimeCreated"=>"2025-12-15 07:55:09 +0100", "EventRecordID"=>48032, "ActivityID"=>"", "RelatedActivityID"=>"", "ProcessID"=>4, "ThreadID"=>37060, "Channel"=>"System", "Computer"=>"DESKTOP-JLLFF9D", "UserID"=>"", "Message"=>"", "StringInserts"=>["", "000088000100B400000000006D1B0040000000000000000000000000000000000000000000000000000000000B0000000D000000F0F84A819378000042756666616C6F2D41362D333436302D5750413300000000000000000000000088030A0064536EC0010000000100000008000000000000000000000000000000000000000000000000000000000000000000010005090AB401000100504A0D030204000006000000000000000100000001000000"]}]
[2025/12/15 07:55:10.970031600] [debug] [out flush] cb_destroy coro_id=0
[2025/12/15 07:55:10.970196200] [debug] [task] destroy task=000001FC2BE78CE0 (task_id=0)
[2025/12/15 07:55:13] [engine] caught signal (SIGINT)
[2025/12/15 07:55:14.46741300] [ warn] [engine] service will shutdown in max 5 seconds
[2025/12/15 07:55:14.46860300] [ info] [engine] pausing all inputs..
[2025/12/15 07:55:14.46870900] [ info] [input] pausing winevtlog.0
[2025/12/15 07:55:15.54323300] [ info] [engine] service has stopped (0 pending tasks)
[2025/12/15 07:55:15.54347000] [ info] [input] pausing winevtlog.0
[2025/12/15 07:55:15.54626300] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/12/15 07:55:15.54953700] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

`"TimeCreated"=>"2025-12-15 07:55:09 +0100"` contains `+0100` offset now. 
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows event log timestamp formatting to ISO8601 with explicit timezone offset (±HHMM), correctly accounting for daylight/standard time adjustments for accurate local times and more reliable error handling when timezone conversions fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->