### PR TITLE
input_thread: replace raw read() with pipe abstraction to fix crash

### DIFF
--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -59,9 +59,9 @@ static inline int handle_input_event(flb_pipefd_t fd, struct flb_input_instance 
     uint64_t val;
     struct flb_config *config = ins->config;
 
-    bytes = read(fd, &val, sizeof(val));
+    bytes = flb_pipe_r(fd, &val, sizeof(val));
     if (bytes == -1) {
-        flb_errno();
+        flb_pipe_error();
         return -1;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
## Issue
In `handle_input_event()`, the raw POSIX `read()` syscall was used to read from the pipe file descriptor:
```
bytes = read(fd, &val, sizeof(val));
if (bytes == -1) {
    flb_errno();
    return -1;
}
```
On Windows, `read()` is not compatible with pipe file descriptors created by Fluent Bit's `flb_pipe` abstraction layer, which can cause a crash or undefined behavior. Even on Linux, bypassing the abstraction is inconsistent with the rest of the codebase.
The crash we get on windows is like:
```
fluent_bit!_invoke_watson+0x18 [minkernel\crts\ucrt\src\appcrt\misc\invalid_parameter.cpp @ 237]
fluent_bit!_invalid_parameter_internal+0xb6 [minkernel\crts\ucrt\src\appcrt\misc\invalid_parameter.cpp @ 113]
fluent_bit!_invalid_parameter+0x52 [minkernel\crts\ucrt\src\appcrt\misc\invalid_parameter.cpp @ 125]
fluent_bit!_invalid_parameter_noinfo+0x19 [minkernel\crts\ucrt\src\appcrt\misc\invalid_parameter.cpp @ 131]
fluent_bit!_read+0x8b [minkernel\crts\ucrt\src\appcrt\lowio\read.cpp @ 403]
fluent_bit!handle_input_event+0x19 [D:\a\_work\1\s\src\flb_input_thread.c @ 62]
fluent_bit!input_thread+0x5f7 [D:\a\_work\1\s\src\flb_input_thread.c @ 466]
fluent_bit!step_callback+0x25 [D:\a\_work\1\s\src\flb_worker.c @ 46]
fluent_bit!pthread_create_wrapper+0x73 [D:\a\_work\1\s\lib\monkey\mk_core\external\winpthreads.c @ 660]
fluent_bit!thread_start_unsigned int (__cdecl*)(void *),1_+0x4f [minkernel\crts\ucrt\src\appcrt\startup\thread.cpp @ 97]
kernel32!BaseThreadInitThunk+0x10 [clientcore\base\win32\client\thread.c @ 75]
ntdll!RtlUserThreadStart+0x2b [minkernel\ntdll\rtlstrt.c @ 1152]
```
## Solution
Replace the `raw read()` call with the cross-platform `flb_pipe_r()` abstraction, and replace `flb_errno()` with `flb_pipe_error()` for consistent error reporting — matching the pattern already used in `handle_input_thread_event()` and elsewhere in the same file:
```
bytes = flb_pipe_r(fd, &val, sizeof(val));
if (bytes == -1) {
    flb_pipe_error();
    return -1;
}
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
Crashes disappeared after this change when enabled threaded in my test environment.
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting accuracy in input thread event processing for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->