### PR TITLE
out_azure_kusto: Close OAuth handles in case of failure

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -39,6 +39,12 @@
 #include "azure_msiauth.h"
 #include "azure_kusto_store.h"
 
+/**
+ * Retrieve an OAuth2 access token using Managed Service Identity (MSI).
+ *
+ * @param ctx  Plugin's context containing the OAuth2 configuration.
+ * @return int 0 on success, -1 on failure.
+ */
 static int azure_kusto_get_msi_token(struct flb_azure_kusto *ctx)
 {
     char *token;
@@ -53,6 +59,12 @@ static int azure_kusto_get_msi_token(struct flb_azure_kusto *ctx)
     return 0;
 }
 
+/**
+ * Retrieve an OAuth2 access token using workload identity federation.
+ *
+ * @param ctx  Plugin's context containing workload identity configuration.
+ * @return int 0 on success, -1 on failure.
+ */
 static int azure_kusto_get_workload_identity_token(struct flb_azure_kusto *ctx)
 {
     int ret;
@@ -70,6 +82,15 @@ static int azure_kusto_get_workload_identity_token(struct flb_azure_kusto *ctx)
     return 0;
 }
 
+/**
+ * Retrieve an OAuth2 access token using service principal credentials.
+ *
+ * Constructs the OAuth2 payload with client credentials and requests
+ * an access token from the configured OAuth2 endpoint.
+ *
+ * @param ctx  Plugin's context containing client credentials and OAuth2 config.
+ * @return int 0 on success, -1 on failure.
+ */
 static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
 {
     int ret;
@@ -117,6 +138,16 @@ static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
     return 0;
 }
 
+/**
+ * Obtain the current Azure Kusto bearer token as a formatted string.
+ *
+ * Acquires the token mutex, refreshes the token if expired based on the
+ * configured authentication type, and returns a copy of the token string
+ * in the format "<token_type> <access_token>".
+ *
+ * @param ctx  Plugin's context.
+ * @return flb_sds_t  The bearer token string, or NULL on error.
+ */
 flb_sds_t get_azure_kusto_token(struct flb_azure_kusto *ctx)
 {
     int ret = 0;
@@ -1143,6 +1174,19 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
     return 0;
 }
 
+/**
+ * Buffer a data chunk into the file storage for later ingestion.
+ *
+ * Writes the formatted chunk data to the upload file via the store layer.
+ *
+ * @param out_context  Plugin's context (cast to struct flb_azure_kusto).
+ * @param upload_file  Target file handle for buffered storage.
+ * @param chunk        Data chunk to buffer.
+ * @param chunk_size   Size of the data chunk.
+ * @param tag          Fluent Bit tag associated with the chunk.
+ * @param tag_len      Length of the tag string.
+ * @return int         0 on success, -1 on failure.
+ */
 static int buffer_chunk(void *out_context, struct azure_kusto_file *upload_file,
                         flb_sds_t chunk, int chunk_size,
                         flb_sds_t tag, size_t tag_len)


### PR DESCRIPTION
Signed-off-by: ag-ramachandran <ramacg@microsoft.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More specific and actionable MSI/OAuth2 error messages to aid troubleshooting.
  * Enabled OAuth2 token retrieval for service-principal authentication flows.
  * Added robust cleanup on initialization failures to prevent resource leaks.
  * Suppressed noisy error logs for transient lock/coordination issues to reduce false alarms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->