### PR TITLE
metrics: change hot_reloaded_times from gauge to counter

### DIFF
--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -332,18 +332,18 @@ static int attach_hot_reload_info(struct flb_config *ctx, struct cmt *cmt, uint6
                                   char *hostname)
 {
     double val;
-    struct cmt_gauge *g;
+    struct cmt_counter *c;
 
-    g = cmt_gauge_create(cmt, "fluentbit", "", "hot_reloaded_times",
-                         "Collect the count of hot reloaded times.",
-                         1, (char *[]) {"hostname"});
-    if (!g) {
+    c = cmt_counter_create(cmt, "fluentbit", "", "hot_reloaded_times",
+                           "Collect the count of hot reloaded times.",
+                           1, (char *[]) {"hostname"});
+    if (!c) {
         return -1;
     }
 
     val = (double) ctx->hot_reloaded_count;
 
-    cmt_gauge_set(g, ts, val, 1, (char *[]) {hostname});
+    cmt_counter_set(c, ts, val, 1, (char *[]) {hostname});
     return 0;
 }
 


### PR DESCRIPTION
  Registering it as a gauge causes incorrect behavior with PromQL
  functions like rate() and increase(), which expect counters.

  - src/flb_metrics.c: replace cmt_gauge_create() with cmt_counter_create() for hot_reloaded_times in attach_hot_reload_info()
  - src/flb_metrics.c: replace struct cmt_gauge with struct cmt_counter
  - src/flb_metrics.c: replace cmt_gauge_set() with cmt_counter_set()

Fixes #11479.

----
**Testing**
- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ YES ] Documentation required for this feature

Docs PR for this change: https://github.com/fluent/fluent-bit-docs/pull/2383

**Backporting**
- [ N/A ] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Converted the hot-reload metric to a count-based metric and added internal checks to ensure the metric is created and updated reliably. This improves metric tracking and alerting accuracy. No public API or observable behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->