### PR TITLE
simd: Define a fallback of flb_vector8_eq on RVV

### DIFF
--- a/include/fluent-bit/flb_simd.h
+++ b/include/fluent-bit/flb_simd.h
@@ -215,22 +215,34 @@ static inline flb_vector8 flb_vector8_ssub(const flb_vector8 v1, const flb_vecto
 /*
  * Return a vector with all bits set in each lane where the corresponding
  * lanes in the inputs are equal.
+ * For CI or dockerized riscv64 environment, it doesn't have SIMD extension.
+ * So, we need to define the fallback.
  */
-#ifndef FLB_SIMD_NONE
 static inline flb_vector8 flb_vector8_eq(const flb_vector8 v1, const flb_vector8 v2)
 {
-#ifdef FLB_SIMD_SSE2
-	return _mm_cmpeq_epi8(v1, v2);
+#if defined(FLB_SIMD_SSE2)
+    return _mm_cmpeq_epi8(v1, v2);
 #elif defined(FLB_SIMD_NEON)
-	return vceqq_u8(v1, v2);
+    return vceqq_u8(v1, v2);
 #elif defined(FLB_SIMD_RVV)
-	vbool8_t ret = __riscv_vmseq_vv_u8m1_b8(v1, v2, RVV_VEC8_INST_LEN);
-	return __riscv_vmerge_vvm_u8m1(__riscv_vmv_v_x_u8m1(0, RVV_VEC8_INST_LEN),
-								   __riscv_vmv_v_x_u8m1(UINT8_MAX, RVV_VEC8_INST_LEN),
-								   ret, RVV_VEC8_INST_LEN);
+    vbool8_t ret = __riscv_vmseq_vv_u8m1_b8(v1, v2, RVV_VEC8_INST_LEN);
+    return __riscv_vmerge_vvm_u8m1(__riscv_vmv_v_x_u8m1(0, RVV_VEC8_INST_LEN),
+                                   __riscv_vmv_v_x_u8m1(UINT8_MAX, RVV_VEC8_INST_LEN),
+                                   ret, RVV_VEC8_INST_LEN);
+#else
+    flb_vector8 result = 0;
+    size_t i;
+    const uint8_t *p1 = (const uint8_t *) &v1;
+    const uint8_t *p2 = (const uint8_t *) &v2;
+    uint8_t *out = (uint8_t *) &result;
+
+    for (i = 0; i < sizeof(flb_vector8); i++) {
+        out[i] = (p1[i] == p2[i]) ? UINT8_MAX : 0;
+    }
+
+    return result;
 #endif
 }
-#endif /* ! FLB_SIMD_NONE */
 
 #ifndef FLB_SIMD_NONE
 static inline flb_vector32 flb_vector32_eq(const flb_vector32 v1, const flb_vector32 v2)


### PR DESCRIPTION
<!-- Provide summary of changes -->

This is an extracted patch from https://github.com/fluent/fluent-bit/pull/11608.
In CI or containerized environment of riscv64, there's no SIMD extensions.
So, we need to define flb_vector8_eq implementation with a fallback.

The CI result of tried to enable SIMD on riscv64 is (green: 🟢 )
https://github.com/fluent/fluent-bit/actions/runs/23449977325/job/68227133002


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vector comparison operations to work consistently across different hardware configurations and SIMD availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->