### PR TITLE
filter_geoip2: Allow nested lookup paths beyond depth 2

### DIFF
--- a/plugins/filter_geoip2/geoip2.c
+++ b/plugins/filter_geoip2/geoip2.c
@@ -240,7 +240,7 @@ static void add_geoip_fields(msgpack_object *map,
         pos = strstr(record->val, "}");
         memset(key, '\0', sizeof(key));
         strncpy(key, record->val + 2, pos - (record->val + 2));
-        split = flb_utils_split(key, '.', 2);
+        split = flb_utils_split(key, '.', 8);
         split_size = mk_list_size(split);
         path = flb_malloc(sizeof(char *) * (split_size + 1));
         i = 0;


### PR DESCRIPTION
geoip2 filter limited lookup path splitting to depth 2, which caused nested paths like 'subdivisions.0.names.en' to be truncated and fail at runtime.

This change allows unlimited nesting by using flb_utils_split(..., 8), making array-backed fields such as subdivisions accessible.

For example,
the following configuration could be broken on loading because of containing three dots:

```yaml
    filters:
        - name: geoip2
          match: '*'
          database: GeoLite2-City.mmdb
          lookup_key: remote_addr
          record:
            - country   remote_addr %{country.names.zh-CN}
            - province  remote_addr %{subdivisions.0.names.en}
            - city      remote_addr %{city.names.zh-CN}
```

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes https://github.com/fluent/fluent-bit/issues/11287.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
pipeline:
    inputs:
        - name: dummy
          dummy: '{"remote_addr": "171.217.41.222"}'

    filters:
        - name: geoip2
          match: '*'
          database: GeoLite2-City.mmdb
          lookup_key: remote_addr
          record:
            - country   remote_addr %{country.names.zh-CN}
            - province  remote_addr %{subdivisions.0.names.en}
            - city      remote_addr %{city.names.zh-CN}

    outputs:
        - name: stdout
          match: '*'

```
- [x] Debug log output from testing the change

```
Fluent Bit v5.0.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____           _            
|  ___| |                | |   | ___ (_) |         |  ___||  _  |         | |           
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |______ __| | _____   __
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |______/ _` |/ _ \ \ / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /     | (_| |  __/\ V / 
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/       \__,_|\___| \_/


[2026/01/19 18:34:28.979573000] [ info] Configuration:
[2026/01/19 18:34:28.979582000] [ info]  flush time     | 1.000000 seconds
[2026/01/19 18:34:28.979588000] [ info]  grace          | 5 seconds
[2026/01/19 18:34:28.979591000] [ info]  daemon         | 0
[2026/01/19 18:34:28.979594000] [ info] ___________
[2026/01/19 18:34:28.979597000] [ info]  inputs:
[2026/01/19 18:34:28.979600000] [ info]      dummy
[2026/01/19 18:34:28.979603000] [ info] ___________
[2026/01/19 18:34:28.979606000] [ info]  filters:
[2026/01/19 18:34:28.979608000] [ info]      geoip2.0
[2026/01/19 18:34:28.979611000] [ info] ___________
[2026/01/19 18:34:28.979614000] [ info]  outputs:
[2026/01/19 18:34:28.979617000] [ info]      stdout.0
[2026/01/19 18:34:28.979620000] [ info] ___________
[2026/01/19 18:34:28.979623000] [ info]  collectors:
[2026/01/19 18:34:28.980226000] [ info] [fluent bit] version=5.0.0, commit=9cf4c9f648, pid=51199
[2026/01/19 18:34:28.980247000] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2026/01/19 18:34:28.980448000] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/19 18:34:28.980618000] [ info] [simd    ] NEON
[2026/01/19 18:34:28.980623000] [ info] [cmetrics] version=1.0.6
[2026/01/19 18:34:28.980767000] [ info] [ctraces ] version=0.6.6
[2026/01/19 18:34:28.981402000] [ info] [input:dummy:dummy.0] initializing
[2026/01/19 18:34:28.981411000] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/01/19 18:34:28.981421000] [debug] [dummy:dummy.0] created event channels: read=25 write=26
[2026/01/19 18:34:28.983751000] [debug] [stdout:stdout.0] created event channels: read=27 write=28
[2026/01/19 18:34:28.983989000] [ info] [output:stdout:stdout.0] worker #0 started
[2026/01/19 18:34:28.984155000] [ info] [sp] stream processor started
[2026/01/19 18:34:28.984194000] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/19 18:34:30.985643000] [debug] [task] created task=0x60f000007840 id=0 OK
[2026/01/19 18:34:30.985745000] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.0: [[1768815269.985744000, {}], {"remote_addr"=>"171.217.41.222", "country"=>"中国", "province"=>"Sichuan", "city"=>"成都"}]
[2026/01/19 18:34:30.987400000] [debug] [out flush] cb_destroy coro_id=0
[2026/01/19 18:34:30.987592000] [debug] [task] destroy task=0x60f000007840 (task_id=0)
[2026/01/19 18:34:31.985519000] [debug] [task] created task=0x60f000007930 id=0 OK
[2026/01/19 18:34:31.985629000] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.0: [[1768815270.987002000, {}], {"remote_addr"=>"171.217.41.222", "country"=>"中国", "province"=>"Sichuan", "city"=>"成都"}]
[2026/01/19 18:34:31.985842000] [debug] [out flush] cb_destroy coro_id=1
[2026/01/19 18:34:31.986340000] [debug] [task] destroy task=0x60f000007930 (task_id=0)
^C[2026/01/19 18:34:32] [engine] caught signal (SIGINT)
[2026/01/19 18:34:32.190470000] [ info] [input] pausing dummy.0
[2026/01/19 18:34:32.190882000] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/01/19 18:34:32.191021000] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GeoIP field retrieval to consider deeper nested location paths, allowing the system to surface more granular location details when available. Existing behavior and error handling are preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->