### PR TITLE
tests: internal: Disable cumulative delta case on Windows because of unistd.h

### DIFF
--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -118,8 +118,14 @@ if(FLB_METRICS)
   set(UNIT_TESTS_FILES
     ${UNIT_TESTS_FILES}
     metrics.c
-    cumulative_to_delta.c
     )
+
+  if (NOT WIN32)
+    set(UNIT_TESTS_FILES
+      ${UNIT_TESTS_FILES}
+      cumulative_to_delta.c
+    )
+  endif()
 endif()
 
 if(FLB_HTTP_SERVER)
@@ -256,7 +262,7 @@ endfunction(prepare_unit_tests)
 
 prepare_unit_tests(flb-it- "${UNIT_TESTS_FILES}")
 
-if(FLB_METRICS AND FLB_PROCESSOR_CUMULATIVE_TO_DELTA)
+if(FLB_METRICS AND FLB_PROCESSOR_CUMULATIVE_TO_DELTA AND NOT WIN32)
   set(CUMULATIVE_TO_DELTA_PLUGIN_DIR
     ${PROJECT_SOURCE_DIR}/plugins/processor_cumulative_to_delta)
   set(CUMULATIVE_TO_DELTA_CORE_SOURCE


### PR DESCRIPTION
<!-- Provide summary of changes -->
Windows does not have unistd.h.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Restricts certain unit tests and related integration wiring to non-Windows platforms, ensuring platform-specific test compilation and plugin integration occur only where supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->