### PR TITLE
out_stackdriver: isolate record formatting failures and fallback to textPayload

### DIFF
--- a/tests/runtime/data/stackdriver/stackdriver_test_payload.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_payload.h
@@ -24,3 +24,43 @@
         "\"logging.googleapis.com/severity\": \"ERROR\"," \
         "\"errorCode\": \"400\"" \
         "}]"
+
+/* Duplicate-key payloads to simulate invalid JSON records from applications. */
+#define DUPLICATE_LABELS_WITH_MESSAGE "[" \
+        "1595349600," \
+        "{" \
+        "\"message\": \"raw_message_payload\"," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"," \
+        "\"logging.googleapis.com/labels\": \"invalid_labels\"," \
+        "\"logging.googleapis.com/labels\": 2" \
+        "}]"
+
+#define DUPLICATE_LABELS_WITH_LOG "[" \
+        "1595349600," \
+        "{" \
+        "\"log\": \"raw_log_payload\"," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"," \
+        "\"logging.googleapis.com/labels\": \"invalid_labels\"," \
+        "\"logging.googleapis.com/labels\": 2" \
+        "}]"
+
+#define DUPLICATE_LABELS_WITH_CUSTOM_TEXT_KEY "[" \
+        "1595349600," \
+        "{" \
+        "\"message\": \"default_message_payload\"," \
+        "\"raw_message\": \"custom_text_payload\"," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"," \
+        "\"logging.googleapis.com/labels\": \"invalid_labels\"," \
+        "\"logging.googleapis.com/labels\": 2" \
+        "}]"
+
+#define DUPLICATE_LABELS_WITH_NON_SCALAR_TEXT_SOURCES "[" \
+        "1595349600," \
+        "{" \
+        "\"message\": {\"nested\": \"value\"}," \
+        "\"log\": {\"inner\": \"value\"}," \
+        "\"errorCode\": \"500\"," \
+        "\"logging.googleapis.com/severity\": \"ERROR\"," \
+        "\"logging.googleapis.com/labels\": \"invalid_labels\"," \
+        "\"logging.googleapis.com/labels\": 2" \
+        "}]"


### PR DESCRIPTION
## Summary
This PR makes `out_stackdriver` resilient to record-level payload formatting failures so one bad record no longer causes an entire batch to be dropped.

It introduces per-record isolation in the entry formatting path and adds a `textPayload` fallback path that preserves original log content when structured payload packing fails.

## Problem Statement
In the GKE Logging Pipeline, logs are sent through Fluent Bit `out_stackdriver`. Certain malformed JSON shapes (including payloads that can trigger strict translation failures, such as duplicate-key edge cases after parse/translation) can fail while converting MsgPack records into Cloud Logging `LogEntry` payloads.

Before this change, a record-level formatting failure could fail chunk-level conversion, causing valid records in the same batch to be dropped.

## Solution
- Isolate formatting at the record level inside the chunk loop.
- Do not fail the whole batch when one record cannot be formatted.
- Fallback failed records to `textPayload` so original log data is preserved.
- Keep `partialSuccess: true` behavior while appending only successfully built entries.

## Implementation
### 1) Record-level isolation in `stackdriver_format`
- Refactors entry construction into a dedicated per-record routine.
- Uses dynamic entries array headers (`flb_mp_array_header_*`) and appends only successfully formatted entries.
- Continues iterating the chunk when a record fails formatting.

### 2) `textPayload` fallback behavior
When structured payload packing fails for a record, the plugin rebuilds that entry using `textPayload` with this precedence:
1. configured `text_payload_key`
2. `message`
3. `log`
4. serialized full record JSON (last-resort preservation)

### 3) Cleanup and safety
- Ensures per-record allocations/extractions are cleaned up on both normal and fallback paths.
- Keeps existing irrecoverable validation behavior (e.g., invalid `insertId`) scoped to the affected record.

## Tests
Runtime fixtures and assertions were added for fallback and batch resilience:
- fallback uses `message`
- fallback uses `log`
- fallback uses configured custom `text_payload_key`
- fallback uses serialized record when no scalar string source is available
- mixed batch behavior: valid + invalid + valid records preserve valid entries and fallback the invalid entry

## Validation
Executed locally:
- `cmake --build build --target flb-rt-out_stackdriver -j8`
- `ctest --test-dir build/tests/runtime -R out_stackdriver --output-on-failure`

Result:
- `flb-rt-out_stackdriver` passed (`1/1`), `100% tests passed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced per-entry Cloud Logging formatting: richer field extraction (severity, trace/span, trace_sampled, insertId, operation, sourceLocation, httpRequest), per-entry timestamps, log name/path resolution, and Kubernetes stdout/stderr handling.
* **Bug Fixes**
  * Improved per-entry error handling with robust textPayload fallback for packing failures; preserves previously formatted entries and skips problematic ones.
* **Tests**
  * Added new payload variants and tests covering fallback behaviors, duplicate-label scenarios, and mixed-entry cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
