### PR TITLE
out_azure_logs_ingestion: increase timestamp precision to 100ns

### DIFF
--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -121,8 +121,8 @@ static int az_li_format(const void *in_buf, size_t in_bytes,
 
             len = snprintf(time_formatted + s,
                             sizeof(time_formatted) - 1 - s,
-                            ".%03" PRIu64 "Z",
-                            (uint64_t) tm.tm.tv_nsec / 1000000);
+                            ".%07" PRIu64 "Z",
+                            (uint64_t) tm.tm.tv_nsec / 100);
             s += len;
             msgpack_pack_str(&mp_pck, s);
             msgpack_pack_str_body(&mp_pck, time_formatted, s);
@@ -429,8 +429,10 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "time_generated", "false",
      0, FLB_TRUE, offsetof(struct flb_az_li, time_generated),
-     "If enabled, will generate a timestamp and append it to JSON. "
-     "The key name is set by the 'time_key' parameter"
+     "Optional. If enabled, the timestamp appended under "
+     "'time_key' is formatted as an ISO 8601 string. If disabled, "
+     "it is a floating-point number representing seconds since "
+     "Unix epoch."
     },
     {
      FLB_CONFIG_MAP_BOOL, "compress", "false",


### PR DESCRIPTION
## Summary

Increase the ISO 8601 timestamp precision in the `azure_log_ingestion` output plugin from milliseconds (3 decimal digits) to 100 nanoseconds (7 decimal digits).

**Before:** `2026-03-11T00:10:36.123Z`
**After:** `2026-03-11T00:10:36.1234567Z`

## Details

The `flb_time` struct already stores nanosecond-precision timestamps via `tv_nsec`. This change preserves that precision in the formatted output instead of truncating to milliseconds.

### Changes
- Format specifier: `%03` → `%07` (7 zero-padded digits)
- Divisor: `/ 1000000` → `/ 100` (100-nanosecond granularity)

Also updates the `time_generated` config description to accurately reflect that it controls the timestamp format (ISO 8601 vs floating-point), not whether a timestamp is appended. Doc PR: https://github.com/fluent/fluent-bit-docs/pull/2411

The `time_formatted` buffer (32 bytes) has sufficient capacity for the longer output (29 bytes max including null terminator).

### Reference

"Time values are measured in 100-nanosecond units called ticks..." - https://learn.microsoft.com/en-us/kusto/query/scalar-data-types/datetime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp precision in Azure Logs ingestion to seven fractional digits, increasing time resolution and accuracy for ingested events.

* **Configuration / Behavior**
  * Clarified time_generated behavior: when enabled, the configured key holds an ISO 8601 timestamp; when disabled, the key contains a floating-point value representing seconds since the Unix epoch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->