### PR TITLE
in_ebpf: Implement exec trace

### DIFF
--- a/plugins/in_ebpf/in_ebpf.c
+++ b/plugins/in_ebpf/in_ebpf.c
@@ -262,7 +262,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "Trace", NULL,
      FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
-     "Set the eBPF trace to enable (for example, bind, malloc, signal, vfs, tcp). Can be set multiple times"
+     "Set the eBPF trace to enable (for example, bind, exec, malloc, signal, vfs, tcp). Can be set multiple times"
     },
     /* EOF */
     {0}

--- a/plugins/in_ebpf/traces/exec/bpf.c
+++ b/plugins/in_ebpf/traces/exec/bpf.c
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+#include <vmlinux.h>
+
+#define _LINUX_TYPES_H
+#define _LINUX_POSIX_TYPES_H
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns_filter.h>
+#include <gadget/types.h>
+
+#include "common/events.h"
+
+#define MAX_ENTRIES 10240
+#define ARGV_MAX_SCAN 20
+
+struct execve_args {
+    gadget_mntns_id mntns_id;
+    char filename[PATH_MAX];
+    char argv[EXECVE_ARG_MAX][EXECVE_ARG_LEN];
+    char argv_last[EXECVE_ARG_LEN];
+    __u32 argc;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, __u32);
+    __type(value, struct execve_args);
+} values SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct execve_args);
+} heap SEC(".maps");
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+
+static __always_inline __u32 get_ppid(void)
+{
+    struct task_struct *task;
+
+    task = (struct task_struct *) bpf_get_current_task_btf();
+    if (!task) {
+        return 0;
+    }
+
+    return BPF_CORE_READ(task, real_parent, tgid);
+}
+
+static __always_inline int submit_exec_event(void *ctx,
+                                             struct execve_args *args,
+                                             enum execve_stage stage,
+                                             int error_raw)
+{
+    __u64 pid_tgid;
+    __u64 uid_gid;
+    struct event *event;
+
+    event = gadget_reserve_buf(&events, sizeof(*event));
+    if (!event) {
+        return -1;
+    }
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    uid_gid = bpf_get_current_uid_gid();
+
+    event->common.timestamp_raw = bpf_ktime_get_boot_ns();
+    event->common.pid = (__u32) (pid_tgid >> 32);
+    event->common.tid = (__u32) pid_tgid;
+    event->common.uid = (__u32) uid_gid;
+    event->common.gid = (__u32) (uid_gid >> 32);
+    event->common.mntns_id = args->mntns_id;
+    bpf_get_current_comm(event->common.comm, sizeof(event->common.comm));
+
+    event->type = EVENT_TYPE_EXECVE;
+    event->details.execve.stage = stage;
+    event->details.execve.ppid = get_ppid();
+    event->details.execve.argc = args->argc;
+    event->details.execve.error_raw = error_raw;
+
+    bpf_probe_read_kernel_str(event->details.execve.filename,
+                              sizeof(event->details.execve.filename),
+                              args->filename);
+    bpf_probe_read_kernel_str(event->details.execve.argv[0],
+                              sizeof(event->details.execve.argv[0]),
+                              args->argv[0]);
+    bpf_probe_read_kernel_str(event->details.execve.argv[1],
+                              sizeof(event->details.execve.argv[1]),
+                              args->argv[1]);
+    bpf_probe_read_kernel_str(event->details.execve.argv[2],
+                              sizeof(event->details.execve.argv[2]),
+                              args->argv[2]);
+    bpf_probe_read_kernel_str(event->details.execve.argv_last,
+                              sizeof(event->details.execve.argv_last),
+                              args->argv_last);
+
+    gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_execve")
+int trace_execve_enter(struct syscall_trace_enter *ctx)
+{
+    __u32 tid;
+    __u32 i;
+    __u64 pid_tgid;
+    __u64 mntns_id;
+    __u32 zero;
+    const char *filename;
+    const char *const *argv;
+    const char *arg;
+    struct execve_args *args;
+
+    mntns_id = gadget_get_mntns_id();
+    if (gadget_should_discard_mntns_id(mntns_id)) {
+        return 0;
+    }
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+
+    zero = 0;
+    args = bpf_map_lookup_elem(&heap, &zero);
+    if (!args) {
+        return 0;
+    }
+
+    args->mntns_id = mntns_id;
+    args->argc = 0;
+    args->filename[0] = '\0';
+    args->argv[0][0] = '\0';
+    args->argv[1][0] = '\0';
+    args->argv[2][0] = '\0';
+    args->argv_last[0] = '\0';
+
+    filename = (const char *) ctx->args[0];
+    if (filename) {
+        bpf_probe_read_user_str(args->filename, sizeof(args->filename), filename);
+    }
+
+    argv = (const char *const *) ctx->args[1];
+    if (argv) {
+#pragma unroll
+        for (i = 0; i < ARGV_MAX_SCAN; i++) {
+            arg = NULL;
+            if (bpf_probe_read_user(&arg, sizeof(arg), &argv[i]) != 0 || arg == NULL) {
+                break;
+            }
+            args->argc++;
+            bpf_probe_read_user_str(args->argv_last, sizeof(args->argv_last), arg);
+
+            if (i == 0) {
+                bpf_probe_read_user_str(args->argv[0], sizeof(args->argv[0]), arg);
+            }
+            else if (i == 1) {
+                bpf_probe_read_user_str(args->argv[1], sizeof(args->argv[1]), arg);
+            }
+            else if (i == 2) {
+                bpf_probe_read_user_str(args->argv[2], sizeof(args->argv[2]), arg);
+            }
+        }
+    }
+
+    bpf_map_update_elem(&values, &tid, args, BPF_ANY);
+    submit_exec_event(ctx, args, EXECVE_STAGE_ENTER, 0);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_execve")
+int trace_execve_exit(struct syscall_trace_exit *ctx)
+{
+    __u32 tid;
+    struct execve_args *args;
+    int error_raw;
+
+    tid = (__u32) bpf_get_current_pid_tgid();
+
+    args = bpf_map_lookup_elem(&values, &tid);
+    if (!args) {
+        return 0;
+    }
+
+    error_raw = ctx->ret < 0 ? -ctx->ret : 0;
+    submit_exec_event(ctx, args, EXECVE_STAGE_EXIT, error_raw);
+
+    bpf_map_delete_elem(&values, &tid);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/plugins/in_ebpf/traces/exec/handler.c
+++ b/plugins/in_ebpf/traces/exec/handler.c
@@ -1,0 +1,175 @@
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "common/events.h"
+#include "common/event_context.h"
+#include "common/encoder.h"
+
+#include "handler.h"
+
+static const char *exec_stage_to_string(enum execve_stage stage)
+{
+    if (stage == EXECVE_STAGE_ENTER) {
+        return "enter";
+    }
+
+    if (stage == EXECVE_STAGE_EXIT) {
+        return "exit";
+    }
+
+    return "unknown";
+}
+
+int encode_exec_event(struct flb_input_instance *ins,
+                      struct flb_log_event_encoder *log_encoder,
+                      const struct event *ev)
+{
+    const char *stage_name;
+    int ret;
+
+    ret = flb_log_event_encoder_begin_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    ret = encode_common_fields(log_encoder, ev);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    stage_name = exec_stage_to_string(ev->details.execve.stage);
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "stage");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, stage_name);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "ppid");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, ev->details.execve.ppid);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "filename");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, ev->details.execve.filename);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "argv");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, ev->details.execve.argv[0]);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "argv1");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, ev->details.execve.argv[1]);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "argv2");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, ev->details.execve.argv[2]);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "argv_last");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, ev->details.execve.argv_last);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "argc");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, ev->details.execve.argc);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "error_raw");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, ev->details.execve.error_raw);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_commit_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    return 0;
+}
+
+int trace_exec_handler(void *ctx, void *data, size_t data_sz)
+{
+    struct trace_event_context *event_ctx = (struct trace_event_context *) ctx;
+    struct event *ev = (struct event *) data;
+    struct flb_log_event_encoder *encoder = event_ctx->log_encoder;
+    int ret;
+
+    if (data_sz < sizeof(struct event) || ev->type != EVENT_TYPE_EXECVE) {
+        return -1;
+    }
+
+    ret = encode_exec_event(event_ctx->ins, encoder, ev);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = flb_input_log_append(event_ctx->ins, NULL, 0,
+                               encoder->output_buffer, encoder->output_length);
+    flb_log_event_encoder_reset(encoder);
+    if (ret == -1) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/plugins/in_ebpf/traces/exec/handler.h
+++ b/plugins/in_ebpf/traces/exec/handler.h
@@ -1,0 +1,14 @@
+#ifndef TRACE_EXEC_HANDLER_H
+#define TRACE_EXEC_HANDLER_H
+
+#include <stddef.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+#include "common/events.h"
+
+int encode_exec_event(struct flb_input_instance *ins,
+                      struct flb_log_event_encoder *log_encoder,
+                      const struct event *ev);
+int trace_exec_handler(void *ctx, void *data, size_t data_sz);
+
+#endif

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -6,6 +6,8 @@
 
 #define TASK_COMM_LEN 16
 #define VFS_PATH_MAX 256
+#define EXECVE_ARG_MAX 3
+#define EXECVE_ARG_LEN 256
 
 enum event_type {
     EVENT_TYPE_EXECVE,
@@ -48,11 +50,19 @@ struct event_common {
     char comm[TASK_COMM_LEN];
 };
 
+enum execve_stage {
+    EXECVE_STAGE_ENTER = 0,
+    EXECVE_STAGE_EXIT = 1
+};
+
 struct execve_event {
-    __u32 tpid;
+    enum execve_stage stage;
+    __u32 ppid;
     char filename[PATH_MAX];
-    char argv[256];
+    char argv[EXECVE_ARG_MAX][EXECVE_ARG_LEN];
+    char argv_last[EXECVE_ARG_LEN];
     __u32 argc;
+    int error_raw;
 };
 
 struct signal_event {

--- a/plugins/in_ebpf/traces/traces.h
+++ b/plugins/in_ebpf/traces/traces.h
@@ -8,12 +8,14 @@
 #include "generated/trace_bind.skel.h"
 #include "generated/trace_vfs.skel.h"
 #include "generated/trace_tcp.skel.h"
+#include "generated/trace_exec.skel.h"
 
 #include "bind/handler.h"
 #include "signal/handler.h"  // Include signal handler
 #include "malloc/handler.h" // Include malloc handler
 #include "vfs/handler.h"
 #include "tcp/handler.h"
+#include "exec/handler.h"
 
 /* Skeleton function pointer types */
 typedef void *(*trace_skel_open_func_t)(void);
@@ -66,6 +68,7 @@ DEFINE_GET_BPF_OBJECT(trace_malloc)
 DEFINE_GET_BPF_OBJECT(trace_bind)
 DEFINE_GET_BPF_OBJECT(trace_vfs)
 DEFINE_GET_BPF_OBJECT(trace_tcp)
+DEFINE_GET_BPF_OBJECT(trace_exec)
 
 static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_signal, trace_signal_handler),
@@ -73,6 +76,7 @@ static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_bind, trace_bind_handler),
     REGISTER_TRACE(trace_vfs, trace_vfs_handler),
     REGISTER_TRACE(trace_tcp, trace_tcp_handler),
+    REGISTER_TRACE(trace_exec, trace_exec_handler),
 };
 
 #endif // TRACE_TRACES_H

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -171,10 +171,17 @@ if(FLB_IN_EBPF)
         "../../plugins/in_ebpf/traces/tcp/handler.c"
     )
 
+    add_ebpf_handler_test(
+        "exec"
+        "in_ebpf_exec_handler.c"
+        "../../plugins/in_ebpf/traces/exec/handler.c"
+    )
+
     add_dependencies(flb-rt-in_ebpf_bind_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_signal_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_malloc_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_tcp_handler fluent-bit-static)
+    add_dependencies(flb-rt-in_ebpf_exec_handler fluent-bit-static)
 
 endif()
 

--- a/tests/runtime/in_ebpf_exec_handler.c
+++ b/tests/runtime/in_ebpf_exec_handler.c
@@ -1,0 +1,267 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_decoder.h>
+#include "flb_tests_runtime.h"
+
+#include "../../plugins/in_ebpf/traces/includes/common/event_context.h"
+#include "../../plugins/in_ebpf/traces/includes/common/events.h"
+#include "../../plugins/in_ebpf/traces/includes/common/encoder.h"
+#include "../../plugins/in_ebpf/traces/exec/handler.h"
+
+struct test_context {
+    struct trace_event_context event_ctx;
+    struct flb_input_instance *ins;
+    struct flb_log_event_decoder *decoder;
+};
+
+static struct test_context *init_test_context()
+{
+    struct test_context *ctx = flb_calloc(1, sizeof(struct test_context));
+
+    if (!ctx) {
+        return NULL;
+    }
+
+    ctx->ins = flb_calloc(1, sizeof(struct flb_input_instance));
+    if (!ctx->ins) {
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->event_ctx.log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!ctx->event_ctx.log_encoder) {
+        flb_free(ctx->ins);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->decoder = flb_log_event_decoder_create(NULL, 0);
+    if (!ctx->decoder) {
+        flb_log_event_encoder_destroy(ctx->event_ctx.log_encoder);
+        flb_free(ctx->ins);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->ins->context = &ctx->event_ctx;
+    ctx->event_ctx.ins = ctx->ins;
+
+    return ctx;
+}
+
+static void cleanup_test_context(struct test_context *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    if (ctx->decoder) {
+        flb_log_event_decoder_destroy(ctx->decoder);
+    }
+
+    if (ctx->event_ctx.log_encoder) {
+        flb_log_event_encoder_destroy(ctx->event_ctx.log_encoder);
+    }
+
+    if (ctx->ins) {
+        flb_free(ctx->ins);
+    }
+
+    flb_free(ctx);
+}
+
+static int key_matches(msgpack_object key, const char *str)
+{
+    if (key.type != MSGPACK_OBJECT_STR) {
+        return 0;
+    }
+
+    return (strncmp(key.via.str.ptr, str, key.via.str.size) == 0 &&
+            strlen(str) == key.via.str.size);
+}
+
+static void verify_decoded_values(struct flb_log_event *event,
+                                  const struct event *original)
+{
+    int seen_pid = FLB_FALSE;
+    int seen_stage = FLB_FALSE;
+    int seen_ppid = FLB_FALSE;
+    int seen_filename = FLB_FALSE;
+    int seen_argv = FLB_FALSE;
+    int seen_argv1 = FLB_FALSE;
+    int seen_argv2 = FLB_FALSE;
+    int seen_argv_last = FLB_FALSE;
+    int seen_argc = FLB_FALSE;
+    int seen_error_raw = FLB_FALSE;
+    msgpack_object_kv *kv;
+    int i;
+
+    TEST_CHECK(event != NULL);
+    TEST_CHECK(event->body->type == MSGPACK_OBJECT_MAP);
+
+    for (i = 0; i < event->body->via.map.size; i++) {
+        kv = &event->body->via.map.ptr[i];
+
+        if (key_matches(kv->key, "pid")) {
+            seen_pid = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+            TEST_CHECK(kv->val.via.u64 == original->common.pid);
+        }
+        else if (key_matches(kv->key, "stage")) {
+            seen_stage = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            if (original->details.execve.stage == EXECVE_STAGE_ENTER) {
+                TEST_CHECK(strncmp(kv->val.via.str.ptr, "enter", kv->val.via.str.size) == 0);
+            }
+            else if (original->details.execve.stage == EXECVE_STAGE_EXIT) {
+                TEST_CHECK(strncmp(kv->val.via.str.ptr, "exit", kv->val.via.str.size) == 0);
+            }
+            else {
+                TEST_CHECK(strncmp(kv->val.via.str.ptr, "unknown", kv->val.via.str.size) == 0);
+            }
+        }
+        else if (key_matches(kv->key, "ppid")) {
+            seen_ppid = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+            TEST_CHECK(kv->val.via.u64 == original->details.execve.ppid);
+        }
+        else if (key_matches(kv->key, "filename")) {
+            seen_filename = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            TEST_CHECK(kv->val.via.str.size ==
+                       strlen(original->details.execve.filename));
+            TEST_CHECK(strncmp(kv->val.via.str.ptr,
+                               original->details.execve.filename,
+                               kv->val.via.str.size) == 0);
+        }
+        else if (key_matches(kv->key, "argv")) {
+            seen_argv = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            TEST_CHECK(kv->val.via.str.size ==
+                       strlen(original->details.execve.argv));
+            TEST_CHECK(strncmp(kv->val.via.str.ptr,
+                               original->details.execve.argv[0],
+                               kv->val.via.str.size) == 0);
+        }
+        else if (key_matches(kv->key, "argv1")) {
+            seen_argv1 = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            TEST_CHECK(strncmp(kv->val.via.str.ptr,
+                               original->details.execve.argv[1],
+                               kv->val.via.str.size) == 0);
+        }
+        else if (key_matches(kv->key, "argv2")) {
+            seen_argv2 = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            TEST_CHECK(strncmp(kv->val.via.str.ptr,
+                               original->details.execve.argv[2],
+                               kv->val.via.str.size) == 0);
+        }
+        else if (key_matches(kv->key, "argv_last")) {
+            seen_argv_last = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            TEST_CHECK(strncmp(kv->val.via.str.ptr,
+                               original->details.execve.argv_last,
+                               kv->val.via.str.size) == 0);
+        }
+        else if (key_matches(kv->key, "argc")) {
+            seen_argc = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+            TEST_CHECK(kv->val.via.u64 == original->details.execve.argc);
+        }
+        else if (key_matches(kv->key, "error_raw")) {
+            seen_error_raw = FLB_TRUE;
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
+                       kv->val.type == MSGPACK_OBJECT_NEGATIVE_INTEGER);
+            TEST_CHECK(kv->val.via.i64 == original->details.execve.error_raw);
+        }
+    }
+
+    TEST_CHECK(seen_pid == FLB_TRUE);
+    TEST_CHECK(seen_stage == FLB_TRUE);
+    TEST_CHECK(seen_ppid == FLB_TRUE);
+    TEST_CHECK(seen_filename == FLB_TRUE);
+    TEST_CHECK(seen_argv == FLB_TRUE);
+    TEST_CHECK(seen_argv1 == FLB_TRUE);
+    TEST_CHECK(seen_argv2 == FLB_TRUE);
+    TEST_CHECK(seen_argv_last == FLB_TRUE);
+    TEST_CHECK(seen_argc == FLB_TRUE);
+    TEST_CHECK(seen_error_raw == FLB_TRUE);
+}
+
+void test_exec_event_encoding()
+{
+    struct event test_event = {
+        .type = EVENT_TYPE_EXECVE,
+        .common = {
+            .pid = 100,
+            .tid = 101,
+            .uid = 1000,
+            .gid = 1000,
+            .comm = "bash"
+        },
+        .details.execve = {
+            .stage = EXECVE_STAGE_EXIT,
+            .ppid = 1,
+            .filename = "/usr/bin/bash",
+            .argv = {"bash", "-lc", "echo hello"},
+            .argv_last = "echo hello",
+            .argc = 3,
+            .error_raw = 0
+        }
+    };
+    struct flb_log_event log_event;
+    struct test_context *ctx;
+    int ret;
+
+    ctx = init_test_context();
+    TEST_CHECK(ctx != NULL);
+
+    ret = encode_exec_event(ctx->ins, ctx->event_ctx.log_encoder, &test_event);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(ctx->event_ctx.log_encoder->output_length > 0);
+
+    ret = flb_log_event_decoder_init(ctx->decoder,
+                                     ctx->event_ctx.log_encoder->output_buffer,
+                                     ctx->event_ctx.log_encoder->output_length);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_log_event_decoder_next(ctx->decoder, &log_event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+
+    verify_decoded_values(&log_event, &test_event);
+
+    cleanup_test_context(ctx);
+}
+
+void test_trace_exec_handler_negative_paths()
+{
+    struct test_context *ctx;
+    struct event invalid_type_event;
+    struct event valid_event;
+    int ret;
+
+    ctx = init_test_context();
+    TEST_CHECK(ctx != NULL);
+
+    memset(&invalid_type_event, 0, sizeof(struct event));
+    invalid_type_event.type = EVENT_TYPE_SIGNAL;
+    ret = trace_exec_handler(&ctx->event_ctx, &invalid_type_event, sizeof(struct event));
+    TEST_CHECK(ret == -1);
+
+    memset(&valid_event, 0, sizeof(struct event));
+    valid_event.type = EVENT_TYPE_EXECVE;
+    ret = trace_exec_handler(&ctx->event_ctx, &valid_event, sizeof(struct event) - 1);
+    TEST_CHECK(ret == -1);
+
+    cleanup_test_context(ctx);
+}
+
+TEST_LIST = {
+    {"exec_event_encoding", test_exec_event_encoding},
+    {"trace_exec_handler_negative_paths", test_trace_exec_handler_negative_paths},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR implements exec/execve trace on in_ebpf plugin.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
$ sudo bin/fluent-bit -i ebpf -ptrace=trace_exec -o stdout -v
```
- [x] Debug log output from testing the change
```
Fluent Bit v5.0.3
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/15 17:53:25.021] [ info] Configuration:
[2026/04/15 17:53:25.021] [ info]  flush time     | 1.000000 seconds
[2026/04/15 17:53:25.021] [ info]  grace          | 5 seconds
[2026/04/15 17:53:25.021] [ info]  daemon         | 0
[2026/04/15 17:53:25.021] [ info] ___________
[2026/04/15 17:53:25.021] [ info]  inputs:
[2026/04/15 17:53:25.021] [ info]      ebpf
[2026/04/15 17:53:25.021] [ info] ___________
[2026/04/15 17:53:25.021] [ info]  filters:
[2026/04/15 17:53:25.021] [ info] ___________
[2026/04/15 17:53:25.021] [ info]  outputs:
[2026/04/15 17:53:25.021] [ info]      stdout.0
[2026/04/15 17:53:25.021] [ info] ___________
[2026/04/15 17:53:25.021] [ info]  collectors:
[2026/04/15 17:53:25.021] [ info] [fluent bit] version=5.0.3, commit=17fd5bce9b, pid=133991
[2026/04/15 17:53:25.021] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/04/15 17:53:25.021] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/15 17:53:25.021] [ info] [simd    ] SSE2
[2026/04/15 17:53:25.021] [ info] [cmetrics] version=2.1.2
[2026/04/15 17:53:25.021] [ info] [ctraces ] version=0.7.1
[2026/04/15 17:53:25.021] [ info] [input:ebpf:ebpf.0] initializing
[2026/04/15 17:53:25.021] [ info] [input:ebpf:ebpf.0] storage_strategy='memory' (memory only)
[2026/04/15 17:53:25.021] [debug] [ebpf:ebpf.0] created event channels: read=21 write=22
[2026/04/15 17:53:25.021] [debug] [input:ebpf:ebpf.0] initializing eBPF input plugin
[2026/04/15 17:53:25.021] [debug] [input:ebpf:ebpf.0] processing trace: trace_exec
[2026/04/15 17:53:25.021] [debug] [input:ebpf:ebpf.0] setting up trace configuration for: trace_exec
[2026/04/15 17:53:25.048] [debug] [input:ebpf:ebpf.0] attaching BPF program for trace: trace_exec
[2026/04/15 17:53:25.050] [debug] [input:ebpf:ebpf.0] registering trace handler for: trace_exec
[2026/04/15 17:53:25.050] [ info] [input:ebpf:ebpf.0] registered trace handler for: trace_exec
[2026/04/15 17:53:25.050] [ info] [input:ebpf:ebpf.0] trace configuration completed for: trace_exec
[2026/04/15 17:53:25.050] [debug] [input:ebpf:ebpf.0] setting up collector with poll interval: 1000 ms
[2026/04/15 17:53:25.050] [ info] [input:ebpf:ebpf.0] eBPF input plugin initialized successfully
[2026/04/15 17:53:25.050] [debug] [stdout:stdout.0] created event channels: read=38 write=39
[2026/04/15 17:53:25.050] [ info] [sp] stream processor started
[2026/04/15 17:53:25.050] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/15 17:53:25.050] [ info] [output:stdout:stdout.0] worker #0 started
[2026/04/15 17:53:25.343] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/15 17:53:25.344] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_exec
[2026/04/15 17:53:25.344] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_exec
[2026/04/15 17:53:26.343] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/15 17:53:26.344] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_exec
[2026/04/15 17:53:26.344] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_exec
[2026/04/15 17:53:27.343] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/15 17:53:27.343] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_exec
[2026/04/15 17:53:27.344] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_exec
[2026/04/15 17:53:28.344] [debug] [task] created task=0x7202f40781b0 id=0 OK
[2026/04/15 17:53:28.344] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/04/15 17:53:28.344] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/15 17:53:28.344] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_exec
[2026/04/15 17:53:28.344] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_exec
[0] ebpf.0: [[1776243207.343952535, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"gnome-shell", "stage"=>"enter", "ppid"=>3265, "filename"=>"/usr/lib/x86_64-linux-gnu/glib-2.0/gio-launch-desktop", "argv"=>"/usr/lib/x86_64-linux-gnu/glib-2.0/gio-launch-desktop", "argv1"=>"/usr/bin/sh", "argv2"=>"-c", "argv_last"=>"sh", "argc"=>5, "error_raw"=>0}]
[1] ebpf.0: [[1776243207.344108622, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"gio-launch-desk", "stage"=>"exit", "ppid"=>3265, "filename"=>"/usr/lib/x86_64-linux-gnu/glib-2.0/gio-launch-desktop", "argv"=>"/usr/lib/x86_64-linux-gnu/glib-2.0/gio-launch-desktop", "argv1"=>"/usr/bin/sh", "argv2"=>"-c", "argv_last"=>"sh", "argc"=>5, "error_raw"=>0}]
[2] ebpf.0: [[1776243207.344143582, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"gio-launch-desk", "stage"=>"enter", "ppid"=>3265, "filename"=>"/usr/bin/sh", "argv"=>"/usr/bin/sh", "argv1"=>"-c", "argv2"=>"if [ -n "$*" ]; then exec /usr/bin/emacsclient --alternate-editor= --reuse-frame "$@"; else exec emacsclient --alternate-editor= --create-frame; fi", "argv_last"=>"sh", "argc"=>4, "error_raw"=>0}]
[3] ebpf.0: [[1776243207.344157460, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"exit", "ppid"=>3265, "filename"=>"/usr/bin/sh", "argv"=>"/usr/bin/sh", "argv1"=>"-c", "argv2"=>"if [ -n "$*" ]; then exec /usr/bin/emacsclient --alternate-editor= --reuse-frame "$@"; else exec emacsclient --alternate-editor= --create-frame; fi", "argv_last"=>"sh", "argc"=>4, "error_raw"=>0}]
[4] ebpf.0: [[1776243207.344169073, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"enter", "ppid"=>3265, "filename"=>"/home/cosmo/bin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>0}]
[5] ebpf.0: [[1776243207.344180755, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"exit", "ppid"=>3265, "filename"=>"/home/cosmo/bin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>2}]
[6] ebpf.0: [[1776243207.344191389, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"enter", "ppid"=>3265, "filename"=>"/usr/local/sbin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>0}]
[7] ebpf.0: [[1776243207.344202332, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"exit", "ppid"=>3265, "filename"=>"/usr/local/sbin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>2}]
[8] ebpf.0: [[1776243207.344212778, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"enter", "ppid"=>3265, "filename"=>"/usr/local/bin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>0}]
[9] ebpf.0: [[1776243207.344223520, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"exit", "ppid"=>3265, "filename"=>"/usr/local/bin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>2}]
[10] ebpf.0: [[1776243207.344234093, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"enter", "ppid"=>3265, "filename"=>"/usr/sbin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>0}]
[11] ebpf.0: [[1776243207.344244775, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"exit", "ppid"=>3265, "filename"=>"/usr/sbin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>2}]
[12] ebpf.0: [[1776243207.344255819, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"sh", "stage"=>"enter", "ppid"=>3265, "filename"=>"/usr/bin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>0}]
[13] ebpf.0: [[1776243207.344266618, {}], {"event_type"=>"execve", "pid"=>133996, "tid"=>133996, "comm"=>"emacsclient", "stage"=>"exit", "ppid"=>3265, "filename"=>"/usr/bin/emacsclient", "argv"=>"emacsclient", "argv1"=>"--alternate-editor=", "argv2"=>"--create-frame", "argv_last"=>"--create-frame", "argc"=>3, "error_raw"=>0}]
[2026/04/15 17:53:28.344] [debug] [out flush] cb_destroy coro_id=0
[2026/04/15 17:53:28.345] [debug] [task] destroy task=0x7202f40781b0 (task_id=0)
[2026/04/15 17:53:29.344] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/15 17:53:29.344] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_exec
[2026/04/15 17:53:29.344] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_exec
^C[2026/04/15 17:53:29] [engine] caught signal (SIGINT)
[2026/04/15 17:53:29.579] [ warn] [engine] service will shutdown in max 5 seconds
[2026/04/15 17:53:29.579] [ info] [engine] pausing all inputs..
[2026/04/15 17:53:29.579] [ info] [input] pausing ebpf.0
[2026/04/15 17:53:29.579] [debug] [input:ebpf:ebpf.0] collector paused
[2026/04/15 17:53:30.344] [ info] [engine] service has stopped (0 pending tasks)
[2026/04/15 17:53:30.344] [ info] [input] pausing ebpf.0
[2026/04/15 17:53:30.344] [debug] [input:ebpf:ebpf.0] collector paused
[2026/04/15 17:53:30.344] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/04/15 17:53:30.344] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/04/15 17:53:30.430] [ info] [input:ebpf:ebpf.0] eBPF input plugin exited
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==134205== 
==134205== HEAP SUMMARY:
==134205==     in use at exit: 0 bytes in 0 blocks
==134205==   total heap usage: 4,327 allocs, 4,327 frees, 19,472,425 bytes allocated
==134205== 
==134205== All heap blocks were freed -- no leaks are possible
==134205== 
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exec syscall tracing to the eBPF plugin, capturing exec events with filename, argv/argc, parent PID (ppid) and raw error codes; exec trace is registered and emitted for processing.

* **Documentation**
  * Updated the Trace option help text to include "exec" as an example trace name.

* **Tests**
  * Added runtime tests validating exec event encoding/decoding and negative-path handler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->