### PR TITLE
out_azure_kusto: Add changes to defer close old resource handles in subsequent cycles

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -84,6 +84,12 @@ struct flb_azure_kusto_resources {
 
     /* used to reload resouces after some time */
     uint64_t load_time;
+
+    /* Old resources pending cleanup - deferred destruction to avoid use-after-free
+     * when other threads may still be using them during high-volume operations */
+    struct flb_upstream_ha *old_blob_ha;
+    struct flb_upstream_ha *old_queue_ha;
+    flb_sds_t old_identity_token;
 };
 
 struct flb_azure_kusto {


### PR DESCRIPTION
This pull request improves the safety and stability of resource management in the Azure Kusto output plugin by introducing deferred destruction of old resources. This change helps prevent use-after-free errors during high-volume operations where resources might still be in use by other threads when a refresh occurs.

Resource lifecycle management improvements:

* Added fields (`old_blob_ha`, `old_queue_ha`, `old_identity_token`) to `struct flb_azure_kusto_resources` to track old resources that are pending cleanup, enabling deferred destruction.
* Updated the resource loading logic in `azure_kusto_load_ingestion_resources` to first destroy resources from two refresh cycles ago, then move current resources to the "old" fields before assigning new ones, ensuring safe resource transitions.
* Modified `flb_azure_kusto_resources_clear` to clean up any old resources pending destruction, ensuring proper resource deallocation and preventing memory leaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Kusto output stability under high-volume concurrent ingestion by adding deferred cleanup and two-stage rotation of connection and token resources to prevent use-after-free and race conditions.
  * Ensured safe cleanup of pending-old resources and added contextual debug/info logging for rotation and destruction to aid reliability and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->