### PR TITLE
bin: Handle CONT signal properly under leaks command

### DIFF
--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -1492,7 +1492,8 @@ static int flb_main_run(int argc, char **argv)
 #ifdef FLB_SYSTEM_WINDOWS
         flb_console_handler_set_ctx(ctx, cf_opts);
 #endif
-        if (dump_requested) {
+        if (dump_requested &&
+            ctx != NULL && ctx->config != NULL) {
             dump_requested = 0;
             flb_dump(ctx->config);
         }


### PR DESCRIPTION
On macOS, we need to handle COND signal properly.
This is because under controling leaks command, it also sends COND signal after releasing its managing process(es).
To mitigate this, we need to use flag to mark for distinguish dump to be requested.
And we need to run it inside main loop.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [x] Debug log output from testing the change

Before applying this patch:

```
Process 33730 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [33730]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x104290000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [33729]
Target Type:     live task

Date/Time:       2026-01-05 16:46:47.791 +0900
Launch Time:     2026-01-05 16:46:15.802 +0900
OS Version:      macOS 26.0.1 (25A362)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         8320K
Physical footprint (peak):  9008K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 33730: 1277 nodes malloced for 216 KB
Process 33730: 0 leaks for 0 total leaked bytes.

[2026/01/05 16:46:49] [engine] caught signal (SIGCONT)
[2026/01/05 16:46:49] Fluent Bit Dump

===== Input =====
[2026/01/05 16:46:49] [engine] caught signal (SIGSEGV)
ERROR: no debug info in Mach-O executable (-1)ERROR: no debug info in Mach-O executable (-1)ERROR: no debug info in Mach-O executable (-1)ERROR: no debug info in Mach-O executable (-1)ERROR: no debug info in Mach-O executable (-1)ERROR: no debug info in Mach-O executable (-1)(base) 
```

SEGV occurred due to free-ed memory region was requested to use.

After applying this patch:

```
rocess 37337 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [37337]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x102f8c000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [37336]
Target Type:     live task

Date/Time:       2026-01-05 16:54:59.581 +0900
Launch Time:     2026-01-05 16:54:52.693 +0900
OS Version:      macOS 26.0.1 (25A362)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         8416K
Physical footprint (peak):  9024K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 37337: 1277 nodes malloced for 216 KB
Process 37337: 0 leaks for 0 total leaked bytes.

[2026/01/05 16:55:00] [engine] caught signal (SIGCONT)
```

Also, CONT signal is properly processed:

```
[2026/01/05 16:55:12] [engine] caught signal (SIGCONT)
[2026/01/05 16:55:12] Fluent Bit Dump

===== Input =====
opentelemetry.0 (opentelemetry)
│
├─ status
│  └─ overlimit     : no
│     ├─ mem size   : 0b (0 bytes)
│     └─ mem limit  : 0b (0 bytes)
│
├─ tasks
│  ├─ total tasks   : 0
│  ├─ new           : 0
│  ├─ running       : 0
│  └─ size          : 0b (0 bytes)
│
└─ chunks
   └─ total chunks  : 0
      ├─ up chunks  : 0
      ├─ down chunks: 0
      └─ busy chunks: 0
         ├─ size    : 0b (0 bytes)
         └─ size err: 0


===== Storage Layer =====
total chunks     : 0
├─ mem chunks    : 0
└─ fs chunks     : 0
   ├─ up         : 0
   └─ down       : 0
^C[2026/01/05 16:55:18] [engine] caught signal (SIGINT)
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling by deferring dump requests to the main event loop rather than executing them inside the signal handler, increasing stability and safety.
  * Added a lightweight, signal-safe request mechanism so dump operations are performed asynchronously during normal processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->