### PR TITLE
processor_labels: fix hash config description

### DIFF
--- a/plugins/processor_labels/labels.c
+++ b/plugins/processor_labels/labels.c
@@ -1928,7 +1928,7 @@ static struct flb_config_map config_map[] = {
         FLB_CONFIG_MAP_STR, "hash", NULL,
         FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct internal_processor_context,
                                                 hash_list),
-        "Replaces a labels value with its SHA1 hash. Usage : 'hash label_name'"
+        "Replaces a label's value with its SHA256 hash. Usage : 'hash label_name'"
     },
 
     /* EOF */


### PR DESCRIPTION
  - Fix incorrect hash algorithm in description: SHA1 -> SHA256 (implementation uses FLB_HASH_SHA256)
  - Fix grammar: "labels value" -> "label's value"

Not attached to an issue, small description fix.

----
**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [ N/A  ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ ALREADY DOCUMENTED ] Documentation required for this feature

**Backporting**
- [ N/A ] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "hash" configuration description to accurately reflect that values are hashed using SHA256 instead of SHA1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->