### PR TITLE
feat: openssl tls.key_file pkcs11:

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -917,8 +917,7 @@ static void *tls_context_create(int verify,
     if (key_file) {
         if (strncmp(key_file, "pkcs11:", 7) == 0) {
 #ifdef OPENSSL_NO_ENGINE
-            flb_error("[tls] pkcs11_key_file '%s': requires OpenSSL ENGINE support",
-                        key_file);
+            flb_error("[tls] key_file 'pkcs11:<REDACTED>': requires OpenSSL ENGINE support");
             goto error;
 #else
             /* PKCS#11 URI detected */


### PR DESCRIPTION
implements #10506 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS can load private keys from PKCS#11 (pkcs11:) URIs, enabling hardware-backed keys (HSM) alongside existing PEM file support.
  * Key/certificate matching validation remains performed after key installation.

* **Bug Fixes**
  * Missing or empty PIN for PKCS#11 URIs now emits a warning instead of hard-failing, improving robustness when PINs are managed externally.
  * Attempts to use PKCS#11 without platform support now produce an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->