### PR TITLE
in_http: minimal http response and Improved Content-Type detection

### DIFF
--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -764,15 +764,23 @@ static int process_payload(struct flb_http *ctx, struct http_conn *conn,
         return -1;
     }
 
-    if (((header->val.len == 16 && strncasecmp(header->val.data, "application/json", 16) == 0)) ||
-        ((header->val.len > 16 && (strncasecmp(header->val.data, "application/json ", 17) == 0)) ||
-        strncasecmp(header->val.data, "application/json;", 17) == 0)) {
-        type = HTTP_CONTENT_JSON;
+    if (header->val.len >= 16 && strncasecmp(header->val.data, "application/json", 16) == 0) {
+        /* Validate that the character after the matched prefix is acceptable */
+        if (header->val.len == 16 || 
+            header->val.data[16] == ';' || 
+            isspace((unsigned char)header->val.data[16])) {
+            type = HTTP_CONTENT_JSON;
+        }
     }
 
-    if (header->val.len == 33 &&
+    if (header->val.len >= 33 &&
         strncasecmp(header->val.data, "application/x-www-form-urlencoded", 33) == 0) {
-        type = HTTP_CONTENT_URLENCODED;
+        /* Validate that the character after the matched prefix is acceptable */
+        if (header->val.len == 33 || 
+            header->val.data[33] == ';' || 
+            isspace((unsigned char)header->val.data[33])) {
+            type = HTTP_CONTENT_URLENCODED;
+        }
     }
 
     if (type == -1) {
@@ -1223,12 +1231,22 @@ static int process_payload_ng(flb_sds_t tag,
         return -1;
     }
 
-    if (strcasecmp(request->content_type, "application/json") == 0) {
-        type = HTTP_CONTENT_JSON;
+    if (strncasecmp(request->content_type, "application/json", 16) == 0) {
+        /* Validate that the character after the matched prefix is acceptable */
+        if (strlen(request->content_type) == 16 || 
+            request->content_type[16] == ';' || 
+            isspace((unsigned char)request->content_type[16])) {
+            type = HTTP_CONTENT_JSON;
+        }
     }
 
-    if (strcasecmp(request->content_type, "application/x-www-form-urlencoded") == 0) {
-        type = HTTP_CONTENT_URLENCODED;
+    if (strncasecmp(request->content_type, "application/x-www-form-urlencoded", 33) == 0) {
+        /* Validate that the character after the matched prefix is acceptable */
+        if (strlen(request->content_type) == 33 || 
+            request->content_type[33] == ';' || 
+            isspace((unsigned char)request->content_type[33])) {
+            type = HTTP_CONTENT_URLENCODED;
+        }
     }
 
     if (type == -1) {

--- a/src/http_server/flb_hs_endpoints.c
+++ b/src/http_server/flb_hs_endpoints.c
@@ -40,57 +40,12 @@ static int endpoint_root(struct flb_hs *hs)
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
+    /* Return minimal information without sensitive details */
     msgpack_pack_map(&mp_pck, 1);
-    msgpack_pack_str(&mp_pck, 10);
-    msgpack_pack_str_body(&mp_pck, "fluent-bit", 10);
-
-    /* entries under fluent-bit parent:
-     *
-     * - version
-     * - edition
-     * - built flags
-     */
-    msgpack_pack_map(&mp_pck, 3);
-
-    /* fluent-bit['version'] */
-    msgpack_pack_str(&mp_pck, 7);
-    msgpack_pack_str_body(&mp_pck, "version", 7);
-    msgpack_pack_str(&mp_pck, sizeof(FLB_VERSION_STR) - 1);
-    msgpack_pack_str_body(&mp_pck, FLB_VERSION_STR, sizeof(FLB_VERSION_STR) - 1);
-
-    /* fluent-bit['edition'] */
-    msgpack_pack_str(&mp_pck, 7);
-    msgpack_pack_str_body(&mp_pck, "edition", 7);
-#ifdef FLB_ENTERPRISE
-    msgpack_pack_str(&mp_pck, 10);
-    msgpack_pack_str_body(&mp_pck, "Enterprise", 10);
-#else
-    msgpack_pack_str(&mp_pck, 9);
-    msgpack_pack_str_body(&mp_pck, "Community", 9);
-#endif
-
-    /* fluent-bit['flags'] */
-    msgpack_pack_str(&mp_pck, 5);
-    msgpack_pack_str_body(&mp_pck, "flags", 5);
-
-    c = 0;
-    list = flb_utils_split(FLB_INFO_FLAGS, ' ', -1);
-    mk_list_foreach(head, list) {
-        entry = mk_list_entry(head, struct flb_split_entry, _head);
-        if (strncmp(entry->value, "FLB_", 4) == 0) {
-            c++;
-        }
-    }
-
-    msgpack_pack_array(&mp_pck, c);
-    mk_list_foreach(head, list) {
-        entry = mk_list_entry(head, struct flb_split_entry, _head);
-        if (strncmp(entry->value, "FLB_", 4) == 0) {
-            msgpack_pack_str(&mp_pck, entry->len);
-            msgpack_pack_str_body(&mp_pck, entry->value, entry->len);
-        }
-    }
-    flb_utils_split_free(list);
+    msgpack_pack_str(&mp_pck, 6);
+    msgpack_pack_str_body(&mp_pck, "status", 6);
+    msgpack_pack_str(&mp_pck, 2);
+    msgpack_pack_str_body(&mp_pck, "ok", 2);
 
     /* export as JSON */
     out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);


### PR DESCRIPTION
## Summary

This PR modifies the HTTP server root endpoint (`/`) to return minimal information instead of exposing sensitive system details.

## Changes

__Before:__

```json
{
  "fluent-bit": {
    "version": "5.0.0",
    "edition": "Community",
    "flags": ["FLB_HAVE_SYS_WAIT_H", "FLB_HAVE_SIMD", ...]
  }
}
```

__After:__

```json
{
  "status": "ok"
}
```

## Motivation

The HTTP server's root endpoint previously exposed sensitive information including:

- Exact version number
- Edition type (Community/Enterprise)
- Detailed build flags and capabilities

This information disclosure could be leveraged by attackers to:

- Identify specific vulnerabilities in the version
- Understand system capabilities and attack surface
- Fingerprint the deployment environment

This change reduces the attack surface by providing only a minimal health status response.

## Modified Files

- `src/http_server/flb_hs_endpoints.c`: Simplified endpoint_root() function to return minimal status

## Testing

- [ ] Example configuration file for the change

  ```conf
  [SERVICE]
      HTTP_Server  On
      HTTP_Listen  0.0.0.0
      HTTP_Port    2020
  ```

- [ ] Debug log output from testing the change

  ```javascript
  # Test the endpoint
  curl http://localhost:2020/
  # Expected output: {"status":"ok"}
  ```

- [ ] Attached Valgrind output that shows no leaks or memory corruption was found

## Packaging

- [ ] Run local packaging test showing all targets build
- [ ] Set `ok-package-test` label to test for all targets

## Documentation

- [ ] Documentation required for this feature

  - Document that the root endpoint now returns minimal information
  - Update any documentation referencing the version/edition/flags output

## Backporting

- [ ] Backport to latest stable release (recommended for security improvement)

## Notes

- Other monitoring endpoints (`/api/v1/metrics`, `/api/v1/health`, etc.) remain unchanged
- Users needing version information can still access it through other means (logs, CLI)
- This is a security hardening measure to reduce information disclosure

---

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Root API endpoint now returns a minimal status indicator ("ok") instead of detailed version/configuration data.
  * Improved Content-Type detection for incoming HTTP requests: JSON and form-encoded payloads are recognized using prefix-and-boundary checks, and requests with invalid Content-Type now receive a 400 error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->