### PR TITLE
io: http_client: Implement batching io write

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -38,11 +38,16 @@
 
 #include <monkey/mk_core.h>
 
+/* POSIX guarantees at least 16 vectors. Keep native vector storage bounded. */
+#define FLB_IOV_MAX 16
+
 #ifdef FLB_SYSTEM_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <windows.h>
 #include <Wincrypt.h> /* flb_io_tls.c */
+#include <errno.h>
+#include <limits.h>
 
 #include <monkey/mk_core/mk_sleep.h>
 #include <fluent-bit/flb_dlfcn_win32.h>
@@ -67,6 +72,66 @@
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #define timegm _mkgmtime
+
+/* Socket writev compatibility; accept at most FLB_IOV_MAX vectors and INT_MAX bytes. */
+static inline ssize_t flb_writev(SOCKET fd, const struct mk_iovec *iov, int count)
+{
+    WSABUF buffers[FLB_IOV_MAX];
+    DWORD written;
+    size_t total;
+    int index;
+    int error;
+
+    if (count < 0 || count > FLB_IOV_MAX || (count > 0 && iov == NULL)) {
+        errno = EINVAL;
+        WSASetLastError(WSAEINVAL);
+        return -1;
+    }
+    if (count == 0) {
+        return 0;
+    }
+
+    total = 0;
+    for (index = 0; index < count; index++) {
+        if (iov[index].iov_len > INT_MAX - total) {
+            errno = EINVAL;
+            WSASetLastError(WSAEINVAL);
+            return -1;
+        }
+        buffers[index].buf = (char *) iov[index].iov_base;
+        buffers[index].len = (ULONG) iov[index].iov_len;
+        total += iov[index].iov_len;
+    }
+
+    if (WSASend(fd, buffers, count, &written, 0, NULL, NULL) == SOCKET_ERROR) {
+        error = WSAGetLastError();
+        switch (error) {
+        case WSAEINTR:
+            errno = EINTR;
+            break;
+        case WSAEWOULDBLOCK:
+            errno = EAGAIN;
+            break;
+        case WSAECONNRESET:
+        case WSAECONNABORTED:
+        case WSAESHUTDOWN:
+            errno = ECONNRESET;
+            break;
+        case WSAENOTCONN:
+            errno = ENOTCONN;
+            break;
+        case WSAENOTSOCK:
+            errno = EBADF;
+            break;
+        default:
+            errno = EIO;
+        }
+        WSASetLastError(error);
+        return -1;
+    }
+
+    return (ssize_t) written;
+}
 
 static inline int getpagesize(void)
 {
@@ -142,8 +207,10 @@ static inline int usleep(LONGLONG usec)
 #include <libgen.h>
 #include <dlfcn.h>
 #include <strings.h>
+#include <sys/uio.h>
 
 #define FLB_DIRCHAR '/'
+#define flb_writev writev
 #endif
 
 #ifdef FLB_HAVE_UNIX_SOCKET

--- a/include/fluent-bit/flb_io.h
+++ b/include/fluent-bit/flb_io.h
@@ -20,6 +20,7 @@
 #ifndef FLB_IO_H
 #define FLB_IO_H
 
+#include <stddef.h>
 #include <monkey/mk_core.h>
 
 #include <fluent-bit/flb_info.h>
@@ -48,7 +49,14 @@
                                 * flb_connection.flags, never on the
                                 * shared stream/upstream flags.          */
 
+/* Maximum temporary buffer size for TLS stream write batching. */
+#define FLB_IO_WRITEV_COALESCE_MAX (64 * 1024)
+
 struct flb_connection;
+struct flb_iovec {
+    const void *iov_base;
+    size_t      iov_len;
+};
 
 int flb_io_net_accept(struct flb_connection *connection,
                        struct flb_coro *th);
@@ -58,6 +66,18 @@ int flb_io_net_connect(struct flb_connection *u_conn,
 
 int flb_io_net_write(struct flb_connection *connection, const void *data,
                      size_t len, size_t *out_len);
+
+/*
+ * Write vectors in order, using native scatter/gather for plain streams and
+ * bounded coalescing through the TLS writer for encrypted streams. The vectors
+ * and their data must remain valid until this call returns (including yields).
+ * Returns nonnegative on success or -1 on failure; out_len always reports the
+ * number of bytes consumed, including partial progress on failure.
+ */
+int flb_io_net_writev(struct flb_connection *connection,
+                      const struct flb_iovec *iov,
+                      int iovcnt,
+                      size_t *out_len);
 
 ssize_t flb_io_net_read(struct flb_connection *connection, void *buf, size_t len);
 

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1846,9 +1846,11 @@ int flb_http_do_request(struct flb_http_client *c, size_t *bytes)
     int ret;
     int crlf = 2;
     int new_size;
+    int saved_errno;
     size_t bytes_header = 0;
     size_t bytes_body = 0;
     char *tmp;
+    struct flb_iovec io_vector[2];
 
     c->header_len = c->base_header_len;
 
@@ -1887,26 +1889,103 @@ int flb_http_do_request(struct flb_http_client *c, size_t *bytes)
     }
 #endif
 
-    /* Write the header */
-    ret = flb_io_net_write(c->u_conn,
-                           c->header_buf, c->header_len,
-                           &bytes_header);
-    if (ret == -1) {
-        /* errno might be changed from the original call */
-        if (errno != 0) {
-            flb_errno();
-        }
-        return FLB_HTTP_ERROR;
-    }
-
     if (c->body_len > 0) {
-        ret = flb_io_net_write(c->u_conn,
-                               c->body_buf, c->body_len,
-                               &bytes_body);
+        io_vector[0].iov_base = c->header_buf;
+        io_vector[0].iov_len = c->header_len;
+        io_vector[1].iov_base = c->body_buf;
+        io_vector[1].iov_len = c->body_len;
+
+        ret = flb_io_net_writev(c->u_conn,
+                                io_vector,
+                                2,
+                                &bytes_header);
         if (ret == -1) {
-            flb_errno();
+            saved_errno = errno;
+
+            if (saved_errno == ENOMEM && bytes_header == 0) {
+                ret = flb_io_net_write(c->u_conn,
+                                       c->header_buf, c->header_len,
+                                       &bytes_header);
+                if (ret == -1) {
+                    saved_errno = errno;
+
+                    if (bytes_header > 0) {
+                        flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
+                    }
+
+                    if (saved_errno != 0) {
+                        errno = saved_errno;
+                        flb_errno();
+                    }
+                    return FLB_HTTP_ERROR;
+                }
+
+                ret = flb_io_net_write(c->u_conn,
+                                       c->body_buf, c->body_len,
+                                       &bytes_body);
+                if (ret == -1) {
+                    saved_errno = errno;
+                    flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
+
+                    if (saved_errno != 0) {
+                        errno = saved_errno;
+                        flb_errno();
+                    }
+                    return FLB_HTTP_ERROR;
+                }
+            }
+            else {
+                if (bytes_header > 0) {
+                    flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
+                }
+
+                if (saved_errno != 0) {
+                    errno = saved_errno;
+                    flb_errno();
+                }
+                return FLB_HTTP_ERROR;
+            }
+        }
+        else {
+            if (bytes_header < (size_t) c->header_len) {
+                flb_error("[http_client] invalid write accounting: total=%zu header=%d",
+                          bytes_header, c->header_len);
+                flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
+
+                return FLB_HTTP_ERROR;
+            }
+
+            bytes_body = bytes_header - c->header_len;
+            bytes_header = c->header_len;
+        }
+    }
+    else {
+        /* Write the header */
+        ret = flb_io_net_write(c->u_conn,
+                               c->header_buf, c->header_len,
+                               &bytes_header);
+        if (ret == -1) {
+            saved_errno = errno;
+
+            if (bytes_header > 0) {
+                flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
+            }
+
+            if (saved_errno != 0) {
+                errno = saved_errno;
+                flb_errno();
+            }
             return FLB_HTTP_ERROR;
         }
+    }
+
+    if (bytes_header != (size_t) c->header_len ||
+        bytes_body != (size_t) c->body_len) {
+        flb_error("[http_client] short request write: header=%zu/%d body=%zu/%d",
+                  bytes_header, c->header_len, bytes_body, c->body_len);
+        flb_upstream_conn_recycle(c->u_conn, FLB_FALSE);
+
+        return FLB_HTTP_ERROR;
     }
 
     /* number of sent bytes */

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -44,7 +44,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <limits.h>
+#include <string.h>
+#include <errno.h>
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/uio.h>
+#endif
 
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_info.h>
@@ -61,6 +65,7 @@
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
+
 
 int flb_io_net_accept(struct flb_connection *connection,
                        struct flb_coro *coro)
@@ -274,8 +279,110 @@ static void net_io_propagate_critical_error(
     }
 }
 
-static int fd_io_write(int fd, struct sockaddr_storage *address,
-                       const void *data, size_t len, size_t *out_len);
+/* POSIX guarantees at least 16 vectors. Bound both stack use and write size. */
+#define FLB_IO_NATIVE_IOV_MAX 16
+#define FLB_IO_NATIVE_WRITE_MAX 524288
+
+struct net_io_vector {
+    const struct flb_iovec *iov;
+    int count;
+    int index;
+    size_t offset;
+};
+
+static ssize_t net_io_vector_send(flb_sockfd_t fd, struct net_io_vector *vector)
+{
+    int index;
+    int count;
+    size_t offset;
+    size_t length;
+    size_t remaining;
+    ssize_t bytes;
+#ifdef FLB_SYSTEM_WINDOWS
+    WSABUF buffers[FLB_IO_NATIVE_IOV_MAX];
+    DWORD written;
+    int error;
+#else
+    struct iovec buffers[FLB_IO_NATIVE_IOV_MAX];
+#endif
+
+    index = vector->index;
+    offset = vector->offset;
+    count = 0;
+    remaining = FLB_IO_NATIVE_WRITE_MAX;
+
+    while (index < vector->count && count < FLB_IO_NATIVE_IOV_MAX && remaining > 0) {
+        length = vector->iov[index].iov_len - offset;
+        if (length > remaining) {
+            length = remaining;
+        }
+        if (length > 0) {
+#ifdef FLB_SYSTEM_WINDOWS
+            buffers[count].buf = (char *) vector->iov[index].iov_base + offset;
+            buffers[count].len = (ULONG) length;
+#else
+            buffers[count].iov_base = (char *) vector->iov[index].iov_base + offset;
+            buffers[count].iov_len = length;
+#endif
+            count++;
+            remaining -= length;
+        }
+        index++;
+        offset = 0;
+    }
+
+#ifdef FLB_SYSTEM_WINDOWS
+    if (WSASend(fd, buffers, count, &written, 0, NULL, NULL) == SOCKET_ERROR) {
+        error = WSAGetLastError();
+        switch (error) {
+        case WSAEINTR:
+            errno = EINTR;
+            break;
+        case WSAEWOULDBLOCK:
+            errno = EAGAIN;
+            break;
+        case WSAECONNRESET:
+        case WSAECONNABORTED:
+        case WSAESHUTDOWN:
+            errno = ECONNRESET;
+            break;
+        case WSAENOTCONN:
+            errno = ENOTCONN;
+            break;
+        case WSAENOTSOCK:
+            errno = EBADF;
+            break;
+        default:
+            errno = EIO;
+        }
+        WSASetLastError(error);
+        return -1;
+    }
+    bytes = written;
+#else
+    bytes = writev(fd, buffers, count);
+#endif
+
+    if (bytes > 0) {
+        remaining = bytes;
+        while (vector->index < vector->count) {
+            length = vector->iov[vector->index].iov_len - vector->offset;
+            if (remaining < length) {
+                vector->offset += remaining;
+                break;
+            }
+            remaining -= length;
+            vector->index++;
+            vector->offset = 0;
+        }
+    }
+
+    return bytes;
+}
+
+static int fd_io_write(flb_sockfd_t fd, struct sockaddr_storage *address,
+                       const void *data, size_t len, size_t *out_len,
+                       struct net_io_vector *vector);
 static int net_io_write(struct flb_connection *connection,
                         const void *data, size_t len, size_t *out_len)
 {
@@ -304,7 +411,7 @@ static int net_io_write(struct flb_connection *connection,
         }
     }
 
-    ret = fd_io_write(connection->fd, address, data, len, out_len);
+    ret = fd_io_write(connection->fd, address, data, len, out_len, NULL);
 
     if (ret == -1) {
         net_io_propagate_critical_error(connection);
@@ -313,15 +420,19 @@ static int net_io_write(struct flb_connection *connection,
     return ret;
 }
 
-static int fd_io_write(int fd, struct sockaddr_storage *address,
-                       const void *data, size_t len, size_t *out_len)
+static int fd_io_write(flb_sockfd_t fd, struct sockaddr_storage *address,
+                       const void *data, size_t len, size_t *out_len,
+                       struct net_io_vector *vector)
 {
-    int ret;
+    int ret = 0;
     int tries = 0;
     size_t total = 0;
 
     while (total < len) {
-        if (address != NULL) {
+        if (vector != NULL) {
+            ret = net_io_vector_send(fd, vector);
+        }
+        else if (address != NULL) {
             ret = sendto(fd, (char *) data + total, len - total, 0,
                          (struct sockaddr *) address,
                          flb_network_address_size(address));
@@ -331,6 +442,9 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
         }
 
         if (ret == -1) {
+            if (vector != NULL && errno == EINTR) {
+                continue;
+            }
             if (FLB_WOULDBLOCK()) {
                 /*
                  * FIXME: for now we are handling this in a very lazy way,
@@ -352,6 +466,14 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
                 continue;
             }
 
+            *out_len = total;
+
+            return -1;
+        }
+
+        if (vector != NULL && ret == 0) {
+            errno = EIO;
+            *out_len = total;
             return -1;
         }
 
@@ -361,7 +483,7 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
 
     *out_len = total;
 
-    return total;
+    return vector != NULL ? ret : (int) total;
 }
 
 static FLB_INLINE void net_io_backup_event(struct flb_connection *connection,
@@ -415,10 +537,12 @@ static FLB_INLINE int net_io_restore_event(struct flb_connection *connection,
  */
 static FLB_INLINE int net_io_write_async(struct flb_coro *co,
                                          struct flb_connection *connection,
-                                         const void *data, size_t len, size_t *out_len)
+                                         const void *data, size_t len, size_t *out_len,
+                                         struct net_io_vector *vector)
 {
     int ret = 0;
     int error;
+    int saved_errno;
     uint32_t mask;
     ssize_t bytes;
     size_t total = 0;
@@ -441,7 +565,21 @@ retry:
         to_send = (len - total);
     }
 
-    bytes = send(connection->fd, (char *) data + total, to_send, 0);
+    if (vector != NULL) {
+        bytes = net_io_vector_send(connection->fd, vector);
+        if (bytes == -1 && errno == EINTR) {
+            goto retry;
+        }
+        if (bytes == 0) {
+            *out_len = total;
+            net_io_restore_event(connection, &event_backup);
+            errno = EIO;
+            return -1;
+        }
+    }
+    else {
+        bytes = send(connection->fd, (char *) data + total, to_send, 0);
+    }
 
 #ifdef FLB_HAVE_TRACE
     if (bytes > 0) {
@@ -548,8 +686,10 @@ retry:
         else {
             *out_len = total;
 
-            net_io_restore_event(connection, &event_backup);
+            saved_errno = errno;
             net_io_propagate_critical_error(connection);
+            net_io_restore_event(connection, &event_backup);
+            errno = saved_errno;
 
             return -1;
         }
@@ -769,11 +909,210 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
     return ret;
 }
 
+
+int flb_io_net_writev(struct flb_connection *connection,
+                      const struct flb_iovec *iov,
+                      int iovcnt,
+                      size_t *out_len)
+{
+    int result;
+    int index;
+    int saved_errno;
+    int flags;
+    int stream_transport;
+    size_t partial_length;
+    size_t total;
+    size_t total_length;
+    size_t buffer_size;
+    size_t buffer_length;
+    size_t offset;
+    size_t length;
+    char *temporary_buffer;
+    struct net_io_vector vector;
+
+    if (out_len == NULL) {
+        errno = EINVAL;
+
+        return -1;
+    }
+
+    *out_len = 0;
+
+    if (connection == NULL || iov == NULL || iovcnt <= 0) {
+        errno = EINVAL;
+
+        return -1;
+    }
+
+    total_length = 0;
+
+    for (index = 0 ; index < iovcnt ; index++) {
+        /* Overflow guard */
+        if (iov[index].iov_len > SIZE_MAX - total_length) {
+            errno = EOVERFLOW;
+
+            return -1;
+        }
+
+        if (iov[index].iov_len > 0 && iov[index].iov_base == NULL) {
+            errno = EINVAL;
+
+            return -1;
+        }
+
+        total_length += iov[index].iov_len;
+    }
+
+    if (total_length == 0) {
+        return 0;
+    }
+
+    flags = flb_connection_get_flags(connection);
+    stream_transport = connection->stream->transport == FLB_TRANSPORT_TCP ||
+                       connection->stream->transport == FLB_TRANSPORT_UNIX_STREAM;
+
+    /* Connecting can establish a TLS session: dispatch only after it completes. */
+    if (stream_transport && !(flags & FLB_IO_ASYNC) && connection->fd <= 0) {
+        if (connection->type != FLB_UPSTREAM_CONNECTION) {
+            errno = ENOTCONN;
+            return -1;
+        }
+        if (flb_io_net_connect(connection, flb_coro_get()) == -1) {
+            return -1;
+        }
+        flags = flb_connection_get_flags(connection);
+    }
+
+    if (stream_transport && connection->tls_session == NULL) {
+        vector.iov = iov;
+        vector.count = iovcnt;
+        vector.index = 0;
+        vector.offset = 0;
+
+        if (flags & FLB_IO_ASYNC) {
+            result = net_io_write_async(flb_coro_get(), connection, NULL,
+                                        total_length, out_len, &vector);
+        }
+        else {
+            result = fd_io_write(connection->fd, NULL, NULL, total_length, out_len, &vector);
+            if (result == -1) {
+                net_io_propagate_critical_error(connection);
+            }
+        }
+        if (result > 0) {
+            flb_connection_reset_io_timeout(connection);
+        }
+        return result;
+    }
+
+    /* Preserve existing datagram boundaries; bounded batching is for streams. */
+    if (!stream_transport && total_length > FLB_IO_WRITEV_COALESCE_MAX) {
+        total = 0;
+
+        for (index = 0; index < iovcnt; index++) {
+            if (iov[index].iov_len == 0) {
+                continue;
+            }
+
+            partial_length = 0;
+            errno = 0;
+            result = flb_io_net_write(connection,
+                                      iov[index].iov_base,
+                                      iov[index].iov_len,
+                                      &partial_length);
+            saved_errno = errno;
+            total += partial_length;
+            *out_len = total;
+
+            if (result == -1) {
+                if (saved_errno == 0) {
+                    saved_errno = EIO;
+                }
+
+                errno = saved_errno;
+
+                return -1;
+            }
+
+            if (partial_length != iov[index].iov_len) {
+                errno = EIO;
+
+                return -1;
+            }
+        }
+
+        return result;
+    }
+
+    buffer_size = total_length;
+    if (buffer_size > FLB_IO_WRITEV_COALESCE_MAX) {
+        buffer_size = FLB_IO_WRITEV_COALESCE_MAX;
+    }
+    temporary_buffer = flb_malloc(buffer_size);
+
+    if (temporary_buffer == NULL) {
+        errno = ENOMEM;
+
+        return -1;
+    }
+
+    total = 0;
+    index = 0;
+    offset = 0;
+
+    while (total < total_length) {
+        buffer_length = 0;
+        while (index < iovcnt && buffer_length < buffer_size) {
+            length = iov[index].iov_len - offset;
+            if (length > buffer_size - buffer_length) {
+                length = buffer_size - buffer_length;
+            }
+            if (length > 0) {
+                memcpy(temporary_buffer + buffer_length,
+                       (const char *) iov[index].iov_base + offset, length);
+            }
+            buffer_length += length;
+            offset += length;
+            if (offset == iov[index].iov_len) {
+                index++;
+                offset = 0;
+            }
+        }
+
+        /* Keep this buffer unchanged until the TLS writer completes all retries. */
+        partial_length = 0;
+        errno = 0;
+        result = flb_io_net_write(connection, temporary_buffer, buffer_length, &partial_length);
+        saved_errno = errno;
+        total += partial_length;
+        *out_len = total;
+
+        if (result >= 0 && partial_length != buffer_length) {
+            result = -1;
+            saved_errno = EIO;
+        }
+        else if (result == -1 && saved_errno == 0) {
+            saved_errno = EIO;
+        }
+        if (result == -1) {
+            break;
+        }
+    }
+
+    flb_free(temporary_buffer);
+
+    if (result == -1) {
+        errno = saved_errno;
+    }
+
+    return result;
+}
+
 /* Write data to fd. For unix socket. */
 int flb_io_fd_write(int fd, const void *data, size_t len, size_t *out_len)
 {
     /* TODO: support async mode */
-    return fd_io_write(fd, NULL, data, len, out_len);
+    return fd_io_write(fd, NULL, data, len, out_len, NULL);
 }
 
 /* Write data to an upstream connection/server */
@@ -781,6 +1120,7 @@ int flb_io_net_write(struct flb_connection *connection, const void *data,
                      size_t len, size_t *out_len)
 {
     int              flags;
+    int              saved_errno;
     struct flb_coro *coro;
     int              ret;
 
@@ -792,7 +1132,7 @@ int flb_io_net_write(struct flb_connection *connection, const void *data,
 
     if (connection->tls_session == NULL) {
         if (flags & FLB_IO_ASYNC) {
-            ret = net_io_write_async(coro, connection, data, len, out_len);
+            ret = net_io_write_async(coro, connection, data, len, out_len, NULL);
         }
         else {
             ret = net_io_write(connection, data, len, out_len);
@@ -813,12 +1153,18 @@ int flb_io_net_write(struct flb_connection *connection, const void *data,
     }
 #endif
 
+    saved_errno = errno;
+
     if (ret > 0) {
         flb_connection_reset_io_timeout(connection);
     }
 
     flb_trace("[io coro=%p] [net_write] ret=%i total=%lu/%lu",
               coro, ret, *out_len, len);
+
+    if (ret == -1) {
+        errno = saved_errno;
+    }
 
     return ret;
 }

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -46,12 +46,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#ifndef FLB_SYSTEM_WINDOWS
-#include <sys/uio.h>
-#endif
 
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_io.h>
 #include <fluent-bit/tls/flb_tls.h>
@@ -279,8 +277,7 @@ static void net_io_propagate_critical_error(
     }
 }
 
-/* POSIX guarantees at least 16 vectors. Bound both stack use and write size. */
-#define FLB_IO_NATIVE_IOV_MAX 16
+/* Bound the size of each native write. */
 #define FLB_IO_NATIVE_WRITE_MAX 524288
 
 struct net_io_vector {
@@ -298,32 +295,21 @@ static ssize_t net_io_vector_send(flb_sockfd_t fd, struct net_io_vector *vector)
     size_t length;
     size_t remaining;
     ssize_t bytes;
-#ifdef FLB_SYSTEM_WINDOWS
-    WSABUF buffers[FLB_IO_NATIVE_IOV_MAX];
-    DWORD written;
-    int error;
-#else
-    struct iovec buffers[FLB_IO_NATIVE_IOV_MAX];
-#endif
+    struct mk_iovec buffers[FLB_IOV_MAX];
 
     index = vector->index;
     offset = vector->offset;
     count = 0;
     remaining = FLB_IO_NATIVE_WRITE_MAX;
 
-    while (index < vector->count && count < FLB_IO_NATIVE_IOV_MAX && remaining > 0) {
+    while (index < vector->count && count < FLB_IOV_MAX && remaining > 0) {
         length = vector->iov[index].iov_len - offset;
         if (length > remaining) {
             length = remaining;
         }
         if (length > 0) {
-#ifdef FLB_SYSTEM_WINDOWS
-            buffers[count].buf = (char *) vector->iov[index].iov_base + offset;
-            buffers[count].len = (ULONG) length;
-#else
             buffers[count].iov_base = (char *) vector->iov[index].iov_base + offset;
             buffers[count].iov_len = length;
-#endif
             count++;
             remaining -= length;
         }
@@ -331,37 +317,7 @@ static ssize_t net_io_vector_send(flb_sockfd_t fd, struct net_io_vector *vector)
         offset = 0;
     }
 
-#ifdef FLB_SYSTEM_WINDOWS
-    if (WSASend(fd, buffers, count, &written, 0, NULL, NULL) == SOCKET_ERROR) {
-        error = WSAGetLastError();
-        switch (error) {
-        case WSAEINTR:
-            errno = EINTR;
-            break;
-        case WSAEWOULDBLOCK:
-            errno = EAGAIN;
-            break;
-        case WSAECONNRESET:
-        case WSAECONNABORTED:
-        case WSAESHUTDOWN:
-            errno = ECONNRESET;
-            break;
-        case WSAENOTCONN:
-            errno = ENOTCONN;
-            break;
-        case WSAENOTSOCK:
-            errno = EBADF;
-            break;
-        default:
-            errno = EIO;
-        }
-        WSASetLastError(error);
-        return -1;
-    }
-    bytes = written;
-#else
-    bytes = writev(fd, buffers, count);
-#endif
+    bytes = flb_writev(fd, buffers, count);
 
     if (bytes > 0) {
         remaining = bytes;

--- a/tests/integration/scenarios/out_http/tests/test_out_http_writev.py
+++ b/tests/integration/scenarios/out_http/tests/test_out_http_writev.py
@@ -1,0 +1,91 @@
+import http.server
+import json
+from pathlib import Path
+import ssl
+import threading
+
+import pytest
+import yaml
+
+from utils.memory_check import memory_check_enabled
+from utils.test_service import FluentBitTestService
+
+
+@pytest.mark.parametrize("use_tls", [False, True], ids=["tcp", "tls"])
+@pytest.mark.parametrize("payload_size", [1024, 65536, 131079])
+def test_out_http_vector_payload(tmp_path, use_tls, payload_size):
+    """Verify headers and bodies across batching boundaries on reused connections."""
+    message = ("0123456789abcdef" * ((payload_size + 15) // 16))[:payload_size]
+    received = []
+    server = None
+    server_thread = None
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_POST(self):
+            length = int(self.headers["Content-Length"])
+            body = self.rfile.read(length)
+            received.append((self.path, dict(self.headers), body, self.client_address))
+            self.send_response(200)
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, *args):
+            pass
+
+    def start_receiver(service):
+        nonlocal server, server_thread
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", service.test_suite_http_port), Handler)
+        if use_tls:
+            cert_dir = Path(__file__).resolve().parents[2] / "in_splunk" / "certificate"
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(cert_dir / "certificate.pem", cert_dir / "private_key.pem")
+            server.socket = context.wrap_socket(server.socket, server_side=True)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+
+    def stop_receiver(service):
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if server_thread is not None:
+            server_thread.join(timeout=5)
+
+    output = {
+        "name": "http", "match": "*", "host": "127.0.0.1",
+        "port": "${TEST_SUITE_HTTP_PORT}", "uri": "/vectors",
+        "format": "json", "json_date_key": False, "workers": 0,
+        "net.keepalive": True,
+    }
+    if use_tls:
+        output.update({"tls": True, "tls.verify": False})
+    config = {
+        "service": {
+            "flush": 0.1, "grace": 1, "http_server": True,
+            "http_port": "${FLUENT_BIT_HTTP_MONITORING_PORT}",
+        },
+        "pipeline": {
+            "inputs": [{"name": "dummy", "samples": 2,
+                        "dummy": json.dumps({"message": message})}],
+            "outputs": [output],
+        },
+    }
+    config_path = tmp_path / "out_http_writev.yaml"
+    config_path.write_text(yaml.safe_dump(config))
+    service = FluentBitTestService(str(config_path), pre_start=start_receiver, post_stop=stop_receiver)
+    try:
+        service.start()
+        service.wait_for_condition(lambda: len(received) >= 2,
+                                   timeout=60 if memory_check_enabled() else 15,
+                                   description="two complete vector HTTP requests")
+    finally:
+        service.stop()
+
+    assert len(received) == 2
+    assert received[0][3] == received[1][3], "the connection should be reused"
+    for path, headers, body, _ in received:
+        assert path == "/vectors"
+        assert len(body) == int(headers["Content-Length"])
+        assert json.loads(body) == [{"message": message}]

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -19,6 +19,7 @@ set(UNIT_TESTS_FILES
   unit_sizes.c
   hashtable.c
   http_client.c
+  io.c
   utils.c
   gzip.c
   zstd.c

--- a/tests/internal/io.c
+++ b/tests/internal/io.c
@@ -221,13 +221,94 @@ static void test_writev_transport_error(void)
     errno = 0;
     result = flb_io_net_writev(&connection, vector, 1, &out_length);
     TEST_CHECK(result == -1);
-#ifndef FLB_SYSTEM_WINDOWS
     TEST_CHECK(errno == EBADF);
-#else
-    TEST_CHECK(errno != 0);
+#ifdef FLB_SYSTEM_WINDOWS
+    TEST_CHECK(WSAGetLastError() == WSAENOTSOCK);
 #endif
     TEST_CHECK(out_length == 0);
 }
+
+static void test_writev_compat(void)
+{
+    flb_pipefd_t pair[2];
+    struct mk_iovec iov[3];
+    char first[] = "hello";
+    char second[] = " world";
+    char output[11];
+    ssize_t result;
+
+    if (!TEST_CHECK(create_socket_pair(pair) == 0)) {
+        return;
+    }
+
+    iov[0].iov_base = first;
+    iov[0].iov_len = sizeof(first) - 1;
+    iov[1].iov_base = NULL;
+    iov[1].iov_len = 0;
+    iov[2].iov_base = second;
+    iov[2].iov_len = sizeof(second) - 1;
+
+    result = flb_writev(pair[0], iov, 3);
+    if (TEST_CHECK(result == sizeof(output))) {
+        result = flb_pipe_read_all(pair[1], output, sizeof(output));
+        TEST_CHECK(result == sizeof(output));
+        TEST_CHECK(memcmp(output, "hello world", sizeof(output)) == 0);
+    }
+
+    result = flb_writev(pair[0], &iov[1], 1);
+    TEST_CHECK(result == 0);
+
+    result = flb_writev(FLB_INVALID_SOCKET, iov, 3);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EBADF);
+#ifdef FLB_SYSTEM_WINDOWS
+    TEST_CHECK(WSAGetLastError() == WSAENOTSOCK);
+#endif
+
+    flb_socket_close(pair[0]);
+    flb_socket_close(pair[1]);
+}
+
+#ifdef FLB_SYSTEM_WINDOWS
+static void test_writev_compat_limits(void)
+{
+    struct mk_iovec iov[2];
+    ssize_t result;
+    char byte;
+
+    TEST_CHECK(flb_writev(INVALID_SOCKET, NULL, 0) == 0);
+
+    result = flb_writev(INVALID_SOCKET, NULL, 1);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(WSAGetLastError() == WSAEINVAL);
+
+    result = flb_writev(INVALID_SOCKET, iov, -1);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(WSAGetLastError() == WSAEINVAL);
+
+    result = flb_writev(INVALID_SOCKET, iov, FLB_IOV_MAX + 1);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(WSAGetLastError() == WSAEINVAL);
+
+    iov[0].iov_base = &byte;
+    iov[0].iov_len = (size_t) INT_MAX + 1;
+    result = flb_writev(INVALID_SOCKET, iov, 1);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(WSAGetLastError() == WSAEINVAL);
+
+    iov[0].iov_len = INT_MAX;
+    iov[1].iov_base = &byte;
+    iov[1].iov_len = 1;
+    result = flb_writev(INVALID_SOCKET, iov, 2);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(WSAGetLastError() == WSAEINVAL);
+}
+#endif
 
 static void test_writev_vector_shapes(void)
 {
@@ -589,6 +670,10 @@ TEST_LIST = {
     { "writev_preconditions", test_writev_preconditions },
     { "writev_empty_vectors", test_writev_empty_vectors },
     { "writev_transport_error", test_writev_transport_error },
+    { "writev_compat", test_writev_compat },
+#ifdef FLB_SYSTEM_WINDOWS
+    { "writev_compat_limits", test_writev_compat_limits },
+#endif
     { "writev_vector_shapes", test_writev_vector_shapes },
     { "writev_coalesce_boundary", test_writev_coalesce_boundary },
     { "writev_async_partial", test_writev_async_partial },

--- a/tests/internal/io.c
+++ b/tests/internal/io.c
@@ -1,0 +1,600 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/socket.h>
+#endif
+
+#include <fluent-bit/flb_connection.h>
+#include <fluent-bit/flb_io.h>
+#include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_stream.h>
+#include <fluent-bit/flb_pthread.h>
+#include <fluent-bit/flb_coro.h>
+#include <fluent-bit/tls/flb_tls.h>
+
+#include "flb_tests_internal.h"
+
+#define LARGE_IOV_COUNT 2048
+
+struct reader_context {
+    flb_pipefd_t fd;
+    char *buffer;
+    size_t length;
+    ssize_t result;
+};
+
+static void *read_payload(void *data)
+{
+    struct reader_context *context;
+
+    context = data;
+    context->result = flb_pipe_read_all(context->fd,
+                                        context->buffer,
+                                        context->length);
+
+    return NULL;
+}
+
+static int create_socket_pair(flb_pipefd_t pair[2])
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    return flb_pipe_create(pair);
+#else
+    return socketpair(AF_UNIX, SOCK_STREAM, 0, pair);
+#endif
+}
+
+static void setup_connection(struct flb_connection *connection,
+                             struct flb_stream *stream,
+                             flb_pipefd_t fd)
+{
+    memset(connection, 0, sizeof(struct flb_connection));
+    memset(stream, 0, sizeof(struct flb_stream));
+
+    flb_net_setup_init(&stream->net);
+    stream->transport = FLB_TRANSPORT_UNIX_STREAM;
+    connection->fd = fd;
+    connection->type = FLB_UPSTREAM_CONNECTION;
+    connection->stream = stream;
+    connection->net = &stream->net;
+    connection->net_error = -1;
+}
+
+static void assert_vector_payload(const struct flb_iovec *iov,
+                                  int iovcnt,
+                                  const char *expected,
+                                  size_t expected_length)
+{
+    int result;
+    size_t out_length;
+    pthread_t reader;
+    flb_pipefd_t pair[2];
+    struct flb_stream stream;
+    struct flb_connection connection;
+    struct reader_context reader_context;
+
+    result = create_socket_pair(pair);
+    TEST_CHECK(result == 0);
+    if (result != 0) {
+        return;
+    }
+
+    reader_context.fd = pair[1];
+    reader_context.buffer = calloc(1, expected_length + 1);
+    reader_context.length = expected_length;
+    reader_context.result = -1;
+    TEST_CHECK(reader_context.buffer != NULL);
+    if (reader_context.buffer == NULL) {
+        flb_socket_close(pair[0]);
+        flb_socket_close(pair[1]);
+        return;
+    }
+
+    setup_connection(&connection, &stream, pair[0]);
+
+    result = pthread_create(&reader, NULL, read_payload, &reader_context);
+    TEST_CHECK(result == 0);
+    if (result != 0) {
+        free(reader_context.buffer);
+        flb_socket_close(pair[0]);
+        flb_socket_close(pair[1]);
+        return;
+    }
+
+    out_length = SIZE_MAX;
+    result = flb_io_net_writev(&connection, iov, iovcnt, &out_length);
+    TEST_CHECK(result > 0);
+    TEST_CHECK(out_length == expected_length);
+
+    /* Unblock the reader even if a regression caused a short write. */
+    shutdown(pair[0], SHUT_WR);
+    pthread_join(reader, NULL);
+    TEST_CHECK(reader_context.result == (ssize_t) expected_length);
+    TEST_CHECK(memcmp(reader_context.buffer, expected, expected_length) == 0);
+
+    free(reader_context.buffer);
+    flb_socket_close(pair[0]);
+    flb_socket_close(pair[1]);
+}
+
+static void test_writev_preconditions(void)
+{
+    int result;
+    char byte;
+    size_t out_length;
+    struct flb_connection connection;
+    struct flb_iovec valid_vector[1];
+    struct flb_iovec overflow_vector[2];
+    struct flb_iovec null_base_vector[1];
+
+    byte = 'x';
+    memset(&connection, 0, sizeof(struct flb_connection));
+    valid_vector[0].iov_base = &byte;
+    valid_vector[0].iov_len = 1;
+
+    out_length = SIZE_MAX;
+    errno = 0;
+    result = flb_io_net_writev(NULL, valid_vector, 1, &out_length);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(out_length == 0);
+
+    out_length = SIZE_MAX;
+    errno = 0;
+    result = flb_io_net_writev(&connection, NULL, 1, &out_length);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(out_length == 0);
+
+    out_length = SIZE_MAX;
+    errno = 0;
+    result = flb_io_net_writev(&connection, valid_vector, 0, &out_length);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(out_length == 0);
+
+    errno = 0;
+    result = flb_io_net_writev(&connection, valid_vector, 1, NULL);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+
+    overflow_vector[0].iov_base = &byte;
+    overflow_vector[0].iov_len = SIZE_MAX;
+    overflow_vector[1].iov_base = &byte;
+    overflow_vector[1].iov_len = 1;
+    out_length = SIZE_MAX;
+    errno = 0;
+    result = flb_io_net_writev(&connection, overflow_vector, 2, &out_length);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EOVERFLOW);
+    TEST_CHECK(out_length == 0);
+
+    null_base_vector[0].iov_base = NULL;
+    null_base_vector[0].iov_len = 1;
+    out_length = SIZE_MAX;
+    errno = 0;
+    result = flb_io_net_writev(&connection, null_base_vector, 1, &out_length);
+    TEST_CHECK(result == -1);
+    TEST_CHECK(errno == EINVAL);
+    TEST_CHECK(out_length == 0);
+}
+
+static void test_writev_empty_vectors(void)
+{
+    int result;
+    size_t out_length;
+    struct flb_connection connection;
+    struct flb_iovec vector[3];
+
+    memset(&connection, 0, sizeof(struct flb_connection));
+    memset(vector, 0, sizeof(vector));
+
+    out_length = SIZE_MAX;
+    result = flb_io_net_writev(&connection, vector, 3, &out_length);
+    TEST_CHECK(result == 0);
+    TEST_CHECK(out_length == 0);
+}
+
+static void test_writev_transport_error(void)
+{
+    int result;
+    char byte;
+    size_t out_length;
+    struct flb_stream stream;
+    struct flb_connection connection;
+    struct flb_iovec vector[1];
+
+    byte = 'x';
+    vector[0].iov_base = &byte;
+    vector[0].iov_len = 1;
+    setup_connection(&connection, &stream, INT_MAX);
+
+    out_length = SIZE_MAX;
+    errno = 0;
+    result = flb_io_net_writev(&connection, vector, 1, &out_length);
+    TEST_CHECK(result == -1);
+#ifndef FLB_SYSTEM_WINDOWS
+    TEST_CHECK(errno == EBADF);
+#else
+    TEST_CHECK(errno != 0);
+#endif
+    TEST_CHECK(out_length == 0);
+}
+
+static void test_writev_vector_shapes(void)
+{
+    int index;
+    char one[] = "one";
+    char two[] = "two";
+    char expected[] = "onetwo";
+    char *large_expected;
+    struct flb_iovec one_vector[1];
+    struct flb_iovec two_vectors[3];
+    struct flb_iovec *large_vector;
+
+    one_vector[0].iov_base = expected;
+    one_vector[0].iov_len = sizeof(expected) - 1;
+    assert_vector_payload(one_vector, 1, expected, sizeof(expected) - 1);
+
+    two_vectors[0].iov_base = one;
+    two_vectors[0].iov_len = sizeof(one) - 1;
+    two_vectors[1].iov_base = NULL;
+    two_vectors[1].iov_len = 0;
+    two_vectors[2].iov_base = two;
+    two_vectors[2].iov_len = sizeof(two) - 1;
+    assert_vector_payload(two_vectors, 3, expected, sizeof(expected) - 1);
+
+    large_vector = calloc(LARGE_IOV_COUNT, sizeof(struct flb_iovec));
+    large_expected = malloc(LARGE_IOV_COUNT);
+    TEST_CHECK(large_vector != NULL);
+    TEST_CHECK(large_expected != NULL);
+    if (large_vector == NULL || large_expected == NULL) {
+        free(large_vector);
+        free(large_expected);
+        return;
+    }
+
+    for (index = 0; index < LARGE_IOV_COUNT; index++) {
+        large_expected[index] = (char) ('a' + (index % 26));
+        large_vector[index].iov_base = &large_expected[index];
+        large_vector[index].iov_len = 1;
+    }
+
+    assert_vector_payload(large_vector, LARGE_IOV_COUNT,
+                          large_expected, LARGE_IOV_COUNT);
+    free(large_vector);
+    free(large_expected);
+}
+
+static void test_writev_coalesce_boundary(void)
+{
+    char *payload;
+    size_t payload_length;
+    struct flb_iovec vector[2];
+
+    payload_length = FLB_IO_WRITEV_COALESCE_MAX + 1;
+    payload = malloc(payload_length);
+    TEST_CHECK(payload != NULL);
+    if (payload == NULL) {
+        return;
+    }
+
+    memset(payload, 'z', payload_length);
+    vector[0].iov_base = payload;
+    vector[0].iov_len = FLB_IO_WRITEV_COALESCE_MAX / 2;
+    vector[1].iov_base = payload + vector[0].iov_len;
+    vector[1].iov_len = FLB_IO_WRITEV_COALESCE_MAX - vector[0].iov_len;
+    assert_vector_payload(vector, 2, payload, FLB_IO_WRITEV_COALESCE_MAX);
+
+    vector[1].iov_len++;
+    assert_vector_payload(vector, 2, payload, payload_length);
+    free(payload);
+}
+
+struct async_writer_context {
+    struct flb_connection *connection;
+    struct flb_iovec *iov;
+    int count;
+    int result;
+    int done;
+    size_t written;
+};
+
+static void write_vectors_async(void)
+{
+    struct flb_coro *coro;
+    struct async_writer_context *context;
+
+    coro = flb_coro_get();
+    context = coro->data;
+    context->result = flb_io_net_writev(context->connection, context->iov,
+                                       context->count, &context->written);
+    context->done = FLB_TRUE;
+    flb_coro_yield(coro, FLB_TRUE);
+}
+
+static void check_writev_async(int cancel)
+{
+    int result;
+    int buffer_size;
+    int iterations;
+    ssize_t bytes;
+    size_t length;
+    size_t received;
+    size_t stack_size;
+    size_t index;
+    char *payload;
+    char *output;
+    flb_pipefd_t pair[2];
+    struct flb_stream stream;
+    struct flb_connection connection;
+    struct flb_iovec iov[4];
+    struct flb_coro *coro;
+    struct flb_coro *parent;
+    struct async_writer_context context;
+
+    length = 1024 * 1024 + 31;
+    payload = malloc(length);
+    output = malloc(length);
+    if (!TEST_CHECK(payload != NULL && output != NULL)) {
+        free(payload);
+        free(output);
+        return;
+    }
+    for (index = 0; index < length; index++) {
+        payload[index] = (char) (index % 251);
+    }
+
+    result = create_socket_pair(pair);
+    if (!TEST_CHECK(result == 0)) {
+        free(payload);
+        free(output);
+        return;
+    }
+    TEST_CHECK(flb_net_socket_nonblocking(pair[0]) == 0);
+    TEST_CHECK(flb_net_socket_nonblocking(pair[1]) == 0);
+    buffer_size = 4096;
+    TEST_CHECK(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                         (const char *) &buffer_size, sizeof(buffer_size)) == 0);
+    setup_connection(&connection, &stream, pair[0]);
+    stream.flags = FLB_IO_ASYNC;
+    connection.evl = mk_event_loop_create(8);
+    if (!TEST_CHECK(connection.evl != NULL)) {
+        goto cleanup_sockets;
+    }
+    MK_EVENT_NEW(&connection.event);
+    TEST_CHECK(mk_event_add(connection.evl, pair[0], MK_EVENT_CUSTOM,
+                            MK_EVENT_READ, &connection.event) == 0);
+
+    iov[0].iov_base = payload;
+    iov[0].iov_len = 13;
+    iov[1].iov_base = NULL;
+    iov[1].iov_len = 0;
+    iov[2].iov_base = payload + 13;
+    iov[2].iov_len = 700001;
+    iov[3].iov_base = payload + 700014;
+    iov[3].iov_len = length - 700014;
+    memset(&context, 0, sizeof(context));
+    context.connection = &connection;
+    context.iov = iov;
+    context.count = 4;
+
+    flb_coro_init();
+    flb_coro_thread_init();
+    parent = flb_coro_get();
+    coro = flb_coro_create(&context);
+    if (!TEST_CHECK(coro != NULL)) {
+        goto cleanup_events;
+    }
+    coro->callee = co_create(test_env_config->coro_stack_size, write_vectors_async, &stack_size);
+    if (!TEST_CHECK(coro->callee != NULL)) {
+        flb_coro_destroy(coro);
+        goto cleanup_events;
+    }
+#ifdef FLB_HAVE_VALGRIND
+    coro->valgrind_stack_id = VALGRIND_STACK_REGISTER(
+                                 coro->callee, ((char *) coro->callee) + stack_size);
+#endif
+    flb_coro_resume(coro);
+    TEST_CHECK(context.done == FLB_FALSE);
+    TEST_CHECK(connection.coroutine == coro);
+
+    /* Resume without draining: exercise EAGAIN after a positive short write. */
+    if (!context.done) {
+        flb_coro_resume(coro);
+        TEST_CHECK(context.done == FLB_FALSE);
+    }
+
+    received = 0;
+    iterations = 0;
+    while (iterations++ < 1000) {
+        while (received < length) {
+            bytes = recv(pair[1], output + received, length - received, 0);
+            if (bytes <= 0) {
+                TEST_CHECK(bytes == -1 && FLB_WOULDBLOCK());
+                break;
+            }
+            received += bytes;
+        }
+        if (context.done) {
+            break;
+        }
+        if (cancel) {
+            connection.net_error = ETIMEDOUT;
+        }
+        else {
+            TEST_CHECK(mk_event_wait_2(connection.evl, 1000) > 0);
+        }
+        flb_coro_resume(coro);
+    }
+    TEST_CHECK(context.done == FLB_TRUE);
+    TEST_CHECK(connection.coroutine == NULL);
+    TEST_CHECK(MK_EVENT_IS_REGISTERED((&connection.event)));
+    TEST_CHECK(connection.event.mask == MK_EVENT_READ);
+    TEST_CHECK(connection.event.type == MK_EVENT_CUSTOM);
+    TEST_CHECK(context.written == received);
+    TEST_CHECK(memcmp(payload, output, received) == 0);
+    if (cancel) {
+        TEST_CHECK(context.result == -1);
+        TEST_CHECK(received > 0 && received < length);
+    }
+    else {
+        TEST_CHECK(context.result > 0);
+        TEST_CHECK(received == length);
+    }
+    flb_coro_set(parent);
+    flb_coro_destroy(coro);
+
+cleanup_events:
+    mk_event_del(connection.evl, &connection.event);
+    mk_event_loop_destroy(connection.evl);
+cleanup_sockets:
+    flb_socket_close(pair[0]);
+    flb_socket_close(pair[1]);
+    free(payload);
+    free(output);
+}
+
+static void test_writev_async_partial(void)
+{
+    check_writev_async(FLB_FALSE);
+}
+
+static void test_writev_async_error(void)
+{
+    check_writev_async(FLB_TRUE);
+}
+
+#ifdef FLB_HAVE_TLS
+struct tls_writer_context {
+    const char *expected;
+    const void *retry_data;
+    size_t retry_length;
+    size_t written;
+    size_t fail_after;
+    int calls;
+};
+
+static int tls_write_vectors(struct flb_tls_session *session, const void *data, size_t length)
+{
+    struct tls_writer_context *context;
+
+    context = session->ptr;
+    context->calls++;
+    TEST_CHECK(length <= FLB_IO_WRITEV_COALESCE_MAX);
+    TEST_CHECK(memcmp(data, context->expected + context->written, length) == 0);
+
+    if (context->calls == 1) {
+        context->retry_data = data;
+        context->retry_length = length;
+        return FLB_TLS_WANT_WRITE;
+    }
+    if (context->calls <= 3) {
+        TEST_CHECK(data == context->retry_data);
+        TEST_CHECK(length == context->retry_length);
+        if (context->calls == 2) {
+            return FLB_TLS_WANT_READ;
+        }
+    }
+    if (context->fail_after > 0) {
+        if (context->written == context->fail_after) {
+            errno = ECONNRESET;
+            return -1;
+        }
+        if (length > context->fail_after - context->written) {
+            length = context->fail_after - context->written;
+        }
+    }
+    context->written += length;
+    return length;
+}
+
+static void test_writev_tls_batching(void)
+{
+    int result;
+    int fail;
+    int proxy;
+    size_t index;
+    size_t length;
+    size_t written;
+    char *payload;
+    struct flb_stream stream;
+    struct flb_connection connection;
+    struct flb_iovec iov[4];
+    struct flb_tls tls;
+    struct flb_tls_session session;
+    struct flb_tls_backend backend;
+    struct tls_writer_context context;
+
+    length = 2 * FLB_IO_WRITEV_COALESCE_MAX + 7;
+    payload = malloc(length);
+    if (!TEST_CHECK(payload != NULL)) {
+        return;
+    }
+    for (index = 0; index < length; index++) {
+        payload[index] = (char) (index % 251);
+    }
+    memset(&backend, 0, sizeof(backend));
+    memset(&tls, 0, sizeof(tls));
+    backend.net_write = tls_write_vectors;
+    tls.api = &backend;
+    setup_connection(&connection, &stream, INT_MAX);
+    connection.tls_session = &session;
+    session.tls = &tls;
+    session.connection = &connection;
+    session.ptr = &context;
+    iov[0].iov_base = payload;
+    iov[0].iov_len = 13;
+    iov[1].iov_base = NULL;
+    iov[1].iov_len = 0;
+    iov[2].iov_base = payload + 13;
+    iov[2].iov_len = FLB_IO_WRITEV_COALESCE_MAX;
+    iov[3].iov_base = payload + 13 + FLB_IO_WRITEV_COALESCE_MAX;
+    iov[3].iov_len = length - 13 - FLB_IO_WRITEV_COALESCE_MAX;
+
+    for (proxy = 0; proxy <= 1; proxy++) {
+        stream.flags = proxy ? 0 : FLB_IO_TLS;
+        connection.flags = proxy ? FLB_IO_PROXY_TLS : 0;
+        for (fail = 0; fail <= 1; fail++) {
+            memset(&context, 0, sizeof(context));
+            context.expected = payload;
+            context.fail_after = fail ? FLB_IO_WRITEV_COALESCE_MAX + 17 : 0;
+            result = flb_io_net_writev(&connection, iov, 4, &written);
+            TEST_CHECK(written == context.written);
+            if (fail) {
+                TEST_CHECK(result == -1);
+                TEST_CHECK(errno == ECONNRESET);
+                TEST_CHECK(written == context.fail_after);
+            }
+            else {
+                TEST_CHECK(result > 0);
+                TEST_CHECK(written == length);
+                TEST_CHECK(context.calls == 5);
+            }
+        }
+    }
+    free(payload);
+}
+#endif
+
+TEST_LIST = {
+    { "writev_preconditions", test_writev_preconditions },
+    { "writev_empty_vectors", test_writev_empty_vectors },
+    { "writev_transport_error", test_writev_transport_error },
+    { "writev_vector_shapes", test_writev_vector_shapes },
+    { "writev_coalesce_boundary", test_writev_coalesce_boundary },
+    { "writev_async_partial", test_writev_async_partial },
+    { "writev_async_error", test_writev_async_error },
+#ifdef FLB_HAVE_TLS
+    { "writev_tls_batching", test_writev_tls_batching },
+#endif
+    { 0 }
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is internal component change and optimization.
When sending HTTP request, we need to send header and body pair if body length is greater than zero.
However, this can be concatenated with one request if possible.
So, we can concatenate with memcpy to reduce calling of write syscall. 

---

Key changes after opened a PR:

- Hardened `flb_io_net_writev()` validation, `out_len`, overflow, and `errno` behavior.
- Added the 64 KiB bounded-coalescing policy and sequential large-payload accounting.
- Removed the irrelevant `IOV_MAX` restriction.
- Fixed hard-error byte accounting in `fd_io_write()`.
- Made `iov_base` const-correct.
- Preserved transport errors across logging/free operations.
- Marked partially written HTTP connections non-reusable.
- Fixed HTTP format/sign mismatches and short-write handling.
- Added focused internal coverage in [io.c](/Users/cosmo/GitHub/fluent-bit/tests/internal/io.c:1).

Verification passed:

- `cmake --build build --target flb-it-io flb-it-http_client -j8`
- `ctest --test-dir build -R '^flb-it-(io|http_client)$' --output-on-failure`
- `leaks --atExit -- build/bin/flb-it-io -E` — 0 leaks
- `leaks --atExit -- build/bin/flb-it-http_client -E` — 0 leaks
- `git diff --check`

The new tests cover sync transport behavior, validation, poisoned error accounting, overflow, empty elements, 2,048-element vectors, hard transport errors, and both sides of the coalescing boundary. Async/TLS and deterministic mid-transfer-close coverage remain future work; this build has no TLS backend configured, and there is no corresponding `tests/integration` scenario for this core API.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform vectorized network write support and a public API to send headers and bodies together for more efficient requests and improved Windows compatibility.

* **Bug Fixes**
  * Improved HTTP write error handling with robust fallback behavior on resource failures.
  * Corrected byte accounting when sending combined header+body to ensure accurate reporting and preserved existing timeout/error semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->