### PR TITLE
out_azure_kusto: fix timer/flush race condition causing SIGSEGV

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -554,8 +554,10 @@ static int ingest_all_chunks(struct flb_azure_kusto *ctx, struct flb_config *con
                 flb_free(final_payload);
             }
 
-            /* data was sent successfully- delete the local buffer */
-            azure_kusto_store_file_cleanup(ctx, chunk);
+            /* Early-delete mode already removed ownership after enqueue. */
+            if (ctx->buffer_file_delete_early != FLB_TRUE) {
+                azure_kusto_store_file_cleanup(ctx, chunk);
+            }
         }
     }
 
@@ -608,6 +610,17 @@ static void cb_azure_kusto_ingest(struct flb_config *config, void *data)
     int backoff_time;
     int max_backoff_time = 64; /* Maximum backoff time in seconds */
 
+    /* Skip this timer run rather than race with flush or exit mutating fstore lists. */
+    if (pthread_mutex_trylock(&ctx->buffer_mutex) != 0) {
+        return;
+    }
+
+    /* Late callbacks must not traverse fstore after exit has detached it. */
+    if (ctx->shutting_down == FLB_TRUE || !ctx->fs || !ctx->stream_active) {
+        pthread_mutex_unlock(&ctx->buffer_mutex);
+        return;
+    }
+
     /* Initialize random seed for staggered refresh intervals */
     srand(time(NULL));
 
@@ -619,6 +632,10 @@ static void cb_azure_kusto_ingest(struct flb_config *config, void *data)
     mk_list_foreach_safe(head, tmp, &ctx->stream_active->files) {
         fsf = mk_list_entry(head, struct flb_fstore_file, _head);
         file = fsf->data;
+        if (file == NULL) {
+            /* Skip entries whose plugin state was already detached. */
+            continue;
+        }
         flb_plg_debug(ctx->ins, "scheduler_kusto_ingest :: Iterating files inside upload timer callback (cb_azure_kusto_ingest).. %s", file->fsf->name);
 
         /* Check if the file has timed out */
@@ -782,6 +799,7 @@ static void cb_azure_kusto_ingest(struct flb_config *config, void *data)
     }
     /* Log the end of the upload timer callback */
     flb_plg_debug(ctx->ins, "Exited upload timer callback (cb_azure_kusto_ingest)..");
+    pthread_mutex_unlock(&ctx->buffer_mutex);
 }
 
 
@@ -925,6 +943,11 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         return -1;
     }
 
+    /* Track buffered fstore lifetime across flush, timer, and exit paths. */
+    ctx->upload_timer = NULL;
+    ctx->shutting_down = FLB_FALSE;
+    pthread_mutex_init(&ctx->buffer_mutex, NULL);
+
     if (ctx->buffering_enabled == FLB_TRUE) {
         ctx->ins = ins;
         ctx->retry_time = 0;
@@ -934,6 +957,7 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to initialize kusto storage: %s",
                           ctx->store_dir);
+            pthread_mutex_destroy(&ctx->buffer_mutex);
             flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
@@ -943,18 +967,21 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         if (ctx->file_size <= 0) {
             flb_plg_error(ctx->ins, "Failed to parse upload_file_size");
             azure_kusto_store_exit(ctx);
+            pthread_mutex_destroy(&ctx->buffer_mutex);
             flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
         if (ctx->file_size < 1000000) {
             flb_plg_error(ctx->ins, "upload_file_size must be at least 1MB");
             azure_kusto_store_exit(ctx);
+            pthread_mutex_destroy(&ctx->buffer_mutex);
             flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
         if (ctx->file_size > MAX_FILE_SIZE) {
             flb_plg_error(ctx->ins, "Max total_file_size must be lower than %ld bytes", MAX_FILE_SIZE);
             azure_kusto_store_exit(ctx);
+            pthread_mutex_destroy(&ctx->buffer_mutex);
             flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
@@ -990,6 +1017,7 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         pthread_mutex_destroy(&ctx->resources_mutex);
         pthread_mutex_destroy(&ctx->token_mutex);
         pthread_mutex_destroy(&ctx->blob_mutex);
+        pthread_mutex_destroy(&ctx->buffer_mutex);
         flb_azure_kusto_conf_destroy(ctx);
         return -1;
     }    
@@ -1013,6 +1041,7 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         pthread_mutex_destroy(&ctx->resources_mutex);
         pthread_mutex_destroy(&ctx->token_mutex);
         pthread_mutex_destroy(&ctx->blob_mutex);
+        pthread_mutex_destroy(&ctx->buffer_mutex);
         flb_azure_kusto_conf_destroy(ctx);
         return -1;
     }
@@ -1247,12 +1276,18 @@ static int buffer_chunk(void *out_context, struct azure_kusto_file *upload_file,
  *
  * @param out_context Pointer to the output context, specifically the Azure Kusto context.
  * @param config Pointer to the Fluent Bit configuration structure.
+ * @return FLB_OK on success, FLB_RETRY when backlog drain or timer setup must retry.
  */
-static void flush_init(void *out_context, struct flb_config *config)
+static int flush_init(void *out_context, struct flb_config *config)
 {
     int ret;
     struct flb_azure_kusto *ctx = out_context;
     struct flb_sched *sched;
+
+    if (ctx->shutting_down == FLB_TRUE) {
+        /* Do not create timers or drain backlog after exit has started. */
+        return FLB_RETRY;
+    }
 
     flb_plg_debug(ctx->ins,
                   "inside flush_init with old_buffers as %d",
@@ -1272,7 +1307,7 @@ static void flush_init(void *out_context, struct flb_config *config)
                           "Failed to send locally buffered data left over "
                           "from previous executions; will retry. Buffer=%s",
                           ctx->fs->root_path);
-            FLB_OUTPUT_RETURN(FLB_RETRY);
+            return FLB_RETRY;
         }
     }
     else {
@@ -1295,13 +1330,18 @@ static void flush_init(void *out_context, struct flb_config *config)
         sched = flb_sched_ctx_get();
 
         ret = flb_sched_timer_cb_create(sched, FLB_SCHED_TIMER_CB_PERM,
-                                        ctx->timer_ms, cb_azure_kusto_ingest, ctx, NULL);
+                                        ctx->timer_ms, cb_azure_kusto_ingest,
+                                        ctx, &ctx->upload_timer);
         if (ret == -1) {
+            ctx->upload_timer = NULL;
+            ctx->timer_created = FLB_FALSE;
             flb_plg_error(ctx->ins, "Failed to create upload timer");
-            FLB_OUTPUT_RETURN(FLB_RETRY);
+            return FLB_RETRY;
         }
         ctx->timer_created = FLB_TRUE;
     }
+
+    return FLB_OK;
 }
 
 /**
@@ -1331,6 +1371,8 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
     int total_file_size_check = FLB_FALSE;
     flb_sds_t tag_name = NULL;
     size_t tag_name_len;
+    /* Track ownership so cleanup and error paths release the buffer mutex once. */
+    int buffer_locked = FLB_FALSE;
 
     (void)i_ins;
     (void)config;
@@ -1352,8 +1394,19 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
             tag_name = event_chunk->tag;
         }
         tag_name_len = flb_sds_len(tag_name);
+
+        /* Serialize buffer file lookup/update with timer and shutdown cleanup. */
+        if (pthread_mutex_lock(&ctx->buffer_mutex) != 0) {
+            ret = FLB_RETRY;
+            goto error;
+        }
+        buffer_locked = FLB_TRUE;
+
         /* Initialize the flush process */
-        flush_init(ctx,config);
+        ret = flush_init(ctx, config);
+        if (ret != FLB_OK) {
+            goto error;
+        }
 
         /* Reformat msgpack to JSON payload */
         ret = azure_kusto_format(ctx, tag_name, tag_name_len, event_chunk->data,
@@ -1416,6 +1469,7 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
 
             if (ret == 0){
                 if (ctx->buffering_enabled == FLB_TRUE && ctx->buffer_file_delete_early == FLB_TRUE){
+                    /* Successful early-delete enqueue released upload_file. */
                     flb_plg_debug(ctx->ins, "buffer file already deleted after blob creation");
                     ret = FLB_OK;
                     goto cleanup;
@@ -1532,6 +1586,9 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
     if (tag_name) {
         flb_sds_destroy(tag_name);
     }
+    if (buffer_locked == FLB_TRUE) {
+        pthread_mutex_unlock(&ctx->buffer_mutex);
+    }
     FLB_OUTPUT_RETURN(ret);
 
     error:
@@ -1544,6 +1601,9 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
     }
     if (tag_name) {
         flb_sds_destroy(tag_name);
+    }
+    if (buffer_locked == FLB_TRUE) {
+        pthread_mutex_unlock(&ctx->buffer_mutex);
     }
     FLB_OUTPUT_RETURN(ret);
 }
@@ -1581,7 +1641,7 @@ static void cb_azure_kusto_flush(struct flb_event_chunk *event_chunk,
 static int cb_azure_kusto_exit(void *data, struct flb_config *config)
 {
     struct flb_azure_kusto *ctx = data;
-    int ret = -1;
+    int ret = 0;
 
     if (!ctx) {
         return -1;
@@ -1589,14 +1649,28 @@ static int cb_azure_kusto_exit(void *data, struct flb_config *config)
 
 
     if (ctx->buffering_enabled == FLB_TRUE){
+        /* Stop timer callbacks before tearing down the fstore they traverse. */
+        if (pthread_mutex_lock(&ctx->buffer_mutex) != 0) {
+            return -1;
+        }
+        ctx->shutting_down = FLB_TRUE;
+
+        if (ctx->upload_timer != NULL) {
+            flb_sched_timer_invalidate(ctx->upload_timer);
+            ctx->upload_timer = NULL;
+            ctx->timer_created = FLB_FALSE;
+        }
+
         if (azure_kusto_store_has_data(ctx) == FLB_TRUE) {
             flb_plg_info(ctx->ins, "Sending all locally buffered data to Kusto");
             ret = ingest_all_chunks(ctx, config);
             if (ret < 0) {
+                /* Propagate final-drain failures to plugin exit. */
                 flb_plg_error(ctx->ins, "Could not send all chunks on exit");
             }
         }
         azure_kusto_store_exit(ctx);
+        pthread_mutex_unlock(&ctx->buffer_mutex);
     }
 
     if (ctx->u) {
@@ -1607,10 +1681,11 @@ static int cb_azure_kusto_exit(void *data, struct flb_config *config)
     pthread_mutex_destroy(&ctx->resources_mutex);
     pthread_mutex_destroy(&ctx->token_mutex);
     pthread_mutex_destroy(&ctx->blob_mutex);
+    pthread_mutex_destroy(&ctx->buffer_mutex);
 
     flb_azure_kusto_conf_destroy(ctx);
 
-    return 0;
+    return ret;
 }
 
 static struct flb_config_map config_map[] = {

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -136,6 +136,10 @@ struct flb_azure_kusto {
 
     int timer_created;
     int timer_ms;
+    /* Keep the timer handle so exit can stop callbacks before fstore teardown. */
+    struct flb_sched_timer *upload_timer;
+    /* Gate flush and timer paths while exit owns fstore cleanup. */
+    int shutting_down;
 
     /* mutex for acquiring oauth tokens */
     pthread_mutex_t token_mutex;
@@ -148,6 +152,7 @@ struct flb_azure_kusto {
 
     pthread_mutex_t blob_mutex;
 
+    /* Protect buffered fstore lists shared by flush, timer, and exit paths. */
     pthread_mutex_t buffer_mutex;
 
     int buffering_enabled;

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -603,8 +603,26 @@ static flb_sds_t azure_kusto_create_blob_id(struct flb_azure_kusto *ctx, flb_sds
     return blob_id;
 }
 
+int azure_kusto_should_early_delete_buffer_file(struct flb_azure_kusto *ctx,
+                                                struct azure_kusto_file *upload_file,
+                                                int enqueue_ret)
+{
+    if (enqueue_ret != 0) {
+        return FLB_FALSE;
+    }
+
+    if (ctx->buffering_enabled == FLB_TRUE && upload_file != NULL &&
+        ctx->buffer_file_delete_early == FLB_TRUE) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 int azure_kusto_queued_ingestion(struct flb_azure_kusto *ctx, flb_sds_t tag,
-                                 size_t tag_len, flb_sds_t payload, size_t payload_size, struct azure_kusto_file *upload_file )
+                                 size_t tag_len, flb_sds_t payload,
+                                 size_t payload_size,
+                                 struct azure_kusto_file *upload_file)
 {
     int ret = -1;
     flb_sds_t blob_id;
@@ -629,17 +647,19 @@ int azure_kusto_queued_ingestion(struct flb_azure_kusto *ctx, flb_sds_t tag,
         blob_uri = azure_kusto_create_blob(ctx, blob_id, payload, payload_size);
 
         if (blob_uri) {
-            if (ctx->buffering_enabled == FLB_TRUE && upload_file != NULL && ctx->buffer_file_delete_early == FLB_TRUE) {
-                flb_plg_debug(ctx->ins, "buffering enabled, ingest to blob successfully done and now deleting the buffer file %s", blob_id);
-                if (azure_kusto_store_file_delete(ctx, upload_file) != 0) {
-                    flb_plg_error(ctx->ins, "blob creation successful but error deleting buffer file %s", blob_id);
-                }
-            }
             ret = azure_kusto_enqueue_ingestion(ctx, blob_uri, payload_size);
 
             if (ret != 0) {
                 flb_plg_error(ctx->ins, "failed to enqueue ingestion blob to queue");
                 ret = -1;
+            }
+
+            if (azure_kusto_should_early_delete_buffer_file(ctx, upload_file, ret) == FLB_TRUE) {
+                /* Delete only after queue enqueue succeeds; failed enqueue keeps the buffer for retry. */
+                flb_plg_debug(ctx->ins, "buffering enabled, ingest to blob and queue successfully done and now deleting the buffer file %s", blob_id);
+                if (azure_kusto_store_file_delete(ctx, upload_file) != 0) {
+                    flb_plg_error(ctx->ins, "blob queue successful but error deleting buffer file %s", blob_id);
+                }
             }
 
             flb_sds_destroy(blob_uri);

--- a/plugins/out_azure_kusto/azure_kusto_ingest.h
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.h
@@ -23,7 +23,13 @@
 #include "azure_kusto.h"
 #include "azure_kusto_store.h"
 
+/* Internal policy: early-delete is safe only after queue enqueue succeeds. */
+int azure_kusto_should_early_delete_buffer_file(struct flb_azure_kusto *ctx,
+                                                struct azure_kusto_file *upload_file,
+                                                int enqueue_ret);
 int azure_kusto_queued_ingestion(struct flb_azure_kusto *ctx, flb_sds_t tag,
-                                 size_t tag_len, flb_sds_t payload, size_t payload_size, struct azure_kusto_file *upload_file);
+                                 size_t tag_len, flb_sds_t payload,
+                                 size_t payload_size,
+                                 struct azure_kusto_file *upload_file);
 
 #endif

--- a/plugins/out_azure_kusto/azure_kusto_store.c
+++ b/plugins/out_azure_kusto/azure_kusto_store.c
@@ -143,10 +143,11 @@ struct azure_kusto_file *azure_kusto_store_file_get(struct flb_azure_kusto *ctx,
     mk_list_foreach_safe(head, tmp, &ctx->stream_active->files) {
         fsf = mk_list_entry(head, struct flb_fstore_file, _head);
 
-        /* skip and warn on partially initialized chunks */
+        /* Delete and skip partially initialized chunks without plugin state. */
         if (fsf->data == NULL) {
             flb_plg_warn(ctx->ins, "BAD: found flb_fstore_file with NULL data reference, tag=%s, file=%s, will try to delete", tag, fsf->name);
             flb_fstore_file_delete(ctx->fs, fsf);
+            continue;
         }
 
         if (fsf->meta_size != tag_len) {
@@ -521,6 +522,8 @@ int azure_kusto_store_exit(struct flb_azure_kusto *ctx)
             fsf = mk_list_entry(f_head, struct flb_fstore_file, _head);
             if (fsf->data != NULL) {
                 azure_kusto_file = fsf->data;
+                /* Avoid leaving fstore with a pointer to freed plugin state. */
+                fsf->data = NULL;
                 flb_free(azure_kusto_file);
             }
         }
@@ -528,6 +531,10 @@ int azure_kusto_store_exit(struct flb_azure_kusto *ctx)
 
     if (ctx->fs) {
         flb_fstore_destroy(ctx->fs);
+        /* Clear stale fstore handles after destroy. */
+        ctx->fs = NULL;
+        ctx->stream_active = NULL;
+        ctx->stream_upload = NULL;
     }
     return 0;
 }
@@ -640,9 +647,12 @@ int azure_kusto_store_file_inactive(struct flb_azure_kusto *ctx, struct azure_ku
     struct flb_fstore_file *fsf;
 
     fsf = azure_kusto_file->fsf;
+    /* Avoid leaving fstore with a pointer to freed plugin state. */
+    fsf->data = NULL;
 
-    flb_free(azure_kusto_file);
     ret = flb_fstore_file_inactive(ctx->fs, fsf);
+    /* Free plugin state after fstore no longer references it. */
+    flb_free(azure_kusto_file);
 
     return ret;
 }
@@ -664,6 +674,8 @@ int azure_kusto_store_file_cleanup(struct flb_azure_kusto *ctx, struct azure_kus
     struct flb_fstore_file *fsf;
 
     fsf = azure_kusto_file->fsf;
+    /* Avoid leaving fstore with a pointer to freed plugin state. */
+    fsf->data = NULL;
 
     /* permanent deletion */
     flb_fstore_file_delete(ctx->fs, fsf);
@@ -691,7 +703,16 @@ int azure_kusto_store_file_delete(struct flb_azure_kusto *ctx, struct azure_kust
     struct flb_fstore_file *fsf;
 
     fsf = azure_kusto_file->fsf;
-    ctx->current_buffer_size -= azure_kusto_file->size;
+    /* Avoid leaving fstore with a pointer to freed plugin state. */
+    fsf->data = NULL;
+
+    if (ctx->current_buffer_size >= azure_kusto_file->size) {
+        ctx->current_buffer_size -= azure_kusto_file->size;
+    }
+    else {
+        /* Clamp repeated cleanup paths instead of underflowing the counter. */
+        ctx->current_buffer_size = 0;
+    }
 
     /* permanent deletion */
     flb_fstore_file_delete(ctx->fs, fsf);

--- a/tests/runtime/out_azure_kusto.c
+++ b/tests/runtime/out_azure_kusto.c
@@ -19,10 +19,110 @@
  */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_utils.h>
+#include <chunkio/cio_utils.h>
 #include "flb_tests_runtime.h"
+#include "../../plugins/out_azure_kusto/azure_kusto_ingest.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#define FLB_KUSTO_GETPID _getpid
+#define FLB_KUSTO_BUFFER_DIR_FORMAT "flb-kusto-test-%d"
+#else
+#include <dirent.h>
+#include <unistd.h>
+#define FLB_KUSTO_GETPID getpid
+#define FLB_KUSTO_BUFFER_DIR_FORMAT "/tmp/flb-kusto-test-%d"
+#endif
 
 /* Test data */
 #include "data/common/json_invalid.h" /* JSON_INVALID */
+
+static int flb_kusto_rm_rf(const char *path)
+{
+    int ret;
+    struct stat st;
+
+    if (stat(path, &st) != 0) {
+        return 0;
+    }
+
+    ret = cio_utils_recursive_delete(path);
+    if (ret != 0) {
+        TEST_MSG("failed to clean buffer directory '%s' errno=%d", path, errno);
+    }
+
+    return ret;
+}
+
+static int flb_kusto_dir_has_entries(const char *path)
+{
+#ifdef _WIN32
+    int ret;
+    int has_entries;
+    char pattern[MAX_PATH];
+    WIN32_FIND_DATAA find_data;
+    HANDLE find_handle;
+
+    ret = snprintf(pattern, sizeof(pattern), "%s\\*", path);
+    if (ret <= 0 || (size_t) ret >= sizeof(pattern)) {
+        return FLB_FALSE;
+    }
+
+    find_handle = FindFirstFileA(pattern, &find_data);
+    if (find_handle == INVALID_HANDLE_VALUE) {
+        return FLB_FALSE;
+    }
+
+    has_entries = FLB_FALSE;
+    do {
+        if (strcmp(find_data.cFileName, ".") != 0 &&
+            strcmp(find_data.cFileName, "..") != 0) {
+            has_entries = FLB_TRUE;
+            break;
+        }
+    } while (FindNextFileA(find_handle, &find_data));
+
+    FindClose(find_handle);
+    return has_entries;
+#else
+    DIR *dir;
+    struct dirent *entry;
+    int has_entries;
+
+    dir = opendir(path);
+    if (!dir) {
+        return FLB_FALSE;
+    }
+
+    has_entries = FLB_FALSE;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") != 0 &&
+            strcmp(entry->d_name, "..") != 0) {
+            has_entries = FLB_TRUE;
+            break;
+        }
+    }
+
+    closedir(dir);
+    return has_entries;
+#endif
+}
+
+static void flb_kusto_sleep_seconds(int seconds)
+{
+#ifdef _WIN32
+    Sleep((DWORD) seconds * 1000);
+#else
+    sleep(seconds);
+#endif
+}
 
 /* Test functions */
 void flb_test_azure_kusto_json_invalid(void);
@@ -30,6 +130,8 @@ void flb_test_azure_kusto_managed_identity_system(void);
 void flb_test_azure_kusto_managed_identity_user(void);
 void flb_test_azure_kusto_service_principal(void);
 void flb_test_azure_kusto_workload_identity(void);
+void flb_test_azure_kusto_buffer_delete_early_enqueue_result(void);
+void flb_test_azure_kusto_buffering_backlog(void);
 
 /* Test list */
 TEST_LIST = {
@@ -38,6 +140,9 @@ TEST_LIST = {
     {"managed_identity_user", flb_test_azure_kusto_managed_identity_user},
     {"service_principal", flb_test_azure_kusto_service_principal},
     {"workload_identity", flb_test_azure_kusto_workload_identity},
+    {"buffer_delete_early_enqueue_result",
+     flb_test_azure_kusto_buffer_delete_early_enqueue_result},
+    {"buffering_backlog", flb_test_azure_kusto_buffering_backlog},
     {NULL, NULL}
 };
 
@@ -78,7 +183,7 @@ void flb_test_azure_kusto_json_invalid(void)
         total++;
     }
 
-    sleep(1); /* waiting flush */
+    flb_kusto_sleep_seconds(1); /* waiting flush */
 
     flb_stop(ctx);
     flb_destroy(ctx);
@@ -210,4 +315,143 @@ void flb_test_azure_kusto_workload_identity(void)
 
     flb_stop(ctx);
     flb_destroy(ctx);
+}
+
+void flb_test_azure_kusto_buffer_delete_early_enqueue_result(void)
+{
+    struct flb_azure_kusto ctx;
+    struct azure_kusto_file upload_file;
+    int ret;
+
+    memset(&ctx, 0, sizeof(ctx));
+    memset(&upload_file, 0, sizeof(upload_file));
+
+    ctx.buffering_enabled = FLB_TRUE;
+    ctx.buffer_file_delete_early = FLB_TRUE;
+
+    ret = azure_kusto_should_early_delete_buffer_file(&ctx, &upload_file, -1);
+    TEST_CHECK_(ret == FLB_FALSE,
+                "failed enqueue must keep local buffer available for retry");
+
+    ret = azure_kusto_should_early_delete_buffer_file(&ctx, &upload_file, 0);
+    TEST_CHECK_(ret == FLB_TRUE,
+                "successful enqueue should allow early local buffer deletion");
+
+    ctx.buffer_file_delete_early = FLB_FALSE;
+    ret = azure_kusto_should_early_delete_buffer_file(&ctx, &upload_file, 0);
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ctx.buffer_file_delete_early = FLB_TRUE;
+    ret = azure_kusto_should_early_delete_buffer_file(&ctx, NULL, 0);
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ctx.buffering_enabled = FLB_FALSE;
+    ret = azure_kusto_should_early_delete_buffer_file(&ctx, &upload_file, 0);
+    TEST_CHECK(ret == FLB_FALSE);
+}
+
+/* Regression: exercise buffering-enabled backlog processing on restart */
+void flb_test_azure_kusto_buffering_backlog(void)
+{
+    int i;
+    int ret;
+    int has_buffered_chunks;
+    char buffer_dir[64];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ret = snprintf(buffer_dir, sizeof(buffer_dir), FLB_KUSTO_BUFFER_DIR_FORMAT,
+                   (int) FLB_KUSTO_GETPID());
+    if (ret <= 0 || (size_t) ret >= sizeof(buffer_dir)) {
+        TEST_MSG("failed to build buffer directory path");
+        TEST_CHECK(ret > 0 && (size_t) ret < sizeof(buffer_dir));
+        return;
+    }
+
+    ret = flb_kusto_rm_rf(buffer_dir);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        return;
+    }
+
+    ret = flb_utils_mkdir(buffer_dir, 0700);
+    if (ret != 0) {
+        TEST_MSG("failed to create buffer directory '%s' errno=%d", buffer_dir, errno);
+        TEST_CHECK(ret == 0);
+        return;
+    }
+
+    /* First run: enable buffering and write data to disk */
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "dummy", "{\"k\":\"v\"}", NULL);
+    flb_input_set(ctx, in_ffd, "samples", "1", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "azure_kusto", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "auth_type", "managed_identity", NULL);
+    flb_output_set(ctx, out_ffd, "client_id", "system", NULL);
+    flb_output_set(ctx, out_ffd, "ingestion_endpoint",
+                   "https://ingest-CLUSTER.kusto.windows.net", NULL);
+    flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
+    flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
+    flb_output_set(ctx, out_ffd, "buffering_enabled", "true", NULL);
+    flb_output_set(ctx, out_ffd, "buffer_dir", buffer_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < 5; i++) {
+        if (flb_kusto_dir_has_entries(buffer_dir) == FLB_TRUE) {
+            break;
+        }
+        flb_kusto_sleep_seconds(1);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    has_buffered_chunks = flb_kusto_dir_has_entries(buffer_dir);
+    TEST_CHECK_(has_buffered_chunks == FLB_TRUE,
+                "expected buffered chunks in '%s'", buffer_dir);
+
+    /* Second run: restart and flush while backlog is present */
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "dummy", "{\"k\":\"v2\"}", NULL);
+    flb_input_set(ctx, in_ffd, "samples", "1", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "azure_kusto", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "auth_type", "managed_identity", NULL);
+    flb_output_set(ctx, out_ffd, "client_id", "system", NULL);
+    flb_output_set(ctx, out_ffd, "ingestion_endpoint",
+                   "https://ingest-CLUSTER.kusto.windows.net", NULL);
+    flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
+    flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
+    flb_output_set(ctx, out_ffd, "buffering_enabled", "true", NULL);
+    flb_output_set(ctx, out_ffd, "buffer_dir", buffer_dir, NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "6s", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_kusto_sleep_seconds(8); /* drive flush, backlog ingest, and upload timer */
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    ret = flb_kusto_rm_rf(buffer_dir);
+    TEST_CHECK(ret == 0);
 }


### PR DESCRIPTION
## Summary

Fix Azure Kusto buffered-file lifecycle races between flush, upload timer, and shutdown paths. The race was observed as intermittent SIGSEGV crashes while the upload timer was reading buffered file contents around task/file cleanup.

Crash signature observed in `out_azure_kusto` buffered mode:

```text
#0  memcpy()
#1  cio_file_content_copy()
#2  flb_fstore_file_content_copy()
#3  construct_request_buffer() at plugins/out_azure_kusto/azure_kusto.c
#4  cb_azure_kusto_ingest() at plugins/out_azure_kusto/azure_kusto.c
#5  flb_sched_event_handler()
#6  output_thread()
```

One failing run logged task destruction immediately before the SIGSEGV, which is consistent with the upload timer and flush/task cleanup paths racing over buffered file state.

Changes:
- guard buffered flush, upload timer, and exit paths so they do not concurrently inspect or mutate fstore file lists
- keep the upload timer handle and invalidate it before shutdown destroys plugin state
- clear `fsf->data` before freeing Azure Kusto file contexts
- when `buffer_file_delete_early` is enabled, delete buffered files only after queue enqueue succeeds
- add runtime coverage for buffered backlog restart and early-delete enqueue policy

## Testing

- `git diff --check origin/master..HEAD`
- `cmake --build build --target flb-plugin-out_azure_kusto -j2`
- `cmake --build build --target flb-rt-out_azure_kusto -j2`
- `./build/bin/flb-rt-out_azure_kusto buffer_delete_early_enqueue_result`
- `ctest --test-dir build -R '^flb-rt-out_azure_kusto$' --output-on-failure`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master uv run --quiet --with gitpython python .github/scripts/commit_prefix_check.py`
