### PR TITLE
filter_kubernetes: Adjust cleanup ordering to avoid use-after-free

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -243,17 +243,16 @@ void flb_kube_conf_destroy(struct flb_kube *ctx)
     if (ctx->kube_api_upstream) {
         flb_upstream_destroy(ctx->kube_api_upstream);
     }
-
-    if (ctx->aws_pod_association_tls) {
-        flb_tls_destroy(ctx->aws_pod_association_tls);
-    }
-
     if (ctx->aws_pod_association_upstream) {
         flb_upstream_destroy(ctx->aws_pod_association_upstream);
     }
 
     if (ctx->platform) {
         flb_free(ctx->platform);
+    }
+
+    if (ctx->aws_pod_association_tls) {
+        flb_tls_destroy(ctx->aws_pod_association_tls);
     }
 
 #ifdef FLB_HAVE_TLS


### PR DESCRIPTION
The ordering in `flb_kube_conf_destroy` is setup such that the `aws_pod_association_tls` may be used after it is destroyed.

```
==1== Invalid read of size 4
==1==    at 0x6AC10B8: __pthread_mutex_unlock_usercnt (in /usr/lib64/libc.so.6)
==1==    by 0x6A4F22: tls_session_destroy (openssl.c:1224)
==1==    by 0x6A6AFC: flb_tls_session_destroy (flb_tls.c:765)
==1==    by 0x5FDB0C: destroy_conn (flb_upstream.c:576)
==1==    by 0x5FDED5: flb_upstream_destroy (flb_upstream.c:683)
==1==    by 0xD29BBD: flb_kube_conf_destroy (kube_conf.c:252)
==1==    by 0xD1FFA7: cb_kube_exit (kubernetes.c:817)
==1==    by 0x59698B: flb_filter_instance_exit (flb_filter.c:400)
==1==    by 0x5969F1: flb_filter_exit (flb_filter.c:418)
==1==    by 0x5D50CE: flb_engine_shutdown (flb_engine.c:1317)
==1==    by 0x5D4C7E: flb_engine_start (flb_engine.c:1200)
==1==    by 0x556358: flb_lib_worker (flb_lib.c:904)
==1==  Address 0xed8037e0 is 32 bytes inside a block of size 72 free'd
==1==    at 0x48490E4: free (vg_replace_malloc.c:872)
==1==    by 0x6A3B02: flb_free (flb_mem.h:127)
==1==    by 0x6A41DA: tls_context_destroy (openssl.c:183)
==1==    by 0x6A5F82: flb_tls_destroy (flb_tls.c:261)
==1==    by 0xD29B9A: flb_kube_conf_destroy (kube_conf.c:248)
==1==    by 0xD1FFA7: cb_kube_exit (kubernetes.c:817)
==1==    by 0x59698B: flb_filter_instance_exit (flb_filter.c:400)
==1==    by 0x5969F1: flb_filter_exit (flb_filter.c:418)
==1==    by 0x5D50CE: flb_engine_shutdown (flb_engine.c:1317)
==1==    by 0x5D4C7E: flb_engine_start (flb_engine.c:1200)
==1==    by 0x556358: flb_lib_worker (flb_lib.c:904)
==1==    by 0x6ABC2E9: start_thread (in /usr/lib64/libc.so.6)
==1==  Block was alloc'd at
==1==    at 0x484B464: calloc (vg_replace_malloc.c:1328)
==1==    by 0x6A3AE8: flb_calloc (flb_mem.h:95)
==1==    by 0x6A4625: tls_context_create (openssl.c:772)
==1==    by 0x6A5DC0: flb_tls_create (flb_tls.c:200)
==1==    by 0xD33AF2: flb_kube_pod_association_init (kube_meta.c:2022)
==1==    by 0xD342F4: flb_kube_network_init (kube_meta.c:2162)
==1==    by 0xD34499: flb_kube_meta_init (kube_meta.c:2187)
==1==    by 0xD1ECB3: cb_kube_init (kubernetes.c:238)
==1==    by 0x5973A8: flb_filter_init (flb_filter.c:660)
==1==    by 0x59744B: flb_filter_init_all (flb_filter.c:681)
==1==    by 0x5D41EB: flb_engine_start (flb_engine.c:962)
==1==    by 0x556358: flb_lib_worker (flb_lib.c:904)
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

https://gist.github.com/ShelbyZ/ef14462abbc7ee1239d57f2bf032583b

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal resource cleanup ordering in Kubernetes plugin operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->