### PR TITLE
tls: Fix infinite retry loops in flb_tls_net_read/write

### DIFF
--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -47,6 +47,8 @@
 #define FLB_TLS_CLIENT_MODE 0
 #define FLB_TLS_SERVER_MODE 1
 
+#define FLB_TLS_DEFAULT_IO_TIMEOUT_S 60
+
 struct flb_tls;
 struct flb_connection;
 

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -20,6 +20,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_socket.h>
+#include <fluent-bit/tls/flb_tls.h>
 
 #include "openssl.c"
 
@@ -349,30 +350,32 @@ int flb_tls_net_read(struct flb_tls_session *session, void *buf, size_t len)
     time_t          current_timestamp;
     struct flb_tls *tls;
     int             ret;
+    int             timeout_value;
 
     tls = session->tls;
 
     if (session->connection->net->io_timeout > 0) {
-        timeout_timestamp = time(NULL) + session->connection->net->io_timeout;
+        timeout_value = session->connection->net->io_timeout;
     }
     else {
-        timeout_timestamp = 0;
+        timeout_value = FLB_TLS_DEFAULT_IO_TIMEOUT_S;
     }
+    timeout_timestamp = time(NULL) + timeout_value;
 
  retry_read:
     ret = tls->api->net_read(session, buf, len);
 
     current_timestamp = time(NULL);
 
-    if (ret == FLB_TLS_WANT_READ) {
-        if (timeout_timestamp > 0 &&
-            timeout_timestamp <= current_timestamp) {
-            return ret;
+    if (ret == FLB_TLS_WANT_READ || ret == FLB_TLS_WANT_WRITE) {
+        if (timeout_timestamp <= current_timestamp) {
+            flb_warn("[tls] Read timed out after %d seconds", timeout_value);
+            return -1;
         }
 
-        goto retry_read;
-    }
-    else if (ret == FLB_TLS_WANT_WRITE) {
+        /* add short delay to prevent CPU hogging */
+        flb_time_msleep(5);
+
         goto retry_read;
     }
     else if (ret < 0) {
@@ -455,22 +458,41 @@ int flb_tls_net_read_async(struct flb_coro *co,
 int flb_tls_net_write(struct flb_tls_session *session,
                       const void *data, size_t len, size_t *out_len)
 {
+    time_t          timeout_timestamp;
+    time_t          current_timestamp;
     size_t          total;
     int             ret;
     struct flb_tls *tls;
+    int             timeout_value;
 
     total = 0;
     tls = session->tls;
+
+    if (session->connection->net->io_timeout > 0) {
+        timeout_value = session->connection->net->io_timeout;
+    }
+    else {
+        timeout_value = FLB_TLS_DEFAULT_IO_TIMEOUT_S;
+    }
+    timeout_timestamp = time(NULL) + timeout_value;
 
 retry_write:
     ret = tls->api->net_write(session,
                               (unsigned char *) data + total,
                               len - total);
 
-    if (ret == FLB_TLS_WANT_WRITE) {
-        goto retry_write;
-    }
-    else if (ret == FLB_TLS_WANT_READ) {
+    current_timestamp = time(NULL);
+
+    if (ret == FLB_TLS_WANT_WRITE || ret == FLB_TLS_WANT_READ) {
+        if (timeout_timestamp <= current_timestamp) {
+            flb_warn("[tls] Write timed out after %d seconds", timeout_value);
+            *out_len = total;
+            return -1;
+        }
+
+        /* add short delay to prevent CPU hogging */
+        flb_time_msleep(5);
+
         goto retry_write;
     }
     else if (ret < 0) {


### PR DESCRIPTION
Attempts to fix 100% CPU hang in flb_tls_net_read and flb_tls_net_write when SSL_read/SSL_write returns WANT_READ/WANT_WRITE and no io_timeout is configured.

This seems to happen when connections are closed unexpectedly. It causes a condition where open SSL just repeatedly returns `WANT_READ`, but there's no new data being received as we've lost the other side, so it just hangs forever and consumes 100% CPU. 

If an `io_timeout` is configured, then everything should be ok as it will eventually give up and return, but the problem arises when the default value of `0` is used for `io_timeout` as it will spin forever in a tight loop.

Proposing changing this to immediately return if there is no io_timeout configured.

----

Intended to address this issue, but may address others instances where CPU was 100% consumed
https://github.com/fluent/fluent-bit/issues/11551

----

Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

This is the relevant part of the config that reproduced the issue
```yaml
pipeline:
  inputs:
    - name: forward
      listen: 0.0.0.0
      port: 24224
      buffer_chunk_size: 1M
      buffer_max_size: 100M
      threaded: True
      storage.type: filesystem
      net.keepalive: on

```
- [x] Debug log output from testing the change
    - Before the change, there is no log, but the application just hangs and consumes 100% CPU
    - After the change I'm able to see this log when the issue reproduces indicating I've caught it: `[2026/03/17 21:57:22.3944407] [ warn] [tls] Read timed out after 60 seconds`
    - I think this proves that the issue is fixed with this change as otherwise, this would have spun forever
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS read/write timeout handling to prevent excessive CPU usage when timeouts are unset or expired.
  * Unified TLS readiness handling to reduce unnecessary retries.
  * Ensures partial write progress is reported when operations end due to timeout.
* **Chores**
  * Added a default TLS I/O timeout of **60 seconds** to stabilize TLS network behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->