### PR TITLE
out_es: sds: Implement es upstream with sds view

### DIFF
--- a/include/fluent-bit/flb_lib.h
+++ b/include/fluent-bit/flb_lib.h
@@ -23,6 +23,8 @@
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_config.h>
 
+struct flb_input_instance;
+
 /* Lib engine status */
 #define FLB_LIB_ERROR     -1
 #define FLB_LIB_NONE       0
@@ -70,6 +72,16 @@ FLB_EXPORT int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                                                          void *, size_t, void *),
                                    void *out_callback_data,
                                    void *test_ctx);
+FLB_EXPORT int flb_output_set_test_with_ctx_callback(
+                                   flb_ctx_t *ctx, int ffd, char *test_name,
+                                   void (*out_callback) (void *, int, int,
+                                                         void *, size_t, void *),
+                                   void *out_callback_data,
+                                   void *test_ctx,
+                                   void *(*test_ctx_callback) (
+                                           struct flb_config *,
+                                           struct flb_input_instance *,
+                                           void *, void *));
 FLB_EXPORT int flb_output_set_callback(flb_ctx_t *ctx, int ffd, char *name,
                                        void (*cb)(char *, void *, void *));
 FLB_EXPORT int flb_output_set_http_test(flb_ctx_t *ctx, int ffd, char *test_name,

--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -154,8 +154,23 @@ struct flb_test_out_formatter {
      */
     void *rt_data;
 
-    /* optional context for flush callback */
+    /* optional context for "flush context callback" */
     void *flush_ctx;
+
+    /*
+     * Callback
+     * =========
+     * Optional "flush context callback": it references the function that extracts
+     * optional flush context for "formatter callback".
+     */
+    void *(*flush_ctx_callback) (/* Fluent Bit context */
+                                 struct flb_config *,
+                                 /* plugin that ingested the records */
+                                 struct flb_input_instance *,
+                                 /* plugin instance context */
+                                 void *plugin_context,
+                                 /* context for "flush context callback" */
+                                 void *flush_ctx);
 
     /*
      * Callback

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -44,11 +44,212 @@ struct flb_output_plugin out_es_plugin;
 
 static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
-                                 struct flb_elasticsearch *ctx);
+                                 int replace_dots);
+
+static const char *es_get_property(const char *property,
+                                   struct flb_upstream_node *node,
+                                   struct flb_elasticsearch *ctx)
+{
+    /*
+     * Lifetime strategy:
+     *
+     * This helper returns a borrowed string owned by either:
+     *
+     * - the upstream node property table, or
+     * - the output instance property table.
+     *
+     * The returned string must be consumed within the current flush/config
+     * call path and must never be stored across calls or freed by the caller.
+     *
+     * Precedence strategy:
+     * - node property (if present)
+     * - output instance property
+     * - NULL
+     */
+    const char *value;
+
+    if (node != NULL) {
+        value = flb_upstream_node_get_property(property, node);
+        if (value != NULL) {
+            return value;
+        }
+    }
+
+    value = flb_output_get_property(property, ctx->ins);
+    return value;
+}
+
+static int es_get_property_bool(const char *property,
+                                struct flb_upstream_node *node,
+                                struct flb_es_node_ctx *node_ctx,
+                                int base_val)
+{
+    /*
+     * Lifetime/ownership strategy:
+     *
+     * This helper returns a copied scalar value (int), so there is no borrowed
+     * lifetime to manage at the call site.
+     *
+     * Resolution strategy:
+     * - explicit value cached in node_ctx (for fast/validated booleans),
+     * - raw node property value parsed as bool,
+     * - plugin/base value fallback.
+     */
+    const char *value;
+    int ret;
+
+    if (node_ctx != NULL) {
+        if (strcmp(property, "logstash_format") == 0 &&
+            node_ctx->has_logstash_format == FLB_TRUE) {
+            return node_ctx->logstash_format;
+        }
+        if (strcmp(property, "suppress_type_name") == 0 &&
+            node_ctx->has_suppress_type_name == FLB_TRUE) {
+            return node_ctx->suppress_type_name;
+        }
+        if (strcmp(property, "replace_dots") == 0 &&
+            node_ctx->has_replace_dots == FLB_TRUE) {
+            return node_ctx->replace_dots;
+        }
+        if (strcmp(property, "current_time_index") == 0 &&
+            node_ctx->has_current_time_index == FLB_TRUE) {
+            return node_ctx->current_time_index;
+        }
+        if (strcmp(property, "generate_id") == 0 &&
+            node_ctx->has_generate_id == FLB_TRUE) {
+            return node_ctx->generate_id;
+        }
+#ifdef FLB_HAVE_AWS
+        if (strcmp(property, "aws_auth") == 0 &&
+            node_ctx->has_aws_auth_override == FLB_TRUE) {
+            return node_ctx->has_aws_auth;
+        }
+#endif
+    }
+
+    if (node != NULL) {
+        value = flb_upstream_node_get_property(property, node);
+        if (value != NULL) {
+            ret = flb_utils_bool(value);
+            if (ret != -1) {
+                return ret;
+            }
+        }
+    }
+
+    return base_val;
+}
+
+static size_t es_get_property_size(const char *property,
+                                   struct flb_upstream_node *node,
+                                   size_t base_val)
+{
+    const char *value;
+    int64_t ret;
+
+    if (node != NULL) {
+        value = flb_upstream_node_get_property(property, node);
+        if (value != NULL) {
+            ret = flb_utils_size_to_bytes(value);
+            if (ret >= 0) {
+                return (size_t) ret;
+            }
+            if (ret == -1) {
+                return 0;
+            }
+        }
+    }
+
+    return base_val;
+}
+
+static int es_get_property_compress(struct flb_upstream_node *node,
+                                    int base_val)
+{
+    const char *value;
+
+    if (node != NULL) {
+        value = flb_upstream_node_get_property("compress", node);
+        if (value != NULL) {
+            if (strcasecmp(value, "gzip") == 0) {
+                return FLB_TRUE;
+            }
+            return FLB_FALSE;
+        }
+    }
+
+    return base_val;
+}
+
+static const char *es_get_action_from_write_operation(const char *write_operation,
+                                                      const char *base_action)
+{
+    if (write_operation == NULL || write_operation[0] == '\0') {
+        return base_action;
+    }
+
+    if (strcasecmp(write_operation, FLB_ES_WRITE_OP_INDEX) == 0) {
+        return FLB_ES_WRITE_OP_INDEX;
+    }
+
+    if (strcasecmp(write_operation, FLB_ES_WRITE_OP_CREATE) == 0) {
+        return FLB_ES_WRITE_OP_CREATE;
+    }
+
+    if (strcasecmp(write_operation, FLB_ES_WRITE_OP_UPDATE) == 0 ||
+        strcasecmp(write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
+        return FLB_ES_WRITE_OP_UPDATE;
+    }
+
+    return base_action;
+}
+
+static flb_sds_t es_compose_bulk_uri(struct flb_elasticsearch *ctx,
+                                     struct flb_upstream_node *node)
+{
+    const char *path;
+    const char *pipeline;
+    flb_sds_t uri;
+    size_t path_len;
+    size_t pipeline_len;
+
+    path = es_get_property("path", node, ctx);
+    pipeline = es_get_property("pipeline", node, ctx);
+
+    if (path == NULL) {
+        path = "";
+    }
+    path_len = strlen(path);
+
+    if (pipeline != NULL && pipeline[0] != '\0') {
+        pipeline_len = strlen(pipeline);
+        uri = flb_sds_create_size(path_len + pipeline_len + 19);
+        if (uri == NULL) {
+            flb_errno();
+            return NULL;
+        }
+
+        uri = flb_sds_printf(&uri, "%s/_bulk?pipeline=%s", path, pipeline);
+    }
+    else {
+        uri = flb_sds_create_size(path_len + 8);
+        if (uri == NULL) {
+            flb_errno();
+            return NULL;
+        }
+
+        uri = flb_sds_printf(&uri, "%s/_bulk", path);
+    }
+
+    return uri;
+}
 
 #ifdef FLB_HAVE_AWS
 static flb_sds_t add_aws_auth(struct flb_http_client *c,
-                              struct flb_elasticsearch *ctx)
+                              struct flb_elasticsearch *ctx,
+                              struct flb_aws_provider *provider,
+                              const char *region,
+                              const char *service_name)
 {
     flb_sds_t signature = NULL;
     int ret;
@@ -66,9 +267,9 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
     flb_http_add_header(c, "User-Agent", 10, "aws-fluent-bit-plugin", 21);
 
     signature = flb_signv4_do(c, FLB_TRUE, FLB_TRUE, time(NULL),
-                              ctx->aws_region, ctx->aws_service_name,
+                              (char *) region, (char *) service_name,
                               S3_MODE_SIGNED_PAYLOAD, ctx->aws_unsigned_headers,
-                              ctx->aws_provider);
+                              provider);
     if (!signature) {
         flb_plg_error(ctx->ins, "could not sign request with sigv4");
         return NULL;
@@ -79,7 +280,7 @@ static flb_sds_t add_aws_auth(struct flb_http_client *c,
 
 static int es_pack_map_content(msgpack_packer *tmp_pck,
                                msgpack_object map,
-                               struct flb_elasticsearch *ctx)
+                               int replace_dots)
 {
     int i;
     char *ptr_key = NULL;
@@ -128,7 +329,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          *
          *   https://goo.gl/R5NMTr
          */
-        if (ctx->replace_dots == FLB_TRUE) {
+        if (replace_dots == FLB_TRUE) {
             char *p   = ptr_key;
             char *end = ptr_key + key_size;
             while (p != end) {
@@ -153,7 +354,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          */
         if (v->type == MSGPACK_OBJECT_MAP) {
             msgpack_pack_map(tmp_pck, v->via.map.size);
-            es_pack_map_content(tmp_pck, *v, ctx);
+            es_pack_map_content(tmp_pck, *v, replace_dots);
         }
         /*
          * The value can be any data type, if it's an array we need to
@@ -161,7 +362,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
          */
         else if (v->type == MSGPACK_OBJECT_ARRAY) {
           msgpack_pack_array(tmp_pck, v->via.array.size);
-          es_pack_array_content(tmp_pck, *v, ctx);
+          es_pack_array_content(tmp_pck, *v, replace_dots);
         }
         else {
             msgpack_pack_object(tmp_pck, *v);
@@ -176,7 +377,7 @@ static int es_pack_map_content(msgpack_packer *tmp_pck,
   */
 static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
-                                 struct flb_elasticsearch *ctx)
+                                 int replace_dots)
 {
     int i;
     msgpack_object *e;
@@ -186,12 +387,12 @@ static int es_pack_array_content(msgpack_packer *tmp_pck,
         if (e->type == MSGPACK_OBJECT_MAP)
         {
             msgpack_pack_map(tmp_pck, e->via.map.size);
-            es_pack_map_content(tmp_pck, *e, ctx);
+            es_pack_map_content(tmp_pck, *e, replace_dots);
         }
         else if (e->type == MSGPACK_OBJECT_ARRAY)
         {
             msgpack_pack_array(tmp_pck, e->via.array.size);
-            es_pack_array_content(tmp_pck, *e, ctx);
+            es_pack_array_content(tmp_pck, *e, replace_dots);
         }
         else
         {
@@ -207,19 +408,19 @@ static int es_pack_array_content(msgpack_packer *tmp_pck,
  * If it failed, return NULL.
 */
 static flb_sds_t es_get_id_value(struct flb_elasticsearch *ctx,
+                                struct flb_record_accessor *ra_id_key,
+                                const char *id_key_name,
                                 msgpack_object *map)
 {
     struct flb_ra_value *rval = NULL;
     flb_sds_t tmp_str;
-    rval = flb_ra_get_value_object(ctx->ra_id_key, *map);
+    rval = flb_ra_get_value_object(ra_id_key, *map);
     if (rval == NULL) {
-        flb_plg_warn(ctx->ins, "the value of %s is missing",
-                     ctx->id_key);
+        flb_plg_warn(ctx->ins, "the value of %s is missing", id_key_name);
         return NULL;
     }
     else if(rval->o.type != MSGPACK_OBJECT_STR) {
-        flb_plg_warn(ctx->ins, "the value of %s is not string",
-                     ctx->id_key);
+        flb_plg_warn(ctx->ins, "the value of %s is not string", id_key_name);
         flb_ra_key_value_destroy(rval);
         return NULL;
     }
@@ -250,35 +451,36 @@ static int es_action_line_value_is_safe(const char *value, size_t len)
     return FLB_TRUE;
 }
 
-static int compose_index_header(struct flb_elasticsearch *ctx,
-                                int es_index_custom_len,
+static int compose_index_header(int es_index_custom_len,
                                 char *logstash_index, size_t logstash_index_size,
-                                char *separator_str,
+                                const char *logstash_prefix,
+                                const char *separator,
+                                const char *dateformat,
                                 struct tm *tm)
 {
     int ret;
     int len;
     char *p;
     size_t s;
+    size_t separator_len;
 
     /* Compose Index header */
     if (es_index_custom_len > 0) {
         p = logstash_index + es_index_custom_len;
     } else {
-        p = logstash_index + flb_sds_len(ctx->logstash_prefix);
+        p = logstash_index + strlen(logstash_prefix);
     }
     len = p - logstash_index;
-    ret = snprintf(p, logstash_index_size - len, "%s",
-                   separator_str);
+    ret = snprintf(p, logstash_index_size - len, "%s", separator);
     if (ret > logstash_index_size - len) {
         /* exceed limit */
         return -1;
     }
-    p += strlen(separator_str);
-    len += strlen(separator_str);
+    separator_len = strlen(separator);
+    p += separator_len;
+    len += separator_len;
 
-    s = strftime(p, logstash_index_size - len,
-                 ctx->logstash_dateformat, tm);
+    s = strftime(p, logstash_index_size - len, dateformat, tm);
     if (s==0) {
         /* exceed limit */
         return -1;
@@ -336,9 +538,27 @@ static int elasticsearch_format(struct flb_config *config,
     msgpack_packer tmp_pck;
     uint16_t hash[8];
     int es_index_custom_len;
+    int logstash_format;
+    int suppress_type_name;
+    int replace_dots;
+    int current_time_index;
+    int generate_id;
     struct flb_elasticsearch *ctx = plugin_context;
+    struct flb_upstream_node *node = flush_ctx;
+    struct flb_es_node_ctx *node_ctx;
+    struct flb_record_accessor *ra_prefix_key;
+    struct flb_record_accessor *ra_id_key;
     struct flb_log_event_decoder log_decoder;
     struct flb_log_event log_event;
+    const char *index;
+    const char *id_key_name;
+    const char *write_operation;
+    const char *logstash_prefix;
+    const char *logstash_prefix_separator;
+    const char *logstash_dateformat;
+    const char *type_name;
+    const char *es_action;
+    flb_sds_t v;
 
     j_index = flb_sds_create_size(ES_BULK_HEADER);
     if (j_index == NULL) {
@@ -364,16 +584,106 @@ static int elasticsearch_format(struct flb_config *config,
         return -1;
     }
 
-    if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0) {
+    node_ctx = NULL;
+    if (node != NULL) {
+        node_ctx = flb_upstream_node_get_data(node);
+    }
+
+    logstash_format = es_get_property_bool("logstash_format", node, node_ctx,
+                                           ctx->logstash_format);
+    suppress_type_name = es_get_property_bool("suppress_type_name", node, node_ctx,
+                                              ctx->suppress_type_name);
+    replace_dots = es_get_property_bool("replace_dots", node, node_ctx,
+                                        ctx->replace_dots);
+    current_time_index = es_get_property_bool("current_time_index", node, node_ctx,
+                                              ctx->current_time_index);
+    generate_id = es_get_property_bool("generate_id", node, node_ctx, ctx->generate_id);
+
+    write_operation = es_get_property("write_operation", node, ctx);
+    es_action = es_get_action_from_write_operation(write_operation, ctx->es_action);
+
+    write_op_update = FLB_FALSE;
+    write_op_upsert = FLB_FALSE;
+    if (write_operation != NULL && write_operation[0] != '\0') {
+        if (strcasecmp(write_operation, FLB_ES_WRITE_OP_UPDATE) == 0) {
+            write_op_update = FLB_TRUE;
+        }
+        else if (strcasecmp(write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
+            write_op_upsert = FLB_TRUE;
+        }
+    }
+    else if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPDATE) == 0) {
         write_op_update = FLB_TRUE;
     }
     else if (strcasecmp(ctx->write_operation, FLB_ES_WRITE_OP_UPSERT) == 0) {
         write_op_upsert = FLB_TRUE;
     }
 
-    if (ctx->ra_id_key && ctx->generate_id == FLB_FALSE &&
+    ra_prefix_key = ctx->ra_prefix_key;
+    if (node_ctx != NULL && node_ctx->ra_prefix_key != NULL) {
+        ra_prefix_key = node_ctx->ra_prefix_key;
+    }
+
+    ra_id_key = ctx->ra_id_key;
+    if (node_ctx != NULL && node_ctx->ra_id_key != NULL) {
+        ra_id_key = node_ctx->ra_id_key;
+    }
+
+    if (ra_id_key != NULL && generate_id == FLB_FALSE &&
         (write_op_update == FLB_TRUE || write_op_upsert == FLB_TRUE)) {
         id_key_required = FLB_TRUE;
+    }
+
+    id_key_name = es_get_property("id_key", node, ctx);
+    if ((id_key_name == NULL || id_key_name[0] == '\0') && ctx->id_key != NULL) {
+        id_key_name = ctx->id_key;
+    }
+
+    logstash_prefix = es_get_property("logstash_prefix", node, ctx);
+    if ((logstash_prefix == NULL || logstash_prefix[0] == '\0') &&
+        ctx->logstash_prefix != NULL) {
+        logstash_prefix = ctx->logstash_prefix;
+    }
+
+    logstash_prefix_separator = es_get_property("logstash_prefix_separator", node, ctx);
+    if ((logstash_prefix_separator == NULL || logstash_prefix_separator[0] == '\0') &&
+        ctx->logstash_prefix_separator != NULL) {
+        logstash_prefix_separator = ctx->logstash_prefix_separator;
+    }
+
+    logstash_dateformat = es_get_property("logstash_dateformat", node, ctx);
+    if ((logstash_dateformat == NULL || logstash_dateformat[0] == '\0') &&
+        ctx->logstash_dateformat != NULL) {
+        logstash_dateformat = ctx->logstash_dateformat;
+    }
+
+    index = es_get_property("index", node, ctx);
+    if ((index == NULL || index[0] == '\0') && ctx->index != NULL) {
+        index = ctx->index;
+    }
+
+    type_name = es_get_property("type", node, ctx);
+    if ((type_name == NULL || type_name[0] == '\0') && ctx->type != NULL) {
+        type_name = ctx->type;
+    }
+
+    if (id_key_name == NULL) {
+        id_key_name = "";
+    }
+    if (logstash_prefix == NULL) {
+        logstash_prefix = "";
+    }
+    if (logstash_prefix_separator == NULL) {
+        logstash_prefix_separator = "";
+    }
+    if (logstash_dateformat == NULL) {
+        logstash_dateformat = "";
+    }
+    if (index == NULL) {
+        index = "";
+    }
+    if (type_name == NULL) {
+        type_name = "";
     }
 
     /*
@@ -383,25 +693,25 @@ static int elasticsearch_format(struct flb_config *config,
      * The header stored in 'j_index' will be used for the all records on
      * this payload.
      */
-    if (ctx->logstash_format == FLB_FALSE && ctx->generate_id == FLB_FALSE) {
+    if (logstash_format == FLB_FALSE && generate_id == FLB_FALSE) {
         flb_time_get(&tms);
         gmtime_r(&tms.tm.tv_sec, &tm);
         strftime(index_formatted, sizeof(index_formatted) - 1,
-                 ctx->index, &tm);
+                 index, &tm);
         es_index = index_formatted;
-        if (ctx->suppress_type_name) {
+        if (suppress_type_name == FLB_TRUE) {
             index_len = flb_sds_snprintf(&j_index,
                                          flb_sds_alloc(j_index),
                                          ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                         ctx->es_action,
+                                         es_action,
                                          es_index);
         }
         else {
             index_len = flb_sds_snprintf(&j_index,
                                          flb_sds_alloc(j_index),
                                          ES_BULK_INDEX_FMT,
-                                         ctx->es_action,
-                                         es_index, ctx->type);
+                                         es_action,
+                                         es_index, type_name);
         }
     }
 
@@ -411,7 +721,7 @@ static int elasticsearch_format(struct flb_config *config,
      * in order to prevent generating millions of indexes
      * we can set to always use current time for index generation
      */
-    if (ctx->current_time_index == FLB_TRUE) {
+    if (current_time_index == FLB_TRUE) {
         flb_time_get(&tms);
     }
 
@@ -421,7 +731,7 @@ static int elasticsearch_format(struct flb_config *config,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
 
         /* Only pop time from record if current_time_index is disabled */
-        if (ctx->current_time_index == FLB_FALSE) {
+        if (current_time_index == FLB_FALSE) {
             flb_time_copy(&tms, &log_event.timestamp);
         }
 
@@ -429,16 +739,19 @@ static int elasticsearch_format(struct flb_config *config,
         map_size = map.via.map.size;
 
         /* Copy logstash prefix for the per-record fallback path. */
-        if (ctx->logstash_format == FLB_TRUE) {
-            strncpy(logstash_index, ctx->logstash_prefix, sizeof(logstash_index));
-            logstash_index[sizeof(logstash_index) - 1] = '\0';
+        if (logstash_format == FLB_TRUE) {
+            len = strlen(logstash_prefix);
+            if (len >= sizeof(logstash_index)) {
+                len = sizeof(logstash_index) - 1;
+            }
+            memcpy(logstash_index, logstash_prefix, len);
+            logstash_index[len] = '\0';
         }
 
         es_index_custom_len = 0;
-        if (ctx->logstash_prefix_key) {
-            flb_sds_t v = flb_ra_translate(ctx->ra_prefix_key,
-                                           (char *) tag, tag_len,
-                                           map, NULL);
+        if (ra_prefix_key != NULL) {
+            v = flb_ra_translate(ra_prefix_key, (char *) tag, tag_len,
+                                 map, NULL);
             if (v) {
                 len = flb_sds_len(v);
                 if (es_action_line_value_is_safe(v, len) == FLB_TRUE) {
@@ -487,40 +800,44 @@ static int elasticsearch_format(struct flb_config *config,
         msgpack_pack_str(&tmp_pck, s);
         msgpack_pack_str_body(&tmp_pck, time_formatted, s);
 
-        es_index = ctx->index;
-        if (ctx->logstash_format == FLB_TRUE) {
-            ret = compose_index_header(ctx, es_index_custom_len,
+        es_index = (char *) index;
+        if (logstash_format == FLB_TRUE) {
+            ret = compose_index_header(es_index_custom_len,
                                        &logstash_index[0], sizeof(logstash_index),
-                                       ctx->logstash_prefix_separator, &tm);
+                                       logstash_prefix,
+                                       logstash_prefix_separator,
+                                       logstash_dateformat, &tm);
             if (ret < 0) {
                 /* retry with default separator */
-                compose_index_header(ctx, es_index_custom_len,
+                compose_index_header(es_index_custom_len,
                                      &logstash_index[0], sizeof(logstash_index),
-                                     "-", &tm);
+                                     logstash_prefix,
+                                     "-",
+                                     logstash_dateformat, &tm);
             }
 
             es_index = logstash_index;
-            if (ctx->generate_id == FLB_FALSE) {
-                if (ctx->suppress_type_name) {
+            if (generate_id == FLB_FALSE) {
+                if (suppress_type_name == FLB_TRUE) {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                                 ctx->es_action,
+                                                 es_action,
                                                  es_index);
                 }
                 else {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT,
-                                                 ctx->es_action,
-                                                 es_index, ctx->type);
+                                                 es_action,
+                                                 es_index, type_name);
                 }
             }
         }
-        else if (ctx->current_time_index == FLB_TRUE) {
+        else if (current_time_index == FLB_TRUE) {
             /* Make sure we handle index time format for index */
             strftime(index_formatted, sizeof(index_formatted) - 1,
-                     ctx->index, &tm);
+                     index, &tm);
             es_index = index_formatted;
         }
 
@@ -539,7 +856,7 @@ static int elasticsearch_format(struct flb_config *config,
          * Elasticsearch have a restriction that key names cannot contain
          * a dot; if some dot is found, it's replaced with an underscore.
          */
-        ret = es_pack_map_content(&tmp_pck, map, ctx);
+        ret = es_pack_map_content(&tmp_pck, map, replace_dots);
         if (ret == -1) {
             flb_log_event_decoder_destroy(&log_decoder);
             msgpack_sbuffer_destroy(&tmp_sbuf);
@@ -548,29 +865,29 @@ static int elasticsearch_format(struct flb_config *config,
             return -1;
         }
 
-        if (ctx->generate_id == FLB_TRUE) {
+        if (generate_id == FLB_TRUE) {
             MurmurHash3_x64_128(tmp_sbuf.data, tmp_sbuf.size, 42, hash);
             snprintf(es_uuid, sizeof(es_uuid),
                      "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
                      hash[0], hash[1], hash[2], hash[3],
                      hash[4], hash[5], hash[6], hash[7]);
-            if (ctx->suppress_type_name) {
+            if (suppress_type_name == FLB_TRUE) {
                 index_len = flb_sds_snprintf(&j_index,
                                              flb_sds_alloc(j_index),
                                              ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                             ctx->es_action,
+                                             es_action,
                                              es_index,  es_uuid);
             }
             else {
                 index_len = flb_sds_snprintf(&j_index,
                                              flb_sds_alloc(j_index),
                                              ES_BULK_INDEX_FMT_ID,
-                                             ctx->es_action,
-                                             es_index, ctx->type, es_uuid);
+                                             es_action,
+                                             es_index, type_name, es_uuid);
             }
         }
-        if (ctx->ra_id_key) {
-            id_key_str = es_get_id_value(ctx ,&map);
+        if (ra_id_key != NULL) {
+            id_key_str = es_get_id_value(ctx, ra_id_key, id_key_name, &map);
             id_key_safe = FLB_FALSE;
 
             if (id_key_str &&
@@ -580,19 +897,19 @@ static int elasticsearch_format(struct flb_config *config,
             }
 
             if (id_key_safe == FLB_TRUE) {
-                if (ctx->suppress_type_name) {
+                if (suppress_type_name == FLB_TRUE) {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_ID_WITHOUT_TYPE,
-                                                 ctx->es_action,
+                                                 es_action,
                                                  es_index,  id_key_str);
                 }
                 else {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_ID,
-                                                 ctx->es_action,
-                                                 es_index, ctx->type, id_key_str);
+                                                 es_action,
+                                                 es_index, type_name, id_key_str);
                 }
             }
             else if (id_key_required == FLB_TRUE) {
@@ -605,20 +922,20 @@ static int elasticsearch_format(struct flb_config *config,
                 msgpack_sbuffer_destroy(&tmp_sbuf);
                 continue;
             }
-            else if (ctx->generate_id == FLB_FALSE && id_key_str) {
-                if (ctx->suppress_type_name) {
+            else if (generate_id == FLB_FALSE && id_key_str) {
+                if (suppress_type_name == FLB_TRUE) {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT_WITHOUT_TYPE,
-                                                 ctx->es_action,
+                                                 es_action,
                                                  es_index);
                 }
                 else {
                     index_len = flb_sds_snprintf(&j_index,
                                                  flb_sds_alloc(j_index),
                                                  ES_BULK_INDEX_FMT,
-                                                 ctx->es_action,
-                                                 es_index, ctx->type);
+                                                 es_action,
+                                                 es_index, type_name);
                 }
             }
 
@@ -892,20 +1209,53 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     size_t b_sent;
     struct flb_elasticsearch *ctx = out_context;
     struct flb_connection *u_conn;
-    struct flb_http_client *c;
+    struct flb_http_client *c = NULL;
+    struct flb_upstream *upstream;
+    struct flb_upstream_node *node = NULL;
+    struct flb_es_node_ctx *node_ctx;
     flb_sds_t signature = NULL;
+    flb_sds_t uri = NULL;
     int compressed = FLB_FALSE;
+    int compress_gzip;
+    size_t buffer_size;
     flb_sds_t header_line = NULL;
+    flb_sds_t tmp_sds = NULL;
+    const char *http_user;
+    const char *http_passwd;
+    const char *http_api_key;
+#ifdef FLB_HAVE_AWS
+    struct flb_aws_provider *aws_provider;
+    const char *aws_region;
+    const char *aws_service_name;
+    int has_aws_auth;
+#endif
+
+    node_ctx = NULL;
+    if (ctx->ha_mode == FLB_TRUE) {
+        node = flb_upstream_ha_node_get(ctx->ha);
+        if (node == NULL) {
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+
+        upstream = node->u;
+        node_ctx = flb_upstream_node_get_data(node);
+    }
+    else {
+        upstream = ctx->u;
+    }
+
+    compress_gzip = es_get_property_compress(node, ctx->compress_gzip);
+    buffer_size = es_get_property_size("buffer_size", node, ctx->buffer_size);
 
     /* Get upstream connection */
-    u_conn = flb_upstream_conn_get(ctx->u);
+    u_conn = flb_upstream_conn_get(upstream);
     if (!u_conn) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
     /* Convert format */
     ret = elasticsearch_format(config, ins,
-                               ctx, NULL,
+                               ctx, node,
                                event_chunk->type,
                                event_chunk->tag, flb_sds_len(event_chunk->tag),
                                event_chunk->data, event_chunk->size,
@@ -925,7 +1275,7 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     pack_size = out_size;
 
     /* Should we compress the payload ? */
-    if (ctx->compress_gzip == FLB_TRUE) {
+    if (compress_gzip == FLB_TRUE) {
         ret = flb_gzip_compress((void *) pack, pack_size,
                                 &out_buf, &out_size);
         if (ret == -1) {
@@ -948,10 +1298,18 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Compose HTTP Client request */
-    c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->uri,
-                        pack, pack_size, NULL, 0, NULL, 0);
+    uri = es_compose_bulk_uri(ctx, node);
+    if (uri == NULL) {
+        goto retry;
+    }
 
-    flb_http_buffer_size(c, ctx->buffer_size);
+    c = flb_http_client(u_conn, FLB_HTTP_POST, uri,
+                        pack, pack_size, NULL, 0, NULL, 0);
+    if (c == NULL) {
+        goto retry;
+    }
+
+    flb_http_buffer_size(c, buffer_size);
 
 #ifndef FLB_HAVE_AWS
     flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
@@ -959,20 +1317,40 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
     flb_http_add_header(c, "Content-Type", 12, "application/x-ndjson", 20);
 
-    if (ctx->http_user && ctx->http_passwd) {
-        flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
+    http_user = es_get_property("http_user", node, ctx);
+    http_passwd = es_get_property("http_passwd", node, ctx);
+    http_api_key = es_get_property("http_api_key", node, ctx);
+
+    if (http_user == NULL) {
+        http_user = ctx->http_user;
     }
-    else if (ctx->cloud_user && ctx->cloud_passwd) {
-        flb_http_basic_auth(c, ctx->cloud_user, ctx->cloud_passwd);
+    if (http_passwd == NULL) {
+        http_passwd = ctx->http_passwd;
     }
-    else if (ctx->http_api_key) {
+    if (http_api_key == NULL) {
+        http_api_key = ctx->http_api_key;
+    }
+
+    if (http_user != NULL && http_user[0] != '\0') {
+        if (http_passwd == NULL) {
+            http_passwd = "";
+        }
+        flb_http_basic_auth(c, (char *) http_user, (char *) http_passwd);
+    }
+    else if (http_api_key != NULL && http_api_key[0] != '\0') {
         /* 7 for ApiKey + space */
-        header_line = flb_sds_create_size(strlen(ctx->http_api_key)+7);
+        header_line = flb_sds_create_size(strlen(http_api_key) + 7);
         if (header_line == NULL) {
             flb_plg_error(ctx->ins, "failed to format API key auth header");
             goto retry;
         }
-        header_line = flb_sds_printf(&header_line, "ApiKey %s", ctx->http_api_key);
+        tmp_sds = flb_sds_printf(&header_line, "ApiKey %s", http_api_key);
+        if (tmp_sds == NULL) {
+            flb_plg_error(ctx->ins, "failed to format API key auth header");
+            flb_sds_destroy(header_line);
+            goto retry;
+        }
+        header_line = tmp_sds;
 
         if (flb_http_add_header(c,
                                 FLB_HTTP_HEADER_AUTH, strlen(FLB_HTTP_HEADER_AUTH),
@@ -984,10 +1362,27 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
         flb_sds_destroy(header_line);
     }
+    else if (ctx->cloud_user && ctx->cloud_passwd) {
+        flb_http_basic_auth(c, ctx->cloud_user, ctx->cloud_passwd);
+    }
 
 #ifdef FLB_HAVE_AWS
-    if (ctx->has_aws_auth == FLB_TRUE) {
-        signature = add_aws_auth(c, ctx);
+    has_aws_auth = es_get_property_bool("aws_auth", node, node_ctx, ctx->has_aws_auth);
+    aws_provider = ctx->aws_provider;
+    aws_region = ctx->aws_region;
+    aws_service_name = ctx->aws_service_name;
+
+    if (node_ctx != NULL && node_ctx->has_aws_auth == FLB_TRUE &&
+        node_ctx->aws_provider != NULL) {
+        aws_provider = node_ctx->aws_provider;
+        aws_region = node_ctx->aws_region;
+        aws_service_name = node_ctx->aws_service_name;
+        has_aws_auth = FLB_TRUE;
+    }
+
+    if (has_aws_auth == FLB_TRUE) {
+        signature = add_aws_auth(c, ctx, aws_provider, aws_region,
+                                 aws_service_name);
         if (!signature) {
             goto retry;
         }
@@ -1007,20 +1402,20 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
     ret = flb_http_do(c, &b_sent);
     if (ret != 0) {
-        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, ctx->uri);
+        flb_plg_warn(ctx->ins, "http_do=%i URI=%s", ret, uri);
         goto retry;
     }
     else {
         /* The request was issued successfully, validate the 'error' field */
-        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ctx->uri);
+        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, uri);
         if (c->resp.status != 200 && c->resp.status != 201) {
             if (c->resp.payload_size > 0) {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s, response:\n%s\n",
-                              c->resp.status, ctx->uri, c->resp.payload);
+                              c->resp.status, uri, c->resp.payload);
             }
             else {
                 flb_plg_error(ctx->ins, "HTTP status=%i URI=%s",
-                              c->resp.status, ctx->uri);
+                              c->resp.status, uri);
             }
             goto retry;
         }
@@ -1068,23 +1463,31 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     }
 
     /* Cleanup */
-    flb_http_client_destroy(c);
+    if (c != NULL) {
+        flb_http_client_destroy(c);
+    }
     flb_free(pack);
     flb_upstream_conn_release(u_conn);
     if (signature) {
         flb_sds_destroy(signature);
     }
+    flb_sds_destroy(uri);
     FLB_OUTPUT_RETURN(FLB_OK);
 
     /* Issue a retry */
  retry:
-    flb_http_client_destroy(c);
+    if (c != NULL) {
+        flb_http_client_destroy(c);
+    }
     flb_free(pack);
-
+    if (signature != NULL) {
+        flb_sds_destroy(signature);
+    }
     if (out_buf != pack) {
         flb_free(out_buf);
     }
 
+    flb_sds_destroy(uri);
     flb_upstream_conn_release(u_conn);
     FLB_OUTPUT_RETURN(FLB_RETRY);
 }
@@ -1221,6 +1624,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "cloud_auth", NULL,
      0, FLB_FALSE, 0,
      "Elastic cloud authentication credentials"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "upstream", NULL,
+     0, FLB_FALSE, 0,
+     "Path to an upstream configuration file to define multiple backend nodes"
     },
 
     /* AWS Authentication */

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -20,6 +20,8 @@
 #ifndef FLB_OUT_ES_H
 #define FLB_OUT_ES_H
 
+#include <fluent-bit/flb_upstream_ha.h>
+
 #define FLB_ES_DEFAULT_HOST       "127.0.0.1"
 #define FLB_ES_DEFAULT_PORT       92000
 #define FLB_ES_DEFAULT_INDEX      "fluent-bit"
@@ -44,6 +46,31 @@
 #define FLB_ES_STATUS_BAD_RESPONSE     (1 << 5)
 #define FLB_ES_STATUS_DUPLICATES       (1 << 6)
 #define FLB_ES_STATUS_ERROR            (1 << 7)
+
+struct flb_es_node_ctx {
+    struct flb_record_accessor *ra_id_key;
+    struct flb_record_accessor *ra_prefix_key;
+    int has_logstash_format;
+    int logstash_format;
+    int has_suppress_type_name;
+    int suppress_type_name;
+    int has_replace_dots;
+    int replace_dots;
+    int has_current_time_index;
+    int current_time_index;
+    int has_generate_id;
+    int generate_id;
+#ifdef FLB_HAVE_AWS
+    struct flb_aws_provider *aws_provider;
+    struct flb_aws_provider *base_aws_provider;
+    struct flb_tls *aws_tls;
+    struct flb_tls *aws_sts_tls;
+    char *aws_region;
+    char *aws_service_name;
+    int has_aws_auth_override;
+    int has_aws_auth;
+#endif
+};
 
 struct flb_elasticsearch {
     /* Elasticsearch index (database) and type (table) */
@@ -142,6 +169,8 @@ struct flb_elasticsearch {
 
     /* Upstream connection to the backend server */
     struct flb_upstream *u;
+    int ha_mode;
+    struct flb_upstream_ha *ha;
 
     /* Plugin output instance reference */
     struct flb_output_instance *ins;

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -25,9 +25,345 @@
 #include <fluent-bit/flb_signv4.h>
 #include <fluent-bit/flb_aws_credentials.h>
 #include <fluent-bit/flb_base64.h>
+#include <fluent-bit/flb_upstream_ha.h>
 
 #include "es.h"
 #include "es_conf.h"
+
+static void flb_es_node_ctx_destroy(struct flb_es_node_ctx *node_ctx)
+{
+    if (node_ctx == NULL) {
+        return;
+    }
+
+    if (node_ctx->ra_id_key != NULL) {
+        flb_ra_destroy(node_ctx->ra_id_key);
+    }
+
+    if (node_ctx->ra_prefix_key != NULL) {
+        flb_ra_destroy(node_ctx->ra_prefix_key);
+    }
+
+#ifdef FLB_HAVE_AWS
+    if (node_ctx->base_aws_provider != NULL) {
+        flb_aws_provider_destroy(node_ctx->base_aws_provider);
+    }
+
+    if (node_ctx->aws_provider != NULL) {
+        flb_aws_provider_destroy(node_ctx->aws_provider);
+    }
+
+    if (node_ctx->aws_tls != NULL) {
+        flb_tls_destroy(node_ctx->aws_tls);
+    }
+
+    if (node_ctx->aws_sts_tls != NULL) {
+        flb_tls_destroy(node_ctx->aws_sts_tls);
+    }
+#endif
+
+    flb_free(node_ctx);
+}
+
+static int flb_es_node_ctx_set_bool_property(struct flb_elasticsearch *ctx,
+                                             struct flb_upstream_node *node,
+                                             const char *property,
+                                             int *is_set,
+                                             int *value)
+{
+    const char *tmp;
+    int ret;
+
+    *is_set = FLB_FALSE;
+
+    tmp = flb_upstream_node_get_property(property, node);
+    if (tmp == NULL) {
+        return 0;
+    }
+
+    ret = flb_utils_bool(tmp);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins,
+                      "invalid value for boolean property '%s=%s' in node '%s'",
+                      property, tmp, node->name);
+        return -1;
+    }
+
+    *is_set = FLB_TRUE;
+    *value = ret;
+
+    return 0;
+}
+
+#ifdef FLB_HAVE_AWS
+static int flb_es_node_ctx_aws_init(struct flb_es_node_ctx *node_ctx,
+                                    struct flb_upstream_node *node,
+                                    struct flb_elasticsearch *ctx,
+                                    struct flb_output_instance *ins,
+                                    struct flb_config *config)
+{
+    const char *node_region;
+    const char *node_sts_endpoint;
+    const char *node_role_arn;
+    const char *node_external_id;
+    const char *node_profile;
+    const char *node_service_name;
+    char *aws_session_name;
+    struct flb_aws_provider *provider;
+
+    if (node_ctx->has_aws_auth_override == FLB_FALSE) {
+        node_ctx->has_aws_auth = ctx->has_aws_auth;
+    }
+
+    if (node_ctx->has_aws_auth != FLB_TRUE) {
+        return 0;
+    }
+
+    node_region = flb_upstream_node_get_property("aws_region", node);
+    if (node_region == NULL) {
+        node_region = ctx->aws_region;
+    }
+    if (node_region == NULL) {
+        flb_plg_error(ctx->ins,
+                      "aws_auth enabled but aws_region not set for node '%s'",
+                      node->name);
+        return -1;
+    }
+    node_ctx->aws_region = (char *) node_region;
+
+    node_service_name = flb_upstream_node_get_property("aws_service_name", node);
+    if (node_service_name == NULL) {
+        node_service_name = ctx->aws_service_name;
+    }
+    node_ctx->aws_service_name = (char *) node_service_name;
+
+    node_sts_endpoint = flb_upstream_node_get_property("aws_sts_endpoint", node);
+    if (node_sts_endpoint == NULL) {
+        node_sts_endpoint = ctx->aws_sts_endpoint;
+    }
+
+    node_profile = flb_upstream_node_get_property("aws_profile", node);
+    if (node_profile == NULL) {
+        node_profile = ctx->aws_profile;
+    }
+
+    node_role_arn = flb_upstream_node_get_property("aws_role_arn", node);
+    node_external_id = flb_upstream_node_get_property("aws_external_id", node);
+
+    node_ctx->aws_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
+                                       FLB_TRUE,
+                                       ins->tls_debug,
+                                       ins->tls_vhost,
+                                       ins->tls_ca_path,
+                                       ins->tls_ca_file,
+                                       ins->tls_crt_file,
+                                       ins->tls_key_file,
+                                       ins->tls_key_passwd);
+    if (node_ctx->aws_tls == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    provider = flb_standard_chain_provider_create(config,
+                                                  node_ctx->aws_tls,
+                                                  node_ctx->aws_region,
+                                                  (char *) node_sts_endpoint,
+                                                  NULL,
+                                                  flb_aws_client_generator(),
+                                                  (char *) node_profile);
+    if (provider == NULL) {
+        flb_plg_error(ctx->ins,
+                      "failed to create AWS Credential Provider for node '%s'",
+                      node->name);
+        return -1;
+    }
+    node_ctx->aws_provider = provider;
+
+    if (node_role_arn != NULL) {
+        node_ctx->base_aws_provider = node_ctx->aws_provider;
+        node_ctx->aws_provider = NULL;
+
+        aws_session_name = flb_sts_session_name();
+        if (aws_session_name == NULL) {
+            flb_plg_error(ctx->ins,
+                          "failed to create aws session name for node '%s'",
+                          node->name);
+            return -1;
+        }
+
+        node_ctx->aws_sts_tls = flb_tls_create(FLB_TLS_CLIENT_MODE,
+                                               FLB_TRUE,
+                                               ins->tls_debug,
+                                               ins->tls_vhost,
+                                               ins->tls_ca_path,
+                                               ins->tls_ca_file,
+                                               ins->tls_crt_file,
+                                               ins->tls_key_file,
+                                               ins->tls_key_passwd);
+        if (node_ctx->aws_sts_tls == NULL) {
+            flb_free(aws_session_name);
+            flb_errno();
+            return -1;
+        }
+
+        provider = flb_sts_provider_create(config,
+                                           node_ctx->aws_sts_tls,
+                                           node_ctx->base_aws_provider,
+                                           (char *) node_external_id,
+                                           (char *) node_role_arn,
+                                           aws_session_name,
+                                           node_ctx->aws_region,
+                                           (char *) node_sts_endpoint,
+                                           NULL,
+                                           flb_aws_client_generator());
+        flb_free(aws_session_name);
+        if (provider == NULL) {
+            flb_plg_error(ctx->ins,
+                          "failed to create AWS STS Credential Provider for node '%s'",
+                          node->name);
+            return -1;
+        }
+
+        node_ctx->aws_provider = provider;
+    }
+
+    node_ctx->aws_provider->provider_vtable->sync(node_ctx->aws_provider);
+    node_ctx->aws_provider->provider_vtable->init(node_ctx->aws_provider);
+    node_ctx->aws_provider->provider_vtable->async(node_ctx->aws_provider);
+    node_ctx->aws_provider->provider_vtable->upstream_set(node_ctx->aws_provider,
+                                                          ctx->ins);
+
+    return 0;
+}
+#endif
+
+static int flb_es_node_ctx_create(struct flb_elasticsearch *ctx,
+                                  struct flb_output_instance *ins,
+                                  struct flb_config *config)
+{
+    int len;
+    const char *tmp;
+    int ret;
+    char *buf;
+    struct mk_list *head;
+    struct flb_upstream_node *node;
+    struct flb_es_node_ctx *node_ctx;
+
+    mk_list_foreach(head, &ctx->ha->nodes) {
+        node = mk_list_entry(head, struct flb_upstream_node, _head);
+
+        node_ctx = flb_calloc(1, sizeof(struct flb_es_node_ctx));
+        if (node_ctx == NULL) {
+            flb_errno();
+            return -1;
+        }
+
+        ret = flb_es_node_ctx_set_bool_property(ctx, node, "logstash_format",
+                                                &node_ctx->has_logstash_format,
+                                                &node_ctx->logstash_format);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+
+        ret = flb_es_node_ctx_set_bool_property(ctx, node, "replace_dots",
+                                                &node_ctx->has_replace_dots,
+                                                &node_ctx->replace_dots);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+
+        ret = flb_es_node_ctx_set_bool_property(ctx, node, "suppress_type_name",
+                                                &node_ctx->has_suppress_type_name,
+                                                &node_ctx->suppress_type_name);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+
+        ret = flb_es_node_ctx_set_bool_property(ctx, node, "current_time_index",
+                                                &node_ctx->has_current_time_index,
+                                                &node_ctx->current_time_index);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+
+        ret = flb_es_node_ctx_set_bool_property(ctx, node, "generate_id",
+                                                &node_ctx->has_generate_id,
+                                                &node_ctx->generate_id);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+
+#ifdef FLB_HAVE_AWS
+        ret = flb_es_node_ctx_set_bool_property(ctx, node, "aws_auth",
+                                                &node_ctx->has_aws_auth_override,
+                                                &node_ctx->has_aws_auth);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+#endif
+
+        tmp = flb_upstream_node_get_property("id_key", node);
+        if (tmp != NULL) {
+            node_ctx->ra_id_key = flb_ra_create((char *) tmp, FLB_FALSE);
+            if (node_ctx->ra_id_key == NULL) {
+                flb_plg_error(ctx->ins,
+                              "could not create node id_key record accessor for '%s'",
+                              node->name);
+                flb_es_node_ctx_destroy(node_ctx);
+                return -1;
+            }
+        }
+
+        tmp = flb_upstream_node_get_property("logstash_prefix_key", node);
+        if (tmp != NULL) {
+            if (tmp[0] != '$') {
+                len = strlen(tmp);
+                buf = flb_malloc(len + 2);
+                if (buf == NULL) {
+                    flb_errno();
+                    flb_es_node_ctx_destroy(node_ctx);
+                    return -1;
+                }
+
+                buf[0] = '$';
+                memcpy(buf + 1, tmp, len);
+                buf[len + 1] = '\0';
+
+                node_ctx->ra_prefix_key = flb_ra_create(buf, FLB_TRUE);
+                flb_free(buf);
+            }
+            else {
+                node_ctx->ra_prefix_key = flb_ra_create((char *) tmp, FLB_TRUE);
+            }
+
+            if (node_ctx->ra_prefix_key == NULL) {
+                flb_plg_error(ctx->ins,
+                              "invalid node logstash_prefix_key pattern '%s'",
+                              tmp);
+                flb_es_node_ctx_destroy(node_ctx);
+                return -1;
+            }
+        }
+
+#ifdef FLB_HAVE_AWS
+        ret = flb_es_node_ctx_aws_init(node_ctx, node, ctx, ins, config);
+        if (ret != 0) {
+            flb_es_node_ctx_destroy(node_ctx);
+            return -1;
+        }
+#endif
+
+        flb_upstream_node_set_data(node_ctx, node);
+    }
+
+    return 0;
+}
 
 /*
  * extract_cloud_host extracts the public hostname
@@ -245,21 +581,48 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
         }
     }
 
-    /* Prepare an upstream handler */
-    upstream = flb_upstream_create(config,
-                                   ins->host.name,
-                                   ins->host.port,
-                                   io_flags,
-                                   ins->tls);
-    if (!upstream) {
-        flb_plg_error(ctx->ins, "cannot create Upstream context");
-        flb_es_conf_destroy(ctx);
-        return NULL;
-    }
-    ctx->u = upstream;
+    tmp = flb_output_get_property("upstream", ins);
+    if (tmp != NULL) {
+        ctx->ha = flb_upstream_ha_from_file(tmp, config);
+        if (ctx->ha == NULL) {
+            flb_plg_error(ctx->ins, "cannot load Upstream file");
+            flb_es_conf_destroy(ctx);
+            return NULL;
+        }
 
-    /* Set instance flags into upstream */
-    flb_output_upstream_set(ctx->u, ins);
+        if (mk_list_is_empty(&ctx->ha->nodes) == 0) {
+            flb_plg_error(ctx->ins, "upstream file does not define any nodes");
+            flb_es_conf_destroy(ctx);
+            return NULL;
+        }
+
+        ctx->ha_mode = FLB_TRUE;
+
+        flb_output_upstream_ha_set(ctx->ha, ins);
+
+        ret = flb_es_node_ctx_create(ctx, ins, config);
+        if (ret != 0) {
+            flb_es_conf_destroy(ctx);
+            return NULL;
+        }
+    }
+    else {
+        /* Prepare an upstream handler */
+        upstream = flb_upstream_create(config,
+                                       ins->host.name,
+                                       ins->host.port,
+                                       io_flags,
+                                       ins->tls);
+        if (!upstream) {
+            flb_plg_error(ctx->ins, "cannot create Upstream context");
+            flb_es_conf_destroy(ctx);
+            return NULL;
+        }
+        ctx->u = upstream;
+
+        /* Set instance flags into upstream */
+        flb_output_upstream_set(ctx->u, ins);
+    }
 
     /* Set manual Index and Type */
     if (f_index) {
@@ -487,11 +850,26 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
 
 int flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 {
+    struct mk_list *head;
+    struct flb_upstream_node *node;
+    struct flb_es_node_ctx *node_ctx;
+
     if (!ctx) {
         return 0;
     }
 
-    if (ctx->u) {
+    if (ctx->ha_mode == FLB_TRUE && ctx->ha != NULL) {
+        mk_list_foreach(head, &ctx->ha->nodes) {
+            node = mk_list_entry(head, struct flb_upstream_node, _head);
+            node_ctx = flb_upstream_node_get_data(node);
+            if (node_ctx != NULL) {
+                flb_es_node_ctx_destroy(node_ctx);
+                flb_upstream_node_set_data(NULL, node);
+            }
+        }
+        flb_upstream_ha_destroy(ctx->ha);
+    }
+    else if (ctx->u) {
         flb_upstream_destroy(ctx->u);
     }
     if (ctx->ra_id_key) {

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -101,17 +101,23 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
 static void test_run_formatter(struct flb_config *config,
                                struct flb_input_instance *i_ins,
                                struct flb_output_instance *o_ins,
-                               struct flb_task *task,
-                               void *flush_ctx)
+                               struct flb_task *task)
 {
     int ret;
     void *out_buf = NULL;
     size_t out_size = 0;
     struct flb_test_out_formatter *otf;
     struct flb_event_chunk *evc;
+    void *flush_ctx;
 
     otf = &o_ins->test_formatter;
     evc = task->event_chunk;
+
+    flush_ctx = otf->flush_ctx;
+    if (otf->flush_ctx_callback) {
+        flush_ctx = otf->flush_ctx_callback(config, i_ins, o_ins->context,
+                                            flush_ctx);
+    }
 
     /* Invoke the output plugin formatter test callback */
     ret = otf->callback(config,
@@ -176,9 +182,7 @@ static int tasks_start(struct flb_input_instance *in,
                 out->test_formatter.callback != NULL) {
 
                 /* Run the formatter test */
-                test_run_formatter(config, in, out,
-                                   task,
-                                   out->test_formatter.flush_ctx);
+                test_run_formatter(config, in, out, task);
 
                 /* Remove the route */
                 mk_list_del(&route->_head);

--- a/src/flb_lib.c
+++ b/src/flb_lib.c
@@ -592,6 +592,21 @@ int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
                         void *out_callback_data,
                         void *test_ctx)
 {
+    return flb_output_set_test_with_ctx_callback(ctx, ffd, test_name,
+                                                 out_callback,
+                                                 out_callback_data,
+                                                 test_ctx, NULL);
+}
+
+int flb_output_set_test_with_ctx_callback(flb_ctx_t *ctx, int ffd,
+                                          char *test_name,
+                                          void (*out_callback) (void *, int, int, void *, size_t, void *),
+                                          void *out_callback_data,
+                                          void *test_ctx,
+                                          void *(*test_ctx_callback) (struct flb_config *,
+                                                                      struct flb_input_instance *,
+                                                                      void *, void *))
+{
     struct flb_output_instance *o_ins;
 
     o_ins = out_instance_get(ctx, ffd);
@@ -612,6 +627,7 @@ int flb_output_set_test(flb_ctx_t *ctx, int ffd, char *test_name,
         o_ins->test_formatter.rt_out_callback = out_callback;
         o_ins->test_formatter.rt_data = out_callback_data;
         o_ins->test_formatter.flush_ctx = test_ctx;
+        o_ins->test_formatter.flush_ctx_callback = test_ctx_callback;
     }
     else {
         return -1;

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -2,9 +2,14 @@
 
 #include <fluent-bit.h>
 #include "flb_tests_runtime.h"
+#include "../include/flb_tests_tmpdir.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <unistd.h>
 
 /* Test data */
 #include "data/es/json_es.h" /* JSON_ES */
+#include "../../plugins/out_es/es.h"
 
 
 static void cb_check_http_api_key(void *ctx, int ffd,
@@ -100,6 +105,29 @@ static void cb_check_index_type(void *ctx, int ffd,
     flb_free(res_data);
 }
 
+static void cb_check_node_index_type(void *ctx, int ffd,
+                                     int res_ret, void *res_data, size_t res_size,
+                                     void *data)
+{
+    char *index_match;
+    char *type_match;
+    char *out_js = res_data;
+    char *index_line = "\"_index\":\"another_index_test\"";
+    char *type_line = "\"_type\":\"another_type_test\"";
+
+    index_match = strstr(out_js, index_line);
+    if (!TEST_CHECK(index_match != NULL)) {
+        TEST_MSG("Got: %s", out_js);
+    }
+
+    type_match = strstr(out_js, type_line);
+    if (!TEST_CHECK(type_match != NULL)) {
+        TEST_MSG("Got: %s", out_js);
+    }
+
+    flb_free(res_data);
+}
+
 static void cb_check_logstash_format(void *ctx, int ffd,
                                      int res_ret, void *res_data, size_t res_size,
                                      void *data)
@@ -179,6 +207,15 @@ static void cb_check_id_key(void *ctx, int ffd,
 
     p = strstr(out_js, record);
     TEST_CHECK(p != NULL);
+    flb_free(res_data);
+}
+
+static void cb_check_empty_bulk(void *ctx, int ffd,
+                                int res_ret, void *res_data, size_t res_size,
+                                void *data)
+{
+    TEST_CHECK(res_ret == 0);
+    TEST_CHECK(res_size == 0);
     flb_free(res_data);
 }
 
@@ -1058,6 +1095,424 @@ void flb_test_response_partially_success()
     flb_destroy(ctx);
 }
 
+static int create_upstream_file_va(char *path, size_t size,
+                                   const char *first_property,
+                                   va_list args)
+{
+#ifndef _WIN32
+    int fd;
+#else
+    FILE *fp;
+    size_t written;
+#endif
+    char *tmp_path;
+    size_t content_len;
+    const char *property;
+    const char *value;
+    int ret;
+    flb_sds_t content = NULL;
+    flb_sds_t tmp_content = NULL;
+    const char *base_content =
+        "[UPSTREAM]\n"
+        "    name es_cluster\n"
+        "\n"
+        "[NODE]\n"
+        "    name es_node_1\n"
+        "    host 127.0.0.1\n"
+        "    port 9200\n";
+
+    content = flb_sds_create(base_content);
+    if (content == NULL) {
+        return -1;
+    }
+
+    property = first_property;
+    while (property != NULL) {
+        value = va_arg(args, const char *);
+        if (value == NULL) {
+            flb_sds_destroy(content);
+            return -1;
+        }
+
+        tmp_content = flb_sds_printf(&content, "    %s %s\n", property, value);
+        if (tmp_content == NULL) {
+            if (content != NULL) {
+                flb_sds_destroy(content);
+            }
+            return -1;
+        }
+        content = tmp_content;
+
+        property = va_arg(args, const char *);
+    }
+
+    tmp_path = flb_test_tmpdir_cat("/flb-es-upstream-XXXXXX");
+    if (tmp_path == NULL) {
+        flb_sds_destroy(content);
+        return -1;
+    }
+
+    if (strlen(tmp_path) + 1 > size) {
+        flb_free(tmp_path);
+        flb_sds_destroy(content);
+        return -1;
+    }
+
+    strncpy(path, tmp_path, size);
+    flb_free(tmp_path);
+
+#ifndef _WIN32
+    fd = mkstemp(path);
+    if (fd == -1) {
+        flb_sds_destroy(content);
+        return -1;
+    }
+
+    content_len = flb_sds_len(content);
+    ret = write(fd, content, content_len);
+    close(fd);
+    flb_sds_destroy(content);
+    if (ret != (int) content_len) {
+        unlink(path);
+        return -1;
+    }
+#else
+    if (_mktemp_s(path, size) != 0) {
+        flb_sds_destroy(content);
+        return -1;
+    }
+
+    fp = fopen(path, "wb");
+    if (fp == NULL) {
+        flb_sds_destroy(content);
+        return -1;
+    }
+
+    content_len = flb_sds_len(content);
+    written = fwrite(content, 1, content_len, fp);
+    ret = fclose(fp);
+    flb_sds_destroy(content);
+    if (written != content_len || ret != 0) {
+        unlink(path);
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+static flb_ctx_t *create_upstream_test_ctx(char *upstream_file,
+                                           size_t upstream_file_size,
+                                           int *in_ffd,
+                                           int *out_ffd,
+                                           const char *first_property, ...)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    va_list args;
+
+    va_start(args, first_property);
+    ret = create_upstream_file_va(upstream_file, upstream_file_size,
+                                  first_property, args);
+    va_end(args);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        return NULL;
+    }
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    *in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, *in_ffd, "tag", "test", NULL);
+
+    *out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, *out_ffd,
+                   "match", "test",
+                   "upstream", upstream_file,
+                   NULL);
+
+    return ctx;
+}
+
+static void *cb_upstream_flush_ctx(struct flb_config *config,
+                                   struct flb_input_instance *ins,
+                                   void *plugin_context,
+                                   void *flush_ctx)
+{
+    struct flb_elasticsearch *ctx = plugin_context;
+
+    (void) config;
+    (void) ins;
+    (void) flush_ctx;
+
+    if (ctx->ha_mode != FLB_TRUE || ctx->ha == NULL) {
+        return NULL;
+    }
+
+    return flb_upstream_ha_node_get(ctx->ha);
+}
+
+void flb_test_upstream_write_operation()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "write_operation", "upsert",
+                                   "generate_id", "on", NULL);
+    if (!ctx) {
+        return;
+    }
+    (void) in_ffd;
+
+    flb_output_set(ctx, out_ffd,
+                   "write_operation", "create",
+                   "generate_id", "off",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_write_op_upsert,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
+void flb_test_upstream_update_unsafe_id()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    char input[] = "[1448403340,{\"key_2\":\"unsafe\\\\id\"}]";
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "write_operation", "update",
+                                   "id_key", "key_2", NULL);
+    if (!ctx) {
+        return;
+    }
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_empty_bulk,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, input, sizeof(input) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
+void flb_test_upstream_null_index()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "generate_id", "off", NULL);
+    if (!ctx) {
+        return;
+    }
+
+    flb_output_set(ctx, out_ffd,
+                   "index", "",
+                   "type", "type_test",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_index_type,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == -1);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
+void flb_test_upstream_index_type()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "index", "another_index_test",
+                                   "type", "another_type_test", NULL);
+    if (!ctx) {
+        return;
+    }
+
+    flb_output_set(ctx, out_ffd,
+                   "index", "index_test",
+                   "type", "type_test",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_node_index_type,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
+void flb_test_upstream_logstash_format()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "logstash_format", "on",
+                                   "logstash_prefix", "prefix",
+                                   "logstash_prefix_separator", "SEP",
+                                   "logstash_dateformat", "%Y-%m-%d",
+                                   NULL);
+    if (!ctx) {
+        return;
+    }
+
+    flb_output_set(ctx, out_ffd,
+                   "logstash_format", "off",
+                   "logstash_prefix", "logstash",
+                   "logstash_prefix_separator", "-",
+                   "logstash_dateformat", "%Y.%m.%d",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_logstash_prefix_separator,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
+void flb_test_upstream_replace_dots()
+{
+    int ret;
+    int size = sizeof(JSON_DOTS) - 1;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "replace_dots", "on", NULL);
+    if (!ctx) {
+        return;
+    }
+
+    flb_output_set(ctx, out_ffd,
+                   "replace_dots", "off",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_replace_dots,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_DOTS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
+void flb_test_upstream_id_key()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    int in_ffd;
+    int out_ffd;
+    char upstream_file[256];
+    flb_ctx_t *ctx;
+
+    ctx = create_upstream_test_ctx(upstream_file, sizeof(upstream_file),
+                                   &in_ffd, &out_ffd,
+                                   "id_key", "key_2", NULL);
+    if (!ctx) {
+        return;
+    }
+
+    flb_output_set(ctx, out_ffd,
+                   "id_key", "key_2",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(ctx, out_ffd, "formatter",
+                                                cb_check_id_key,
+                                                NULL, NULL,
+                                                cb_upstream_flush_ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    unlink(upstream_file);
+}
+
 /* Test list */
 TEST_LIST = {
     {"long_index"            , flb_test_long_index },
@@ -1077,5 +1532,12 @@ TEST_LIST = {
     {"response_success"      , flb_test_response_success },
     {"response_successes", flb_test_response_successes },
     {"response_partially_success" , flb_test_response_partially_success },
+    {"upstream_write_operation"  , flb_test_upstream_write_operation },
+    {"upstream_update_unsafe_id" , flb_test_upstream_update_unsafe_id },
+    {"upstream_null_index"       , flb_test_upstream_null_index },
+    {"upstream_index_type"       , flb_test_upstream_index_type },
+    {"upstream_logstash_format"  , flb_test_upstream_logstash_format },
+    {"upstream_replace_dots"     , flb_test_upstream_replace_dots },
+    {"upstream_id_key"           , flb_test_upstream_id_key },
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
To implement Elasticsearch upstream connection feature,
we need to implement sds_view which means borrowed sds type operations at first.
Then, we can implement upstream HA feature on out_es plugin.

This could be more simple approach against https://github.com/fluent/fluent-bit/pull/7608.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

Example configs are here:
Normal es ingestions:
[fluent-bit-es/fluent-bit.conf](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es/fluent-bit.conf) and (same in YAML format) [fluent-bit-es/fluent-bit.yaml](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es/fluent-bit.yaml)
upstream ingestions:
[fluent-bit-es-cluster/fluent-bit.yaml](https://github.com/mabrarov/elastic-stack/blob/main/fluent-bit-es-cluster/fluent-bit.yaml) in [mabrarov/elastic-stack](https://github.com/mabrarov/elastic-stack) repository.

- [x] Debug log output from testing the change

Normal:

```
Fluent Bit v5.0.2
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/02 17:04:42.401] [ info] Configuration:
[2026/04/02 17:04:42.423] [ info]  flush time     | 10.000000 seconds
[2026/04/02 17:04:42.431] [ info]  grace          | 5 seconds
[2026/04/02 17:04:42.431] [ info]  daemon         | 0
[2026/04/02 17:04:42.431] [ info] ___________
[2026/04/02 17:04:42.431] [ info]  inputs:
[2026/04/02 17:04:42.432] [ info]      dummy
[2026/04/02 17:04:42.432] [ info] ___________
[2026/04/02 17:04:42.432] [ info]  filters:
[2026/04/02 17:04:42.432] [ info] ___________
[2026/04/02 17:04:42.433] [ info]  outputs:
[2026/04/02 17:04:42.433] [ info]      es.0
[2026/04/02 17:04:42.433] [ info] ___________
[2026/04/02 17:04:42.434] [ info]  collectors:
[2026/04/02 17:04:42.497] [ info] [fluent bit] version=5.0.2, commit=fb8617662e, pid=2737294
[2026/04/02 17:04:42.502] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/04/02 17:04:42.508] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/02 17:04:42.508] [ info] [simd    ] SSE2
[2026/04/02 17:04:42.508] [ info] [cmetrics] version=2.1.1
[2026/04/02 17:04:42.509] [ info] [ctraces ] version=0.7.1
[2026/04/02 17:04:42.523] [ info] [input:dummy:dummy.0] initializing
[2026/04/02 17:04:42.523] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/04/02 17:04:42.525] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2026/04/02 17:04:42.542] [debug] [es:es.0] created event channels: read=23 write=24
[2026/04/02 17:04:42.907] [debug] [output:es:es.0] host=localhost port=9201 uri=/_bulk index=fluent-bit type=_doc
[2026/04/02 17:04:42.982] [ info] [sp] stream processor started
[2026/04/02 17:04:42.984] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/02 17:04:43.028] [ info] [output:es:es.0] worker #0 started
[2026/04/02 17:04:43.031] [ info] [output:es:es.0] worker #3 started
[2026/04/02 17:04:43.031] [ info] [output:es:es.0] worker #1 started
[2026/04/02 17:04:43.034] [ info] [output:es:es.0] worker #2 started
[2026/04/02 17:04:52.019] [debug] [task] created task=0x9863950 id=0 OK
[2026/04/02 17:04:52.021] [debug] [output:es:es.0] task_id=0 assigned to thread #0
[2026/04/02 17:04:52.591] [debug] [upstream] KA connection #69 to localhost:9201 is connected
[2026/04/02 17:04:52.607] [debug] [out_es] converted_size is 0
[2026/04/02 17:04:52.610] [debug] [out_es] converted_size is 0
[2026/04/02 17:04:52.614] [debug] [http_client] not using http_proxy for header
[2026/04/02 17:04:52.687] [debug] [output:es:es.0] HTTP Status=200 URI=/_bulk
[2026/04/02 17:04:52.698] [debug] [output:es:es.0] Elasticsearch response
{"errors":false,"took":0,"items":[{"create":{"_index":"fluent-bit","_id":"2u45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":539,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"2-45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":540,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"3O45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":541,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"3e45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":542,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"3u45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":543,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"3-45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":544,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"4O45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":545,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"4e45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":546,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"4u45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":547,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"4-45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":548,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"5O45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":549,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"5e45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":550,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"5u45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":551,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"5-45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":552,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"6O45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":553,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"6e45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":554,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"6u45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":555,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"6-45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":556,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"7O45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":557,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"7e45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":558,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"7u45TZ0BckMZbRRnR-wd","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":559,"_primary_term":
[2026/04/02 17:04:52.701] [debug] [upstream] KA connection #69 to localhost:9201 is now available
[2026/04/02 17:04:52.704] [debug] [out flush] cb_destroy coro_id=0
[2026/04/02 17:04:52.711] [debug] [task] destroy task=0x9863950 (task_id=0)
^C[2026/04/02 17:04:53] [engine] caught signal (SIGINT)
[2026/04/02 17:04:53.201] [debug] [task] created task=0x9be4f70 id=0 OK
[2026/04/02 17:04:53.202] [debug] [output:es:es.0] task_id=0 assigned to thread #1
[2026/04/02 17:04:53.203] [ warn] [engine] service will shutdown in max 5 seconds
[2026/04/02 17:04:53.204] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/04/02 17:04:53.204] [ info] [engine] pausing all inputs..
[2026/04/02 17:04:53.206] [ info] [input] pausing dummy.0
[2026/04/02 17:04:53.235] [debug] [upstream] KA connection #70 to localhost:9201 is connected
[2026/04/02 17:04:53.236] [debug] [http_client] not using http_proxy for header
[2026/04/02 17:04:53.267] [debug] [output:es:es.0] HTTP Status=200 URI=/_bulk
[2026/04/02 17:04:53.268] [debug] [output:es:es.0] Elasticsearch response
{"errors":false,"took":0,"items":[{"create":{"_index":"fluent-bit","_id":"Ne45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":630,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Nu45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":631,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"N-45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":632,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"OO45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":633,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Oe45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":634,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Ou45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":635,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"O-45TZ0BckMZbRRnSe14","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":636,"_primary_term":1,"status":201}}]}
[2026/04/02 17:04:53.268] [debug] [upstream] KA connection #70 to localhost:9201 is now available
[2026/04/02 17:04:53.268] [debug] [out flush] cb_destroy coro_id=0
[2026/04/02 17:04:53.269] [debug] [task] destroy task=0x9be4f70 (task_id=0)
[2026/04/02 17:04:54.014] [ info] [engine] service has stopped (0 pending tasks)
[2026/04/02 17:04:54.014] [ info] [input] pausing dummy.0
[2026/04/02 17:04:54.016] [ info] [output:es:es.0] thread worker #0 stopping...
[2026/04/02 17:04:54.035] [ info] [output:es:es.0] thread worker #0 stopped
[2026/04/02 17:04:54.056] [ info] [output:es:es.0] thread worker #1 stopping...
[2026/04/02 17:04:54.057] [ info] [output:es:es.0] thread worker #1 stopped
[2026/04/02 17:04:54.058] [ info] [output:es:es.0] thread worker #2 stopping...
[2026/04/02 17:04:54.058] [ info] [output:es:es.0] thread worker #2 stopped
[2026/04/02 17:04:54.058] [ info] [output:es:es.0] thread worker #3 stopping...
[2026/04/02 17:04:54.058] [ info] [output:es:es.0] thread worker #3 stopped
```

Upstream:

```
Fluent Bit v5.0.2
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/02 17:02:43.323] [ info] Configuration:
[2026/04/02 17:02:43.345] [ info]  flush time     | 10.000000 seconds
[2026/04/02 17:02:43.352] [ info]  grace          | 5 seconds
[2026/04/02 17:02:43.352] [ info]  daemon         | 0
[2026/04/02 17:02:43.353] [ info] ___________
[2026/04/02 17:02:43.353] [ info]  inputs:
[2026/04/02 17:02:43.353] [ info]      dummy
[2026/04/02 17:02:43.353] [ info] ___________
[2026/04/02 17:02:43.354] [ info]  filters:
[2026/04/02 17:02:43.354] [ info] ___________
[2026/04/02 17:02:43.354] [ info]  outputs:
[2026/04/02 17:02:43.354] [ info]      es.0
[2026/04/02 17:02:43.355] [ info] ___________
[2026/04/02 17:02:43.355] [ info]  collectors:
[2026/04/02 17:02:43.422] [ info] [fluent bit] version=5.0.2, commit=fb8617662e, pid=2736553
[2026/04/02 17:02:43.429] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/04/02 17:02:43.435] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/02 17:02:43.435] [ info] [simd    ] SSE2
[2026/04/02 17:02:43.435] [ info] [cmetrics] version=2.1.1
[2026/04/02 17:02:43.436] [ info] [ctraces ] version=0.7.1
[2026/04/02 17:02:43.450] [ info] [input:dummy:dummy.0] initializing
[2026/04/02 17:02:43.450] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/04/02 17:02:43.452] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2026/04/02 17:02:43.469] [debug] [es:es.0] created event channels: read=23 write=24
[2026/04/02 17:02:43.480] [debug] [upstream_ha] opening file ./upstream.conf
[2026/04/02 17:02:43.863] [debug] [output:es:es.0] host=127.0.0.1 port=9200 uri=/_bulk index=fluent-bit type=_doc
[2026/04/02 17:02:43.938] [ info] [sp] stream processor started
[2026/04/02 17:02:43.941] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/02 17:02:43.982] [ info] [output:es:es.0] worker #3 started
[2026/04/02 17:02:43.985] [ info] [output:es:es.0] worker #0 started
[2026/04/02 17:02:43.986] [ info] [output:es:es.0] worker #2 started
[2026/04/02 17:02:43.985] [ info] [output:es:es.0] worker #1 started
[2026/04/02 17:02:53.019] [debug] [task] created task=0x98edc90 id=0 OK
[2026/04/02 17:02:53.021] [debug] [output:es:es.0] task_id=0 assigned to thread #0
[2026/04/02 17:02:53.163] [debug] [tls] connection #69 SSL_connect: before SSL initialization
[2026/04/02 17:02:53.253] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS write client hello
[2026/04/02 17:02:53.257] [debug] [tls] connection #69 WANT_READ
[2026/04/02 17:02:53.262] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS write client hello
[2026/04/02 17:02:53.393] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS read server hello
[2026/04/02 17:02:53.395] [debug] [tls] connection #69 SSL_connect: TLSv1.3 read encrypted extensions
[2026/04/02 17:02:53.564] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS read server certificate
[2026/04/02 17:02:53.581] [debug] [tls] connection #69 SSL_connect: TLSv1.3 read server certificate verify
[2026/04/02 17:02:53.586] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS read finished
[2026/04/02 17:02:53.587] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS write change cipher spec
[2026/04/02 17:02:53.596] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS write finished
[2026/04/02 17:02:53.598] [debug] [upstream] KA connection #69 to localhost:9201 is connected
[2026/04/02 17:02:53.615] [debug] [out_es] converted_size is 0
[2026/04/02 17:02:53.618] [debug] [out_es] converted_size is 0
[2026/04/02 17:02:53.623] [debug] [http_client] not using http_proxy for header
[2026/04/02 17:02:53.646] [debug] [tls] connection #69 SSL_connect: SSL negotiation finished successfully
[2026/04/02 17:02:53.646] [debug] [tls] connection #69 SSL_connect: SSL negotiation finished successfully
[2026/04/02 17:02:53.652] [debug] [tls] connection #69 SSL_connect: SSLv3/TLS read server session ticket
[2026/04/02 17:02:53.683] [debug] [output:es:es.0] HTTP Status=200 URI=/_bulk
[2026/04/02 17:02:53.699] [debug] [output:es:es.0] Elasticsearch response
{"errors":false,"took":0,"items":[{"create":{"_index":"fluent-bit","_id":"f-43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":432,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"gO43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":433,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"ge43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":434,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"gu43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":435,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"g-43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":436,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"hO43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":437,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"he43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":438,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"hu43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":439,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"h-43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":440,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"iO43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":441,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"ie43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":442,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"iu43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":443,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"i-43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":444,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"jO43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":445,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"je43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":446,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"ju43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":447,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"j-43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":448,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"kO43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":449,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"ke43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":450,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"ku43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":451,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"k-43TZ0BckMZbRRnduxO","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":452,"_primary_term":
[2026/04/02 17:02:53.704] [debug] [upstream] KA connection #69 to localhost:9201 is now available
[2026/04/02 17:02:53.708] [debug] [out flush] cb_destroy coro_id=0
[2026/04/02 17:02:53.720] [debug] [task] destroy task=0x98edc90 (task_id=0)
^C[2026/04/02 17:02:55] [engine] caught signal (SIGINT)
[2026/04/02 17:02:55.054] [debug] [task] created task=0x9cc00c0 id=0 OK
[2026/04/02 17:02:55.055] [debug] [output:es:es.0] task_id=0 assigned to thread #1
[2026/04/02 17:02:55.056] [ warn] [engine] service will shutdown in max 5 seconds
[2026/04/02 17:02:55.056] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/04/02 17:02:55.057] [ info] [engine] pausing all inputs..
[2026/04/02 17:02:55.058] [ info] [input] pausing dummy.0
[2026/04/02 17:02:55.066] [debug] [tls] connection #70 SSL_connect: before SSL initialization
[2026/04/02 17:02:55.069] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS write client hello
[2026/04/02 17:02:55.069] [debug] [tls] connection #70 WANT_READ
[2026/04/02 17:02:55.073] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS write client hello
[2026/04/02 17:02:55.077] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS read server hello
[2026/04/02 17:02:55.077] [debug] [tls] connection #70 SSL_connect: TLSv1.3 read encrypted extensions
[2026/04/02 17:02:55.085] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS read server certificate
[2026/04/02 17:02:55.087] [debug] [tls] connection #70 SSL_connect: TLSv1.3 read server certificate verify
[2026/04/02 17:02:55.088] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS read finished
[2026/04/02 17:02:55.088] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS write change cipher spec
[2026/04/02 17:02:55.090] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS write finished
[2026/04/02 17:02:55.090] [debug] [upstream] KA connection #70 to localhost:9202 is connected
[2026/04/02 17:02:55.092] [debug] [http_client] not using http_proxy for header
[2026/04/02 17:02:55.093] [debug] [tls] connection #70 SSL_connect: SSL negotiation finished successfully
[2026/04/02 17:02:55.093] [debug] [tls] connection #70 SSL_connect: SSL negotiation finished successfully
[2026/04/02 17:02:55.094] [debug] [tls] connection #70 SSL_connect: SSLv3/TLS read server session ticket
[2026/04/02 17:02:55.125] [debug] [output:es:es.0] HTTP Status=200 URI=/_bulk
[2026/04/02 17:02:55.126] [debug] [output:es:es.0] Elasticsearch response
{"errors":false,"took":0,"items":[{"create":{"_index":"fluent-bit","_id":"Kls3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":523,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"K1s3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":524,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"LFs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":525,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"LVs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":526,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Lls3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":527,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"L1s3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":528,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"MFs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":529,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"MVs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":530,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Mls3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":531,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"M1s3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":532,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"NFs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":533,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"NVs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":534,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Nls3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":535,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"N1s3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":536,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"OFs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":537,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"OVs3TZ0BfsFs5OVhfD8C","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":538,"_primary_term":1,"status":201}}]}
[2026/04/02 17:02:55.127] [debug] [upstream] KA connection #70 to localhost:9202 is now available
[2026/04/02 17:02:55.127] [debug] [out flush] cb_destroy coro_id=0
[2026/04/02 17:02:55.127] [debug] [task] destroy task=0x9cc00c0 (task_id=0)
[2026/04/02 17:02:56.013] [ info] [engine] service has stopped (0 pending tasks)
[2026/04/02 17:02:56.014] [ info] [input] pausing dummy.0
[2026/04/02 17:02:56.018] [ info] [output:es:es.0] thread worker #0 stopping...
[2026/04/02 17:02:56.029] [debug] [tls] connection #69 SSL3 alert write:warning:close notify
[2026/04/02 17:02:56.043] [ info] [output:es:es.0] thread worker #0 stopped
[2026/04/02 17:02:56.064] [ info] [output:es:es.0] thread worker #1 stopping...
[2026/04/02 17:02:56.065] [debug] [tls] connection #70 SSL3 alert write:warning:close notify
[2026/04/02 17:02:56.065] [ info] [output:es:es.0] thread worker #1 stopped
[2026/04/02 17:02:56.066] [ info] [output:es:es.0] thread worker #2 stopping...
[2026/04/02 17:02:56.066] [ info] [output:es:es.0] thread worker #2 stopped
[2026/04/02 17:02:56.066] [ info] [output:es:es.0] thread worker #3 stopping...
[2026/04/02 17:02:56.066] [ info] [output:es:es.0] thread worker #3 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Normal:

```
==2737294== 
==2737294== HEAP SUMMARY:
==2737294==     in use at exit: 0 bytes in 0 blocks
==2737294==   total heap usage: 20,676 allocs, 20,676 frees, 9,024,073 bytes allocated
==2737294== 
==2737294== All heap blocks were freed -- no leaks are possible
==2737294== 
==2737294== For lists of detected and suppressed errors, rerun with: -s
==2737294== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Upstream:

```
==2736553== 
==2736553== HEAP SUMMARY:
==2736553==     in use at exit: 0 bytes in 0 blocks
==2736553==   total heap usage: 24,036 allocs, 24,036 frees, 9,949,052 bytes allocated
==2736553== 
==2736553== All heap blocks were freed -- no leaks are possible
==2736553== 
==2736553== For lists of detected and suppressed errors, rerun with: -s
==2736553== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elasticsearch output: added upstream (HA) support with per-node routing and per-request bulk URI composition.
  * Public SDS API: introduced a lightweight string-view type and a constructor to create SDS from a view.

* **Behavior Changes**
  * Node-scoped authentication now takes precedence over instance-level credentials; logs and retries report composed per-request URIs.

* **Tests**
  * Added unit and runtime tests for upstream/HA and SDS view behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->