### PR TITLE
in_prometheus_remote_write: add missing config param descriptions

### DIFF
--- a/plugins/in_prometheus_remote_write/prom_rw.c
+++ b/plugins/in_prometheus_remote_write/prom_rw.c
@@ -200,19 +200,19 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_prom_remote_write, enable_http2),
-     NULL
+     "Enable HTTP/2 support"
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_prom_remote_write, buffer_max_size),
-     ""
+     "Maximum size of the HTTP request buffer"
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", HTTP_BUFFER_CHUNK_SIZE,
      0, FLB_TRUE, offsetof(struct flb_prom_remote_write, buffer_chunk_size),
-     ""
+     "Size of each buffer chunk allocated for HTTP requests"
     },
 
     {


### PR DESCRIPTION
 - add missing http2 description
 - add missing buffer_max_size description
 - add buffer_chunk_size missing description

Fixes #11377

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ Yes ] Documentation required for this feature
<!--  Doc PR (not required but highly recommended) -->
Issue: https://github.com/fluent/fluent-bit-docs/issues/2333
PR: https://github.com/fluent/fluent-bit-docs/pull/2334

**Backporting**
- [ N/A ] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration option descriptions to include helpful text for HTTP/2 support, maximum HTTP request buffer size, and buffer chunk allocation settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->