### PR TITLE
http: default HTTP User-Agent header with version information

### DIFF
--- a/include/fluent-bit/flb_http_client.h
+++ b/include/fluent-bit/flb_http_client.h
@@ -20,6 +20,7 @@
 #ifndef FLB_HTTP_CLIENT_H
 #define FLB_HTTP_CLIENT_H
 
+#include <fluent-bit/flb_version.h>
 #include <fluent-bit/flb_io.h>
 #include <fluent-bit/flb_lock.h>
 #include <fluent-bit/flb_upstream.h>
@@ -71,12 +72,14 @@
 #define FLB_HTTP_CHUNK_AVAILABLE  3 /* means chunk is available, but there is more data. end of all chunks returns FLB_HTTP_OK */
 
 /* Useful headers */
-#define FLB_HTTP_HEADER_AUTH             "Authorization"
-#define FLB_HTTP_HEADER_PROXY_AUTH       "Proxy-Authorization"
-#define FLB_HTTP_HEADER_CONTENT_TYPE     "Content-Type"
-#define FLB_HTTP_HEADER_CONTENT_ENCODING "Content-Encoding"
-#define FLB_HTTP_HEADER_CONNECTION       "Connection"
-#define FLB_HTTP_HEADER_KA               "keep-alive"
+#define FLB_HTTP_HEADER_AUTH                "Authorization"
+#define FLB_HTTP_HEADER_PROXY_AUTH          "Proxy-Authorization"
+#define FLB_HTTP_HEADER_CONTENT_TYPE        "Content-Type"
+#define FLB_HTTP_HEADER_CONTENT_ENCODING    "Content-Encoding"
+#define FLB_HTTP_HEADER_CONNECTION          "Connection"
+#define FLB_HTTP_HEADER_KA                  "keep-alive"
+#define FLB_HTTP_HEADER_USER_AGENT          "User-Agent"
+#define FLB_HTTP_HEADER_USER_AGENT_DEFAULT  "Fluent-Bit/" FLB_VERSION_STR " (Git commit: " FLB_GIT_HASH ")"
 
 #define FLB_HTTP_CLIENT_HEADER_ARRAY                      0
 #define FLB_HTTP_CLIENT_HEADER_LIST                       1

--- a/plugins/filter_ecs/ecs.c
+++ b/plugins/filter_ecs/ecs.c
@@ -409,7 +409,11 @@ static int get_ecs_cluster_metadata(struct flb_filter_ecs *ctx)
                             NULL, 0);
         flb_http_buffer_size(c, 0); /* 0 means unlimited */
 
-        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                            FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
         ret = flb_http_do(c, &b_sent);
         flb_plg_debug(ctx->ins, "http_do=%i, "
@@ -1009,7 +1013,11 @@ static int get_task_metadata(struct flb_filter_ecs *ctx, char* short_id)
                             NULL, 0);
         flb_http_buffer_size(c, 0); /* 0 means unlimited */
 
-        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                            FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
         ret = flb_http_do(c, &b_sent);
         flb_plg_debug(ctx->ins, "http_do=%i, "

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -408,7 +408,11 @@ static int get_meta_info_from_request(struct flb_kube *ctx,
                         NULL, 0, NULL, 0, NULL, 0);
     flb_http_buffer_size(c, ctx->buffer_size);
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(c, "Connection", 10, "close", 5);
     if (ctx->auth_len > 0) {
         flb_http_add_header(c, "Authorization", 13, ctx->auth, ctx->auth_len);

--- a/plugins/filter_nightfall/nightfall_api.c
+++ b/plugins/filter_nightfall/nightfall_api.c
@@ -501,7 +501,11 @@ int scan_log(struct flb_filter_nightfall *ctx, msgpack_object *data,
     flb_http_buffer_size(client, 0);
 
     flb_http_add_header(client, "Authorization", 13, ctx->auth_header, 42);
-    flb_http_add_header(client, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(client,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(client, "Content-Type", 12, "application/json", 16);
 
     /* Perform request */

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -1012,6 +1012,13 @@ static struct flb_http_client *fleet_http_do(struct flb_in_calyptia_fleet_config
                         CALYPTIA_HEADERS_PROJECT, sizeof(CALYPTIA_HEADERS_PROJECT) - 1,
                         ctx->api_key, flb_sds_len(ctx->api_key));
 
+    /* User-Agent */
+    flb_http_add_header(client,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
+
     ret = flb_http_do(client, &b_sent);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "http do error");

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -779,7 +779,11 @@ static void initialize_http_client(struct flb_http_client* c, struct k8s_events*
 {
     flb_http_buffer_size(c, 0);
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     if (ctx->auth_len > 0) {
         flb_http_add_header(c, "Authorization", 13, ctx->auth, ctx->auth_len);
     }

--- a/plugins/in_nginx_exporter_metrics/nginx.c
+++ b/plugins/in_nginx_exporter_metrics/nginx.c
@@ -133,6 +133,13 @@ static int nginx_collect_stub_status(struct flb_input_instance *ins,
         goto client_error;
     }
 
+    /* User-Agent */
+    flb_http_add_header(client,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
+
     ret = flb_http_do(client, &b_sent);
     if (ret != 0) {
         flb_plg_error(ins, "http do error");

--- a/plugins/in_prometheus_scrape/prom_scrape.c
+++ b/plugins/in_prometheus_scrape/prom_scrape.c
@@ -109,7 +109,11 @@ static int collect_metrics(struct prom_scrape *ctx)
     }
 
     /* Add User-Agent */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {

--- a/plugins/out_azure/azure.c
+++ b/plugins/out_azure/azure.c
@@ -260,7 +260,11 @@ static int build_headers(struct flb_http_client *c,
     tmp[olen] = '\0';
 
     /* Append headers */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(c, "Log-Type", 8,
                         log_type, flb_sds_len(log_type));
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);

--- a/plugins/out_azure_blob/azure_blob_conf.c
+++ b/plugins/out_azure_blob/azure_blob_conf.c
@@ -448,8 +448,10 @@ static int flb_azure_blob_apply_remote_configuration(struct flb_azure_blob *cont
 
     /* User Agent */
     flb_http_add_header(http_client,
-                        "User-Agent", 10,
-                        "Fluent-Bit", 10);
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     if (context->configuration_endpoint_username != NULL &&
         context->configuration_endpoint_password != NULL) {

--- a/plugins/out_azure_blob/azure_blob_http.c
+++ b/plugins/out_azure_blob/azure_blob_http.c
@@ -302,7 +302,11 @@ int azb_http_client_setup(struct flb_azure_blob *ctx, struct flb_http_client *c,
     flb_sds_t auth;
 
     /* Header: User Agent */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     /* Header: Content-Type */
     if (content_type == AZURE_BLOB_CT_JSON) {

--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -211,7 +211,11 @@ flb_sds_t execute_ingest_csl_command(struct flb_azure_kusto *ctx, const char *cs
 
                 if (c) {
                     /* Add headers */
-                    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+                    flb_http_add_header(c,
+                                        FLB_HTTP_HEADER_USER_AGENT,
+                                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
                     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
                     flb_http_add_header(c, "Accept", 6, "application/json", 16);
                     flb_http_add_header(c, "Authorization", 13, token,

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -200,7 +200,11 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
                                 NULL, 0);
 
             if (c) {
-                flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+                flb_http_add_header(c,
+                                    FLB_HTTP_HEADER_USER_AGENT,
+                                    sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                                    FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                                    sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
                 flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
                 flb_http_add_header(c, "x-ms-blob-type", 14, "BlockBlob", 9);
                 flb_http_add_header(c, "x-ms-date", 9, tmp, len);
@@ -456,7 +460,11 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
                                     flb_sds_len(payload), NULL, 0, NULL, 0);
 
                 if (c) {
-                    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+                    flb_http_add_header(c,
+                                        FLB_HTTP_HEADER_USER_AGENT,
+                                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
                     flb_http_add_header(c, "Content-Type", 12, "application/atom+xml",
                                         20);
                     flb_http_add_header(c, "x-ms-date", 9, tmp, len);

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -310,7 +310,11 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Append headers */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
     if (is_compressed) {
         flb_http_add_header(c, "Content-Encoding", 16, "gzip", 4);

--- a/plugins/out_bigquery/bigquery.c
+++ b/plugins/out_bigquery/bigquery.c
@@ -1017,7 +1017,11 @@ static void cb_bigquery_flush(struct flb_event_chunk *event_chunk,
     }
 
     flb_http_buffer_size(c, 4192);
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
 
     /* Compose and append Authorization header */

--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -405,7 +405,11 @@ static int check_chronicle_log_type(struct flb_chronicle *ctx, struct flb_config
 
     /* Chronicle supported types are growing. Not to specify the read limit. */
     flb_http_buffer_size(c, 0);
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
 
     /* Compose and append Authorization header */
@@ -1050,7 +1054,11 @@ static void cb_chronicle_flush(struct flb_event_chunk *event_chunk,
         }
 
         flb_http_buffer_size(c, 4192);
-        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                            FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
         flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
 
         /* Compose and append Authorization header */

--- a/plugins/out_datadog/datadog.c
+++ b/plugins/out_datadog/datadog.c
@@ -420,7 +420,11 @@ static void cb_datadog_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Add the required headers to the URI */
-    flb_http_add_header(client, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(client,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(client, FLB_DATADOG_API_HDR, sizeof(FLB_DATADOG_API_HDR) - 1, ctx->api_key, flb_sds_len(ctx->api_key));
     flb_http_add_header(client, FLB_DATADOG_ORIGIN_HDR, sizeof(FLB_DATADOG_ORIGIN_HDR) - 1, "Fluent-Bit", 10);
     flb_http_add_header(client, FLB_DATADOG_ORIGIN_VERSION_HDR, sizeof(FLB_DATADOG_ORIGIN_VERSION_HDR) - 1, FLB_VERSION_STR, sizeof(FLB_VERSION_STR) - 1);

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -63,7 +63,10 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
     }
 
     /* AWS Fluent Bit user agent */
-    flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
                               ctx->aws_region, ctx->aws_service_name,
@@ -878,7 +881,11 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     flb_http_buffer_size(c, ctx->buffer_size);
 
 #ifndef FLB_HAVE_AWS
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 #endif
 
     flb_http_add_header(c, "Content-Type", 12, "application/x-ndjson", 20);
@@ -917,7 +924,11 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
         }
     }
     else {
-        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                            FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     }
 #endif
 

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -267,7 +267,11 @@ static int http_request(struct flb_out_http *ctx,
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     flb_config_map_foreach(head, mv, ctx->headers) {
         key = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);

--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -522,7 +522,11 @@ static void cb_influxdb_flush(struct flb_event_chunk *event_chunk,
     /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
                         pack, bytes_out, NULL, 0, NULL, 0);
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     if (ctx->http_token) {
         ret = snprintf(tmp, sizeof(tmp) - 1, "Token %s", ctx->http_token);

--- a/plugins/out_kafka_rest/kafka.c
+++ b/plugins/out_kafka_rest/kafka.c
@@ -279,7 +279,11 @@ static void cb_kafka_flush(struct flb_event_chunk *event_chunk,
     /* Compose HTTP Client request */
     c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
                         js, js_size, NULL, 0, NULL, 0);
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     if (ctx->avro_http_header == FLB_TRUE) {
         flb_http_add_header(c,
                             "Content-Type", 12,

--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -439,7 +439,11 @@ static void cb_logdna_flush(struct flb_event_chunk *event_chunk,
     flb_http_set_callback_context(c, ctx->ins->callback);
 
     /* User Agent */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     /* Add Content-Type header */
     flb_http_add_header(c,

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -1919,7 +1919,11 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     flb_http_set_callback_context(c, ctx->ins->callback);
 
     /* User Agent */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     /* Auth headers */
     if (ctx->http_user && ctx->http_passwd) { /* Basic */

--- a/plugins/out_nrlogs/newrelic.c
+++ b/plugins/out_nrlogs/newrelic.c
@@ -429,7 +429,11 @@ static void cb_newrelic_flush(struct flb_event_chunk *event_chunk,
     flb_http_set_callback_context(c, ctx->ins->callback);
 
     /* User Agent */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     /* API / License Key */
     if (ctx->license_key) {

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -57,7 +57,10 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
     }
 
     /* AWS Fluent Bit user agent */
-    flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
                               ctx->aws_region, ctx->aws_service_name,
@@ -940,7 +943,11 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     flb_http_buffer_size(c, ctx->buffer_size);
 
 #ifndef FLB_HAVE_AWS
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 #endif
 
     flb_http_add_header(c, "Content-Type", 12, "application/x-ndjson", 20);
@@ -957,7 +964,11 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
         }
     }
     else {
-        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                            FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     }
 #endif
 

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -289,7 +289,11 @@ int opentelemetry_legacy_post(struct opentelemetry_context *ctx,
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     flb_config_map_foreach(head, mv, ctx->headers) {
         key = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);

--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -140,7 +140,11 @@ static int http_post(struct prometheus_remote_write_context *ctx,
         flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
     }
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     flb_config_map_foreach(head, mv, ctx->headers) {
         key = mk_list_entry_first(mv->val.list, struct flb_slist_entry, _head);

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -2132,8 +2132,10 @@ static int blob_request_pre_signed_url(struct flb_s3 *context,
 
     /* User Agent */
     flb_http_add_header(http_client,
-                        "User-Agent", 10,
-                        "Fluent-Bit", 10);
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     if (context->authorization_endpoint_username != NULL &&
         context->authorization_endpoint_password != NULL) {

--- a/plugins/out_skywalking/skywalking.c
+++ b/plugins/out_skywalking/skywalking.c
@@ -355,8 +355,11 @@ static void cb_sw_flush(struct flb_event_chunk *event_chunk,
 
     flb_http_add_header(client, "Content-Type", 12,
                     "application/json", 16);
-    flb_http_add_header(client, "User-Agent", 10,
-                        "Fluent-Bit", 10);
+    flb_http_add_header(client,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     if (check_sw_under_test() == FLB_TRUE) {
         tmp_ret = mock_oap_request(client, 200);

--- a/plugins/out_slack/slack.c
+++ b/plugins/out_slack/slack.c
@@ -254,7 +254,11 @@ static void cb_slack_flush(struct flb_event_chunk *event_chunk,
                         sizeof(FLB_HTTP_CONTENT_TYPE) - 1,
                         FLB_HTTP_MIME_JSON,
                         sizeof(FLB_HTTP_MIME_JSON) - 1);
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     ret = flb_http_do(c, &b_sent);
     if (ret == 0) {

--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -952,7 +952,11 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
     metadata_auth_header = get_metadata_auth_header(ctx);
 
     /* HTTP Client */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     /*
      * Authentication mechanism & order:

--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -71,7 +71,11 @@ static int fetch_metadata(struct flb_stackdriver *ctx,
 
     flb_http_buffer_size(c, FLB_STD_METADATA_TOKEN_SIZE_MAX);
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     flb_http_add_header(c, "Content-Type", 12, "application/text", 16);
     flb_http_add_header(c, "Metadata-Flavor", 15, "Google", 6);
 

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -3024,12 +3024,18 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     flb_http_buffer_size(c, 4192);
 
     if (ctx->stackdriver_agent) {
-        flb_http_add_header(c, "User-Agent", 10,
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
                             ctx->stackdriver_agent,
                             flb_sds_len(ctx->stackdriver_agent));
     }
     else {
-        flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+        flb_http_add_header(c,
+                            FLB_HTTP_HEADER_USER_AGENT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                            FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                            sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
     }
 
     flb_http_add_header(c, "Content-Type", 12, "application/json", 16);

--- a/plugins/out_td/td.c
+++ b/plugins/out_td/td.c
@@ -177,6 +177,12 @@ static void cb_td_flush(struct flb_event_chunk *event_chunk,
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
+    /* User-Agent */
+    flb_http_add_header(c, FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
+
     /* Issue HTTP request */
     ret = flb_http_do(c, &b_sent);
 

--- a/plugins/out_websocket/websocket.c
+++ b/plugins/out_websocket/websocket.c
@@ -77,6 +77,12 @@ static int flb_ws_handshake(struct flb_connection *u_conn,
                             val->str, flb_sds_len(val->str));
     }
 
+    /* User-Agent */
+    flb_http_add_header(c, FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
+
     /* Perform request*/
     ret = flb_http_do(c, &bytes_sent);
 

--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -443,8 +443,11 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
 
     /* Add AWS Fluent Bit user agent header */
     if (strcasecmp(aws_client->extra_user_agent, AWS_USER_AGENT_NONE) == 0) {
-        ret = flb_http_add_header(c, "User-Agent", 10,
-                                  FLB_AWS_BASE_USER_AGENT, FLB_AWS_BASE_USER_AGENT_LEN);
+        ret = flb_http_add_header(c,
+                                  FLB_HTTP_HEADER_USER_AGENT,
+                                  sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                                  FLB_AWS_BASE_USER_AGENT,
+                                  FLB_AWS_BASE_USER_AGENT_LEN);
     }
     else {
         user_agent_prefix = flb_sds_create_size(64);
@@ -463,7 +466,10 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
         }
         user_agent_prefix = tmp;
 
-        ret = flb_http_add_header(c, "User-Agent", 10, user_agent_prefix,
+        ret = flb_http_add_header(c,
+                                  FLB_HTTP_HEADER_USER_AGENT,
+                                  sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                                  user_agent_prefix,
                                   flb_sds_len(user_agent_prefix));
         flb_sds_destroy(user_agent_prefix);
     }

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1790,7 +1790,11 @@ int flb_http_client_proxy_connect(struct flb_connection *u_conn)
 
     flb_http_buffer_size(c, 4192);
 
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c,
+                        FLB_HTTP_HEADER_USER_AGENT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                        FLB_HTTP_HEADER_USER_AGENT_DEFAULT,
+                        sizeof(FLB_HTTP_HEADER_USER_AGENT_DEFAULT) - 1);
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);

--- a/tests/internal/http_client.c
+++ b/tests/internal/http_client.c
@@ -162,7 +162,10 @@ void test_http_add_get_header()
     }
 
     /* Check User-Agent */
-    ret = flb_http_add_header(c, "User-Agent", 10, ua, strlen(ua));
+    ret = flb_http_add_header(c,
+                              FLB_HTTP_HEADER_USER_AGENT,
+                              sizeof(FLB_HTTP_HEADER_USER_AGENT) - 1,
+                              ua, strlen(ua));
     TEST_CHECK(ret == 0);
 
     ret_str = flb_http_get_header(c, "User-Agent", 10);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

This will implement a standard User-Agent header for all http requests.

For ex.:

```
User-Agent: Fluent-Bit/5.0.0 (Git commit: e4466f5114bdff387774d6998666d5f60fb801da)
```

Ideally, I'd like to have something like this with os/arch and plugin information:

```
User-Agent: Fluent-Bit/5.0.0 (Linux/amd64, input: in_prometheus_scrape, Git commit: e4466f5114bdff387774d6998666d5f60fb801da)
```

Tell me if I should work on something like that for this PR or another.

Fixes #8880

The issue was closed beacause it was stale. Please open it  please.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized User-Agent header added to outgoing HTTP requests, including product version and git commit.

* **Bug Fixes**
  * User-Agent is now applied consistently across inputs, outputs, and plugins so requests carry uniform client metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->