### PR TITLE
dockerfiles: windows: fixed VS Build Tools installation

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -52,9 +52,9 @@ RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
       '--add Microsoft.VisualStudio.Component.VC.CoreBuildTools', `
       '--add Microsoft.VisualStudio.Component.VC.MSVC.143', `
       '--add Microsoft.VisualStudio.Component.Windows10SDK.19041' `
-      -NoNewWindow -Wait; `
-    if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 3010) { `
-      throw \"Visual Studio Build Tools installer failed with exit code $($p.ExitCode)\" `
+      -NoNewWindow -Wait -PassThru; `
+    if (${p}.ExitCode -ne 0 -and ${p}.ExitCode -ne 3010) { `
+      throw \"Visual Studio Build Tools installer failed with exit code $(${p}.ExitCode)\" `
     }; `
     if (-not (Test-Path \"${env:MSVS_HOME}\VC\Auxiliary\Build\vcvars64.bat\")) { `
       throw \"Visual Studio Build Tools installation is incomplete: ${env:MSVS_HOME}\VC\Auxiliary\Build\vcvars64.bat not found\" `


### PR DESCRIPTION
Fixed Visual Studio Build Tools installation when building docker image for Windows Server containers (refer to https://learn.microsoft.com/hr-hr/powershell/module/microsoft.powershell.management/start-process?view=powershell-5.1#-passthru).

Example of issue can be found in https://github.com/fluent/fluent-bit/actions/runs/23797507599/job/69348572273?pr=11397:

> ```text
> Visual Studio Build Tools installer failed with exit code 
> At line:1 char:1609
> + ... -ne 3010) { throw "Visual Studio Build Tools installer failed with ex ...
> +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     + CategoryInfo          : OperationStopped: (Visual Studio B...with exit c 
>    ode :String) [], RuntimeException
>     + FullyQualifiedErrorId : Visual Studio Build Tools installer failed with  
>    exit code 
> ````

----

**Testing**

- [N/A] Example configuration file for the change.
- [N/A] Debug log output from testing the change.
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found.
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature.

**Backporting**

- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Windows Docker build process for improved reliability in Visual Studio Build Tools installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->