### PR TITLE
out_azure_kusto: add region-based auth for global and China cloud

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -82,7 +82,10 @@ static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
         return -1;
     }
 
-    ret = flb_oauth2_payload_append(ctx->o, "scope", 5, FLB_AZURE_KUSTO_SCOPE, 39);
+    /* scope depends on cloud environment */
+        const char *scope = flb_azure_kusto_get_scope(ctx->cloud_environment);
+        ret = flb_oauth2_payload_append(ctx->o, "scope", 5, scope, strlen(scope));
+
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error appending oauth2 params");
         return -1;

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -83,8 +83,8 @@ static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
     }
 
     /* scope depends on cloud environment */
-        const char *scope = flb_azure_kusto_get_scope(ctx->cloud_environment);
-        ret = flb_oauth2_payload_append(ctx->o, "scope", 5, scope, strlen(scope));
+    const char *scope = flb_azure_kusto_get_scope(ctx->cloud_environment);
+    ret = flb_oauth2_payload_append(ctx->o, "scope", 5, scope, strlen(scope));
 
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error appending oauth2 params");

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -72,7 +72,8 @@ static int azure_kusto_get_workload_identity_token(struct flb_azure_kusto *ctx)
 static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
 {
     int ret;
-    
+    const char *scope;
+
     /* Clear any previous oauth2 payload content */
     flb_oauth2_payload_clear(ctx->o);
 
@@ -83,7 +84,7 @@ static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
     }
 
     /* scope depends on cloud environment */
-    const char *scope = flb_azure_kusto_get_scope(ctx->cloud_environment);
+    scope = flb_azure_kusto_get_scope(ctx->cloud_environment);
     ret = flb_oauth2_payload_append(ctx->o, "scope", 5, scope, strlen(scope));
 
     if (ret == -1) {

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -825,6 +825,10 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
     if (ctx->auth_type == FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_SYSTEM || 
         ctx->auth_type == FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_USER) {
         /* MSI auth */
+        const char *imds_resource;
+
+        imds_resource = get_imds_resource(ctx->cloud_environment);
+
         /* Construct the URL template with or without client_id for managed identity */
         if (ctx->auth_type == FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_SYSTEM) {
             ctx->oauth_url = flb_sds_create_size(sizeof(FLB_AZURE_MSIAUTH_URL_TEMPLATE) - 1);
@@ -834,7 +838,8 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
                 return NULL;
             }
             flb_sds_snprintf(&ctx->oauth_url, flb_sds_alloc(ctx->oauth_url),
-                            FLB_AZURE_MSIAUTH_URL_TEMPLATE, "", "");
+                            FLB_AZURE_MSIAUTH_URL_TEMPLATE,
+                            "", "", imds_resource);
         } else {
             /* User-assigned managed identity */
             ctx->oauth_url = flb_sds_create_size(sizeof(FLB_AZURE_MSIAUTH_URL_TEMPLATE) - 1 +
@@ -846,7 +851,8 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
                 return NULL;
             }
             flb_sds_snprintf(&ctx->oauth_url, flb_sds_alloc(ctx->oauth_url),
-                            FLB_AZURE_MSIAUTH_URL_TEMPLATE, "&client_id=", ctx->client_id);
+                            FLB_AZURE_MSIAUTH_URL_TEMPLATE,
+                            "&client_id=", ctx->client_id, imds_resource);
         }
     } else {
         /* Standard OAuth2 for service principal or workload identity */

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -857,7 +857,7 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
     } else {
         /* Standard OAuth2 for service principal or workload identity */
         const char *tmpl = get_msal_auth_url_template(ctx->cloud_environment);
-        ctx->oauth_url = flb_sds_create_size(strlen(tmpl) - 1 + flb_sds_len(ctx->tenant_id));
+        ctx->oauth_url = flb_sds_create_size(sizeof(tmpl) - 1 + flb_sds_len(ctx->tenant_id));
         if (!ctx->oauth_url) {
             flb_errno();
             flb_azure_kusto_conf_destroy(ctx);

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -41,11 +41,6 @@ static const char *get_msal_auth_url_template(int cloud_env)
     return FLB_MSAL_AUTH_URL_TEMPLATE_GLOBAL;
 }
 
-static const char *get_kusto_scope(int cloud_env)
-{
-    return flb_azure_kusto_get_scope(cloud_env);
-}
-
 static const char *get_imds_resource(int cloud_env)
 {
     return flb_azure_kusto_get_imds_resource(cloud_env);
@@ -831,7 +826,7 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
 
         /* Construct the URL template with or without client_id for managed identity */
         if (ctx->auth_type == FLB_AZURE_KUSTO_AUTH_MANAGED_IDENTITY_SYSTEM) {
-            ctx->oauth_url = flb_sds_create_size(sizeof(FLB_AZURE_MSIAUTH_URL_TEMPLATE) - 1);
+           ctx->oauth_url = flb_sds_create_size(strlen(FLB_AZURE_MSIAUTH_URL_TEMPLATE) + strlen(imds_resource) + 1);
             if (!ctx->oauth_url) {
                 flb_errno();
                 flb_azure_kusto_conf_destroy(ctx);
@@ -842,9 +837,10 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
                             "", "", imds_resource);
         } else {
             /* User-assigned managed identity */
-            ctx->oauth_url = flb_sds_create_size(sizeof(FLB_AZURE_MSIAUTH_URL_TEMPLATE) - 1 +
-                                                sizeof("&client_id=") - 1 +
-                                                flb_sds_len(ctx->client_id));
+            ctx->oauth_url = flb_sds_create_size(strlen(FLB_AZURE_MSIAUTH_URL_TEMPLATE) +
+                                                 strlen("&client_id=") +
+                                                 flb_sds_len(ctx->client_id) +
+                                                 strlen(imds_resource) + 1);
             if (!ctx->oauth_url) {
                 flb_errno();
                 flb_azure_kusto_conf_destroy(ctx);

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -857,7 +857,7 @@ struct flb_azure_kusto *flb_azure_kusto_conf_create(struct flb_output_instance *
     } else {
         /* Standard OAuth2 for service principal or workload identity */
         const char *tmpl = get_msal_auth_url_template(ctx->cloud_environment);
-        ctx->oauth_url = flb_sds_create_size(sizeof(tmpl) - 1 + flb_sds_len(ctx->tenant_id));
+        ctx->oauth_url = flb_sds_create_size(strlen(tmpl) + flb_sds_len(ctx->tenant_id) + 1);
         if (!ctx->oauth_url) {
             flb_errno();
             flb_azure_kusto_conf_destroy(ctx);

--- a/plugins/out_azure_kusto/azure_msiauth.c
+++ b/plugins/out_azure_kusto/azure_msiauth.c
@@ -139,11 +139,13 @@ static flb_sds_t read_token_from_file(const char *token_file)
 int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *token_file, const char *client_id, const char *tenant_id)
 {
     int ret;
+    int cloud_env;
     size_t b_sent;
     struct flb_connection *u_conn;
     struct flb_http_client *c;
     flb_sds_t federated_token;
     flb_sds_t body = NULL;
+    const char *scope;
 
     flb_info("[azure workload identity] inside flb_azure_workload_identity_token_get");
 
@@ -177,16 +179,14 @@ int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *to
     body = flb_sds_cat(body, "&client_assertion=", 18);
     body = flb_sds_cat(body, federated_token, flb_sds_len(federated_token));
     /* Use the correct scope and length for Kusto */
-    {
-        int cloud_env = FLB_AZURE_CLOUD_GLOBAL;
-        if ((ctx->host && strstr(ctx->host, "chinacloudapi.cn") != NULL) ||
-            (ctx->uri && strstr(ctx->uri, "chinacloudapi.cn") != NULL)) {
-            cloud_env = FLB_AZURE_CLOUD_CHINA;
-        }
-        const char *scope = flb_azure_kusto_get_scope(cloud_env);
-        body = flb_sds_cat(body, "&scope=", 7);
-        body = flb_sds_cat(body, scope, strlen(scope));
+    cloud_env = FLB_AZURE_CLOUD_GLOBAL;
+    if ((ctx->host && strstr(ctx->host, "chinacloudapi.cn") != NULL) ||
+        (ctx->uri && strstr(ctx->uri, "chinacloudapi.cn") != NULL)) {
+        cloud_env = FLB_AZURE_CLOUD_CHINA;
     }
+    scope = flb_azure_kusto_get_scope(cloud_env);
+    body = flb_sds_cat(body, "&scope=", 7);
+    body = flb_sds_cat(body, scope, strlen(scope));
 
     if (!body) {
         /* This check might be redundant if flb_sds_cat handles errors, but safe */

--- a/plugins/out_azure_kusto/azure_msiauth.c
+++ b/plugins/out_azure_kusto/azure_msiauth.c
@@ -184,7 +184,7 @@ int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *to
             cloud_env = FLB_AZURE_CLOUD_CHINA;
         }
         const char *scope = flb_azure_kusto_get_scope(cloud_env);
-        body = flb_sds_cat(body, "&scope=", -1);
+        body = flb_sds_cat(body, "&scope=", 7);
         body = flb_sds_cat(body, scope, strlen(scope));
     }
 

--- a/plugins/out_azure_kusto/azure_msiauth.h
+++ b/plugins/out_azure_kusto/azure_msiauth.h
@@ -21,7 +21,7 @@
 
 /* MSAL authorization URL  */
 #define FLB_AZURE_MSIAUTH_URL_TEMPLATE \
-    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01%s%s&resource=https://api.kusto.windows.net"
+    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01%s%s&resource=%s"
 
 char *flb_azure_msiauth_token_get(struct flb_oauth2 *ctx);
 int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *token_file, const char *client_id, const char *tenant_id);

--- a/tests/runtime/out_azure_kusto.c
+++ b/tests/runtime/out_azure_kusto.c
@@ -30,6 +30,8 @@ void flb_test_azure_kusto_managed_identity_system(void);
 void flb_test_azure_kusto_managed_identity_user(void);
 void flb_test_azure_kusto_service_principal(void);
 void flb_test_azure_kusto_workload_identity(void);
+void flb_test_azure_kusto_cloud_global_inference(void);
+void flb_test_azure_kusto_cloud_china_inference(void);
 
 /* Test list */
 TEST_LIST = {
@@ -38,6 +40,8 @@ TEST_LIST = {
     {"managed_identity_user", flb_test_azure_kusto_managed_identity_user},
     {"service_principal", flb_test_azure_kusto_service_principal},
     {"workload_identity", flb_test_azure_kusto_workload_identity},
+    {"cloud_global_inference", flb_test_azure_kusto_cloud_global_inference},
+    {"cloud_china_inference", flb_test_azure_kusto_cloud_china_inference},
     {NULL, NULL}
 };
 
@@ -202,6 +206,74 @@ void flb_test_azure_kusto_workload_identity(void)
     flb_output_set(ctx, out_ffd, "client_id", "your-client-id", NULL);
     flb_output_set(ctx, out_ffd, "workload_identity_token_file", "/path/to/token/file", NULL);
     flb_output_set(ctx, out_ffd, "ingestion_endpoint", "https://ingest-CLUSTER.kusto.windows.net", NULL);
+    flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
+    flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test for cloud inference: "Global", based on ingestion_endpoint */
+void flb_test_azure_kusto_cloud_global_inference(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "azure_kusto", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "auth_type", "service_principal", NULL);
+    flb_output_set(ctx, out_ffd, "tenant_id", "your-tenant-id", NULL);
+    flb_output_set(ctx, out_ffd, "client_id", "your-client-id", NULL);
+    flb_output_set(ctx, out_ffd, "client_secret", "your-client-secret", NULL);
+    /* Global ingestion endpoint */
+    flb_output_set(ctx, out_ffd, "ingestion_endpoint", "https://ingest-CLUSTER.kusto.windows.net", NULL);
+    flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
+    flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test for cloud inference: "China", based on ingestion_endpoint */
+void flb_test_azure_kusto_cloud_china_inference(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "1", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "azure_kusto", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "test", NULL);
+    flb_output_set(ctx, out_ffd, "auth_type", "service_principal", NULL);
+    flb_output_set(ctx, out_ffd, "tenant_id", "your-tenant-id", NULL);
+    flb_output_set(ctx, out_ffd, "client_id", "your-client-id", NULL);
+    flb_output_set(ctx, out_ffd, "client_secret", "your-client-secret", NULL);
+    /* China ingestion endpoint */
+    flb_output_set(ctx, out_ffd, "ingestion_endpoint", "https://ingest-CLUSTER.kusto.chinacloudapi.cn", NULL);
     flb_output_set(ctx, out_ffd, "database_name", "telemetrydb", NULL);
     flb_output_set(ctx, out_ffd, "table_name", "logs", NULL);
 


### PR DESCRIPTION
Added Authentication based on two different clouds, Azure global and Azure china

<!-- Provide summary of changes -->
Direct log ingestion from Fluent Bit to Azure Data Explorer via the azure_kusto plugin previously supported only Azure Global, as token generation relied on the Global Azure authentication authority.

Azure China uses a different authentication host, which was not supported by the existing Fluent Bit image, preventing direct ingestion into China cloud clusters.

This change adds support for Azure China cloud by updating the authentication configuration, enabling direct ingestion to Azure Data Explorer in China cloud.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
Use case1: Using Global ingestion endpoint
Config file used
<img width="963" height="659" alt="image" src="https://github.com/user-attachments/assets/dccd9483-6073-4614-a0d8-735034e36db2" />

Output :
<img width="1460" height="589" alt="image" src="https://github.com/user-attachments/assets/dc0761f3-a0ca-4280-bbe1-d4e927a0ce76" />

Use case2: Using China ingestion endpoint
Config file used
<img width="963" height="659" alt="image" src="https://github.com/user-attachments/assets/9ae59bfb-c7fd-4eb7-8132-49a27fa88948" />

Output:
<img width="1366" height="541" alt="image" src="https://github.com/user-attachments/assets/2bf2ff46-6c5e-4c1d-a0f5-b18fdcf72b5c" />



<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for Azure China cloud alongside Azure Global.

* **Improvements**
  * Automatic cloud environment detection from ingestion endpoint.
  * Cloud-aware authentication: scopes, token endpoints and managed identity resource selection adapt per cloud at runtime.
  * OAuth/MSI URL construction now adjusts to the detected cloud.

* **Tests**
  * Added tests validating cloud environment inference for Global and China.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->