### PR TITLE
in_winevtlog: Plug glitches of time offset for DST/STD switches [Backport to 4.1]

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -276,28 +276,20 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
     int offset_hours;
     int offset_minutes;
     char offset_sign;
-    _locale_t locale;
     DWORD tz_id;
 
     _tzset();
-
-    locale = _get_current_locale();
-    if (locale == NULL) {
-        return -1;
-    }
 
     ft.dwHighDateTime = (DWORD)(filetime >> 32);
     ft.dwLowDateTime  = (DWORD)(filetime & 0xFFFFFFFF);
 
     if (!FileTimeToSystemTime(&ft, &st_utc)) {
-        _free_locale(locale);
         return -1;
     }
 
     tz_id = GetDynamicTimeZoneInformation(&dtzi);
 
     if (!SystemTimeToTzSpecificLocalTimeEx(&dtzi, &st_utc, &st_local)) {
-        _free_locale(locale);
         return -1;
     }
 
@@ -337,11 +329,8 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
                       offset_minutes);
 
     if (len <= 0) {
-        _free_locale(locale);
         return -1;
     }
-
-    _free_locale(locale);
 
     flb_log_event_encoder_append_body_string(ctx->log_encoder, buf, len);
     return 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backporting of https://github.com/fluent/fluent-bit/pull/11291.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
