### PR TITLE
tests: http_client_chunked: Plug SEGV occurence on macOS

### DIFF
--- a/tests/runtime/http_client_chunked.c
+++ b/tests/runtime/http_client_chunked.c
@@ -14,6 +14,7 @@
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_http_client.h>
 
 #include <monkey/mk_core.h>
@@ -151,6 +152,7 @@ static void *chunked_server_thread(void *data)
 static struct runtime_http_client_ctx *runtime_http_client_ctx_create(int port)
 {
     struct runtime_http_client_ctx *ctx;
+    static int coro_initialized = FLB_FALSE;
 
     ctx = flb_calloc(1, sizeof(struct runtime_http_client_ctx));
     if (!TEST_CHECK(ctx != NULL)) {
@@ -166,6 +168,12 @@ static struct runtime_http_client_ctx *runtime_http_client_ctx_create(int port)
 
     flb_engine_evl_init();
     flb_engine_evl_set(ctx->evl);
+
+    if (coro_initialized == FLB_FALSE) {
+        flb_coro_init();
+        coro_initialized = FLB_TRUE;
+    }
+    flb_coro_thread_init();
 
     ctx->config = flb_config_init();
     if (!TEST_CHECK(ctx->config != NULL)) {


### PR DESCRIPTION
<!-- Provide summary of changes -->

http_client_chunked test case is always failing on macOS due to uninitialized conroutine on the test case.
We need to ensure initializing coroutine before running the actual assertions. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for coroutine support initialization.

*No user-facing changes in this update.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->