### PR TITLE
in_ebpf: Add vfs trace

### DIFF
--- a/plugins/in_ebpf/in_ebpf.c
+++ b/plugins/in_ebpf/in_ebpf.c
@@ -244,7 +244,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "Trace", NULL,
      FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
-     "Set the eBPF trace to enable (for example, bind, malloc, signal). Can be set multiple times"
+     "Set the eBPF trace to enable (for example, bind, malloc, signal, vfs). Can be set multiple times"
     },
     /* EOF */
     {0}

--- a/plugins/in_ebpf/traces/includes/common/encoder.h
+++ b/plugins/in_ebpf/traces/includes/common/encoder.h
@@ -17,6 +17,8 @@ static inline char *event_type_to_string(enum event_type type) {
             return "malloc";
         case EVENT_TYPE_BIND:
             return "bind";
+        case EVENT_TYPE_VFS:
+            return "vfs";
         default:
             return "unknown";
     }

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -5,12 +5,18 @@
 #include <linux/types.h>  // For __u32, __u64, etc.
 
 #define TASK_COMM_LEN 16
+#define VFS_PATH_MAX 256
 
 enum event_type {
     EVENT_TYPE_EXECVE,
     EVENT_TYPE_SIGNAL,
     EVENT_TYPE_MEM,   // For memory operations
     EVENT_TYPE_BIND,  // Added event type for bind operations
+    EVENT_TYPE_VFS,
+};
+
+enum vfs_op {
+    VFS_OP_OPENAT,
 };
 
 /* Define memory operation types */
@@ -78,6 +84,15 @@ struct bind_event {
     int error_raw;                 // Error code for the bind operation
 };
 
+struct vfs_event {
+    enum vfs_op operation;
+    char path[VFS_PATH_MAX];
+    __u32 flags;
+    __u32 mode;
+    int fd;
+    int error_raw;
+};
+
 /* The main event structure */
 struct event {
     enum event_type type;           // Type of event (execve, signal, mem, bind)
@@ -87,6 +102,7 @@ struct event {
         struct signal_event signal;
         struct mem_event mem;       // Memory event details
         struct bind_event bind;     // Bind event details
+        struct vfs_event vfs;       // VFS event details
     } details;                      // Event-specific details
 };
 

--- a/plugins/in_ebpf/traces/traces.h
+++ b/plugins/in_ebpf/traces/traces.h
@@ -6,10 +6,12 @@
 #include "generated/trace_signal.skel.h"
 #include "generated/trace_malloc.skel.h"
 #include "generated/trace_bind.skel.h"
+#include "generated/trace_vfs.skel.h"
 
 #include "bind/handler.h"
 #include "signal/handler.h"  // Include signal handler
 #include "malloc/handler.h" // Include malloc handler
+#include "vfs/handler.h"
 
 /* Skeleton function pointer types */
 typedef void *(*trace_skel_open_func_t)(void);
@@ -58,11 +60,13 @@ struct trace_registration {
 DEFINE_GET_BPF_OBJECT(trace_signal)
 DEFINE_GET_BPF_OBJECT(trace_malloc)
 DEFINE_GET_BPF_OBJECT(trace_bind)
+DEFINE_GET_BPF_OBJECT(trace_vfs)
 
 static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_signal, trace_signal_handler),
     REGISTER_TRACE(trace_malloc, trace_malloc_handler),
     REGISTER_TRACE(trace_bind, trace_bind_handler),
+    REGISTER_TRACE(trace_vfs, trace_vfs_handler),
 };
 
 #endif // TRACE_TRACES_H

--- a/plugins/in_ebpf/traces/vfs/bpf.c
+++ b/plugins/in_ebpf/traces/vfs/bpf.c
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+#include <vmlinux.h>
+
+#define _LINUX_TYPES_H
+#define _LINUX_POSIX_TYPES_H
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns_filter.h>
+#include <gadget/types.h>
+
+#include "common/events.h"
+
+#define MAX_ENTRIES 10240
+
+struct vfs_open_args {
+    gadget_mntns_id mntns_id;
+    __u32 flags;
+    __u32 mode;
+    char path[VFS_PATH_MAX];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, __u32);
+    __type(value, struct vfs_open_args);
+} values SEC(".maps");
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int trace_vfs_openat_enter(struct syscall_trace_enter *ctx)
+{
+    __u32 tid;
+    __u64 pid_tgid;
+    __u64 mntns_id;
+    const char *filename;
+    struct vfs_open_args val = {};
+
+    mntns_id = gadget_get_mntns_id();
+    if (gadget_should_discard_mntns_id(mntns_id)) {
+        return 0;
+    }
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+
+    filename = (const char *) ctx->args[1];
+    bpf_probe_read_user_str(val.path, sizeof(val.path), filename);
+
+    val.flags = (__u32) ctx->args[2];
+    val.mode = (__u32) ctx->args[3];
+    val.mntns_id = mntns_id;
+
+    bpf_map_update_elem(&values, &tid, &val, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_openat")
+int trace_vfs_openat_exit(struct syscall_trace_exit *ctx)
+{
+    __u32 tid;
+    __u64 pid_tgid;
+    __u64 uid_gid;
+    struct vfs_open_args *val;
+    struct event *event;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+
+    val = bpf_map_lookup_elem(&values, &tid);
+    if (!val) {
+        return 0;
+    }
+
+    event = gadget_reserve_buf(&events, sizeof(*event));
+    if (!event) {
+        bpf_map_delete_elem(&values, &tid);
+        return 0;
+    }
+
+    uid_gid = bpf_get_current_uid_gid();
+
+    event->common.timestamp_raw = bpf_ktime_get_boot_ns();
+    event->common.pid = pid_tgid >> 32;
+    event->common.tid = tid;
+    event->common.uid = (u32) uid_gid;
+    event->common.gid = (u32) (uid_gid >> 32);
+    event->common.mntns_id = val->mntns_id;
+    bpf_get_current_comm(event->common.comm, sizeof(event->common.comm));
+
+    event->type = EVENT_TYPE_VFS;
+    event->details.vfs.operation = VFS_OP_OPENAT;
+    event->details.vfs.flags = val->flags;
+    event->details.vfs.mode = val->mode;
+    event->details.vfs.fd = (int) ctx->ret;
+    event->details.vfs.error_raw = ctx->ret < 0 ? -ctx->ret : 0;
+
+    __builtin_memcpy(event->details.vfs.path, val->path, sizeof(event->details.vfs.path));
+
+    gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+    bpf_map_delete_elem(&values, &tid);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/plugins/in_ebpf/traces/vfs/handler.c
+++ b/plugins/in_ebpf/traces/vfs/handler.c
@@ -1,0 +1,126 @@
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "common/events.h"
+#include "common/event_context.h"
+#include "common/encoder.h"
+
+#include "handler.h"
+
+int encode_vfs_event(struct flb_input_instance *ins,
+                     struct flb_log_event_encoder *log_encoder,
+                     const struct event *ev)
+{
+    int ret;
+
+    ret = flb_log_event_encoder_begin_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    ret = encode_common_fields(log_encoder, ev);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "operation");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, ev->details.vfs.operation);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "path");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, ev->details.vfs.path);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "flags");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, ev->details.vfs.flags);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "mode");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, ev->details.vfs.mode);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "fd");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, ev->details.vfs.fd);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "error_raw");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, ev->details.vfs.error_raw);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_commit_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int trace_vfs_handler(void *ctx, void *data, size_t data_sz)
+{
+    struct trace_event_context *event_ctx = (struct trace_event_context *) ctx;
+    struct event *ev = (struct event *) data;
+    struct flb_log_event_encoder *encoder = event_ctx->log_encoder;
+    int ret;
+
+    if (data_sz < sizeof(struct event) || ev->type != EVENT_TYPE_VFS) {
+        return -1;
+    }
+
+    ret = encode_vfs_event(event_ctx->ins, encoder, ev);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = flb_input_log_append(event_ctx->ins, NULL, 0,
+                               encoder->output_buffer, encoder->output_length);
+    if (ret == -1) {
+        return -1;
+    }
+
+    flb_log_event_encoder_reset(encoder);
+
+    return 0;
+}

--- a/plugins/in_ebpf/traces/vfs/handler.h
+++ b/plugins/in_ebpf/traces/vfs/handler.h
@@ -1,0 +1,12 @@
+#ifndef VFS_HANDLER_H
+#define VFS_HANDLER_H
+
+#include <stddef.h>
+#include "common/events.h"
+
+int trace_vfs_handler(void *ctx, void *data, size_t data_sz);
+int encode_vfs_event(struct flb_input_instance *ins,
+                     struct flb_log_event_encoder *log_encoder,
+                     const struct event *ev);
+
+#endif


### PR DESCRIPTION
<!-- Provide summary of changes -->
VFS also provides eBPF entrypoints so we can provide this type of traces.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
$ sudo bin/fluent-bit -i ebpf -ptrace=trace_vfs -o stdout 
```
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->

```
Fluent Bit v5.0.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____           _            
|  ___| |                | |   | ___ (_) |         |  ___||  _  |         | |           
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |______ __| | _____   __
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |______/ _` |/ _ \ \ / /
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /     | (_| |  __/\ V / 
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/       \__,_|\___| \_/


[2026/03/17 14:19:46.866] [ info] Configuration:
[2026/03/17 14:19:46.866] [ info]  flush time     | 1.000000 seconds
[2026/03/17 14:19:46.866] [ info]  grace          | 5 seconds
[2026/03/17 14:19:46.866] [ info]  daemon         | 0
[2026/03/17 14:19:46.866] [ info] ___________
[2026/03/17 14:19:46.866] [ info]  inputs:
[2026/03/17 14:19:46.866] [ info]      ebpf
[2026/03/17 14:19:46.866] [ info] ___________
[2026/03/17 14:19:46.866] [ info]  filters:
[2026/03/17 14:19:46.866] [ info] ___________
[2026/03/17 14:19:46.866] [ info]  outputs:
[2026/03/17 14:19:46.866] [ info]      stdout.0
[2026/03/17 14:19:46.866] [ info] ___________
[2026/03/17 14:19:46.866] [ info]  collectors:
[2026/03/17 14:19:46.866] [ info] [fluent bit] version=5.0.0, commit=d758d4212e, pid=2490979
[2026/03/17 14:19:46.867] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/03/17 14:19:46.867] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/03/17 14:19:46.867] [ info] [simd    ] SSE2
[2026/03/17 14:19:46.867] [ info] [cmetrics] version=2.0.2
[2026/03/17 14:19:46.867] [ info] [ctraces ] version=0.7.0
[2026/03/17 14:19:46.867] [ info] [input:ebpf:ebpf.0] initializing
[2026/03/17 14:19:46.867] [ info] [input:ebpf:ebpf.0] storage_strategy='memory' (memory only)
[2026/03/17 14:19:46.867] [debug] [ebpf:ebpf.0] created event channels: read=21 write=22
[2026/03/17 14:19:46.867] [debug] [input:ebpf:ebpf.0] initializing eBPF input plugin
[2026/03/17 14:19:46.867] [debug] [input:ebpf:ebpf.0] processing trace: trace_vfs
[2026/03/17 14:19:46.867] [debug] [input:ebpf:ebpf.0] setting up trace configuration for: trace_vfs
[2026/03/17 14:19:46.888] [debug] [input:ebpf:ebpf.0] attaching BPF program for trace: trace_vfs
[2026/03/17 14:19:46.890] [debug] [input:ebpf:ebpf.0] registering trace handler for: trace_vfs
[2026/03/17 14:19:46.890] [ info] [input:ebpf:ebpf.0] registered trace handler for: trace_vfs
[2026/03/17 14:19:46.890] [ info] [input:ebpf:ebpf.0] trace configuration completed for: trace_vfs
[2026/03/17 14:19:46.890] [debug] [input:ebpf:ebpf.0] setting up collector with poll interval: 1000 ms
[2026/03/17 14:19:46.890] [ info] [input:ebpf:ebpf.0] eBPF input plugin initialized successfully
[2026/03/17 14:19:46.890] [debug] [stdout:stdout.0] created event channels: read=37 write=38
[2026/03/17 14:19:46.891] [ info] [sp] stream processor started
[2026/03/17 14:19:46.891] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/03/17 14:19:46.891] [ info] [output:stdout:stdout.0] worker #0 started
[2026/03/17 14:19:47.203] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/03/17 14:19:47.203] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_vfs
[2026/03/17 14:19:47.203] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_vfs
[2026/03/17 14:19:48.203] [debug] [task] created task=0x714da4070990 id=0 OK
[2026/03/17 14:19:48.203] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/03/17 14:19:48.203] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/03/17 14:19:48.203] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_vfs
[0] ebpf.0: [[1773724787.203364419, {}], {"event_type"=>"vfs", "pid"=>982, "tid"=>982, "comm"=>"iio-sensor-prox", "operation"=>0, "path"=>"/dev/iio:device5", "flags"=>2048, "mode"=>0, "fd"=>8, "error_raw"=>0}]
[1] ebpf.0: [[1773724787.203467824, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/proc/2487125/cgroup", "flags"=>524288, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[2] ebpf.0: [[1773724787.203479856, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/proc/1/cgroup", "flags"=>524288, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[3] ebpf.0: [[1773724787.203489011, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/proc/2487125/stat", "flags"=>524288, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[4] ebpf.0: [[1773724787.203497971, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/", "flags"=>2686976, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[5] ebpf.0: [[1773724787.203506275, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/", "flags"=>2686976, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[6] ebpf.0: [[1773724787.203514271, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/", "flags"=>2686976, "mode"=>0, "fd"=>26, "error_raw"=>0}]
[7] ebpf.0: [[1773724787.203522448, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"sys", "flags"=>2752512, "mode"=>0, "fd"=>27, "error_raw"=>0}]
[8] ebpf.0: [[1773724787.203530298, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"class", "flags"=>2752512, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[9] ebpf.0: [[1773724787.203538071, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"backlight", "flags"=>2752512, "mode"=>0, "fd"=>27, "error_raw"=>0}]
[10] ebpf.0: [[1773724787.203546552, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"intel_backlight", "flags"=>2752512, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[11] ebpf.0: [[1773724787.203554624, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"..", "flags"=>2818048, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[12] ebpf.0: [[1773724787.203562754, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"..", "flags"=>2818048, "mode"=>0, "fd"=>27, "error_raw"=>0}]
[13] ebpf.0: [[1773724787.203570724, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"devices", "flags"=>2752512, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[14] ebpf.0: [[1773724787.203578495, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"pci0000:00", "flags"=>2752512, "mode"=>0, "fd"=>27, "error_raw"=>0}]
[15] ebpf.0: [[1773724787.203586334, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"0000:00:02.0", "flags"=>2752512, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[16] ebpf.0: [[1773724787.203594098, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"drm", "flags"=>2752512, "mode"=>0, "fd"=>27, "error_raw"=>0}]
[17] ebpf.0: [[1773724787.203601901, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"card1", "flags"=>2752512, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[18] ebpf.0: [[1773724787.203609786, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"card1-eDP-1", "flags"=>2752512, "mode"=>0, "fd"=>27, "error_raw"=>0}]
[19] ebpf.0: [[1773724787.203617596, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"intel_backlight", "flags"=>2752512, "mode"=>0, "fd"=>22, "error_raw"=>0}]
[20] ebpf.0: [[1773724787.203625391, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/proc/self/fd/22", "flags"=>2621696, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[21] ebpf.0: [[1773724787.203633258, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/sys/devices/pci0000:00/0000:00:02.0/drm/card1/card1-eDP-1/intel_backlight/uevent", "flags"=>524544, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[22] ebpf.0: [[1773724787.203641625, {}], {"event_type"=>"vfs", "pid"=>1004, "tid"=>1004, "comm"=>"systemd-logind", "operation"=>0, "path"=>"/run/udev/data/+backlight:intel_backlight", "flags"=>524288, "mode"=>0, "fd"=>11, "error_raw"=>0}]
[23] ebpf.0: [[1773724787.203649333, {}], {"event_type"=>"vfs", "pid"=>2490983, "tid"=>2490983, "comm"=>"(sd-bright)", "operation"=>0, "path"=>"/dev/null", "flags"=>524290, "mode"=>0, "fd"=>3, "error_raw"=>0}]
[24] ebpf.0: [[1773724787.203657159, {}], {"event_type"=>"vfs", "pid"=>2490983, "tid"=>2490983, "comm"=>"(sd-bright)", "operation"=>0, "path"=>"/sys/devices/pci0000:00/0000:00:02.0/drm/card1/card1-eDP-1/intel_backlight/brightness", "flags"=>655617, "mode"=>0, "fd"=>4, "error_raw"=>0}]
[25] ebpf.0: [[1773724787.203664982, {}], {"event_type"=>"vfs", "pid"=>1517883, "tid"=>1517883, "comm"=>"systemd-udevd", "operation"=>0, "path"=>"/run/udev/queue", "flags"=>2752512, "mode"=>0, "fd"=>-2, "error_raw"=>2}]
[26] ebpf.0: [[1773724787.203673033, {}], {"event_type"=>"vfs", "pid"=>1517883, "tid"=>1517883, "comm"=>"systemd-udevd", "operation"=>0, "path"=>"/run/udev/queue", "flags"=>524481, "mode"=>420, "fd"=>16, "error_raw"=>0}]
[27] ebpf.0: [[1773724787.203680813, {}], {"event_type"=>"vfs", "pid"=>2486417, "tid"=>2486417, "comm"=>"(udev-worker)", "operation"=>0, "path"=>"/run/udev/data/+backlight:intel_backlight", "flags"=>524288, "mode"=>0, "fd"=>18, "error_raw"=>0}]
[2026/03/17 14:19:48.204] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_vfs
[28] ebpf.0: [[1773724787.203688796, {}], {"event_type"=>"vfs", "pid"=>2486417, "tid"=>2486417, "comm"=>"(udev-worker)", "operation"=>0, "path"=>"/", "flags"=>2686976, "mode"=>0, "fd"=>18, "error_raw"=>0}]
```
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VFS event tracing (captures openat operations)
  * Captures operation details: path, flags, mode, file descriptor, and error info
  * Per-thread tracking and mount-namespace filtering to reduce noise

* **Documentation**
  * Updated configuration examples to include the new "vfs" trace option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->