### PR TITLE
coro: Extend coro stack for SIMD operated yyjson

### DIFF
--- a/include/fluent-bit/flb_coro.h
+++ b/include/fluent-bit/flb_coro.h
@@ -71,10 +71,16 @@ struct flb_coro {
 #define STACK_FACTOR 1
 #endif
 
+#ifdef FLB_HAVE_SIMD
+#define SIMD_STACK_FACTOR 2   /* Use bigger size for coro stacks with SIMD */
+#else
+#define SIMD_STACK_FACTOR 1   /* no-op */
+#endif
+
 #ifdef FLB_CORO_STACK_SIZE
 #define FLB_CORO_STACK_SIZE_BYTE      FLB_CORO_STACK_SIZE
 #else
-#define FLB_CORO_STACK_SIZE_BYTE      ((3 * STACK_FACTOR * PTHREAD_STACK_MIN) / 2)
+#define FLB_CORO_STACK_SIZE_BYTE      ((3 * STACK_FACTOR * SIMD_STACK_FACTOR * PTHREAD_STACK_MIN) / 2)
 #endif
 
 #define FLB_CORO_DATA(coro)      (((char *) coro) + sizeof(struct flb_coro))


### PR DESCRIPTION
<!-- Provide summary of changes -->
### Root Cause Analysis

Enabling SIMD causes the default JSON pack APIs (`flb_pack_json()` and `flb_pack_json_recs()`) to be routed through the extensible (`_ext`) path, which selects the **YYJSON backend**.

The YYJSON parser (`yyjson_read_opts()`) allocates a **very large stack frame (~38 KiB)** at function entry:

```asm
sub $0x9520, %rsp   // ~38 KiB
```

```
(gdb) disassemble /r yyjson_read_opts Dump of assembler code for function yyjson_read_opts:
 0x000055555592a6f0 <+0>: 55 push %rbp
 0x000055555592a6f1 <+1>: 48 89 e5 mov %rsp,%rbp
 0x000055555592a6f4 <+4>: 48 81 ec 20 95 00 00 sub $0x9520,%rsp
 => 0x000055555592a6fb <+11>: 48 89 bd e8 6f ff ff mov %rdi,-0x9018(%rbp)
 0x000055555592a702 <+18>: 48 89 b5 e0 6f ff ff mov %rsi,-0x9020(%rbp)
 0x000055555592a709 <+25>: 89 95 dc 6f ff ff mov %edx,-0x9024(%rbp)
 0x000055555592a70f <+31>: 48 89 8d d0 6f ff ff mov %rcx,-0x9030(%rbp)
 0x000055555592a716 <+38>: 4c 89 85 c8 6f ff ff mov %r8,-0x9038(%rbp)
 0x000055555592a71d <+45>: 48 8b 05 64 58 e2 00 mov 0xe25864(%rip),%rax # 0x55555674ff88  
 0x000055555592a724 <+52>: 48 8b 38 mov (%rax),%rdi
```

In the current execution context (libco coroutine stack), this exceeds the available stack space. As a result, the stack pointer (`rsp`) crosses into an unmapped/guard region immediately after the allocation. The crash occurs at the first local variable write:

```asm
mov %rdi, -0x9018(%rbp)
```

This happens **before any JSON parsing logic executes**, so the failure is not related to input data or parsing correctness.

---

### Key Observations

* Function arguments are passed correctly (verified via registers: `rdi`, `rsi`, `rdx`, etc.).
* The crash occurs in the **function prologue**, not in parsing logic.
* `yyjson_read_opts()` requires significantly more stack than the legacy pack path.
* Increasing coroutine stack size (e.g., via `STACK_FACTOR`) did not resolve the issue, indicating:

  * The change may not affect this execution context, or
  * The effective available stack is still insufficient.

---

### Why This Is a Regression

Before this change:

```
flb_pack_json → legacy path (small stack usage)
```

After this change (with SIMD enabled):

```
flb_pack_json → _ext → yyjson → ~38 KiB stack usage
```

This rerouting exposes existing callers (e.g., output plugins like Kinesis) to a backend whose stack requirements are incompatible with the coroutine stack constraints.

---

### Conclusion

The issue is **not caused by invalid inputs or API misuse**, but by:

> Routing the default JSON pack APIs to a backend (`yyjson`) that requires a large stack frame, which exceeds the limits of the libco coroutine stack.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized coroutine stack memory allocation to better utilize system resources and improve performance when SIMD support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->