### PR TITLE
tests: runtime_shell: Don't use Golang compiler on RISC-V 64bit Linux

### DIFF
--- a/tests/runtime_shell/CMakeLists.txt
+++ b/tests/runtime_shell/CMakeLists.txt
@@ -18,7 +18,11 @@ set(UNIT_TESTS_SH
   )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  list(APPEND UNIT_TESTS_SH proxy_logs_expect.sh)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64)")
+    message(STATUS "We don't test Golang plugins on RISC-V 64bit platform for now")
+  else()
+    list(APPEND UNIT_TESTS_SH proxy_logs_expect.sh)
+  endif()
 endif()
 
 # Prepare list of unit tests


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, riscv64 architecture is not assumed to test Golang plugin in our CI tasks.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to conditionally skip certain proxy log tests on RISC-V 64-bit Linux systems while maintaining existing behavior on other Linux architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->