### PR TITLE
doc: update maintainers company

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,5 +11,5 @@ Fluent Bit is developed and supported by many individuals and companies.  The fo
 | [Fujimoto Seiji](https://github.com/fujimotos)        | Windows Platform         | Individual                                        |
 | [Wesley Pettit](https://github.com/PettitWesley)      | Amazon Plugins (AWS)     | [Amazon Web Services](https://aws.amazon.com/)    |
 | [Cedric Lamoriniere](https://github.com/clamoriniere) | Datadog Output Plugin    | [Datadog](https://www.datadoghq.com/)             |
-| [Jonathan Gonzalez V.](https://github.com/sxd)        | PostgreSQL Output Plugin | [2ndQuadrant](https://www.2ndquadrant.com/en/)    |
+| [Jonathan Gonzalez V.](https://github.com/sxd)        | PostgreSQL Output Plugin | [EDB](https://www.enterprisedb.com/)              |
 | [Jorge Niedbalski](https://github.com/niedbalski)     | CI && Containers         | [Personal Blog](https://niedbalski.dev/)                 |


### PR DESCRIPTION
Update company for Jonathan Gonzalez V. from 2ndQuadrant to EDB
(2ndQuadrant was aquired many years ago by EDB)

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the PostgreSQL Output Plugin maintainer listing to show the maintainer’s current affiliation as EDB instead of 2ndQuadrant.
  * Updated the associated company link to point to EDB, keeping the project’s publicly displayed maintainer information accurate and current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->