### PR TITLE
tests: core_routes: Handle limit of rlimit's soft limit

### DIFF
--- a/tests/runtime/core_routes.c
+++ b/tests/runtime/core_routes.c
@@ -2,6 +2,12 @@
 
 #include <fluent-bit.h>
 #include <fluent-bit/flb_time.h>
+#ifdef FLB_SYSTEM_MACOS
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/resource.h>
+#endif
 #include "flb_tests_runtime.h"
 
 pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -44,7 +50,11 @@ void flb_test_basic_functionality_test(void)
     int                   result;
     size_t                index;
     flb_ctx_t            *ctx;
-
+    size_t                olimit = 257;
+#ifdef FLB_SYSTEM_MACOS
+    struct rlimit rlim;
+    int           rlimit_rc;
+#endif
     cb_context = 0;
 
     /* Prepare output callback with expected result */
@@ -56,9 +66,20 @@ void flb_test_basic_functionality_test(void)
     input_instance = flb_input(ctx, (char *) "lib", NULL);
     TEST_CHECK(input_instance >= 0);
 
+#ifdef FLB_SYSTEM_MACOS
+    rlimit_rc = getrlimit(RLIMIT_NOFILE, &rlim);
+    TEST_CHECK(rlimit_rc == 0);
+    if (rlimit_rc == 0 && rlim.rlim_cur > 10) {
+        olimit = (size_t)(rlim.rlim_cur / 2.5);
+        if (olimit < 2) {
+            olimit = 2;
+        }
+    }
+#endif
+
     flb_input_set(ctx, input_instance, "tag", "test", NULL);
 
-    for (index = 0 ; index < 257 ; index++) {
+    for (index = 0 ; index < olimit ; index++) {
         output_instances[index] = flb_output(ctx, (char *) "lib", &cb_data);
         TEST_CHECK(output_instances[index] >= 0);
 
@@ -82,14 +103,14 @@ void flb_test_basic_functionality_test(void)
     delivery_counter = get_output_num();
 
     for (index = 0 ;
-         index < 100 && delivery_counter < 257 ;
+         index < 100 && delivery_counter < olimit ;
          index++) {
         flb_time_msleep(100);
 
         delivery_counter = get_output_num();
     }
 
-    TEST_CHECK(delivery_counter == 257);
+    TEST_CHECK(delivery_counter == olimit);
 
     flb_stop(ctx);
     flb_destroy(ctx);


### PR DESCRIPTION
By default, macOS's soft limit of rlimit is up to 256. SO, just eating up 256 of output instances could cause too many open errors.

This is because the default value of masOS's `ulimit -n` is:

```console
$ ulimit -n
256
```
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability on macOS by adapting expected delivery counts to the system's file-descriptor limits at runtime; tests now scale with local resource limits, reducing false failures and making CI/local runs more robust and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->