### PR TITLE
github: scripts: commit_prefix_check: Add tests into umbrella rule

### DIFF
--- a/.github/scripts/tests/test_commit_lint.py
+++ b/.github/scripts/tests/test_commit_lint.py
@@ -617,6 +617,24 @@ def test_valid_test_file_changes():
     ok, _ = validate_commit(commit)
     assert ok is True
 
+
+def test_invalid_test_file_changes_without_umbrella_prefix():
+    """
+    Test that test file changes are disallowed without tests umbrella under tests components.
+
+
+    Test files (in tests/ directory) basically allows tests umbrella prefix.
+    Without "tests:" umbrella prefix are not acceptable for test-related changes.
+    """
+    commit = make_commit(
+        "test_router: add unit test\n\nSigned-off-by: User",
+        ["tests/internal/test_router.c"]
+    )
+    ok, msg = validate_commit(commit)
+    assert ok is False
+    assert "Expected one of: test_router:, tests:" in msg
+
+
 def test_valid_build_file_changes():
     """
     Test that build system file changes are allowed with generic prefixes.

--- a/.github/scripts/tests/test_commit_lint.py
+++ b/.github/scripts/tests/test_commit_lint.py
@@ -611,7 +611,7 @@ def test_valid_test_file_changes():
     Generic prefixes like "tests:" are acceptable for test-related changes.
     """
     commit = make_commit(
-        "tests: add unit test\n\nSigned-off-by: User",
+        "tests: test_router: add unit test\n\nSigned-off-by: User",
         ["tests/unit/test_router.c"]
     )
     ok, _ = validate_commit(commit)


### PR DESCRIPTION
<!-- Provide summary of changes -->

We need to permit this kind of style of commit messages:

```
tests: in_splunk: Add a remote_addr extraction case

Signed-off-by: ...
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced commit prefix validation for test-related contributions with more specific naming conventions and umbrella handling
  * Expanded umbrella prefix policies to better organize changes across lib and tests categories
  * Improved validation to ensure changes align with declared prefixes, with clearer error messages for mismatches

* **Tests**
  * Updated and added tests to validate the new prefix rules and error reporting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->