### PR TITLE
in_http: add support for fixed tag configuration parameter

### DIFF
--- a/plugins/in_http/http.c
+++ b/plugins/in_http/http.c
@@ -221,6 +221,12 @@ static int in_http_exit(void *data, struct flb_config *config)
 /* Configuration properties map */
 static struct flb_config_map config_map[] = {
     {
+     FLB_CONFIG_MAP_STR, "fixed_tag", NULL,
+     0, FLB_TRUE, offsetof(struct flb_http, tag),
+     "Set a fixed tag for all incoming records, overriding URL path-based tags."
+    },
+
+    {
      FLB_CONFIG_MAP_BOOL, "http2", "true",
      0, FLB_TRUE, offsetof(struct flb_http, enable_http2),
      "Enable HTTP/2 support."

--- a/plugins/in_http/http.h
+++ b/plugins/in_http/http.h
@@ -38,6 +38,7 @@ struct flb_http {
     int successful_response_code;
     flb_sds_t listen;
     flb_sds_t tcp_port;
+    flb_sds_t tag;                     /* User configured fixed_tag */
     flb_sds_t tag_key;
     struct flb_record_accessor *ra_tag_key;
 

--- a/plugins/in_http/http_config.c
+++ b/plugins/in_http/http_config.c
@@ -156,6 +156,10 @@ int http_config_destroy(struct flb_http *ctx)
         flb_ra_destroy(ctx->ra_tag_key);
     }
 
+    if (ctx->tag) {
+        flb_sds_destroy(ctx->tag);
+    }
+
     /* release all connections */
     http_conn_release_all(ctx);
 

--- a/plugins/in_http/http_prot.c
+++ b/plugins/in_http/http_prot.c
@@ -259,8 +259,16 @@ static int process_pack_record(struct flb_http *ctx, struct flb_time *tm,
                                    ctx->log_encoder.output_buffer,
                                    ctx->log_encoder.output_length);
     }
+    else if (ctx->tag) {
+        /* use user configured tag */
+        ret = flb_input_log_append(ctx->ins,
+                                   ctx->tag,
+                                   flb_sds_len(ctx->tag),
+                                   ctx->log_encoder.output_buffer,
+                                   ctx->log_encoder.output_length);
+    }
     else {
-        /* use default plugin Tag (it internal name, e.g: http.0 */
+        /* use default plugin Tag (its internal name, e.g: http.0) */
         ret = flb_input_log_append(ctx->ins, NULL, 0,
                                    ctx->log_encoder.output_buffer,
                                    ctx->log_encoder.output_length);

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -966,7 +966,7 @@ void flb_test_http_fixed_tag()
 
     /* Configure fixed tag */
     ret = flb_input_set(ctx->flb, ctx->i_ffd,
-                        "tag", "fixed_tag",
+                        "fixed_tag", "fixed_tag",
                         NULL);
     TEST_CHECK(ret == 0);
 
@@ -988,14 +988,14 @@ void flb_test_http_fixed_tag()
     c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", 
                         buf, strlen(buf),
                         "127.0.0.1", 9880, NULL, 0);
-    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, 
-                              strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
-                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
-    TEST_CHECK(ret == 0);
     if (!TEST_CHECK(c != NULL)) {
         TEST_MSG("http_client failed");
         exit(EXIT_FAILURE);
     }
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, 
+                              strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
 
     ret = flb_http_do(c, &b_sent);
     if (!TEST_CHECK(ret == 0)) {

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -941,6 +941,86 @@ void flb_test_http_oauth2_accepts_valid_token()
     jwks_mock_server_stop(&jwks);
 }
 
+/* Test fixed tag configuration */
+void flb_test_http_fixed_tag()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+    int ret;
+    int num;
+    size_t b_sent;
+
+    char *buf = "{\"test\":\"msg\"}";
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Configure fixed tag */
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "tag", "fixed_tag",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Output matches the fixed tag */
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "fixed_tag",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    ctx->httpc = http_client_ctx_create();
+    TEST_CHECK(ctx->httpc != NULL);
+
+    /* Send to root path (not using URL path as tag) */
+    c = flb_http_client(ctx->httpc->u_conn, FLB_HTTP_POST, "/", 
+                        buf, strlen(buf),
+                        "127.0.0.1", 9880, NULL, 0);
+    ret = flb_http_add_header(c, FLB_HTTP_HEADER_CONTENT_TYPE, 
+                              strlen(FLB_HTTP_HEADER_CONTENT_TYPE),
+                              JSON_CONTENT_TYPE, strlen(JSON_CONTENT_TYPE));
+    TEST_CHECK(ret == 0);
+    if (!TEST_CHECK(c != NULL)) {
+        TEST_MSG("http_client failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("ret error. ret=%d\n", ret);
+    }
+    else if (!TEST_CHECK(b_sent > 0)){
+        TEST_MSG("b_sent size error. b_sent = %lu\n", b_sent);
+    }
+    else if (!TEST_CHECK(c->resp.status == 201)) {
+        TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
+    }
+
+    /* waiting to flush */
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0))  {
+        TEST_MSG("no outputs - tag may not match");
+    }
+    
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(ctx->httpc->u_conn);
+    test_ctx_destroy(ctx);
+}
+
 TEST_LIST = {
     {"http", flb_test_http},
     {"successful_response_code_200", flb_test_http_successful_response_code_200},
@@ -949,6 +1029,7 @@ TEST_LIST = {
     {"failure_response_code_400_bad_disk_write", flb_test_http_failure_400_bad_disk_write},
     {"tag_key_with_map_input", flb_test_http_tag_key_with_map_input},
     {"tag_key_with_array_input", flb_test_http_tag_key_with_array_input},
+    {"fixed_tag", flb_test_http_fixed_tag},
     {"oauth2_requires_token", flb_test_http_oauth2_requires_token},
     {"oauth2_accepts_valid_token", flb_test_http_oauth2_accepts_valid_token},
     {NULL, NULL}


### PR DESCRIPTION
# Add Fixed Tag Configuration Parameter to in_http Plugin

## Description

This PR adds support for a `tag` configuration parameter in the `in_http` input plugin, allowing users to specify a fixed tag for all incoming records. This addresses scenarios where users want consistent tagging without relying on URL paths or dynamic extraction from record content.

## Problem Statement

Currently, the `in_http` plugin determines tags using the following logic:
1. Extract from record content if `tag_key` is configured
2. Use URL path from the HTTP request
3. Fall back to default plugin instance name (e.g., `http.0`)

This creates issues when:
- Users want a consistent fixed tag for all records
- The default `http.0` tag doesn't match their routing configuration
- Dynamic URL-based tagging is not desired
- To consistent with other plugins to eliminate misunderstandings

## Solution

Added a new `tag` configuration parameter that allows users to specify a fixed tag. The updated tag selection priority is now:

1. **tag_key** - Extract from record content (highest priority)
2. **URL path** - From HTTP request path
3. **tag parameter** - User-configured fixed tag (new)
4. **Default plugin tag** - Plugin instance name (e.g., `http.0`)

## Changes

### Source Code
- **plugins/in_http/http.h**: Added `flb_sds_t tag` field to `struct flb_http`
- **plugins/in_http/http.c**: Added `tag` parameter to config_map
- **plugins/in_http/http_prot.c**: Updated `process_pack_record()` to use `ctx->tag` as fallback
- **plugins/in_http/http_config.c**: Added cleanup for `ctx->tag` in `http_config_destroy()`

### Tests
- **tests/runtime/in_http.c**: Added `flb_test_http_fixed_tag()` test case

## Usage Example

```ini
[INPUT]
    Name http
    Port 9880
    Tag http_logs    # Fixed tag for all incoming records

[OUTPUT]
    Name kafka
    Match http_logs  # Now correctly matches the configured tag
````

## Testing

All unit tests pass successfully:

```javascript
Test http...                                    [ OK ]
Test successful_response_code_200...            [ OK ]
Test successful_response_code_204...            [ OK ]
Test failure_response_code_400_bad_json...      [ OK ]
Test failure_response_code_400_bad_disk_write... [ OK ]
Test tag_key_with_map_input...                  [ OK ]
Test tag_key_with_array_input...                [ OK ]
Test fixed_tag...                               [ OK ] ⭐ (new test)
Test oauth2_requires_token...                   [ OK ]
Test oauth2_accepts_valid_token...              [ OK ]

SUCCESS: All unit tests have passed.
```

## Backward Compatibility

✅ This change is __fully backward compatible__. Existing configurations will continue to work as before since the `tag` parameter is optional and defaults to `NULL`.

## Checklist

- [x] Code follows project coding style
- [x] Commit message follows project convention (`in_http: description`)
- [x] All existing unit tests pass
- [x] New unit test added for the feature
- [x] Code compiles without errors or new warnings
- [x] Memory cleanup properly implemented
- [x] Signed-off-by line included in commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP input can be configured with a fixed tag to apply to all incoming requests.

* **Bug Fixes**
  * Fixed-tag configuration now reliably overrides URL/path-based tagging when present.

* **Tests**
  * Added automated test validating fixed-tag routing, request handling, and output generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->