### PR TITLE
network: Handle baraketed ipv6 addresses

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1648,18 +1648,38 @@ flb_sockfd_t flb_net_server(const char *port, const char *listen_addr,
 {
     flb_sockfd_t fd = -1;
     int ret;
+    size_t listen_addr_len;
     struct addrinfo hints;
     struct addrinfo *res, *rp;
+    const char *normalized_listen_addr;
+    char *listen_addr_copy;
+
+    listen_addr_copy = NULL;
+    normalized_listen_addr = listen_addr;
+
+    if (listen_addr != NULL && listen_addr[0] == '[') {
+        listen_addr_len = strlen(listen_addr);
+
+        if (listen_addr_len >= 3 && listen_addr[listen_addr_len - 1] == ']') {
+            listen_addr_copy = flb_strndup(listen_addr + 1, listen_addr_len - 2);
+            if (listen_addr_copy != NULL) {
+                normalized_listen_addr = listen_addr_copy;
+            }
+        }
+    }
 
     memset(&hints, 0, sizeof hints);
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = AI_PASSIVE;
 
-    ret = getaddrinfo(listen_addr, port, &hints, &res);
+    ret = getaddrinfo(normalized_listen_addr, port, &hints, &res);
     if (ret != 0) {
         flb_warn("net_server: getaddrinfo(listen='%s:%s'): %s",
                  listen_addr, port, gai_strerror(ret));
+        if (listen_addr_copy != NULL) {
+            flb_free(listen_addr_copy);
+        }
         return -1;
     }
 
@@ -1687,6 +1707,10 @@ flb_sockfd_t flb_net_server(const char *port, const char *listen_addr,
     }
     freeaddrinfo(res);
 
+    if (listen_addr_copy != NULL) {
+        flb_free(listen_addr_copy);
+    }
+
     if (rp == NULL) {
         return -1;
     }
@@ -1698,18 +1722,38 @@ flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr, int s
 {
     flb_sockfd_t fd = -1;
     int ret;
+    size_t listen_addr_len;
     struct addrinfo hints;
     struct addrinfo *res, *rp;
+    const char *normalized_listen_addr;
+    char *listen_addr_copy;
+
+    listen_addr_copy = NULL;
+    normalized_listen_addr = listen_addr;
+
+    if (listen_addr != NULL && listen_addr[0] == '[') {
+        listen_addr_len = strlen(listen_addr);
+
+        if (listen_addr_len >= 3 && listen_addr[listen_addr_len - 1] == ']') {
+            listen_addr_copy = flb_strndup(listen_addr + 1, listen_addr_len - 2);
+            if (listen_addr_copy != NULL) {
+                normalized_listen_addr = listen_addr_copy;
+            }
+        }
+    }
 
     memset(&hints, 0, sizeof hints);
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags = AI_PASSIVE;
 
-    ret = getaddrinfo(listen_addr, port, &hints, &res);
+    ret = getaddrinfo(normalized_listen_addr, port, &hints, &res);
     if (ret != 0) {
         flb_warn("net_server_udp: getaddrinfo(listen='%s:%s'): %s",
                  listen_addr, port, gai_strerror(ret));
+        if (listen_addr_copy != NULL) {
+            flb_free(listen_addr_copy);
+        }
         return -1;
     }
 
@@ -1733,6 +1777,10 @@ flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr, int s
         break;
     }
     freeaddrinfo(res);
+
+    if (listen_addr_copy != NULL) {
+        flb_free(listen_addr_copy);
+    }
 
     if (rp == NULL) {
         return -1;

--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -13,6 +13,7 @@
 
 #define TEST_HOSTv4           "127.0.0.1"
 #define TEST_HOSTv6           "::1"
+#define TEST_HOSTv6_BRACKETED "[::1]"
 #define TEST_PORT             "41322"
 
 #define TEST_EV_CLIENT        MK_EVENT_NOTIFICATION
@@ -159,8 +160,30 @@ void test_ipv6_client_server()
     test_client_server(FLB_TRUE);
 }
 
+void test_ipv6_bracketed_listen()
+{
+    flb_sockfd_t fd_server;
+
+    errno = 0;
+    fd_server = flb_net_server(TEST_PORT, TEST_HOSTv6_BRACKETED,
+                               FLB_NETWORK_DEFAULT_BACKLOG_SIZE,
+                               FLB_FALSE);
+
+    if (fd_server == -1 && errno == EAFNOSUPPORT) {
+        TEST_MSG("This protocol is not supported in this platform");
+        return;
+    }
+
+    TEST_CHECK(fd_server != -1);
+
+    if (fd_server != -1) {
+        flb_socket_close(fd_server);
+    }
+}
+
 TEST_LIST = {
     { "ipv4_client_server", test_ipv4_client_server},
     { "ipv6_client_server", test_ipv6_client_server},
+    { "ipv6_bracketed_listen", test_ipv6_bracketed_listen},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Closes https://github.com/fluent/fluent-bit/issues/11668.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
    flush:           1
    daemon:          off
    log_level:       debug
    hot_reload:      on
    http_server:     on
    http_listen:     "[::]"

pipeline:
    inputs:
        - name: random
          tag:  test

    filters:
        - name: lua
          match: "*"
          call: append_tag
          code: |
            function append_tag(tag, timestamp, record)
              new_record = record
              new_record["tag"] = tag
              return 1, timestamp, new_record
            end
    outputs:
        - name: stdout
          match: "*"
```

- [x] Debug log output from testing the change

```
Fluent Bit v5.0.2
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/06 16:17:55.706] [ info] Configuration:
[2026/04/06 16:17:55.706] [ info]  flush time     | 1.000000 seconds
[2026/04/06 16:17:55.706] [ info]  grace          | 5 seconds
[2026/04/06 16:17:55.706] [ info]  daemon         | 0
[2026/04/06 16:17:55.706] [ info] ___________
[2026/04/06 16:17:55.706] [ info]  inputs:
[2026/04/06 16:17:55.706] [ info]      random
[2026/04/06 16:17:55.706] [ info] ___________
[2026/04/06 16:17:55.706] [ info]  filters:
[2026/04/06 16:17:55.706] [ info]      lua.0
[2026/04/06 16:17:55.706] [ info] ___________
[2026/04/06 16:17:55.706] [ info]  outputs:
[2026/04/06 16:17:55.706] [ info]      stdout.0
[2026/04/06 16:17:55.706] [ info] ___________
[2026/04/06 16:17:55.706] [ info]  collectors:
[2026/04/06 16:17:55.706] [ info] [fluent bit] version=5.0.2, commit=24a62bc6f2, pid=1514
[2026/04/06 16:17:55.706] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2026/04/06 16:17:55.706] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/06 16:17:55.706] [ info] [simd    ] NEON
[2026/04/06 16:17:55.706] [ info] [cmetrics] version=2.1.1
[2026/04/06 16:17:55.706] [ info] [ctraces ] version=0.7.1
[2026/04/06 16:17:55.706] [ info] [input:random:random.0] initializing
[2026/04/06 16:17:55.706] [ info] [input:random:random.0] storage_strategy='memory' (memory only)
[2026/04/06 16:17:55.706] [debug] [random:random.0] created event channels: read=21 write=22
[2026/04/06 16:17:55.706] [debug] [input:random:random.0] interval_sec=1 interval_nsec=0
[2026/04/06 16:17:55.707] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2026/04/06 16:17:55.707] [ info] [output:stdout:stdout.0] worker #0 started
[2026/04/06 16:17:55.707] [debug] [downstream] listening on [::]:2020
[2026/04/06 16:17:55.707] [ info] [http_server] listen iface=[::] tcp_port=2020
[2026/04/06 16:17:55.707] [ info] [sp] stream processor started
[2026/04/06 16:17:55.707] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
^C[2026/04/06 16:17:57] [engine] caught signal (SIGINT)
[2026/04/06 16:17:57.706] [ info] [input] pausing random.0
[2026/04/06 16:17:57.706] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/04/06 16:17:57.706] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

leaks command's result on macOS:

```
Process 1802 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [1802]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x10274c000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [1801]
Target Type:     live task

Date/Time:       2026-04-06 16:19:02.607 +0900
Launch Time:     2026-04-06 16:18:55.330 +0900
OS Version:      macOS 26.3.1 (25D2128)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 26.4 (17E192)

Physical footprint:         7681K
Physical footprint (peak):  7793K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 1802: 1257 nodes malloced for 197 KB
Process 1802: 0 leaks for 0 total leaked bytes.

[2026/04/06 16:19:03] [engine] caught signal (SIGCONT)
[2026/04/06 16:19:03] [engine] caught signal (SIGHUP)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proper handling of IPv6 addresses in bracket notation (e.g., [::1]) when configuring servers, improving reliability across environments.

* **Tests**
  * Added targeted test coverage for listening on bracketed IPv6 addresses to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->