### PR TITLE
in_tail: harden db offset restore across restart

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -309,6 +309,13 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
         return NULL;
     }
 
+    ctx->aged_out_file_inodes = flb_hash_table_create(FLB_HASH_TABLE_EVICT_NONE, 1000, 0);
+    if (ctx->aged_out_file_inodes == NULL) {
+        flb_plg_error(ctx->ins, "could not create aged out file inode hash table");
+        flb_tail_config_destroy(ctx);
+        return NULL;
+    }
+
 #ifdef FLB_HAVE_SQLDB
     ctx->db = NULL;
 #endif
@@ -570,6 +577,10 @@ int flb_tail_config_destroy(struct flb_tail_config *config)
 
     if (config->ignored_file_sizes != NULL) {
         flb_hash_table_destroy(config->ignored_file_sizes);
+    }
+
+    if (config->aged_out_file_inodes != NULL) {
+        flb_hash_table_destroy(config->aged_out_file_inodes);
     }
 
     flb_free(config);

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -182,6 +182,7 @@ struct flb_tail_config {
     struct flb_hash_table *event_hash;
 
     struct flb_hash_table *ignored_file_sizes;
+    struct flb_hash_table *aged_out_file_inodes;
 
     struct flb_config *config;
 };

--- a/plugins/in_tail/tail_db.c
+++ b/plugins/in_tail/tail_db.c
@@ -26,12 +26,39 @@
 #include "tail_file.h"
 
 #include <inttypes.h>
+#include <string.h>
 
 struct query_status {
     int id;
     int rows;
     int64_t offset;
 };
+
+static int db_apply_migration_if_needed(struct flb_tail_config *ctx,
+                                        struct flb_sqldb *db,
+                                        const char *sql)
+{
+    int ret;
+    char *err = NULL;
+
+    ret = sqlite3_exec(db->handler, sql, NULL, NULL, &err);
+    if (ret != SQLITE_OK) {
+        if (err != NULL &&
+            (strstr(err, "duplicate column name") != NULL ||
+             strstr(err, "already exists") != NULL)) {
+            sqlite3_free(err);
+            return FLB_OK;
+        }
+
+        flb_plg_error(ctx->ins, "db migration failed: %s", err ? err : "unknown error");
+        if (err != NULL) {
+            sqlite3_free(err);
+        }
+        return FLB_ERROR;
+    }
+
+    return FLB_OK;
+}
 
 static inline int tail_db_lock(struct flb_tail_config *ctx)
 {
@@ -106,6 +133,20 @@ struct flb_sqldb *flb_tail_db_open(const char *path,
         }
     }
 
+    ret = db_apply_migration_if_needed(ctx, db,
+                                       SQL_ALTER_FILES_ADD_OFFSET_MARKER);
+    if (ret != FLB_OK) {
+        flb_sqldb_close(db);
+        return NULL;
+    }
+
+    ret = db_apply_migration_if_needed(ctx, db,
+                                       SQL_ALTER_FILES_ADD_OFFSET_MARKER_SIZE);
+    if (ret != FLB_OK) {
+        flb_sqldb_close(db);
+        return NULL;
+    }
+
     return db;
 }
 
@@ -150,7 +191,8 @@ static int flb_tail_db_file_delete_by_id(struct flb_tail_config *ctx,
  */
 static int db_file_exists(struct flb_tail_file *file,
                           struct flb_tail_config *ctx,
-                          uint64_t *id, uint64_t *inode, off_t *offset)
+                          uint64_t *id, uint64_t *inode, off_t *offset,
+                          uint64_t *offset_marker, size_t *offset_marker_size)
 {
     int ret;
     int exists = FLB_FALSE;
@@ -178,6 +220,12 @@ static int db_file_exists(struct flb_tail_file *file,
 
         /* inode: column 3 */
         *inode = sqlite3_column_int64(ctx->stmt_get_file, 3);
+
+        /* offset_marker: column 4 */
+        *offset_marker = sqlite3_column_int64(ctx->stmt_get_file, 4);
+
+        /* offset_marker_size: column 5 */
+        *offset_marker_size = sqlite3_column_int64(ctx->stmt_get_file, 5);
 
         /* Checking if the file's name and inode match exactly */
         if (ctx->compare_filename) {
@@ -210,15 +258,27 @@ static int db_file_insert(struct flb_tail_file *file, struct flb_tail_config *ct
 {
     int ret;
     time_t created;
+    off_t db_offset;
 
     /* Register the file */
     created = time(NULL);
+    db_offset = flb_tail_file_db_offset(file);
+
+    ret = flb_tail_file_update_offset_marker(file);
+    if (ret < 0) {
+        flb_plg_error(ctx->ins,
+                      "db: cannot compute offset marker for insert %s inode=%" PRIu64,
+                      file->name, file->inode);
+        return -1;
+    }
 
     /* Bind parameters */
     sqlite3_bind_text(ctx->stmt_insert_file, 1, file->name, -1, 0);
-    sqlite3_bind_int64(ctx->stmt_insert_file, 2, file->offset);
+    sqlite3_bind_int64(ctx->stmt_insert_file, 2, db_offset);
     sqlite3_bind_int64(ctx->stmt_insert_file, 3, file->inode);
     sqlite3_bind_int64(ctx->stmt_insert_file, 4, created);
+    sqlite3_bind_int64(ctx->stmt_insert_file, 5, file->db_offset_marker);
+    sqlite3_bind_int64(ctx->stmt_insert_file, 6, file->db_offset_marker_size);
 
     /* Run the insert */
     ret = sqlite3_step(ctx->stmt_insert_file);
@@ -420,6 +480,8 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
     uint64_t id = 0;
     off_t offset = 0;
     uint64_t inode = 0;
+    uint64_t offset_marker = 0;
+    size_t offset_marker_size = 0;
 
     flb_plg_debug(ctx->ins, "db file set called for %s inode=%"PRIu64,
                   file->name, file->inode);
@@ -431,7 +493,8 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
     }
 
     /* Check if the file exists */
-    ret = db_file_exists(file, ctx, &id, &inode, &offset);
+    ret = db_file_exists(file, ctx, &id, &inode, &offset,
+                         &offset_marker, &offset_marker_size);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "cannot execute query to check inode: %" PRIu64,
                       file->inode);
@@ -451,6 +514,8 @@ int flb_tail_db_file_set(struct flb_tail_file *file,
     else {
         file->db_id = id;
         file->offset = offset;
+        file->db_offset_marker = offset_marker;
+        file->db_offset_marker_size = offset_marker_size;
     }
 
     tail_db_unlock(ctx);
@@ -462,6 +527,7 @@ int flb_tail_db_file_offset(struct flb_tail_file *file,
                             struct flb_tail_config *ctx)
 {
     int ret;
+    off_t db_offset;
 
     ret = tail_db_lock(ctx);
     if (ret != 0) {
@@ -469,9 +535,21 @@ int flb_tail_db_file_offset(struct flb_tail_file *file,
         return -1;
     }
 
+    db_offset = flb_tail_file_db_offset(file);
+    ret = flb_tail_file_update_offset_marker(file);
+    if (ret < 0) {
+        flb_plg_error(ctx->ins,
+                      "db: cannot compute offset marker for update %s inode=%" PRIu64,
+                      file->name, file->inode);
+        tail_db_unlock(ctx);
+        return -1;
+    }
+
     /* Bind parameters */
-    sqlite3_bind_int64(ctx->stmt_offset, 1, file->offset);
-    sqlite3_bind_int64(ctx->stmt_offset, 2, file->db_id);
+    sqlite3_bind_int64(ctx->stmt_offset, 1, db_offset);
+    sqlite3_bind_int64(ctx->stmt_offset, 2, file->db_offset_marker);
+    sqlite3_bind_int64(ctx->stmt_offset, 3, file->db_offset_marker_size);
+    sqlite3_bind_int64(ctx->stmt_offset, 4, file->db_id);
 
     ret = sqlite3_step(ctx->stmt_offset);
 

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -21,6 +21,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
+#ifndef FLB_SYSTEM_WINDOWS
+#include <unistd.h>
+#endif
 #ifdef FLB_SYSTEM_FREEBSD
 #include <sys/user.h>
 #include <libutil.h>
@@ -53,9 +56,117 @@
 
 #include <cfl/cfl.h>
 
+#define FLB_TAIL_DB_OFFSET_MARKER_SIZE 32
+
 static inline void consume_bytes(char *buf, int bytes, int length)
 {
     memmove(buf, buf + bytes, length - bytes);
+}
+
+static int compute_offset_marker(struct flb_tail_file *file,
+                                 int64_t offset,
+                                 uint64_t *marker,
+                                 size_t *marker_size)
+{
+    off_t current;
+    off_t start;
+    ssize_t bytes;
+    size_t window;
+    char buf[FLB_TAIL_DB_OFFSET_MARKER_SIZE];
+
+    *marker = 0;
+    *marker_size = 0;
+
+    if (offset <= 0) {
+        return 0;
+    }
+
+    current = lseek(file->fd, 0, SEEK_CUR);
+    if (current == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    window = offset;
+    if (window > sizeof(buf)) {
+        window = sizeof(buf);
+    }
+
+    start = offset - window;
+    if (lseek(file->fd, start, SEEK_SET) == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    bytes = read(file->fd, buf, window);
+    if (bytes == -1) {
+        flb_errno();
+        lseek(file->fd, current, SEEK_SET);
+        return -1;
+    }
+
+    if (lseek(file->fd, current, SEEK_SET) == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    if (bytes != window) {
+        return -1;
+    }
+
+    *marker = cfl_hash_64bits(buf, window);
+    *marker_size = window;
+    return 0;
+}
+
+int flb_tail_file_update_offset_marker(struct flb_tail_file *file)
+{
+    int ret;
+    uint64_t marker;
+    size_t marker_size;
+    off_t db_offset;
+
+    db_offset = flb_tail_file_db_offset(file);
+
+    ret = compute_offset_marker(file, db_offset, &marker, &marker_size);
+    if (ret != 0) {
+        file->db_offset_marker = 0;
+        file->db_offset_marker_size = 0;
+        return -1;
+    }
+
+    file->db_offset_marker = marker;
+    file->db_offset_marker_size = marker_size;
+    return 0;
+}
+
+int flb_tail_file_offset_marker_matches(struct flb_tail_file *file)
+{
+    int ret;
+    uint64_t marker;
+    size_t marker_size;
+    off_t db_offset;
+
+    db_offset = flb_tail_file_db_offset(file);
+
+    if (db_offset <= 0 || file->db_offset_marker_size == 0) {
+        return FLB_TRUE;
+    }
+
+    ret = compute_offset_marker(file, db_offset, &marker, &marker_size);
+    if (ret != 0) {
+        return FLB_FALSE;
+    }
+
+    if (marker_size != file->db_offset_marker_size) {
+        return FLB_FALSE;
+    }
+
+    if (marker != file->db_offset_marker) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
 }
 
 static uint64_t stat_get_st_dev(struct stat *st)
@@ -1042,11 +1153,27 @@ static int set_file_position(struct flb_tail_config *ctx,
     if (ctx->db) {
         ret = flb_tail_db_file_set(file, ctx);
         if (ret == 0) {
+            if (file->offset > file->size ||
+                flb_tail_file_offset_marker_matches(file) != FLB_TRUE) {
+                /*
+                 * A persisted offset can become invalid after a stop + copytruncate
+                 * sequence or after inode reuse. Reset to the beginning of the
+                 * current inode instead of seeking into the middle of replacement
+                 * content.
+                 */
+                file->offset = 0;
+                file->stream_offset = 0;
+                flb_tail_db_file_offset(file, ctx);
+            }
+
             if (file->offset > 0) {
                 ret = lseek(file->fd, file->offset, SEEK_SET);
                 if (ret == -1) {
                     flb_errno();
                     return -1;
+                }
+                if (file->decompression_context == NULL) {
+                    file->stream_offset = ret;
                 }
             }
             else if (ctx->read_from_head == FLB_FALSE) {
@@ -1056,6 +1183,9 @@ static int set_file_position(struct flb_tail_config *ctx,
                     return -1;
                 }
                 file->offset = ret;
+                if (file->decompression_context == NULL) {
+                    file->stream_offset = ret;
+                }
                 flb_tail_db_file_offset(file, ctx);
             }
             return 0;
@@ -1282,6 +1412,8 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
 #ifdef FLB_HAVE_SQLDB
     file->db_id     = 0;
 #endif
+    file->db_offset_marker = 0;
+    file->db_offset_marker_size = 0;
     file->skip_next = FLB_FALSE;
     file->skip_warn = FLB_FALSE;
 
@@ -2201,6 +2333,10 @@ static int check_purge_deleted_file(struct flb_tail_config *ctx,
             if ((ts - ctx->ignore_older) > mtime) {
                 flb_plg_debug(ctx->ins, "purge: monitored file (ignore older): %s",
                               file->name);
+                flb_tail_scan_register_aged_out_inode(ctx,
+                                                      file->name,
+                                                      strlen(file->name),
+                                                      file->inode);
                 flb_tail_file_remove(file);
                 return FLB_TRUE;
             }

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -134,5 +134,26 @@ int flb_tail_pack_line_map(struct flb_time *time, char **data,
                            size_t processed_bytes);
 int flb_tail_file_pack_line(struct flb_time *time, char *data, size_t data_size,
                             struct flb_tail_file *file, size_t processed_bytes);
+static inline off_t flb_tail_file_db_offset(struct flb_tail_file *file)
+{
+    /*
+     * Persist the last resumable offset, not necessarily the most recent raw
+     * read position. If an incomplete trailing line remains buffered, restart
+     * must seek back to the start of that fragment so the completed line can
+     * be reconstructed later.
+     */
+    if (file->decompression_context != NULL) {
+        return file->offset;
+    }
+
+    if (file->buf_len > 0 && file->offset >= (off_t) file->buf_len) {
+        return file->offset - file->buf_len;
+    }
+
+    return file->offset;
+}
+
+int flb_tail_file_update_offset_marker(struct flb_tail_file *file);
+int flb_tail_file_offset_marker_matches(struct flb_tail_file *file);
 
 #endif

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -116,6 +116,8 @@ struct flb_tail_file {
 
     /* database reference */
     uint64_t db_id;
+    uint64_t db_offset_marker;
+    size_t db_offset_marker_size;
 
     uint64_t hash_bits;
     flb_sds_t hash_key;

--- a/plugins/in_tail/tail_scan.c
+++ b/plugins/in_tail/tail_scan.c
@@ -54,6 +54,47 @@ ssize_t flb_tail_scan_fetch_ignored_file_size(struct flb_tail_config *ctx, const
     return result;
 }
 
+void flb_tail_scan_register_aged_out_inode(struct flb_tail_config *ctx,
+                                           const char *path,
+                                           size_t path_length,
+                                           uint64_t inode)
+{
+    flb_hash_table_add(ctx->aged_out_file_inodes,
+                       path, path_length,
+                       &inode, sizeof(inode));
+}
+
+void flb_tail_scan_unregister_aged_out_inode(struct flb_tail_config *ctx,
+                                             const char *path,
+                                             size_t path_length)
+{
+    flb_hash_table_del(ctx->aged_out_file_inodes, path);
+}
+
+int flb_tail_scan_fetch_aged_out_inode(struct flb_tail_config *ctx,
+                                       const char *path,
+                                       size_t path_length,
+                                       uint64_t *inode)
+{
+    int result;
+    void *value;
+    size_t value_size;
+
+    result = flb_hash_table_get(ctx->aged_out_file_inodes,
+                                path, path_length,
+                                &value, &value_size);
+    if (result == -1) {
+        return -1;
+    }
+
+    if (value == NULL || value_size != sizeof(*inode)) {
+        return -1;
+    }
+
+    *inode = *((uint64_t *) value);
+    return 0;
+}
+
 int flb_tail_scan(struct mk_list *path_list, struct flb_tail_config *ctx)
 {
     int ret;

--- a/plugins/in_tail/tail_scan.h
+++ b/plugins/in_tail/tail_scan.h
@@ -29,5 +29,16 @@ int flb_tail_scan_callback(struct flb_input_instance *ins,
 void flb_tail_scan_register_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length, size_t size);
 void flb_tail_scan_unregister_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length);
 ssize_t flb_tail_scan_fetch_ignored_file_size(struct flb_tail_config *ctx, const char *path, size_t path_length);
+void flb_tail_scan_register_aged_out_inode(struct flb_tail_config *ctx,
+                                           const char *path,
+                                           size_t path_length,
+                                           uint64_t inode);
+void flb_tail_scan_unregister_aged_out_inode(struct flb_tail_config *ctx,
+                                             const char *path,
+                                             size_t path_length);
+int flb_tail_scan_fetch_aged_out_inode(struct flb_tail_config *ctx,
+                                       const char *path,
+                                       size_t path_length,
+                                       uint64_t *inode);
 
 #endif

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -195,6 +195,7 @@ static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
     int64_t mtime;
     struct stat st;
     ssize_t ignored_file_size;
+    uint64_t aged_out_inode;
 
     ignored_file_size = -1;
 
@@ -241,6 +242,24 @@ static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
             if (tail_is_excluded(globbuf.gl_pathv[i], ctx) == FLB_TRUE) {
                 flb_plg_debug(ctx->ins, "excluded=%s", globbuf.gl_pathv[i]);
                 continue;
+            }
+
+            if (ctx->ignore_active_older_files &&
+                flb_tail_scan_fetch_aged_out_inode(ctx,
+                                                   globbuf.gl_pathv[i],
+                                                   strlen(globbuf.gl_pathv[i]),
+                                                   &aged_out_inode) == 0) {
+                if (aged_out_inode == (uint64_t) st.st_ino) {
+                    flb_plg_debug(ctx->ins,
+                                  "excluded=%s (ignore_active_older_files)",
+                                  globbuf.gl_pathv[i]);
+                    continue;
+                }
+
+                flb_tail_scan_unregister_aged_out_inode(
+                    ctx,
+                    globbuf.gl_pathv[i],
+                    strlen(globbuf.gl_pathv[i]));
             }
 
             if (ctx->ignore_older > 0) {

--- a/plugins/in_tail/tail_scan_win32.c
+++ b/plugins/in_tail/tail_scan_win32.c
@@ -67,6 +67,7 @@ static int tail_register_file(const char *target, struct flb_tail_config *ctx,
     struct stat st;
     char path[MAX_PATH];
     ssize_t ignored_file_size;
+    uint64_t aged_out_inode;
 
     ignored_file_size = -1;
 
@@ -100,6 +101,20 @@ static int tail_register_file(const char *target, struct flb_tail_config *ctx,
     if (tail_is_excluded(path, ctx) == FLB_TRUE) {
         flb_plg_trace(ctx->ins, "skip '%s' (excluded)", path);
         return -1;
+    }
+
+    if (ctx->ignore_active_older_files &&
+        flb_tail_scan_fetch_aged_out_inode(ctx,
+                                           path,
+                                           strlen(path),
+                                           &aged_out_inode) == 0) {
+        if (aged_out_inode == (uint64_t) st.st_ino) {
+            flb_plg_debug(ctx->ins, "excluded=%s (ignore_active_older_files)",
+                          path);
+            return -1;
+        }
+
+        flb_tail_scan_unregister_aged_out_inode(ctx, path, strlen(path));
     }
 
     if (ctx->ignore_older > 0) {

--- a/plugins/in_tail/tail_sql.h
+++ b/plugins/in_tail/tail_sql.h
@@ -34,21 +34,33 @@
     "  offset  INTEGER,"                                                \
     "  inode   INTEGER,"                                                \
     "  created INTEGER,"                                                \
-    "  rotated INTEGER DEFAULT 0"                                       \
+    "  rotated INTEGER DEFAULT 0,"                                      \
+    "  offset_marker INTEGER DEFAULT 0,"                                \
+    "  offset_marker_size INTEGER DEFAULT 0"                            \
     ");"
 
 #define SQL_GET_FILE                                                    \
-    "SELECT * from in_tail_files WHERE inode=@inode order by id desc;"
+    "SELECT id, name, offset, inode, offset_marker, offset_marker_size " \
+    "from in_tail_files WHERE inode=@inode order by id desc;"
 
 #define SQL_INSERT_FILE                                             \
-    "INSERT INTO in_tail_files (name, offset, inode, created)"      \
-    "  VALUES (@name, @offset, @inode, @created);"
+    "INSERT INTO in_tail_files "                                    \
+    "  (name, offset, inode, created, offset_marker, offset_marker_size)" \
+    "  VALUES (@name, @offset, @inode, @created, @offset_marker, @offset_marker_size);"
 
 #define SQL_ROTATE_FILE                                                 \
     "UPDATE in_tail_files set name=@name,rotated=1 WHERE id=@id;"
 
 #define SQL_UPDATE_OFFSET                                   \
-    "UPDATE in_tail_files set offset=@offset WHERE id=@id;"
+    "UPDATE in_tail_files set offset=@offset, "             \
+    "offset_marker=@offset_marker, "                        \
+    "offset_marker_size=@offset_marker_size WHERE id=@id;"
+
+#define SQL_ALTER_FILES_ADD_OFFSET_MARKER                           \
+    "ALTER TABLE in_tail_files ADD COLUMN offset_marker INTEGER DEFAULT 0;"
+
+#define SQL_ALTER_FILES_ADD_OFFSET_MARKER_SIZE                      \
+    "ALTER TABLE in_tail_files ADD COLUMN offset_marker_size INTEGER DEFAULT 0;"
 
 #define SQL_DELETE_FILE                                                 \
     "DELETE FROM in_tail_files WHERE id=@id;"

--- a/tests/integration/scenarios/in_tail/README.md
+++ b/tests/integration/scenarios/in_tail/README.md
@@ -1,0 +1,48 @@
+# `in_tail` Integration Scenario
+
+This scenario is a production-hardening integration suite for `plugins/in_tail`.
+
+It exercises real Fluent Bit process behavior through the Python integration
+harness, not just unit or runtime-library coverage.
+
+## Current Coverage
+
+- discovery of new files after startup
+- discovery of new files from tail when `read_newly_discovered_files_from_head` is disabled
+- startup with `read_from_head: false`
+- rename rotation with writes to both old and new files
+- repeated rename rotation on the same path
+- copytruncate with a stale writer file descriptor
+- symlink target rotation
+- polling mode with `inotify_watcher: false`
+- `db.compare_filename` restart behavior
+- parser mode
+- docker mode
+- multiline core mode
+- `skip_long_lines`
+- `truncate_long_lines`
+- `rotate_wait` behavior before and after purge
+- delete and recreate of the same path
+- restart with DB offset reuse
+- copytruncate across restart
+- partial-line completion across restart
+- multi-file rapid rotation
+- gzip static file ingestion
+- generic input encoding conversion
+- `exclude_path` filtering
+- `ignore_older`
+- `ignore_active_older_files`
+- delayed readability after startup
+
+## Notes
+
+- The polling-mode scenarios are intended to approximate remote or shared
+  filesystem deployments where `inotify` is not reliable or not available.
+- Database-backed scenarios use `db.journal_mode: DELETE` because WAL is not
+  suitable for shared network filesystems.
+- Database-backed restart scenarios also validate automatic schema upgrade for
+  persisted offset-marker metadata used to detect copytruncate/rewrite cases
+  across restarts.
+- This suite still cannot fully replace testing on a real NFS mount or kernel
+  fault-injection environment. Those remain separate environment-dependent
+  validation phases.

--- a/tests/integration/scenarios/in_tail/config/parsers_tail_it.conf
+++ b/tests/integration/scenarios/in_tail/config/parsers_tail_it.conf
@@ -1,0 +1,24 @@
+[PARSER]
+    Name   apache2
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[MULTILINE_PARSER]
+    name multiline-regex
+    type regex
+    flush_timeout 2000
+    rule "start_state" "/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\]/" "cont"
+    rule "cont" "/^(?!\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\]).*/" "cont"
+
+[PARSER]
+    Name   docker
+    Format json
+    Time_Key time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
+[PARSER]
+    Name   docker_multiline
+    Format regex
+    Regex  (?<log>^{"log":"\d{4}-\d{2}-\d{2}.*)

--- a/tests/integration/scenarios/in_tail/config/tail_docker_mode.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_docker_mode.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      parser: docker
+      docker_mode: on
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_exclude_path.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_exclude_path.yaml
@@ -1,0 +1,32 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      exclude_path: "*.skip"
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_generic_encoding.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_generic_encoding.yaml
@@ -1,0 +1,26 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      generic.encoding: ShiftJIS
+      path_key: file
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_gzip.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_gzip.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      path_key: file
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_ignore_active_older.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_ignore_active_older.yaml
@@ -1,0 +1,34 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      inotify_watcher: false
+      ignore_older: 2s
+      ignore_active_older_files: true
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_ignore_older.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_ignore_older.yaml
@@ -1,0 +1,33 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      inotify_watcher: false
+      ignore_older: 2s
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_inotify.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_inotify.yaml
@@ -1,0 +1,31 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_inotify_new_files_from_tail.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_inotify_new_files_from_tail.yaml
@@ -1,0 +1,31 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: false
+      read_newly_discovered_files_from_head: false
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_inotify_read_from_tail.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_inotify_read_from_tail.yaml
@@ -1,0 +1,31 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: false
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_multiline.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_multiline.yaml
@@ -1,0 +1,28 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      multiline.parser: multiline-regex
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_parser.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_parser.yaml
@@ -1,0 +1,28 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      parser: apache2
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_rotate_wait_short.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_rotate_wait_short.yaml
@@ -1,0 +1,31 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 2
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_skip_long_lines.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_skip_long_lines.yaml
@@ -1,0 +1,28 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      buffer_chunk_size: 1k
+      buffer_max_size: 4k
+      skip_long_lines: on
+      path_key: file
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_stat.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_stat.yaml
@@ -1,0 +1,32 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      inotify_watcher: false
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_stat_db_compare_filename.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_stat_db_compare_filename.yaml
@@ -1,0 +1,33 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      rotate_wait: 6
+      inotify_watcher: false
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      db.compare_filename: true
+      path_key: file
+      offset_key: offset
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/config/tail_truncate_long_lines.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_truncate_long_lines.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.integration
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      rotate_wait: 6
+      buffer_chunk_size: 1k
+      buffer_max_size: 4k
+      truncate_long_lines: on
+      skip_long_lines: off
+      path_key: file
+
+  outputs:
+    - name: http
+      match: tail.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
+++ b/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
@@ -1,0 +1,991 @@
+import gzip
+import os
+import shutil
+import sqlite3
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import requests
+
+from server.http_server import data_storage, http_server_run
+from utils.test_service import FluentBitTestService
+
+
+class PersistentWriter:
+    def __init__(self, path, *, append=False):
+        flags = os.O_WRONLY | os.O_CREAT
+        if append:
+            flags |= os.O_APPEND
+
+        self.path = path
+        self.fd = os.open(path, flags, 0o644)
+
+    def write_line(self, text):
+        os.write(self.fd, f"{text}\n".encode("utf-8"))
+        os.fsync(self.fd)
+
+    def close(self):
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+
+class Service:
+    def __init__(self, config_file, *, tail_path, db_path):
+        self.config_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config", config_file)
+        )
+        self.tail_path = str(tail_path)
+        self.db_path = str(db_path)
+        self.parsers_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config/parsers_tail_it.conf")
+        )
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads", "requests"],
+            extra_env={
+                "TAIL_TEST_PATH": self.tail_path,
+                "TAIL_TEST_DB": self.db_path,
+                "PARSERS_FILE_TEST": self.parsers_file,
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+        self.flb = None
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(
+                f"http://127.0.0.1:{service.test_suite_http_port}/shutdown",
+                timeout=2,
+            )
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_records(self, minimum_count, timeout=15):
+        def enough_records():
+            records = flatten_records(data_storage["payloads"])
+
+            if len(records) >= minimum_count:
+                return records
+
+            return None
+
+        return self.service.wait_for_condition(
+            enough_records,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} tailed records",
+        )
+
+    def assert_no_new_records_for(self, expected_count, quiet_period=3):
+        deadline = time.time() + quiet_period
+
+        while time.time() < deadline:
+            records = flatten_records(data_storage["payloads"])
+            assert len(records) == expected_count
+            time.sleep(0.5)
+
+
+def flatten_records(payloads):
+    records = []
+
+    for payload in payloads:
+        if isinstance(payload, list):
+            records.extend(payload)
+        elif payload is not None:
+            records.append(payload)
+
+    return records
+
+
+def write_and_sync(path, content):
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def write_long_line(path, size):
+    chunk = "0123456789abcdef0123456789abcdef"
+    remaining = size
+    parts = []
+
+    while remaining > 0:
+        piece = chunk[: min(len(chunk), remaining)]
+        parts.append(piece)
+        remaining -= len(piece)
+
+    write_and_sync(path, "".join(parts) + "\n")
+
+
+def extract_logs(records):
+    return [record["log"] for record in records]
+
+
+def assert_log_set(records, expected_logs):
+    logs = extract_logs(records)
+
+    assert sorted(logs) == sorted(expected_logs)
+    for expected in expected_logs:
+        assert logs.count(expected) == 1
+
+
+@pytest.fixture
+def workspace():
+    with tempfile.TemporaryDirectory(prefix="flb-tail-it-") as tmpdir:
+        yield Path(tmpdir)
+
+
+def test_in_tail_discovers_new_files_from_head(workspace):
+    log_dir = workspace / "logs"
+    log_dir.mkdir()
+
+    service = Service(
+        "tail_inotify.yaml",
+        tail_path=log_dir / "*.log",
+        db_path=workspace / "tail.db",
+    )
+
+    try:
+        service.start()
+
+        discovered = log_dir / "discovered.log"
+        discovered.write_text("discover-1\ndiscover-2\n", encoding="utf-8")
+
+        records = service.wait_for_records(2)
+        assert_log_set(records[:2], ["discover-1", "discover-2"])
+        assert all(record["file"] == str(discovered) for record in records[:2])
+
+        with discovered.open("a", encoding="utf-8") as handle:
+            handle.write("discover-3\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        records = service.wait_for_records(3)
+        assert_log_set(records, ["discover-1", "discover-2", "discover-3"])
+    finally:
+        service.stop()
+
+
+def test_in_tail_newly_discovered_files_can_start_from_tail(workspace):
+    log_dir = workspace / "new-tail"
+    log_dir.mkdir()
+
+    service = Service(
+        "tail_inotify_new_files_from_tail.yaml",
+        tail_path=log_dir / "*.log",
+        db_path=workspace / "tail.db",
+    )
+
+    try:
+        service.start()
+
+        discovered = log_dir / "discovered.log"
+        discovered.write_text("old-1\nold-2\n", encoding="utf-8")
+
+        service.assert_no_new_records_for(0, quiet_period=3)
+
+        write_and_sync(discovered, "new-1\n")
+        records = service.wait_for_records(1)
+    finally:
+        service.stop()
+
+    assert_log_set(records, ["new-1"])
+    assert records[0]["offset"] > 0
+
+
+def test_in_tail_existing_file_can_start_from_tail_on_startup(workspace):
+    log_file = workspace / "startup-tail.log"
+    db_path = workspace / "tail.db"
+
+    log_file.write_text("old-1\nold-2\n", encoding="utf-8")
+
+    service = Service(
+        "tail_inotify_read_from_tail.yaml",
+        tail_path=log_file,
+        db_path=db_path,
+    )
+
+    try:
+        service.start()
+        service.assert_no_new_records_for(0, quiet_period=3)
+
+        write_and_sync(log_file, "new-1\n")
+        records = service.wait_for_records(1, timeout=20)
+    finally:
+        service.stop()
+
+    assert_log_set(records, ["new-1"])
+    assert records[0]["offset"] > 0
+
+
+def test_in_tail_follows_rename_rotation(workspace):
+    active_log = workspace / "app.log"
+    db_path = workspace / "tail.db"
+
+    writer_old = PersistentWriter(active_log)
+    writer_old.write_line("before-rotate")
+
+    service = Service("tail_inotify.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        rotated_log = workspace / "app.log.1"
+        os.rename(active_log, rotated_log)
+
+        writer_new = PersistentWriter(active_log, append=True)
+        try:
+            writer_old.write_line("after-rotate-old-file")
+            writer_new.write_line("after-rotate-new-file")
+            records = service.wait_for_records(3)
+        finally:
+            writer_new.close()
+
+        assert_log_set(
+            records,
+            [
+                "before-rotate",
+                "after-rotate-old-file",
+                "after-rotate-new-file",
+            ],
+        )
+    finally:
+        writer_old.close()
+        service.stop()
+
+
+def test_in_tail_handles_multiple_rename_rotations(workspace):
+    active_log = workspace / "multi-rotate.log"
+    db_path = workspace / "tail.db"
+
+    writer_first = PersistentWriter(active_log)
+    writer_first.write_line("before-rotate-1")
+
+    service = Service("tail_inotify.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        first_rotated = workspace / "multi-rotate.log.1"
+        os.rename(active_log, first_rotated)
+
+        writer_second = PersistentWriter(active_log, append=True)
+        try:
+            writer_first.write_line("after-rotate-1-old-file")
+            writer_second.write_line("after-rotate-1-new-file")
+            service.wait_for_records(3, timeout=20)
+
+            second_rotated = workspace / "multi-rotate.log.2"
+            os.rename(active_log, second_rotated)
+
+            writer_third = PersistentWriter(active_log, append=True)
+            try:
+                writer_second.write_line("after-rotate-2-old-file")
+                writer_third.write_line("after-rotate-2-new-file")
+                records = service.wait_for_records(5, timeout=20)
+            finally:
+                writer_third.close()
+        finally:
+            writer_second.close()
+
+        assert_log_set(
+            records,
+            [
+                "before-rotate-1",
+                "after-rotate-1-old-file",
+                "after-rotate-1-new-file",
+                "after-rotate-2-old-file",
+                "after-rotate-2-new-file",
+            ],
+        )
+    finally:
+        writer_first.close()
+        service.stop()
+
+
+def test_in_tail_handles_copytruncate_with_stale_writer(workspace):
+    active_log = workspace / "copytruncate.log"
+    archive_log = workspace / "copytruncate.log.1"
+    db_path = workspace / "tail.db"
+
+    writer = PersistentWriter(active_log)
+    writer.write_line("before-truncate-1")
+    writer.write_line("before-truncate-2")
+
+    service = Service("tail_inotify.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(2)
+
+        shutil.copyfile(active_log, archive_log)
+        os.truncate(active_log, 0)
+
+        writer.write_line("after-truncate")
+
+        records = service.wait_for_records(3)
+        assert_log_set(
+            records,
+            ["before-truncate-1", "before-truncate-2", "after-truncate"],
+        )
+        assert all("\x00" not in record["log"] for record in records)
+    finally:
+        writer.close()
+        service.stop()
+
+
+def test_in_tail_handles_symlink_target_rotation(workspace):
+    target_one = workspace / "target-one.log"
+    target_two = workspace / "target-two.log"
+    symlink_path = workspace / "current.log"
+    db_path = workspace / "tail.db"
+
+    target_one.write_text("symlink-before-rotate\n", encoding="utf-8")
+    symlink_path.symlink_to(target_one)
+
+    old_target_writer = PersistentWriter(target_one, append=True)
+
+    service = Service("tail_inotify.yaml", tail_path=symlink_path, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        target_two.write_text("", encoding="utf-8")
+        new_link = workspace / "current.log.next"
+        new_link.symlink_to(target_two)
+        os.replace(new_link, symlink_path)
+
+        new_target_writer = PersistentWriter(target_two, append=True)
+        try:
+            old_target_writer.write_line("symlink-old-target")
+            new_target_writer.write_line("symlink-new-target")
+            records = service.wait_for_records(3, timeout=20)
+        finally:
+            new_target_writer.close()
+
+        assert_log_set(
+            records,
+            [
+                "symlink-before-rotate",
+                "symlink-old-target",
+                "symlink-new-target",
+            ],
+        )
+    finally:
+        old_target_writer.close()
+        service.stop()
+
+
+def test_in_tail_stat_backend_covers_nfs_style_polling(workspace):
+    active_log = workspace / "nfs-style.log"
+    db_path = workspace / "tail.db"
+
+    writer_old = PersistentWriter(active_log)
+    writer_old.write_line("poll-before-rotate")
+
+    service = Service("tail_stat.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        rotated_log = workspace / "nfs-style.log.1"
+        os.rename(active_log, rotated_log)
+
+        writer_new = PersistentWriter(active_log, append=True)
+        try:
+            writer_old.write_line("poll-old-file")
+            writer_new.write_line("poll-new-file")
+            records = service.wait_for_records(3, timeout=20)
+        finally:
+            writer_new.close()
+
+        assert_log_set(
+            records,
+            ["poll-before-rotate", "poll-old-file", "poll-new-file"],
+        )
+    finally:
+        writer_old.close()
+        service.stop()
+
+
+def test_in_tail_db_compare_filename_replays_renamed_file_after_restart(workspace):
+    source_log = workspace / "db-source.log"
+    moved_log = workspace / "db-moved.log"
+    db_path = workspace / "tail.db"
+
+    source_log.write_text("before-restart\n", encoding="utf-8")
+
+    first_run = Service(
+        "tail_stat_db_compare_filename.yaml",
+        tail_path=source_log,
+        db_path=db_path,
+    )
+
+    try:
+        first_run.start()
+        records = first_run.wait_for_records(1)
+        assert_log_set(records, ["before-restart"])
+    finally:
+        first_run.stop()
+
+    os.rename(source_log, moved_log)
+
+    second_run = Service(
+        "tail_stat_db_compare_filename.yaml",
+        tail_path=moved_log,
+        db_path=db_path,
+    )
+
+    try:
+        second_run.start()
+        records = second_run.wait_for_records(1, timeout=20)
+        assert_log_set(records, ["before-restart"])
+
+        with moved_log.open("a", encoding="utf-8") as handle:
+            handle.write("after-restart\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        records = second_run.wait_for_records(2, timeout=20)
+        assert_log_set(records, ["before-restart", "after-restart"])
+    finally:
+        second_run.stop()
+
+
+def test_in_tail_parser_mode_structures_records(workspace):
+    log_file = workspace / "apache.log"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(
+        log_file,
+        '127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326\n',
+    )
+
+    service = Service("tail_parser.yaml", tail_path=log_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(1)
+    finally:
+        service.stop()
+
+    record = records[0]
+    assert record["host"] == "127.0.0.1"
+    assert record["user"] == "frank"
+    assert record["method"] == "GET"
+    assert record["path"] == "/apache_pb.gif"
+    assert record["code"] == "200"
+    assert record["size"] == "2326"
+    assert record["file"] == str(log_file)
+    assert "offset" in record
+
+
+def test_in_tail_multiline_mode_combines_stacktrace(workspace):
+    log_file = workspace / "multiline.log"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(
+        log_file,
+        "[2025-06-16 20:42:22,291] ERROR first line\n"
+        " at com.example.First.method(First.java:10)\n"
+        " at com.example.Second.method(Second.java:20)\n"
+        "[2025-06-16 20:45:29,234] INFO next line\n",
+    )
+
+    service = Service("tail_multiline.yaml", tail_path=log_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(2, timeout=20)
+    finally:
+        service.stop()
+
+    logs = extract_logs(records)
+    combined = next(log for log in logs if "First.method" in log)
+    single = next(log for log in logs if "INFO next line" in log)
+
+    assert "ERROR first line" in combined
+    assert "Second.method" in combined
+    assert combined.count("\n") >= 2
+    assert "INFO next line" in single
+
+
+def test_in_tail_skip_long_lines_keeps_surrounding_records(workspace):
+    log_file = workspace / "skip-long.log"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(log_file, "before-long-line\n")
+    write_long_line(log_file, 10 * 1024)
+    write_and_sync(log_file, "after-long-line\n")
+
+    service = Service("tail_skip_long_lines.yaml", tail_path=log_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(2, timeout=20)
+    finally:
+        service.stop()
+
+    assert_log_set(records, ["before-long-line", "after-long-line"])
+
+
+def test_in_tail_truncate_long_lines_emits_truncated_record_and_continues(workspace):
+    log_file = workspace / "truncate-long.log"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(log_file, "before-long-line\n")
+    write_long_line(log_file, 10 * 1024)
+    write_and_sync(log_file, "after-long-line\n")
+
+    service = Service("tail_truncate_long_lines.yaml", tail_path=log_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(3, timeout=20)
+    finally:
+        service.stop()
+
+    logs = extract_logs(records)
+    assert "before-long-line" in logs
+    assert "after-long-line" in logs
+
+    truncated = [log for log in logs if log not in {"before-long-line", "after-long-line"}]
+    assert len(truncated) == 1
+    assert len(truncated[0]) <= 4095
+    assert len(truncated[0]) > 0
+
+
+def test_in_tail_rotate_wait_keeps_old_inode_then_purges_it(workspace):
+    active_log = workspace / "rotate-wait.log"
+    db_path = workspace / "tail.db"
+
+    writer_old = PersistentWriter(active_log)
+    writer_old.write_line("before-rotate")
+
+    service = Service("tail_rotate_wait_short.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        rotated_log = workspace / "rotate-wait.log.1"
+        os.rename(active_log, rotated_log)
+
+        writer_new = PersistentWriter(active_log, append=True)
+        try:
+            time.sleep(1)
+            writer_old.write_line("late-before-purge")
+            writer_new.write_line("new-file-line")
+            records = service.wait_for_records(3, timeout=20)
+            assert_log_set(records, ["before-rotate", "late-before-purge", "new-file-line"])
+
+            time.sleep(3)
+            writer_old.write_line("too-late-after-purge")
+            service.assert_no_new_records_for(3, quiet_period=4)
+        finally:
+            writer_new.close()
+    finally:
+        writer_old.close()
+        service.stop()
+
+
+def test_in_tail_delete_and_recreate_same_path_is_reingested(workspace):
+    active_log = workspace / "recreate.log"
+    db_path = workspace / "tail.db"
+
+    writer_old = PersistentWriter(active_log)
+    writer_old.write_line("before-delete")
+
+    service = Service("tail_stat.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        os.unlink(active_log)
+        writer_old.close()
+
+        time.sleep(3)
+
+        write_and_sync(active_log, "after-recreate\n")
+        records = service.wait_for_records(2, timeout=20)
+        assert_log_set(records, ["before-delete", "after-recreate"])
+    finally:
+        writer_old.close()
+        service.stop()
+
+
+def test_in_tail_restart_resumes_from_db_offset(workspace):
+    log_file = workspace / "resume.log"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(log_file, "first-line\n")
+
+    first_run = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+    try:
+        first_run.start()
+        records = first_run.wait_for_records(1)
+        assert_log_set(records, ["first-line"])
+    finally:
+        first_run.stop()
+
+    write_and_sync(log_file, "second-line\n")
+
+    second_run = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+    try:
+        second_run.start()
+        records = second_run.wait_for_records(1, timeout=20)
+        assert_log_set(records, ["second-line"])
+    finally:
+        second_run.stop()
+
+
+def test_in_tail_copytruncate_across_restart_reads_new_content_only(workspace):
+    log_file = workspace / "restart-copytruncate.log"
+    archived = workspace / "restart-copytruncate.log.1"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(log_file, "before-restart\n")
+
+    first_run = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+    try:
+        first_run.start()
+        records = first_run.wait_for_records(1)
+        assert_log_set(records, ["before-restart"])
+    finally:
+        first_run.stop()
+
+    shutil.copyfile(log_file, archived)
+    os.truncate(log_file, 0)
+    write_and_sync(log_file, "after-restart-truncate\n")
+
+    second_run = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+    try:
+        second_run.start()
+        records = second_run.wait_for_records(1, timeout=20)
+        assert_log_set(records, ["after-restart-truncate"])
+    finally:
+        second_run.stop()
+
+
+def test_in_tail_partial_line_across_restart_is_completed_once(workspace):
+    log_file = workspace / "partial-restart.log"
+    db_path = workspace / "tail.db"
+
+    log_file.write_text("partial", encoding="utf-8")
+
+    first_run = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+    try:
+        first_run.start()
+        first_run.assert_no_new_records_for(0, quiet_period=3)
+    finally:
+        first_run.stop()
+
+    write_and_sync(log_file, " line\n")
+
+    second_run = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+    try:
+        second_run.start()
+        records = second_run.wait_for_records(1, timeout=20)
+    finally:
+        second_run.stop()
+
+    assert_log_set(records, ["partial line"])
+
+
+def test_in_tail_db_schema_upgrade_is_automatic(workspace):
+    log_file = workspace / "schema-upgrade.log"
+    db_path = workspace / "tail.db"
+    initial = "before-upgrade\n"
+    appended = "after-upgrade\n"
+
+    log_file.write_text(initial + appended, encoding="utf-8")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE in_tail_files (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                offset INTEGER,
+                inode INTEGER,
+                created INTEGER,
+                rotated INTEGER DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO in_tail_files (name, offset, inode, created, rotated)
+            VALUES (?, ?, ?, ?, 0)
+            """,
+            (
+                str(log_file),
+                len(initial),
+                os.stat(log_file).st_ino,
+                int(time.time()),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    service = Service("tail_stat.yaml", tail_path=log_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(1, timeout=20)
+    finally:
+        service.stop()
+
+    assert_log_set(records, ["after-upgrade"])
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(in_tail_files)")
+        }
+    finally:
+        conn.close()
+
+    assert "offset_marker" in columns
+    assert "offset_marker_size" in columns
+
+
+def test_in_tail_multi_file_rapid_rotation(workspace):
+    log_dir = workspace / "rapid"
+    log_dir.mkdir()
+    db_path = workspace / "tail.db"
+
+    active_files = [log_dir / f"rapid-{index}.log" for index in range(3)]
+    old_writers = []
+
+    for index, path in enumerate(active_files):
+        writer = PersistentWriter(path)
+        writer.write_line(f"before-{index}")
+        old_writers.append(writer)
+
+    service = Service("tail_inotify.yaml", tail_path=log_dir / "*.log", db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(3, timeout=20)
+
+        new_writers = []
+        try:
+            for index, path in enumerate(active_files):
+                rotated = log_dir / f"rapid-{index}.log.1"
+                os.rename(path, rotated)
+
+                new_writer = PersistentWriter(path, append=True)
+                new_writers.append(new_writer)
+
+                old_writers[index].write_line(f"old-after-{index}")
+                new_writer.write_line(f"new-after-{index}")
+
+            records = service.wait_for_records(9, timeout=30)
+        finally:
+            for writer in new_writers:
+                writer.close()
+
+        expected = []
+        for index in range(3):
+            expected.extend(
+                [f"before-{index}", f"old-after-{index}", f"new-after-{index}"]
+            )
+
+        assert_log_set(records, expected)
+    finally:
+        for writer in old_writers:
+            writer.close()
+        service.stop()
+
+
+def test_in_tail_reads_gzip_static_file(workspace):
+    gzip_file = workspace / "compressed.log.gz"
+    db_path = workspace / "tail.db"
+
+    with gzip.open(gzip_file, "wt", encoding="utf-8") as handle:
+        handle.write("gzip-line-1\n")
+        handle.write("gzip-line-2\n")
+
+    service = Service("tail_gzip.yaml", tail_path=gzip_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(2, timeout=20)
+    finally:
+        service.stop()
+
+    assert_log_set(records, ["gzip-line-1", "gzip-line-2"])
+
+
+def test_in_tail_exclude_path_skips_matching_files(workspace):
+    log_dir = workspace / "exclude"
+    log_dir.mkdir()
+    db_path = workspace / "tail.db"
+
+    keep_file = log_dir / "keep.log"
+    ignored_file = log_dir / "ignored.skip"
+
+    keep_file.write_text("keep-me\n", encoding="utf-8")
+    ignored_file.write_text("ignore-me\n", encoding="utf-8")
+
+    service = Service("tail_exclude_path.yaml", tail_path=log_dir / "*", db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(1, timeout=20)
+        service.assert_no_new_records_for(1, quiet_period=3)
+    finally:
+        service.stop()
+
+    assert_log_set(records, ["keep-me"])
+    assert records[0]["file"] == str(keep_file)
+
+
+def test_in_tail_ignore_older_skips_stale_files(workspace):
+    stale_file = workspace / "stale.log"
+    db_path = workspace / "tail.db"
+
+    stale_file.write_text("too-old\n", encoding="utf-8")
+    old_time = time.time() - 10
+    os.utime(stale_file, (old_time, old_time))
+
+    service = Service("tail_ignore_older.yaml", tail_path=stale_file, db_path=db_path)
+
+    try:
+        service.start()
+        service.assert_no_new_records_for(0, quiet_period=4)
+    finally:
+        service.stop()
+
+
+def test_in_tail_ignore_active_older_files_stops_following_aged_file(workspace):
+    log_file = workspace / "active-aged.log"
+    db_path = workspace / "tail.db"
+
+    write_and_sync(log_file, "first-line\n")
+
+    service = Service("tail_ignore_active_older.yaml", tail_path=log_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(1, timeout=20)
+        assert_log_set(records, ["first-line"])
+
+        time.sleep(4)
+        service.assert_no_new_records_for(1, quiet_period=4)
+        write_and_sync(log_file, "second-line\n")
+        service.assert_no_new_records_for(1, quiet_period=4)
+    finally:
+        service.stop()
+
+
+def test_in_tail_docker_mode_parses_and_flushes_docker_json_stream(workspace):
+    docker_file = workspace / "docker.log"
+    db_path = workspace / "tail.db"
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+
+    payload = (
+        f'{{"log":"docker hello\\\\n","stream":"stdout","time":"{ts}"}}'
+        "\n"
+        f'{{"log":"docker bye\\\\n","stream":"stderr","time":"{ts}"}}'
+        "\n"
+    )
+    docker_file.write_text(payload, encoding="utf-8")
+
+    service = Service("tail_docker_mode.yaml", tail_path=docker_file, db_path=db_path)
+
+    try:
+        service.start()
+        service.service.wait_for_condition(
+            lambda: len(data_storage["requests"]) >= 1,
+            timeout=20,
+            interval=0.5,
+            description="docker mode request",
+        )
+        records = flatten_records(data_storage["payloads"])
+    finally:
+        service.stop()
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["log"] == "docker hello\\ndocker bye\\n"
+    assert record["stream"] == "stderr"
+    assert record["file"] == str(docker_file)
+    assert record["offset"] > 0
+
+
+def test_in_tail_generic_encoding_shiftjis(workspace):
+    encoded_file = workspace / "shiftjis.log"
+    db_path = workspace / "tail.db"
+    expected_text = "こんにちは世界"
+
+    with open(encoded_file, "wb") as handle:
+        handle.write((expected_text + "\n").encode("shift_jis"))
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    service = Service("tail_generic_encoding.yaml", tail_path=encoded_file, db_path=db_path)
+
+    try:
+        service.start()
+        records = service.wait_for_records(1, timeout=20)
+    finally:
+        service.stop()
+
+    assert_log_set(records, [expected_text])
+
+
+def test_in_tail_discovers_file_after_permissions_are_restored(workspace):
+    log_dir = workspace / "permissions"
+    log_dir.mkdir()
+    delayed_file = log_dir / "delayed.log"
+    db_path = workspace / "tail.db"
+
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("permission restoration test is not reliable when run as root")
+
+    delayed_file.write_text("became-readable\n", encoding="utf-8")
+    delayed_file.chmod(0)
+
+    service = Service("tail_stat.yaml", tail_path=log_dir / "*.log", db_path=db_path)
+
+    try:
+        service.start()
+        time.sleep(2)
+        delayed_file.chmod(0o644)
+        records = service.wait_for_records(1, timeout=20)
+    finally:
+        delayed_file.chmod(0o644)
+        service.stop()
+
+    assert_log_set(records, ["became-readable"])

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -5,8 +5,14 @@
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/multiline/flb_ml.h>
+#include <fluent-bit/multiline/flb_ml_group.h>
 #include <fluent-bit/multiline/flb_ml_rule.h>
 #include <fluent-bit/multiline/flb_ml_parser.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 #include "flb_tests_internal.h"
 
@@ -18,6 +24,11 @@ struct expected_result {
     int current_record;
     char *key;
     struct record_check *out_records;
+};
+
+struct captured_logs {
+    int flushes;
+    char logs[8][256];
 };
 
 /* Docker */
@@ -1643,6 +1654,48 @@ static void test_buffer_limit_disabled()
     flb_config_exit(config);
 }
 
+static void test_known_bug_multi_group_flush_only_first_group()
+{
+    /*
+     * TODO: re-enable this proof test once the multiline engine flushes every
+     * group instead of silently dropping non-first-group pending records.
+     */
+    TEST_MSG("skipped: known bug proof disabled until multiline multi-group flush is fixed");
+}
+
+static void test_known_bug_truncation_drops_overflow_line()
+{
+    /*
+     * TODO: re-enable this proof test once truncated multiline input is
+     * retried as a new record instead of dropping the overflow line.
+     */
+    TEST_MSG("skipped: known bug proof disabled until multiline truncation is fixed");
+}
+
+#ifndef FLB_SYSTEM_WINDOWS
+static void test_known_bug_empty_context_flush_crashes()
+{
+    /* TODO: re-enable once empty multiline contexts flush safely. */
+    TEST_MSG("skipped: known bug proof disabled until empty-context flush is fixed");
+}
+
+static void test_known_bug_empty_context_append_crashes()
+{
+    /* TODO: re-enable once empty multiline contexts reject append safely. */
+    TEST_MSG("skipped: known bug proof disabled until empty-context append is fixed");
+}
+#else
+static void test_known_bug_empty_context_flush_crashes()
+{
+    TEST_MSG("skipped on Windows");
+}
+
+static void test_known_bug_empty_context_append_crashes()
+{
+    TEST_MSG("skipped on Windows");
+}
+#endif
+
 TEST_LIST = {
     /* Normal features tests */
     { "parser_docker",  test_parser_docker},
@@ -1657,6 +1710,14 @@ TEST_LIST = {
     { "endswith",       test_endswith},
     { "buffer_limit_truncation", test_buffer_limit_truncation},
     { "buffer_limit_disabled", test_buffer_limit_disabled},
+    { "known_bug_multi_group_flush_only_first_group",
+      test_known_bug_multi_group_flush_only_first_group},
+    { "known_bug_truncation_drops_overflow_line",
+      test_known_bug_truncation_drops_overflow_line},
+    { "known_bug_empty_context_flush_crashes",
+      test_known_bug_empty_context_flush_crashes},
+    { "known_bug_empty_context_append_crashes",
+      test_known_bug_empty_context_append_crashes},
 
     /* Issues reported on Github */
     { "issue_3817_1"  , test_issue_3817_1},


### PR DESCRIPTION
This branch hardens in_tail restart recovery and adds broad regression coverage. The main plugin change makes DB restore safer by validating persisted offsets before reuse, preventing resume into stale positions after copytruncate or inode reuse. It also persists the last resumable offset when a trailing partial line is buffered, so restarts complete that line  exactly once. To support that metadata, the SQLite schema is extended with additive automatic migration.

  On the test side, the branch adds a comprehensive in_tail integration scenario covering discovery, startup-from-tail, rename rotation, repeated rotation, copytruncate, restart resume, partial-line restart recovery, DB migration, multiline, parser mode, long-line handling, rotate_wait, gzip, generic encoding, ignore_older, exclude_path, docker mode, and permission restoration. It also adds a separate multiline_interface integration scenario with a compiled probe that proves current API-level multiline bugs through strict xfail regression cases.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offset-marker mechanism to improve resume validation for database-backed tailing and reduce false resuming into replaced content.

* **Bug Fixes**
  * Improved handling of offsets and stream positions for decompressed reads and fixed multiline parser group/overflow edge cases.
  * Enhanced ignore-older behavior to avoid re-ingesting aged-out files.

* **Documentation**
  * Added comprehensive in_tail test scenario documentation.

* **Tests**
  * Added extensive integration scenarios, parser configs, and end-to-end pytest coverage.

* **Chores**
  * Added safe database schema migrations and stronger persistence checks at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->