### PR TITLE
bin: Use proper ISO 8601 format for logging

### DIFF
--- a/src/flb_dump.c
+++ b/src/flb_dump.c
@@ -225,7 +225,7 @@ void flb_dump(struct flb_config *ctx)
     current = localtime(&now);
 
     fprintf(stderr,
-            "[%i/%02i/%02i %02i:%02i:%02i] Fluent Bit Dump\n",
+            "[%i-%02i-%02iT%02i:%02i:%02i] Fluent Bit Dump\n",
             current->tm_year + 1900,
             current->tm_mon + 1,
             current->tm_mday,

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -218,7 +218,7 @@ static int log_prepare_header(char *buf, size_t size, int type,
     header_title = flb_log_message_type_str(type);
 
     return snprintf(buf, size,
-                    "%s[%s%i/%02i/%02i %02i:%02i:%02i.%03ld%s]%s [%s%5s%s] ",
+                    "%s[%s%i-%02i-%02iT%02i:%02i:%02i.%03ld%s]%s [%s%5s%s] ",
                     bold_color, reset_color,
                     current->tm_year + 1900,
                     current->tm_mon + 1,

--- a/src/fluent-bit.c
+++ b/src/fluent-bit.c
@@ -562,7 +562,7 @@ static void flb_signal_exit(int signal)
 
     now = time(NULL);
     cur = localtime(&now);
-    len = snprintf(ts, sizeof(ts) - 1, "[%i/%02i/%02i %02i:%02i:%02i] ",
+    len = snprintf(ts, sizeof(ts) - 1, "[%i-%02i-%02iT%02i:%02i:%02i] ",
                    cur->tm_year + 1900,
                    cur->tm_mon + 1,
                    cur->tm_mday,
@@ -595,7 +595,7 @@ static void flb_signal_handler_status_line(struct flb_cf *cf_opts)
 
     now = time(NULL);
     cur = localtime(&now);
-    len = snprintf(ts, sizeof(ts) - 1, "[%i/%02i/%02i %02i:%02i:%02i] ",
+    len = snprintf(ts, sizeof(ts) - 1, "[%i-%02i-%02iT%02i:%02i:%02i] ",
                    cur->tm_year + 1900,
                    cur->tm_mon + 1,
                    cur->tm_mday,


### PR DESCRIPTION
Instead of using a custom format, use proper extended ISO 8601 datetime format.

Change is straight forward. Output now:
```
root@135-release-amd64-default-head:/usr/ports/sysutils/fluent-bit # fluent-bit
Fluent Bit v4.2.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _             ___   _____
|  ___| |                | |   | ___ (_) |           /   | / __  \
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `' / /'
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |   / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |_./ /___
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)_____/

             Fluent Bit v4.2 – Direct Routes Ahead
         Celebrating 10 Years of Open, Fluent Innovation!

[2026-02-14 16:48:08.479196279] [ info] [fluent bit] version=4.2.2, commit=, pid=51299
[2026-02-14 16:48:08.479304309] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026-02-14 16:48:08.479316303] [ info] [simd    ] disabled
[2026-02-14 16:48:08.479331868] [ info] [cmetrics] version=1.0.6
[2026-02-14 16:48:08.479341850] [ info] [ctraces ] version=0.6.6
[2026-02-14 16:48:08.479426082] [ info] [sp] stream processor started
[2026-02-14 16:48:08.479455774] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
^C[2026/02/14 16:48:14] [engine] caught signal (SIGINT)
[2026-02-14 16:48:14.437349155] [ warn] [engine] service will shutdown in max 5 seconds
[2026-02-14 16:48:14.437375002] [ info] [engine] pausing all inputs..
[2026-02-14 16:48:15.437451218] [ info] [engine] service has stopped (0 pending tasks)
root@135-release-amd64-default-head:/usr/ports/sysutils/fluent-bit #
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized visible timestamps across logs, dumps and status/signal messages: dates now use hyphen separators and an ISO-like "T" between date and time (e.g., YYYY-MM-DDTHH:MM:SS), ensuring consistent timestamp formatting without changing log content or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->