### PR TITLE
 out_stackdriver: fix metrics on partial failures and retries

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -2777,6 +2777,7 @@ static int parse_partial_success_response(struct flb_http_client* c,
     msgpack_object logEntryError_map;
     msgpack_object logEntryCode;
     msgpack_object at_type;
+    int partial_success_found = FLB_FALSE;
 
     if (c->resp.status != 400 && c->resp.status != 403) {
         return -1;
@@ -2866,14 +2867,19 @@ static int parse_partial_success_response(struct flb_http_client* c,
                                                    "@type", 5,
                                                    MSGPACK_OBJECT_STR,
                                                    &at_type);
-        strncpy(at_type_str, at_type.via.str.ptr,
-                PARTIAL_SUCCESS_GRPC_TYPE_SIZE);
         if (ret != 0 ||
-            at_type.via.str.size != PARTIAL_SUCCESS_GRPC_TYPE_SIZE ||
-            strncmp(at_type_str, PARTIAL_SUCCESS_GRPC_TYPE,
-                           PARTIAL_SUCCESS_GRPC_TYPE_SIZE) != 0) {
+            at_type.via.str.size != PARTIAL_SUCCESS_GRPC_TYPE_SIZE) {
             continue;
         }
+
+        strncpy(at_type_str, at_type.via.str.ptr,
+                PARTIAL_SUCCESS_GRPC_TYPE_SIZE);
+        if (strncmp(at_type_str, PARTIAL_SUCCESS_GRPC_TYPE,
+                    PARTIAL_SUCCESS_GRPC_TYPE_SIZE) != 0) {
+            continue;
+        }
+
+        partial_success_found = FLB_TRUE;
 
         ret = extract_msgpack_obj_from_msgpack_map(&details_map.via.map,
                                                    "logEntryErrors", 14,
@@ -2925,7 +2931,7 @@ static int parse_partial_success_response(struct flb_http_client* c,
     }
     flb_free(buffer);
     msgpack_unpacked_destroy(&result);
-    return 0;
+    return partial_success_found == FLB_TRUE ? 0 : -1;
 }
 static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
                                  struct flb_output_flush *out_flush,
@@ -2937,7 +2943,8 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     (void) config;
     int ret;
     int code;
-    int ret_partial_success;
+    int failed_records = 0;
+    int ret_partial_success = -1;
     int ret_code = FLB_RETRY;
     int formatted_records = 0;
     int grpc_status_counts[GRPC_STATUS_CODES_SIZE] = {0};
@@ -2953,9 +2960,9 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
     uint64_t write_entries_start = 0;
     uint64_t write_entries_end = 0;
     float write_entries_latency = 0.0;
+    uint64_t ts = cfl_time_now();
 #ifdef FLB_HAVE_METRICS
     char *name = (char *) flb_output_name(ctx->ins);
-    uint64_t ts = cfl_time_now();
 #endif
 
     /* Reformat msgpack to stackdriver JSON payload */
@@ -3069,7 +3076,6 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
             ret_code = FLB_OK;
         }
         else {
-#ifdef FLB_HAVE_METRICS
           /* check partial success */
           ret_partial_success =
                 parse_partial_success_response(c,
@@ -3077,45 +3083,53 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
                                                ts,
                                                grpc_status_counts);
 
-            int failed_records = 0;
-            if (ret_partial_success == 0) {
-              for (code = 0; code < GRPC_STATUS_CODES_SIZE; code++) {
-                if (grpc_status_counts[code] != 0) {
-                  failed_records += grpc_status_counts[code];
-                }
-              }
-              cmt_counter_add(ctx->ins->cmt_dropped_records, ts,
-                              failed_records, 1, (char* []) {name});
-              int successful_records =
-                  formatted_records - failed_records;
-              if (successful_records != 0) {
-                add_record_metrics(ctx, ts, successful_records, 200, 0);
+          if (ret_partial_success == 0) {
+            ret_code = FLB_OK;
+
+            for (code = 0; code < GRPC_STATUS_CODES_SIZE; code++) {
+              if (grpc_status_counts[code] != 0) {
+                failed_records += grpc_status_counts[code];
               }
             }
-            else {
-              add_record_metrics(ctx, ts, formatted_records,
-                                 c->resp.status, -1);
-              cmt_counter_add(ctx->ins->cmt_dropped_records, ts,
-                              formatted_records, 1,
-                              (char* []) {name});
+
+            flb_plg_warn(ctx->ins, "partial success: %d of %d records dropped",
+                         failed_records, formatted_records);
+
+#ifdef FLB_HAVE_METRICS
+            cmt_counter_add(ctx->ins->cmt_dropped_records, ts,
+                            failed_records, 1, (char* []) {name});
+            int successful_records =
+                formatted_records - failed_records;
+            if (successful_records != 0) {
+              add_record_metrics(ctx, ts, successful_records, 200, 0);
             }
 #endif
-          if (c->resp.status >= 400 && c->resp.status < 500) {
-            ret_code = FLB_ERROR;
-            flb_plg_warn(ctx->ins, "tag=%s error sending to Cloud Logging: %s", event_chunk->tag,
-                         c->resp.payload);
           }
+#ifdef FLB_HAVE_METRICS
           else {
-            if (c->resp.payload_size > 0) {
-              /* we got an error */
+            add_record_metrics(ctx, ts, formatted_records,
+                               c->resp.status, -1);
+          }
+#endif
+          /* Partial success is set FLB_OK, with manual update of failure metrics */
+          if (ret_partial_success != 0) {
+            if (c->resp.status >= 400 && c->resp.status < 500) {
+              ret_code = FLB_ERROR;
               flb_plg_warn(ctx->ins, "tag=%s error sending to Cloud Logging: %s", event_chunk->tag,
                            c->resp.payload);
             }
             else {
-              flb_plg_debug(ctx->ins, "tag=%s response from Cloud Logging: %s", event_chunk->tag,
-                            c->resp.payload);
+              if (c->resp.payload_size > 0) {
+                /* we got an error */
+                flb_plg_warn(ctx->ins, "tag=%s error sending to Cloud Logging: %s", event_chunk->tag,
+                             c->resp.payload);
+              }
+              else {
+                flb_plg_debug(ctx->ins, "tag=%s response from Cloud Logging: %s", event_chunk->tag,
+                              c->resp.payload);
+              }
+              ret_code = FLB_RETRY;
             }
-            ret_code = FLB_RETRY;
           }
         }
     }
@@ -3127,7 +3141,10 @@ static void cb_stackdriver_flush(struct flb_event_chunk *event_chunk,
         if (write_entries_latency > 0.0) {
           cmt_histogram_observe(ctx->cmt_write_entries_latency, ts, write_entries_latency, 1, (char *[]) {name});
         }
-        add_record_metrics(ctx, ts, formatted_records, 200, 0);
+        /* Only add full batch metrics if this was NOT a partial success */
+        if (ret_partial_success != 0) {
+            add_record_metrics(ctx, ts, formatted_records, 200, 0);
+        }
 
         /* OLD api */
         flb_metrics_sum(FLB_STACKDRIVER_SUCCESSFUL_REQUESTS, 1, ctx->ins->metrics);


### PR DESCRIPTION
<!-- Provide summary of changes -->

This change makes a few fixes:

1. `ctx->ins->cmt_dropped_records` is no longer updated outside of the partial failure scenario. The plugin previously incremented this core metric when receiving a retryable 5xx error or standard 4xx errors (which would get double-counted due to core engine incrementing).

2. Upon partial failure ret_code is now set to `FLB_OK`. 
    Previously, we would fall through to trigger `FLB_ERROR` for any 4xx. In the case of a partial failure this would double-count failures (plugin would manually increment counter for failed records, then the core engine would increment counter for all records in chunk).
   
   This behavior seems to align with what is done in other plugins that handle partial failure. I left in the logic of manually incrementing the failure counter for only the failed records. Other plugins don't do the metric updates, but it seemed like a good feature.

3. Log number of logs dropped on partial failure. Since we return `FLB_OK` to clear the chunk, logs are otherwise silent about these drops. Added a `flb_plg_warn` to maintain operational visibility.

4. `failed_records` is no longer within #ifdef, put up at top of function definition to align with style guide.

5. Moved the partial success parsing logic outside of the `#ifdef FLB_HAVE_METRICS` compile flag. This ensures all builds identify partial successes and clear the chunk consistently.

6. Guarded the batch success metrics update at the bottom of the function to only update them if it wasn't a partial success, stopping double counting of successful records.

7. Tightened up `parse_partial_success_response` to only return success if it actually found a partial success detail in the response, to avoid accidentally dropping logs on standard 400/403 errors with other details. Also split the type check step there to ensure string operations are safe from garbage memory if parsing failed.

**Motivation**:

The `out_stackdriver` plugin was erroneously incrementing the instance `cmt_dropped_records` metric when receiving a retryable 5xx error from stackdriver.

Logs look like:
```
[2026/04/02 06:54:08.610] [ warn] [output:stackdriver:stackdriver.0] tag=log.systemd error sending to Cloud Logging: {
"error": {
"code": 503,
"message": "Authentication backend unavailable.",
"status": "UNAVAILABLE"
}
}
[2026/04/02 06:54:08.610] [ warn] [engine] failed to flush chunk '26829-1775112843.103700327.flb', retry in 8 seconds: task_id=7, input=router > output=stackdriver.0 (out_id=0)
[2026/04/02 06:54:16.684] [ info] [engine] flush chunk '26829-1775112843.103700327.flb' succeeded at retry 1: task_id=7, input=router > output=stackdriver.0 (out_id=0)
```

The retry succeeds but the `fluentbit_output_dropped_records_total` metric already had been incremented.

This violates the contract for `fluentbit_output_dropped_records_total`:

> The number of log records dropped by the output. These records hit an unrecoverable error or retries expired for their chunk.

From my understanding, the plugin shouldn't be updating `ctx->ins->cmt_dropped_records` as the fluentbit core should be updating the metrics on the batch based on the ret_code (`FLB_OK`, `FLB_RETRY`, `FLB_ERROR`). The partial failure is an edgecase, where it makes sense to increment the failure, though other plugins don't opt to do that.

For transparency , I used an LLM to track down the source of the bug I had seen (failed metric incrementing during successful retries). I reviewed the suggested change manually to ensure the changes made sense to me. I am not familiar with the fluentbit codebase though, so there could be a glaring error I misssed.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [X] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected partial-success handling so dropped vs processed record counts are reported accurately per batch.
  * Improved warnings and logging to better surface partial failures and when records are retried.
  * Refined metrics: dropped and successful record counters are now updated for partial successes, and per-batch metrics reflect HTTP status classification (client vs server errors) to inform retries and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->