### PR TITLE
out_kafka: fix SIGSEGV and memory leak when rd_kafka_new() fails

### DIFF
--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -49,6 +49,7 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     }
     ctx->ins = ins;
     ctx->blocked = FLB_FALSE;
+    mk_list_init(&ctx->topics);
 
     ret = flb_output_config_map_set(ins, (void*) ctx);
     if (ret == -1) {
@@ -239,9 +240,13 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     if (!ctx->kafka.rk) {
         flb_plg_error(ctx->ins, "failed to create producer: %s",
                       errstr);
+        rd_kafka_conf_destroy(ctx->conf);
+        ctx->conf = NULL;
         flb_out_kafka_destroy(ctx);
         return NULL;
     }
+    /* rd_kafka_new() succeeded, conf ownership transferred to rk */
+    ctx->conf = NULL;
 
 #ifdef FLB_HAVE_AVRO_ENCODER
     /* Config AVRO */
@@ -256,7 +261,6 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
 #endif
 
     /* Config: Topic */
-    mk_list_init(&ctx->topics);
     tmp = flb_output_get_property("topics", ins);
     if (!tmp) {
         flb_kafka_topic_create(FLB_KAFKA_TOPIC, ctx);
@@ -302,6 +306,10 @@ int flb_out_kafka_destroy(struct flb_out_kafka *ctx)
 
     if (ctx->kafka.rk) {
         rd_kafka_destroy(ctx->kafka.rk);
+    }
+
+    if (ctx->conf) {
+        rd_kafka_conf_destroy(ctx->conf);
     }
 
     if (ctx->opaque) {


### PR DESCRIPTION
Move mk_list_init(&ctx->topics) to early initialization to prevent SIGSEGV crash when rd_kafka_new() fails and flb_out_kafka_destroy() is called with an uninitialized topics list.

Also fix memory leak of rd_kafka_conf_t by calling rd_kafka_conf_destroy() on failure path and in flb_out_kafka_destroy() for other error paths. Set ctx->conf to NULL after successful rd_kafka_new() since ownership is transferred to the rd_kafka_t handle.

Fixes https://github.com/fluent/fluent-bit/issues/11358

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
cmake -DFLB_CHUNK_TRACE=Off -DFLB_SIMD=Yes -DFLB_OUT_KAFKA=On -DFLB_RELEASE=On -DFLB_DEBUG=On -DFLB_JEMALLOC=On ..
```

```
Fluent Bit v5.0.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____           _            
|  ___| |                | |   | ___ (_) |         |  ___||  _  |         | |           
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |______ __| | _____   __
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |______/ _` |/ _ \ \ / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /     | (_| |  __/\ V / 
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/       \__,_|\___| \_/


[2026/01/09 16:35:52.311371051] [ info] [fluent bit] version=5.0.0, commit=7d0f98ef1b, pid=583636
[2026/01/09 16:35:52.343602487] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/09 16:35:52.344007684] [ info] [simd    ] SSE2
[2026/01/09 16:35:52.344790280] [ info] [cmetrics] version=1.0.6
[2026/01/09 16:35:52.345063476] [ info] [ctraces ] version=0.6.6
[2026/01/09 16:35:52.356656738] [ info] [input:dummy:dummy.0] initializing
[2026/01/09 16:35:52.357212303] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/01/09 16:35:52.469694003] [error] [output:kafka:kafka.0] failed to create producer: `max.in.flight` must be set <= 5 when `enable.idempotence` is true
[2026/01/09 16:35:52.472582803] [error] [output:kafka:kafka.0] failed to initialize
[2026/01/09 16:35:52.472910412] [error] [output] failed to initialize 'kafka' plugin
[2026/01/09 16:35:52.478619952] [error] [engine] output initialization failed
[2026/01/09 16:35:53.484799683] [ info] [input] pausing dummy.0
==583636== 
==583636== HEAP SUMMARY:
==583636==     in use at exit: 0 bytes in 0 blocks
==583636==   total heap usage: 6,618 allocs, 6,618 frees, 668,313 bytes allocated
==583636== 
==583636== All heap blocks were freed -- no leaks are possible
==583636== 
==583636== For lists of detected and suppressed errors, rerun with: -s
==583636== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved Kafka plugin resource initialization and cleanup procedures to enhance stability during error scenarios and prevent potential resource leaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->