### PR TITLE
parser: add IANA time_zone support for naive timestamps

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -49,6 +49,7 @@ struct flb_parser {
     char *time_key;       /* field name that contains the time */
     int time_offset;      /* fixed UTC offset */
     int time_system_timezone; /* use the system timezone as a fallback */
+    char *time_zone;      /* IANA timezone for naive timestamps (e.g. America/New_York) */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
     int logfmt_no_bare_keys; /* in logfmt parsers, require all keys to have values */
@@ -75,21 +76,10 @@ enum {
     FLB_PARSER_TYPE_HEX,
 };
 
-static inline time_t flb_parser_tm2time(const struct flb_tm *src,
-                                        int use_system_timezone)
-{
-    struct tm tmp;
-    time_t res;
+time_t flb_parser_tm2time_simple(const struct flb_tm *src,
+                                 int use_system_timezone);
 
-    tmp = src->tm;
-    if (use_system_timezone) {
-        tmp.tm_isdst = -1;
-        res = mktime(&tmp);
-    } else {
-        res = timegm(&tmp) - flb_tm_gmtoff(src);
-    }
-    return res;
-}
+time_t flb_parser_tm2time(const struct flb_tm *src, struct flb_parser *parser);
 
 
 struct flb_parser *flb_parser_create(const char *name, const char *format,
@@ -100,6 +90,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      int time_keep,
                                      int time_strict,
                                      int time_system_timezone,
+                                     const char *time_zone,
                                      int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -227,7 +227,7 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
         return -2;
     }
 
-    val->tm.tv_sec = flb_parser_tm2time(&tm, FLB_FALSE);
+    val->tm.tv_sec = flb_parser_tm2time_simple(&tm, FLB_FALSE);
     val->tm.tv_nsec = 0;
 
     return 0;

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -42,7 +42,70 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include <fluent-bit/flb_pthread.h>
+
+static pthread_mutex_t flb_time_zone_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+time_t flb_parser_tm2time_simple(const struct flb_tm *src, int use_system_timezone)
+{
+    struct tm tmp;
+    time_t res;
+
+    tmp = src->tm;
+    if (use_system_timezone) {
+        tmp.tm_isdst = -1;
+        res = mktime(&tmp);
+    }
+    else {
+        res = timegm(&tmp) - flb_tm_gmtoff(src);
+    }
+    return res;
+}
+
+time_t flb_parser_tm2time(const struct flb_tm *src, struct flb_parser *parser)
+{
+#ifndef FLB_SYSTEM_WINDOWS
+    if (parser->time_zone) {
+        char *old_tz = NULL;
+        const char *prev;
+        struct tm tmp;
+        time_t res;
+
+        pthread_mutex_lock(&flb_time_zone_mutex);
+        prev = getenv("TZ");
+        if (prev) {
+            old_tz = flb_strdup(prev);
+            if (!old_tz) {
+                pthread_mutex_unlock(&flb_time_zone_mutex);
+                return (time_t) -1;
+            }
+        }
+        if (setenv("TZ", parser->time_zone, 1) != 0) {
+            flb_free(old_tz);
+            pthread_mutex_unlock(&flb_time_zone_mutex);
+            return (time_t) -1;
+        }
+        tzset();
+        tmp = src->tm;
+        tmp.tm_isdst = -1;
+        res = mktime(&tmp);
+        if (old_tz) {
+            setenv("TZ", old_tz, 1);
+            flb_free(old_tz);
+        }
+        else {
+            unsetenv("TZ");
+        }
+        tzset();
+        pthread_mutex_unlock(&flb_time_zone_mutex);
+        return res;
+    }
+#endif
+    return flb_parser_tm2time_simple(src, parser->time_system_timezone);
+}
 
 static inline uint32_t digits10(uint64_t v) {
     if (v < 10) return 1;
@@ -140,6 +203,9 @@ static void flb_interim_parser_destroy(struct flb_parser *parser)
     if (parser->time_key) {
         flb_free(parser->time_key);
     }
+    if (parser->time_zone) {
+        flb_free(parser->time_zone);
+    }
 
     mk_list_del(&parser->_head);
     flb_free(parser);
@@ -153,6 +219,7 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      int time_keep,
                                      int time_strict,
                                      int time_system_timezone,
+                                     const char *time_zone,
                                      int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,
@@ -230,6 +297,24 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     }
 
     p->name = flb_strdup(name);
+
+#if defined(FLB_SYSTEM_WINDOWS)
+    if (time_zone && time_zone[0]) {
+        flb_error("[parser:%s] time_zone is not supported on Windows", name);
+        mk_list_del(&p->_head);
+        flb_free(p->name);
+        flb_free(p);
+        return NULL;
+    }
+#endif
+
+    if (time_zone && time_zone[0] && !time_fmt) {
+        flb_error("[parser:%s] time_zone requires time_format", name);
+        mk_list_del(&p->_head);
+        flb_free(p->name);
+        flb_free(p);
+        return NULL;
+    }
 
     if (time_fmt) {
         p->time_fmt_full = flb_strdup(time_fmt);
@@ -319,11 +404,33 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
          */
         p->time_system_timezone = time_system_timezone;
 
+        if (time_zone && time_zone[0]) {
+            if (time_system_timezone) {
+                flb_error("[parser:%s] time_zone cannot be combined with "
+                          "time_system_timezone",
+                          name);
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+            if (time_offset && time_offset[0]) {
+                flb_error("[parser:%s] time_zone cannot be combined with "
+                          "time_offset",
+                          name);
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+            p->time_zone = flb_strdup(time_zone);
+            if (!p->time_zone) {
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+        }
+
         /*
          * Optional fixed timezone offset, only applied if
-         * not falling back to system timezone.
+         * not falling back to system timezone or IANA time_zone.
          */
-        if (!p->time_system_timezone && time_offset) {
+        if (!p->time_system_timezone && !p->time_zone && time_offset) {
             diff = 0;
             len = strlen(time_offset);
             ret = flb_parser_tzone_offset(time_offset, len, &diff);
@@ -366,6 +473,9 @@ void flb_parser_destroy(struct flb_parser *parser)
     }
     if (parser->time_key) {
         flb_free(parser->time_key);
+    }
+    if (parser->time_zone) {
+        flb_free(parser->time_zone);
     }
     if (parser->types_len != 0) {
         for (i=0; i<parser->types_len; i++){
@@ -492,6 +602,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     flb_sds_t time_fmt;
     flb_sds_t time_key;
     flb_sds_t time_offset;
+    flb_sds_t time_zone;
     flb_sds_t types_str;
     flb_sds_t tmp_str;
     int skip_empty;
@@ -513,6 +624,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         time_fmt = NULL;
         time_key = NULL;
         time_offset = NULL;
+        time_zone = NULL;
         types_str = NULL;
         tmp_str = NULL;
 
@@ -582,6 +694,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         /* time_offset (UTC offset) */
         time_offset = get_parser_key(config, cf, s, "time_offset");
 
+        /* time_zone (IANA region, DST-aware; Unix only) */
+        time_zone = get_parser_key(config, cf, s, "time_zone");
+
         /* logfmt_no_bare_keys */
         logfmt_no_bare_keys = FLB_FALSE;
         tmp_str = get_parser_key(config, cf, s, "logfmt_no_bare_keys");
@@ -605,7 +720,8 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         /* Create the parser context */
         if (!flb_parser_create(name, format, regex, skip_empty,
                                time_fmt, time_key, time_offset, time_keep, time_strict,
-                               time_system_timezone, logfmt_no_bare_keys, types, types_len,
+                               time_system_timezone, time_zone, logfmt_no_bare_keys,
+                               types, types_len,
                                decoders, config)) {
             goto fconf_error;
         }
@@ -627,6 +743,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         if (time_offset) {
             flb_sds_destroy(time_offset);
         }
+        if (time_zone) {
+            flb_sds_destroy(time_zone);
+        }
         if (types_str) {
             flb_sds_destroy(types_str);
         }
@@ -635,8 +754,8 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
 
     return 0;
 
- /* Use early exit before call to flb_parser_create */
- fconf_early_error:
+    /* Use early exit before call to flb_parser_create */
+    fconf_early_error:
     if (name) {
         flb_sds_destroy(name);
     }
@@ -662,6 +781,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     }
     if (time_offset) {
         flb_sds_destroy(time_offset);
+    }
+    if (time_zone) {
+        flb_sds_destroy(time_zone);
     }
     if (types_str) {
         flb_sds_destroy(types_str);
@@ -1271,7 +1393,12 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
     }
 
     if (parser->time_with_tz == FLB_FALSE) {
-        flb_tm_gmtoff(tm) = parser->time_offset;
+        if (parser->time_zone) {
+            flb_tm_gmtoff(tm) = 0;
+        }
+        else {
+            flb_tm_gmtoff(tm) = parser->time_offset;
+        }
     }
 
     return 0;

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -211,7 +211,7 @@ int flb_parser_json_do(struct flb_parser *parser,
         skip = map_size;
     }
     else {
-        time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+        time_lookup = flb_parser_tm2time(&tm, parser);
     }
 
     /* Compose a new map without the time_key field */

--- a/src/flb_parser_logfmt.c
+++ b/src/flb_parser_logfmt.c
@@ -166,7 +166,7 @@ static int logfmt_parser(struct flb_parser *parser,
                                   parser->name, parser->time_fmt_full);
                         return -1;
                     }
-                    *time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+                    *time_lookup = flb_parser_tm2time(&tm, parser);
                 }
                 time_found = FLB_TRUE;
             }

--- a/src/flb_parser_ltsv.c
+++ b/src/flb_parser_ltsv.c
@@ -139,7 +139,7 @@ static int ltsv_parser(struct flb_parser *parser,
                                  parser->name, parser->time_fmt_full);
                        return -1;
                     }
-                    *time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+                    *time_lookup = flb_parser_tm2time(&tm, parser);
                 }
                 time_found = FLB_TRUE;
             }

--- a/src/flb_parser_regex.c
+++ b/src/flb_parser_regex.c
@@ -87,7 +87,7 @@ static void cb_results(const char *name, const char *value,
             }
 
             pcb->time_frac = frac;
-            pcb->time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+            pcb->time_lookup = flb_parser_tm2time(&tm, parser);
 
             if (parser->time_keep == FLB_FALSE) {
                 pcb->num_skipped++;

--- a/src/multiline/flb_ml_parser_cri.c
+++ b/src/multiline/flb_ml_parser_cri.c
@@ -41,6 +41,7 @@ static struct flb_parser *cri_parser_create(struct flb_config *config)
                           FLB_TRUE,                /* time keep */
                           FLB_FALSE,               /* time strict */
                           FLB_FALSE,               /* time system timezone */
+                          NULL,                    /* time zone (IANA) */
                           FLB_FALSE,               /* no bare keys */
                           NULL,                    /* parser types */
                           0,                       /* types len */

--- a/src/multiline/flb_ml_parser_docker.c
+++ b/src/multiline/flb_ml_parser_docker.c
@@ -36,6 +36,7 @@ static struct flb_parser *docker_parser_create(struct flb_config *config)
                           FLB_TRUE,               /* time keep */
                           FLB_FALSE,              /* time strict */
                           FLB_FALSE,              /* time system timezone */
+                          NULL,                   /* time zone (IANA) */
                           FLB_FALSE,              /* no bare keys */
                           NULL,                   /* parser types */
                           0,                      /* types len */

--- a/tests/internal/fuzzers/engine_fuzzer.c
+++ b/tests/internal/fuzzers/engine_fuzzer.c
@@ -143,7 +143,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv) {
 
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
                                 "%s.%L", "time", NULL, MK_FALSE, 0, FLB_FALSE,
-                               FLB_FALSE, NULL, 0, NULL, ctx->config);
+                               NULL, FLB_FALSE, NULL, 0, NULL, ctx->config);
     filter_ffd = flb_filter(ctx, (char *) "parser", NULL);
     int ret;
     ret = flb_filter_set(ctx, filter_ffd, "Match", "test",

--- a/tests/internal/fuzzers/parse_json_fuzzer.c
+++ b/tests/internal/fuzzers/parse_json_fuzzer.c
@@ -51,7 +51,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     }
 
     fuzz_parser = flb_parser_create("fuzzer", "json", NULL, FLB_TRUE, NULL,
-                                    NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                                    NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                     NULL, 0, NULL, fuzz_config);
     if (fuzz_parser) {
         flb_parser_do(fuzz_parser, (char*)data, size,

--- a/tests/internal/fuzzers/parse_logfmt_fuzzer.c
+++ b/tests/internal/fuzzers/parse_logfmt_fuzzer.c
@@ -32,7 +32,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     }
     fuzz_parser = flb_parser_create("fuzzer", "logfmt", NULL, FLB_TRUE,
                                     NULL, NULL, NULL, MK_FALSE,
-                                    MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                                    MK_TRUE, FLB_FALSE, NULL, FLB_FALSE, NULL, 0,
                                     NULL, fuzz_config);
     if (fuzz_parser) {
         flb_parser_do(fuzz_parser, (char*)data, size,

--- a/tests/internal/fuzzers/parse_ltsv_fuzzer.c
+++ b/tests/internal/fuzzers/parse_ltsv_fuzzer.c
@@ -18,8 +18,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
     /* ltsvc parser */
     fuzz_config = flb_config_init();
     fuzz_parser = flb_parser_create("fuzzer", "ltsv", NULL, FLB_TRUE,
-                                    NULL, NULL, NULL, MK_FALSE, 
-                                    MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                                    NULL, NULL, NULL, MK_FALSE,
+                                    MK_TRUE, FLB_FALSE, NULL, FLB_FALSE, NULL, 0,
                                     NULL, fuzz_config);
     flb_parser_do(fuzz_parser, (char*)data, size,
                   &out_buf, &out_size, &out_time);

--- a/tests/internal/fuzzers/parser_fuzzer.c
+++ b/tests/internal/fuzzers/parser_fuzzer.c
@@ -154,7 +154,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     /* now call into the parser */
     fuzz_parser = flb_parser_create("fuzzer", format, pregex, FLB_TRUE,
             time_fmt, time_key, time_offset, time_keep, 0, FLB_FALSE,
-            FLB_FALSE, types, types_len, list, fuzz_config);
+            NULL, FLB_FALSE, types, types_len, list, fuzz_config);
 
     /* Second step is to use the random parser to parse random input */
     if (fuzz_parser != NULL) {

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -231,7 +231,7 @@ void test_parser_time_lookup()
             continue;
         }
 
-        epoch = flb_parser_tm2time(&tm, FLB_FALSE);
+        epoch = flb_parser_tm2time(&tm, p);
         epoch -= year_diff;
         TEST_CHECK(t->epoch == epoch);
         TEST_CHECK(t->frac_seconds == ns);
@@ -517,6 +517,114 @@ void test_mysql_unquoted()
 
 }
 
+/*
+ * IANA time_zone (DST-aware) for naive timestamps; requires tzdata on the system.
+ */
+void test_parser_time_zone_iana(void)
+{
+#ifndef FLB_SYSTEM_WINDOWS
+    struct flb_config *config;
+    struct flb_parser *p;
+    struct flb_tm tm;
+    double ns;
+    time_t epoch;
+    int ret;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        return;
+    }
+
+    p = flb_parser_create("iana_ny", "regex",
+                          "^(?<time>.*)$",
+                          FLB_FALSE,
+                          "%m/%d/%Y %H:%M:%S",
+                          "time",
+                          NULL,
+                          FLB_FALSE,
+                          FLB_TRUE,
+                          FLB_FALSE,
+                          "America/New_York",
+                          FLB_FALSE,
+                          NULL, 0, NULL, config);
+    if (!TEST_CHECK(p != NULL)) {
+        flb_config_exit(config);
+        return;
+    }
+
+    ret = flb_parser_time_lookup("07/17/2017 16:17:03", 19, 0, p, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time(&tm, p);
+    TEST_CHECK(epoch == (time_t) 1500322623);
+
+    ret = flb_parser_time_lookup("01/15/2017 15:00:00", 19, 0, p, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time(&tm, p);
+    TEST_CHECK(epoch == (time_t) 1484510400);
+
+    flb_parser_destroy(p);
+    flb_config_exit(config);
+#else
+    TEST_CHECK(1);
+#endif
+}
+
+/*
+ * IANA Australia/Sydney: southern-hemisphere DST (AEDT +11 vs AEST +10).
+ */
+void test_parser_time_zone_iana_australia(void)
+{
+#ifndef FLB_SYSTEM_WINDOWS
+    struct flb_config *config;
+    struct flb_parser *p;
+    struct flb_tm tm;
+    double ns;
+    time_t epoch;
+    int ret;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        return;
+    }
+
+    p = flb_parser_create("iana_sydney", "regex",
+                          "^(?<time>.*)$",
+                          FLB_FALSE,
+                          "%m/%d/%Y %H:%M:%S",
+                          "time",
+                          NULL,
+                          FLB_FALSE,
+                          FLB_TRUE,
+                          FLB_FALSE,
+                          "Australia/Sydney",
+                          FLB_FALSE,
+                          NULL, 0, NULL, config);
+    if (!TEST_CHECK(p != NULL)) {
+        flb_config_exit(config);
+        return;
+    }
+
+    /* January: AEDT (daylight); same wall-clock seasonality as NY July test */
+    ret = flb_parser_time_lookup("01/15/2017 15:00:00", 19, 0, p, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time(&tm, p);
+    TEST_CHECK(epoch == (time_t) 1484452800);
+
+    /* July: AEST (standard) */
+    ret = flb_parser_time_lookup("07/17/2017 16:17:03", 19, 0, p, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time(&tm, p);
+    TEST_CHECK(epoch == (time_t) 1500272223);
+
+    flb_parser_destroy(p);
+    flb_config_exit(config);
+#else
+    TEST_CHECK(1);
+#endif
+}
+
 
 TEST_LIST = {
     { "tzone_offset", test_parser_tzone_offset},
@@ -524,5 +632,7 @@ TEST_LIST = {
     { "json_time_lookup", test_json_parser_time_lookup},
     { "regex_time_lookup", test_regex_parser_time_lookup},
     { "mysql_unquoted" , test_mysql_unquoted },
+    { "time_zone_iana", test_parser_time_zone_iana },
+    { "time_zone_iana_australia", test_parser_time_zone_iana_australia },
     { 0 }
 };

--- a/tests/internal/parser_json.c
+++ b/tests/internal/parser_json.c
@@ -171,7 +171,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -223,7 +223,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -365,7 +365,7 @@ void test_types_is_not_supported()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -450,7 +450,7 @@ void test_decode_field_json()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, decoder, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -505,7 +505,7 @@ void test_time_key_kept_if_parse_fails()
     }
 
     parser = flb_parser_create("json", "json", NULL, FLB_FALSE, time_format, "time", NULL,
-                               FLB_FALSE, FLB_TRUE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/internal/parser_logfmt.c
+++ b/tests/internal/parser_logfmt.c
@@ -171,7 +171,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -223,7 +223,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -361,7 +361,7 @@ void test_types()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("logfmt", "logfmt", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/internal/parser_ltsv.c
+++ b/tests/internal/parser_ltsv.c
@@ -171,7 +171,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -223,7 +223,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -361,7 +361,7 @@ void test_types()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -446,7 +446,7 @@ void test_decode_field_json()
     }
 
     parser = flb_parser_create("ltsv", "ltsv", NULL, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, decoder, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/internal/parser_regex.c
+++ b/tests/internal/parser_regex.c
@@ -172,7 +172,7 @@ void test_basic()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -225,7 +225,7 @@ void test_time_key()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -365,7 +365,7 @@ void test_types()
     types->type = FLB_PARSER_TYPE_HEX;
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                types, 1, NULL, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");
@@ -451,7 +451,7 @@ void test_decode_field_json()
     }
 
     parser = flb_parser_create("regex", "regex", regex, FLB_FALSE, NULL, NULL, NULL,
-                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, decoder, config);
     if (!TEST_CHECK(parser != NULL)) {
         TEST_MSG("flb_parser_create failed");

--- a/tests/runtime/filter_parser.c
+++ b/tests/runtime/filter_parser.c
@@ -108,7 +108,7 @@ void flb_test_filter_parser_extract_fields()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -195,7 +195,7 @@ void flb_test_filter_parser_record_accessor()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -282,7 +282,7 @@ void flb_test_filter_parser_reserve_data_off()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -360,7 +360,7 @@ void flb_test_filter_parser_handle_time_key()
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
                                "%Y-%m-%dT%H:%M:%S.%L",
                                "time",
-                               NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                               NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -438,7 +438,7 @@ void flb_test_filter_parser_handle_time_key_with_fractional_timestamp()
     parser = flb_parser_create("timestamp", "regex", "^(?<time>.*)$", FLB_TRUE,
                                "%s.%L",
                                "time",
-                               NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                               NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -527,6 +527,7 @@ void flb_test_filter_parser_handle_time_key_with_time_zone()
                                MK_FALSE, // time_keep
                                MK_TRUE, // time_strict
                                FLB_FALSE, // time_system_timezone
+                               NULL, // time_zone (IANA)
                                MK_FALSE, // logfmt_no_bare_keys
                                NULL, // types
                                0, // types_len
@@ -654,6 +655,7 @@ void test_parser_timestamp_timezone(char *tz,
                              MK_FALSE,
                              MK_TRUE,
                              use_system_timezone,
+                             NULL,
                              MK_FALSE,
                              NULL, 0,
                              NULL,
@@ -785,7 +787,7 @@ void flb_test_filter_parser_ignore_malformed_time()
     parser = flb_parser_create("timestamp", "regex",
                                "^(?<time>.*)$", FLB_TRUE,
                                "%Y-%m-%dT%H:%M:%S.%L", "time",
-                               NULL, FLB_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                               NULL, FLB_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -863,7 +865,7 @@ void flb_test_filter_parser_preserve_original_field()
     /* Parser */
     parser = flb_parser_create("dummy_test", "regex", "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE, NULL, 0,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE, NULL, 0,
                                NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -948,13 +950,13 @@ void flb_test_filter_parser_first_matched_when_mutilple_parser()
     /* Parser */
     parser = flb_parser_create("one", "regex", "^(?<one>.+?)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
     parser = flb_parser_create("two", "regex", "^(?<two>.+?)$",
                                FLB_TRUE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -1035,7 +1037,7 @@ void flb_test_filter_parser_skip_empty_values_false()
     /* Parser */
     parser = flb_parser_create("one", "regex", "^(?<one>.+?)$",
                                FLB_FALSE,
-                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, FLB_FALSE,
+                               NULL, NULL, NULL, MK_FALSE, MK_TRUE, FLB_FALSE, NULL, FLB_FALSE,
                                NULL, 0, NULL, ctx->config);
     TEST_CHECK(parser != NULL);
 
@@ -1140,7 +1142,7 @@ static struct test_ctx *test_ctx_create(char *reserve_data, char *preserve_key)
                               FLB_TRUE,
                               NULL, NULL, NULL,
                               MK_FALSE, MK_TRUE,
-                              FLB_FALSE, FLB_FALSE,
+                              FLB_FALSE, NULL, FLB_FALSE,
                               NULL, 0,
                               NULL, ctx->flb->config);
     if (!parser) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add optional parser setting time_zone (IANA name, e.g. from tzdata) so naive timestamps from time_format are converted with local rules and DST, instead of only fixed offset or system timezone.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
[N/A]

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
