### PR TITLE
in_tcp: in_udp: Enhance of parser capabilities

### DIFF
--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -187,6 +187,11 @@ static struct flb_config_map config_map[] = {
      "Set separator"
     },
     {
+     FLB_CONFIG_MAP_STR, "parser", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_tcp_config, parser_name),
+     "Optional parser for line-delimited records"
+    },
+    {
       FLB_CONFIG_MAP_STR, "chunk_size", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_in_tcp_config, chunk_size_str),
       "Set the chunk size"

--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -27,6 +27,9 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#ifdef FLB_HAVE_PARSER
+#include <fluent-bit/flb_parser.h>
+#endif
 #include <msgpack.h>
 
 struct flb_in_tcp_config {
@@ -41,6 +44,12 @@ struct flb_in_tcp_config {
     flb_sds_t raw_separator;           /* Unescaped string delimiterr */
     flb_sds_t separator;               /* String delimiter            */
     flb_sds_t source_address_key;      /* Source IP address           */
+    flb_sds_t parser_name;             /* Parser name                 */
+#ifdef FLB_HAVE_PARSER
+    struct flb_parser *parser;         /* Parser context              */
+#else
+    void *parser;
+#endif
     int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager */
     struct mk_list connections;        /* List of active connections  */

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -67,6 +67,31 @@ struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *ins)
         }
     }
 
+    if (ctx->parser_name != NULL) {
+#ifdef FLB_HAVE_PARSER
+        ctx->parser = flb_parser_get(ctx->parser_name, ins->config);
+        if (ctx->parser == NULL) {
+            flb_plg_error(ctx->ins, "requested parser '%s' not found",
+                          ctx->parser_name);
+            flb_free(ctx);
+            return NULL;
+        }
+
+        if (ctx->format != FLB_TCP_FMT_NONE) {
+            flb_plg_warn(ctx->ins,
+                         "'parser' requires line-delimited payloads; "
+                         "switching format from '%s' to 'none'",
+                         ctx->format_name != NULL ? ctx->format_name : "json");
+            ctx->format = FLB_TCP_FMT_NONE;
+        }
+#else
+        flb_plg_error(ctx->ins,
+                      "'parser' option is not supported in this build");
+        flb_free(ctx);
+        return NULL;
+#endif
+    }
+
     /* String separator used to split records when using 'format none' */
     if (ctx->raw_separator) {
         len = strlen(ctx->raw_separator);

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -24,6 +24,9 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_error.h>
 #include <fluent-bit/flb_msgpack_append_message.h>
+#ifdef FLB_HAVE_PARSER
+#include <fluent-bit/flb_time.h>
+#endif
 
 #include "tcp.h"
 #include "tcp_conn.h"
@@ -209,6 +212,16 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
     char *buf;
     char *s;
     char *separator;
+#ifdef FLB_HAVE_PARSER
+    size_t out_size;
+    int parser_ret;
+    void *out_buf;
+    struct flb_time out_time;
+    char *source_address;
+    char *appended_address_buffer;
+    size_t appended_address_size;
+    int append_result;
+#endif
     struct flb_in_tcp_config *ctx;
 
     ctx = conn->ctx;
@@ -227,21 +240,120 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
             break;
         }
         else if (len > 0) {
-            ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
+#ifdef FLB_HAVE_PARSER
+            if (ctx->parser != NULL) {
+                out_buf = NULL;
+                out_size = 0;
+                source_address = NULL;
+                appended_address_buffer = NULL;
+                appended_address_size = 0;
+                flb_time_zero(&out_time);
 
-            if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-                ret = flb_log_event_encoder_set_current_timestamp(ctx->log_encoder);
+                parser_ret = flb_parser_do(ctx->parser, buf, len,
+                                           &out_buf, &out_size, &out_time);
+                if (parser_ret >= 0) {
+                    ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        if (flb_time_to_nanosec(&out_time) == 0L) {
+                            flb_time_get(&out_time);
+                        }
+                        ret = flb_log_event_encoder_set_timestamp(
+                                ctx->log_encoder, &out_time);
+                    }
+
+                    if (ctx->source_address_key != NULL) {
+                        source_address = flb_connection_get_remote_address(
+                                            conn->connection);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS &&
+                        source_address != NULL) {
+                        append_result = flb_msgpack_append_message_to_record(
+                                &appended_address_buffer,
+                                &appended_address_size,
+                                ctx->source_address_key,
+                                out_buf,
+                                out_size,
+                                source_address,
+                                strlen(source_address),
+                                MSGPACK_OBJECT_STR);
+                        if (append_result != FLB_MAP_EXPAND_SUCCESS) {
+                            if (appended_address_buffer != NULL) {
+                                flb_free(appended_address_buffer);
+                            }
+                            appended_address_buffer = NULL;
+                            appended_address_size = 0;
+                        }
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS &&
+                        appended_address_buffer != NULL) {
+                        ret = flb_log_event_encoder_set_body_from_raw_msgpack(
+                                ctx->log_encoder, appended_address_buffer,
+                                appended_address_size);
+                    }
+                    else if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_set_body_from_raw_msgpack(
+                                ctx->log_encoder, out_buf, out_size);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_commit_record(
+                                ctx->log_encoder);
+                    }
+                }
+                else {
+                    flb_plg_debug(ctx->ins, "parser '%s' failed on incoming data",
+                                  ctx->parser_name);
+                    ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_set_current_timestamp(
+                                ctx->log_encoder);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_append_body_values(
+                                ctx->log_encoder,
+                                FLB_LOG_EVENT_CSTRING_VALUE("log"),
+                                FLB_LOG_EVENT_STRING_VALUE(buf, len));
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_commit_record(
+                                ctx->log_encoder);
+                    }
+                }
+
+                if (parser_ret >= 0 && out_buf != NULL) {
+                    flb_free(out_buf);
+                }
+                if (appended_address_buffer != NULL) {
+                    flb_free(appended_address_buffer);
+                }
             }
+            else
+#endif
+            {
+                ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
-            if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-                ret = flb_log_event_encoder_append_body_values(
-                        ctx->log_encoder,
-                        FLB_LOG_EVENT_CSTRING_VALUE("log"),
-                        FLB_LOG_EVENT_STRING_VALUE(buf, len));
-            }
+                if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    ret = flb_log_event_encoder_set_current_timestamp(
+                            ctx->log_encoder);
+                }
 
-            if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-                ret = flb_log_event_encoder_commit_record(ctx->log_encoder);
+                if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    ret = flb_log_event_encoder_append_body_values(
+                            ctx->log_encoder,
+                            FLB_LOG_EVENT_CSTRING_VALUE("log"),
+                            FLB_LOG_EVENT_STRING_VALUE(buf, len));
+                }
+
+                if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    ret = flb_log_event_encoder_commit_record(
+                            ctx->log_encoder);
+                }
             }
 
             if (ret != FLB_EVENT_ENCODER_SUCCESS) {

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -313,7 +313,21 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
                                 ctx->log_encoder);
                     }
 
-                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    if (ctx->source_address_key != NULL) {
+                        source_address = flb_connection_get_remote_address(
+                                            conn->connection);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS &&
+                        source_address != NULL) {
+                        ret = flb_log_event_encoder_append_body_values(
+                                ctx->log_encoder,
+                                FLB_LOG_EVENT_CSTRING_VALUE("log"),
+                                FLB_LOG_EVENT_STRING_VALUE(buf, len),
+                                FLB_LOG_EVENT_CSTRING_VALUE(ctx->source_address_key),
+                                FLB_LOG_EVENT_CSTRING_VALUE(source_address));
+                    }
+                    else if (ret == FLB_EVENT_ENCODER_SUCCESS) {
                         ret = flb_log_event_encoder_append_body_values(
                                 ctx->log_encoder,
                                 FLB_LOG_EVENT_CSTRING_VALUE("log"),

--- a/plugins/in_udp/udp.c
+++ b/plugins/in_udp/udp.c
@@ -165,6 +165,11 @@ static struct flb_config_map config_map[] = {
      "Set separator"
     },
     {
+     FLB_CONFIG_MAP_STR, "parser", (char *)NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_udp_config, parser_name),
+     "Optional parser for line-delimited records"
+    },
+    {
       FLB_CONFIG_MAP_STR, "chunk_size", (char *)NULL,
       0, FLB_TRUE, offsetof(struct flb_in_udp_config, chunk_size_str),
       "Set the chunk size"

--- a/plugins/in_udp/udp.h
+++ b/plugins/in_udp/udp.h
@@ -27,6 +27,9 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#ifdef FLB_HAVE_PARSER
+#include <fluent-bit/flb_parser.h>
+#endif
 #include <msgpack.h>
 
 struct udp_conn;
@@ -44,6 +47,12 @@ struct flb_in_udp_config {
     flb_sds_t raw_separator;           /* Unescaped string delimiterr */
     flb_sds_t separator;               /* String delimiter            */
     flb_sds_t source_address_key;      /* Source IP address           */
+    flb_sds_t parser_name;             /* Parser name                 */
+#ifdef FLB_HAVE_PARSER
+    struct flb_parser *parser;         /* Parser context              */
+#else
+    void *parser;
+#endif
     int collector_id;                  /* Listener collector id       */
     struct flb_downstream *downstream; /* Client manager              */
     struct udp_conn *dummy_conn;       /* Datagram dummy connection   */

--- a/plugins/in_udp/udp_config.c
+++ b/plugins/in_udp/udp_config.c
@@ -67,6 +67,31 @@ struct flb_in_udp_config *udp_config_init(struct flb_input_instance *ins)
         }
     }
 
+    if (ctx->parser_name != NULL) {
+#ifdef FLB_HAVE_PARSER
+        ctx->parser = flb_parser_get(ctx->parser_name, ins->config);
+        if (ctx->parser == NULL) {
+            flb_plg_error(ctx->ins, "requested parser '%s' not found",
+                          ctx->parser_name);
+            flb_free(ctx);
+            return NULL;
+        }
+
+        if (ctx->format != FLB_UDP_FMT_NONE) {
+            flb_plg_warn(ctx->ins,
+                         "'parser' requires line-delimited payloads; "
+                         "switching format from '%s' to 'none'",
+                         ctx->format_name != NULL ? ctx->format_name : "json");
+            ctx->format = FLB_UDP_FMT_NONE;
+        }
+#else
+        flb_plg_error(ctx->ins,
+                      "'parser' option is not supported in this build");
+        flb_free(ctx);
+        return NULL;
+#endif
+    }
+
     /* String separator used to split records when using 'format none' */
     if (ctx->raw_separator) {
         len = strlen(ctx->raw_separator);

--- a/plugins/in_udp/udp_conn.c
+++ b/plugins/in_udp/udp_conn.c
@@ -23,6 +23,9 @@
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_error.h>
+#ifdef FLB_HAVE_PARSER
+#include <fluent-bit/flb_time.h>
+#endif
 
 #include "udp.h"
 #include "udp_conn.h"
@@ -264,6 +267,16 @@ static ssize_t parse_payload_none(struct udp_conn *conn)
     char *buf;
     char *s;
     char *separator;
+#ifdef FLB_HAVE_PARSER
+    size_t out_size;
+    int parser_ret;
+    void *out_buf;
+    struct flb_time out_time;
+    char *source_address;
+    char *appended_address_buffer;
+    size_t appended_address_size;
+    int append_result;
+#endif
     struct flb_in_udp_config *ctx;
 
     ctx = conn->ctx;
@@ -282,28 +295,144 @@ static ssize_t parse_payload_none(struct udp_conn *conn)
             break;
         }
         else if (len > 0) {
-            ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
+#ifdef FLB_HAVE_PARSER
+            if (ctx->parser != NULL) {
+                out_buf = NULL;
+                out_size = 0;
+                source_address = NULL;
+                appended_address_buffer = NULL;
+                appended_address_size = 0;
+                flb_time_zero(&out_time);
 
-            if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-                ret = flb_log_event_encoder_set_current_timestamp(ctx->log_encoder);
+                parser_ret = flb_parser_do(ctx->parser, buf, len,
+                                           &out_buf, &out_size, &out_time);
+                if (parser_ret >= 0) {
+                    ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        if (flb_time_to_nanosec(&out_time) == 0L) {
+                            flb_time_get(&out_time);
+                        }
+                        ret = flb_log_event_encoder_set_timestamp(
+                                ctx->log_encoder, &out_time);
+                    }
+
+                    if (ctx->source_address_key != NULL) {
+                        source_address = flb_connection_get_remote_address(
+                                            conn->connection);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS &&
+                        source_address != NULL) {
+                        append_result = append_message_to_record_data(
+                                &appended_address_buffer,
+                                &appended_address_size,
+                                ctx->source_address_key,
+                                out_buf,
+                                out_size,
+                                source_address,
+                                strlen(source_address),
+                                MSGPACK_OBJECT_STR);
+                        if (append_result != FLB_MAP_EXPAND_SUCCESS) {
+                            if (appended_address_buffer != NULL) {
+                                flb_free(appended_address_buffer);
+                            }
+                            appended_address_buffer = NULL;
+                            appended_address_size = 0;
+                        }
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS &&
+                        appended_address_buffer != NULL) {
+                        ret = flb_log_event_encoder_set_body_from_raw_msgpack(
+                                ctx->log_encoder, appended_address_buffer,
+                                appended_address_size);
+                    }
+                    else if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_set_body_from_raw_msgpack(
+                                ctx->log_encoder, out_buf, out_size);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_commit_record(
+                                ctx->log_encoder);
+                    }
+                }
+                else {
+                    source_address = NULL;
+                    appended_address_buffer = NULL;
+                    appended_address_size = 0;
+
+                    flb_plg_debug(ctx->ins, "parser '%s' failed on incoming data",
+                                  ctx->parser_name);
+                    ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_set_current_timestamp(
+                                ctx->log_encoder);
+                    }
+
+                    if (ctx->source_address_key != NULL) {
+                        source_address = flb_connection_get_remote_address(
+                                            conn->connection);
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS && source_address != NULL) {
+                        ret = flb_log_event_encoder_append_body_values(
+                                ctx->log_encoder,
+                                FLB_LOG_EVENT_CSTRING_VALUE("log"),
+                                FLB_LOG_EVENT_STRING_VALUE(buf, len),
+                                FLB_LOG_EVENT_CSTRING_VALUE(ctx->source_address_key),
+                                FLB_LOG_EVENT_CSTRING_VALUE(source_address));
+                    }
+                    else if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_append_body_values(
+                                ctx->log_encoder,
+                                FLB_LOG_EVENT_CSTRING_VALUE("log"),
+                                FLB_LOG_EVENT_STRING_VALUE(buf, len));
+                    }
+
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        ret = flb_log_event_encoder_commit_record(
+                                ctx->log_encoder);
+                    }
+                }
+
+                if (parser_ret >= 0 && out_buf != NULL) {
+                    flb_free(out_buf);
+                }
+                if (appended_address_buffer != NULL) {
+                    flb_free(appended_address_buffer);
+                }
             }
+            else
+#endif
+            {
+                ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
-            if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-                ret = flb_log_event_encoder_append_body_values(
-                        ctx->log_encoder,
-                        FLB_LOG_EVENT_CSTRING_VALUE("log"),
-                        FLB_LOG_EVENT_STRING_VALUE(buf, len));
-            }
+                if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    ret = flb_log_event_encoder_set_current_timestamp(
+                            ctx->log_encoder);
+                }
 
-            if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-                ret = flb_log_event_encoder_commit_record(ctx->log_encoder);
+                if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    ret = flb_log_event_encoder_append_body_values(
+                            ctx->log_encoder,
+                            FLB_LOG_EVENT_CSTRING_VALUE("log"),
+                            FLB_LOG_EVENT_STRING_VALUE(buf, len));
+                }
+
+                if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                    ret = flb_log_event_encoder_commit_record(
+                            ctx->log_encoder);
+                }
             }
 
             if (ret != FLB_EVENT_ENCODER_SUCCESS) {
                 break;
             }
 
-            consumed += len + 1;
+            consumed += len + sep_len;
             buf += len + sep_len;
         }
         else {

--- a/tests/integration/scenarios/in_tcp/config/in_tcp_parser_json.yaml
+++ b/tests/integration/scenarios/in_tcp/config/in_tcp_parser_json.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
+
+pipeline:
+  inputs:
+    - name: tcp
+      tag: target_input
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      format: none
+      separator: "\\n"
+      parser: json
+
+  outputs:
+    - name: http
+      match: target_input
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_tcp/tests/test_in_tcp_001.py
+++ b/tests/integration/scenarios/in_tcp/tests/test_in_tcp_001.py
@@ -1,0 +1,95 @@
+import os
+import socket
+
+import requests
+
+from server.http_server import data_storage, http_server_run
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        test_path = os.path.dirname(os.path.abspath(__file__))
+        self.parsers_file = os.environ.get("FLUENT_BIT_PARSERS_FILE") or os.path.abspath(
+            os.path.join(test_path, "../../../../../conf/parsers.conf")
+        )
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads"],
+            extra_env={
+                "PARSERS_FILE_TEST": self.parsers_file,
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(f"http://127.0.0.1:{service.test_suite_http_port}/shutdown", timeout=2)
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_single_record(self, timeout=10):
+        payloads = self.service.wait_for_condition(
+            lambda: data_storage["payloads"] if data_storage["payloads"] else None,
+            timeout=timeout,
+            interval=0.5,
+            description="forwarded TCP payloads",
+        )
+
+        assert len(payloads) == 1
+        assert isinstance(payloads[0], list)
+        assert len(payloads[0]) == 1
+
+        return payloads[0][0]
+
+
+def _send_line(port, line):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(line.encode("utf-8"))
+        sock.shutdown(socket.SHUT_WR)
+
+
+def test_in_tcp_parser_json_success():
+    service = Service("in_tcp_parser_json.yaml")
+    service.start()
+
+    try:
+        _send_line(service.flb_listener_port, '{"message":"hello","value":42}\n')
+        record = service.wait_for_single_record()
+    finally:
+        service.stop()
+
+    assert record["message"] == "hello"
+    assert record["value"] == 42
+
+
+def test_in_tcp_parser_json_fallback_to_log():
+    service = Service("in_tcp_parser_json.yaml")
+    service.start()
+
+    try:
+        _send_line(service.flb_listener_port, 'not-json\n')
+        record = service.wait_for_single_record()
+    finally:
+        service.stop()
+
+    assert "log" in record
+    assert record["log"].strip() == "not-json"

--- a/tests/integration/scenarios/in_udp/config/in_udp_parser_json.yaml
+++ b/tests/integration/scenarios/in_udp/config/in_udp_parser_json.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
+
+pipeline:
+  inputs:
+    - name: udp
+      tag: target_input
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      format: none
+      separator: "\\n"
+      parser: json
+
+  outputs:
+    - name: http
+      match: target_input
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_udp/tests/test_in_udp_001.py
+++ b/tests/integration/scenarios/in_udp/tests/test_in_udp_001.py
@@ -1,0 +1,94 @@
+import os
+import socket
+
+import requests
+
+from server.http_server import data_storage, http_server_run
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        test_path = os.path.dirname(os.path.abspath(__file__))
+        self.parsers_file = os.environ.get("FLUENT_BIT_PARSERS_FILE") or os.path.abspath(
+            os.path.join(test_path, "../../../../../conf/parsers.conf")
+        )
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads"],
+            extra_env={
+                "PARSERS_FILE_TEST": self.parsers_file,
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(f"http://127.0.0.1:{service.test_suite_http_port}/shutdown", timeout=2)
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_single_record(self, timeout=10):
+        payloads = self.service.wait_for_condition(
+            lambda: data_storage["payloads"] if data_storage["payloads"] else None,
+            timeout=timeout,
+            interval=0.5,
+            description="forwarded UDP payloads",
+        )
+
+        assert len(payloads) == 1
+        assert isinstance(payloads[0], list)
+        assert len(payloads[0]) == 1
+
+        return payloads[0][0]
+
+
+def _send_datagram(port, payload):
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.sendto(payload.encode("utf-8"), ("127.0.0.1", port))
+
+
+def test_in_udp_parser_json_success():
+    service = Service("in_udp_parser_json.yaml")
+    service.start()
+
+    try:
+        _send_datagram(service.flb_listener_port, '{"message":"hello","value":42}\n')
+        record = service.wait_for_single_record()
+    finally:
+        service.stop()
+
+    assert record["message"] == "hello"
+    assert record["value"] == 42
+
+
+def test_in_udp_parser_json_fallback_to_log():
+    service = Service("in_udp_parser_json.yaml")
+    service.start()
+
+    try:
+        _send_datagram(service.flb_listener_port, 'not-json\n')
+        record = service.wait_for_single_record()
+    finally:
+        service.stop()
+
+    assert "log" in record
+    assert record["log"].strip() == "not-json"

--- a/tests/runtime/in_tcp.c
+++ b/tests/runtime/in_tcp.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include "flb_tests_runtime.h"
 
+#define DPATH            FLB_TESTS_DATA_PATH "/data/common"
 #define DEFAULT_IO_TIMEOUT 10
 #define DEFAULT_HOST       "127.0.0.1"
 #define DEFAULT_PORT       5170
@@ -263,6 +264,7 @@ static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
                     "Flush", "0.200000000",
                     "Grace", "1",
                     "Log_Level", "error",
+                    "Parsers_File", DPATH "/parsers.conf",
                     NULL);
 
     /* Input */
@@ -672,6 +674,105 @@ void flb_test_format_none_separator()
     test_ctx_destroy(ctx);
 }
 
+#ifdef FLB_HAVE_PARSER
+void flb_test_format_none_with_parser()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    flb_sockfd_t fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+    char *buf = "{\"test\":\"msg\"}\n";
+    size_t size = strlen(buf);
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "format", "none",
+                        "parser", "json",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    fd = connect_tcp(NULL, -1);
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+
+    w_size = send(fd, buf, size, 0);
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        flb_socket_close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0)) {
+        TEST_MSG("no outputs");
+    }
+
+    flb_socket_close(fd);
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_format_none_with_unknown_parser()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "format", "none",
+                        "parser", "nonexistent_parser",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("flb_start unexpectedly succeeded with unknown parser");
+    }
+
+    test_ctx_destroy(ctx);
+}
+#endif
+
 /*
  * Ingest 64k records.
  * https://github.com/fluent/fluent-bit/issues/5336
@@ -841,8 +942,11 @@ TEST_LIST = {
     {"tcp_with_tls", flb_test_tcp_with_tls},
     {"format_none", flb_test_format_none},
     {"format_none_separator", flb_test_format_none_separator},
+#ifdef FLB_HAVE_PARSER
+    {"format_none_with_parser", flb_test_format_none_with_parser},
+    {"format_none_with_unknown_parser", flb_test_format_none_with_unknown_parser},
+#endif
     {"format_none_large_record", flb_test_format_none_large_record},
     {"65535_records_issue_5336", flb_test_issue_5336},
     {NULL, NULL}
 };
-

--- a/tests/runtime/in_udp.c
+++ b/tests/runtime/in_udp.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include "flb_tests_runtime.h"
 
+#define DPATH            FLB_TESTS_DATA_PATH "/data/common"
 #define DEFAULT_IO_TIMEOUT 10
 #define DEFAULT_HOST       "127.0.0.1"
 #define DEFAULT_PORT       5180
@@ -117,6 +118,7 @@ static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
                     "Flush", "0.200000000",
                     "Grace", "1",
                     "Log_Level", "error",
+                    "Parsers_File", DPATH "/parsers.conf",
                     NULL);
 
     /* Input */
@@ -431,10 +433,179 @@ void flb_test_format_none_separator()
     test_ctx_destroy(ctx);
 }
 
+#ifdef FLB_HAVE_PARSER
+void flb_test_format_none_with_parser()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct sockaddr_in addr;
+    flb_sockfd_t fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+    char *buf = "{\"test\":\"msg\"}\n";
+    size_t size = strlen(buf);
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "format", "none",
+                        "parser", "json",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    fd = init_udp(NULL, -1, &addr);
+    if (!TEST_CHECK(fd >= 0)) {
+        exit(EXIT_FAILURE);
+    }
+
+    w_size = sendto(fd, buf, size, 0, (const struct sockaddr *) &addr, sizeof(addr));
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        flb_socket_close(fd);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0)) {
+        TEST_MSG("no outputs");
+    }
+
+    flb_socket_close(fd);
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_format_none_with_unknown_parser()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    int ret;
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"test\":\"msg\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "format", "none",
+                        "parser", "no_such_parser",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("flb_start unexpectedly succeeded with unknown parser");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_format_none_parser_fallback_udp()
+{
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+    struct sockaddr_in addr;
+    flb_sockfd_t fd;
+    int ret;
+    int num;
+    ssize_t w_size;
+    char *buf = "plain text\n";
+    size_t size = strlen(buf);
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_result_json;
+    cb_data.data = "\"log\":\"plain text\"";
+
+    ctx = test_ctx_create(&cb_data);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "format", "none",
+                        "parser", "json",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    fd = init_udp(NULL, -1, &addr);
+    if (!TEST_CHECK(fd >= 0)) {
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    w_size = sendto(fd, buf, size, 0, (const struct sockaddr *) &addr, sizeof(addr));
+    if (!TEST_CHECK(w_size == size)) {
+        TEST_MSG("failed to send, errno=%d", errno);
+        flb_socket_close(fd);
+        test_ctx_destroy(ctx);
+        exit(EXIT_FAILURE);
+    }
+
+    flb_time_msleep(1500);
+
+    num = get_output_num();
+    if (!TEST_CHECK(num > 0)) {
+        TEST_MSG("no outputs");
+    }
+
+    flb_socket_close(fd);
+    test_ctx_destroy(ctx);
+}
+#endif
+
 TEST_LIST = {
     {"udp", flb_test_udp},
     {"udp_with_source_address", flb_test_udp_with_source_address},
     {"format_none", flb_test_format_none},
     {"format_none_separator", flb_test_format_none_separator},
+#ifdef FLB_HAVE_PARSER
+    {"format_none_with_parser", flb_test_format_none_with_parser},
+    {"format_none_with_unknown_parser", flb_test_format_none_with_unknown_parser},
+    {"format_none_parser_fallback_udp", flb_test_format_none_parser_fallback_udp},
+#endif
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the current master branch, we didn't handle parser on in_tcp and in_udp plugins.
This could be reasonable to handle parser in both of plugins.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Closes https://github.com/fluent/fluent-bit/issues/11688.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TCP and UDP inputs: optional parser for line-delimited records, parsed timestamps, and optional source-address enrichment; selecting a parser forces the input format to "none" with a warning.

* **Bug Fixes / Behavior**
  * Better fallback on parse failures, improved timestamp handling, and clearer initialization error reporting and cleanup when a configured parser is unavailable.

* **Tests**
  * Added runtime tests for parser-present, unknown-parser, and parser-fallback scenarios (enabled when parser support is available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->