### PR TITLE
workflows: Verify CMakeLists version against assumed release version

### DIFF
--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -38,6 +38,11 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
     - name: Get the version on staging
       run: |
         curl --fail -LO "$AWS_URL/latest-version.txt"
@@ -49,6 +54,58 @@ jobs:
       shell: bash
       env:
         AWS_URL: https://${{ secrets.AWS_S3_BUCKET_STAGING }}.s3.amazonaws.com
+        RELEASE_VERSION: ${{ github.event.inputs.version }}
+
+    - name: Verify version is newer than latest release on target branch
+      run: |
+        set -euo pipefail
+
+        if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Release version must be in x.y.z format, got: $RELEASE_VERSION"
+          exit 1
+        fi
+
+        RELEASE_MAJOR="${RELEASE_VERSION%%.*}"
+        RELEASE_MINOR="${RELEASE_VERSION#*.}"
+        RELEASE_MINOR="${RELEASE_MINOR%%.*}"
+        RELEASE_MM="${RELEASE_MAJOR}.${RELEASE_MINOR}"
+
+        TARGET_BRANCH="$RELEASE_MM"
+        if [[ "$RELEASE_MM" == "4.2" ]] || (( RELEASE_MAJOR >= 5 )); then
+          TARGET_BRANCH="master"
+        fi
+
+        echo "Using target branch: $TARGET_BRANCH"
+
+        git fetch origin "$TARGET_BRANCH" --tags
+
+        BRANCH_TAGS=$(git tag --merged "origin/$TARGET_BRANCH" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+
+        if [[ -z "$BRANCH_TAGS" ]]; then
+          echo "No prior release tags found on origin/$TARGET_BRANCH. Continuing."
+          exit 0
+        fi
+
+        LATEST_TAG=$(printf '%s\n' "$BRANCH_TAGS" | sed 's/^v//' | sort -V | tail -n 1)
+        echo "Latest release tag on origin/$TARGET_BRANCH: v$LATEST_TAG"
+
+        if [[ "$TARGET_BRANCH" != "master" ]]; then
+          LATEST_MM="${LATEST_TAG%.*}"
+          if [[ "$LATEST_MM" != "$RELEASE_MM" ]]; then
+            echo "Latest branch tag stream mismatch on $TARGET_BRANCH: $LATEST_MM"
+            exit 1
+          fi
+        fi
+
+        if [[ "$(printf '%s\n%s\n' "$LATEST_TAG" "$RELEASE_VERSION" | sort -V | tail -n 1)" != "$RELEASE_VERSION" ]] ||
+           [[ "$LATEST_TAG" == "$RELEASE_VERSION" ]]; then
+          echo "Release version must be greater than latest branch release: $RELEASE_VERSION <= $LATEST_TAG"
+          exit 1
+        fi
+
+        echo "Release version validated: $RELEASE_VERSION > $LATEST_TAG on $TARGET_BRANCH"
+      shell: bash
+      env:
         RELEASE_VERSION: ${{ github.event.inputs.version }}
 
     # Get the major version, i.e. 1.9.3 --> 1.9, or just return the passed in version.
@@ -63,9 +120,6 @@ jobs:
       shell: bash
       env:
         RELEASE_VERSION: ${{ github.event.inputs.version }}
-
-    - name: Checkout repository
-      uses: actions/checkout@v6
 
   staging-release-generate-package-matrix:
     name: Get package matrix


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backport version of https://github.com/fluent/fluent-bit/pull/11695.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
