### PR TITLE
in_tail: drop redundant fstat() on event collection

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -340,14 +340,7 @@ static int in_tail_watcher_callback(struct flb_input_instance *ins,
 int in_tail_collect_event(void *file, struct flb_config *config)
 {
     int ret;
-    struct stat st;
     struct flb_tail_file *f = file;
-
-    ret = fstat(f->fd, &st);
-    if (ret == -1) {
-        flb_tail_file_remove(f);
-        return 0;
-    }
 
     ret = flb_tail_file_chunk(f);
     switch (ret) {


### PR DESCRIPTION
The event collection path in in_tail_collect_event() performed an early fstat() only to remove the file on failure, then immediately called flb_tail_file_chunk(), which already reaches adjust_counters() and does its own fstat()-based validation and counter update.

Removing the pre-check reduces one fstat() per event-driven collection cycle without changing truncation, rotation, deletion, or pending-byte handling. Those behaviors remain in the backend-specific handlers and in adjust_counters().

This change is intentionally narrow and is based on a conversation about Fluent Bit tail syscall cost with Fabian Ponce from OpenAI (@FabianPonce).

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized file collection event handling by removing redundant file operations and streamlining error handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->