### PR TITLE
input_chunk: fix tv_sec type mismatch in chunk name snprintf

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -437,9 +437,9 @@ static void generate_chunk_name(struct flb_input_instance *in,
 
     flb_time_get(&tm);
     snprintf(out_buf, buf_size - 1,
-             "%i-%lu.%4lu.flb",
+             "%i-%llu.%4lu.flb",
              getpid(),
-             tm.tm.tv_sec, tm.tm.tv_nsec);
+             (unsigned long long)tm.tm.tv_sec, tm.tm.tv_nsec);
 }
 
 ssize_t flb_input_chunk_get_size(struct flb_input_chunk *ic)


### PR DESCRIPTION
Fix undefined behavior in generate_chunk_name(): tv_sec is 64-bit time_t but format specifier %lu expects unsigned long (32-bit on ARM32).

Cast to unsigned long long (%llu) to match the argument type and support TIME_BITS=64.

**Summary of changes**
- `src/flb_input_chunk.c`: Cast `tm.tm.tv_sec` from `time_t` to `unsigned long long` in `snprintf()` call
- Fixes type mismatch undefined behavior on ARM32 where `unsigned long` is 32-bit but time_t is 64-bit

**Fixes #11424**

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced timestamp handling in chunk file operations to prevent potential overflow or truncation with large timestamp values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->