### PR TITLE
out_stackdriver: fix batch drop on invalid labels

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1805,6 +1805,48 @@ static int pack_payload(int insert_id_extracted,
         return ret;
 }
 
+/*
+ * should_skip_record
+ * Check if a record should be skipped due to invalid fields.
+ * Returns FLB_TRUE if the record should be dropped.
+ *
+ * log_errors: if FLB_TRUE, log why the record is being dropped.
+ *             Set to FLB_FALSE during prescan to avoid duplicate logging.
+ */
+static int should_skip_record(struct flb_stackdriver *ctx,
+                              msgpack_object *obj,
+                              int log_errors)
+{
+    insert_id_status in_status;
+    msgpack_object insert_id_obj;
+    msgpack_object *payload_labels_ptr;
+
+    /* Check insertId */
+    in_status = validate_insert_id(&insert_id_obj, obj);
+    if (in_status == INSERTID_INVALID) {
+        if (log_errors == FLB_TRUE) {
+            flb_plg_error(ctx->ins,
+                          "Incorrect insertId received. "
+                          "InsertId should be non-empty string.");
+        }
+        return FLB_TRUE;
+    }
+
+    /* Check labels type */
+    payload_labels_ptr = get_payload_labels(ctx, obj);
+    if (payload_labels_ptr != NULL &&
+        payload_labels_ptr->type != MSGPACK_OBJECT_MAP) {
+        if (log_errors == FLB_TRUE) {
+            flb_plg_error(ctx->ins,
+                          "the type of payload labels should be map, "
+                          "dropping record");
+        }
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
                                     int total_records,
                                     const char *tag, int tag_len,
@@ -1889,16 +1931,16 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     /* Count number of records */
     array_size = total_records;
 
-    if (formatted_records != NULL) {
-        *formatted_records = 0;
-    }
-
     /* Parameters for labels */
     msgpack_object *payload_labels_ptr;
     int labels_size = 0;
 
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
+
+    if (formatted_records != NULL) {
+        *formatted_records = -1;
+    }
 
     ret = flb_log_event_decoder_init(&log_decoder, (char *) data, bytes);
 
@@ -1910,20 +1952,14 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     }
 
     /*
-     * Search each entry and validate insertId.
-     * Reject the entry if insertId is invalid.
+     * Search each entry and validate record fields.
+     * Reject entries with invalid insertId or non-map labels.
      * If all the entries are rejected, stop formatting.
-     *
      */
     while ((ret = flb_log_event_decoder_next(
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
-        /* Extract insertId */
-        in_status = validate_insert_id(&insert_id_obj, log_event.body);
-
-        if (in_status == INSERTID_INVALID) {
-            flb_plg_error(ctx->ins,
-                          "Incorrect insertId received. InsertId should be non-empty string.");
+        if (should_skip_record(ctx, log_event.body, FLB_FALSE) == FLB_TRUE) {
             array_size -= 1;
         }
     }
@@ -1932,11 +1968,13 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
 
     /* Sounds like this should compare to -1 instead of zero */
     if (array_size == 0) {
+        flb_plg_warn(ctx->ins,
+                     "all %d entries skipped due to invalid insertId "
+                     "or labels, dropping batch", total_records);
+        if (formatted_records != NULL) {
+            *formatted_records = 0;
+        }
         return NULL;
-    }
-
-    if (formatted_records != NULL) {
-        *formatted_records = array_size;
     }
 
     /* Create temporal msgpack buffer */
@@ -2354,6 +2392,12 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
         obj = log_event.body;
+
+        /* Skip records with invalid fields */
+        if (should_skip_record(ctx, obj, FLB_TRUE) == FLB_TRUE) {
+            continue;
+        }
+
         tms_status = extract_timestamp(obj, &log_event.timestamp);
 
         /*
@@ -2418,33 +2462,14 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             log_name_extracted = FLB_TRUE;
         }
 
-        /* Extract insertId */
+        /* Extract insertId (INVALID case already handled by should_skip_record) */
         in_status = validate_insert_id(&insert_id_obj, obj);
         if (in_status == INSERTID_VALID) {
             insert_id_extracted = FLB_TRUE;
             entry_size += 1;
         }
-        else if (in_status == INSERTID_NOT_PRESENT) {
-            insert_id_extracted = FLB_FALSE;
-        }
         else {
-            if (trace_extracted == FLB_TRUE) {
-                flb_sds_destroy(trace);
-            }
-
-            if (span_id_extracted == FLB_TRUE) {
-                flb_sds_destroy(span_id);
-            }
-
-            if (project_id_extracted == FLB_TRUE) {
-                flb_sds_destroy(project_id_key);
-            }
-
-            if (log_name_extracted == FLB_TRUE) {
-                flb_sds_destroy(log_name);
-            }
-
-            continue;
+            insert_id_extracted = FLB_FALSE;
         }
 
         /* Extract operation */
@@ -2487,39 +2512,8 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             entry_size += 1;
         }
 
-        /* Extract payload labels */
+        /* Extract payload labels (non-map case already handled by should_skip_record) */
         payload_labels_ptr = get_payload_labels(ctx, obj);
-        if (payload_labels_ptr != NULL &&
-            payload_labels_ptr->type != MSGPACK_OBJECT_MAP) {
-            flb_plg_error(ctx->ins, "the type of payload labels should be map");
-            flb_sds_destroy(operation_id);
-            flb_sds_destroy(operation_producer);
-            flb_sds_destroy(source_location_file);
-            flb_sds_destroy(source_location_function);
-
-            if (trace_extracted == FLB_TRUE) {
-                flb_sds_destroy(trace);
-            }
-
-            if (span_id_extracted == FLB_TRUE) {
-                flb_sds_destroy(span_id);
-            }
-
-            if (project_id_extracted == FLB_TRUE) {
-                flb_sds_destroy(project_id_key);
-            }
-
-            if (log_name_extracted == FLB_TRUE) {
-                flb_sds_destroy(log_name);
-            }
-
-            destroy_http_request(&http_request);
-
-            flb_log_event_decoder_destroy(&log_decoder);
-            msgpack_sbuffer_destroy(&mp_sbuf);
-
-            return NULL;
-        }
 
         /* Number of parsed labels */
         labels_size = mk_list_size(&ctx->config_labels);
@@ -2708,6 +2702,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
         return NULL;
     }
 
+    if (formatted_records != NULL) {
+        *formatted_records = array_size;
+    }
+
     return out_buf;
 }
 
@@ -2728,7 +2726,7 @@ static int stackdriver_format_test(struct flb_config *config,
     total_records = flb_mp_count_log_records(data, bytes);
 
     payload = stackdriver_format(ctx, total_records,
-                                (char *) tag, tag_len, data, bytes, config, NULL);
+                                 (char *) tag, tag_len, data, bytes, config, NULL);
     if (payload == NULL) {
         return -1;
     }
@@ -2777,9 +2775,9 @@ static void update_http_metrics(struct flb_stackdriver* ctx,
 }
 
 static void update_retry_metric(struct flb_stackdriver *ctx,
-                                 int retried_records,
-                                 uint64_t ts,
-                                 int http_status)
+                                int retried_records,
+                                uint64_t ts,
+                                int http_status)
 {
     char tmp[32];
     char *name = (char *) flb_output_name(ctx->ins);
@@ -2978,7 +2976,10 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     int code;
     int ret_partial_success;
     int ret_code = FLB_RETRY;
-    int formatted_records = 0;
+    int formatted_records = -1;
+    int skipped_records = 0;
+    int failed_records = 0;
+    int successful_records = 0;
     int grpc_status_counts[GRPC_STATUS_CODES_SIZE] = {0};
     size_t b_sent;
     flb_sds_t token;
@@ -3005,6 +3006,15 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
                                      config,
                                      &formatted_records);
     if (!payload_buf) {
+        if (formatted_records == 0) {
+#ifdef FLB_HAVE_METRICS
+            cmt_counter_add(ctx->ins->cmt_dropped_records, ts,
+                            (int) event_chunk->total_events,
+                            1, (char *[]) {name});
+#endif
+            FLB_OUTPUT_RETURN(FLB_OK);
+        }
+
 #ifdef FLB_HAVE_METRICS
         cmt_counter_inc(ctx->cmt_failed_requests,
                         ts, 1, (char *[]) {name});
@@ -3013,6 +3023,11 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
         flb_metrics_sum(FLB_STACKDRIVER_FAILED_REQUESTS, 1, ctx->ins->metrics);
 #endif
         FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    skipped_records = (int) event_chunk->total_events - formatted_records;
+    if (skipped_records < 0) {
+        skipped_records = 0;
     }
 
     if (ctx->test_log_entry_format) {
@@ -3116,7 +3131,6 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
                                                ts,
                                                grpc_status_counts);
 
-            int failed_records = 0;
             if (ret_partial_success == 0) {
               for (code = 0; code < GRPC_STATUS_CODES_SIZE; code++) {
                 if (grpc_status_counts[code] != 0) {
@@ -3125,8 +3139,10 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
               }
               cmt_counter_add(ctx->ins->cmt_dropped_records, ts,
                               failed_records, 1, (char* []) {name});
-              int successful_records =
-                  formatted_records - failed_records;
+              successful_records = formatted_records - failed_records;
+              if (successful_records < 0) {
+                successful_records = 0;
+              }
               if (successful_records != 0) {
                 add_record_metrics(ctx, ts, successful_records, 200, 0);
               }
@@ -3176,6 +3192,11 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_FAILED_REQUESTS, 1, ctx->ins->metrics);
+    }
+
+    if (ret_code != FLB_RETRY && skipped_records > 0) {
+        cmt_counter_add(ctx->ins->cmt_dropped_records, ts,
+                        skipped_records, 1, (char *[]) {name});
     }
 
     if (ret_code == FLB_RETRY) {

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1812,10 +1812,19 @@ static int pack_payload(int insert_id_extracted,
  *
  * log_errors: if FLB_TRUE, log why the record is being dropped.
  *             Set to FLB_FALSE during prescan to avoid duplicate logging.
+ *
+ * The insertId and payload labels are validated by traversing the record;
+ * the results are returned through in_status_out, insert_id_obj_out and
+ * payload_labels_ptr_out (any of which may be NULL) so the caller can reuse
+ * them instead of traversing the record again. They are only written when the
+ * record is not skipped.
  */
 static int should_skip_record(struct flb_stackdriver *ctx,
                               msgpack_object *obj,
-                              int log_errors)
+                              int log_errors,
+                              insert_id_status *in_status_out,
+                              msgpack_object *insert_id_obj_out,
+                              msgpack_object **payload_labels_ptr_out)
 {
     insert_id_status in_status;
     msgpack_object insert_id_obj;
@@ -1842,6 +1851,16 @@ static int should_skip_record(struct flb_stackdriver *ctx,
                           "dropping record");
         }
         return FLB_TRUE;
+    }
+
+    if (in_status_out != NULL) {
+        *in_status_out = in_status;
+    }
+    if (insert_id_obj_out != NULL) {
+        *insert_id_obj_out = insert_id_obj;
+    }
+    if (payload_labels_ptr_out != NULL) {
+        *payload_labels_ptr_out = payload_labels_ptr;
     }
 
     return FLB_FALSE;
@@ -1959,7 +1978,8 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     while ((ret = flb_log_event_decoder_next(
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
-        if (should_skip_record(ctx, log_event.body, FLB_FALSE) == FLB_TRUE) {
+        if (should_skip_record(ctx, log_event.body, FLB_FALSE,
+                               NULL, NULL, NULL) == FLB_TRUE) {
             array_size -= 1;
         }
     }
@@ -2393,8 +2413,13 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
         obj = log_event.body;
 
-        /* Skip records with invalid fields */
-        if (should_skip_record(ctx, obj, FLB_TRUE) == FLB_TRUE) {
+        /*
+         * Skip records with invalid fields. The insertId and payload labels
+         * validated here are returned so they are not re-extracted below.
+         */
+        if (should_skip_record(ctx, obj, FLB_TRUE,
+                               &in_status, &insert_id_obj,
+                               &payload_labels_ptr) == FLB_TRUE) {
             continue;
         }
 
@@ -2462,8 +2487,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             log_name_extracted = FLB_TRUE;
         }
 
-        /* Extract insertId (INVALID case already handled by should_skip_record) */
-        in_status = validate_insert_id(&insert_id_obj, obj);
+        /*
+         * insertId was already validated and extracted by should_skip_record
+         * (the INVALID case is handled there); reuse that result.
+         */
         if (in_status == INSERTID_VALID) {
             insert_id_extracted = FLB_TRUE;
             entry_size += 1;
@@ -2512,8 +2539,10 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             entry_size += 1;
         }
 
-        /* Extract payload labels (non-map case already handled by should_skip_record) */
-        payload_labels_ptr = get_payload_labels(ctx, obj);
+        /*
+         * payload labels were already extracted by should_skip_record (the
+         * non-map case is handled there); reuse that result.
+         */
 
         /* Number of parsed labels */
         labels_size = mk_list_size(&ctx->config_labels);

--- a/tests/runtime/data/stackdriver/stackdriver_batch_all_labels_not_a_map.log
+++ b/tests/runtime/data/stackdriver/stackdriver_batch_all_labels_not_a_map.log
@@ -1,0 +1,2 @@
+{"message":"bad record 1", "logging.googleapis.com/labels": "not_a_map"}
+{"message":"bad record 2", "logging.googleapis.com/labels": 12345}

--- a/tests/runtime/data/stackdriver/stackdriver_batch_first_record_labels_not_a_map.log
+++ b/tests/runtime/data/stackdriver/stackdriver_batch_first_record_labels_not_a_map.log
@@ -1,0 +1,2 @@
+{"message":"bad first record", "logging.googleapis.com/labels": "not_a_map"}
+{"message":"valid second record"}

--- a/tests/runtime/data/stackdriver/stackdriver_batch_labels_not_a_map.log
+++ b/tests/runtime/data/stackdriver/stackdriver_batch_labels_not_a_map.log
@@ -1,0 +1,3 @@
+{"message":"valid record with labels", "logging.googleapis.com/labels": {"testA": "valA", "testB": "valB"}}
+{"message":"bad labels - not a map", "logging.googleapis.com/labels": "not_a_map"}
+{"message":"valid record without labels"}

--- a/tests/runtime/data/stackdriver/stackdriver_batch_mixed_errors.log
+++ b/tests/runtime/data/stackdriver/stackdriver_batch_mixed_errors.log
@@ -1,0 +1,4 @@
+{"message":"valid record no special fields"}
+{"message":"bad insertId", "logging.googleapis.com/insertId": 123}
+{"message":"bad labels", "logging.googleapis.com/labels": "not_a_map"}
+{"message":"valid record with labels", "logging.googleapis.com/labels": {"testA": "valA"}}

--- a/tests/runtime/data/stackdriver/stackdriver_test_labels.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_labels.h
@@ -42,3 +42,75 @@
         "}"     \
 	"}]"
 
+/* labels value is a string instead of a map - should cause record to be dropped */
+#define LABELS_NOT_A_MAP	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/labels\": \"not_a_map\""		\
+	"}]"
+
+/* custom labels key with string value instead of map */
+#define LABELS_NOT_A_MAP_CUSTOM_KEY	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/customlabels\": \"not_a_map\""	\
+	"}]"
+
+/* invalid labels record with extracted fields (httpRequest, operation, */
+/* sourceLocation, trace, spanId) to verify cleanup on skip path */
+#define LABELS_NOT_A_MAP_WITH_FIELDS	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/labels\": \"not_a_map\","	\
+        "\"logging.googleapis.com/trace\": \"test_trace\","	\
+        "\"logging.googleapis.com/spanId\": \"test_span\","	\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": \"test_id\","          \
+            "\"producer\": \"test_producer\","      \
+            "\"first\": true,"      \
+            "\"last\": true"      \
+        "},"     \
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\""      \
+        "},"     \
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"GET\","          \
+            "\"requestUrl\": \"https://example.com\","      \
+            "\"status\": 200"      \
+        "}"     \
+	"}]"
+
+/* two-record batch: first record has invalid labels, second is valid */
+#define BATCH_FIRST_RECORD_LABELS_NOT_A_MAP	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/labels\": \"not_a_map\","	\
+        "\"message\": \"bad first record\""		\
+	"}]"
+
+#define BATCH_FIRST_RECORD_VALID	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"message\": \"valid second record\""		\
+	"}]"
+
+/* all records have invalid labels */
+#define BATCH_ALL_LABELS_NOT_A_MAP_1	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/labels\": \"not_a_map\","	\
+        "\"message\": \"bad record 1\""		\
+	"}]"
+
+#define BATCH_ALL_LABELS_NOT_A_MAP_2	"["		\
+	"1591649196,"			\
+	"{"				\
+        "\"logging.googleapis.com/labels\": 12345,"	\
+        "\"message\": \"bad record 2\""		\
+	"}]"
+

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -1381,6 +1381,125 @@ static void cb_check_default_labels_k8s_resource_type(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_labels_not_a_map(void *ctx, int ffd,
+                                      int res_ret, void *res_data, size_t res_size,
+                                      void *data)
+{
+    /* single record with labels as string should produce no output */
+    TEST_CHECK(res_size == 0);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_batch_labels_not_a_map(void *ctx, int ffd,
+                                            int res_ret, void *res_data, size_t res_size,
+                                            void *data)
+{
+    int ret;
+
+    /* record 0 has valid labels */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['labels']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['labels']['testA']", "valA");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['labels']['testB']", "valB");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* record 1 (originally record 2) has no labels */
+    ret = mp_kv_exists(res_data, res_size, "$entries[1]['labels']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* record 1 should have the message from the third input record */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$entries[1]['jsonPayload']['message']",
+                    "valid record without labels");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* there should be no entry at index 2 (the bad record was dropped) */
+    ret = mp_kv_exists(res_data, res_size, "$entries[2]");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_batch_mixed_errors(void *ctx, int ffd,
+                                        int res_ret, void *res_data, size_t res_size,
+                                        void *data)
+{
+    int ret;
+
+    /* record 0: valid record with no special fields */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$entries[0]['jsonPayload']['message']",
+                    "valid record no special fields");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* record 1: valid record with labels (originally record 3) */
+    ret = mp_kv_exists(res_data, res_size, "$entries[1]['labels']");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[1]['labels']['testA']", "valA");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* there should be no entry at index 2 (2 out of 4 records dropped) */
+    ret = mp_kv_exists(res_data, res_size, "$entries[2]");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_labels_not_a_map_custom_key(void *ctx, int ffd,
+                                                  int res_ret, void *res_data, size_t res_size,
+                                                  void *data)
+{
+    /* single record with custom labels key as string should produce no output */
+    TEST_CHECK(res_size == 0);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_batch_first_record_labels_not_a_map(void *ctx, int ffd,
+                                                         int res_ret, void *res_data, size_t res_size,
+                                                         void *data)
+{
+    int ret;
+
+    /* first record was dropped, only the valid second record remains */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$entries[0]['jsonPayload']['message']",
+                    "valid second record");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* there should be no second entry */
+    ret = mp_kv_exists(res_data, res_size, "$entries[1]");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_labels_not_a_map_with_fields(void *ctx, int ffd,
+                                                   int res_ret, void *res_data, size_t res_size,
+                                                   void *data)
+{
+    /* single record with invalid labels + many extracted fields */
+    /* exercises the skip path with extracted fields present */
+    TEST_CHECK(res_size == 0);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_batch_all_labels_not_a_map(void *ctx, int ffd,
+                                                int res_ret, void *res_data, size_t res_size,
+                                                void *data)
+{
+    /* all records have invalid labels, should produce no output */
+    TEST_CHECK(res_size == 0);
+
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_resource_labels_one_field(void *ctx, int ffd,
                                 int res_ret, void *res_data, size_t res_size, void *data)
 {
@@ -5150,6 +5269,303 @@ void flb_test_custom_labels_k8s_resource_type()
     flb_destroy(ctx);
 }
 
+void flb_test_labels_not_a_map()
+{
+    int ret;
+    int size = sizeof(LABELS_NOT_A_MAP) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_labels_not_a_map,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) LABELS_NOT_A_MAP, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_batch_labels_not_a_map()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    ret = flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+    TEST_CHECK_(ret == 0, "setting service options");
+
+    /* Tail input mode */
+    in_ffd = flb_input(ctx, (char *) "tail", NULL);
+    ret = flb_input_set(ctx, in_ffd,
+                        "Path", STACKDRIVER_DATA_PATH "/stackdriver_batch_labels_not_a_map.log",
+                        "tag", "test",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting input options");
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    ret = flb_output_set(ctx, out_ffd,
+                        "match", "test",
+                        "resource", "gce_instance",
+                        "google_service_credentials", SERVICE_CREDENTIALS,
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting output options");
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_batch_labels_not_a_map,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_batch_mixed_errors()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    ret = flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+    TEST_CHECK_(ret == 0, "setting service options");
+
+    /* Tail input mode */
+    in_ffd = flb_input(ctx, (char *) "tail", NULL);
+    ret = flb_input_set(ctx, in_ffd,
+                        "Path", STACKDRIVER_DATA_PATH "/stackdriver_batch_mixed_errors.log",
+                        "tag", "test",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting input options");
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    ret = flb_output_set(ctx, out_ffd,
+                        "match", "test",
+                        "resource", "gce_instance",
+                        "google_service_credentials", SERVICE_CREDENTIALS,
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting output options");
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_batch_mixed_errors,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_labels_not_a_map_custom_key()
+{
+    int ret;
+    int size = sizeof(LABELS_NOT_A_MAP_CUSTOM_KEY) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output with custom labels key */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   "labels_key", "logging.googleapis.com/customlabels",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_labels_not_a_map_custom_key,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) LABELS_NOT_A_MAP_CUSTOM_KEY, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_batch_first_record_labels_not_a_map()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second */
+    ctx = flb_create();
+    ret = flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+    TEST_CHECK_(ret == 0, "setting service options");
+
+    /* Tail input mode */
+    in_ffd = flb_input(ctx, (char *) "tail", NULL);
+    ret = flb_input_set(ctx, in_ffd,
+                        "Path", STACKDRIVER_DATA_PATH "/stackdriver_batch_first_record_labels_not_a_map.log",
+                        "tag", "test",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting input options");
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    ret = flb_output_set(ctx, out_ffd,
+                        "match", "test",
+                        "resource", "gce_instance",
+                        "google_service_credentials", SERVICE_CREDENTIALS,
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting output options");
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_batch_first_record_labels_not_a_map,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_labels_not_a_map_with_extracted_fields()
+{
+    int ret;
+    int size = sizeof(LABELS_NOT_A_MAP_WITH_FIELDS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_labels_not_a_map_with_fields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data: invalid labels with httpRequest, operation, etc. */
+    flb_lib_push(ctx, in_ffd, (char *) LABELS_NOT_A_MAP_WITH_FIELDS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_batch_all_records_labels_not_a_map()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second */
+    ctx = flb_create();
+    ret = flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+    TEST_CHECK_(ret == 0, "setting service options");
+
+    /* Tail input mode */
+    in_ffd = flb_input(ctx, (char *) "tail", NULL);
+    ret = flb_input_set(ctx, in_ffd,
+                        "Path", STACKDRIVER_DATA_PATH "/stackdriver_batch_all_labels_not_a_map.log",
+                        "tag", "test",
+                        "read_from_head", "true",
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting input options");
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    ret = flb_output_set(ctx, out_ffd,
+                        "match", "test",
+                        "resource", "gce_instance",
+                        "google_service_credentials", SERVICE_CREDENTIALS,
+                        NULL);
+    TEST_CHECK_(ret == 0, "setting output options");
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_batch_all_labels_not_a_map,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_resource_k8s_container_no_local_resource_id()
 {
     int ret;
@@ -6621,6 +7037,13 @@ TEST_LIST = {
     {"config_labels_no_conflict", flb_test_config_labels_no_conflict },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
     {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
+    {"labels_not_a_map", flb_test_labels_not_a_map },
+    {"batch_labels_not_a_map", flb_test_batch_labels_not_a_map },
+    {"batch_mixed_errors", flb_test_batch_mixed_errors },
+    {"labels_not_a_map_custom_key", flb_test_labels_not_a_map_custom_key },
+    {"batch_first_record_labels_not_a_map", flb_test_batch_first_record_labels_not_a_map },
+    {"labels_not_a_map_with_extracted_fields", flb_test_labels_not_a_map_with_extracted_fields },
+    {"batch_all_records_labels_not_a_map", flb_test_batch_all_records_labels_not_a_map },
 
     /* test resource labels api */
     {"resource_labels_one_field", flb_test_resource_labels_one_field },


### PR DESCRIPTION
## Description

When a single record contains a `logging.googleapis.com/labels` field that is not a map, the `out_stackdriver` plugin drops the **entire batch**. This causes data loss for all other valid records in that batch, and because the formatter returns `NULL` the chunk is retried forever — the malformed record makes every retry fail the same way.

### Root Cause

In `stackdriver_format()`, the labels type check is performed **after** operation, sourceLocation and httpRequest extraction, and its failure path bails out of the whole payload (`out_buf = NULL; goto cleanup;`) instead of skipping the offending record. An invalid `insertId` on the same record is already handled the other way — that record is simply skipped — so the two cases were inconsistent.

### Fix

Validate each record once, up front, in a shared `should_skip_record()` helper:

```c
static int should_skip_record(struct flb_stackdriver *ctx,
                              msgpack_object *obj,
                              insert_id_status *in_status_out,
                              msgpack_object *insert_id_obj_out,
                              msgpack_object **payload_labels_ptr_out)
```

It is called once, at the top of the entries loop, *before* any field extraction, so an invalid record is skipped with no cleanup to unwind. The entries array is packed with a dynamic header (`flb_mp_array_header_*`), so dropping a record mid-loop needs no other bookkeeping.

The helper also hands the validated `insertId` (status + object) and the payload-labels pointer back to the packing loop, so the record is not traversed a second time to re-extract them.

### Metrics

The number of formatted records is reported back to `cb_stackdriver_flush()` so processed, retry and dropped-record metrics reflect the records actually sent:

- Records skipped by `should_skip_record()` are added to the dropped-records counter once the flush completes without retry.
- A batch where **all** records are invalid reports zero formatted records and is treated as locally dropped (`FLB_OK` + dropped-records counter) instead of a retryable formatter failure, which previously caused infinite retries of an unformattable chunk.

### Scope

> **This PR fixes only the `labels not a map` per-record drop case.**

The following batch-level drop scenarios remain **unchanged** as they affect shared batch-level state by design:
- `flb_log_event_decoder_init()` failure
- `flb_log_event_decoder_next()` failure
- k8s `local_resource_id` extraction/processing failures (`k8s_container`, `k8s_node`, `k8s_pod`)
- `process_local_resource_id()` failures
- Final msgpack-to-JSON serialization failure

## Testing

### New Tests (7 total)

| Test | Scenario |
|---|---|
| `labels_not_a_map` | Single record with labels as string → no output |
| `labels_not_a_map_custom_key` | Non-default `labels_key` with string value → no output |
| `labels_not_a_map_with_extracted_fields` | Record with invalid labels + httpRequest, operation, sourceLocation, trace, spanId → exercises skip path with extracted fields present |
| `batch_labels_not_a_map` | 3-record batch (valid/invalid/valid) → 2 entries, bad record dropped |
| `batch_first_record_labels_not_a_map` | First record invalid, second valid → only valid record emitted |
| `batch_all_records_labels_not_a_map` | All records have invalid labels → no output |
| `batch_mixed_errors` | 4-record batch mixing invalid insertId + invalid labels + valid → only valid records emitted |

Batch tests with content assertions (`batch_labels_not_a_map`, `batch_first_record_labels_not_a_map`, `batch_mixed_errors`) use tail/file-backed fixtures to guarantee single-batch semantics. The `batch_all_records_labels_not_a_map` test uses a fixture file as well but only asserts no output.

### Regression Tests

Full `flb-rt-out_stackdriver` suite passes locally after rebasing onto current master (111 cases). A full `ctest` run on the rebased branch is clean apart from environment-dependent failures unrelated to this change.
