### PR TITLE
out_es: fix retry on 409 reponse

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -992,8 +992,10 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
                     fflush(stderr);
                 }
             }
-            /* Only retry on actual errors (not 409 version conflicts) */
-            if (ret & FLB_ES_STATUS_ERROR) {
+            /* Retry on actual errors or unparseable responses */
+            if ((ret & FLB_ES_STATUS_ERROR) ||
+                (!(ret & FLB_ES_STATUS_SUCCESS) &&
+                 !(ret & FLB_ES_STATUS_DUPLICATES))) {
                 goto retry;
             }
         }


### PR DESCRIPTION
## Summary

When using generate_id or id_key with the Elasticsearch output plugin, documents that already exist return a 409 (version conflict) status in the bulk API response.
The plugin would retry 409 codes indefinitely because:

  1. 409 responses did not set the FLB_ES_STATUS_SUCCESS flag
  2. The retry decision was based on !(ret & FLB_ES_STATUS_SUCCESS) rather than checking for actual errors
  
## Changes

- Uses the existing but unused FLB_ES_STATUS_DUPLICATES flag to track 409 responses
- Changes retry logic to only retry when FLB_ES_STATUS_ERROR is set
- Fixes FLB_ES_STATUS_ERROR to not be set for 200/201 responses (not a problem at the moment, but it was wrongly set)
- Logs a warning when 409 duplicates are detected (with response payload)
- Traces 409 responses when trace_error is enabled (without retrying)

## Test

Built the container image and deployed. Now the output when Elasticsearch returns a 409 code for a record print a warning and, if enabled, the trace_error. 
From both the logs and internal Fluent Bit metrics, no retry is issued after the 409 code is received.
No new memory is allocated.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Elasticsearch error handling to treat conflict (409) responses as duplicates and distinguish true errors, ensuring retries occur only for actual failures.
  * Considered 200/201 as success and flagged other unexpected statuses as errors.
  * Reduced noisy trace logs by activating trace output only when duplicates or errors occur, and refined retry paths for errors, unparsable responses, or empty payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->