### PR TITLE
Rename custom target from 'check' to 'nghttp2_check'

### DIFF
--- a/lib/nghttp2-1.65.0/CMakeLists.txt
+++ b/lib/nghttp2-1.65.0/CMakeLists.txt
@@ -188,7 +188,7 @@ endif()
 # APP_LIBRARIES if it is really specific to OpenSSL?
 
 enable_testing()
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+add_custom_target(nghttp2_check COMMAND ${CMAKE_CTEST_COMMAND})
 
 # openssl (for src)
 include(CheckSymbolExists)


### PR DESCRIPTION
<!-- Provide summary of changes -->

Rename add_custom_target (check ...  to nghttp2_check as it conflicts with another variable with the same name.
This happens when building from source with -DFLB_AVRO_ENCODER=On


ERROR TEXT:

CMake Error at lib/nghttp2-1.65.0/CMakeLists.txt:191 (add_custom_target):
  add_custom_target cannot create target "check" because another target with
  the same name already exists. The existing target is a custom target
  created in source directory
  "/tmp/build/fluent-bit-4.2.1/lib/jansson-e23f558". See documentation for
  policy CMP0002 for more details.











Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration for the nghttp2 library.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->