### PR TITLE
build: Detect version bump to permit "release: " prefix

### DIFF
--- a/.github/scripts/commit_prefix_check.py
+++ b/.github/scripts/commit_prefix_check.py
@@ -178,6 +178,47 @@ def detect_bad_squash(body):
 # Validate commit based on expected behavior and test rules
 # ------------------------------------------------
 def validate_commit(commit):
+    VERSION_PATTERN = re.compile(
+        r"set\(FLB_VERSION_(MAJOR|MINOR|PATCH)\s+\d+\)"
+    )
+
+    def is_version_bump(commit):
+        if not commit.parents:
+            return False
+
+        diffs = commit.diff(commit.parents[0], create_patch=True)
+        found_version_change = False
+        saw_cmakelists = False
+
+        for d in diffs:
+            path = (d.b_path or "").replace("\\", "/")
+
+            if not path.endswith("CMakeLists.txt"):
+                continue
+
+            saw_cmakelists = True
+            patch = d.diff.decode(errors="ignore")
+
+            for line in patch.splitlines():
+                stripped = line.lstrip()
+
+                if not stripped:
+                    continue
+
+                if stripped.startswith(("diff --git ", "index ", "@@ ", "+++ ", "--- ")):
+                    continue
+
+                if not stripped.startswith(("+", "-")):
+                    continue
+
+                if VERSION_PATTERN.search(stripped):
+                    found_version_change = True
+                    continue
+
+                return False
+
+        return saw_cmakelists and found_version_change
+
     msg = commit.message.strip()
     first_line, *rest = msg.split("\n")
     body = "\n".join(rest)
@@ -224,6 +265,14 @@ def validate_commit(commit):
             "The repository checkout is likely missing commit parent history. "
             "Use a full-depth checkout for commit-prefix validation."
         )
+
+    # -------------------------------
+    # release special rule
+    # -------------------------------
+    if is_version_bump(commit):
+        if not first_line.startswith("release:"):
+            return False, "Version bump must use release: prefix"
+        return True, ""
 
     expected, build_optional = infer_prefix_from_paths(files)
 

--- a/.github/scripts/tests/test_commit_lint.py
+++ b/.github/scripts/tests/test_commit_lint.py
@@ -910,3 +910,68 @@ def test_valid_commit_multiline_subject_ignored():
     )
     ok, _ = validate_commit(commit)
     assert ok is True
+
+
+class FakeDiff:
+    def __init__(self, path, patch):
+        self.b_path = path
+        self.diff = patch.encode()
+
+
+class FakeStats:
+    def __init__(self, files):
+        self.files = {f: {} for f in files}
+
+
+class FakeCommit:
+    def __init__(self, message, diffs):
+        self.message = message
+        self._diffs = diffs
+        self.parents = [object()]
+
+        file_paths = [d.b_path for d in diffs]
+        self.stats = FakeStats(file_paths)
+
+    def diff(self, parent, create_patch=True):
+        return self._diffs
+
+
+def make_fake_commit(message, changes):
+    """
+    changes: list of (path, patch)
+    """
+    diffs = [FakeDiff(path, patch) for path, patch in changes]
+    return FakeCommit(message, diffs)
+
+def test_release_with_version_bump():
+    commit = make_fake_commit(
+        "release: update to 5.0.2\n\nSigned-off-by: User",
+        [
+            ("CMakeLists.txt", """
+-set(FLB_VERSION_PATCH  0)
++set(FLB_VERSION_PATCH  2)
+"""),
+            ("dockerfiles/Dockerfile", """
+-FROM fluent-bit:5.0.0
++FROM fluent-bit:5.0.2
+""")
+        ]
+    )
+
+    ok, msg = validate_commit(commit)
+    assert ok is True, msg
+
+def test_release_rejected_when_cmakelists_has_non_version_change():
+    commit = make_fake_commit(
+        "release: update to 5.0.2\n\nSigned-off-by: User",
+        [
+            ("CMakeLists.txt", """
+-set(FLB_VERSION_PATCH  0)
++set(FLB_VERSION_PATCH  2)
++set(SOME_FLAG ON)
+""")
+        ]
+    )
+
+    ok, _ = validate_commit(commit)
+    assert ok is False


### PR DESCRIPTION
<!-- Provide summary of changes -->

Version bumping process that we always use needs to use `release:` prefix but this rule is not implemented in our linter. So, we need to handle this.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced commit validation for version bump releases. Version update commits now require the `release:` prefix in the commit message and cannot include unrelated changes.
  * Added automated tests to verify release commit validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->