### PR TITLE
filter_log_to_metrics: allow counter metrics to use value_field instead of increment by 1 only

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.c
+++ b/plugins/filter_log_to_metrics/log_to_metrics.c
@@ -849,6 +849,7 @@ static int cb_log_to_metrics_filter(const void *data, size_t bytes,
     char **label_values = NULL;
     int label_count = 0;
     int i;
+    int sscanf_ret = 0;
     double gauge_value = 0;
     double histogram_value = 0;
     double counter_value = 0;
@@ -937,7 +938,7 @@ static int cb_log_to_metrics_filter(const void *data, size_t bytes,
                         else {
                             /* Read value from field */
                             if (rval->type == FLB_RA_STRING) {
-                                int sscanf_ret = sscanf(rval->val.string, "%lf", &counter_value);
+                                sscanf_ret = sscanf(rval->val.string, "%lf", &counter_value);
                                 if (sscanf_ret != 1) {
                                     flb_plg_error(f_ins,
                                                 "cannot parse value_field '%s' as numeric, falling back to increment by 1",


### PR DESCRIPTION
It allows users to specify a key (value_field) as the value to increment the counters by, instead of only incrementing by 1.

Closes #11343 

Testing:

First test uncommented `#value_field        duration`

```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info
    Parsers_File parsers.conf

    HTTP_Server  On
    HTTP_Listen  0.0.0.0
    HTTP_Port    2020

[INPUT]
    Name        dummy
    Dummy       {"message":"dummy", "kubernetes":{"namespace_name": "default", "docker_id": "abc123", "pod_name": "pod1", "container_name": "mycontainer", "pod_id": "def456", "labels":{"app": "app1"}}, "duration": 20, "color": "red", "shape": "circle"}
    Tag         dummy.log

[INPUT]
    Name        dummy
    Dummy       {"message":"hello", "kubernetes":{"namespace_name": "default", "docker_id": "abc123", "pod_name": "pod1", "container_name": "mycontainer", "pod_id": "def456", "labels":{"app": "app1"}}, "duration": 60, "color": "blue", "shape": "square"}
    Tag         dummy.log2

[FILTER]
    name               log_to_metrics
    match              dummy.log*
    tag                test_metric
    metric_mode        counter
    metric_name        count_all_dummy_messages
    metric_description This metric counts dummy messages (increments by 1)

[FILTER]
    name               log_to_metrics
    match              dummy.log*
    tag                test_metric
    metric_mode        counter
    metric_name        duration_total
    metric_description Total duration accumulated (tests value_field support)
    #value_field        duration
    label_field        color
    label_field        shape

[OUTPUT]
    name    prometheus_exporter
    match   *
    host    0.0.0.0
    port    9999

```
Using value_field
```
curl localhost:9999/metrics
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages (increments by 1)
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 5
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages (increments by 1)
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 6
# HELP log_metric_counter_duration_total Total duration accumulated (tests value_field support)
# TYPE log_metric_counter_duration_total counter
log_metric_counter_duration_total{color="red",shape="circle"} 60
log_metric_counter_duration_total{color="blue",shape="square"} 120
# HELP log_metric_counter_duration_total Total duration accumulated (tests value_field support)
# TYPE log_metric_counter_duration_total counter
log_metric_counter_duration_total{color="red",shape="circle"} 60
log_metric_counter_duration_total{color="blue",shape="square"} 180

```


Default (commented out value_field): increment by 1 
```
curl localhost:9999/metrics
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages (increments by 1)
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 3
# HELP log_metric_counter_count_all_dummy_messages This metric counts dummy messages (increments by 1)
# TYPE log_metric_counter_count_all_dummy_messages counter
log_metric_counter_count_all_dummy_messages 4
# HELP log_metric_counter_duration_total Total duration accumulated (tests value_field support)
# TYPE log_metric_counter_duration_total counter
log_metric_counter_duration_total{color="red",shape="circle"} 2
log_metric_counter_duration_total{color="blue",shape="square"} 1
# HELP log_metric_counter_duration_total Total duration accumulated (tests value_field support)
# TYPE log_metric_counter_duration_total counter
log_metric_counter_duration_total{color="red",shape="circle"} 2
log_metric_counter_duration_total{color="blue",shape="square"} 2

```

```
valgrind --leak-check=full bin/fluent-bit -c fluent-bit.conf 
==2611580== Memcheck, a memory error detector
==2611580== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==2611580== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==2611580== Command: bin/fluent-bit -c fluent-bit.conf
==2611580== 
Fluent Bit v4.2.3
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____ 
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /  
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/
                                                                  
             Fluent Bit v4.2 – Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2026/01/06 12:01:21.536942211] [error] [/home/i/workspace/triton/fluent-bit/src/config_format/flb_cf_fluentbit.c:289 errno=2] No such file or directory
[2026/01/06 12:01:21.551482920] [error] file=/home/i/workspace/triton/fluent-bit/build/parsers.conf
[2026/01/06 12:01:21.626731651] [ info] [fluent bit] version=4.2.3, commit=7b0c1aebb6, pid=2611580
[2026/01/06 12:01:21.639521437] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/06 12:01:21.639948404] [ info] [simd    ] disabled
[2026/01/06 12:01:21.640220556] [ info] [cmetrics] version=1.0.6
[2026/01/06 12:01:21.640453141] [ info] [ctraces ] version=0.6.6
[2026/01/06 12:01:21.652611648] [ info] [input:dummy:dummy.0] initializing
[2026/01/06 12:01:21.653217679] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/01/06 12:01:21.668451275] [ info] [input:dummy:dummy.1] initializing
[2026/01/06 12:01:21.668512362] [ info] [input:dummy:dummy.1] storage_strategy='memory' (memory only)
[2026/01/06 12:01:21.678781931] [ info] [input:emitter:emitter_for_log_to_metrics.0] initializing
[2026/01/06 12:01:21.680224323] [ info] [input:emitter:emitter_for_log_to_metrics.0] storage_strategy='memory' (memory only)
[2026/01/06 12:01:21.687729868] [ info] [input:emitter:emitter_for_log_to_metrics.1] initializing
[2026/01/06 12:01:21.687810473] [ info] [input:emitter:emitter_for_log_to_metrics.1] storage_strategy='memory' (memory only)
[2026/01/06 12:01:21.782692676] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=9999
[2026/01/06 12:01:21.847173454] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2026/01/06 12:01:21.848473193] [ info] [sp] stream processor started
[2026/01/06 12:01:21.853101638] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
==2611580== Warning: client switching stacks?  SP change: 0x63ac198 --> 0x5a68290
==2611580==          to suppress, use: --max-stackframe=9715464 or greater
==2611580== Warning: client switching stacks?  SP change: 0x5a68178 --> 0x63ac198
==2611580==          to suppress, use: --max-stackframe=9715744 or greater
==2611580== Warning: client switching stacks?  SP change: 0x63ac198 --> 0x5a6e850
==2611580==          to suppress, use: --max-stackframe=9689416 or greater
==2611580==          further instances of this message will not be shown.
^C[2026/01/06 12:01:28] [engine] caught signal (SIGINT)
[2026/01/06 12:01:28.742793356] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/06 12:01:28.745915055] [ info] [engine] pausing all inputs..
[2026/01/06 12:01:28.748610819] [ info] [input] pausing dummy.0
[2026/01/06 12:01:28.750595550] [ info] [input] pausing dummy.1
[2026/01/06 12:01:28.750717534] [ info] [input] pausing emitter_for_log_to_metrics.0
[2026/01/06 12:01:28.751139462] [ info] [input] pausing emitter_for_log_to_metrics.1
[2026/01/06 12:01:28.865394107] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/06 12:01:28.865606734] [ info] [input] pausing dummy.0
[2026/01/06 12:01:28.865698209] [ info] [input] pausing dummy.1
[2026/01/06 12:01:28.865740580] [ info] [input] pausing emitter_for_log_to_metrics.0
[2026/01/06 12:01:28.865777040] [ info] [input] pausing emitter_for_log_to_metrics.1
==2611580== 
==2611580== HEAP SUMMARY:
==2611580==     in use at exit: 0 bytes in 0 blocks
==2611580==   total heap usage: 24,407 allocs, 24,407 frees, 11,017,711 bytes allocated
==2611580== 
==2611580== All heap blocks were freed -- no leaks are possible
==2611580== 
==2611580== For lists of detected and suppressed errors, rerun with: -s
==2611580== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

```
valgrind --leak-check=full bin/fluent-bit -c fluent-bit.conf 
==2612802== Memcheck, a memory error detector
==2612802== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==2612802== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==2612802== Command: bin/fluent-bit -c fluent-bit.conf
==2612802== 
Fluent Bit v4.2.3
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____ 
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /  
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/
                                                                  
             Fluent Bit v4.2 – Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2026/01/06 12:02:13.923881011] [error] [/home/i/workspace/triton/fluent-bit/src/config_format/flb_cf_fluentbit.c:289 errno=2] No such file or directory
[2026/01/06 12:02:13.937950753] [error] file=/home/i/workspace/triton/fluent-bit/build/parsers.conf
[2026/01/06 12:02:14.5145604] [ info] [fluent bit] version=4.2.3, commit=7b0c1aebb6, pid=2612802
[2026/01/06 12:02:14.17649336] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/06 12:02:14.18073809] [ info] [simd    ] disabled
[2026/01/06 12:02:14.18358455] [ info] [cmetrics] version=1.0.6
[2026/01/06 12:02:14.18597373] [ info] [ctraces ] version=0.6.6
[2026/01/06 12:02:14.30416683] [ info] [input:dummy:dummy.0] initializing
[2026/01/06 12:02:14.30999420] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/01/06 12:02:14.46074389] [ info] [input:dummy:dummy.1] initializing
[2026/01/06 12:02:14.46126088] [ info] [input:dummy:dummy.1] storage_strategy='memory' (memory only)
[2026/01/06 12:02:14.56271561] [ info] [input:emitter:emitter_for_log_to_metrics.0] initializing
[2026/01/06 12:02:14.56322368] [ info] [input:emitter:emitter_for_log_to_metrics.0] storage_strategy='memory' (memory only)
[2026/01/06 12:02:14.59272522] [ info] [input:emitter:emitter_for_log_to_metrics.1] initializing
[2026/01/06 12:02:14.59320143] [ info] [input:emitter:emitter_for_log_to_metrics.1] storage_strategy='memory' (memory only)
[2026/01/06 12:02:14.151418218] [ info] [output:prometheus_exporter:prometheus_exporter.0] listening iface=0.0.0.0 tcp_port=9999
[2026/01/06 12:02:14.213239983] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2026/01/06 12:02:14.214016802] [ info] [sp] stream processor started
[2026/01/06 12:02:14.216024850] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
==2612802== Warning: client switching stacks?  SP change: 0x63ac198 --> 0x5a67360
==2612802==          to suppress, use: --max-stackframe=9719352 or greater
==2612802== Warning: client switching stacks?  SP change: 0x5a67248 --> 0x63ac198
==2612802==          to suppress, use: --max-stackframe=9719632 or greater
==2612802== Warning: client switching stacks?  SP change: 0x63ac198 --> 0x5a6d920
==2612802==          to suppress, use: --max-stackframe=9693304 or greater
==2612802==          further instances of this message will not be shown.
^C[2026/01/06 12:02:22] [engine] caught signal (SIGINT)
[2026/01/06 12:02:22.79837968] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/06 12:02:22.80637892] [ info] [engine] pausing all inputs..
[2026/01/06 12:02:22.81454376] [ info] [input] pausing dummy.0
[2026/01/06 12:02:22.84141937] [ info] [input] pausing dummy.1
[2026/01/06 12:02:22.84578945] [ info] [input] pausing emitter_for_log_to_metrics.0
[2026/01/06 12:02:22.86426907] [ info] [input] pausing emitter_for_log_to_metrics.1
[2026/01/06 12:02:22.874632189] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/06 12:02:22.875139922] [ info] [input] pausing dummy.0
[2026/01/06 12:02:22.875347931] [ info] [input] pausing dummy.1
[2026/01/06 12:02:22.875490625] [ info] [input] pausing emitter_for_log_to_metrics.0
[2026/01/06 12:02:22.875590196] [ info] [input] pausing emitter_for_log_to_metrics.1
==2612802== 
==2612802== HEAP SUMMARY:
==2612802==     in use at exit: 0 bytes in 0 blocks
==2612802==   total heap usage: 29,929 allocs, 29,929 frees, 12,646,511 bytes allocated
==2612802== 
==2612802== All heap blocks were freed -- no leaks are possible
==2612802== 
==2612802== For lists of detected and suppressed errors, rerun with: -s
==2612802== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gauge and histogram now require a configured value field and will fail setup if missing.
  * Counter metrics accept an optional value field; when provided counters add the specified numeric amount, otherwise they increment by 1.
  * Improved runtime validation and clearer error messages for missing, invalid, or non-numeric value fields.

* **Documentation**
  * Configuration description clarified for required vs. optional value field usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->