### PR TITLE
log_event_decoder: time: plug 2038 problem on timestamp

### DIFF
--- a/include/fluent-bit/flb_time.h
+++ b/include/fluent-bit/flb_time.h
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_time_utils.h>
 
 #include <time.h>
+#include <limits.h>
 #include <msgpack.h>
 #include <mpack/mpack.h>
 struct flb_time {
@@ -84,15 +85,55 @@ static inline void flb_time_copy(struct flb_time *dst, struct flb_time *src)
     dst->tm.tv_nsec = src->tm.tv_nsec;
 }
 
-static inline void flb_time_from_uint64(struct flb_time *dst, uint64_t value)
+static inline int flb_time_is_valid_eventtime(struct flb_time *tm)
 {
-    dst->tm.tv_sec = (long) (value / 1000000000L);
+    if (tm == NULL || tm->tm.tv_sec < 0 ||
+        (uint64_t) tm->tm.tv_sec > UINT32_MAX ||
+        tm->tm.tv_nsec < 0 || tm->tm.tv_nsec >= 1000000000L) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+}
+
+static inline int flb_time_from_uint64(struct flb_time *dst, uint64_t value)
+{
+    uint64_t seconds;
+    uint64_t maximum_seconds;
+    unsigned int bit_count;
+
+    if (dst == NULL) {
+        return -1;
+    }
+
+    seconds = value / 1000000000L;
+
+    bit_count = sizeof(time_t) * CHAR_BIT;
+    if ((time_t) -1 < 0) {
+        bit_count--;
+    }
+
+    if (bit_count >= sizeof(uint64_t) * CHAR_BIT) {
+        maximum_seconds = UINT64_MAX;
+    }
+    else {
+        maximum_seconds = UINT64_MAX >>
+                          (sizeof(uint64_t) * CHAR_BIT - bit_count);
+    }
+
+    if (seconds > maximum_seconds) {
+        return -1;
+    }
+
+    dst->tm.tv_sec = (time_t) seconds;
     dst->tm.tv_nsec = (long) (value - ((uint64_t) dst->tm.tv_sec * 1000000000L));
+
+    return 0;
 }
 
 static inline void flb_time_from_double(struct flb_time *dst, double d)
 {
-    dst->tm.tv_sec = (int) d;
+    dst->tm.tv_sec = (time_t) d;
     dst->tm.tv_nsec = (long) ((d - dst->tm.tv_sec) * 1000000000L);
 }
 

--- a/plugins/in_opentelemetry/opentelemetry_logs.c
+++ b/plugins/in_opentelemetry/opentelemetry_logs.c
@@ -567,12 +567,20 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
 
                 if (ret == FLB_EVENT_ENCODER_SUCCESS) {
                     if (log_records[log_record_index]->time_unix_nano > 0) {
-                        flb_time_from_uint64(&tm, log_records[log_record_index]->time_unix_nano);
-                        ret = flb_log_event_encoder_set_timestamp(encoder, &tm);
+                        ret = flb_time_from_uint64(
+                                &tm,
+                                log_records[log_record_index]->time_unix_nano);
+                        if (ret == 0) {
+                            ret = flb_log_event_encoder_set_timestamp(encoder, &tm);
+                        }
                     }
                     else if (log_records[log_record_index]->observed_time_unix_nano > 0) {
-                        flb_time_from_uint64(&tm, log_records[log_record_index]->observed_time_unix_nano);
-                        ret = flb_log_event_encoder_set_timestamp(encoder, &tm);
+                        ret = flb_time_from_uint64(
+                                &tm,
+                                log_records[log_record_index]->observed_time_unix_nano);
+                        if (ret == 0) {
+                            ret = flb_log_event_encoder_set_timestamp(encoder, &tm);
+                        }
                     }
                     else {
                         flb_time_get(&tm);

--- a/plugins/out_stdout/stdout.c
+++ b/plugins/out_stdout/stdout.c
@@ -36,6 +36,7 @@
 #include <cprofiles/cprof_decode_msgpack.h>
 
 #include <msgpack.h>
+#include <inttypes.h>
 #include "stdout.h"
 
 
@@ -402,7 +403,7 @@ static void cb_stdout_flush(struct flb_event_chunk *event_chunk,
 
             printf("[%zd] %s: [[", cnt++, event_chunk->tag);
 
-            printf("%"PRId32".%09lu, ", (int32_t) log_event.timestamp.tm.tv_sec,
+            printf("%"PRId64".%09lu, ", (int64_t) log_event.timestamp.tm.tv_sec,
                     log_event.timestamp.tm.tv_nsec);
 
             msgpack_object_print(stdout, *log_event.metadata);

--- a/src/flb_log_event_decoder.c
+++ b/src/flb_log_event_decoder.c
@@ -22,6 +22,8 @@
 #include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_log.h>
 
+#include <inttypes.h>
+
 #define FLB_LOG_EVENT_DECODER_MAX_RECURSION_DEPTH        1000  /* Safety limit for recursion */
 
 static int create_empty_map(struct flb_log_event_decoder *context) {
@@ -180,6 +182,9 @@ void flb_log_event_decoder_destroy(struct flb_log_event_decoder *context)
 int flb_log_event_decoder_decode_timestamp(msgpack_object *input,
                                            struct flb_time *output)
 {
+    uint32_t seconds;
+    uint32_t nanoseconds;
+
     flb_time_zero(output);
 
     if (input->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
@@ -194,15 +199,43 @@ int flb_log_event_decoder_decode_timestamp(msgpack_object *input,
             return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
         }
 
-        output->tm.tv_sec  =
-            (int32_t) FLB_UINT32_TO_HOST_BYTE_ORDER(
-                        FLB_ALIGNED_DWORD_READ(
-                            (unsigned char *) &input->via.ext.ptr[0]));
+        seconds = FLB_UINT32_TO_HOST_BYTE_ORDER(
+                      FLB_ALIGNED_DWORD_READ(
+                          (unsigned char *) &input->via.ext.ptr[0]));
 
-        output->tm.tv_nsec  =
-            (int32_t) FLB_UINT32_TO_HOST_BYTE_ORDER(
-                        FLB_ALIGNED_DWORD_READ(
-                            (unsigned char *) &input->via.ext.ptr[4]));
+        /*
+         * EventTime seconds are unsigned. Only the two exact values used by
+         * Fluent Bit's legacy group records are special; all other values,
+         * including 0xfffffffd, are normal timestamps.
+         */
+        if (seconds == UINT32_MAX) {
+            nanoseconds = FLB_UINT32_TO_HOST_BYTE_ORDER(
+                              FLB_ALIGNED_DWORD_READ(
+                                  (unsigned char *) &input->via.ext.ptr[4]));
+            if (nanoseconds != 0) {
+                return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
+            }
+            output->tm.tv_sec = FLB_LOG_EVENT_GROUP_START;
+            output->tm.tv_nsec = 0;
+            return FLB_EVENT_DECODER_SUCCESS;
+        }
+        else if (seconds == UINT32_MAX - 1) {
+            nanoseconds = FLB_UINT32_TO_HOST_BYTE_ORDER(
+                              FLB_ALIGNED_DWORD_READ(
+                                  (unsigned char *) &input->via.ext.ptr[4]));
+            if (nanoseconds != 0) {
+                return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
+            }
+            output->tm.tv_sec = FLB_LOG_EVENT_GROUP_END;
+            output->tm.tv_nsec = 0;
+            return FLB_EVENT_DECODER_SUCCESS;
+        }
+
+        if (flb_time_msgpack_to_time(output, input) != 0) {
+            return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
+        }
+
+        return FLB_EVENT_DECODER_SUCCESS;
     }
     else {
         return FLB_EVENT_DECODER_ERROR_WRONG_TIMESTAMP_TYPE;
@@ -313,7 +346,7 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
     int result;
     int record_type;
     size_t previous_offset;
-    int32_t invalid_timestamp;
+    int64_t invalid_timestamp;
 
     if (context == NULL) {
         return FLB_EVENT_DECODER_ERROR_INVALID_CONTEXT;
@@ -368,8 +401,8 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
              * to avoid losing valid group metadata if corruption occurs mid-group.
              * Skip the record and continue processing.
              */
-            invalid_timestamp = (int32_t) event->timestamp.tm.tv_sec;
-            flb_debug("[decoder] Invalid group marker timestamp (%d), skipping record. "
+            invalid_timestamp = (int64_t) event->timestamp.tm.tv_sec;
+            flb_debug("[decoder] Invalid group marker timestamp (%" PRId64 "), skipping record. "
                      "Group state preserved.", invalid_timestamp);
 
             /* Increment recursion depth before recursive call */
@@ -457,9 +490,9 @@ int flb_log_event_decoder_next(struct flb_log_event_decoder *context,
 
 int flb_log_event_decoder_get_record_type(struct flb_log_event *event, int32_t *type)
 {
-    int32_t s;
+    time_t s;
 
-    s = (int32_t) event->timestamp.tm.tv_sec;
+    s = event->timestamp.tm.tv_sec;
 
     if (s >= 0) {
         *type = FLB_LOG_EVENT_NORMAL;

--- a/src/flb_log_event_encoder.c
+++ b/src/flb_log_event_encoder.c
@@ -346,6 +346,13 @@ int flb_log_event_encoder_set_timestamp(struct flb_log_event_encoder *context,
                                         struct flb_time *timestamp)
 {
     if (timestamp != NULL) {
+        if (flb_time_is_valid_eventtime(timestamp) != FLB_TRUE &&
+            !(timestamp->tm.tv_nsec == 0 &&
+              (timestamp->tm.tv_sec == FLB_LOG_EVENT_GROUP_START ||
+               timestamp->tm.tv_sec == FLB_LOG_EVENT_GROUP_END))) {
+            return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
+        }
+
         flb_time_copy(&context->timestamp, timestamp);
     }
     else {

--- a/src/flb_log_event_encoder_primitives.c
+++ b/src/flb_log_event_encoder_primitives.c
@@ -519,6 +519,10 @@ int flb_log_event_encoder_append_forward_v1_timestamp(
 {
     uint32_t value[2];
 
+    if (flb_time_is_valid_eventtime(timestamp) != FLB_TRUE) {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
+    }
+
     value[0] = FLB_UINT32_TO_NETWORK_BYTE_ORDER((uint32_t) timestamp->tm.tv_sec);
     value[1] = FLB_UINT32_TO_NETWORK_BYTE_ORDER((uint32_t) timestamp->tm.tv_nsec);
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -875,7 +875,7 @@ static int pack_print_fluent_record(size_t cnt, msgpack_unpacked result)
     flb_time_pop_from_msgpack(&tms, &result, &obj);
     flb_metadata_pop_from_msgpack(&metadata, &result, &obj);
 
-    fprintf(stdout, "[%zd] [[%"PRId32".%09lu, ", cnt, (int32_t) tms.tm.tv_sec, tms.tm.tv_nsec);
+    fprintf(stdout, "[%zd] [[%"PRId64".%09lu, ", cnt, (int64_t) tms.tm.tv_sec, tms.tm.tv_nsec);
 
     msgpack_object_print(stdout, *metadata);
 

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -184,6 +184,10 @@ int flb_time_append_to_mpack(mpack_writer_t *writer, struct flb_time *tm, int fm
         /* We can't set with msgpack-c !! */
         /* see pack_template.h and msgpack_pack_inline_func(_ext) */
     case FLB_TIME_ETFMT_V1_FIXEXT:
+        if (flb_time_is_valid_eventtime(tm) != FLB_TRUE) {
+            return -1;
+        }
+
         tmp = htonl((uint32_t)tm->tm.tv_sec); /* second from epoch */
         memcpy(&ext_data, &tmp, 4);
         tmp = htonl((uint32_t)tm->tm.tv_nsec);/* nanosecond */
@@ -235,6 +239,10 @@ int flb_time_append_to_msgpack(struct flb_time *tm, msgpack_packer *pk, int fmt)
         /* We can't set with msgpack-c !! */
         /* see pack_template.h and msgpack_pack_inline_func(_ext) */
     case FLB_TIME_ETFMT_V1_FIXEXT:
+        if (flb_time_is_valid_eventtime(tm) != FLB_TRUE) {
+            return -1;
+        }
+
         tmp = htonl((uint32_t)tm->tm.tv_sec); /* second from epoch */
         memcpy(&ext_data, &tmp, 4);
         tmp = htonl((uint32_t)tm->tm.tv_nsec);/* nanosecond */
@@ -283,6 +291,10 @@ int flb_time_msgpack_to_time(struct flb_time *time, msgpack_object *obj)
         time->tm.tv_sec = (uint32_t) ntohl(tmp);
         memcpy(&tmp, &obj->via.ext.ptr[4], 4);
         time->tm.tv_nsec = (uint32_t) ntohl(tmp);
+        if (flb_time_is_valid_eventtime(time) != FLB_TRUE) {
+            flb_warn("[time] invalid EventTime value");
+            return -1;
+        }
         break;
     default:
         flb_warn("unknown time format %x", obj->type);
@@ -376,6 +388,10 @@ int flb_time_pop_from_mpack(struct flb_time *time, mpack_reader_t *reader)
             time->tm.tv_sec = (uint32_t) ntohl(tmp);
             memcpy(&tmp, extbuf + 4, 4);
             time->tm.tv_nsec = (uint32_t) ntohl(tmp);
+            if (flb_time_is_valid_eventtime(time) != FLB_TRUE) {
+                flb_warn("invalid EventTime value");
+                return -1;
+            }
             break;
         default:
             flb_warn("unknown time format %d", tag.type);

--- a/src/opentelemetry/flb_opentelemetry_logs.c
+++ b/src/opentelemetry/flb_opentelemetry_logs.c
@@ -119,7 +119,12 @@ static int process_json_payload_log_records_entry(
             return -FLB_OTEL_LOGS_ERR_UNEXPECTED_TIMESTAMP_TYPE;
         }
 
-        flb_time_from_uint64(&timestamp, timestamp_uint64);
+        if (flb_time_from_uint64(&timestamp, timestamp_uint64) != 0) {
+            if (error_status) {
+                *error_status = FLB_OTEL_LOGS_ERR_UNEXPECTED_TIMESTAMP_TYPE;
+            }
+            return -FLB_OTEL_LOGS_ERR_UNEXPECTED_TIMESTAMP_TYPE;
+        }
     }
 
     /* observedTimeUnixNano (only camelCase) */

--- a/tests/integration/scenarios/in_opentelemetry/tests/data_files/test_logs_2038.in.json
+++ b/tests/integration/scenarios/in_opentelemetry/tests/data_files/test_logs_2038.in.json
@@ -1,0 +1,23 @@
+{
+    "resource_logs": [
+        {
+            "scope_logs": [
+                {
+                    "scope": {
+                        "name": "post-2038"
+                    },
+                    "log_records": [
+                        {
+                            "time_unix_nano": "2209072510808241446",
+                            "severity_number": 9,
+                            "severity_text": "INFO",
+                            "body": {
+                                "string_value": "post-2038 timestamp"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration/scenarios/out_stdout/tests/test_out_stdout_001.py
+++ b/tests/integration/scenarios/out_stdout/tests/test_out_stdout_001.py
@@ -200,6 +200,16 @@ def test_out_stdout_logs_accepts_otlp_json_ingestion():
     assert "This is another example log message." in log_text
 
 
+def test_out_stdout_preserves_post_2038_otlp_timestamp():
+    service = Service("out_stdout_otel.yaml")
+    service.start()
+    service.send_logs_json_payload("test_logs_2038.in.json")
+    log_text = service.wait_for_log_contains("post-2038 timestamp")
+    service.stop()
+
+    assert "2209072510.808241446" in log_text
+
+
 def test_out_stdout_metrics_accepts_otlp_json_ingestion():
     service = Service("out_stdout_otel.yaml")
     service.start()

--- a/tests/internal/flb_time.c
+++ b/tests/internal/flb_time.c
@@ -213,6 +213,71 @@ void test_msgpack_to_time_eventtime()
     msgpack_unpacked_destroy(&result);
 }
 
+void test_eventtime_boundaries()
+{
+    struct flb_time tm;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    msgpack_unpacked result;
+    msgpack_object tm_obj;
+    uint32_t value[2];
+    int ret;
+
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    value[0] = htonl(UINT32_MAX - 2);
+    value[1] = htonl(999999999);
+    msgpack_pack_ext(&mp_pck, 8, 0);
+    msgpack_pack_ext_body(&mp_pck, value, sizeof(value));
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+    tm_obj = result.data;
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(tm.tm.tv_sec == (time_t) (UINT32_MAX - 2));
+    TEST_CHECK(tm.tm.tv_nsec == 999999999);
+    msgpack_unpacked_destroy(&result);
+
+    msgpack_sbuffer_clear(&mp_sbuf);
+    value[0] = htonl(2209072510U);
+    value[1] = htonl(808241446);
+    msgpack_pack_ext(&mp_pck, 8, 0);
+    msgpack_pack_ext_body(&mp_pck, value, sizeof(value));
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+    tm_obj = result.data;
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(tm.tm.tv_sec == (time_t) 2209072510U);
+    TEST_CHECK(tm.tm.tv_nsec == 808241446);
+    msgpack_unpacked_destroy(&result);
+
+    msgpack_sbuffer_clear(&mp_sbuf);
+    value[0] = htonl(2209072510U);
+    value[1] = htonl(1000000000U);
+    msgpack_pack_ext(&mp_pck, 8, 0);
+    msgpack_pack_ext_body(&mp_pck, value, sizeof(value));
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, mp_sbuf.data, mp_sbuf.size, NULL);
+    tm_obj = result.data;
+    ret = flb_time_msgpack_to_time(&tm, &tm_obj);
+    TEST_CHECK(ret != 0);
+    msgpack_unpacked_destroy(&result);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
+void test_from_uint64_post_2038()
+{
+    struct flb_time tm;
+    int ret;
+
+    ret = flb_time_from_uint64(&tm, UINT64_C(2209072510808241446));
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(tm.tm.tv_sec == (time_t) 2209072510U);
+    TEST_CHECK(tm.tm.tv_nsec == 808241446);
+}
+
 void test_msgpack_to_time_invalid()
 {
     struct flb_time tm;
@@ -472,6 +537,8 @@ TEST_LIST = {
     { "msgpack_to_time_int"           , test_msgpack_to_time_int},
     { "msgpack_to_time_double"        , test_msgpack_to_time_double},
     { "msgpack_to_time_eventtime"     , test_msgpack_to_time_eventtime},
+    { "eventtime_boundaries"          , test_eventtime_boundaries},
+    { "from_uint64_post_2038"         , test_from_uint64_post_2038},
     { "msgpack_to_time_invalid"       , test_msgpack_to_time_invalid},
     { "append_to_msgpack_eventtime"   , test_append_to_msgpack_eventtime},
     { "windows_zone_to_iana"          , test_windows_zone_to_iana},

--- a/tests/internal/log_event_decoder.c
+++ b/tests/internal/log_event_decoder.c
@@ -1036,20 +1036,19 @@ void decoder_corrupted_group_timestamps()
 
     flb_time_set(&tm1, 1000, 100);
 
-    /* Test Case 1: Invalid negative timestamp (not -1 or -2) - should skip */
+    /* Test Case 1: 0xfffffffd is a valid EventTime, not a corrupted -3. */
     msgpack_sbuffer_init(&sbuf);
     msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
 
-    /* Create a record with corrupted group timestamp (-3) */
-    flb_time_set(&corrupted_tm, -3, 0);  /* Invalid group marker timestamp */
+    flb_time_set(&corrupted_tm, (time_t) (UINT32_MAX - 2), 0);
 
     msgpack_pack_array(&pck, 2);  /* Root array: [header, body] */
     msgpack_pack_array(&pck, 2);  /* Header array: [timestamp, metadata] */
-    pack_event_time(&pck, &corrupted_tm);  /* Invalid group marker timestamp */
+    pack_event_time(&pck, &corrupted_tm);
     msgpack_pack_map(&pck, 0);     /* Empty metadata */
     msgpack_pack_map(&pck, 0);     /* Empty body */
 
-    /* Normal log after corrupted marker */
+    /* Normal log after the high EventTime */
     msgpack_pack_array(&pck, 2);
     msgpack_pack_array(&pck, 2);
     pack_event_time(&pck, &tm1);
@@ -1066,7 +1065,13 @@ void decoder_corrupted_group_timestamps()
     ret = flb_log_event_decoder_read_groups(&dec, FLB_FALSE);
     TEST_CHECK(ret == 0);
 
-    /* When read_groups=false, corrupted group marker should be skipped */
+    ret = flb_log_event_decoder_next(&dec, &event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+    ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(decoded_record_type == FLB_LOG_EVENT_NORMAL);
+    TEST_CHECK(flb_time_equal(&corrupted_tm, &event.timestamp));
+
     ret = flb_log_event_decoder_next(&dec, &event);
     TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
     ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
@@ -1077,11 +1082,11 @@ void decoder_corrupted_group_timestamps()
     flb_log_event_decoder_destroy(&dec);
     msgpack_sbuffer_destroy(&sbuf);
 
-    /* Test Case 2: Invalid negative timestamp with read_groups=true - should also skip */
+    /* Test Case 2: 0xfffffff6 is a valid EventTime with read_groups=true. */
     msgpack_sbuffer_init(&sbuf2);
     msgpack_packer_init(&pck2, &sbuf2, msgpack_sbuffer_write);
 
-    flb_time_set(&corrupted_tm, -10, 0);  /* Another invalid group marker timestamp */
+    flb_time_set(&corrupted_tm, (time_t) (UINT32_MAX - 9), 0);
 
     msgpack_pack_array(&pck2, 2);
     msgpack_pack_array(&pck2, 2);
@@ -1089,7 +1094,7 @@ void decoder_corrupted_group_timestamps()
     msgpack_pack_map(&pck2, 0);
     msgpack_pack_map(&pck2, 0);
 
-    /* Normal log after corrupted marker */
+    /* Normal log after the high EventTime */
     msgpack_pack_array(&pck2, 2);
     msgpack_pack_array(&pck2, 2);
     pack_event_time(&pck2, &tm1);
@@ -1106,7 +1111,13 @@ void decoder_corrupted_group_timestamps()
     ret = flb_log_event_decoder_read_groups(&dec, FLB_TRUE);
     TEST_CHECK(ret == 0);
 
-    /* When read_groups=true, corrupted group marker should also be skipped */
+    ret = flb_log_event_decoder_next(&dec, &event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+    ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(decoded_record_type == FLB_LOG_EVENT_NORMAL);
+    TEST_CHECK(flb_time_equal(&corrupted_tm, &event.timestamp));
+
     ret = flb_log_event_decoder_next(&dec, &event);
     TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
     ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
@@ -1117,11 +1128,44 @@ void decoder_corrupted_group_timestamps()
     flb_log_event_decoder_destroy(&dec);
     msgpack_sbuffer_destroy(&sbuf2);
 
-    /* Test Case 3: Very negative timestamp - should skip */
+    /* Test Case 3: Post-2038 timestamp should remain a normal record. */
     msgpack_sbuffer_init(&sbuf);
     msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
 
-    flb_time_set(&corrupted_tm, -1000, 0);  /* Very negative but invalid */
+    /* 2040-01-03 03:15:10 UTC */
+    flb_time_set(&tm1, 2209072510LL, 808241446);
+
+    msgpack_pack_array(&pck, 2);
+    msgpack_pack_array(&pck, 2);
+    pack_event_time(&pck, &tm1);
+    msgpack_pack_map(&pck, 0);
+    msgpack_pack_map(&pck, 1);
+    msgpack_pack_str(&pck, 3);
+    msgpack_pack_str_body(&pck, "log", 3);
+    msgpack_pack_str(&pck, 4);
+    msgpack_pack_str_body(&pck, "2040", 4);
+
+    ret = flb_log_event_decoder_init(&dec, (char *)sbuf.data, sbuf.size);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+
+    ret = flb_log_event_decoder_read_groups(&dec, FLB_TRUE);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_log_event_decoder_next(&dec, &event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+    ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(decoded_record_type == FLB_LOG_EVENT_NORMAL);
+    TEST_CHECK(flb_time_equal(&tm1, &event.timestamp));
+
+    flb_log_event_decoder_destroy(&dec);
+    msgpack_sbuffer_destroy(&sbuf);
+
+    /* Test Case 4: 0xfffffc18 is a valid high EventTime. */
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
+
+    flb_time_set(&corrupted_tm, (time_t) (UINT32_MAX - 999), 0);
 
     msgpack_pack_array(&pck, 2);
     msgpack_pack_array(&pck, 2);
@@ -1129,7 +1173,7 @@ void decoder_corrupted_group_timestamps()
     msgpack_pack_map(&pck, 0);
     msgpack_pack_map(&pck, 0);
 
-    /* Normal log after corrupted marker */
+    /* Normal log after the high EventTime */
     msgpack_pack_array(&pck, 2);
     msgpack_pack_array(&pck, 2);
     pack_event_time(&pck, &tm1);
@@ -1146,7 +1190,13 @@ void decoder_corrupted_group_timestamps()
     ret = flb_log_event_decoder_read_groups(&dec, FLB_FALSE);
     TEST_CHECK(ret == 0);
 
-    /* Corrupted marker should be skipped, normal log should be returned */
+    ret = flb_log_event_decoder_next(&dec, &event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+    ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(decoded_record_type == FLB_LOG_EVENT_NORMAL);
+    TEST_CHECK(flb_time_equal(&corrupted_tm, &event.timestamp));
+
     ret = flb_log_event_decoder_next(&dec, &event);
     TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
     ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
@@ -1174,8 +1224,7 @@ void decoder_invalid_marker_preserves_group_state()
     flb_time_set(&tm1, 1000, 100);
     flb_time_set(&tm2, 2000, 200);
 
-    /* Test: GROUP_START → normal_log1 → [corrupted -3 marker] → normal_log2
-     * Expected: normal_log2 should STILL have group metadata (state preserved) */
+    /* Test: GROUP_START → normal_log1 → high EventTime → normal_log2. */
     msgpack_sbuffer_init(&sbuf);
     msgpack_packer_init(&pck, &sbuf, msgpack_sbuffer_write);
 
@@ -1193,15 +1242,15 @@ void decoder_invalid_marker_preserves_group_state()
     msgpack_pack_str(&pck, 1);
     msgpack_pack_str_body(&pck, "1", 1);
 
-    /* Corrupted marker (-3) - should NOT clear group state */
-    flb_time_set(&corrupted_tm, -3, 0);
+    /* A valid high EventTime must not clear group state. */
+    flb_time_set(&corrupted_tm, (time_t) (UINT32_MAX - 2), 0);
     msgpack_pack_array(&pck, 2);
     msgpack_pack_array(&pck, 2);
     pack_event_time(&pck, &corrupted_tm);
     msgpack_pack_map(&pck, 0);
     msgpack_pack_map(&pck, 0);
 
-    /* Normal log 2 - should STILL have group metadata (state preserved) */
+    /* Normal log 2 should still have group metadata. */
     msgpack_pack_array(&pck, 2);
     msgpack_pack_array(&pck, 2);
     pack_event_time(&pck, &tm2);
@@ -1228,18 +1277,27 @@ void decoder_invalid_marker_preserves_group_state()
     TEST_CHECK(event.group_metadata != NULL || event.group_attributes != NULL);
     record_count++;
 
-    /* Read normal log 2 - should STILL have group metadata (state preserved) */
+    /* Read the high EventTime record. */
+    ret = flb_log_event_decoder_next(&dec, &event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+    ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(decoded_record_type == FLB_LOG_EVENT_NORMAL);
+    TEST_CHECK(flb_time_equal(&corrupted_tm, &event.timestamp));
+    TEST_CHECK(event.group_metadata != NULL || event.group_attributes != NULL);
+    record_count++;
+
+    /* Group state remains active for the following normal record. */
     ret = flb_log_event_decoder_next(&dec, &event);
     TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
     ret = flb_log_event_decoder_get_record_type(&event, &decoded_record_type);
     TEST_CHECK(ret == 0);
     TEST_CHECK(decoded_record_type == FLB_LOG_EVENT_NORMAL);
     TEST_CHECK(flb_time_equal(&tm2, &event.timestamp));
-    /* CRITICAL: Group state should be preserved despite invalid marker */
     TEST_CHECK(event.group_metadata != NULL || event.group_attributes != NULL);
     record_count++;
 
-    TEST_CHECK(record_count == 2);
+    TEST_CHECK(record_count == 3);
 
     flb_log_event_decoder_destroy(&dec);
     msgpack_sbuffer_destroy(&sbuf);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes https://github.com/fluent/fluent-bit/issues/11532.

On Fluent Bit core, we still have 2038 issues.
second part of flb_tm struct was processed as int32_t type and out_stdout has int32_t assumed part of printing timestamps.
So, those of operations can be truncate after 2038 cut-off of timestamps issue.
We need to fix and process after surpassed of 2038 timestamps.

After patching this, we can process until 2106 A.D logs.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```conf
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    debug

[INPUT]
    Name         dummy
    Tag          test.lua
    Dummy        {"KEY_OF_TIMESTAMP":2209161600.123456,"msg":"hello-from-2040"}
    Samples      1

[FILTER]
    Name         lua
    Match        test.lua
    Script       override_time_2040.lua
    Call         override_time_2040

[OUTPUT]
    Name         stdout
    Match        test.lua
```

* override_time_2040.lua
```lua
function override_time_2040(tag, timestamp, record)
    return 1, record["KEY_OF_TIMESTAMP"], record
end
```
- [x] Debug log output from testing the change
```
% bin/fluent-bit -c future-of-lua-script.conf -v
Fluent Bit v5.0.2
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/03 19:45:16.122] [ info] Configuration:
[2026/04/03 19:45:16.124] [ info]  flush time     | 1.000000 seconds
[2026/04/03 19:45:16.124] [ info]  grace          | 5 seconds
[2026/04/03 19:45:16.124] [ info]  daemon         | 0
[2026/04/03 19:45:16.124] [ info] ___________
[2026/04/03 19:45:16.124] [ info]  inputs:
[2026/04/03 19:45:16.124] [ info]      dummy
[2026/04/03 19:45:16.124] [ info] ___________
[2026/04/03 19:45:16.124] [ info]  filters:
[2026/04/03 19:45:16.124] [ info]      lua.0
[2026/04/03 19:45:16.124] [ info] ___________
[2026/04/03 19:45:16.124] [ info]  outputs:
[2026/04/03 19:45:16.124] [ info]      stdout.0
[2026/04/03 19:45:16.124] [ info] ___________
[2026/04/03 19:45:16.124] [ info]  collectors:
[2026/04/03 19:45:16.124] [ info] [fluent bit] version=5.0.2, commit=d835ea9ee9, pid=77022
[2026/04/03 19:45:16.124] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2026/04/03 19:45:16.124] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/03 19:45:16.124] [ info] [simd    ] disabled
[2026/04/03 19:45:16.124] [ info] [cmetrics] version=2.1.1
[2026/04/03 19:45:16.125] [ info] [ctraces ] version=0.7.1
[2026/04/03 19:45:16.125] [ info] [input:dummy:dummy.0] initializing
[2026/04/03 19:45:16.125] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/04/03 19:45:16.125] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2026/04/03 19:45:16.125] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2026/04/03 19:45:16.125] [ info] [sp] stream processor started
[2026/04/03 19:45:16.125] [ info] [output:stdout:stdout.0] worker #0 started
[2026/04/03 19:45:16.126] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/03 19:45:18.129] [debug] [task] created task=0x6000012b4000 id=0 OK
[2026/04/03 19:45:18.129] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] test.lua: [[2209161600.123456001, {}], {"KEY_OF_TIMESTAMP"=>2209161600.123456, "msg"=>"hello-from-2040"}]
[2026/04/03 19:45:18.130] [debug] [out flush] cb_destroy coro_id=0
[2026/04/03 19:45:18.130] [debug] [task] destroy task=0x6000012b4000 (task_id=0)
^C[2026/04/03 19:45:32] [engine] caught signal (SIGINT)
[2026/04/03 19:45:32.865] [ info] [input] pausing dummy.0
[2026/04/03 19:45:32.865] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/04/03 19:45:32.865] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

It's not valgrind but it ran under leaks command on macOS:

```
Process 77174 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [77174]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x10205c000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [77173]
Target Type:     live task

Date/Time:       2026-04-03 19:46:03.932 +0900
Launch Time:     2026-04-03 19:45:51.097 +0900
OS Version:      macOS 15.7.4 (24G517)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         4737K
Physical footprint (peak):  4881K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 77174: 750 nodes malloced for 81 KB
Process 77174: 0 leaks for 0 total leaked bytes.

[2026/04/03 19:46:04] [engine] caught signal (SIGCONT)
----

leaks Report Version: 4.0, multi-line stacks
Process 77148: 750 nodes malloced for 81 KB
Process 77148: 0 leaks for 0 total leaked bytes.
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp handling to correctly support dates beyond 2038.
  * Improved decoding of extended timestamp formats to preserve group markers and edge cases.
  * Updated timestamp output formatting for accurate 64-bit second values across components.
  * Strengthened validation and logging for malformed or special-case timestamps.
  * Added/updated tests to verify post-2038 timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->