### PR TITLE
snappy: fix intermittent decompression failures for raw snappy data

### DIFF
--- a/include/fluent-bit/flb_snappy.h
+++ b/include/fluent-bit/flb_snappy.h
@@ -21,6 +21,7 @@
 #define FLB_SNAPPY_H
 
 #include <fluent-bit/flb_info.h>
+#include <cfl/cfl.h>
 #include <cfl/cfl_list.h>
 
 #include <stdio.h>

--- a/src/flb_snappy.c
+++ b/src/flb_snappy.c
@@ -302,7 +302,6 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
     }
 
     aggregated_data_buffer = NULL;
-    aggregated_data_length = 0;
 
     if (compressed_chunk_count == 1 &&
         uncompressed_chunk_count == 0 &&
@@ -322,7 +321,7 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
         flb_free(chunk);
     }
     else {
-        if (aggregated_data_length > 0) {
+        if (aggregated_data_length > 0 && result == 0) {
             aggregated_data_buffer = flb_calloc(aggregated_data_length,
                                                 sizeof(char));
 
@@ -355,6 +354,12 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
 
             flb_free(chunk);
         }
+    }
+
+    if (result != 0) {
+        flb_free(aggregated_data_buffer);
+        aggregated_data_buffer = NULL;
+        aggregated_data_offset = 0;
     }
 
     *out_data = (char *) aggregated_data_buffer;

--- a/src/flb_snappy.c
+++ b/src/flb_snappy.c
@@ -29,6 +29,8 @@
 
 #include <snappy.h>
 
+#include <string.h>
+
 int flb_snappy_compress(char *in_data, size_t in_len,
                         char **out_data, size_t *out_len)
 {
@@ -139,7 +141,25 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
     struct cfl_list               chunks;
     struct flb_snappy_data_chunk *chunk;
 
-    if (*((uint8_t *) in_data) != FLB_SNAPPY_FRAME_TYPE_STREAM_IDENTIFIER) {
+    /*
+     * Distinguish raw/block snappy from the framed/streaming format.
+     *
+     * The framed format always starts with a stream identifier frame:
+     *   byte 0:   0xFF (stream identifier chunk type)
+     *   bytes 1-3: 0x06 0x00 0x00 (length = 6, little-endian 24-bit)
+     *   bytes 4-9: "sNaPpY"
+     *
+     * A single first-byte check is insufficient because raw snappy data
+     * encodes the uncompressed length as a varint whose first byte can
+     * be 0xFF (e.g. when the uncompressed size mod 128 == 127 and >= 128).
+     * Checking the full 10-byte header avoids this false positive.
+     */
+    if (in_len < 10 ||
+        *((uint8_t *) &in_data[0]) != 0xFF ||
+        *((uint8_t *) &in_data[1]) != 0x06 ||
+        *((uint8_t *) &in_data[2]) != 0x00 ||
+        *((uint8_t *) &in_data[3]) != 0x00 ||
+        memcmp(&in_data[4], FLB_SNAPPY_STREAM_IDENTIFIER_STRING, 6) != 0) {
         return flb_snappy_uncompress(in_data, in_len, out_data, out_len);
     }
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -20,6 +20,7 @@ set(UNIT_TESTS_FILES
   http_client.c
   utils.c
   gzip.c
+  snappy.c
   zstd.c
   random.c
   config_map.c

--- a/tests/internal/snappy.c
+++ b/tests/internal/snappy.c
@@ -1,0 +1,168 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_snappy.h>
+#include <cfl/cfl_checksum.h>
+
+#include "flb_tests_internal.h"
+
+static uint32_t calculate_snappy_checksum(char *buffer, size_t length)
+{
+    uint32_t checksum;
+
+    checksum = cfl_checksum_crc32c((unsigned char *) buffer, length);
+
+    return ((checksum >> 15) |
+            (checksum << 17)) + 0xa282ead8;
+}
+
+static void write_frame_header(char *buffer, size_t *offset,
+                               unsigned char frame_type, size_t frame_length)
+{
+    buffer[*offset] = frame_type;
+    buffer[*offset + 1] = (char) (frame_length & 0xff);
+    buffer[*offset + 2] = (char) ((frame_length >> 8) & 0xff);
+    buffer[*offset + 3] = (char) ((frame_length >> 16) & 0xff);
+
+    *offset += 4;
+}
+
+static void write_uint32_le(char *buffer, size_t *offset, uint32_t value)
+{
+    buffer[*offset] = (char) (value & 0xff);
+    buffer[*offset + 1] = (char) ((value >> 8) & 0xff);
+    buffer[*offset + 2] = (char) ((value >> 16) & 0xff);
+    buffer[*offset + 3] = (char) ((value >> 24) & 0xff);
+
+    *offset += 4;
+}
+
+static void write_uncompressed_frame(char *buffer, size_t *offset,
+                                     char *data, size_t data_length)
+{
+    uint32_t checksum;
+
+    checksum = calculate_snappy_checksum(data, data_length);
+
+    write_frame_header(buffer, offset,
+                       FLB_SNAPPY_FRAME_TYPE_UNCOMPRESSED_DATA,
+                       data_length + sizeof(uint32_t));
+    write_uint32_le(buffer, offset, checksum);
+    memcpy(&buffer[*offset], data, data_length);
+
+    *offset += data_length;
+}
+
+void test_raw_block_data_with_stream_identifier_byte(void)
+{
+    int ret;
+    char raw_data[255];
+    char *compressed_data;
+    char *uncompressed_data;
+    size_t compressed_length;
+    size_t uncompressed_length;
+    size_t index;
+
+    for (index = 0; index < sizeof(raw_data); index++) {
+        raw_data[index] = (char) index;
+    }
+
+    compressed_data = NULL;
+    compressed_length = 0;
+    ret = flb_snappy_compress(raw_data, sizeof(raw_data),
+                              &compressed_data, &compressed_length);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(compressed_data != NULL);
+    TEST_CHECK(compressed_length > 0);
+    TEST_CHECK((unsigned char) compressed_data[0] ==
+               FLB_SNAPPY_FRAME_TYPE_STREAM_IDENTIFIER);
+
+    uncompressed_data = NULL;
+    uncompressed_length = 0;
+    ret = flb_snappy_uncompress_framed_data(compressed_data, compressed_length,
+                                            &uncompressed_data,
+                                            &uncompressed_length);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(uncompressed_data != NULL);
+    TEST_CHECK(uncompressed_length == sizeof(raw_data));
+
+    if (ret != 0 || uncompressed_data == NULL ||
+        uncompressed_length != sizeof(raw_data)) {
+        flb_free(compressed_data);
+        flb_free(uncompressed_data);
+        return;
+    }
+
+    TEST_CHECK(memcmp(raw_data, uncompressed_data, sizeof(raw_data)) == 0);
+
+    flb_free(compressed_data);
+    flb_free(uncompressed_data);
+}
+
+void test_framed_data_with_multiple_chunks(void)
+{
+    int ret;
+    char *first_chunk;
+    char *second_chunk;
+    char *expected_data;
+    char framed_data[128];
+    char *uncompressed_data;
+    size_t first_length;
+    size_t second_length;
+    size_t expected_length;
+    size_t framed_length;
+    size_t uncompressed_length;
+
+    first_chunk = "first framed chunk";
+    second_chunk = "second framed chunk";
+    first_length = strlen(first_chunk);
+    second_length = strlen(second_chunk);
+    expected_length = first_length + second_length;
+
+    framed_length = 0;
+    write_frame_header(framed_data, &framed_length,
+                       FLB_SNAPPY_FRAME_TYPE_STREAM_IDENTIFIER,
+                       strlen(FLB_SNAPPY_STREAM_IDENTIFIER_STRING));
+    memcpy(&framed_data[framed_length],
+           FLB_SNAPPY_STREAM_IDENTIFIER_STRING,
+           strlen(FLB_SNAPPY_STREAM_IDENTIFIER_STRING));
+    framed_length += strlen(FLB_SNAPPY_STREAM_IDENTIFIER_STRING);
+
+    write_uncompressed_frame(framed_data, &framed_length,
+                             first_chunk, first_length);
+    write_uncompressed_frame(framed_data, &framed_length,
+                             second_chunk, second_length);
+
+    uncompressed_data = NULL;
+    uncompressed_length = 0;
+    ret = flb_snappy_uncompress_framed_data(framed_data, framed_length,
+                                            &uncompressed_data,
+                                            &uncompressed_length);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(uncompressed_data != NULL);
+    TEST_CHECK(uncompressed_length == expected_length);
+
+    if (ret != 0 || uncompressed_data == NULL ||
+        uncompressed_length != expected_length) {
+        flb_free(uncompressed_data);
+        return;
+    }
+
+    expected_data = flb_malloc(expected_length);
+    TEST_CHECK(expected_data != NULL);
+    memcpy(expected_data, first_chunk, first_length);
+    memcpy(expected_data + first_length, second_chunk, second_length);
+    TEST_CHECK(memcmp(expected_data, uncompressed_data, expected_length) == 0);
+
+    flb_free(expected_data);
+    flb_free(uncompressed_data);
+}
+
+TEST_LIST = {
+    { "raw_block_data_with_stream_identifier_byte",
+      test_raw_block_data_with_stream_identifier_byte },
+    { "framed_data_with_multiple_chunks",
+      test_framed_data_with_multiple_chunks },
+    { 0 }
+};


### PR DESCRIPTION
## Summary

- Fix raw/block snappy data being misidentified as framed/streaming format, causing intermittent decompression failures
- Fix multi-chunk framed snappy payloads being silently dropped due to an accumulated length reset

## Problem

We observed that when sending metrics to Fluent Bit via the Prometheus Remote Write input plugin, some requests would randomly fail with:

```
[error] [http snappy] decompression failed
```

All metrics were confirmed as being sent correctly to Fluent Bit, yet not all of them made it through. The failures were intermittent and appeared random — the same configuration would work most of the time but occasionally drop data.

## Root Cause

### Bug 1: Raw snappy misidentified as framed (the intermittent failure)

Prometheus Remote Write uses **raw/block snappy** compression (as per the spec). Fluent Bit's `flb_snappy_uncompress_framed_data()` tries to detect whether incoming data is raw or framed by checking if the first byte equals `0xFF` — the snappy stream identifier frame type.

The problem is that raw snappy data **also** starts with a varint-encoded uncompressed length, and a varint byte of `0xFF` naturally occurs whenever the uncompressed payload size satisfies `size >= 128 && size % 128 == 127` (e.g. sizes 255, 383, 511, 639, ...).

When this happens (~1 in 128 payloads depending on data size), the raw data is incorrectly routed into the framed parser, which then fails trying to match the `"sNaPpY"` stream identifier against compressed binary data.

This explains why the issue is **intermittent** — it depends entirely on the serialized protobuf payload size, which varies with the number and shape of metrics in each batch.

### Bug 2: Multi-chunk framed data silently dropped

In the framed snappy code path, after the parsing loop accumulates the total decompressed length across all chunks, this code runs:

```c
aggregated_data_buffer = NULL;
aggregated_data_length = 0;   // <-- bug: resets the accumulated length
```

The `aggregated_data_length = 0` zeroes out the total before it is used for the output buffer allocation. For multi-chunk payloads, no buffer is allocated and all decompressed chunk data is discarded — while the function still returns success (0). This is a silent data loss bug.

## Fix

### Commit 1 [7800ae2e2bbcd732461b0fc467939462591e91f9]: Full stream identifier validation

Replace the single first-byte check with validation of the complete 10-byte snappy framed stream identifier header:

| Offset | Value | Meaning |
|--------|-------|---------|
| 0 | `0xFF` | Stream identifier chunk type |
| 1-3 | `0x06 0x00 0x00` | Length = 6 (little-endian 24-bit) |
| 4-9 | `sNaPpY` | Magic string |

This eliminates false positives from raw snappy data whose varint happens to start with `0xFF`.

### Commit 2 [d1b8f034f385b68056674f818c1e334780c33022]: Remove erroneous length reset

Remove the `aggregated_data_length = 0` line so the accumulated length from the parsing loop is preserved and used for buffer allocation in the multi-chunk path.

## Test plan

- [x] Fluent Bit builds with no errors
- [x] All 80 internal tests pass (`ctest` — 100% pass rate)
- [x] Both patches apply cleanly on top of `v4.1.0`
- [x] Verified with Prometheus Remote Write workload that previously triggered ~1-in-128 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Bug Fixes
* Improved detection of framed compressed data to prevent misclassification of inputs, ensuring streams are routed to the correct decompression path and handled consistently.

## Chores
* Updated header inclusions to improve compilation compatibility for code that relies on this interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->