### PR TITLE
change http_passwd default value from "" to NULL

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -1072,7 +1072,7 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_STR, "http_passwd", "",
+     FLB_CONFIG_MAP_STR, "http_passwd", NULL,
      0, FLB_TRUE, offsetof(struct flb_splunk, http_passwd),
      "Set HTTP auth password"
     },


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

addresses https://github.com/fluent/fluent-bit/issues/11301

`from` FLB_CONFIG_MAP_STR, "http_passwd", **""**,

`to` FLB_CONFIG_MAP_STR, "http_passwd", **NULL**,



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [ ] Debug log output from testing the change

example run:
<img width="554" height="249" alt="image" src="https://github.com/user-attachments/assets/5248121e-7b4c-4085-a9f1-92b64ce4e438" />

conf
```
[INPUT]
  name splunk
  listen 0.0.0.0
  port 8088
  tls off
  tls.verify off
  store_token_in_metadata true

[OUTPUT]
  name stdout
  match *

[OUTPUT]
  name splunk
  match *
  host localhost
  port 8888
  tls off
  tls.verify off
  http_user ZZZ
```

conf2
```
[INPUT]
  name dummy

[OUTPUT]
  name splunk
  host localhost
  port 8088
  tls off
  tls.verify off
  Splunk_Token AAA
```

conf3
```
[INPUT]
  name dummy

[OUTPUT]
  name splunk
  host localhost
  port 8088
  tls off
  tls.verify off
  Splunk_Token BBB
```

start print
```
Fluent Bit v4.2.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____ 
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /  
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/
                                                                  
             Fluent Bit v4.2 – Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2025/12/24 21:24:51.95145216] [ info] [fluent bit] version=4.2.2, commit=ddfef360d7, pid=63145
[2025/12/24 21:24:51.95213048] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/12/24 21:24:51.95229948] [ info] [simd    ] disabled
[2025/12/24 21:24:51.95235329] [ info] [cmetrics] version=1.0.6
[2025/12/24 21:24:51.95244089] [ info] [ctraces ] version=0.6.6
[2025/12/24 21:24:51.95322881] [ info] [input:splunk:splunk.0] initializing
[2025/12/24 21:24:51.95335211] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2025/12/24 21:24:51.95441444] [ info] [input:splunk:splunk.0] listening on 0.0.0.0:8088
[2025/12/24 21:24:51.95757213] [ info] [output:stdout:stdout.0] worker #0 started
[2025/12/24 21:24:51.95979679] [ info] [output:splunk:splunk.1] worker #0 started
[2025/12/24 21:24:51.96092022] [ info] [sp] stream processor started
[2025/12/24 21:24:51.96123483] [ info] [output:splunk:splunk.1] worker #1 started
[2025/12/24 21:24:51.96148123] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[0] splunk.0: [[1766611491.302205969, {"hec_token"=>"Splunk BBB"}], {"time"=>1766611480.299107, "event"=>{"message"=>"dummy"}}]
[1] splunk.0: [[1766611491.302364073, {"hec_token"=>"Splunk BBB"}], {"time"=>1766611484.299124, "event"=>{"message"=>"dummy"}}]
[2] splunk.0: [[1766611491.302420675, {"hec_token"=>"Splunk AAA"}], {"time"=>1766611479.299183, "event"=>{"message"=>"dummy"}}]
```

flask app
```python
from flask import Flask, request
app = Flask(__name__)

@app.route('/services/collector/event', methods=['POST'])
def hello_world():
    print(request.headers)
    return 'Hello, World!'

if __name__ == '__main__':
    app.run(host="0.0.0.0", port="8888", debug=True)
```

flask application to get headers
<img width="732" height="258" alt="image" src="https://github.com/user-attachments/assets/b9fbba5e-db06-4b88-8b5c-983ba9455d2c" />


Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>

valgrind run
`valgrind ./fluent-bit -c conf`

ending

```
[2025/12/24 21:23:27.304159569] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2025/12/24 21:23:27.310661178] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2025/12/24 21:23:27.344923999] [ info] [output:splunk:splunk.1] thread worker #0 stopping...
[2025/12/24 21:23:27.346641964] [ info] [output:splunk:splunk.1] thread worker #0 stopped
[2025/12/24 21:23:27.348299827] [ info] [output:splunk:splunk.1] thread worker #1 stopping...
[2025/12/24 21:23:27.348608595] [ info] [output:splunk:splunk.1] thread worker #1 stopped
==63061== 
==63061== HEAP SUMMARY:
==63061==     in use at exit: 0 bytes in 0 blocks
==63061==   total heap usage: 13,061 allocs, 13,061 frees, 12,303,089 bytes allocated
==63061== 
==63061== All heap blocks were freed -- no leaks are possible
==63061== 
==63061== Use --track-origins=yes to see where uninitialised values come from
==63061== For lists of detected and suppressed errors, rerun with: -s
==63061== ERROR SUMMARY: 325184 errors from 1000 contexts (suppressed: 0 from 0)
```


----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default password configuration behavior in the Splunk output plugin to correctly represent and handle cases where no password is specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->