### PR TITLE
Ipv6 literal fixes

### DIFF
--- a/include/fluent-bit/flb_connection.h
+++ b/include/fluent-bit/flb_connection.h
@@ -36,13 +36,14 @@
 
 /* FLB_CONNECTION_MAX_LABEL_LENGTH is the maximum length of
  * any of the following variants plus an optional colon if
- * the spec includes a port number :
+ * the spec includes a port number, as well as enclosing
+ * square brackets for IPv6 addresses :
  *
- * udp://
- * tcp://
- * unix://
+ * udp://  (6 for prefix + 1 for colon + 2 for brackets = 9 total)
+ * tcp://  (6 for prefix + 1 for colon + 2 for brackets = 9 total)
+ * unix:// (7 for prefix)
  */
-#define FLB_CONNECTION_MAX_LABEL_LENGTH 7
+#define FLB_CONNECTION_MAX_LABEL_LENGTH 9
 
 #define FLB_CONNECTION_MAX_IPV4_ADDRESS_LENGTH 15
 #define FLB_CONNECTION_MAX_IPV6_ADDRESS_LENGTH 39

--- a/plugins/in_syslog/syslog_server.c
+++ b/plugins/in_syslog/syslog_server.c
@@ -164,12 +164,12 @@ static int syslog_server_net_create(struct flb_syslog *ctx)
                                             &ctx->ins->net_setup);
 
     if (ctx->downstream != NULL) {
-        flb_info("[in_syslog] %s server binding %s:%s",
+        flb_info("[in_syslog] %s server binding %s port %s",
                  ((ctx->mode == FLB_SYSLOG_TCP) ? "TCP" : "UDP"),
                  ctx->listen, ctx->port);
     }
     else {
-        flb_error("[in_syslog] could not bind address %s:%s. Aborting",
+        flb_error("[in_syslog] could not bind address %s port %s. Aborting",
                   ctx->listen, ctx->port);
 
         return -1;

--- a/src/flb_connection.c
+++ b/src/flb_connection.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <string.h>
 
 #include <fluent-bit/flb_connection.h>
 #include <fluent-bit/flb_upstream.h>
@@ -89,17 +90,23 @@ static void compose_user_friendly_remote_host(struct flb_connection *connection)
 
     connection_type = connection->stream->transport;
 
-    if (connection_type == FLB_TRANSPORT_TCP) {
+    if (connection_type == FLB_TRANSPORT_TCP ||
+        connection_type == FLB_TRANSPORT_UDP) {
+        const char *fmt;
+
+        /* If the address is an IPv6 literal, we need to
+         * enclose the address in square brackets.
+         */
+        if (strchr(connection->remote_host, ':') != NULL) {
+            fmt = "%s://[%s]:%u";
+        }
+        else {
+            fmt = "%s://%s:%u";
+        }
         snprintf(connection->user_friendly_remote_host,
                  sizeof(connection->user_friendly_remote_host),
-                 "tcp://%s:%u",
-                 connection->remote_host,
-                 connection->remote_port);
-    }
-    else if (connection_type == FLB_TRANSPORT_UDP) {
-        snprintf(connection->user_friendly_remote_host,
-                 sizeof(connection->user_friendly_remote_host),
-                 "udp://%s:%u",
+                 fmt,
+                 connection_type == FLB_TRANSPORT_TCP ? "tcp" : "udp",
                  connection->remote_host,
                  connection->remote_port);
     }

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -2145,6 +2145,7 @@ static int net_address_ip_str(flb_sockfd_t fd,
                               size_t *output_data_size)
 {
     void *address_data;
+    int   family;
     int   result;
 
     errno = 0;
@@ -2184,7 +2185,22 @@ static int net_address_ip_str(flb_sockfd_t fd,
         return -1;
     }
 
-    if ((inet_ntop(address->ss_family,
+    family = address->ss_family;
+
+    /*
+     * For IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1),
+     * emit a plain IPv4 literal instead.
+     */
+    if (address->ss_family == AF_INET6) {
+        struct in6_addr *addr6 = (struct in6_addr *) address_data;
+
+        if (IN6_IS_ADDR_V4MAPPED(addr6)) {
+            family = AF_INET;
+            address_data = &addr6->s6_addr[12];
+        }
+    }
+
+    if ((inet_ntop(family,
                    address_data,
                    output_buffer,
                    output_buffer_size)) == NULL) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes #11560 and fixes #11558 and fixes #11559

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 addresses now display with correct bracket notation in connection details.
  * IPv4-mapped IPv6 addresses are presented as IPv4 for clearer network info.
  * TCP and UDP connection displays unified for a more consistent user experience.
  * Connection label length increased to accommodate IPv6 bracketed addresses and port notation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->