### PR TITLE
in_node_exporter_metrics: add timex linux collector

### DIFF
--- a/plugins/in_node_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_node_exporter_metrics/CMakeLists.txt
@@ -10,6 +10,7 @@ set(src
   ne_netstat.c
   ne_sockstat.c
   ne_time.c
+  ne_timex.c
   ne_loadavg.c
   ne_filefd.c
   ne_textfile.c

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -36,6 +36,7 @@
 #include "ne_uname.h"
 #include "ne_stat.h"
 #include "ne_time.h"
+#include "ne_timex.h"
 #include "ne_loadavg.h"
 #include "ne_vmstat.h"
 #include "ne_netdev.h"
@@ -193,6 +194,7 @@ static int in_ne_init(struct flb_input_instance *in,
     mk_list_add(&uname_collector._head, &ctx->collectors);
     mk_list_add(&stat_collector._head, &ctx->collectors);
     mk_list_add(&time_collector._head, &ctx->collectors);
+    mk_list_add(&timex_collector._head, &ctx->collectors);
     mk_list_add(&loadavg_collector._head, &ctx->collectors);
     mk_list_add(&vmstat_collector._head, &ctx->collectors);
     mk_list_add(&netdev_collector._head, &ctx->collectors);
@@ -373,6 +375,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "collector.time.scrape_interval", "0",
      0, FLB_FALSE, 0,
      "scrape interval to collect time metrics from the node."
+    },
+
+    {
+     FLB_CONFIG_MAP_TIME, "collector.timex.scrape_interval", "0",
+     0, FLB_FALSE, 0,
+     "scrape interval to collect timex metrics from the node."
     },
 
     {

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -33,7 +33,7 @@
 /* Default enabled metrics */
 
 #ifdef __linux__
-#define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,netstat,sockstat,filefd,systemd,nvme,thermal_zone,hwmon,powersupplyclass"
+#define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,timex,loadavg,vmstat,netdev,netstat,sockstat,filefd,systemd,nvme,thermal_zone,hwmon,powersupplyclass"
 #elif __APPLE__
 #define NE_DEFAULT_ENABLED_METRICS "cpu,loadavg,meminfo,diskstats,filesystem,uname,netdev,powersupplyclass"
 #endif
@@ -196,6 +196,25 @@ struct flb_ne {
 
     /* time */
     struct cmt_gauge *time;
+
+    /* timex */
+    struct cmt_gauge   *timex_offset;
+    struct cmt_gauge   *timex_freq;
+    struct cmt_gauge   *timex_maxerror;
+    struct cmt_gauge   *timex_esterror;
+    struct cmt_gauge   *timex_status;
+    struct cmt_gauge   *timex_constant;
+    struct cmt_gauge   *timex_tick;
+    struct cmt_gauge   *timex_pps_freq;
+    struct cmt_gauge   *timex_jitter;
+    struct cmt_gauge   *timex_shift;
+    struct cmt_gauge   *timex_stabil;
+    struct cmt_counter *timex_jitcnt;
+    struct cmt_counter *timex_calcnt;
+    struct cmt_counter *timex_errcnt;
+    struct cmt_counter *timex_stbcnt;
+    struct cmt_gauge   *timex_tai;
+    struct cmt_gauge   *timex_sync_status;
 
     /* loadavg */
     struct cmt_gauge *lavg_1;

--- a/plugins/in_node_exporter_metrics/ne_timex.c
+++ b/plugins/in_node_exporter_metrics/ne_timex.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef __linux__
+#include "ne_timex_linux.c"
+#else
+
+#include "ne.h"
+
+struct flb_ne_collector timex_collector = {
+     .name = "timex",
+     .cb_init = NULL,
+     .cb_update = NULL,
+     .cb_exit = NULL
+};
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_timex.h
+++ b/plugins/in_node_exporter_metrics/ne_timex.h
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_NE_TIMEX_H
+#define FLB_IN_NE_TIMEX_H
+
+#include "ne.h"
+
+extern struct flb_ne_collector timex_collector;
+
+#endif

--- a/plugins/in_node_exporter_metrics/ne_timex_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_timex_linux.c
@@ -1,0 +1,268 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "ne.h"
+#include "ne_utils.h"
+
+#include <sys/timex.h>
+
+/* 1 second in */
+#define NANOSECONDS     1000000000.0
+#define MICROSECONDS    1000000.0
+
+/* See NOTES in adjtimex(2) */
+#define PPM16FRAC       (1000000.0 * 65536.0)
+
+static int timex_configure(struct flb_ne *ctx)
+{
+    struct cmt_gauge *g;
+    struct cmt_counter *c;
+
+    /* node_timex_offset_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "offset_seconds",
+                         "Time offset in between local system and reference clock.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_offset = g;
+
+    /* node_timex_frequency_adjustment_ratio */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "frequency_adjustment_ratio",
+                         "Local clock frequency adjustment.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_freq = g;
+
+    /* node_timex_maxerror_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "maxerror_seconds",
+                         "Maximum error in seconds.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_maxerror = g;
+
+    /* node_timex_estimated_error_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "estimated_error_seconds",
+                         "Estimated error in seconds.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_esterror = g;
+
+    /* node_timex_status */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "status",
+                         "Value of the status array bits.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_status = g;
+
+    /* node_timex_loop_time_constant */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "loop_time_constant",
+                         "Phase-locked loop time constant.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_constant = g;
+
+    /* node_timex_tick_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "tick_seconds",
+                         "Seconds between clock ticks.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_tick = g;
+
+    /* node_timex_pps_frequency_hertz */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "pps_frequency_hertz",
+                         "Pulse per second frequency.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_pps_freq = g;
+
+    /* node_timex_pps_jitter_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "pps_jitter_seconds",
+                         "Pulse per second jitter.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_jitter = g;
+
+    /* node_timex_pps_shift_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "pps_shift_seconds",
+                         "Pulse per second interval duration.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_shift = g;
+
+    /* node_timex_pps_stability_hertz */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "pps_stability_hertz",
+                         "Pulse per second stability, average of recent frequency changes.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_stabil = g;
+
+    /* node_timex_pps_jitter_total */
+    c = cmt_counter_create(ctx->cmt, "node", "timex", "pps_jitter_total",
+                         "Pulse per second count of jitter limit exceeded events",
+                         0, NULL);
+    if (!c) {
+        return -1;
+    }
+    ctx->timex_jitcnt = c;
+
+    /* node_timex_pps_calibration_total */
+    c = cmt_counter_create(ctx->cmt, "node", "timex", "pps_calibration_total",
+                         "Pulse per second count of calibration intervals.",
+                         0, NULL);
+    if (!c) {
+        return -1;
+    }
+    ctx->timex_calcnt = c;
+
+    /* node_timex_pps_error_total */
+    c = cmt_counter_create(ctx->cmt, "node", "timex", "pps_error_total",
+                         "Pulse per second count of calibration errors.",
+                         0, NULL);
+    if (!c) {
+        return -1;
+    }
+    ctx->timex_errcnt = c;
+
+    /* node_timex_pps_stability_exceeded_total */
+    c = cmt_counter_create(ctx->cmt, "node", "timex", "pps_stability_exceeded_total",
+                         "Pulse per second count of stability limit exceeded events.",
+                         0, NULL);
+    if (!c) {
+        return -1;
+    }
+    ctx->timex_stbcnt = c;
+
+    /* node_timex_pps_tai_offset_seconds */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "tai_offset_seconds",
+                         "International Atomic Time (TAI) offset.",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_tai = g;
+
+    /* node_timex_sync_status */
+    g = cmt_gauge_create(ctx->cmt, "node", "timex", "sync_status",
+                         "Is clock synchronized to a reliable server (1 = yes, 0 = no).",
+                         0, NULL);
+    if (!g) {
+        return -1;
+    }
+    ctx->timex_sync_status = g;
+
+    return 0;
+}
+
+static int timex_update(struct flb_ne *ctx, uint64_t ts)
+{
+    struct timex tx = {};
+    int ret = 0;
+
+    double sync_status = 0;
+    double divisor = 0;
+
+    ret = adjtimex(&tx);
+
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "error on  adjtimex: error: %d, %s", errno, strerror(errno));
+        return -1;
+    }
+
+    if (ret == TIME_ERROR) {
+        sync_status = 0;
+    }
+    else {
+        sync_status = 1;
+    }
+
+    if (tx.status & STA_NANO) {
+        divisor = NANOSECONDS;
+    }
+    else {
+        divisor = MICROSECONDS;
+    }
+
+    cmt_gauge_set(ctx->timex_sync_status, ts, sync_status, 0, NULL);
+    cmt_gauge_set(ctx->timex_offset, ts, tx.offset / divisor, 0, NULL);
+    cmt_gauge_set(ctx->timex_freq, ts, 1.0 + tx.freq / PPM16FRAC, 0, NULL);
+    cmt_gauge_set(ctx->timex_maxerror, ts, tx.maxerror / MICROSECONDS, 0, NULL);
+    cmt_gauge_set(ctx->timex_esterror, ts, tx.esterror / MICROSECONDS, 0, NULL);
+    cmt_gauge_set(ctx->timex_status, ts, tx.status, 0, NULL);
+    cmt_gauge_set(ctx->timex_constant, ts, tx.constant, 0, NULL);
+    cmt_gauge_set(ctx->timex_tick, ts, tx.tick / MICROSECONDS, 0, NULL);
+    cmt_gauge_set(ctx->timex_pps_freq, ts, tx.ppsfreq / PPM16FRAC, 0, NULL);
+    cmt_gauge_set(ctx->timex_jitter, ts, tx.jitter / divisor, 0, NULL);
+    cmt_gauge_set(ctx->timex_shift, ts, tx.shift, 0, NULL);
+    cmt_gauge_set(ctx->timex_stabil, ts, tx.stabil / PPM16FRAC, 0, NULL);
+    cmt_counter_set(ctx->timex_jitcnt, ts, tx.jitcnt, 0, NULL);
+    cmt_counter_set(ctx->timex_calcnt, ts, tx.calcnt, 0, NULL);
+    cmt_counter_set(ctx->timex_errcnt, ts, tx.errcnt, 0, NULL);
+    cmt_counter_set(ctx->timex_stbcnt, ts, tx.stbcnt, 0, NULL);
+    cmt_gauge_set(ctx->timex_tai, ts, tx.tai, 0, NULL);
+
+    return 0;
+}
+
+static int ne_timex_init(struct flb_ne *ctx)
+{
+    return timex_configure(ctx);
+}
+
+static int ne_timex_update(struct flb_input_instance *ins, struct flb_config *config, void *in_context)
+{
+    uint64_t ts;
+    struct flb_ne *ctx = (struct flb_ne *)in_context;
+
+    ts = cfl_time_now();
+
+    return timex_update(ctx, ts);
+}
+
+struct flb_ne_collector timex_collector = {
+    .name = "timex",
+    .cb_init = ne_timex_init,
+    .cb_update = ne_timex_update,
+    .cb_exit = NULL
+};


### PR DESCRIPTION
Extend node_exporter_metrics by exposing timex metrics by parsing struct timex from adjtimex and aligning the output with Prometheus node_exporter conventions.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
**New metrics**

- `node_timex_offset_seconds`: Time offset in between local system and reference clock.
- `node_timex_frequency_adjustment_ratio`: Local clock frequency adjustment.
- `node_timex_maxerror_seconds`: Maximum error in seconds.
- `node_timex_estimated_error_seconds`: Estimated error in seconds.
- `node_timex_status`: Value of the status array bits.
- `node_timex_loop_time_constant`: Phase-locked loop time constant.
- `node_timex_tick_seconds`: Seconds between clock ticks.
- `node_timex_pps_frequency_hertz`: Pulse per second frequency.
- `node_timex_pps_jitter_seconds`: Pulse per second jitter.
- `node_timex_pps_shift_seconds`: Pulse per second interval duration.
- `node_timex_pps_stability_hertz`: Pulse per second stability, average of recent frequency changes.
- `node_timex_pps_jitter_total`: Pulse per second count of jitter limit exceeded events.
- `node_timex_pps_calibration_total`: Pulse per second count of calibration intervals.
- `node_timex_pps_error_total`: Pulse per second count of calibration errors.
- `node_timex_pps_stability_exceeded_total`: Pulse per second count of stability limit exceeded events.
- `node_timex_tai_offset_seconds`: International Atomic Time (TAI) offset.
- `node_timex_sync_status`: Is clock synchronized to a reliable server (1 = yes, 0 = no).

**Configuration**
- `collector.timex.scrape_interval`: Set the scrape interval for this collector.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
  flush: 1
  log_level: debug

pipeline:
  inputs:
    - name: node_exporter_metrics
      tag:  node_metrics
      metrics: timex

  outputs:
    - name: stdout
      match: node_metrics
```

- [x] Debug log output from testing the change
```
Fluent Bit v5.0.3
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/28 18:11:05.980] [ info] Configuration:
[2026/04/28 18:11:05.980] [ info]  flush time     | 1.000000 seconds
[2026/04/28 18:11:05.980] [ info]  grace          | 5 seconds
[2026/04/28 18:11:05.980] [ info]  daemon         | 0
[2026/04/28 18:11:05.980] [ info] ___________
[2026/04/28 18:11:05.980] [ info]  inputs:
[2026/04/28 18:11:05.980] [ info]      node_exporter_metrics
[2026/04/28 18:11:05.980] [ info] ___________
[2026/04/28 18:11:05.980] [ info]  filters:
[2026/04/28 18:11:05.980] [ info] ___________
[2026/04/28 18:11:05.980] [ info]  outputs:
[2026/04/28 18:11:05.980] [ info]      stdout.0
[2026/04/28 18:11:05.980] [ info] ___________
[2026/04/28 18:11:05.980] [ info]  collectors:
[2026/04/28 18:11:05.981] [ info] [fluent bit] version=5.0.3, commit=5a21c14e64, pid=10121
[2026/04/28 18:11:05.981] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/04/28 18:11:05.981] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/28 18:11:05.981] [ info] [simd    ] SSE2
[2026/04/28 18:11:05.981] [ info] [cmetrics] version=2.1.2
[2026/04/28 18:11:05.981] [ info] [ctraces ] version=0.7.1
[2026/04/28 18:11:05.981] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2026/04/28 18:11:05.981] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2026/04/28 18:11:05.981] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.rootfs = /
[2026/04/28 18:11:05.981] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2026/04/28 18:11:05.981] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2026/04/28 18:11:05.982] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics timex
[2026/04/28 18:11:05.982] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2026/04/28 18:11:05.982] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2026/04/28 18:11:05.982] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=32 write=33
[2026/04/28 18:11:05.982] [debug] [stdout:stdout.0] created event channels: read=36 write=37
[2026/04/28 18:11:05.982] [ info] [sp] stream processor started
[2026/04/28 18:11:05.982] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/28 18:11:05.982] [ info] [output:stdout:stdout.0] worker #0 started
[2026/04/28 18:11:11.207] [debug] [task] created task=0x7c30280294e0 id=0 OK
[2026/04/28 18:11:11.207] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2026-04-28T16:11:10.207435976Z node_timex_pps_jitter_total = 0
2026-04-28T16:11:10.207435976Z node_timex_pps_calibration_total = 0
2026-04-28T16:11:10.207435976Z node_timex_pps_error_total = 0
2026-04-28T16:11:10.207435976Z node_timex_pps_stability_exceeded_total = 0
2026-04-28T16:11:10.207435976Z node_timex_offset_seconds = -0.001164514
2026-04-28T16:11:10.207435976Z node_timex_frequency_adjustment_ratio = 0.99999547375488285
2026-04-28T16:11:10.207435976Z node_timex_maxerror_seconds = 0.107944
2026-04-28T16:11:10.207435976Z node_timex_estimated_error_seconds = 0.0036259999999999999
2026-04-28T16:11:10.207435976Z node_timex_status = 8193
2026-04-28T16:11:10.207435976Z node_timex_loop_time_constant = 6
2026-04-28T16:11:10.207435976Z node_timex_tick_seconds = 0.01
2026-04-28T16:11:10.207435976Z node_timex_pps_frequency_hertz = 0
2026-04-28T16:11:10.207435976Z node_timex_pps_jitter_seconds = 0
2026-04-28T16:11:10.207435976Z node_timex_pps_shift_seconds = 0
2026-04-28T16:11:10.207435976Z node_timex_pps_stability_hertz = 0
2026-04-28T16:11:10.207435976Z node_timex_tai_offset_seconds = 37
2026-04-28T16:11:10.207435976Z node_timex_sync_status = 1
[2026/04/28 18:11:11.208] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2026/04/28 18:11:11.208] [debug] [out flush] cb_destroy coro_id=0
[2026/04/28 18:11:11.208] [debug] [task] destroy task=0x7c30280294e0 (task_id=0)
^C[2026/04/28 18:11:12] [engine] caught signal (SIGINT)
[2026/04/28 18:11:12.834] [ warn] [engine] service will shutdown in max 5 seconds
[2026/04/28 18:11:12.834] [ info] [engine] pausing all inputs..
[2026/04/28 18:11:12.834] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2026/04/28 18:11:13.207] [ info] [engine] service has stopped (0 pending tasks)
[2026/04/28 18:11:13.207] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2026/04/28 18:11:13.207] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/04/28 18:11:13.207] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/04/28 18:11:13.208] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==87060== 
==87060== HEAP SUMMARY:
==87060==     in use at exit: 0 bytes in 0 blocks
==87060==   total heap usage: 3,614 allocs, 3,614 frees, 1,519,499 bytes allocated
==87060== 
==87060== All heap blocks were freed -- no leaks are possible
==87060== 
==87060== For lists of detected and suppressed errors, rerun with: -s
==87060== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
Documented in fluent-bit-docs PR [#2579](https://github.com/fluent/fluent-bit-docs/pull/2579).

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **timex** metrics collector for NTP/clock synchronization, including offset, frequency adjustment, error estimates, status, PPS metrics, counters, TAI offset, and a computed sync status.
  * Added optional configuration: **collector.timex.scrape_interval** (default: `"0"`, disabled by default).

* **Compatibility**
  * **Enabled by default on Linux** by expanding the default enabled metrics set.
  * **Linux-only** availability for the timex collector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->