### PR TITLE
tests: fixed running with run_code_analysis.sh script

### DIFF
--- a/tests/runtime_shell/go_plugins/build_test_plugins.sh
+++ b/tests/runtime_shell/go_plugins/build_test_plugins.sh
@@ -6,6 +6,16 @@ set -e
 GO_PLUGIN_DIR="${FLB_ROOT}/tests/runtime_shell/go_plugins"
 BUILD_DIR="${FLB_ROOT}/build"
 
+# Support of environment without sudo, but running as root user.
+# Like container used in run_code_analysis.sh script.
+sudo_if_not_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
 install_go_if_needed() {
     if ! command -v go &> /dev/null; then 
     echo "Go not found, installing Go..."
@@ -46,9 +56,9 @@ install_go_if_needed() {
 
     if [ -w "/usr/local" ]; then
         if [ -d /usr/local/go ]; then
-            sudo rm -rf /usr/local/go
+            sudo_if_not_root rm -rf /usr/local/go
         fi
-        sudo mv go /usr/local/go
+        sudo_if_not_root mv go /usr/local/go
         export PATH="/usr/local/go/bin:$PATH"
     else
         echo "No write permission to /usr/local. Installing Go to $HOME/.local/go"


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed execution of tests within run_code_analysis.sh script which is recommended in [Guide to Contributing to Fluent Bit](https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#testing).

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Fixes https://github.com/fluent/fluent-bit/pull/11011#discussion_r2835996936 introduced in #11011.

----

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found - refer to [flb_run_code_analysis.log](https://drive.google.com/file/d/1SoVJDljmcH5vMvqhMaH9KlIoOBoiWVtb/view?usp=sharing) for the output of command
    ```bash
    TEST_PRESET=valgrind SKIP_TESTS='flb-rt-out_td flb-it-network' ./run_code_analysis.sh
    ```
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test scripts now include conditional privilege handling so install/remove operations run with elevation only when needed—preserving direct execution for root and delegating to sudo for non-root—improving compatibility across root and non-root environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->