### PR TITLE
out_kafka: add add_timestamp option to suppress timestamp field

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -153,47 +153,58 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     if (ctx->format == FLB_KAFKA_FMT_JSON || ctx->format == FLB_KAFKA_FMT_MSGP) {
-        /* Make room for the timestamp */
-        size = map->via.map.size + 1;
+        if (ctx->add_timestamp) {
+            /* Make room for the timestamp */
+            size = map->via.map.size + 1;
+        }
+        else {
+            size = map->via.map.size;
+        }
         msgpack_pack_map(&mp_pck, size);
 
-        /* Pack timestamp */
-        msgpack_pack_str(&mp_pck, ctx->timestamp_key_len);
-        msgpack_pack_str_body(&mp_pck,
-                              ctx->timestamp_key, ctx->timestamp_key_len);
-        switch (ctx->timestamp_format) {
-            case FLB_JSON_DATE_DOUBLE:
-                msgpack_pack_double(&mp_pck, flb_time_to_double(tm));
-                break;
+        if (ctx->add_timestamp) {
+            /* Pack timestamp */
+            msgpack_pack_str(&mp_pck, ctx->timestamp_key_len);
+            msgpack_pack_str_body(&mp_pck,
+                                  ctx->timestamp_key, ctx->timestamp_key_len);
+            switch (ctx->timestamp_format) {
+                case FLB_JSON_DATE_DOUBLE:
+                    msgpack_pack_double(&mp_pck, flb_time_to_double(tm));
+                    break;
 
-            case FLB_JSON_DATE_ISO8601:
-            case FLB_JSON_DATE_ISO8601_NS:
-                {
-                size_t date_len;
-                int len;
-                struct tm _tm;
-                char time_formatted[36];
+                case FLB_JSON_DATE_ISO8601:
+                case FLB_JSON_DATE_ISO8601_NS:
+                    {
+                    size_t date_len;
+                    int len;
+                    struct tm _tm;
+                    char time_formatted[36];
 
-                /* Format the time; use microsecond precision (not nanoseconds). */
-                gmtime_r(&tm->tm.tv_sec, &_tm);
-                date_len = strftime(time_formatted, sizeof(time_formatted) - 1,
-                             FLB_JSON_DATE_ISO8601_FMT, &_tm);
+                    /* Format the time; use microsecond precision (not nanoseconds). */
+                    gmtime_r(&tm->tm.tv_sec, &_tm);
+                    date_len = strftime(time_formatted, sizeof(time_formatted) - 1,
+                                 FLB_JSON_DATE_ISO8601_FMT, &_tm);
 
-                if (ctx->timestamp_format == FLB_JSON_DATE_ISO8601) {
-                    len = snprintf(time_formatted + date_len, sizeof(time_formatted) - 1 - date_len,
-                                   ".%06" PRIu64 "Z", (uint64_t) tm->tm.tv_nsec / 1000);
-                }
-                else {
-                    /* FLB_JSON_DATE_ISO8601_NS */
-                    len = snprintf(time_formatted + date_len, sizeof(time_formatted) - 1 - date_len,
-                                   ".%09" PRIu64 "Z", (uint64_t) tm->tm.tv_nsec);
-                }
-                date_len += len;
+                    if (ctx->timestamp_format == FLB_JSON_DATE_ISO8601) {
+                        len = snprintf(time_formatted + date_len,
+                                       sizeof(time_formatted) - 1 - date_len,
+                                       ".%06" PRIu64 "Z",
+                                       (uint64_t) tm->tm.tv_nsec / 1000);
+                    }
+                    else {
+                        /* FLB_JSON_DATE_ISO8601_NS */
+                        len = snprintf(time_formatted + date_len,
+                                       sizeof(time_formatted) - 1 - date_len,
+                                       ".%09" PRIu64 "Z",
+                                       (uint64_t) tm->tm.tv_nsec);
+                    }
+                    date_len += len;
 
-                msgpack_pack_str(&mp_pck, date_len);
-                msgpack_pack_str_body(&mp_pck, time_formatted, date_len);
-                }
-                break;
+                    msgpack_pack_str(&mp_pck, date_len);
+                    msgpack_pack_str_body(&mp_pck, time_formatted, date_len);
+                    }
+                    break;
+            }
         }
     }
     else {
@@ -601,6 +612,12 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_STR, "timestamp_format", (char *)NULL,
     0, FLB_TRUE, offsetof(struct flb_out_kafka, timestamp_format_str),
     "Set the format the timestamp is in."
+   },
+   {
+    FLB_CONFIG_MAP_BOOL, "add_timestamp", "true",
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, add_timestamp),
+    "When enabled, a timestamp field (timestamp_key) is appended to the record. "
+    "Set to false to suppress the timestamp field entirely."
    },
    {
     FLB_CONFIG_MAP_INT, "queue_full_retries", FLB_KAFKA_QUEUE_FULL_RETRIES,

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -75,6 +75,7 @@ struct flb_out_kafka {
     char *timestamp_key;
     int timestamp_format;
     flb_sds_t timestamp_format_str;
+    int add_timestamp;
 
     int message_key_len;
     char *message_key;


### PR DESCRIPTION
The Kafka output plugin unconditionally injects an @timestamp field into every record when using json or msgpack formats. This prevents users from piping data through Fluent Bit into downstream Kafka consumers (e.g. JDBC sink connector) that enforce a strict schema, as the extra field causes schema mismatch errors.

Add a new boolean config option `add_timestamp` (default: true) that controls whether the timestamp field is injected into the output record. When set to false, the field is omitted entirely.

This is fully backward compatible — existing configurations are unaffected since the option defaults to true.

Example usage to disable timestamp injection:

    [OUTPUT]
        Name          kafka
        Match         *
        Brokers       localhost:9092
        Topics        my-topic
        add_timestamp false

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `add_timestamp` configuration option to the Kafka output plugin
  * Timestamp fields are now appended to records by default
  * Can be disabled to suppress timestamp fields and reduce message size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->