### PR TITLE
out_s3: Add SSE support + validation tests

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -267,7 +267,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n].val_len = strlen(ctx->sse);
         n++;
     }
-    if (ctx->sse_kms_key_id != NULL && ctx->sse != NULL && (strcmp(ctx->sse, "aws:kms") == 0 || strcmp(ctx->sse, "aws:kms:dsse") == 0)) {
+    if (ctx->sse_kms_key_id != NULL && ctx->sse != NULL && (strncmp(ctx->sse, "aws:kms", sizeof("aws:kms")) == 0 || strncmp(ctx->sse, "aws:kms:dsse", sizeof("aws:kms:dsse")) == 0)) {
         s3_headers[n] = sse_kms_key_id_header;
         s3_headers[n].val = ctx->sse_kms_key_id;
         s3_headers[n].val_len = strlen(ctx->sse_kms_key_id);
@@ -895,9 +895,9 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     tmp = flb_output_get_property("sse", ins);
     if (tmp) {
-        if (strcmp(tmp, "AES256") != 0 &&
-            strcmp(tmp, "aws:kms") != 0 &&
-            strcmp(tmp, "aws:kms:dsse") != 0) {
+        if (strncmp(tmp, "AES256", sizeof("AES256")) != 0 &&
+            strncmp(tmp, "aws:kms", sizeof("aws:kms")) != 0 &&
+            strncmp(tmp, "aws:kms:dsse", sizeof("aws:kms:dsse")) != 0) {
             flb_plg_error(ctx->ins, "Invalid 'sse' value '%s'. Must be 'AES256', 'aws:kms', or 'aws:kms:dsse'", tmp);
             return -1;
         }
@@ -906,7 +906,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     tmp = flb_output_get_property("sse_kms_key_id", ins);
     if (tmp) {
-        if (ctx->sse == NULL || (strcmp(ctx->sse, "aws:kms") != 0 && strcmp(ctx->sse, "aws:kms:dsse") != 0)) {
+        if (ctx->sse == NULL || (strncmp(ctx->sse, "aws:kms", sizeof("aws:kms")) != 0 && strncmp(ctx->sse, "aws:kms:dsse", sizeof("aws:kms:dsse")) != 0)) {
             flb_plg_error(ctx->ins, "Invalid 'sse_kms_key_id' value '%s'. 'sse_kms_key_id' is only applicable when 'sse' is set to 'aws:kms' or 'aws:kms:dsse'", tmp);
             return -1;
         }

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -267,7 +267,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n].val_len = strlen(ctx->sse);
         n++;
     }
-    if (ctx->sse_kms_key_id != NULL && ctx->sse != NULL && (strcasecmp(ctx->sse, "aws:kms") == 0 || strcasecmp(ctx->sse, "aws:kms:dsse") == 0)) {
+    if (ctx->sse_kms_key_id != NULL && ctx->sse != NULL && (strcmp(ctx->sse, "aws:kms") == 0 || strcmp(ctx->sse, "aws:kms:dsse") == 0)) {
         s3_headers[n] = sse_kms_key_id_header;
         s3_headers[n].val = ctx->sse_kms_key_id;
         s3_headers[n].val_len = strlen(ctx->sse_kms_key_id);
@@ -895,9 +895,9 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     tmp = flb_output_get_property("sse", ins);
     if (tmp) {
-        if (strcasecmp(tmp, "AES256") != 0 &&
-            strcasecmp(tmp, "aws:kms") != 0 &&
-            strcasecmp(tmp, "aws:kms:dsse") != 0) {
+        if (strcmp(tmp, "AES256") != 0 &&
+            strcmp(tmp, "aws:kms") != 0 &&
+            strcmp(tmp, "aws:kms:dsse") != 0) {
             flb_plg_error(ctx->ins, "Invalid 'sse' value '%s'. Must be 'AES256', 'aws:kms', or 'aws:kms:dsse'", tmp);
             return -1;
         }
@@ -906,7 +906,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     tmp = flb_output_get_property("sse_kms_key_id", ins);
     if (tmp) {
-        if (ctx->sse == NULL || (strcasecmp(ctx->sse, "aws:kms") != 0 && strcasecmp(ctx->sse, "aws:kms:dsse") != 0)) {
+        if (ctx->sse == NULL || (strcmp(ctx->sse, "aws:kms") != 0 && strcmp(ctx->sse, "aws:kms:dsse") != 0)) {
             flb_plg_error(ctx->ins, "Invalid 'sse_kms_key_id' value '%s'. 'sse_kms_key_id' is only applicable when 'sse' is set to 'aws:kms' or 'aws:kms:dsse'", tmp);
             return -1;
         }

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -267,7 +267,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n].val_len = strlen(ctx->sse);
         n++;
     }
-    if (ctx->sse_kms_key_id != NULL) {
+    if (ctx->sse_kms_key_id != NULL && ctx->sse != NULL && (strcasecmp(ctx->sse, "aws:kms") == 0 || strcasecmp(ctx->sse, "aws:kms:dsse") == 0)) {
         s3_headers[n] = sse_kms_key_id_header;
         s3_headers[n].val = ctx->sse_kms_key_id;
         s3_headers[n].val_len = strlen(ctx->sse_kms_key_id);
@@ -906,6 +906,10 @@ static int cb_s3_init(struct flb_output_instance *ins,
 
     tmp = flb_output_get_property("sse_kms_key_id", ins);
     if (tmp) {
+        if (ctx->sse == NULL || (strcasecmp(ctx->sse, "aws:kms") != 0 && strcasecmp(ctx->sse, "aws:kms:dsse") != 0)) {
+            flb_plg_error(ctx->ins, "Invalid 'sse_kms_key_id' value '%s'. 'sse_kms_key_id' is only applicable when 'sse' is set to 'aws:kms' or 'aws:kms:dsse'", tmp);
+            return -1;
+        }
         ctx->sse_kms_key_id = (char *) tmp;
     }
 
@@ -4216,7 +4220,7 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "sse_kms_key_id", NULL,
      0, FLB_FALSE, 0,
      "AWS KMS key ID (or key ARN) for server-side encryption. Only applicable when "
-     "'sse' is set to 'aws:kms'. If not specified, the default AWS-managed KMS key "
+     "'sse' is set to 'aws:kms' or 'aws:kms:dsse'. If not specified, the default AWS-managed KMS key "
      "for S3 will be used."
     },
 

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -4213,13 +4213,13 @@ static struct flb_config_map config_map[] = {
      "Server-side encryption for S3 objects. Set to 'AES256' for S3-managed keys "
      "(SSE-S3), 'aws:kms' for AWS KMS-managed keys (SSE-KMS), or 'aws:kms:dsse' for "
      "dual-layer server-side encryption with KMS (DSSE-KMS). When using 'aws:kms' or "
-     "'aws:kms:dsse', you can optionally specify the KMS key ID with the 'sse_kms_key_id' option."
+     "'aws:kms:dsse'"
     },
 
     {
      FLB_CONFIG_MAP_STR, "sse_kms_key_id", NULL,
      0, FLB_FALSE, 0,
-     "AWS KMS key ID (or key ARN) for server-side encryption. Only applicable when "
+     "AWS key ARN for server-side encryption. Only applicable when "
      "'sse' is set to 'aws:kms' or 'aws:kms:dsse'. If not specified, the default AWS-managed KMS key "
      "for S3 will be used."
     },

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -138,6 +138,20 @@ static struct flb_aws_header storage_class_header = {
     .val_len = 0,
 };
 
+static struct flb_aws_header sse_header = {
+    .key = "x-amz-server-side-encryption",
+    .key_len = 28,
+    .val = "",
+    .val_len = 0,
+};
+
+static struct flb_aws_header sse_kms_key_id_header = {
+    .key = "x-amz-server-side-encryption-aws-kms-key-id",
+    .key_len = 43,
+    .val = "",
+    .val_len = 0,
+};
+
 static char *mock_error_response(char *error_env_var)
 {
     char *err_val = NULL;
@@ -194,6 +208,12 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
     if (ctx->storage_class != NULL) {
         headers_len++;
     }
+    if (ctx->sse != NULL) {
+        headers_len++;
+    }
+    if (ctx->sse_kms_key_id != NULL) {
+        headers_len++;
+    }
     if (headers_len == 0) {
         *num_headers = headers_len;
         *headers = s3_headers;
@@ -239,6 +259,19 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n] = storage_class_header;
         s3_headers[n].val = ctx->storage_class;
         s3_headers[n].val_len = strlen(ctx->storage_class);
+        n++;
+    }
+    if (ctx->sse != NULL) {
+        s3_headers[n] = sse_header;
+        s3_headers[n].val = ctx->sse;
+        s3_headers[n].val_len = strlen(ctx->sse);
+        n++;
+    }
+    if (ctx->sse_kms_key_id != NULL) {
+        s3_headers[n] = sse_kms_key_id_header;
+        s3_headers[n].val = ctx->sse_kms_key_id;
+        s3_headers[n].val_len = strlen(ctx->sse_kms_key_id);
+        n++;
     }
 
     *num_headers = headers_len;
@@ -858,6 +891,22 @@ static int cb_s3_init(struct flb_output_instance *ins,
     tmp = flb_output_get_property("storage_class", ins);
     if (tmp) {
         ctx->storage_class = (char *) tmp;
+    }
+
+    tmp = flb_output_get_property("sse", ins);
+    if (tmp) {
+        if (strcasecmp(tmp, "AES256") != 0 &&
+            strcasecmp(tmp, "aws:kms") != 0 &&
+            strcasecmp(tmp, "aws:kms:dsse") != 0) {
+            flb_plg_error(ctx->ins, "Invalid 'sse' value '%s'. Must be 'AES256', 'aws:kms', or 'aws:kms:dsse'", tmp);
+            return -1;
+        }
+        ctx->sse = (char *) tmp;
+    }
+
+    tmp = flb_output_get_property("sse_kms_key_id", ins);
+    if (tmp) {
+        ctx->sse_kms_key_id = (char *) tmp;
     }
 
     if (ctx->insecure == FLB_FALSE) {
@@ -4152,6 +4201,23 @@ static struct flb_config_map config_map[] = {
      0, FLB_FALSE, 0,
      "Specify the storage class for S3 objects. If this option is not specified, objects "
      "will be stored with the default 'STANDARD' storage class."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "sse", NULL,
+     0, FLB_FALSE, 0,
+     "Server-side encryption for S3 objects. Set to 'AES256' for S3-managed keys "
+     "(SSE-S3), 'aws:kms' for AWS KMS-managed keys (SSE-KMS), or 'aws:kms:dsse' for "
+     "dual-layer server-side encryption with KMS (DSSE-KMS). When using 'aws:kms' or "
+     "'aws:kms:dsse', you can optionally specify the KMS key ID with the 'sse_kms_key_id' option."
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "sse_kms_key_id", NULL,
+     0, FLB_FALSE, 0,
+     "AWS KMS key ID (or key ARN) for server-side encryption. Only applicable when "
+     "'sse' is set to 'aws:kms'. If not specified, the default AWS-managed KMS key "
+     "for S3 will be used."
     },
 
     {

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -114,6 +114,8 @@ struct flb_s3 {
     char *canned_acl;
     char *content_type;
     char *storage_class;
+    char *sse;
+    char *sse_kms_key_id;
     char *log_key;
     char *external_id;
     char *profile;

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -228,6 +228,99 @@ void flb_test_s3_complete_upload_error(void)
     unsetenv("TEST_COMPLETE_MULTIPART_UPLOAD_ERROR");
 }
 
+void flb_test_s3_sse_invalid_value(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_S3_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "s3", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "sse", "invalid_encryption", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);  /* Expect failure due to invalid sse value */
+
+    flb_destroy(ctx);
+}
+
+void flb_test_s3_sse_kms_valid(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_S3_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "s3", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "sse", "aws:kms", NULL);
+    flb_output_set(ctx, out_ffd, "Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);  /* Expect success with valid sse value */
+
+    sleep(1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_s3_sse_aes256_valid(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_S3_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "s3", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "sse", "AES256", NULL);
+    flb_output_set(ctx, out_ffd, "Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);  /* Expect success with valid sse value */
+
+    sleep(1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 
 /* Test list */
 TEST_LIST = {
@@ -237,5 +330,9 @@ TEST_LIST = {
     {"create_upload_error", flb_test_s3_create_upload_error },
     {"upload_part_error", flb_test_s3_upload_part_error },
     {"complete_upload_error", flb_test_s3_complete_upload_error },
+    {"sse_invalid_value", flb_test_s3_sse_invalid_value },
+    {"sse_kms_valid", flb_test_s3_sse_kms_valid },
+    {"sse_aes256_valid", flb_test_s3_sse_aes256_valid },
     {NULL, NULL}
 };
+


### PR DESCRIPTION
## Summary
Adds server-side encryption support for S3 uploads with SSE-KMS and DSSE-KMS.

## Changes
- New `sse` configuration option: `AES256`, `aws:kms`, `aws:kms:dsse`
- New `sse_kms_key_id` option to specify a custom KMS key ARN
- Unit tests for SSE validation

## Configuration Example
```ini
[OUTPUT]
    Name         s3
    Match        *
    bucket       my-bucket
    region       us-east-1
    sse          aws:kms
    sse_kms_key_id arn:aws:kms:us-east-1:123456789:key/my-key-id
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<details>
<summary>Click to expand practical test results</summary>

### No SSE
```ini
[OUTPUT]
    Name         s3
    Match        valid_no_sse
    bucket       <BUCKET-NAME>
    region       eu-west-1
    upload_timeout 5s
    use_put_object true
    total_file_size 1M
    s3_key_format /flb-test/valid_no_sse.log
```
```text
[2026/01/28 11:43:47.983944606] [ info] [output:s3:s3.0] Running upload timer callback (cb_s3_upload)..
[2026/01/28 11:43:48.158802195] [debug] [upstream] KA connection #147 to s3.eu-west-1.amazonaws.com:443 is connected
[2026/01/28 11:43:48.158833956] [debug] [http_client] not using http_proxy for header
[2026/01/28 11:43:48.158850304] [debug] [aws_credentials] Requesting credentials from the env provider..
[2026/01/28 11:43:48.275608046] [debug] [upstream] KA connection #147 to s3.eu-west-1.amazonaws.com:443 is now available
[2026/01/28 11:43:48.275638338] [debug] [output:s3:s3.0] PutObject http status=200
[2026/01/28 11:43:48.275643840] [ info] [output:s3:s3.0] Successfully uploaded object /flb-test/valid_no_sse.log
```

---

### SSE-KMS (single layer)
```ini
[OUTPUT]
    Name         s3
    Match        valid_sse_kms
    bucket       <BUCKET-NAME>
    region       eu-west-1
    upload_timeout 5s
    use_put_object true
    total_file_size 1M
    sse          aws:kms
    s3_key_format /flb-test/valid_sse_kms.log
```

#### Trying to upload without SSE headers (bucket requires SSE-KMS):
```text
[2026/01/28 12:02:25.166312743] [error] [output:s3:s3.0] PutObject API responded with error='AccessDenied', message='User: arn:aws:iam::XXXXXXXXXXXX:user/test-user is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::<BUCKET-NAME>/flb-test/valid_no_sse.log" with an explicit deny in a resource-based policy'
[2026/01/28 12:02:25.166314777] [error] [output:s3:s3.0] Raw PutObject response: HTTP/1.1 403 Forbidden
x-amz-request-id: XXXXXXXXXXXXXXXX
x-amz-id-2: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Wed, 28 Jan 2026 12:02:23 GMT
Connection: close
Server: AmazonS3

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>User: arn:aws:iam::XXXXXXXXXXXX:user/test-user is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::<BUCKET-NAME>/flb-test/valid_no_sse.log" with an explicit deny in a resource-based policy</Message><RequestId>XXXXXXXXXXXXXXXX</RequestId><HostId>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</HostId></Error>
[2026/01/28 12:02:25.166319539] [error] [output:s3:s3.0] PutObject request failed
[2026/01/28 12:02:25.166321907] [error] [output:s3:s3.0] Could not send chunk with tag valid_no_sse
[2026/01/28 12:02:25.166323864] [ warn] [output:s3:s3.0] Chunk for tag valid_no_sse failed to send 1/1 times, will not retry
```

#### With SSE header:
```text
[2026/01/28 12:00:25.860282879] [ info] [output:s3:s3.2] Running upload timer callback (cb_s3_upload)..
[2026/01/28 12:00:26.33316549] [debug] [upstream] KA connection #147 to s3.eu-west-1.amazonaws.com:443 is connected
[2026/01/28 12:00:26.33349606] [debug] [http_client] not using http_proxy for header
[2026/01/28 12:00:26.33373796] [debug] [aws_credentials] Requesting credentials from the env provider..
[2026/01/28 12:00:26.189999339] [debug] [upstream] KA connection #147 to s3.eu-west-1.amazonaws.com:443 is now available
[2026/01/28 12:00:26.190058831] [debug] [output:s3:s3.2] PutObject http status=200
[2026/01/28 12:00:26.190071739] [ info] [output:s3:s3.2] Successfully uploaded object /flb-test/valid_sse_kms.log
```

---

### SSE-S3 (AES256)
```ini
[OUTPUT]
    Name         s3
    Match        valid_sse_aes256
    bucket       <BUCKET-NAME>
    region       eu-west-1
    upload_timeout 5s
    use_put_object true
    total_file_size 1M
    sse          AES256
    s3_key_format /flb-test/valid_sse_aes256.log
```
```text
[2026/01/28 12:10:39.800385154] [ info] [output:s3:s3.1] Running upload timer callback (cb_s3_upload)..
[2026/01/28 12:10:39.957785800] [debug] [upstream] KA connection #132 to s3.eu-west-1.amazonaws.com:443 is connected
[2026/01/28 12:10:39.957885708] [debug] [http_client] not using http_proxy for header
[2026/01/28 12:10:39.957923267] [debug] [aws_credentials] Requesting credentials from the env provider..
[2026/01/28 12:10:40.72762610] [debug] [upstream] KA connection #132 to s3.eu-west-1.amazonaws.com:443 is now available
[2026/01/28 12:10:40.72816454] [debug] [output:s3:s3.1] PutObject http status=200
[2026/01/28 12:10:40.72828231] [ info] [output:s3:s3.1] Successfully uploaded object /flb-test/valid_sse_aes256.log
```

---

### DSSE-KMS (dual layer)
```ini
[OUTPUT]
    Name         s3
    Match        valid_sse_kms_dsse
    bucket       <BUCKET-NAME>
    region       eu-west-1
    upload_timeout 5s
    use_put_object true
    total_file_size 1M
    sse          aws:kms:dsse
    s3_key_format /flb-test/valid_sse_kms_dsse.log
```
```text
[2026/01/28 12:13:41.783349004] [ info] [output:s3:s3.3] Running upload timer callback (cb_s3_upload)..
[2026/01/28 12:13:41.957309834] [debug] [upstream] KA connection #131 to s3.eu-west-1.amazonaws.com:443 is connected
[2026/01/28 12:13:41.957382060] [debug] [http_client] not using http_proxy for header
[2026/01/28 12:13:41.957420743] [debug] [aws_credentials] Requesting credentials from the env provider..
[2026/01/28 12:13:42.107501670] [debug] [upstream] KA connection #131 to s3.eu-west-1.amazonaws.com:443 is now available
[2026/01/28 12:13:42.107643274] [debug] [output:s3:s3.3] PutObject http status=200
[2026/01/28 12:13:42.107671339] [ info] [output:s3:s3.3] Successfully uploaded object /flb-test/valid_sse_kms_dsse.log
```

---

### SSE-KMS with specific key ID
```ini
[OUTPUT]
    Name         s3
    Match        valid_sse_kms_with_key
    bucket       <BUCKET-NAME>
    region       eu-west-1
    upload_timeout 5s
    use_put_object true
    total_file_size 1M
    sse          aws:kms
    sse_kms_key_id arn:aws:kms:eu-west-1:<ACCOUNT-NUMBER>:key/<KEY-ID>
    s3_key_format /flb-test/valid_sse_kms_with_key.log
```
```text
[2026/01/28 12:13:41.783349004] [ info] [output:s3:s3.3] Running upload timer callback (cb_s3_upload)..
[2026/01/28 13:38:48.447545255] [debug] [upstream] KA connection #131 to s3.eu-west-1.amazonaws.com:443 is connected
[2026/01/28 13:38:48.447578127] [debug] [http_client] not using http_proxy for header
[2026/01/28 13:38:48.447609260] [debug] [aws_credentials] Requesting credentials from the env provider..
[2026/01/28 13:38:48.589414610] [debug] [upstream] KA connection #131 to s3.eu-west-1.amazonaws.com:443 is now available
[2026/01/28 13:38:48.589444360] [debug] [output:s3:s3.4] PutObject http status=200
[2026/01/28 13:38:48.589448962] [ info] [output:s3:s3.4] Successfully uploaded object /flb-test/valid_sse_kms_with_key.log
```

---

### DSSE-KMS with specific key ID
```ini
[OUTPUT]
    Name         s3
    Match        valid_sse_kms_dsse_with_key
    bucket       <BUCKET-NAME>
    region       eu-west-1
    upload_timeout 5s
    use_put_object true
    total_file_size 1M
    sse          aws:kms:dsse
    sse_kms_key_id arn:aws:kms:eu-west-1:<ACCOUNT-NUMBER>:key/<KEY-ID>
    s3_key_format /flb-test/valid_sse_kms_dsse_with_key.log
```
```text
[2026/01/28 13:46:21.251935530] [ info] [output:s3:s3.5] Running upload timer callback (cb_s3_upload)..
[2026/01/28 13:46:21.413864736] [debug] [upstream] KA connection #131 to s3.eu-west-1.amazonaws.com:443 is connected
[2026/01/28 13:46:21.413897266] [debug] [http_client] not using http_proxy for header
[2026/01/28 13:46:21.413916397] [debug] [aws_credentials] Requesting credentials from the env provider..
[2026/01/28 13:46:21.548542101] [debug] [upstream] KA connection #131 to s3.eu-west-1.amazonaws.com:443 is now available
[2026/01/28 13:46:21.548572734] [debug] [output:s3:s3.5] PutObject http status=200
[2026/01/28 13:46:21.548578248] [ info] [output:s3:s3.5] Successfully uploaded object /flb-test/valid_sse_kms_dsse_with_key.log
```

---

### Invalid SSE value rejected
```ini
[OUTPUT]
   Name         s3
   Match        invalid_sse_value
   bucket       <BUCKET-NAME>
   region       eu-west-1
   upload_timeout 5s
   use_put_object true
   total_file_size 1M
   sse          invalid_encryption
   s3_key_format /flb-test/invalid_sse_value.log
```
```text
[2026/01/28 13:45:09.851380496] [ info] [output:s3:s3.5] initializing worker
[2026/01/28 13:45:09.851410184] [ info] [output:s3:s3.5] worker #0 started
[2026/01/28 13:45:09.851601410] [ info] [output:s3:s3.6] Using upload size 1000000 bytes
[2026/01/28 13:45:09.851626236] [error] [output:s3:s3.6] Invalid 'sse' value 'invalid_encryption'. Must be 'AES256', 'aws:kms', or 'aws:kms:dsse'
[2026/01/28 13:45:09.851631572] [error] [output] failed to initialize 's3' plugin
[2026/01/28 13:45:09.851679524] [error] [engine] output initialization failed
[2026/01/28 13:45:10.852269768] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 13:45:10.852387434] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 13:45:10.852515803] [ info] [output:s3:s3.0] thread worker #0 stopped
```
</details>

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
<details>
<summary>Click to expand valgrind report</summary>

### Even though this PR introduced no memory allocations, I've ran the valgrind test just to be safe and add it here.

```
==20663== Memcheck, a memory error detector
==20663== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==20663== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==20663== Command: ./build/bin/flb-rt-out_s3
==20663== 
Test multipart_success...                       [2026/01/28 14:00:36.915156988] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:36.946457925] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:36.946897950] [ info] [simd    ] disabled
[2026/01/28 14:00:36.947217525] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:36.947455194] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:36.959635663] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:36.960198015] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:37.262989097] [ info] [fstore] created root path /tmp/fluent-bit/s3/fluent
[2026/01/28 14:00:37.271847997] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:37.311629725] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:37.337715222] [ info] [sp] stream processor started
[2026/01/28 14:00:37.339931674] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:37.406297969] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:37.407453103] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:38.246151051] [error] [output:s3:s3.0] Could not find upload ID in CreateMultipartUpload response
[2026/01/28 14:00:38.247085834] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:38.256420242] [ warn] [engine] failed to flush chunk '20663-1769608837.390753539.flb', retry in 9 seconds: task_id=0, input=lib.0 > output=s3.0 (out_id=0)
[2026/01/28 14:00:39.356032322] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:39.361177465] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:39.390369967] [error] [output:s3:s3.0] Could not find upload ID in CreateMultipartUpload response
[2026/01/28 14:00:39.393507982] [error] [engine] chunk '20663-1769608837.390753539.flb' cannot be retried: task_id=0, input=lib.0 > output=s3.0
[2026/01/28 14:00:39.390477588] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:40.172760366] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:40.200200154] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2026/01/28 14:00:40.174854728] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:40.202925121] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/test/2026/01/28/14/00/38-objectBXnxMp5v
[2026/01/28 14:00:40.176179941] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:40.180087543] [ info] [output:s3:s3.0] thread worker #0 stopped
[ OK ]
Test putobject_success...                       [2026/01/28 14:00:40.266794231] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:40.266948638] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:40.267021111] [ info] [simd    ] disabled
[2026/01/28 14:00:40.267087880] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:40.267153083] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:40.267836758] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:40.267907101] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:40.274258209] [ info] [output:s3:s3.0] Using upload size 5000000 bytes
[2026/01/28 14:00:40.282611516] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:40.283656247] [ info] [sp] stream processor started
[2026/01/28 14:00:40.283138080] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:40.283896629] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:40.283254876] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:41.206066973] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/test/2026/01/28/14/00/41-objectOrA0oZ4x
[2026/01/28 14:00:42.289988736] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:42.290086291] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:43.171808651] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:43.172084129] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:43.172174062] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:43.172631520] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2026/01/28 14:00:43.172335403] [ info] [output:s3:s3.0] thread worker #0 stopped
[2026/01/28 14:00:43.172983358] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/test/2026/01/28/14/00/41-objectqYRrsccA
[ OK ]
Test putobject_error...                         [2026/01/28 14:00:43.185186076] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:43.185341121] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:43.185414004] [ info] [simd    ] disabled
[2026/01/28 14:00:43.185508241] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:43.185588147] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:43.186210464] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:43.186314050] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:43.192858631] [ info] [output:s3:s3.0] Using upload size 5000000 bytes
[2026/01/28 14:00:43.201136517] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:43.202078944] [ info] [sp] stream processor started
[2026/01/28 14:00:43.201639089] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:43.202664612] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:43.201768076] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:44.194709407] [error] [output:s3:s3.0] PutObject API responded with error='AccessDenied', message='Access Denied'
[2026/01/28 14:00:44.195321314] [error] [output:s3:s3.0] Raw PutObject response: <?xml version="1.0" encoding="UTF-8"?>                            <Error>                            <Code>AccessDenied</Code>                            <Message>Access Denied</Message>                            <RequestId>656c76696e6727732072657175657374</RequestId>                            <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>                            </Error>
[2026/01/28 14:00:44.195881304] [error] [output:s3:s3.0] PutObject request failed
[2026/01/28 14:00:44.196548673] [ warn] [engine] failed to flush chunk '20663-1769608843.208735159.flb', retry in 7 seconds: task_id=0, input=lib.0 > output=s3.0 (out_id=0)
[2026/01/28 14:00:45.203380526] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:45.203805222] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:45.230057035] [error] [output:s3:s3.0] PutObject API responded with error='AccessDenied', message='Access Denied'
[2026/01/28 14:00:45.230130044] [error] [output:s3:s3.0] Raw PutObject response: <?xml version="1.0" encoding="UTF-8"?>                            <Error>                            <Code>AccessDenied</Code>                            <Message>Access Denied</Message>                            <RequestId>656c76696e6727732072657175657374</RequestId>                            <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>                            </Error>
[2026/01/28 14:00:45.230178238] [error] [output:s3:s3.0] PutObject request failed
[2026/01/28 14:00:45.230758981] [error] [engine] chunk '20663-1769608843.208735159.flb' cannot be retried: task_id=0, input=lib.0 > output=s3.0
[2026/01/28 14:00:46.172354248] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:46.173289735] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:46.173721750] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:46.175866251] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2026/01/28 14:00:46.174503887] [ info] [output:s3:s3.0] thread worker #0 stopped
[2026/01/28 14:00:46.178904093] [ warn] [output:s3:s3.0] Chunk for tag test failed to send 1/1 times, will not retry
[ OK ]
Test create_upload_error...                     [2026/01/28 14:00:46.196662771] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:46.196818234] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:46.196893264] [ info] [simd    ] disabled
[2026/01/28 14:00:46.196965291] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:46.197033493] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:46.197682065] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:46.197748883] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:46.203264363] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:46.211375254] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:46.212378296] [ info] [sp] stream processor started
[2026/01/28 14:00:46.211900420] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:46.212619815] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:46.212045946] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:47.198028382] [error] [output:s3:s3.0] CreateMultipartUpload API responded with error='AccessDenied', message='Access Denied'
[2026/01/28 14:00:47.198633060] [error] [output:s3:s3.0] CreateMultipartUpload request failed
[2026/01/28 14:00:47.198736994] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:47.199134863] [ warn] [engine] failed to flush chunk '20663-1769608846.217553123.flb', retry in 8 seconds: task_id=0, input=lib.0 > output=s3.0 (out_id=0)
[2026/01/28 14:00:48.219367051] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:48.220192259] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:48.250678670] [error] [output:s3:s3.0] CreateMultipartUpload API responded with error='AccessDenied', message='Access Denied'
[2026/01/28 14:00:48.251085454] [error] [engine] chunk '20663-1769608846.217553123.flb' cannot be retried: task_id=0, input=lib.0 > output=s3.0
[2026/01/28 14:00:48.250757015] [error] [output:s3:s3.0] CreateMultipartUpload request failed
[2026/01/28 14:00:48.250798705] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:49.172877926] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:49.173884580] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:49.174399159] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:49.176564991] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2026/01/28 14:00:49.175212629] [ info] [output:s3:s3.0] thread worker #0 stopped
[2026/01/28 14:00:49.178143137] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/test/2026/01/28/14/00/47-objectRC7ZS1B8
[ OK ]
Test upload_part_error...                       [2026/01/28 14:00:49.193234630] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:49.193402222] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:49.193471821] [ info] [simd    ] disabled
[2026/01/28 14:00:49.193514394] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:49.193566129] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:49.194170332] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:49.194229224] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:49.199490747] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:49.207263320] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:49.207816460] [ info] [sp] stream processor started
[2026/01/28 14:00:49.208238965] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:49.208380960] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:49.209066742] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:50.196301731] [error] [output:s3:s3.0] Could not find upload ID in CreateMultipartUpload response
[2026/01/28 14:00:50.196379609] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:50.196694124] [ warn] [engine] failed to flush chunk '20663-1769608849.213568128.flb', retry in 8 seconds: task_id=0, input=lib.0 > output=s3.0 (out_id=0)
[2026/01/28 14:00:51.214336606] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:51.214638091] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:51.241950070] [error] [output:s3:s3.0] Could not find upload ID in CreateMultipartUpload response
[2026/01/28 14:00:51.242066427] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:51.242610636] [error] [engine] chunk '20663-1769608849.213568128.flb' cannot be retried: task_id=0, input=lib.0 > output=s3.0
[2026/01/28 14:00:52.171725740] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:52.171963905] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:52.172053951] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:52.172210441] [ info] [output:s3:s3.0] thread worker #0 stopped
[2026/01/28 14:00:52.172500953] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2026/01/28 14:00:52.172894606] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/test/2026/01/28/14/00/50-objectQDL42VkY
[ OK ]
Test complete_upload_error...                   [2026/01/28 14:00:52.182754250] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:52.182908258] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:52.182982674] [ info] [simd    ] disabled
[2026/01/28 14:00:52.183050314] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:52.183133702] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:52.183862887] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:52.183939140] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:52.189505077] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:52.197398292] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:52.198018668] [ info] [sp] stream processor started
[2026/01/28 14:00:52.198215999] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:52.198846084] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:52.198313663] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:53.195459671] [error] [output:s3:s3.0] Could not find upload ID in CreateMultipartUpload response
[2026/01/28 14:00:53.195583303] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:53.195893228] [ warn] [engine] failed to flush chunk '20663-1769608852.203412382.flb', retry in 10 seconds: task_id=0, input=lib.0 > output=s3.0 (out_id=0)
[2026/01/28 14:00:54.199306215] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:54.199470196] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:54.224314232] [error] [engine] chunk '20663-1769608852.203412382.flb' cannot be retried: task_id=0, input=lib.0 > output=s3.0
[2026/01/28 14:00:54.223835146] [error] [output:s3:s3.0] Could not find upload ID in CreateMultipartUpload response
[2026/01/28 14:00:54.223935478] [error] [output:s3:s3.0] Could not initiate multipart upload
[2026/01/28 14:00:55.171775071] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:55.172027954] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:55.172137723] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:55.172292845] [ info] [output:s3:s3.0] thread worker #0 stopped
[2026/01/28 14:00:55.172571677] [ info] [output:s3:s3.0] Sending all locally buffered data to S3
[2026/01/28 14:00:55.172995782] [ info] [output:s3:s3.0] Successfully uploaded object /fluent-bit-logs/test/2026/01/28/14/00/53-objectEUgFxLCV
[ OK ]
Test sse_invalid_value...                       [2026/01/28 14:00:55.183919127] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:55.184072102] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:55.184202383] [ info] [simd    ] disabled
[2026/01/28 14:00:55.184284134] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:55.184353616] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:55.185068046] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:55.185129172] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:55.192263943] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:55.192946104] [error] [output:s3:s3.0] Invalid 'sse' value 'invalid_encryption'. Must be 'AES256', 'aws:kms', or 'aws:kms:dsse'
[2026/01/28 14:00:55.193255891] [error] [output] failed to initialize 's3' plugin
[2026/01/28 14:00:55.193991801] [error] [engine] output initialization failed
[ OK ]
Test sse_kms_valid...                           [2026/01/28 14:00:56.203596574] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:56.203752603] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:56.203829480] [ info] [simd    ] disabled
[2026/01/28 14:00:56.203904321] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:56.203973396] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:56.204718044] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:56.204840324] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:56.213117231] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:56.221967133] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:56.222631301] [ info] [sp] stream processor started
[2026/01/28 14:00:56.223262966] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:56.223509525] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:56.223365219] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:57.224348552] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:57.224680916] [ info] [engine] pausing all inputs..
[2026/01/28 14:00:58.171895766] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:00:58.172248336] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:00:58.172377705] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:00:58.172603800] [ info] [output:s3:s3.0] thread worker #0 stopped
[ OK ]
Test sse_aes256_valid...                        [2026/01/28 14:00:58.185545889] [ info] [fluent bit] version=5.0.0, commit=9b32a6af64, pid=20663
[2026/01/28 14:00:58.185726166] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 14:00:58.185816028] [ info] [simd    ] disabled
[2026/01/28 14:00:58.185872689] [ info] [cmetrics] version=1.0.6
[2026/01/28 14:00:58.185948815] [ info] [ctraces ] version=0.6.6
[2026/01/28 14:00:58.186709157] [ info] [input:lib:lib.0] initializing
[2026/01/28 14:00:58.186784267] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 14:00:58.192740039] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 14:00:58.200771369] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 14:00:58.201497541] [ info] [sp] stream processor started
[2026/01/28 14:00:58.201705843] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 14:00:58.202153415] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 14:00:58.201804935] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 14:00:59.202460136] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 14:00:59.202568832] [ info] [engine] pausing all inputs..
[2026/01/28 14:01:00.171881855] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 14:01:00.172172009] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 14:01:00.172330287] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 14:01:00.172551636] [ info] [output:s3:s3.0] thread worker #0 stopped
[ OK ]
SUCCESS: All unit tests have passed.
==20663== 
==20663== HEAP SUMMARY:
==20663==     in use at exit: 217,918 bytes in 26 blocks
==20663==   total heap usage: 36,177 allocs, 36,151 frees, 12,769,253 bytes allocated
==20663== 
==20663== 20 bytes in 1 blocks are indirectly lost in loss record 1 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x55467A9: strdup (strdup.c:42)
==20663==    by 0x11E5AD0: cio_stream_create (cio_stream.c:163)
==20663==    by 0xA1E3D7: flb_fstore_stream_create (flb_fstore.c:373)
==20663==    by 0x8F9612: s3_store_init (s3_store.c:304)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 26 bytes in 1 blocks are indirectly lost in loss record 2 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x55467A9: strdup (strdup.c:42)
==20663==    by 0x11E662A: cio_create (chunkio.c:162)
==20663==    by 0xA1E82D: flb_fstore_create (flb_fstore.c:496)
==20663==    by 0x8F9597: s3_store_init (s3_store.c:276)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 26 bytes in 1 blocks are indirectly lost in loss record 3 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x55467A9: strdup (strdup.c:42)
==20663==    by 0x11E5AD0: cio_stream_create (cio_stream.c:163)
==20663==    by 0xA1E3D7: flb_fstore_stream_create (flb_fstore.c:373)
==20663==    by 0x8F9722: s3_store_init (s3_store.c:315)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 27 bytes in 1 blocks are indirectly lost in loss record 4 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0x1149B1C: flb_calloc (flb_mem.h:95)
==20663==    by 0x1149E9C: flb_aws_endpoint (flb_aws_util.c:98)
==20663==    by 0x8E93A8: cb_s3_init (s3.c:871)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 40 bytes in 1 blocks are indirectly lost in loss record 5 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0xA1D846: flb_calloc (flb_mem.h:95)
==20663==    by 0xA1E8F1: flb_fstore_create (flb_fstore.c:510)
==20663==    by 0x8F9597: s3_store_init (s3_store.c:276)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 48 bytes in 1 blocks are definitely lost in loss record 6 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0x8F8409: flb_calloc (flb_mem.h:95)
==20663==    by 0x8F8EA2: s3_store_buffer_put (s3_store.c:170)
==20663==    by 0x8F2CD9: unit_test_flush (s3.c:3577)
==20663==    by 0x8F408F: cb_s3_flush (s3.c:3879)
==20663==    by 0x1D3D48: output_pre_cb_flush (flb_output.h:709)
==20663==    by 0x1554B26: co_init (amd64.c:117)
==20663== 
==20663== 56 bytes in 1 blocks are indirectly lost in loss record 7 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0xA1D846: flb_calloc (flb_mem.h:95)
==20663==    by 0xA1E433: flb_fstore_stream_create (flb_fstore.c:380)
==20663==    by 0x8F9612: s3_store_init (s3_store.c:304)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 56 bytes in 1 blocks are indirectly lost in loss record 8 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0xA1D846: flb_calloc (flb_mem.h:95)
==20663==    by 0xA1E433: flb_fstore_stream_create (flb_fstore.c:380)
==20663==    by 0x8F9722: s3_store_init (s3_store.c:315)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 81 bytes in 1 blocks are indirectly lost in loss record 9 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x19D8CB: flb_malloc (flb_mem.h:80)
==20663==    by 0x1A1231: sds_alloc (flb_sds.c:42)
==20663==    by 0x1A1370: flb_sds_create_size (flb_sds.c:94)
==20663==    by 0x8E6EC8: concat_path (s3.c:372)
==20663==    by 0x8E824E: cb_s3_init (s3.c:710)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 88 bytes in 1 blocks are indirectly lost in loss record 10 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x11E5A89: cio_stream_create (cio_stream.c:157)
==20663==    by 0xA1E3D7: flb_fstore_stream_create (flb_fstore.c:373)
==20663==    by 0x8F9612: s3_store_init (s3_store.c:304)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 88 bytes in 1 blocks are indirectly lost in loss record 11 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x11E5A89: cio_stream_create (cio_stream.c:157)
==20663==    by 0xA1E3D7: flb_fstore_stream_create (flb_fstore.c:373)
==20663==    by 0x8F9722: s3_store_init (s3_store.c:315)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 136 bytes in 1 blocks are indirectly lost in loss record 12 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0x11E647A: cio_create (chunkio.c:120)
==20663==    by 0xA1E82D: flb_fstore_create (flb_fstore.c:496)
==20663==    by 0x8F9597: s3_store_init (s3_store.c:276)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 273 bytes in 1 blocks are indirectly lost in loss record 13 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x19D8CB: flb_malloc (flb_mem.h:80)
==20663==    by 0x1A1231: sds_alloc (flb_sds.c:42)
==20663==    by 0x1A1370: flb_sds_create_size (flb_sds.c:94)
==20663==    by 0xA1E487: flb_fstore_stream_create (flb_fstore.c:388)
==20663==    by 0x8F9612: s3_store_init (s3_store.c:304)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 273 bytes in 1 blocks are indirectly lost in loss record 14 of 16
==20663==    at 0x4844818: malloc (vg_replace_malloc.c:446)
==20663==    by 0x19D8CB: flb_malloc (flb_mem.h:80)
==20663==    by 0x1A1231: sds_alloc (flb_sds.c:42)
==20663==    by 0x1A1370: flb_sds_create_size (flb_sds.c:94)
==20663==    by 0xA1E487: flb_fstore_stream_create (flb_fstore.c:388)
==20663==    by 0x8F9722: s3_store_init (s3_store.c:315)
==20663==    by 0x8E831D: cb_s3_init (s3.c:718)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 1,918 (728 direct, 1,190 indirect) bytes in 1 blocks are definitely lost in loss record 15 of 16
==20663==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==20663==    by 0x8E5D4C: flb_calloc (flb_mem.h:95)
==20663==    by 0x8E7E52: cb_s3_init (s3.c:641)
==20663==    by 0x1CF146: flb_output_init_all (flb_output.c:1564)
==20663==    by 0x20150A: flb_engine_start (flb_engine.c:972)
==20663==    by 0x197C0E: flb_lib_worker (flb_lib.c:904)
==20663==    by 0x552FB7A: start_thread (pthread_create.c:448)
==20663==    by 0x55AD5EF: clone (clone.S:100)
==20663== 
==20663== 215,952 bytes in 11 blocks are definitely lost in loss record 16 of 16
==20663==    at 0x484BDD0: realloc (vg_replace_malloc.c:1801)
==20663==    by 0x19D8F0: flb_realloc (flb_mem.h:101)
==20663==    by 0x1A13C4: flb_sds_increase (flb_sds.c:108)
==20663==    by 0x1A1470: flb_sds_cat (flb_sds.c:128)
==20663==    by 0x312C00: flb_pack_msgpack_to_json_format (flb_pack.c:1390)
==20663==    by 0x8F3DC8: cb_s3_flush (s3.c:3825)
==20663==    by 0x1D3D48: output_pre_cb_flush (flb_output.h:709)
==20663==    by 0x1554B26: co_init (amd64.c:117)
==20663== 
==20663== LEAK SUMMARY:
==20663==    definitely lost: 216,728 bytes in 13 blocks
==20663==    indirectly lost: 1,190 bytes in 13 blocks
==20663==      possibly lost: 0 bytes in 0 blocks
==20663==    still reachable: 0 bytes in 0 blocks
==20663==         suppressed: 0 bytes in 0 blocks
==20663== 
==20663== For lists of detected and suppressed errors, rerun with: -s
==20663== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```

### Memory Analysis (Valgrind)
> **Note**: Valgrind was run on both `master` and this branch to verify no new memory leaks were introduced.
- master: 216,000 bytes lost (2 error contexts, 6 tests)
- this PR: 216,728 bytes lost (3 error contexts, 9 tests)

This PR does not allocate new memory — the SSE feature only reads config values and sets header pointers to static strings.

</details>

</details>

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

### New unit tests report
<details>
<summary>Click to expand test results</summary>

```
Test sse_invalid_value...                       [ OK ]
[2026/01/28 15:12:00.838671983] [ info] [fluent bit] version=5.0.0, commit=84be0b4d73, pid=28075
[2026/01/28 15:12:00.838755395] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 15:12:00.838761956] [ info] [simd    ] disabled
[2026/01/28 15:12:00.838763823] [ info] [cmetrics] version=1.0.6
[2026/01/28 15:12:00.838767074] [ info] [ctraces ] version=0.6.6
[2026/01/28 15:12:00.838796539] [ info] [input:lib:lib.0] initializing
[2026/01/28 15:12:00.838798390] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 15:12:00.840959304] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 15:12:00.842344742] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 15:12:00.842522571] [ info] [sp] stream processor started
[2026/01/28 15:12:00.842601992] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 15:12:00.842636525] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 15:12:00.842661777] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 15:12:01.842914247] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 15:12:01.842943462] [ info] [engine] pausing all inputs..
[2026/01/28 15:12:02.829173682] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 15:12:02.829278486] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 15:12:02.829304450] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 15:12:02.829340208] [ info] [output:s3:s3.0] thread worker #0 stopped
Test sse_kms_valid...                           [ OK ]
[2026/01/28 15:12:02.832475523] [ info] [fluent bit] version=5.0.0, commit=84be0b4d73, pid=28079
[2026/01/28 15:12:02.832573836] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/01/28 15:12:02.832580370] [ info] [simd    ] disabled
[2026/01/28 15:12:02.832582513] [ info] [cmetrics] version=1.0.6
[2026/01/28 15:12:02.832588400] [ info] [ctraces ] version=0.6.6
[2026/01/28 15:12:02.832617974] [ info] [input:lib:lib.0] initializing
[2026/01/28 15:12:02.832632625] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/01/28 15:12:02.834710258] [ info] [output:s3:s3.0] Using upload size 100000000 bytes
[2026/01/28 15:12:02.835985225] [ warn] [imds] unable to evaluate IMDS version
[2026/01/28 15:12:02.836204729] [ info] [sp] stream processor started
[2026/01/28 15:12:02.836259715] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/01/28 15:12:02.836322304] [ info] [output:s3:s3.0] initializing worker
[2026/01/28 15:12:02.836349663] [ info] [output:s3:s3.0] worker #0 started
[2026/01/28 15:12:03.836596395] [ warn] [engine] service will shutdown in max 5 seconds
[2026/01/28 15:12:03.836647949] [ info] [engine] pausing all inputs..
[2026/01/28 15:12:04.829221054] [ info] [engine] service has stopped (0 pending tasks)
[2026/01/28 15:12:04.829333536] [ info] [output:s3:s3.0] thread worker #0 stopping...
[2026/01/28 15:12:04.829360449] [ info] [output:s3:s3.0] terminating worker
[2026/01/28 15:12:04.829395753] [ info] [output:s3:s3.0] thread worker #0 stopped
Test sse_aes256_valid...                        [ OK ]
SUCCESS: All unit tests have passed.
```

</details>

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/2365

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side encryption (SSE) support for S3 output: AES256, AWS-KMS, and DSSE-KMS modes.
  * Added configuration option to provide an optional KMS key ID when using AWS-KMS/DSSE-KMS; configuration is validated for compatibility.

* **Tests**
  * Added tests covering SSE configuration: invalid value, AES256 valid, and KMS valid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->