### PR TITLE
in_prometheus_scrape: add missing config param description

### DIFF
--- a/plugins/in_prometheus_scrape/prom_scrape.c
+++ b/plugins/in_prometheus_scrape/prom_scrape.c
@@ -220,7 +220,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct prom_scrape, buffer_max_size),
-     ""
+     "Set the maximum buffer size for the HTTP response."
     },
 
     {


### PR DESCRIPTION
  - Add description for buffer_max_size configuration parameter

Fixes ##11385

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ Already in docs ] Documentation required for this feature

**Backporting**
- [ N/A ] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced help text descriptions for buffer configuration settings in Prometheus scraping options, providing clearer guidance to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->