### PR TITLE
compat: fix basename buffer to be thread-local on Windows

### DIFF
--- a/include/fluent-bit/flb_compat.h
+++ b/include/fluent-bit/flb_compat.h
@@ -109,7 +109,7 @@ static inline char* basename(const char *path)
     char dir[_MAX_DIR];
     char fname[_MAX_FNAME];
     char ext[_MAX_EXT];
-    static char buf[_MAX_PATH];
+    static __declspec(thread) char buf[_MAX_PATH];
 
     _splitpath_s(path, drive, _MAX_DRIVE, dir, _MAX_DIR,
                        fname, _MAX_FNAME, ext, _MAX_EXT);


### PR DESCRIPTION
Add `__declspec(thread)` to the static buffer in the Windows `basename` func to prevent data races in multi-threaded contexts, where concurrent calls could corrupt a shared static buffer.

[__declspec(thread)](https://learn.microsoft.com/en-us/cpp/cpp/thread?view=msvc-170)

Issue: Windows basename() race condition causing false file rotation.

basename() in flb_compat.h returns a pointer to a global static char buf[_MAX_PATH]. 

When two tail inputs run their
worker threads concurrently call basename() via [tail_file.h]:
  flb_tail_file_is_rotated() -> flb_tail_target_file_name_cmp()

Thread A sets base_b = basename(name_b) (pointer to shared buf), then Thread B
overwrites that buf before Thread A's _stricmp(base_a, base_b) reads it.
The corrupted comparison returns non-zero -> file falsely detected as rotated.

Symptom: repeated log entries on Windows:
  [debug] inode=XXXXXXXXXX rotated: C:\logs\svc\svc_2.log => C:\logs\svc\svc_2.log
followed by the file being purged from DB and re-read from offset 0.

Example Config to reproduce:
```
[INPUT]
    Name      tail
    Alias     in.tail.app
    Tag       svc.*
    Path      C:\logs\app\*.log
    DB        C:\fluent-bit\db\app.db
    Threaded  On

[INPUT]
    Name      tail
    Alias     in.tail.svc
    Tag       svc.*
    Path      C:\logs\svc\*.log
    DB        C:\fluent-bit\db\svc.db
    Threaded  On

```

Logs:
```
[2026/03/13 09:30:43.857854900] [debug] [input:tail:in.tail.svc] inode=1407374883875495 with offset=0 appended as C:\logs\svc\svc.log
[2026/03/13 09:30:44.357575600] [debug] [input:tail:in.tail.svc] inode=1407374883875495 file=C:\logs\svc\svc.log promote to TAIL_EVENT
[2026/03/13 09:39:44.336436200] [debug] [input:tail:in.tail.svc] inode=1407374883875495 rotated: C:\logs\svc\svc.log => C:\logs\svc\svc.log
[2026/03/13 09:39:44.336504700] [debug] [input:tail:in.tail.svc] inode=1407374883875495 rotated C:\logs\svc\svc.log -> C:\logs\svc\svc.log
[2026/03/13 09:39:44.336823100] [ info] [input:tail:in.tail.svc] inode=1407374883875495 handle rotation(): C:\logs\svc\svc.log => C:\logs\svc\svc.log
[2026/03/13 09:39:49.338439700] [debug] [input:tail:in.tail.svc] inode=1407374883875495 purge rotated file C:\logs\svc\svc.log (offset=120909 / size = 120909)
[2026/03/13 09:39:49.338471200] [debug] [input:tail:in.tail.svc] inode=1407374883875495 removing file name C:\logs\svc\svc.log
[2026/03/13 09:39:49.338552700] [debug] [input:tail:in.tail.svc] db: file deleted from database: C:\logs\svc\svc.log
[2026/03/13 09:39:59.322467100] [debug] [input:tail:in.tail.svc] inode=1407374883875495 with offset=0 appended as C:\logs\svc\svc.log
[2026/03/13 09:39:59.326828400] [debug] [input:tail:in.tail.svc] inode=1407374883875495 file=C:\logs\svc\svc.log promote to TAIL_EVENT
[2026/03/13 09:43:04.305067800] [debug] [input:tail:in.tail.svc] inode=1407374883875495 rotated: C:\logs\svc\svc.log => C:\logs\svc\svc.log
[2026/03/13 09:43:04.305146400] [debug] [input:tail:in.tail.svc] inode=1407374883875495 rotated C:\logs\svc\svc.log -> C:\logs\svc\svc.log
[2026/03/13 09:43:04.305202400] [ info] [input:tail:in.tail.svc] inode=1407374883875495 handle rotation(): C:\logs\svc\svc.log => C:\logs\svc\svc.log
[2026/03/13 09:43:09.318865100] [debug] [input:tail:in.tail.svc] inode=1407374883875495 purge rotated file C:\logs\svc\svc.log (offset=120909 / size = 120909)
[2026/03/13 09:43:09.318889600] [debug] [input:tail:in.tail.svc] inode=1407374883875495 removing file name C:\logs\svc\svc.log
[2026/03/13 09:43:09.318964600] [debug] [input:tail:in.tail.svc] db: file deleted from database: C:\logs\svc\svc.log
[2026/03/13 09:43:14.306752900] [debug] [input:tail:in.tail.svc] inode=1407374883875495 with offset=0 appended as C:\logs\svc\svc.log
[2026/03/13 09:43:14.310211200] [debug] [input:tail:in.tail.svc] inode=1407374883875495 file=C:\logs\svc\svc.log promote to TAIL_EVENT

```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved thread-safety in an internal compatibility layer to enhance stability in multithreaded scenarios.
  * Reduces risk of concurrency-related errors and intermittent crashes, improving overall reliability without changing public behavior or APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->