### PR TITLE
config: Add support for --no-banner command line argument

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -78,8 +78,9 @@ struct flb_config {
     int daemon;               /* Run as a daemon ?              */
     flb_pipefd_t shutdown_fd; /* Shutdown FD, 5 seconds         */
 
-    int verbose;           /* Verbose mode (default OFF)     */
-    time_t init_time;      /* Time when Fluent Bit started   */
+    int verbose;           /* Verbose mode (default OFF)        */
+    int banner;            /* Print version banner (default ON) */
+    time_t init_time;      /* Time when Fluent Bit started      */
 
     /* Used in library mode */
     pthread_t worker;               /* worker tid */

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -274,6 +274,7 @@ struct flb_config *flb_config_init()
     config->init_time    = time(NULL);
     config->kernel       = flb_kernel_info();
     config->verbose      = 3;
+    config->banner       = FLB_TRUE;
     config->grace        = 5;
     config->grace_count  = 0;
     config->grace_input  = config->grace / 2;

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -170,6 +170,7 @@ static void flb_help(int rc, struct flb_config *config)
     print_opt_i("-s, --coro_stack_size", "set coroutines stack size in bytes",
                 config->coro_stack_size);
     print_opt("-q, --quiet", "quiet mode");
+    print_opt("-B, --no-banner", "Disable printing of version banner");
     print_opt("-S, --sosreport", "support report for Enterprise customers");
     print_opt("-Y, --enable-hot-reload", "enable for hot reloading");
     print_opt("-W, --disable-thread-safety-on-hot-reloading", "disable thread safety on hot reloading");
@@ -1068,6 +1069,7 @@ static int flb_main_run(int argc, char **argv)
         { "verbose",         no_argument      , NULL, 'v' },
         { "workdir",         required_argument, NULL, 'w' },
         { "quiet",           no_argument      , NULL, 'q' },
+        { "no-banner",       no_argument      , NULL, 'B' },
         { "help",            no_argument      , NULL, 'h' },
         { "help-json",       no_argument      , NULL, 'J' },
         { "coro_stack_size", required_argument, NULL, 's' },
@@ -1125,7 +1127,7 @@ static int flb_main_run(int argc, char **argv)
     /* Parse the command line options */
     while ((opt = getopt_long(argc, argv,
                               "b:c:dDf:C:i:m:M:o:R:r:F:p:e:"
-                              "t:T:l:vw:qVhJL:HP:s:SWYZ",
+                              "t:T:l:vBw:qVhJL:HP:s:SWYZ",
                               long_opts, NULL)) != -1) {
 
         switch (opt) {
@@ -1284,6 +1286,9 @@ static int flb_main_run(int argc, char **argv)
         case 'v':
             config->verbose++;
             break;
+        case 'B':
+            config->banner = FLB_FALSE;
+            break;
         case 'w':
             config->workdir =  flb_strdup(optarg);
             break;
@@ -1341,7 +1346,8 @@ static int flb_main_run(int argc, char **argv)
 
     set_log_level_from_env(config);
 
-    if (config->verbose != FLB_LOG_OFF) {
+    /* Show banner only if the configuration explicitly says so */
+    if (config->verbose != FLB_LOG_OFF && config->banner == FLB_TRUE) {
         flb_version_banner();
     }
 


### PR DESCRIPTION
Implement --no-banner command line argument in order to disable version banner printing altogether.

<!-- Provide summary of changes -->

This PR adds a new config flag that disables the version banner but preserves the normal logging mechanism. 
Using FluentBit in the context of a service sidecar with frequent service rotation, the version banner adds a non-negligent amount of log data to be consumed. Additionally, the MOTD is not indexed correctly and pollutes the log stream of FluentBit itself.

Having this flag will enable users to preserve needed logging but avoid the overhead of the version banner.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to suppress the version banner at startup (-B/--no-banner).
  * Version banner is enabled by default; use the new option to disable it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->