### PR TITLE
build: CMake project fixes for MS Visual C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,33 +56,45 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   endif()
 endif()
 
+set(FLB_EXTRA_CMAKE_CXX_FLAGS)
+set(FLB_EXTRA_CMAKE_CXX_LINK_FLAGS)
+
 # Update CFLAGS
 if (MSVC)
+  # Use static C runtime
+  if (NOT (CMAKE_VERSION VERSION_LESS "3.15"))
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
+  add_compile_options(/MT$<$<CONFIG:Debug>:d>)
+  # Replace (/|-)MD(d?) with (/|-)MT(d?) to avoid D9025 warning
+  foreach(config_type ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE} Debug Release RelWithDebInfo MinSizeRel)
+    string(TOUPPER ${config_type} upper_config_type)
+    set(flag_var "CMAKE_C_FLAGS_${upper_config_type}")
+    string(REGEX REPLACE "(^| |\\t|\\r|\\n)(-|/)(MD)(d?)($| |\\t|\\r|\\n)" "\\1\\2MT\\4\\5" ${flag_var} "${${flag_var}}")
+  endforeach()
+  set(flag_var)
+  set(upper_config_type)
+  set(config_type)
+
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
 
   # Use custom CFLAGS for MSVC
   #
   #   /Zi ...... Generate pdb files.
-  #   /MT ...... Static link C runtimes.
   #   /wd4711 .. C4711 (function selected for inline expansion)
   #   /wd4100 .. C4100 (unreferenced formal parameter)
   #   /wd5045 .. C5045 (Spectre mitigation)
   #
   # Restore /OPT:REF after setting /Debug, enable /OPT:ICF for 64-bit
   # builds per Microsoft recommended best practices.
-  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /O2 /Zi /wd4100 /wd4711 /wd5045")
+  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /Zi /wd4100 /wd4711 /wd5045")
   set(CMAKE_EXE_LINKER_FLAGS "/DEBUG /OPT:REF /INCREMENTAL:NO")
   set(CMAKE_SHARED_LINKER_FLAGS "/DEBUG /OPT:REF /INCREMENTAL:NO")
-  set(CMAKE_BUILD_TYPE None)
   if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /OPT:ICF")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /OPT:ICF")
   endif()
-
-  # Use add_compile_options() to set /MT since Visual Studio
-  # Generator does not notice /MT in CMAKE_C_FLAGS.
-  add_compile_options(/MT)
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -105,16 +117,26 @@ else()
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FLB_FILENAME__=__FILE__")
+# CMAKE_CXX_FLAGS will be extended with FLB_EXTRA_CMAKE_CXX_FLAGS,
+# when / if C++ language support will be enabled.
+# Until C++ language support is enabled, CMAKE_CXX_FLAGS is empty / undefined.
+set(FLB_EXTRA_CMAKE_CXX_FLAGS "${FLB_EXTRA_CMAKE_CXX_FLAGS} -D__FLB_FILENAME__=__FILE__")
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
   set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -latomic")
-  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
+  # CMAKE_CXX_LINK_FLAGS will be extended with FLB_EXTRA_CMAKE_CXX_LINK_FLAGS,
+  # when / if C++ language support will be enabled.
+  # Until C++ language support is enabled, CMAKE_CXX_LINK_FLAGS is empty / undefined.
+  set(FLB_EXTRA_CMAKE_CXX_LINK_FLAGS "${FLB_EXTRA_CMAKE_CXX_LINK_FLAGS} -latomic")
 endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   set(FLB_SYSTEM_FREEBSD On)
   add_definitions(-DFLB_SYSTEM_FREEBSD)
   set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -lutil")
-  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -lutil")
+  # CMAKE_CXX_LINK_FLAGS will be extended with FLB_EXTRA_CMAKE_CXX_LINK_FLAGS,
+  # when / if C++ language support will be enabled.
+  # Until C++ language support is enabled, CMAKE_CXX_LINK_FLAGS is empty / undefined.
+  set(FLB_EXTRA_CMAKE_CXX_LINK_FLAGS "${FLB_EXTRA_CMAKE_CXX_LINK_FLAGS} -lutil")
 endif()
 
 # *BSD is not supported platform for wasm-micro-runtime except for FreeBSD.
@@ -527,7 +549,10 @@ endif()
 if(FLB_COVERAGE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
   if (FLB_UNICODE_ENCODER)
-    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+    # CMAKE_CXX_FLAGS will be extended with FLB_EXTRA_CMAKE_CXX_FLAGS,
+    # when / if C++ language support will be enabled.
+    # Until C++ language support is enabled, CMAKE_CXX_FLAGS is empty / undefined.
+    set(FLB_EXTRA_CMAKE_CXX_FLAGS "${FLB_EXTRA_CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
   endif()
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
@@ -544,9 +569,7 @@ if(FLB_COMPILER_STRICT_POINTER_TYPES)
 endif()
 
 # Enable Debug symbols if specified
-if(MSVC)
-  set(CMAKE_BUILD_TYPE None)  # Avoid flag conflicts (See CMakeList.txt:L18)
-elseif(FLB_RELEASE)
+if(FLB_RELEASE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 elseif(FLB_DEBUG)
   set(CMAKE_BUILD_TYPE "Debug")
@@ -757,13 +780,30 @@ if(FLB_UTF8_ENCODER)
   add_subdirectory(${FLB_PATH_LIB_TUTF8E} EXCLUDE_FROM_ALL)
 endif()
 
+# All cases when C++ language support is needed should be checked here
+if((FLB_UNICODE_ENCODER AND FLB_USE_SIMDUTF) OR FLB_RIPSER)
+  enable_language(CXX)
+
+  # Perform delayed modification / extension of CMAKE_CXX_* variables.
+  if(MSVC)
+    # Replace (/|-)MD(d?) with (/|-)MT(d?) to avoid D9025 warning
+    foreach(config_type ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE} Debug Release RelWithDebInfo MinSizeRel)
+      string(TOUPPER ${config_type} upper_config_type)
+      set(flag_var "CMAKE_CXX_FLAGS_${upper_config_type}")
+      string(REGEX REPLACE "(^| |\\t|\\r|\\n)(-|/)(MD)(d?)($| |\\t|\\r|\\n)" "\\1\\2MT\\4\\5" ${flag_var} "${${flag_var}}")
+    endforeach()
+    set(flag_var)
+    set(upper_config_type)
+    set(config_type)
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLB_EXTRA_CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${FLB_EXTRA_CMAKE_CXX_LINK_FLAGS}")
+
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
 # simdutf
 if(FLB_UNICODE_ENCODER AND FLB_USE_SIMDUTF)
-  if (NOT FLB_USE_SIMDUTF)
-    message(FATAL_ERROR "FLB_UNICODE_ENCODER requires FLB_USE_SIMDUTF")
-  endif()
-  enable_language(CXX)
-  set (CMAKE_CXX_STANDARD 11)
   add_subdirectory(${FLB_PATH_LIB_SIMDUTF} EXCLUDE_FROM_ALL)
   FLB_DEFINITION(FLB_HAVE_UNICODE_ENCODER)
 endif()
@@ -823,7 +863,9 @@ macro(MK_SET_OPTION option value)
   set(${option} ${value} CACHE INTERNAL "" FORCE)
 endmacro()
 MK_SET_OPTION(MK_SYSTEM_MALLOC    ON)
-MK_SET_OPTION(MK_DEBUG            ON)
+if(NOT MSVC)
+  MK_SET_OPTION(MK_DEBUG          ON)
+endif()
 
 # Monkey backend event loop
 if (FLB_EVENT_LOOP_EPOLL)
@@ -920,8 +962,6 @@ endif()
 
 # ripser
 if(FLB_RIPSER)
-  enable_language(CXX)
-  set (CMAKE_CXX_STANDARD 11)
   add_subdirectory(${FLB_PATH_LIB_RIPSER} EXCLUDE_FROM_ALL)
   FLB_DEFINITION(FLB_HAVE_RIPSER)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ if (MSVC)
   set(upper_config_type)
   set(config_type)
 
+  # Make compiler aware of source code using UTF-8 encoding
+  add_compile_options(/utf-8)
+
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ endif()
 set(FLB_EXTRA_CMAKE_CXX_FLAGS)
 set(FLB_EXTRA_CMAKE_CXX_LINK_FLAGS)
 
+# For consistency with MSVC debug C/C++ runtime (/MTd and /MDd options),
+# which is used for the Debug build and which automatically adds _DEBUG.
+add_compile_definitions($<$<CONFIG:Debug>:_DEBUG>)
+
 # Update CFLAGS
 if (MSVC)
   # Use static C runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,12 +554,12 @@ if(FLB_UNICODE_ENCODER)
 endif()
 
 if(FLB_COVERAGE)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic")
   if (FLB_UNICODE_ENCODER)
     # CMAKE_CXX_FLAGS will be extended with FLB_EXTRA_CMAKE_CXX_FLAGS,
     # when / if C++ language support will be enabled.
     # Until C++ language support is enabled, CMAKE_CXX_FLAGS is empty / undefined.
-    set(FLB_EXTRA_CMAKE_CXX_FLAGS "${FLB_EXTRA_CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage")
+    set(FLB_EXTRA_CMAKE_CXX_FLAGS "${FLB_EXTRA_CMAKE_CXX_FLAGS} -g -O0 --coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic")
   endif()
   set(CMAKE_BUILD_TYPE "Debug")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,11 +123,7 @@ else()
   endif()
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FLB_FILENAME__=__FILE__")
-# CMAKE_CXX_FLAGS will be extended with FLB_EXTRA_CMAKE_CXX_FLAGS,
-# when / if C++ language support will be enabled.
-# Until C++ language support is enabled, CMAKE_CXX_FLAGS is empty / undefined.
-set(FLB_EXTRA_CMAKE_CXX_FLAGS "${FLB_EXTRA_CMAKE_CXX_FLAGS} -D__FLB_FILENAME__=__FILE__")
+add_compile_definitions(__FLB_FILENAME__=__FILE__)
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7l")
   set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -latomic")
@@ -809,8 +805,8 @@ if((FLB_UNICODE_ENCODER AND FLB_USE_SIMDUTF) OR FLB_RIPSER)
     set(upper_config_type)
     set(config_type)
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLB_EXTRA_CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${FLB_EXTRA_CMAKE_CXX_LINK_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}${FLB_EXTRA_CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS}${FLB_EXTRA_CMAKE_CXX_LINK_FLAGS}")
 
   set(CMAKE_CXX_STANDARD 11)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,12 @@ endif()
 
 # MPack
 add_definitions(-DMPACK_EXTENSIONS=1)
+# MPack read / write tracking seems to have issues with nested types,
+# so it needs to be disabled explicitly, because otherwise MPack
+# read / write tracking is automatically enabled for the Debug build
+# (when _DEBUG macro is defined) with some compilers, like MSVC
+# (refer to https://learn.microsoft.com/en-us/cpp/c-runtime-library/debug).
+add_definitions(-DMPACK_READ_TRACKING=0 -DMPACK_WRITE_TRACKING=0)
 add_subdirectory(${FLB_PATH_LIB_MPACK} EXCLUDE_FROM_ALL)
 
 # Miniz (zip)

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -853,7 +853,7 @@ The following steps have been tested on a Windows Server 2022 Datacenter edition
 7. **Run the binary build**
 
     ```bash
-    cmake --build . --parallel 4 --clean-first
+    cmake --build . --config Release --parallel 4 --clean-first
     ```
 
     **Notes**:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -746,54 +746,54 @@ The following steps have been tested on a Windows Server 2022 Datacenter edition
 2. **Install Flex and Bison**
     1. Create a new file called `setup-flex-bison.ps1` and paste the following script:
 
-    ```powershell
-    # Define variables for Flex and Bison
-    $flexBisonUrl = "https://sourceforge.net/projects/winflexbison/files/win_flex_bison3-latest.zip/download"
-    $downloadPath = "$env:TEMP\win_flex_bison.zip"
-    $extractPath = "C:\win_flex_bison"
-    $flexExe = "flex.exe"
-    $bisonExe = "bison.exe"
+        ```powershell
+        # Define variables for Flex and Bison
+        $flexBisonUrl = "https://sourceforge.net/projects/winflexbison/files/win_flex_bison3-latest.zip/download"
+        $downloadPath = "$env:TEMP\win_flex_bison.zip"
+        $extractPath = "C:\win_flex_bison"
+        $flexExe = "flex.exe"
+        $bisonExe = "bison.exe"
 
-    # Step 2: Download and Setup Flex and Bison
-    Write-Output "Downloading win_flex_bison..."
-    Invoke-WebRequest -Uri $flexBisonUrl -OutFile $downloadPath
+        # Step 2: Download and Setup Flex and Bison
+        Write-Output "Downloading win_flex_bison..."
+        Invoke-WebRequest -Uri $flexBisonUrl -OutFile $downloadPath
 
-    # Create the extract directory if it does not exist
-    If (!(Test-Path -Path $extractPath)) {
-        New-Item -ItemType Directory -Path $extractPath
-    }
+        # Create the extract directory if it does not exist
+        If (!(Test-Path -Path $extractPath)) {
+            New-Item -ItemType Directory -Path $extractPath
+        }
 
-    # Extract the zip file
-    Write-Output "Extracting win_flex_bison..."
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($downloadPath, $extractPath)
+        # Extract the zip file
+        Write-Output "Extracting win_flex_bison..."
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($downloadPath, $extractPath)
 
-    # Rename the executables
-    Write-Output "Renaming executables..."
-    Rename-Item "$extractPath\win_flex.exe" "$extractPath\$flexExe" -Force
-    Rename-Item "$extractPath\win_bison.exe" "$extractPath\$bisonExe" -Force
+        # Rename the executables
+        Write-Output "Renaming executables..."
+        Rename-Item "$extractPath\win_flex.exe" "$extractPath\$flexExe" -Force
+        Rename-Item "$extractPath\win_bison.exe" "$extractPath\$bisonExe" -Force
 
-    # Add Flex and Bison path to system environment variables
-    Write-Output "Adding Flex and Bison path to environment variables..."
-    $envPath = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
-    If ($envPath -notlike "*$extractPath*") {
-        [System.Environment]::SetEnvironmentVariable("Path", "$envPath;$extractPath", "Machine")
-        Write-Output "Path updated. Please restart your command prompt to apply changes."
-    } else {
-        Write-Output "Path already contains the Flex and Bison directory."
-    }
+        # Add Flex and Bison path to system environment variables
+        Write-Output "Adding Flex and Bison path to environment variables..."
+        $envPath = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+        If ($envPath -notlike "*$extractPath*") {
+            [System.Environment]::SetEnvironmentVariable("Path", "$envPath;$extractPath", "Machine")
+            Write-Output "Path updated. Please restart your command prompt to apply changes."
+        } else {
+            Write-Output "Path already contains the Flex and Bison directory."
+        }
 
-    # Cleanup
-    Remove-Item $downloadPath
+        # Cleanup
+        Remove-Item $downloadPath
 
-    Write-Output "Flex and Bison setup complete."
-    ```
+        Write-Output "Flex and Bison setup complete."
+        ```
 
     2. Run the Script: Open PowerShell as administrator.
 
-    ```powershell
-    .\setup-flex-bison.ps1
-    ```
+        ```powershell
+        .\setup-flex-bison.ps1
+        ```
 
     3. Restart the command prompt: After the script completes, restart your command prompt or Visual Studio for the changes to take effect.
 

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -202,7 +202,6 @@ RUN call "%MSVS_HOME%\VC\Auxiliary\Build\vcvars64.bat" && `
       -DOPENSSL_ROOT_DIR='C:\dev\vcpkg\packages\openssl_x64-windows-static' `
       -DFLB_LIBYAML_DIR='C:\dev\vcpkg\packages\libyaml_x64-windows-static' `
       -DFLB_SIMD=On `
-      -DCMAKE_BUILD_TYPE=Release `
       -DFLB_SHARED_LIB=Off `
       -DFLB_EXAMPLES=Off `
       -DFLB_DEBUG=Off `

--- a/lib/librdkafka-2.15.0/src/rdkafka_ssl.c
+++ b/lib/librdkafka-2.15.0/src/rdkafka_ssl.c
@@ -41,8 +41,6 @@
 #ifdef _WIN32
 #include <wincrypt.h>
 #pragma comment(lib, "crypt32.lib")
-#pragma comment(lib, "libcrypto.lib")
-#pragma comment(lib, "libssl.lib")
 #endif
 
 #include <openssl/x509.h>

--- a/lib/onigmo/CMakeLists.txt
+++ b/lib/onigmo/CMakeLists.txt
@@ -30,27 +30,37 @@ endif()
 
 # Update CFLAGS
 if (MSVC)
+  # Use static C runtime
+  if (NOT (CMAKE_VERSION VERSION_LESS "3.15"))
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
+  add_compile_options(/MT$<$<CONFIG:Debug>:d>)
+  # Replace (/|-)MD(d?) with (/|-)MT(d?) to avoid D9025 warning
+  foreach(config_type ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE} Debug Release RelWithDebInfo MinSizeRel)
+    string(TOUPPER ${config_type} upper_config_type)
+    set(flag_var "CMAKE_C_FLAGS_${upper_config_type}")
+    string(REGEX REPLACE "(^| |\\t|\\r|\\n)(-|/)(MD)(d?)($| |\\t|\\r|\\n)" "\\1\\2MT\\4\\5" ${flag_var} "${${flag_var}}")
+  endforeach()
+  set(flag_var)
+  set(upper_config_type)
+  set(config_type)
+
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
 
   # Use custom CFLAGS for MSVC
   #
   #   /Zi ...... Generate pdb files.
-  #   /MT ...... Static link C runtimes.
   #   /wd4711 .. C4711 (function selected for inline expansion)
   #   /wd4100 .. C4100 (unreferenced formal parameter)
   #   /wd5045 .. C5045 (Spectre mitigation)
   #
-  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /DNDEBUG /O2 /Zi /wd4100 /wd4711 /wd5045")
+  set(CMAKE_C_FLAGS "/DWIN32 /D_WINDOWS /Zi /wd4100 /wd4711 /wd5045")
   set(CMAKE_EXE_LINKER_FLAGS "/Debug /INCREMENTAL:NO")
-  set(CMAKE_BUILD_TYPE None)
 
   # We need this line in order to link libonigmo.lib statically.
   # Read onigmo/README for details.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DEXPORT -DHAVE_CONFIG_H")
-  # Use add_compile_options() to set /MT since Visual Studio
-  # Generator does not notice /MT in CMAKE_C_FLAGS.
-  add_compile_options(/MT)
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/lib/onigmo/CMakeLists.txt
+++ b/lib/onigmo/CMakeLists.txt
@@ -45,6 +45,9 @@ if (MSVC)
   set(upper_config_type)
   set(config_type)
 
+  # Make compiler aware of source code using UTF-8 encoding
+  add_compile_options(/utf-8)
+
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
 

--- a/lib/onigmo/CMakeLists.txt
+++ b/lib/onigmo/CMakeLists.txt
@@ -270,7 +270,7 @@ if(ONIGMO_SHARED_LIB)
       PROPERTIES PDB_NAME onigmo.dll)
     target_link_options(onigmo-shared
       PUBLIC /pdb:$<TARGET_PDB_FILE:onigmo-shared>
-      PRIVATE /LTCG)
+      PRIVATE $<$<NOT:$<CONFIG:Debug>>:/LTCG>)
   endif()
 
   # Library install routines


### PR DESCRIPTION
**Summary**

* Fixed C/C++ compiler options in CMake project especially when MSVC is used (e.g. fixed passing preprocessor definitions required for #10158). It makes possible debugging of (Windows build of) Fluent Bit / tests on Windows.
* Fixed (formatting, build command) development guide for Windows.
* Fixed support of "Visual Studio" [CMake Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html) - refer to #10158. 
    **Note:** multi-config CMake Generators (like "Visual Studio" ones) can still have issues due to Fluent Bit CMake project doesn't honor and doesn't support the build type(s) specified when CMake generates native build system project - e.g. `CMAKE_BUILD_TYPE` passed through command line and `CMAKE_CONFIGURATION_TYPES`. Support of multi-config CMake Generators can require usage of [CMake generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html) everywhere build-config specific compiler / linker options are added / modified, can require revisiting of the way linked libraries are specified, e.g. they should not use `-l` option with hard-coded name of static library file, because the name of library file can depend on build configuration on Windows - e.g. libcrypto.lib for `Release` and `RelWithDebInfo` builds with `/MT` compiler option (static release MS C/C++ runtime) vs libcrypto**d**.lib for `Debug` build with `/MTd` compiler option (static debug MS C/C++ runtime).
* Fixed parallel build of Fluent Bit when building docker image for Windows containers.
* Fixed "negative coverage" error when collecting test coverage with coverage profiled build.
* Speedup of building debug version on Windows by disabling [Link-Time Code Generation](https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation) for Debug build only.
* Fixed count with MPack when data are empty (https://github.com/ludocode/mpack/pull/119).

----

**Testing**

- [N/A] Example configuration file for the change.
- [N/A] Debug log output from testing the change.
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found - refer to [flb_run_code_analysis.log](https://drive.google.com/file/d/1OpPgdQQbjlklUy7Y-qasvLnBXgeCmRSi/view?usp=sharing) for the output of command
    ```bash
    TEST_PRESET=valgrind ./run_code_analysis.sh
    ```
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature.

**Backporting**

- [N/A] Backport to latest stable release.

**PRs in other repositories implementing same changes**

1. https://github.com/fluent/onigmo/pull/9
1. https://github.com/fluent/chunkio/pull/113
1. https://github.com/confluentinc/librdkafka/pull/5334

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Infrastructure**
  * Windows builder switched to Ninja; build invocation updated.
  * Added delayed-extension variables for C++ compiler/linker flags and applied when C++ is enabled.
  * Improved MSVC handling: UTF‑8 enabled; static-runtime selection moved to per-configuration logic; MK_DEBUG disabled on MSVC.
  * Coverage and platform-specific linker-flag handling improved; MPack tracking explicitly disabled.

* **Documentation**
  * Windows setup docs updated with vcpkg integration and revised build commands.

* **Bug Fixes**
  * Fixed 64-bit file-mapping size handling on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->