### PR TITLE
in_tail: Add error log when flb fails to update the DB. Currently it fails silently.

### DIFF
--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -299,6 +299,8 @@ int flb_tail_db_file_offset(struct flb_tail_file *file,
     ret = sqlite3_step(ctx->stmt_offset);
 
     if (ret != SQLITE_DONE) {
+        flb_plg_error(ctx->ins, "db: cannot update file offset for %s (id=%"PRIu64"), ret=%d,
+                      file->name, file->db_id, ret");
         sqlite3_clear_bindings(ctx->stmt_offset);
         sqlite3_reset(ctx->stmt_offset);
         return -1;

--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -299,8 +299,9 @@ int flb_tail_db_file_offset(struct flb_tail_file *file,
     ret = sqlite3_step(ctx->stmt_offset);
 
     if (ret != SQLITE_DONE) {
-        flb_plg_error(ctx->ins, "db: cannot update file offset for %s (id=%"PRIu64"), ret=%d,
-                      file->name, file->db_id, ret");
+        flb_plg_error(ctx->ins,
+                      "db: cannot update file offset for %s (id=%"PRIu64"), ret=%d",
+                      file->name, file->db_id, ret);
         sqlite3_clear_bindings(ctx->stmt_offset);
         sqlite3_reset(ctx->stmt_offset);
         return -1;


### PR DESCRIPTION
Fixes #11416

Description:
When using the in_tail plugin with a database configured (db parameter), if the SQLite database becomes locked (e.g., receives SQLITE_BUSY or SQLITE_LOCKED), the plugin silently fails to update the file offset. The function flb_tail_db_file_offset returns -1, but no error message is logged to indicate that the persistence failed.

Change:
Add an error log line so that the error is not silent.

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change

```
[SERVICE]
    Flush 1
    Log_Level info
[INPUT]
    Name tail
    Path /tmp/test.log
    DB   /tmp/tail.db
[OUTPUT]
    Name stdout
```

- [ ] Debug log output from testing the change

```
[error] [input:tail:tail.0] db: cannot update file offset for /tmp/test.log (id=1), ret=5
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging and handling in the tail input plugin when updating tracked file offsets fails. This enhances diagnostic messages and operational visibility, making it easier to detect and troubleshoot file-tracking and offset-management issues during log collection, improving reliability of continuing or resuming log ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->