### PR TITLE
out_azure_kusto: fix SIGSEGV crashes, resource handle leaks, and HTTP buffer sizing

### DIFF
--- a/plugins/out_azure_kusto/azure_kusto.c
+++ b/plugins/out_azure_kusto/azure_kusto.c
@@ -39,6 +39,12 @@
 #include "azure_msiauth.h"
 #include "azure_kusto_store.h"
 
+/**
+ * Retrieve an OAuth2 access token using Managed Service Identity (MSI).
+ *
+ * @param ctx  Plugin's context containing the OAuth2 configuration.
+ * @return int 0 on success, -1 on failure.
+ */
 static int azure_kusto_get_msi_token(struct flb_azure_kusto *ctx)
 {
     char *token;
@@ -46,13 +52,19 @@ static int azure_kusto_get_msi_token(struct flb_azure_kusto *ctx)
     /* Retrieve access token */
     token = flb_azure_msiauth_token_get(ctx->o);
     if (!token) {
-        flb_plg_error(ctx->ins, "error retrieving oauth2 access token");
+        flb_plg_error(ctx->ins, "error retrieving oauth2 access token (MSI access token is NULL)");
         return -1;
     }
 
     return 0;
 }
 
+/**
+ * Retrieve an OAuth2 access token using workload identity federation.
+ *
+ * @param ctx  Plugin's context containing workload identity configuration.
+ * @return int 0 on success, -1 on failure.
+ */
 static int azure_kusto_get_workload_identity_token(struct flb_azure_kusto *ctx)
 {
     int ret;
@@ -70,6 +82,15 @@ static int azure_kusto_get_workload_identity_token(struct flb_azure_kusto *ctx)
     return 0;
 }
 
+/**
+ * Retrieve an OAuth2 access token using service principal credentials.
+ *
+ * Constructs the OAuth2 payload with client credentials and requests
+ * an access token from the configured OAuth2 endpoint.
+ *
+ * @param ctx  Plugin's context containing client credentials and OAuth2 config.
+ * @return int 0 on success, -1 on failure.
+ */
 static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
 {
     int ret;
@@ -100,11 +121,13 @@ static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
         flb_plg_error(ctx->ins, "error appending oauth2 params");
         return -1;
     }
-
     /* Retrieve access token */
     char *token = flb_oauth2_token_get(ctx->o);
     if (!token) {
-        flb_plg_error(ctx->ins, "error retrieving oauth2 access token");
+        flb_plg_error(ctx->ins, "error retrieving oauth2 access token - "
+                      "check Fluent Bit logs for '[oauth2]' errors "
+                      "(common causes: connection failure to '%s', invalid credentials, "
+                      "or malformed response)", ctx->oauth_url ? ctx->oauth_url : "unknown");
         return -1;
     }
 
@@ -112,13 +135,22 @@ static int azure_kusto_get_service_principal_token(struct flb_azure_kusto *ctx)
     return 0;
 }
 
+/**
+ * Obtain the current Azure Kusto bearer token as a formatted string.
+ *
+ * Acquires the token mutex, refreshes the token if expired based on the
+ * configured authentication type, and returns a copy of the token string
+ * in the format "<token_type> <access_token>".
+ *
+ * @param ctx  Plugin's context.
+ * @return flb_sds_t  The bearer token string, or NULL on error.
+ */
 flb_sds_t get_azure_kusto_token(struct flb_azure_kusto *ctx)
 {
     int ret = 0;
     flb_sds_t output = NULL;
 
     if (pthread_mutex_lock(&ctx->token_mutex)) {
-        flb_plg_error(ctx->ins, "error locking mutex");
         return NULL;
     }
 
@@ -144,6 +176,9 @@ flb_sds_t get_azure_kusto_token(struct flb_azure_kusto *ctx)
                                      flb_sds_len(ctx->o->access_token) + 2);
         if (!output) {
             flb_plg_error(ctx->ins, "error creating token buffer");
+            if (pthread_mutex_unlock(&ctx->token_mutex)) {
+                flb_plg_error(ctx->ins, "error unlocking mutex");
+            }
             return NULL;
         }
         flb_sds_snprintf(&output, flb_sds_alloc(output), "%s %s", ctx->o->token_type,
@@ -411,6 +446,7 @@ static int ingest_all_chunks(struct flb_azure_kusto *ctx, struct flb_config *con
     struct mk_list *tmp;
     struct mk_list *head;
     struct mk_list *f_head;
+    struct mk_list *f_tmp;
     struct flb_fstore_file *fsf;
     struct flb_fstore_stream *fs_stream;
     flb_sds_t payload = NULL;
@@ -428,9 +464,14 @@ static int ingest_all_chunks(struct flb_azure_kusto *ctx, struct flb_config *con
             continue;
         }
 
-        mk_list_foreach_safe(f_head, tmp, &fs_stream->files) {
+        mk_list_foreach_safe(f_head, f_tmp, &fs_stream->files) {
             fsf = mk_list_entry(f_head, struct flb_fstore_file, _head);
             chunk = fsf->data;
+
+            /* Skip files with no associated chunk data (may happen during shutdown) */
+            if (chunk == NULL) {
+                continue;
+            }
 
             /* Locked chunks are being processed, skip */
             if (chunk->locked == FLB_TRUE) {
@@ -893,6 +934,7 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         if (ret == -1) {
             flb_plg_error(ctx->ins, "Failed to initialize kusto storage: %s",
                           ctx->store_dir);
+            flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
         ctx->has_old_buffers = azure_kusto_store_has_data(ctx);
@@ -900,14 +942,20 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         /* validate 'total_file_size' */
         if (ctx->file_size <= 0) {
             flb_plg_error(ctx->ins, "Failed to parse upload_file_size");
+            azure_kusto_store_exit(ctx);
+            flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
         if (ctx->file_size < 1000000) {
             flb_plg_error(ctx->ins, "upload_file_size must be at least 1MB");
+            azure_kusto_store_exit(ctx);
+            flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
         if (ctx->file_size > MAX_FILE_SIZE) {
             flb_plg_error(ctx->ins, "Max total_file_size must be lower than %ld bytes", MAX_FILE_SIZE);
+            azure_kusto_store_exit(ctx);
+            flb_azure_kusto_conf_destroy(ctx);
             return -1;
         }
 
@@ -934,14 +982,21 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
      * Create upstream context for Kusto Ingestion endpoint
      */
     ctx->u = flb_upstream_create_url(config, ctx->ingestion_endpoint, io_flags, ins->tls);
+    if (!ctx->u) {
+        flb_plg_error(ctx->ins, "upstream creation failed");
+        if (ctx->buffering_enabled == FLB_TRUE) {
+            azure_kusto_store_exit(ctx);
+        }
+        pthread_mutex_destroy(&ctx->resources_mutex);
+        pthread_mutex_destroy(&ctx->token_mutex);
+        pthread_mutex_destroy(&ctx->blob_mutex);
+        flb_azure_kusto_conf_destroy(ctx);
+        return -1;
+    }    
     if (ctx->buffering_enabled ==  FLB_TRUE){
         flb_stream_disable_flags(&ctx->u->base, FLB_IO_ASYNC);
         ctx->u->base.net.io_timeout = ctx->io_timeout;
         ctx->has_old_buffers = azure_kusto_store_has_data(ctx);
-    }
-    if (!ctx->u) {
-        flb_plg_error(ctx->ins, "upstream creation failed");
-        return -1;
     }
 
     flb_plg_debug(ctx->ins, "async flag is %d", flb_stream_is_async(&ctx->u->base));
@@ -951,6 +1006,14 @@ static int cb_azure_kusto_init(struct flb_output_instance *ins, struct flb_confi
         flb_oauth2_create(ctx->config, ctx->oauth_url, FLB_AZURE_KUSTO_TOKEN_REFRESH);
     if (!ctx->o) {
         flb_plg_error(ctx->ins, "cannot create oauth2 context");
+        if (ctx->buffering_enabled == FLB_TRUE) {
+            azure_kusto_store_exit(ctx);
+        }
+        flb_upstream_destroy(ctx->u);
+        pthread_mutex_destroy(&ctx->resources_mutex);
+        pthread_mutex_destroy(&ctx->token_mutex);
+        pthread_mutex_destroy(&ctx->blob_mutex);
+        flb_azure_kusto_conf_destroy(ctx);
         return -1;
     }
     flb_output_upstream_set(ctx->u, ins);
@@ -1114,6 +1177,19 @@ static int azure_kusto_format(struct flb_azure_kusto *ctx, const char *tag, int 
     return 0;
 }
 
+/**
+ * Buffer a data chunk into the file storage for later ingestion.
+ *
+ * Writes the formatted chunk data to the upload file via the store layer.
+ *
+ * @param out_context  Plugin's context (cast to struct flb_azure_kusto).
+ * @param upload_file  Target file handle for buffered storage.
+ * @param chunk        Data chunk to buffer.
+ * @param chunk_size   Size of the data chunk.
+ * @param tag          Fluent Bit tag associated with the chunk.
+ * @param tag_len      Length of the tag string.
+ * @return int         0 on success, -1 on failure.
+ */
 static int buffer_chunk(void *out_context, struct azure_kusto_file *upload_file,
                         flb_sds_t chunk, int chunk_size,
                         flb_sds_t tag, size_t tag_len)

--- a/plugins/out_azure_kusto/azure_kusto.h
+++ b/plugins/out_azure_kusto/azure_kusto.h
@@ -84,6 +84,15 @@ struct flb_azure_kusto_resources {
 
     /* used to reload resouces after some time */
     uint64_t load_time;
+
+    /* flag to prevent concurrent coroutines from reloading simultaneously */
+    int loading_in_progress;
+
+    /* Old resources pending cleanup - deferred destruction to avoid use-after-free
+     * when other threads may still be using them during high-volume operations */
+    struct flb_upstream_ha *old_blob_ha;
+    struct flb_upstream_ha *old_queue_ha;
+    flb_sds_t old_identity_token;
 };
 
 struct flb_azure_kusto {

--- a/plugins/out_azure_kusto/azure_kusto_conf.c
+++ b/plugins/out_azure_kusto/azure_kusto_conf.c
@@ -146,6 +146,22 @@ static int flb_azure_kusto_resources_clear(struct flb_azure_kusto_resources *res
         resources->identity_token = NULL;
     }
 
+    /* Also clean up any old resources pending destruction */
+    if (resources->old_blob_ha) {
+        flb_upstream_ha_destroy(resources->old_blob_ha);
+        resources->old_blob_ha = NULL;
+    }
+
+    if (resources->old_queue_ha) {
+        flb_upstream_ha_destroy(resources->old_queue_ha);
+        resources->old_queue_ha = NULL;
+    }
+
+    if (resources->old_identity_token) {
+        flb_sds_destroy(resources->old_identity_token);
+        resources->old_identity_token = NULL;
+    }
+
     resources->load_time = 0;
 
     return 0;
@@ -548,14 +564,48 @@ int azure_kusto_load_ingestion_resources(struct flb_azure_kusto *ctx,
     flb_plg_debug(ctx->ins, "difference is  %" PRIu64, now - ctx->resources->load_time);
     flb_plg_debug(ctx->ins, "effective ingestion resource interval is %d", ctx->ingestion_resources_refresh_interval * 1000 + generated_random_integer);
 
+    /* Acquire the mutex for the staleness check to prevent concurrent coroutines
+     * from both deciding to reload and rotate resources simultaneously.
+     * Without this, two flushes can race: the second rotation destroys old_blob_ha
+     * which is still being used by the first flush's in-flight blob upload,
+     * causing a use-after-free SIGSEGV in cmt_gauge_inc.
+     */
+    if (pthread_mutex_lock(&ctx->resources_mutex)) {
+        flb_plg_error(ctx->ins, "error locking resources mutex for staleness check");
+        return -1;
+    }
+
     /* check if we have all resources and they are not stale */
     if (ctx->resources->blob_ha && ctx->resources->queue_ha &&
         ctx->resources->identity_token &&
         now - ctx->resources->load_time < ctx->ingestion_resources_refresh_interval * 1000 + generated_random_integer) {
         flb_plg_debug(ctx->ins, "resources are already loaded and are not stale");
+        pthread_mutex_unlock(&ctx->resources_mutex);
         ret = 0;
     }
+    else if (ctx->resources->loading_in_progress) {
+        /*
+         * Another coroutine is already loading resources. Return error to
+         * trigger FLB_RETRY so this flush will be retried once the resources
+         * are available. This prevents concurrent rotations that caused
+         * use-after-free SIGSEGV.
+         */
+        flb_plg_info(ctx->ins, "ingestion resources loading already in progress by another coroutine, will retry");
+        pthread_mutex_unlock(&ctx->resources_mutex);
+        /* Return -1 directly without going through cleanup, since cleanup
+         * would reset load_time and loading_in_progress which belong to
+         * the coroutine that is actually doing the loading.
+         */
+        return -1;
+    }
     else {
+        /*
+         * Mark loading in progress (while holding mutex) to prevent other
+         * concurrent coroutines from also starting a reload.
+         */
+        ctx->resources->loading_in_progress = FLB_TRUE;
+        /* Release the mutex before making network calls (which may yield the coroutine) */
+        pthread_mutex_unlock(&ctx->resources_mutex);
         flb_plg_info(ctx->ins, "loading kusto ingestion resources and refresh interval is %d", ctx->ingestion_resources_refresh_interval * 1000 + generated_random_integer);
         response = execute_ingest_csl_command(ctx, ".get ingestion resources");
 
@@ -598,16 +648,57 @@ int azure_kusto_load_ingestion_resources(struct flb_azure_kusto *ctx,
                                     parse_ingestion_identity_token(ctx, response);
 
                             if (identity_token) {
+                                /* 
+                                    Deferred cleanup: destroy resources from two refresh cycles ago,
+                                    then move current resources to 'old' before assigning new ones.
+                                    This avoids use-after-free when other threads may still be using
+                                    the current resources during high-volume operations.
+                                    
+                                    With a 1-hour refresh interval, the race condition requires an 
+                                    ingest operation to take >1 hour (the deferred cleanup grace period). 
+                                    This is extremely unlikely under normal conditions (and hence a lock based 
+                                    mechanism is avoided for performance).
+                                */
+                                if (ctx->resources->old_blob_ha) {
+                                    flb_upstream_ha_destroy(ctx->resources->old_blob_ha);
+                                    flb_plg_debug(ctx->ins, "clearing up old blob HA");
+                                }
+                                if (ctx->resources->old_queue_ha) {
+                                    flb_upstream_ha_destroy(ctx->resources->old_queue_ha);
+                                    flb_plg_debug(ctx->ins, "clearing up old queue HA");
+                                }
+                                if (ctx->resources->old_identity_token) {
+                                    flb_sds_destroy(ctx->resources->old_identity_token);
+                                    flb_plg_debug(ctx->ins, "clearing up old identity token");
+                                }
+
+                                /* Move current to old */
+                                ctx->resources->old_blob_ha = ctx->resources->blob_ha;
+                                ctx->resources->old_queue_ha = ctx->resources->queue_ha;
+                                ctx->resources->old_identity_token = ctx->resources->identity_token;
+
+                                /* Assign new resources */
                                 ctx->resources->blob_ha = blob_ha;
                                 ctx->resources->queue_ha = queue_ha;
                                 ctx->resources->identity_token = identity_token;
                                 ctx->resources->load_time = now;
 
+                                flb_plg_info(ctx->ins, "ingestion resources rotated successfully, "
+                                             "previous resources moved to deferred cleanup");
+
+                                /* Clear the loading flag on success */
+                                ctx->resources->loading_in_progress = FLB_FALSE;
                                 ret = 0;
                             }
                             else {
                                 flb_plg_error(ctx->ins,
                                               "error parsing ingestion identity token");
+                                /*
+                                 * Must unlock the mutex before goto cleanup to avoid
+                                 * deadlock (cleanup also acquires the mutex to reset
+                                 * load_time). This was a pre-existing bug.
+                                 */
+                                pthread_mutex_unlock(&ctx->resources_mutex);
                                 ret = -1;
                                 goto cleanup;
                             }
@@ -665,6 +756,16 @@ int azure_kusto_load_ingestion_resources(struct flb_azure_kusto *ctx,
 
     cleanup:
     if (ret == -1) {
+        /*
+         * Reset load_time to 0 so the next call will retry the reload.
+         * We set load_time = now at the start to prevent concurrent reloads,
+         * but if the reload failed, we need to allow future retries.
+         */
+        if (pthread_mutex_lock(&ctx->resources_mutex) == 0) {
+            ctx->resources->load_time = 0;
+            ctx->resources->loading_in_progress = FLB_FALSE;
+            pthread_mutex_unlock(&ctx->resources_mutex);
+        }
         if (queue_ha) {
             flb_upstream_ha_destroy(queue_ha);
         }

--- a/plugins/out_azure_kusto/azure_kusto_ingest.c
+++ b/plugins/out_azure_kusto/azure_kusto_ingest.c
@@ -188,13 +188,14 @@ static flb_sds_t azure_kusto_create_blob(struct flb_azure_kusto *ctx, flb_sds_t 
             goto cleanup;
         }
 
+
         if (uri) {
-            flb_plg_debug(ctx->ins, "azure_kusto: before calling azure storage api :: value of set io_timeout is %d", u_conn->net->io_timeout);
             flb_plg_debug(ctx->ins, "uploading payload to blob uri: %s", uri);
             c = flb_http_client(u_conn, FLB_HTTP_PUT, uri, payload, payload_size, NULL, 0,
                                 NULL, 0);
 
             if (c) {
+                flb_http_buffer_size(c, 0);
                 flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
                 flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
                 flb_http_add_header(c, "x-ms-blob-type", 14, "BlockBlob", 9);
@@ -451,6 +452,7 @@ static int azure_kusto_enqueue_ingestion(struct flb_azure_kusto *ctx, flb_sds_t 
                                     flb_sds_len(payload), NULL, 0, NULL, 0);
 
                 if (c) {
+                    flb_http_buffer_size(c, 0);
                     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
                     flb_http_add_header(c, "Content-Type", 12, "application/atom+xml",
                                         20);

--- a/plugins/out_azure_kusto/azure_msiauth.c
+++ b/plugins/out_azure_kusto/azure_msiauth.c
@@ -62,6 +62,9 @@ char *flb_azure_msiauth_token_get(struct flb_oauth2 *ctx)
          return NULL;
      }
 
+     /* Allow response buffer to grow as needed */
+     flb_http_buffer_size(c, 0);
+
      /* Append HTTP Header */
      flb_http_add_header(c, "Metadata", 8, "true", 4);
 
@@ -205,6 +208,9 @@ int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *to
         flb_sds_destroy(body); /* Clean up allocated body */
         return -1;
     }
+
+    /* Allow response buffer to grow as needed */
+    flb_http_buffer_size(c, 0);
 
     /* Prepare token exchange request headers */
     flb_http_add_header(c, "Content-Type", 12, "application/x-www-form-urlencoded", 33);


### PR DESCRIPTION
this PR fixes several stability and reliability fixes for the out_azure_kusto plugin:

- **Defer close old resource handles in next cycle** — prevents use-after-free by deferring destruction of old resource handles to the next rotation cycle
- **Add comments & logs for cleanup** — improved logging and documentation for resource cleanup paths
- **Close OAuth handles in case of failure** — proper cleanup of OAuth handles on error paths to prevent handle leaks
- **Add comments** — additional code documentation for clarity
- **Fix SIGSEGV crashes from concurrent resource rotation and shutdown** — fixes segfault caused by concurrent access during resource rotation and plugin shutdown
- **Increased HTTP buffer size configuration** — allows HTTP response buffer to grow as needed for MSI auth and workload identity token endpoints

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication error logging for improved troubleshooting of MSI and OAuth2 token failures with clearer context
  * Strengthened resource cleanup during initialization to prevent resource leaks
  * Added protection against concurrent resource reloading conflicts to improve stability
  * Optimized HTTP client buffer sizing for more reliable Azure ingestion operations
  * Improved error handling in token retrieval and mutex management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->