### PR TITLE
alias: handle input, output, filter, and processor plugin aliases

### DIFF
--- a/include/fluent-bit/flb_plugin_alias.h
+++ b/include/fluent-bit/flb_plugin_alias.h
@@ -1,0 +1,58 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_PLUGIN_ALIAS_H
+#define FLB_PLUGIN_ALIAS_H
+
+#include <stddef.h>
+
+/*
+ * Returned by flb_plugin_alias_rewrite() when an alias exists but an internal
+ * error prevents generating a rewritten string.
+ */
+#define FLB_PLUGIN_ALIAS_ERR ((char *) -1)
+
+struct flb_plugin_alias_entry {
+    int plugin_type;
+    const char *alias_name;
+    const char *plugin_name;
+};
+
+/*
+ * Returns the canonical plugin name for alias_name when a mapping exists,
+ * otherwise returns NULL.
+ */
+const char *flb_plugin_alias_get(int plugin_type, const char *alias_name,
+                                 size_t alias_name_length);
+
+/*
+ * Rewrites plugin_reference when it starts with a known alias.
+ *
+ * Return values:
+ *   - NULL: no rewrite needed
+ *   - FLB_PLUGIN_ALIAS_ERR: rewrite needed but failed
+ *   - allocated string: rewritten plugin reference (caller must free)
+ */
+char *flb_plugin_alias_rewrite(int plugin_type, const char *plugin_reference);
+
+void flb_plugin_alias_set_custom_entries(
+        const struct flb_plugin_alias_entry *entries);
+void flb_plugin_alias_reset_custom_entries(void);
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ set(src
   flb_crypto.c
   flb_random.c
   flb_plugin.c
+  flb_plugin_alias.c
   flb_gzip.c
   flb_snappy.c
   flb_zstd.c

--- a/src/flb_filter.c
+++ b/src/flb_filter.c
@@ -27,6 +27,8 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_plugin.h>
+#include <fluent-bit/flb_plugin_alias.h>
 #include <chunkio/chunkio.h>
 
 #ifdef FLB_HAVE_CHUNK_TRACE
@@ -435,6 +437,8 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
                                            const char *filter, void *data)
 {
     int id;
+    const char *alias_target;
+    const char *effective_filter_name;
     struct mk_list *head;
     struct flb_filter_plugin *plugin;
     struct flb_filter_instance *instance = NULL;
@@ -443,12 +447,30 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
         return NULL;
     }
 
+    effective_filter_name = filter;
+
     mk_list_foreach(head, &config->filter_plugins) {
         plugin = mk_list_entry(head, struct flb_filter_plugin, _head);
-        if (strcasecmp(plugin->name, filter) == 0) {
+        if (strcasecmp(plugin->name, effective_filter_name) == 0) {
             break;
         }
         plugin = NULL;
+    }
+
+    if (plugin == NULL) {
+        alias_target = flb_plugin_alias_get(FLB_PLUGIN_FILTER, filter,
+                                            strlen(filter));
+        if (alias_target != NULL) {
+            effective_filter_name = alias_target;
+
+            mk_list_foreach(head, &config->filter_plugins) {
+                plugin = mk_list_entry(head, struct flb_filter_plugin, _head);
+                if (strcasecmp(plugin->name, effective_filter_name) == 0) {
+                    break;
+                }
+                plugin = NULL;
+            }
+        }
     }
 
     if (!plugin) {
@@ -493,7 +515,6 @@ struct flb_filter_instance *flb_filter_new(struct flb_config *config,
 
     mk_list_init(&instance->properties);
     mk_list_add(&instance->_head, &config->filters);
-
     return instance;
 }
 

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -44,6 +44,7 @@
 #include <fluent-bit/flb_ring_buffer.h>
 #include <fluent-bit/flb_processor.h>
 #include <fluent-bit/flb_oauth2_jwt.h>
+#include <fluent-bit/flb_plugin_alias.h>
 
 /* input plugin macro helpers */
 #include <fluent-bit/flb_input_plugin.h>
@@ -197,13 +198,21 @@ struct mk_list *flb_input_get_global_config_map(struct flb_config *config)
 static int check_protocol(const char *prot, const char *output)
 {
     int len;
+    char *separator;
 
-    len = strlen(prot);
-    if (len != strlen(output)) {
+    separator = strstr(output, "://");
+    if (separator != NULL && separator != output) {
+        len = separator - output;
+    }
+    else {
+        len = strlen(output);
+    }
+
+    if (strlen(prot) != (size_t) len) {
         return 0;
     }
 
-    if (protcmp(prot, output) != 0) {
+    if (strncasecmp(prot, output, len) != 0) {
         return 0;
     }
 
@@ -275,8 +284,12 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
     int id;
     int ret;
     int flags = 0;
+    size_t input_name_length;
+    const char *alias_target;
+    const char *input_name;
+    const char *separator;
     struct mk_list *head;
-    struct flb_input_plugin *plugin;
+    struct flb_input_plugin *plugin = NULL;
     struct flb_input_instance *instance = NULL;
 
 /* use for locking the use of the chunk trace context. */
@@ -289,9 +302,36 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
         return NULL;
     }
 
+    input_name = input;
+
+    /* Prefer an exact registered plugin name over an alias with the same name. */
     mk_list_foreach(head, &config->in_plugins) {
         plugin = mk_list_entry(head, struct flb_input_plugin, _head);
-        if (!check_protocol(plugin->name, input)) {
+        if (check_protocol(plugin->name, input_name)) {
+            break;
+        }
+        plugin = NULL;
+    }
+
+    if (plugin == NULL) {
+        separator = strstr(input, "://");
+        if (separator != NULL && separator != input) {
+            input_name_length = separator - input;
+        }
+        else {
+            input_name_length = strlen(input);
+        }
+        alias_target = flb_plugin_alias_get(FLB_PLUGIN_INPUT, input,
+                                            input_name_length);
+        if (alias_target == NULL) {
+            return NULL;
+        }
+        input_name = alias_target;
+    }
+
+    mk_list_foreach(head, &config->in_plugins) {
+        plugin = mk_list_entry(head, struct flb_input_plugin, _head);
+        if (!check_protocol(plugin->name, input_name)) {
             plugin = NULL;
             continue;
         }
@@ -471,7 +511,12 @@ struct flb_input_instance *flb_input_new(struct flb_config *config,
 
         /* Plugin use networking */
         if (plugin->flags & (FLB_INPUT_NET | FLB_INPUT_NET_SERVER)) {
-            ret = flb_net_host_set(plugin->name, &instance->host, input);
+            if (strstr(input, "://") != NULL) {
+                ret = flb_net_host_set(plugin->name, &instance->host, input);
+            }
+            else {
+                ret = flb_net_host_set(plugin->name, &instance->host, input_name);
+            }
             if (ret != 0) {
                 if (instance->ht_log_chunks) {
                     flb_hash_table_destroy(instance->ht_log_chunks);

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -161,20 +161,26 @@ int flb_net_host_set(const char *plugin_name, struct flb_net_host *host, const c
     int len;
     int olen;
     const char *s, *e, *u;
+    const char *separator;
 
     memset(host, '\0', sizeof(struct flb_net_host));
 
     olen = strlen(address);
-    if (olen == strlen(plugin_name)) {
-        return 0;
+    separator = strstr(address, "://");
+    if (separator != NULL && separator != address) {
+        s = separator + 3;
     }
+    else {
+        if (olen == strlen(plugin_name)) {
+            return 0;
+        }
 
-    len = strlen(plugin_name) + 3;
-    if (olen < len) {
-        return -1;
+        len = strlen(plugin_name) + 3;
+        if (olen < len) {
+            return -1;
+        }
+        s = address + len;
     }
-
-    s = address + len;
     if (*s == '[') {
         /* IPv6 address (RFC 3986) */
         e = strchr(++s, ']');

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -35,6 +35,7 @@
 #include <fluent-bit/flb_macros.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_plugin.h>
+#include <fluent-bit/flb_plugin_alias.h>
 #include <fluent-bit/flb_plugin_proxy.h>
 #include <fluent-bit/flb_http_client_debug.h>
 #include <fluent-bit/flb_output_thread.h>
@@ -137,12 +138,9 @@ static int check_protocol(const char *prot, const char *output)
         len = strlen(output);
     }
 
-    if (strlen(prot) != len) {
-        return 0;
-    }
-
     /* Output plugin match */
-    if (strncasecmp(prot, output, len) == 0) {
+    if (strlen(prot) == (size_t) len &&
+        strncasecmp(prot, output, len) == 0) {
         return 1;
     }
 
@@ -676,17 +674,24 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
 {
     int ret = -1;
     int flags = 0;
+    size_t output_name_length;
+    const char *alias_target;
+    const char *output_name;
+    const char *separator;
     struct mk_list *head;
-    struct flb_output_plugin *plugin;
+    struct flb_output_plugin *plugin = NULL;
     struct flb_output_instance *instance = NULL;
 
     if (!output) {
         return NULL;
     }
 
+    output_name = output;
+
+    /* Prefer an exact registered plugin name over an alias with the same name. */
     mk_list_foreach(head, &config->out_plugins) {
         plugin = mk_list_entry(head, struct flb_output_plugin, _head);
-        if (!check_protocol(plugin->name, output)) {
+        if (!check_protocol(plugin->name, output_name)) {
             plugin = NULL;
             continue;
         }
@@ -695,6 +700,34 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
             return NULL;
         }
         break;
+    }
+
+    if (plugin == NULL) {
+        separator = strstr(output, "://");
+        if (separator != NULL && separator != output) {
+            output_name_length = separator - output;
+        }
+        else {
+            output_name_length = strlen(output);
+        }
+        alias_target = flb_plugin_alias_get(FLB_PLUGIN_OUTPUT, output,
+                                            output_name_length);
+        if (alias_target != NULL) {
+            output_name = alias_target;
+
+            mk_list_foreach(head, &config->out_plugins) {
+                plugin = mk_list_entry(head, struct flb_output_plugin, _head);
+                if (!check_protocol(plugin->name, output_name)) {
+                    plugin = NULL;
+                    continue;
+                }
+
+                if (public_only && plugin->flags & FLB_OUTPUT_PRIVATE) {
+                    return NULL;
+                }
+                break;
+            }
+        }
     }
 
     if (!plugin) {
@@ -819,10 +852,24 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
 #endif
 
     if (plugin->flags & FLB_OUTPUT_NET) {
-        ret = flb_net_host_set(plugin->name, &instance->host, output);
+        if (strstr(output, "://") != NULL) {
+            ret = flb_net_host_set(plugin->name, &instance->host, output);
+        }
+        else {
+            ret = flb_net_host_set(plugin->name, &instance->host, output_name);
+        }
+
         if (ret != 0) {
-            if (instance->flags & FLB_OUTPUT_SYNCHRONOUS) {
+            if ((instance->flags & FLB_OUTPUT_SYNCHRONOUS) &&
+                 instance->singleplex_queue != NULL) {
                 flb_task_queue_destroy(instance->singleplex_queue);
+            }
+            if (instance->callback != NULL) {
+                flb_callback_destroy(instance->callback);
+            }
+            if (plugin->type != FLB_OUTPUT_PLUGIN_CORE &&
+                instance->context != NULL) {
+                flb_free(instance->context);
             }
             flb_free(instance->http_server_config);
             flb_free(instance);

--- a/src/flb_plugin_alias.c
+++ b/src/flb_plugin_alias.c
@@ -1,0 +1,180 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_plugin.h>
+#include <fluent-bit/flb_plugin_alias.h>
+#include <fluent-bit/flb_compat.h>
+
+/*
+ * Table that maps user-facing aliases to plugin short names.
+ *
+ * Keep this table focused on backwards/forwards compatibility names where the
+ * historical short name is still used internally by the plugin implementation.
+ */
+static struct flb_plugin_alias_entry plugin_aliases[] = {
+    {
+        FLB_PLUGIN_OUTPUT,
+        "elasticsearch",
+        "es"
+    },
+    {
+        0,
+        NULL,
+        NULL
+    }
+};
+
+static const struct flb_plugin_alias_entry *custom_plugin_aliases = NULL;
+static pthread_mutex_t custom_plugin_aliases_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static size_t protocol_part_length(const char *plugin_reference)
+{
+    char *separator;
+
+    separator = strstr(plugin_reference, "://");
+    if (separator != NULL && separator != plugin_reference) {
+        return (size_t) (separator - plugin_reference);
+    }
+
+    return strlen(plugin_reference);
+}
+
+const char *flb_plugin_alias_get(int plugin_type, const char *alias_name,
+                                 size_t alias_name_length)
+{
+    int index;
+    const struct flb_plugin_alias_entry *entry;
+    const struct flb_plugin_alias_entry *aliases;
+
+    if (alias_name == NULL || alias_name_length == 0) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&custom_plugin_aliases_lock);
+    aliases = custom_plugin_aliases;
+    if (aliases != NULL) {
+        for (index = 0; aliases[index].alias_name != NULL; index++) {
+            entry = &aliases[index];
+
+            if (entry->plugin_type != plugin_type) {
+                continue;
+            }
+
+            if (strlen(entry->alias_name) != alias_name_length) {
+                continue;
+            }
+
+            if (strncasecmp(entry->alias_name, alias_name, alias_name_length) == 0) {
+                pthread_mutex_unlock(&custom_plugin_aliases_lock);
+                return entry->plugin_name;
+            }
+        }
+    }
+    pthread_mutex_unlock(&custom_plugin_aliases_lock);
+
+    for (index = 0; plugin_aliases[index].alias_name != NULL; index++) {
+        entry = &plugin_aliases[index];
+
+        if (entry->plugin_type != plugin_type) {
+            continue;
+        }
+
+        if (strlen(entry->alias_name) != alias_name_length) {
+            continue;
+        }
+
+        if (strncasecmp(entry->alias_name, alias_name, alias_name_length) == 0) {
+            return entry->plugin_name;
+        }
+    }
+
+    return NULL;
+}
+
+void flb_plugin_alias_set_custom_entries(
+        const struct flb_plugin_alias_entry *entries)
+{
+    pthread_mutex_lock(&custom_plugin_aliases_lock);
+    custom_plugin_aliases = entries;
+    pthread_mutex_unlock(&custom_plugin_aliases_lock);
+}
+
+void flb_plugin_alias_reset_custom_entries(void)
+{
+    pthread_mutex_lock(&custom_plugin_aliases_lock);
+    custom_plugin_aliases = NULL;
+    pthread_mutex_unlock(&custom_plugin_aliases_lock);
+}
+
+char *flb_plugin_alias_rewrite(int plugin_type, const char *plugin_reference)
+{
+    int ret;
+    size_t reference_length;
+    size_t protocol_length;
+    size_t plugin_name_length;
+    char *rewritten_reference;
+    const char *plugin_name;
+
+    if (plugin_reference == NULL) {
+        return NULL;
+    }
+
+    protocol_length = protocol_part_length(plugin_reference);
+    if (protocol_length == 0) {
+        return NULL;
+    }
+
+    plugin_name = flb_plugin_alias_get(plugin_type, plugin_reference,
+                                       protocol_length);
+    if (plugin_name == NULL) {
+        return NULL;
+    }
+
+    plugin_name_length = strlen(plugin_name);
+
+    if (plugin_name_length == protocol_length &&
+        strncasecmp(plugin_name, plugin_reference, protocol_length) == 0) {
+        return NULL;
+    }
+
+    reference_length = strlen(plugin_reference);
+    rewritten_reference = flb_calloc(1, reference_length - protocol_length +
+                                        plugin_name_length + 1);
+    if (rewritten_reference == NULL) {
+        flb_errno();
+        return FLB_PLUGIN_ALIAS_ERR;
+    }
+
+    memcpy(rewritten_reference, plugin_name, plugin_name_length);
+
+    ret = snprintf(rewritten_reference + plugin_name_length,
+                   reference_length - protocol_length + 1,
+                   "%s", plugin_reference + protocol_length);
+    if (ret < 0) {
+        flb_free(rewritten_reference);
+        return FLB_PLUGIN_ALIAS_ERR;
+    }
+
+    return rewritten_reference;
+}

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -35,6 +35,7 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_plugin.h>
+#include <fluent-bit/flb_plugin_alias.h>
 #include <cfl/cfl.h>
 
 struct flb_config_map processor_global_properties[] = {
@@ -618,13 +619,19 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
                                                      char *unit_name)
 {
     int result;
+    int native_plugin_found;
     struct mk_list *head;
     int    filter_event_type;
+    const char *alias_target;
+    const char *effective_unit_name;
     struct flb_filter_plugin *f = NULL;
     struct flb_filter_instance *f_ins;
     struct flb_config *config = proc->config;
     struct flb_processor_unit *pu = NULL;
     struct flb_processor_instance *processor_instance;
+    struct flb_processor_plugin *processor_plugin;
+
+    effective_unit_name = unit_name;
 
     /*
      * Looking the processor unit by using it's name and type, the first list we
@@ -641,12 +648,57 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
 
         /* skip filters which don't handle the required type */
         if ((event_type & filter_event_type) != 0) {
-            if (strcmp(f->name, unit_name) == 0) {
+            if (strcasecmp(f->name, effective_unit_name) == 0) {
                 break;
             }
         }
 
         f = NULL;
+    }
+
+    /* A processor unit may be either a filter or a native processor. */
+    native_plugin_found = FLB_FALSE;
+    if (f == NULL) {
+        mk_list_foreach(head, &config->processor_plugins) {
+            processor_plugin = mk_list_entry(head, struct flb_processor_plugin, _head);
+            if (strcasecmp(processor_plugin->name, unit_name) == 0) {
+                native_plugin_found = FLB_TRUE;
+                break;
+            }
+        }
+    }
+
+    /* Prefer exact registered names before falling back to aliases. */
+    if (f == NULL && native_plugin_found == FLB_FALSE) {
+        alias_target = flb_plugin_alias_get(FLB_PLUGIN_FILTER, unit_name,
+                                            strlen(unit_name));
+        if (alias_target != NULL) {
+            effective_unit_name = alias_target;
+
+            mk_list_foreach(head, &config->filter_plugins) {
+                f = mk_list_entry(head, struct flb_filter_plugin, _head);
+
+                filter_event_type = f->event_type;
+                if (filter_event_type == 0) {
+                    filter_event_type = FLB_FILTER_LOGS;
+                }
+
+                if ((event_type & filter_event_type) != 0 &&
+                    strcasecmp(f->name, effective_unit_name) == 0) {
+                    break;
+                }
+                f = NULL;
+            }
+        }
+
+        if (f == NULL) {
+            effective_unit_name = unit_name;
+            alias_target = flb_plugin_alias_get(FLB_PLUGIN_PROCESSOR, unit_name,
+                                                strlen(unit_name));
+            if (alias_target != NULL) {
+                effective_unit_name = alias_target;
+            }
+        }
     }
 
     /* allocate and initialize processor unit context */
@@ -659,7 +711,7 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
 
     pu->parent = proc;
     pu->event_type = event_type;
-    pu->name = flb_sds_create(unit_name);
+    pu->name = flb_sds_create(effective_unit_name);
     pu->condition = NULL;
 
     if (!pu->name) {
@@ -673,14 +725,13 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
     if (result != 0) {
         flb_sds_destroy(pu->name);
         flb_free(pu);
-
         return NULL;
     }
 
     /* If we matched a pipeline filter, create the speacial processing unit for it */
     if (f) {
         /* create an instance of the filter */
-        f_ins = flb_filter_new(config, unit_name, NULL);
+        f_ins = flb_filter_new(config, effective_unit_name, NULL);
 
         if (!f_ins) {
             pthread_mutex_destroy(&pu->lock);
@@ -725,7 +776,7 @@ struct flb_processor_unit *flb_processor_unit_create(struct flb_processor *proc,
         processor_instance = flb_processor_instance_create(config,
                                                            pu,
                                                            pu->event_type,
-                                                           unit_name, NULL);
+                                                           (char *) effective_unit_name, NULL);
 
         if (processor_instance == NULL) {
             flb_error("[processor] error creating processor '%s': plugin doesn't exist or failed to initialize", unit_name);

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -56,6 +56,7 @@ set(UNIT_TESTS_FILES
   endianness.c
   task_map.c
   strptime.c
+  plugin_alias.c
   storage_inherit.c
   unicode.c
   opentelemetry.c

--- a/tests/internal/plugin_alias.c
+++ b/tests/internal/plugin_alias.c
@@ -1,0 +1,395 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_plugin.h>
+#include <fluent-bit/flb_plugin_alias.h>
+#include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_filter.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_processor.h>
+
+#include <string.h>
+
+#include "flb_tests_internal.h"
+
+static struct flb_plugin_alias_entry custom_aliases[] = {
+    { FLB_PLUGIN_INPUT, "tailing", "tail" },
+    { FLB_PLUGIN_INPUT, "httping", "http" },
+    { FLB_PLUGIN_FILTER, "grepper", "grep" },
+    { FLB_PLUGIN_PROCESSOR, "countering", "content_modifier" },
+    { FLB_PLUGIN_OUTPUT, "elasticsearch", "es_custom" },
+    { 0, NULL, NULL }
+};
+
+static struct flb_plugin_alias_entry colliding_aliases[] = {
+    { FLB_PLUGIN_INPUT, "dummy", "tail" },
+    { FLB_PLUGIN_FILTER, "grep", "modify" },
+    { FLB_PLUGIN_PROCESSOR, "content_modifier", "labels" },
+    { FLB_PLUGIN_OUTPUT, "stdout", "null" },
+    { 0, NULL, NULL }
+};
+
+void plugin_alias_lookup_test()
+{
+    const char *alias_target;
+
+    alias_target = flb_plugin_alias_get(FLB_PLUGIN_OUTPUT, "elasticsearch",
+                                        strlen("elasticsearch"));
+    if (!TEST_CHECK(alias_target != NULL)) {
+        TEST_MSG("output plugin alias was not resolved");
+        return;
+    }
+
+    if (!TEST_CHECK(strcmp(alias_target, "es") == 0)) {
+        TEST_MSG("unexpected alias target: %s", alias_target);
+    }
+}
+
+void plugin_alias_custom_map_test()
+{
+    const char *alias_target;
+
+    flb_plugin_alias_set_custom_entries(custom_aliases);
+
+    alias_target = flb_plugin_alias_get(FLB_PLUGIN_INPUT, "tailing",
+                                        strlen("tailing"));
+    TEST_CHECK(alias_target != NULL);
+    TEST_CHECK(strcmp(alias_target, "tail") == 0);
+
+    alias_target = flb_plugin_alias_get(FLB_PLUGIN_FILTER, "grepper",
+                                        strlen("grepper"));
+    TEST_CHECK(alias_target != NULL);
+    TEST_CHECK(strcmp(alias_target, "grep") == 0);
+
+    alias_target = flb_plugin_alias_get(FLB_PLUGIN_OUTPUT, "elasticsearch",
+                                        strlen("elasticsearch"));
+    TEST_CHECK(alias_target != NULL);
+    TEST_CHECK(strcmp(alias_target, "es_custom") == 0);
+
+    flb_plugin_alias_reset_custom_entries();
+
+    alias_target = flb_plugin_alias_get(FLB_PLUGIN_OUTPUT, "elasticsearch",
+                                        strlen("elasticsearch"));
+    TEST_CHECK(alias_target != NULL);
+    TEST_CHECK(strcmp(alias_target, "es") == 0);
+}
+
+void plugin_alias_rewrite_test()
+{
+    char *rewritten_name;
+
+    rewritten_name = flb_plugin_alias_rewrite(FLB_PLUGIN_OUTPUT,
+                                              "elasticsearch://127.0.0.1:9200");
+    if (!TEST_CHECK(rewritten_name != FLB_PLUGIN_ALIAS_ERR)) {
+        TEST_MSG("error while rewriting output plugin alias");
+        return;
+    }
+    if (!TEST_CHECK(rewritten_name != NULL)) {
+        TEST_MSG("could not rewrite output plugin alias");
+        return;
+    }
+
+    if (!TEST_CHECK(strcmp(rewritten_name, "es://127.0.0.1:9200") == 0)) {
+        TEST_MSG("unexpected rewritten output plugin name: %s", rewritten_name);
+    }
+
+    flb_free(rewritten_name);
+}
+
+void network_alias_address_parse_test()
+{
+    int ret;
+    struct flb_net_host host;
+
+    ret = flb_net_host_set("es", &host, "elasticsearch://127.0.0.1:9200/path");
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("could not parse alias output address");
+        return;
+    }
+
+    if (!TEST_CHECK(strcmp(host.name, "127.0.0.1") == 0)) {
+        TEST_MSG("unexpected host name parsed from alias output address: %s",
+                 host.name);
+    }
+
+    if (!TEST_CHECK(host.port == 9200)) {
+        TEST_MSG("unexpected host port parsed from alias output address: %d",
+                 host.port);
+    }
+
+    flb_sds_destroy(host.name);
+    flb_sds_destroy(host.listen);
+    if (host.uri != NULL) {
+        flb_uri_destroy(host.uri);
+    }
+    flb_sds_destroy(host.address);
+
+    ret = flb_net_host_set("very_long_original_plugin", &host,
+                           "x://localhost:1234");
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("could not parse a URI with an alias shorter than its target");
+        return;
+    }
+    TEST_CHECK(host.name != NULL && strcmp(host.name, "localhost") == 0);
+    TEST_CHECK(host.port == 1234);
+
+    flb_sds_destroy(host.name);
+    flb_sds_destroy(host.listen);
+    if (host.uri != NULL) {
+        flb_uri_destroy(host.uri);
+    }
+    flb_sds_destroy(host.address);
+}
+
+void output_alias_instantiation_test()
+{
+    struct flb_config *config;
+    struct flb_output_instance *instance;
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        TEST_MSG("could not initialize config context");
+        return;
+    }
+
+    instance = flb_output_new(config,
+                              "elasticsearch://127.0.0.1:9200/test",
+                              NULL, FLB_TRUE);
+    if (!TEST_CHECK(instance != NULL)) {
+        TEST_MSG("could not instantiate aliased output plugin");
+        flb_config_exit(config);
+        return;
+    }
+
+    if (!TEST_CHECK(strcmp(instance->p->name, "es") == 0)) {
+        TEST_MSG("unexpected output plugin instantiated for alias: %s",
+                 instance->p->name);
+    }
+    TEST_CHECK(instance->host.name != NULL &&
+               strcmp(instance->host.name, "127.0.0.1") == 0);
+    TEST_CHECK(instance->host.port == 9200);
+
+    flb_output_instance_destroy(instance);
+
+    instance = flb_output_new(config, "es", NULL, FLB_TRUE);
+    if (!TEST_CHECK(instance != NULL && strcmp(instance->p->name, "es") == 0)) {
+        TEST_MSG("could not instantiate output plugin by its original name");
+        flb_config_exit(config);
+        return;
+    }
+    flb_output_instance_destroy(instance);
+    flb_config_exit(config);
+}
+
+void input_alias_uri_instantiation_test()
+{
+    struct flb_config *config;
+    struct flb_input_instance *alias_instance;
+    struct flb_input_instance *original_instance;
+
+    alias_instance = NULL;
+    original_instance = NULL;
+    flb_plugin_alias_set_custom_entries(custom_aliases);
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        goto cleanup;
+    }
+
+    alias_instance = flb_input_new(config, "httping://127.0.0.1:9880",
+                                   NULL, FLB_TRUE);
+    if (!TEST_CHECK(alias_instance != NULL &&
+                    strcmp(alias_instance->p->name, "http") == 0)) {
+        TEST_MSG("could not instantiate URI input through its alias");
+        goto cleanup;
+    }
+    TEST_CHECK(alias_instance->host.name != NULL &&
+               strcmp(alias_instance->host.name, "127.0.0.1") == 0);
+    TEST_CHECK(alias_instance->host.port == 9880);
+
+    original_instance = flb_input_new(config, "http://127.0.0.1:9881",
+                                      NULL, FLB_TRUE);
+    if (!TEST_CHECK(original_instance != NULL &&
+                    strcmp(original_instance->p->name, "http") == 0)) {
+        TEST_MSG("could not instantiate URI input through its original name");
+        goto cleanup;
+    }
+    TEST_CHECK(original_instance->host.name != NULL &&
+               strcmp(original_instance->host.name, "127.0.0.1") == 0);
+    TEST_CHECK(original_instance->host.port == 9881);
+
+cleanup:
+    if (original_instance != NULL) {
+        flb_input_instance_destroy(original_instance);
+    }
+    if (alias_instance != NULL) {
+        flb_input_instance_destroy(alias_instance);
+    }
+    if (config != NULL) {
+        flb_config_exit(config);
+    }
+    flb_plugin_alias_reset_custom_entries();
+}
+
+void plugin_alias_instance_types_test()
+{
+    struct flb_config *config;
+    struct flb_input_instance *input;
+    struct flb_filter_instance *filter;
+    struct flb_processor *processor;
+    struct flb_processor_unit *filter_unit;
+    struct flb_processor_unit *native_unit;
+
+    input = NULL;
+    filter = NULL;
+    processor = NULL;
+    flb_plugin_alias_set_custom_entries(custom_aliases);
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        TEST_MSG("could not initialize config context");
+        goto cleanup;
+    }
+
+    input = flb_input_new(config, "tailing", NULL, FLB_TRUE);
+    if (!TEST_CHECK(input != NULL && strcmp(input->p->name, "tail") == 0)) {
+        TEST_MSG("could not instantiate an input plugin through its alias");
+        goto cleanup;
+    }
+
+    filter = flb_filter_new(config, "grepper", NULL);
+    if (!TEST_CHECK(filter != NULL && strcmp(filter->p->name, "grep") == 0)) {
+        TEST_MSG("could not instantiate a filter plugin through its alias");
+        goto cleanup;
+    }
+
+    processor = flb_processor_create(config, "alias_test", NULL, FLB_PLUGIN_INPUT);
+    if (!TEST_CHECK(processor != NULL)) {
+        TEST_MSG("could not create processor context");
+        goto cleanup;
+    }
+
+    filter_unit = flb_processor_unit_create(processor, FLB_PROCESSOR_LOGS,
+                                            "grepper");
+    if (!TEST_CHECK(filter_unit != NULL &&
+                    filter_unit->unit_type == FLB_PROCESSOR_UNIT_FILTER)) {
+        TEST_MSG("could not instantiate a processor filter through its alias");
+        goto cleanup;
+    }
+
+    native_unit = flb_processor_unit_create(processor, FLB_PROCESSOR_LOGS,
+                                            "countering");
+    if (!TEST_CHECK(native_unit != NULL &&
+                    native_unit->unit_type == FLB_PROCESSOR_UNIT_NATIVE)) {
+        TEST_MSG("could not instantiate a native processor through its alias");
+    }
+
+cleanup:
+    if (processor != NULL) {
+        flb_processor_destroy(processor);
+    }
+    if (filter != NULL) {
+        flb_filter_instance_destroy(filter);
+    }
+    if (input != NULL) {
+        flb_input_instance_destroy(input);
+    }
+    if (config != NULL) {
+        flb_config_exit(config);
+    }
+    flb_plugin_alias_reset_custom_entries();
+}
+
+void plugin_original_name_precedence_test()
+{
+    struct flb_config *config;
+    struct flb_input_instance *input;
+    struct flb_filter_instance *filter;
+    struct flb_output_instance *output;
+    struct flb_processor *processor;
+    struct flb_processor_unit *unit;
+
+    input = NULL;
+    filter = NULL;
+    output = NULL;
+    processor = NULL;
+    flb_plugin_alias_set_custom_entries(colliding_aliases);
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        TEST_MSG("could not initialize config context");
+        goto cleanup;
+    }
+
+    input = flb_input_new(config, "dummy", NULL, FLB_TRUE);
+    TEST_CHECK(input != NULL && strcmp(input->p->name, "dummy") == 0);
+
+    filter = flb_filter_new(config, "grep", NULL);
+    TEST_CHECK(filter != NULL && strcmp(filter->p->name, "grep") == 0);
+
+    output = flb_output_new(config, "stdout", NULL, FLB_TRUE);
+    TEST_CHECK(output != NULL && strcmp(output->p->name, "stdout") == 0);
+
+    processor = flb_processor_create(config, "precedence_test", NULL,
+                                     FLB_PLUGIN_INPUT);
+    if (processor != NULL) {
+        unit = flb_processor_unit_create(processor, FLB_PROCESSOR_LOGS,
+                                         "content_modifier");
+        TEST_CHECK(unit != NULL &&
+                   strcmp(((struct flb_processor_instance *) unit->ctx)->p->name,
+                          "content_modifier") == 0);
+    }
+    else {
+        TEST_CHECK(processor != NULL);
+    }
+
+cleanup:
+    if (processor != NULL) {
+        flb_processor_destroy(processor);
+    }
+    if (output != NULL) {
+        flb_output_instance_destroy(output);
+    }
+    if (filter != NULL) {
+        flb_filter_instance_destroy(filter);
+    }
+    if (input != NULL) {
+        flb_input_instance_destroy(input);
+    }
+    if (config != NULL) {
+        flb_config_exit(config);
+    }
+    flb_plugin_alias_reset_custom_entries();
+}
+
+TEST_LIST = {
+    { "plugin_alias_lookup_test", plugin_alias_lookup_test },
+    { "plugin_alias_custom_map_test", plugin_alias_custom_map_test },
+    { "plugin_alias_rewrite_test", plugin_alias_rewrite_test },
+    { "network_alias_address_parse_test", network_alias_address_parse_test },
+    { "output_alias_instantiation_test", output_alias_instantiation_test },
+    { "input_alias_uri_instantiation_test", input_alias_uri_instantiation_test },
+    { "plugin_alias_instance_types_test", plugin_alias_instance_types_test },
+    { "plugin_original_name_precedence_test", plugin_original_name_precedence_test },
+    { 0 }
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
We can instantiate out_es as output elasticsearch plugin but the input of elasticsearch plugin is in_elasticsearch.
To maintain naming coherence, we need to handle plugin alias at least of out_es as out_elasticsearch.

With this patch, we can instantiate out_elasticsearch as out_es.

Closes https://github.com/fluent/fluent-bit/issues/9261.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```ini
[SERVICE]
    Flush               10

[INPUT]
    Name                dummy
    Dummy               { "message" : "this is dummy data" }
    Rate                10

[OUTPUT]
    Workers             4
    Name                elasticsearch
    Host                localhost
    Port                9201
    TLS                 On
    tls.verify_hostname On
    tls.ca_file         <your_cert>
    tls.vhost           your-elasticsearch-host
    Retry_Limit         6
    Replace_Dots        On
    Suppress_Type_Name  On
    HTTP_User           elastic
    HTTP_Passwd         elastic
    Index               fluent-bit
```

- [x] Debug log output from testing the change

```
Fluent Bit v5.0.2
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/02 19:46:50.277] [ info] Configuration:
[2026/04/02 19:46:50.298] [ info]  flush time     | 10.000000 seconds
[2026/04/02 19:46:50.306] [ info]  grace          | 5 seconds
[2026/04/02 19:46:50.306] [ info]  daemon         | 0
[2026/04/02 19:46:50.306] [ info] ___________
[2026/04/02 19:46:50.307] [ info]  inputs:
[2026/04/02 19:46:50.307] [ info]      dummy
[2026/04/02 19:46:50.308] [ info] ___________
[2026/04/02 19:46:50.308] [ info]  filters:
[2026/04/02 19:46:50.308] [ info] ___________
[2026/04/02 19:46:50.309] [ info]  outputs:
[2026/04/02 19:46:50.309] [ info]      es.0
[2026/04/02 19:46:50.309] [ info] ___________
[2026/04/02 19:46:50.310] [ info]  collectors:
[2026/04/02 19:46:50.372] [ info] [fluent bit] version=5.0.2, commit=4efcaf7d0e, pid=2864687
[2026/04/02 19:46:50.380] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/04/02 19:46:50.385] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/02 19:46:50.386] [ info] [simd    ] SSE2
[2026/04/02 19:46:50.386] [ info] [cmetrics] version=2.1.1
[2026/04/02 19:46:50.386] [ info] [ctraces ] version=0.7.1
[2026/04/02 19:46:50.400] [ info] [input:dummy:dummy.0] initializing
[2026/04/02 19:46:50.401] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/04/02 19:46:50.402] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2026/04/02 19:46:50.419] [debug] [es:es.0] created event channels: read=23 write=24
[2026/04/02 19:46:50.784] [debug] [output:es:es.0] host=localhost port=9201 uri=/_bulk index=fluent-bit type=_doc
[2026/04/02 19:46:50.859] [ info] [sp] stream processor started
[2026/04/02 19:46:50.861] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/02 19:46:50.899] [ info] [output:es:es.0] worker #2 started
[2026/04/02 19:46:50.900] [ info] [output:es:es.0] worker #0 started
[2026/04/02 19:46:50.899] [ info] [output:es:es.0] worker #1 started
[2026/04/02 19:46:50.902] [ info] [output:es:es.0] worker #3 started
[2026/04/02 19:47:00.017] [debug] [task] created task=0x986bcb0 id=0 OK
[2026/04/02 19:47:00.019] [debug] [output:es:es.0] task_id=0 assigned to thread #0
[2026/04/02 19:47:00.590] [debug] [upstream] KA connection #69 to localhost:9201 is connected
[2026/04/02 19:47:00.606] [debug] [out_es] converted_size is 0
[2026/04/02 19:47:00.609] [debug] [out_es] converted_size is 0
[2026/04/02 19:47:00.611] [debug] [http_client] not using http_proxy for header
[2026/04/02 19:47:00.678] [debug] [output:es:es.0] HTTP Status=200 URI=/_bulk
[2026/04/02 19:47:00.689] [debug] [output:es:es.0] Elasticsearch response
{"errors":false,"took":0,"items":[{"create":{"_index":"fluent-bit","_id":"Re7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":646,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Ru7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":647,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"R-7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":648,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"SO7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":649,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Se7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":650,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Su7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":651,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"S-7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":652,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"TO7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":653,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Te7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":654,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Tu7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":655,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"T-7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":656,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"UO7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":657,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Ue7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":658,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Uu7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":659,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"U-7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":660,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"VO7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":661,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Ve7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":662,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"Vu7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":663,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"V-7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":664,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"WO7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":665,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"We7NTZ0BckMZbRRnt-0m","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":666,"_primary_term":
[2026/04/02 19:47:00.693] [debug] [upstream] KA connection #69 to localhost:9201 is now available
[2026/04/02 19:47:00.695] [debug] [out flush] cb_destroy coro_id=0
[2026/04/02 19:47:00.704] [debug] [task] destroy task=0x986bcb0 (task_id=0)
^C[2026/04/02 19:47:01] [engine] caught signal (SIGINT)
[2026/04/02 19:47:01.244] [debug] [task] created task=0x9c03d10 id=0 OK
[2026/04/02 19:47:01.245] [debug] [output:es:es.0] task_id=0 assigned to thread #1
[2026/04/02 19:47:01.245] [ warn] [engine] service will shutdown in max 5 seconds
[2026/04/02 19:47:01.246] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/04/02 19:47:01.246] [ info] [engine] pausing all inputs..
[2026/04/02 19:47:01.247] [ info] [input] pausing dummy.0
[2026/04/02 19:47:01.279] [debug] [upstream] KA connection #70 to localhost:9201 is connected
[2026/04/02 19:47:01.280] [debug] [http_client] not using http_proxy for header
[2026/04/02 19:47:01.312] [debug] [output:es:es.0] HTTP Status=200 URI=/_bulk
[2026/04/02 19:47:01.313] [debug] [output:es:es.0] Elasticsearch response
{"errors":false,"took":0,"items":[{"create":{"_index":"fluent-bit","_id":"oe7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":738,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"ou7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":739,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"o-7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":740,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"pO7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":741,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"pe7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":742,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"pu7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":743,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"p-7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":744,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"qO7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":745,"_primary_term":1,"status":201}},{"create":{"_index":"fluent-bit","_id":"qe7NTZ0BckMZbRRnue2j","_version":1,"result":"created","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":746,"_primary_term":1,"status":201}}]}
[2026/04/02 19:47:01.313] [debug] [upstream] KA connection #70 to localhost:9201 is now available
[2026/04/02 19:47:01.313] [debug] [out flush] cb_destroy coro_id=0
[2026/04/02 19:47:01.314] [debug] [task] destroy task=0x9c03d10 (task_id=0)
[2026/04/02 19:47:02.012] [ info] [engine] service has stopped (0 pending tasks)
[2026/04/02 19:47:02.013] [ info] [input] pausing dummy.0
[2026/04/02 19:47:02.016] [ info] [output:es:es.0] thread worker #0 stopping...
[2026/04/02 19:47:02.035] [ info] [output:es:es.0] thread worker #0 stopped
[2026/04/02 19:47:02.056] [ info] [output:es:es.0] thread worker #1 stopping...
[2026/04/02 19:47:02.057] [ info] [output:es:es.0] thread worker #1 stopped
[2026/04/02 19:47:02.057] [ info] [output:es:es.0] thread worker #2 stopping...
[2026/04/02 19:47:02.058] [ info] [output:es:es.0] thread worker #2 stopped
[2026/04/02 19:47:02.058] [ info] [output:es:es.0] thread worker #3 stopping...
[2026/04/02 19:47:02.058] [ info] [output:es:es.0] thread worker #3 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==2864687== 
==2864687== HEAP SUMMARY:
==2864687==     in use at exit: 0 bytes in 0 blocks
==2864687==   total heap usage: 20,719 allocs, 20,719 frees, 9,198,473 bytes allocated
==2864687== 
==2864687== All heap blocks were freed -- no leaks are possible
==2864687== 
==2864687== For lists of detected and suppressed errors, rerun with: -s
==2864687== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin aliasing: refer to output plugins by friendly names (e.g., "elasticsearch" → "es") during selection.
  * Automatic URI rewriting: alias-style connection strings are rewritten to canonical plugin identifiers at instantiation.

* **Improvements**
  * Network address parsing correctly handles URIs with scheme prefixes when extracting host/port.

* **Bug Fixes**
  * Improved cleanup and error handling when alias rewriting or network parsing fail.

* **Tests**
  * Added unit tests for alias lookup, URI rewrite, address parsing, and plugin instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->