### PR TITLE
in_forward: fix init error cleanup and parser state handling

### DIFF
--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -222,6 +222,14 @@ static int setup_users(struct flb_in_fw_config *ctx,
 
         /* As a value we expect a pair of a username and a passowrd */
         split = flb_utils_split(kv->val, ' ', 1);
+        if (split == NULL) {
+            flb_plg_error(ctx->ins,
+                          "invalid value, expected username and password");
+            delete_users(ctx);
+            flb_free(user);
+            return -1;
+        }
+
         if (mk_list_size(split) != 2) {
             flb_plg_error(ctx->ins,
                           "invalid value, expected username and password");
@@ -348,7 +356,7 @@ static int in_fw_init(struct flb_input_instance *ins,
     /* Load users */
     ret = setup_users(ctx, ins);
     if (ret == -1) {
-        flb_free(ctx);
+        fw_config_destroy(ctx);
         return -1;
     }
 

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -90,7 +90,7 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
     ret = flb_input_config_map_set(i_ins, (void *)config);
     if (ret == -1) {
         flb_plg_error(i_ins, "config map set error");
-        flb_free(config);
+        fw_config_destroy(config);
         return NULL;
     }
 
@@ -117,6 +117,7 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
     /* Shared Key */
     if (config->empty_shared_key) {
         if (fw_create_empty_shared_key(config, i_ins) == -1) {
+            fw_config_destroy(config);
             return NULL;
         }
     }


### PR DESCRIPTION
  - Reset per-message option state in forward parser to avoid stale options reuse.
  - Fix HELO handshake path to return error immediately on send failure.
  - Add NULL-check for security.users split parsing.
  - Use fw_config_destroy() on init failures to cleanly release allocated resources.
  - Align options index types/sentinels (chunk_id/metadata_id) to int for safer comparisons.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and resource cleanup in the forward input plugin to ensure proper shutdown during failure scenarios.
  * Improved validation of user data parsing with comprehensive error recovery and cleanup procedures.
  * Standardized error handling across plugin components for increased reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->