### PR TITLE
dockerfiles: Install minimum components and avoiding to use includeRecommended

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -41,13 +41,18 @@ RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
     Invoke-WebRequest -OutFile \"${msvs_build_tools_dist}\" \"${msvs_build_tools_dist_url}\"; `
     Invoke-WebRequest -OutFile \"${msvs_build_tools_channel}\" \"${msvs_build_tools_channel_url}\"; `
     Write-Host \"Installing Visual Studio Build Tools into ${env:MSVS_HOME}...\"; `
-    Start-Process \"${msvs_build_tools_dist}\" `
+    $p = Start-Process \"${msvs_build_tools_dist}\" `
       -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
       \"--installPath ${env:MSVS_HOME}\", `
       \"--channelUri ${msvs_build_tools_channel}\", `
       \"--installChannelUri ${msvs_build_tools_channel}\", `
       '--add Microsoft.VisualStudio.Workload.VCTools', `
-      '--includeRecommended'  -NoNewWindow -Wait; `
+      '--add Microsoft.VisualStudio.Workload.MSBuildTools', `
+      '--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64', `
+      '--add Microsoft.VisualStudio.Component.VC.CoreBuildTools', `
+      '--add Microsoft.VisualStudio.Component.VC.MSVC.143', `
+      '--add Microsoft.VisualStudio.Component.Windows10SDK.19041' `
+      -NoNewWindow -Wait; `
     Remove-Item -Force \"${msvs_build_tools_dist}\"; `
     Remove-Item -Path \"${msvs_build_tools_channel}\" -Force;
 
@@ -142,7 +147,8 @@ RUN $vcpkg_dist_base_name=\"vcpkg-${env:VCPKG_VERSION}\"; `
 
 # Ensure we only attempt to build release and static linking
 ENV VCPKG_BUILD_TYPE=release `
-    VCPKG_LIBRARY_LINKAGE=static
+    VCPKG_LIBRARY_LINKAGE=static `
+    VCPKG_VISUAL_STUDIO_PATH="C:\BuildTools"
 
 # Install dependencies and clean temporary files to save space
 RUN vcpkg install --recurse openssl --triplet x64-windows-static; `


### PR DESCRIPTION


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Windows build environment to install specific Visual C++ components (explicit VC toolchain pieces) and the Windows 10 SDK, replacing prior workload-based install flags.
  * Configured vcpkg to use the explicit Visual Studio build tools path (VCPKG_VISUAL_STUDIO_PATH) under release builds, ensuring native dependency installs run within the intended Visual C++ environment and improving reliability of Windows image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->