### PR TITLE
in_tail: fix DB.compare_filename mismatch when monitoring symlinks

### DIFF
--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -94,6 +94,20 @@ static inline int flb_tail_target_file_name_cmp(char *name,
 
     base_b = basename(name_b);
     ret = _stricmp(base_a, base_b);
+
+    /*
+     * Fallback: when monitoring symlinks the DB stores the symlink path
+     * (file->name) while real_name resolves to the target.  Compare
+     * against the original path so the entry is still recognised.
+     */
+    if (ret != 0 && file->name) {
+        flb_free(name_b);
+        name_b = flb_strdup(file->name);
+        if (name_b) {
+            base_b = basename(name_b);
+            ret = _stricmp(base_a, base_b);
+        }
+    }
 #else
     name_b = flb_strdup(file->real_name);
     if (!name_b) {
@@ -103,6 +117,20 @@ static inline int flb_tail_target_file_name_cmp(char *name,
     }
     base_b = basename(name_b);
     ret = strcmp(base_a, base_b);
+
+    /*
+     * Fallback: when monitoring symlinks the DB stores the symlink path
+     * (file->name) while real_name resolves to the target.  Compare
+     * against the original path so the entry is still recognised.
+     */
+    if (ret != 0 && file->name) {
+        flb_free(name_b);
+        name_b = flb_strdup(file->name);
+        if (name_b) {
+            base_b = basename(name_b);
+            ret = strcmp(base_a, base_b);
+        }
+    }
 #endif
 
  out:


### PR DESCRIPTION
When DB.compare_filename is enabled and the monitored path is a symbolic link (e.g. glog-style logging), the filename comparison in flb_tail_target_file_name_cmp() always fails on restart.

The database stores the symlink path (file->name), but the comparison checks against file->real_name which is resolved via the file descriptor to the actual target path.  For symlinks such as:

  app.INFO -> app.INFO.20250303-120000.12345

the basenames differ ("app.INFO" vs "app.INFO.20250303-120000.12345"), so db_file_exists() returns FLB_FALSE.  The existing entry is then deleted as stale and re-inserted with offset 0, causing a full re-read of the file and duplicate log ingestion.

Fix this by adding a fallback comparison against file->name (the original glob-matched path) when the real_name comparison fails. This correctly handles symlinks while still protecting against inode reuse for regular files.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced symlink handling in file comparison operations to provide more robust fallback behavior across platforms, improving reliability in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->