### PR TITLE
pack: Check whether inside of coroutine or not

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -671,12 +671,22 @@ int flb_pack_json(const char *js, size_t len, char **buffer, size_t *size,
 #ifdef FLB_HAVE_SIMD
     /*
      * When SIMD support is compiled in, route the default JSON pack API through
-     * the extensible frontend so callers inherit the YYJSON backend selection.
+     * the extensible frontend so callers inherit the YYJSON backend
+     * selection.
+     * However, all of the defaulting to use YYSJON is dangerous on
+     * coroutine.
+     * So, we only enabled it for normal thread.
+     * Still, we use legacy backend on using coroutine.
      * Explicit backend-specific entry points remain available for forced JSMN
      * or YYJSON behavior.
      */
-    return flb_pack_json_recs_ext(js, len, buffer, size, root_type,
-                                  &records, consumed, NULL);
+    if (flb_coro_get() != NULL) {
+        return flb_pack_json_legacy(js, len, buffer, size, root_type, consumed);
+    }
+    else {
+        return flb_pack_json_recs_ext(js, len, buffer, size, root_type,
+                                      &records, consumed, NULL);
+    }
 #endif
 
     return flb_pack_json_legacy(js, len, buffer, size, root_type, consumed);


### PR DESCRIPTION
<!-- Provide summary of changes -->

This is another attempt of https://github.com/fluent/fluent-bit/pull/11586.
When compiling with SIMD and using YYJSON which is stack based high performance JSON library, it causes SEGV on processing large size of JSON.
Plus, inside of coroutines, we often experienced SEGV which is caused by stack overflow that is ran out of the allocated size of coroutine.
So, we should detect the JSON component could be running on whether coroutine or not.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
