### PR TITLE
config_format: Align the behavior of dirname against POSIX in Windows

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -537,8 +537,10 @@ static char *dirname(char *path)
     ptr = strrchr(path, '\\');
 
     if (ptr == NULL) {
-        return path;
+        /* No directory component */
+        return ".";
     }
+
     *ptr++='\0';
     return path;
 }


### PR DESCRIPTION
When nothing found of directory separators on the given argument of dirname(), we need to align this behavior.
After aligning the behavior, we can proceed to load configurations from specified workdir folders.

<!-- Provide summary of changes -->

Closes https://github.com/fluent/fluent-bit/issues/11295.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Same as attached in #11295.

```
service:
  flush: 5
  daemon: false
  log_level: trace
  parsers_file: parsers.yaml

includes:
   - dpc-1.yaml
```
**dpc-1.yaml**
```
env:
  flush_interval: 1
```

```powershell
PS> bin/fluent-bit --config repro.yaml --workdir E:\fluent-bit\ -H -P 2021 -Y
```

- [x] Debug log output from testing the change

Then, we get to succeeded to load configurations with relative paths.

```log
Fluent Bit v4.2.3
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/

             Fluent Bit v4.2 ΓÇô Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2026/01/06 16:13:16.399835100] [ info] Configuration:
[2026/01/06 16:13:16.400089500] [ info]  flush time     | 5.000000 seconds
[2026/01/06 16:13:16.400115300] [ info]  grace          | 5 seconds
[2026/01/06 16:13:16.400131300] [ info]  daemon         | 0
[2026/01/06 16:13:16.400146300] [ info] ___________
[2026/01/06 16:13:16.400161600] [ info]  inputs:
[2026/01/06 16:13:16.400176200] [ info] ___________
[2026/01/06 16:13:16.400190800] [ info]  filters:
[2026/01/06 16:13:16.400205600] [ info] ___________
[2026/01/06 16:13:16.400220200] [ info]  outputs:
[2026/01/06 16:13:16.400234900] [ info] ___________
[2026/01/06 16:13:16.400249500] [ info]  collectors:
[2026/01/06 16:13:16.401349700] [ info] [fluent bit] version=4.2.3, commit=9191f70794, pid=40568
[2026/01/06 16:13:16.401364400] [debug] [engine] maxstdio set: 512
[2026/01/06 16:13:16.401373300] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2026/01/06 16:13:16.401569300] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/06 16:13:16.401583700] [ info] [simd    ] SSE2
[2026/01/06 16:13:16.401591300] [ info] [cmetrics] version=1.0.6
[2026/01/06 16:13:16.401599300] [ info] [ctraces ] version=0.6.6
[2026/01/06 16:13:16.403254900] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2021
[2026/01/06 16:13:16.403282800] [ info] [sp] stream processor started
[2026/01/06 16:13:16.403567500] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/06 16:13:18.419403800] [ info] reloading instance pid=40568 tid=0000017311249D20
[2026/01/06 16:13:18.421596000] [ info] [reload] stop everything of the old context
[2026/01/06 16:13:18.421689600] [ warn] [engine] service will shutdown when all remaining tasks are flushed
[2026/01/06 16:13:18.421723700] [ info] [engine] pausing all inputs..
[2026/01/06 16:13:19.411231000] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/06 16:13:20.438255100] [ info] [reload] start everything
[2026/01/06 16:13:20.439534500] [ info] [fluent bit] version=4.2.3, commit=9191f70794, pid=40568
[2026/01/06 16:13:20.439582700] [debug] [engine] maxstdio set: 512
[2026/01/06 16:13:20.439597000] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2026/01/06 16:13:20.439926100] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/06 16:13:20.439940900] [ info] [simd    ] SSE2
[2026/01/06 16:13:20.439949200] [ info] [cmetrics] version=1.0.6
[2026/01/06 16:13:20.439956800] [ info] [ctraces ] version=0.6.6
[2026/01/06 16:13:20.441680500] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2021
[2026/01/06 16:13:20.441702200] [ info] [sp] stream processor started
[2026/01/06 16:13:20.441974600] [ info] [reload] successful reload done.
[2026/01/06 16:13:20.441972500] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/06 16:13:27.496399800] [ info] reloading instance pid=40568 tid=0000017311249D20
[2026/01/06 16:13:27.497697800] [ info] [reload] stop everything of the old context
[2026/01/06 16:13:27.497963300] [ warn] [engine] service will shutdown when all remaining tasks are flushed
[2026/01/06 16:13:27.498040100] [ info] [engine] pausing all inputs..
[2026/01/06 16:13:28.505692300] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/06 16:13:30.523283900] [ info] [reload] start everything
[2026/01/06 16:13:30.524294900] [ info] [fluent bit] version=4.2.3, commit=9191f70794, pid=40568
[2026/01/06 16:13:30.524306600] [debug] [engine] maxstdio set: 512
[2026/01/06 16:13:30.524317200] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2026/01/06 16:13:30.524511700] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/06 16:13:30.524523000] [ info] [simd    ] SSE2
[2026/01/06 16:13:30.524529700] [ info] [cmetrics] version=1.0.6
[2026/01/06 16:13:30.524535800] [ info] [ctraces ] version=0.6.6
[2026/01/06 16:13:30.526179700] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2021
[2026/01/06 16:13:30.526201800] [ info] [sp] stream processor started
[2026/01/06 16:13:30.526478300] [ info] [reload] successful reload done.
[2026/01/06 16:13:30.526476100] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/06 16:13:32] [engine] caught signal (SIGINT)
[2026/01/06 16:13:33.544790100] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/06 16:13:33.544806900] [ info] [engine] pausing all inputs..
[2026/01/06 16:13:34.561899600] [ info] [engine] service has stopped (0 pending tasks)
```

Also, we can now proceed to handle hot-reloading with relative paths by:

```powershell
C:\Users\cosmo> curl -XPOST -d '{}' 127.0.0.1:2021/api/v2/reload
{"reload":"done","status":1}
C:\Users\cosmo> curl -XPOST -d '{}' 127.0.0.1:2021/api/v2/reload
{"reload":"in progress","status":-2}
C:\Users\cosmo> curl -XPOST -d '{}' 127.0.0.1:2021/api/v2/reload
{"reload":"done","status":1}
C:\Users\cosmo> curl -XGET 127.0.0.1:2021/api/v2/reload
{"hot_reload_count":2}
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows path handling: inputs without a directory component are now treated as the current directory ("."), ensuring consistent normalization and more predictable configuration file path resolution for bare filenames and relative paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->