### PR TITLE
out_syslog: address invalid configurations on in syslog

### DIFF
--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -1047,7 +1047,8 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "mode", "udp",
      0, FLB_TRUE, offsetof(struct flb_syslog, mode),
      "Set the desired transport type, the available options are tcp and udp. If you need to "
-     "use a TLS secure channel, choose 'tcp' mode here and enable the 'tls' option separately."
+     "use a TLS secure channel, choose 'tcp' mode here and enable the 'tls' option separately. "
+     "DTLS over udp is not supported by this plugin."
     },
 
     {

--- a/plugins/out_syslog/syslog_conf.c
+++ b/plugins/out_syslog/syslog_conf.c
@@ -109,6 +109,14 @@ struct flb_syslog *flb_syslog_config_create(struct flb_output_instance *ins,
         }
     }
 
+    if (ctx->parsed_mode == FLB_SYSLOG_UDP && ins->use_tls == FLB_TRUE) {
+        flb_plg_error(ctx->ins,
+                      "invalid configuration: mode=udp with tls=on is unsupported "
+                      "(DTLS is not implemented)");
+        flb_syslog_config_destroy(ctx);
+        return NULL;
+    }
+
     /* syslog_format */
     tmp = flb_output_get_property("syslog_format", ins);
     if (tmp) {

--- a/tests/runtime/out_syslog.c
+++ b/tests/runtime/out_syslog.c
@@ -1608,6 +1608,32 @@ void flb_test_malformed_longer_sd_id_rfc5424()
     test_ctx_destroy(ctx);
 }
 
+void flb_test_udp_mode_rejects_tls()
+{
+    struct test_ctx *ctx;
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "mode", "udp",
+                         "tls", "on",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("expected startup failure for mode=udp with tls=on");
+    }
+
+    test_ctx_destroy(ctx);
+}
+
 TEST_LIST = {
     /* rfc3164 */
     /* procid_key, msgid_key, sd_key are not supported */
@@ -1639,6 +1665,6 @@ TEST_LIST = {
     {"format_msgid_preset_rfc5424", flb_test_msgid_preset_rfc5424},
     {"allow_longer_sd_id_rfc5424", flb_test_allow_longer_sd_id_rfc5424},
     {"malformed_longer_sd_id_rfc5424", flb_test_malformed_longer_sd_id_rfc5424},
+    {"udp_mode_rejects_tls", flb_test_udp_mode_rejects_tls},
     {NULL, NULL}
 };
-


### PR DESCRIPTION
<!-- Provide summary of changes -->

We need to notify UDP with TLS settings is not supported on the current master of Fluent Bit code base.

Closes https://github.com/fluent/fluent-bit/issues/11703.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Syslog output now validates and rejects configurations combining UDP mode with TLS encryption, returning an error at startup.

* **Documentation**
  * Updated syslog mode option description to clarify that DTLS over UDP is unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->