### PR TITLE
tests: fixed Windows support for cumulative_to_delta test case

### DIFF
--- a/tests/internal/cumulative_to_delta.c
+++ b/tests/internal/cumulative_to_delta.c
@@ -1,8 +1,8 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <math.h>
-#include <unistd.h>
 
+#include <fluent-bit/flb_compat.h>
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_decode_opentelemetry.h>


### PR DESCRIPTION
This PR fixes part of issue with building of internal tests on Windows - refer to https://github.com/fluent/fluent-bit/pull/11472#discussion_r2961218101. The 2nd part of the fix is located in https://github.com/fluent/cmetrics/pull/258 which after merging needs to be copied (as part of CMetrics library) into this repository.

----

**Testing**

Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change.
- [N/A] Debug log output from testing the change.
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature.

**Backporting**

- [N/A] Backport to latest stable release.

**Related PRs in other repositories**

1. https://github.com/fluent/cmetrics/pull/258 for similar changes in CMetrics library.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows header handling to avoid conflicts and ensure cleaner builds on Windows.
* **Tests**
  * Replaced a direct POSIX include in a test with the project's compatibility header to standardize test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->