### PR TITLE
add gzip compression option for prometheus exporter

### DIFF
--- a/plugins/out_prometheus_exporter/prom_http.c
+++ b/plugins/out_prometheus_exporter/prom_http.c
@@ -260,7 +260,8 @@ static void cb_metrics(mk_request_t *request, void *data)
         mk_http_header(request, "Content-Encoding", 16, "gzip", 4);
         mk_http_send(request, compressed_data, compressed_size, NULL);
         flb_free(compressed_data);
-    } else {
+    }
+    else {
         mk_http_send(request, buf->buf_data, buf->buf_size, NULL);
     }
     


### PR DESCRIPTION
<!-- Provide summary of changes -->
It allows the prometheus exporter to serve compressed responses when the appropriate Accept Encoding header is set by the client.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes https://github.com/fluent/fluent-bit/issues/11320

----

**Testing**

fluent-bit.conf
```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    Parsers_File parsers.conf

    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name        dummy
    Dummy       {"message":"dummy", "kubernetes":{"namespace_name": "default", "docker_id": "abc123", "pod_name": "pod1", "container_name": "mycontainer", "pod_id": "def456", "labels":{"app": "app1"}}, "duration": 20, "color": "red", "shape": "circle"}
    Tag         dummy.log

[INPUT]
    Name        dummy
    Dummy       {"message":"hello", "kubernetes":{"namespace_name": "default", "docker_id": "abc123", "pod_name": "pod1", "container_name": "mycontainer", "pod_id": "def456", "labels":{"app": "app1"}}, "duration": 60, "color": "blue", "shape": "square"}
    Tag         dummy.log2

[FILTER]
    name               log_to_metrics
    match              dummy.log*
    tag                test_metric
    metric_mode        counter
    metric_name        count_all_dummy_messages
    metric_description This metric counts dummy messages

[OUTPUT]
    name    prometheus_exporter
    match   *
    host    0.0.0.0
    port    9999

```

test requests
```
i@i:~/workspace/triton/fluent-bit/build$ curl localhost:9999/metrics -H "Accept-Encoding: gzip" -v --compressed
* Host localhost:9999 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:9999...
* connect to ::1 port 9999 from ::1 port 49998 failed: Connection refused
*   Trying 127.0.0.1:9999...
* Connected to localhost (127.0.0.1) port 9999
> GET /metrics HTTP/1.1
> Host: localhost:9999
> User-Agent: curl/8.5.0
> Accept: */*
> Accept-Encoding: gzip
> 
< HTTP/1.1 200 OK
< Server: Monkey/1.8.6
< Date: Mon, 29 Dec 2025 10:42:38 GMT
< Transfer-Encoding: chunked
< Content-Type: text/plain; version=0.0.4
< Content-Encoding: gzip
< 
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 21
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 22
* Connection #0 to host localhost left intact
i@i:~/workspace/triton/fluent-bit/build$ curl localhost:9999/metrics -v
* Host localhost:9999 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:9999...
* connect to ::1 port 9999 from ::1 port 50006 failed: Connection refused
*   Trying 127.0.0.1:9999...
* Connected to localhost (127.0.0.1) port 9999
> GET /metrics HTTP/1.1
> Host: localhost:9999
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: Monkey/1.8.6
< Date: Mon, 29 Dec 2025 10:42:41 GMT
< Transfer-Encoding: chunked
< Content-Type: text/plain; version=0.0.4
< 
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 27
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 28
* Connection #0 to host localhost left intact

```

valgrind
```
valgrind --leak-check=full bin/fluent-bit --config fluent-bit.conf 
==378238== Memcheck, a memory error detector
==378238== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==378238== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==378238== Command: bin/fluent-bit --config fluent-bit.conf
==378238== 
Fluent Bit v4.2.3
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____ 
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /  
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/
                                                                  
             Fluent Bit v4.2 – Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2025/12/29 17:42:26.859033176] [error] [/home/i/workspace/triton/fluent-bit/src/config_format/flb_cf_fluentbit.c:289 errno=2] No such file or directory
[2025/12/29 17:42:26.873744505] [error] file=/home/i/workspace/triton/fluent-bit/build/parsers.conf
[2025/12/29 17:42:26.942204959] [ info] [fluent bit] version=4.2.3, commit=7b0c1aebb6, pid=378238
[2025/12/29 17:42:26.954875222] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/12/29 17:42:26.955273358] [ info] [simd    ] disabled
[2025/12/29 17:42:26.955536705] [ info] [cmetrics] version=1.0.6
[2025/12/29 17:42:26.955774331] [ info] [ctraces ] version=0.6.6
[2025/12/29 17:42:26.969658549] [ info] [input:dummy:dummy.0] initializing
[2025/12/29 17:42:26.970305614] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/12/29 17:42:26.990696434] [ info] [input:dummy:dummy.1] initializing
[2025/12/29 17:42:26.990853866] [ info] [input:dummy:dummy.1] storage_strategy='memory' (memory only)
[2025/12/29 17:42:27.4379214] [ info] [input:emitter:emitter_for_log_to_metrics.0] initializing
[2025/12/29 17:42:27.4518352] [ info] [input:emitter:emitter_for_log_to_metrics.0] storage_strategy='memory' (memory only)
[2025/12/29 17:42:27.95259058] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=9999
[2025/12/29 17:42:27.158827405] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2025/12/29 17:42:27.160001703] [ info] [sp] stream processor started
[2025/12/29 17:42:27.162278621] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
==378238== Warning: client switching stacks?  SP change: 0x63ac198 --> 0x59ebdb0
==378238==          to suppress, use: --max-stackframe=10224616 or greater
==378238== Warning: client switching stacks?  SP change: 0x59ebc98 --> 0x63ac198
==378238==          to suppress, use: --max-stackframe=10224896 or greater
==378238== Warning: client switching stacks?  SP change: 0x63ac4f8 --> 0x59ebc98
==378238==          to suppress, use: --max-stackframe=10225760 or greater
==378238==          further instances of this message will not be shown.
^C[2025/12/29 17:42:55] [engine] caught signal (SIGINT)
[2025/12/29 17:42:55.552831886] [ warn] [engine] service will shutdown in max 5 seconds
[2025/12/29 17:42:55.554362770] [ info] [engine] pausing all inputs..
[2025/12/29 17:42:55.556146059] [ info] [input] pausing dummy.0
[2025/12/29 17:42:55.559915898] [ info] [input] pausing dummy.1
[2025/12/29 17:42:55.560153776] [ info] [input] pausing emitter_for_log_to_metrics.0
[2025/12/29 17:42:56.448458227] [ info] [engine] service has stopped (0 pending tasks)
[2025/12/29 17:42:56.448966294] [ info] [input] pausing dummy.0
[2025/12/29 17:42:56.449161069] [ info] [input] pausing dummy.1
[2025/12/29 17:42:56.449256903] [ info] [input] pausing emitter_for_log_to_metrics.0
==378238== 
==378238== HEAP SUMMARY:
==378238==     in use at exit: 0 bytes in 0 blocks
==378238==   total heap usage: 77,249 allocs, 77,249 frees, 31,956,228 bytes allocated
==378238== 
==378238== All heap blocks were freed -- no leaks are possible
==378238== 
==378238== For lists of detected and suppressed errors, rerun with: -s
==378238== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics endpoint negotiates gzip per request, sending compressed responses when clients indicate support and adding the Content-Encoding: gzip header.
  * Accept-Encoding parsing is case-insensitive and token-aware for more robust client detection.
  * Metrics endpoint returns 404 when no metrics are available.

* **Bug Fixes / Reliability**
  * Gracefully falls back to uncompressed responses if compression fails.
  * Ensures compressed buffers are properly cleaned up to prevent resource issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->