### PR TITLE
in_storage_backlog: Preserve DLQ on restarting

### DIFF
--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -331,6 +331,25 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
     return 0;
 }
 
+static inline int sb_is_rejected_stream(struct flb_config *config,
+                                        struct cio_stream *stream)
+{
+    const char *rp;
+
+    if (!config || !stream || !stream->name) {
+        return FLB_FALSE;
+    }
+
+    if (config->storage_keep_rejected != FLB_TRUE) {
+        return FLB_FALSE;
+    }
+
+    rp = config->storage_rejected_path ?
+         config->storage_rejected_path : "rejected";
+
+    return strcmp(stream->name, rp) == 0;
+}
+
 int sb_segregate_chunks(struct flb_config *config)
 {
     int                ret;
@@ -356,6 +375,12 @@ int sb_segregate_chunks(struct flb_config *config)
 
     mk_list_foreach(stream_iterator, &context->cio->streams) {
         stream = mk_list_entry(stream_iterator, struct cio_stream, _head);
+
+        /* DLQ stream is not part of backlog. Just skip. */
+        if (sb_is_rejected_stream(config, stream)) {
+            flb_debug("[storage backlog] skipping DLQ stream '%s'", stream->name);
+            continue;
+        }
 
         mk_list_foreach_safe(chunk_iterator, tmp, &stream->chunks) {
             chunk = mk_list_entry(chunk_iterator, struct cio_chunk, _head);


### PR DESCRIPTION
<!-- Provide summary of changes -->

Previously, lacking of handling DLQ preservations on restarting.
We ought to preserve them on restarting.

This PR is also semantically resolving https://github.com/fluent/fluent-bit/issues/9363.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
pipeline:
  inputs:
    - name: dummy
      storage.type: filesystem
      tag: test
      samples: 3
  outputs:
    - name: http
      host: localhostsss
      port: 8080
      match: '*'
    - name: stdout
      match: '*'
service:
  flush: 1
  storage.path: ./storage
  storage.keep.rejected: on
  storage.rejected.path: rejected
```
- [x] Debug log output from testing the change

1st attempt:

```
Fluent Bit v5.0.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____           _            
|  ___| |                | |   | ___ (_) |         |  ___||  _  |         | |           
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |______ __| | _____   __
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |______/ _` |/ _ \ \ / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /     | (_| |  __/\ V / 
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/       \__,_|\___| \_/


[2026/01/23 14:31:18.804846000] [ info] [fluent bit] version=5.0.0, commit=9cf4c9f648, pid=8856
[2026/01/23 14:31:18.805010000] [ info] [storage] created root path ./storage
[2026/01/23 14:31:18.805150000] [ info] [storage] ver=1.4.0, type=memory+filesystem, sync=normal, checksum=off, max_chunks_up=128
[2026/01/23 14:31:18.805158000] [ info] [storage] backlog input plugin: storage_backlog.1
[2026/01/23 14:31:18.805163000] [ info] [simd    ] NEON
[2026/01/23 14:31:18.805168000] [ info] [cmetrics] version=1.0.6
[2026/01/23 14:31:18.805185000] [ info] [ctraces ] version=0.6.6
[2026/01/23 14:31:18.805346000] [ info] [input:dummy:dummy.0] initializing
[2026/01/23 14:31:18.805352000] [ info] [input:dummy:dummy.0] storage_strategy='filesystem' (memory + filesystem)
[2026/01/23 14:31:18.805471000] [ info] [input:storage_backlog:storage_backlog.1] initializing
[2026/01/23 14:31:18.805478000] [ info] [input:storage_backlog:storage_backlog.1] storage_strategy='memory' (memory only)
[2026/01/23 14:31:18.805503000] [ info] [input:storage_backlog:storage_backlog.1] queue memory limit: 95.4M
[2026/01/23 14:31:18.805753000] [ info] [output:http:http.0] worker #0 started
[2026/01/23 14:31:18.805768000] [ info] [output:http:http.0] worker #1 started
[2026/01/23 14:31:18.805813000] [ info] [output:stdout:stdout.1] worker #0 started
[2026/01/23 14:31:18.805830000] [ info] [sp] stream processor started
[2026/01/23 14:31:18.805884000] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[0] test: [[1769146279.806656000, {}], {"message"=>"dummy"}]
[2026/01/23 14:31:20.852548000] [ warn] [net] getaddrinfo(host='localhostsss', err=4): Domain name not found
[2026/01/23 14:31:20.852609000] [error] [output:http:http.0] no upstream connections available to localhostsss:8080
[2026/01/23 14:31:20.852727000] [ warn] [engine] failed to flush chunk '8856-1769146279.806978000.flb', retry in 7 seconds: task_id=0, input=dummy.0 > output=http.0 (out_id=0)
[0] test: [[1769146280.807698000, {}], {"message"=>"dummy"}]
[2026/01/23 14:31:21.841990000] [ warn] [net] getaddrinfo(host='localhostsss', err=4): Domain name not found
[2026/01/23 14:31:21.842047000] [error] [output:http:http.0] no upstream connections available to localhostsss:8080
[2026/01/23 14:31:21.842149000] [ warn] [engine] failed to flush chunk '8856-1769146280.807799000.flb', retry in 8 seconds: task_id=1, input=dummy.0 > output=http.0 (out_id=0)
[0] test: [[1769146281.811844000, {}], {"message"=>"dummy"}]
[2026/01/23 14:31:22.835107000] [ warn] [net] getaddrinfo(host='localhostsss', err=4): Domain name not found
[2026/01/23 14:31:22.835154000] [error] [output:http:http.0] no upstream connections available to localhostsss:8080
[2026/01/23 14:31:22.835241000] [ warn] [engine] failed to flush chunk '8856-1769146281.811927000.flb', retry in 9 seconds: task_id=2, input=dummy.0 > output=http.0 (out_id=0)
[2026/01/23 14:31:27.884364000] [ warn] [net] getaddrinfo(host='localhostsss', err=4): Domain name not found
[2026/01/23 14:31:27.884415000] [error] [output:http:http.0] no upstream connections available to localhostsss:8080
[2026/01/23 14:31:27.885053000] [ info] [storage] quarantined rejected chunk into DLQ stream (bytes=36)
[2026/01/23 14:31:27.885097000] [error] [engine] chunk '8856-1769146279.806978000.flb' cannot be retried: task_id=0, input=dummy.0 > output=http.0
[2026/01/23 14:31:29.879828000] [ warn] [net] getaddrinfo(host='localhostsss', err=4): Domain name not found
[2026/01/23 14:31:29.879897000] [error] [output:http:http.0] no upstream connections available to localhostsss:8080
[2026/01/23 14:31:29.880612000] [ info] [storage] quarantined rejected chunk into DLQ stream (bytes=36)
[2026/01/23 14:31:29.880648000] [error] [engine] chunk '8856-1769146280.807799000.flb' cannot be retried: task_id=1, input=dummy.0 > output=http.0
[2026/01/23 14:31:31.872571000] [ warn] [net] getaddrinfo(host='localhostsss', err=4): Domain name not found
[2026/01/23 14:31:31.872631000] [error] [output:http:http.0] no upstream connections available to localhostsss:8080
[2026/01/23 14:31:31.873253000] [ info] [storage] quarantined rejected chunk into DLQ stream (bytes=36)
[2026/01/23 14:31:31.873281000] [error] [engine] chunk '8856-1769146281.811927000.flb' cannot be retried: task_id=2, input=dummy.0 > output=http.0
^C[2026/01/23 14:31:32] [engine] caught signal (SIGINT)
[2026/01/23 14:31:32.705447000] [ info] [input] pausing dummy.0
[2026/01/23 14:31:32.705509000] [ info] [input] pausing storage_backlog.1
[2026/01/23 14:31:32.705569000] [ info] [output:http:http.0] thread worker #0 stopping...
[2026/01/23 14:31:32.705675000] [ info] [output:http:http.0] thread worker #0 stopped
[2026/01/23 14:31:32.705968000] [ info] [output:http:http.0] thread worker #1 stopping...
[2026/01/23 14:31:32.706080000] [ info] [output:http:http.0] thread worker #1 stopped
[2026/01/23 14:31:32.706401000] [ info] [output:stdout:stdout.1] thread worker #0 stopping...
[2026/01/23 14:31:32.706498000] [ info] [output:stdout:stdout.1] thread worker #0 stopped
```

2nd attempt:

```
Fluent Bit v5.0.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____           _            
|  ___| |                | |   | ___ (_) |         |  ___||  _  |         | |           
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |______ __| | _____   __
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |______/ _` |/ _ \ \ / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /     | (_| |  __/\ V / 
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/       \__,_|\___| \_/


[2026/01/23 14:32:16.796392000] [ info] Configuration:
[2026/01/23 14:32:16.796402000] [ info]  flush time     | 1.000000 seconds
[2026/01/23 14:32:16.796409000] [ info]  grace          | 5 seconds
[2026/01/23 14:32:16.796413000] [ info]  daemon         | 0
[2026/01/23 14:32:16.796417000] [ info] ___________
[2026/01/23 14:32:16.796421000] [ info]  inputs:
[2026/01/23 14:32:16.796424000] [ info]      dummy
[2026/01/23 14:32:16.796427000] [ info] ___________
[2026/01/23 14:32:16.796430000] [ info]  filters:
[2026/01/23 14:32:16.796433000] [ info] ___________
[2026/01/23 14:32:16.796436000] [ info]  outputs:
[2026/01/23 14:32:16.796439000] [ info]      http.0
[2026/01/23 14:32:16.796442000] [ info]      stdout.1
[2026/01/23 14:32:16.796444000] [ info] ___________
[2026/01/23 14:32:16.796447000] [ info]  collectors:
[2026/01/23 14:32:16.796614000] [ info] [fluent bit] version=5.0.0, commit=9cf4c9f648, pid=8960
[2026/01/23 14:32:16.796631000] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2026/01/23 14:32:16.796919000] [ info] [storage] ver=1.4.0, type=memory+filesystem, sync=normal, checksum=off, max_chunks_up=128
[2026/01/23 14:32:16.796927000] [ info] [storage] backlog input plugin: storage_backlog.1
[2026/01/23 14:32:16.796934000] [ info] [simd    ] NEON
[2026/01/23 14:32:16.796940000] [ info] [cmetrics] version=1.0.6
[2026/01/23 14:32:16.796948000] [ info] [ctraces ] version=0.6.6
[2026/01/23 14:32:16.797059000] [ info] [input:dummy:dummy.0] initializing
[2026/01/23 14:32:16.797065000] [ info] [input:dummy:dummy.0] storage_strategy='filesystem' (memory + filesystem)
[2026/01/23 14:32:16.797074000] [debug] [dummy:dummy.0] created event channels: read=30 write=31
[2026/01/23 14:32:16.797176000] [ info] [input:storage_backlog:storage_backlog.1] initializing
[2026/01/23 14:32:16.797182000] [ info] [input:storage_backlog:storage_backlog.1] storage_strategy='memory' (memory only)
[2026/01/23 14:32:16.797191000] [debug] [storage_backlog:storage_backlog.1] created event channels: read=32 write=33
[2026/01/23 14:32:16.797209000] [ info] [input:storage_backlog:storage_backlog.1] queue memory limit: 95.4M
[2026/01/23 14:32:16.797220000] [debug] [http:http.0] created event channels: read=34 write=35
[2026/01/23 14:32:16.797389000] [debug] [stdout:stdout.1] created event channels: read=48 write=49
[2026/01/23 14:32:16.797459000] [ info] [output:http:http.0] worker #0 started
[2026/01/23 14:32:16.797473000] [ info] [output:http:http.0] worker #1 started
[2026/01/23 14:32:16.797508000] [debug] [router] match rule dummy.0:http.0
[2026/01/23 14:32:16.797515000] [debug] [router] match rule dummy.0:stdout.1
[2026/01/23 14:32:16.797526000] [debug] [router] match rule storage_backlog.1:http.0
[2026/01/23 14:32:16.797534000] [debug] [router] match rule storage_backlog.1:stdout.1
[2026/01/23 14:32:16.797536000] [ info] [output:stdout:stdout.1] worker #0 started
[2026/01/23 14:32:16.797552000] [ info] [sp] stream processor started
[2026/01/23 14:32:16.797607000] [debug] [storage backlog] skipping DLQ stream 'rejected'
[2026/01/23 14:32:16.797625000] [ info] [input:storage_backlog:storage_backlog.1] register dummy.0/8897-1769146307.250503000.flb
[2026/01/23 14:32:16.797651000] [ info] [input:storage_backlog:storage_backlog.1] register dummy.0/8897-1769146308.251033000.flb
[2026/01/23 14:32:16.797666000] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/23 14:32:17.804440000] [ info] [input:storage_backlog:storage_backlog.1] queueing dummy.0:8897-1769146307.250503000.flb
[2026/01/23 14:32:17.804874000] [ info] [input:storage_backlog:storage_backlog.1] queueing dummy.0:8897-1769146308.251033000.flb

^C[2026/01/23 14:32:18] [engine] caught signal (SIGINT)
[2026/01/23 14:32:18.575121000] [ info] [input] pausing dummy.0
[2026/01/23 14:32:18.575181000] [ info] [input] pausing storage_backlog.1
```

Now quarantined DLQs are preserved:

```
% ls ./storage/rejected
test_0_http.0_0x60800000d620.flb test_0_http.0_0x60800000d720.flb test_0_http.0_0x60800000d7a0.flb
```


<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

With macOS's leaks, there's no leakages found:

```
Process 19936 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [19936]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x102160000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [19935]
Target Type:     live task

Date/Time:       2026-01-23 14:38:49.659 +0900
Launch Time:     2026-01-23 14:38:45.458 +0900
OS Version:      macOS 26.2 (25C56)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         8000K
Physical footprint (peak):  8112K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 19936: 1298 nodes malloced for 200 KB
Process 19936: 0 leaks for 0 total leaked bytes.
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rejected and dead-letter queue streams to ensure they are properly skipped during processing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->