### PR TITLE
in_splunk: add missing config param descriptions

### DIFF
--- a/plugins/in_splunk/splunk.c
+++ b/plugins/in_splunk/splunk.c
@@ -217,19 +217,19 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_splunk, enable_http2),
-     NULL
+     "Enable HTTP/2 support"
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_max_size", HTTP_BUFFER_MAX_SIZE,
      0, FLB_TRUE, offsetof(struct flb_splunk, buffer_max_size),
-     ""
+     "Set the maximum size of buffer"
     },
 
     {
      FLB_CONFIG_MAP_SIZE, "buffer_chunk_size", HTTP_BUFFER_CHUNK_SIZE,
      0, FLB_TRUE, offsetof(struct flb_splunk, buffer_chunk_size),
-     ""
+     "Set the initial buffer size to store incoming data"
     },
 
     {
@@ -247,7 +247,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "store_token_in_metadata", "true",
      0, FLB_TRUE, offsetof(struct flb_splunk, store_token_in_metadata),
-     "Store Splunk HEC tokens in matadata. If set as false, they will be stored into records."
+     "Store Splunk HEC tokens in metadata. If set as false, they will be stored into records."
     },
 
     {
@@ -259,7 +259,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "tag_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_splunk, tag_key),
-     ""
+     "Set a record key to specify the tag of the record"
     },
 
 


### PR DESCRIPTION
  - http2: add description
  - buffer_max_size: add description
  - buffer_chunk_size: add description
  - tag_key: add description
  - store_token_in_metadata: fix typo (matadata -> metadata)

Fixes #11390

----
**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ Already exists in docs ] Documentation required for this feature

**Backporting**
- [ N/A ] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and clarified descriptions for multiple configuration options including the http2 enable flag, buffer size and chunk size parameters, token storage in metadata setting, and tag key configuration to provide better guidance for users.
  * Fixed a typographical error in configuration help text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->