### PR TITLE
tests: serialize conflictive runtime tests (perf improvement)

### DIFF
--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -296,3 +296,25 @@ foreach(source_file ${CHECK_PROGRAMS})
     set_property(TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-D${o_source_file_we}")
   endif()
 endforeach()
+
+function(flb_runtime_lock_tests resource_name)
+  foreach(test_name ${ARGN})
+    if (TEST ${test_name})
+      set_property(TEST ${test_name} APPEND PROPERTY RESOURCE_LOCK "${resource_name}")
+    endif()
+  endforeach()
+endfunction()
+
+# Most runtime tests can run concurrently under `ctest -j`.
+# Only serialize executables that bind the same well-known port.
+flb_runtime_lock_tests("runtime-port-2020"
+  flb-rt-core_internal_logger
+  flb-rt-filter_wasm)
+
+flb_runtime_lock_tests("runtime-port-4318"
+  flb-rt-in_opentelemetry
+  flb-rt-in_opentelemetry_routing)
+
+flb_runtime_lock_tests("runtime-port-5170"
+  flb-rt-in_tcp
+  flb-rt-out_tcp)


### PR DESCRIPTION
This change improves unit-test wall-clock time in CI by allowing the runtime suite to run safely in parallel under ctest -j, while explicitly serializing only the known conflicting cases.

What changed:

  - Added CTest RESOURCE_LOCK handling in tests/runtime/CMakeLists.txt:300
  - Serialized only the runtime executables that bind the same fixed ports:
      - flb-rt-core_internal_logger and flb-rt-filter_wasm on 2020
      - flb-rt-in_opentelemetry and flb-rt-in_opentelemetry_routing on 4318
      - flb-rt-in_tcp and flb-rt-out_tcp on 5170
  - No CI workflow changes were required because GitHub Actions already invokes ctest -j $nparallel

  Measured impact:

  - Sequential internal+runtime suite: about 2321.23s (38m 41s)
  - Parallel internal+runtime suite with locks: about 299.53s (4m 59s)
  - Reduction: about 87.1% wall-clock time
  
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved reliability of runtime tests by preventing concurrent execution conflicts on shared resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->