### PR TITLE
tests: oauth2: Windows support

### DIFF
--- a/tests/internal/oauth2.c
+++ b/tests/internal/oauth2.c
@@ -512,19 +512,30 @@ static int write_text_file(const char *path, const char *content)
 static int test_setup_private_key_jwt_files(char *key_path, size_t key_path_size,
                                             char *cert_path, size_t cert_path_size)
 {
+    char *tmpdir;
     int ret;
 
-    ret = snprintf(key_path, key_path_size, "/tmp/%s.%d",
-                   TEST_KEY_FILENAME, (int) getpid());
-    if (ret < 0 || (size_t) ret >= key_path_size) {
+    tmpdir = flb_test_env_tmpdir();
+    TEST_CHECK(tmpdir != NULL);
+    if (!tmpdir) {
         return -1;
     }
 
-    ret = snprintf(cert_path, cert_path_size, "/tmp/%s.%d",
-                   TEST_CERT_FILENAME, (int) getpid());
-    if (ret < 0 || (size_t) ret >= cert_path_size) {
+    ret = snprintf(key_path, key_path_size, "%s/%s.%d",
+                   tmpdir, TEST_KEY_FILENAME, (int) getpid());
+    if (ret < 0 || (size_t) ret >= key_path_size) {
+        flb_free(tmpdir);
         return -1;
     }
+
+    ret = snprintf(cert_path, cert_path_size, "%s/%s.%d",
+                   tmpdir, TEST_CERT_FILENAME, (int) getpid());
+    if (ret < 0 || (size_t) ret >= cert_path_size) {
+        flb_free(tmpdir);
+        return -1;
+    }
+
+    flb_free(tmpdir);
 
     ret = write_text_file(key_path, TEST_PRIVATE_KEY_PEM);
     if (ret != 0) {


### PR DESCRIPTION
Support of Windows in tests for OAuth 2.0 (fix of [issue](https://github.com/fluent/fluent-bit/pull/11485/changes#r2867580169) introduced in #11485).

----

**Testing**

- [N/A] Example configuration file for the change.
- [N/A] Debug log output from testing the change.
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found - refer to [flb_run_code_analysis.log](https://drive.google.com/file/d/194QgyFhInM9aj7Fc7Q6PSqaIR_egbXVy/view?usp=sharing) for the output of command
    ```bash
    TEST_PRESET=valgrind SKIP_TESTS='flb-rt-out_td flb-it-network' ./run_code_analysis.sh
    ```
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature.

**Backporting**

- [N/A] Backport to latest stable release.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OAuth2 test reliability through improved temporary directory management and resource cleanup, preventing potential file conflicts and ensuring consistent test execution across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->