### PR TITLE
in_tail: support recursive directory monitoring

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -717,6 +717,11 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE, offsetof(struct flb_tail_config, exit_on_eof),
      "exit Fluent Bit when reaching EOF on a monitored file."
     },
+    {
+     FLB_CONFIG_MAP_BOOL, "path_recursion", "false",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, recursive),
+     "Enable or disable recursive file scanning when a path is a directory."
+    },
 
     {
      FLB_CONFIG_MAP_BOOL, "skip_empty_lines", "false",

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -106,6 +106,7 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
     ctx->ins = ins;
     ctx->ignore_older = 0;
     ctx->skip_long_lines = FLB_FALSE;
+    ctx->recursive = FLB_FALSE;
 #ifdef FLB_HAVE_SQLDB
     ctx->db_sync = 1;  /* sqlite sync 'normal' */
 #endif

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -100,6 +100,7 @@ struct flb_tail_config {
     int   skip_long_lines;     /* skip long lines              */
     int   skip_empty_lines;    /* skip empty lines (off)       */
     int   exit_on_eof;         /* exit fluent-bit on EOF, test */
+    int   recursive;           /* recursive scanning           */
 #ifdef __linux__
     int   file_cache_advise;   /* Use posix_fadvise for file access */
 #endif

--- a/plugins/in_tail/tail_scan_win32.c
+++ b/plugins/in_tail/tail_scan_win32.c
@@ -247,18 +247,80 @@ static int tail_filepath(char *buf, int len, const char *basedir, const char *fi
     return 0;
 }
 
+static int tail_scan_directory(const char *dir, struct flb_tail_config *ctx, time_t now)
+{
+    HANDLE hFind;
+    WIN32_FIND_DATA data;
+    char path[MAX_PATH];
+    int count = 0;
+    int ret;
+
+    /* Construct path for FindFirstFile: dir\* */
+    if (snprintf(path, sizeof(path), "%s\\*", dir) >= sizeof(path)) {
+        flb_plg_error(ctx->ins, "path too long: %s", dir);
+        return -1;
+    }
+
+    hFind = FindFirstFileA(path, &data);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        flb_plg_error(ctx->ins, "cannot open directory: %s", dir);
+        return -1;
+    }
+
+    do {
+        if (strcmp(data.cFileName, ".") == 0 || strcmp(data.cFileName, "..") == 0) {
+            continue;
+        }
+
+        if (snprintf(path, sizeof(path), "%s\\%s", dir, data.cFileName) >= sizeof(path)) {
+            flb_plg_warn(ctx->ins, "path too long: %s\\%s", dir, data.cFileName);
+            continue;
+        }
+
+        if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            ret = tail_scan_directory(path, ctx, now);
+            if (ret > 0) {
+                count += ret;
+            }
+        }
+        else {
+             /* It's a file */
+             ret = tail_register_file(path, ctx, now);
+             if (ret == 0) {
+                 count++;
+             }
+        }
+    } while (FindNextFileA(hFind, &data));
+
+    FindClose(hFind);
+    return count;
+}
+
 static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
 {
     int ret;
     int n_added = 0;
     time_t now;
+    DWORD attrs;
 
     if (strchr(path, '*')) {
         return tail_scan_pattern(path, ctx);
     }
 
-    /* No wildcard involved. Let's just handle the file... */
     now = time(NULL);
+
+    attrs = GetFileAttributesA(path);
+    if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+        if (ctx->recursive == FLB_TRUE) {
+            return tail_scan_directory(path, ctx, now);
+        }
+        else {
+            flb_plg_debug(ctx->ins, "skip directory %s (recursion disabled)", path);
+            return 0;
+        }
+    }
+
+    /* No wildcard involved. Let's just handle the file... */
     ret = tail_register_file(path, ctx, now);
     if (ret == 0) {
         n_added++;


### PR DESCRIPTION
This PR introduces recursive directory monitoring support for the Tail input plugin.


Key changes:
- Added 'path_recursion' configuration option (default: false).
- Implemented recursive directory scanning for POSIX (opendir/readdir).
- Implemented recursive directory scanning for Windows (FindFirstFile/FindNextFile).
- Added unit tests to verify recursion behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional configuration to enable recursive directory scanning when tailing a directory path, discovering files in subfolders automatically. Disabled by default to preserve existing behavior. Available on Linux/Unix and Windows.

- Tests
  - Added runtime tests covering recursive scanning enabled/disabled scenarios to ensure correct discovery and ingestion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->