### PR TITLE
in_podman_metrics: fix multiple cgroup v2 issues

### DIFF
--- a/plugins/in_podman_metrics/podman_metrics.c
+++ b/plugins/in_podman_metrics/podman_metrics.c
@@ -113,10 +113,15 @@ static int collect_container_data(struct flb_in_metrics *ctx)
                 metadata_token_start = strstr(metadata, JSON_SUBFIELD_IMAGE_NAME);
                 if (metadata_token_start) {
                     metadata_token_stop = strstr(metadata_token_start + JSON_SUBFIELD_SIZE_IMAGE_NAME+1, "\\\"");
-                    metadata_token_size = metadata_token_stop - metadata_token_start - JSON_SUBFIELD_SIZE_IMAGE_NAME;
-
-                    strncpy(image_name, metadata_token_start+JSON_SUBFIELD_SIZE_IMAGE_NAME, metadata_token_size);
-                    image_name[metadata_token_size] = '\0';
+                    if (metadata_token_stop) {
+                        metadata_token_size = metadata_token_stop - metadata_token_start - JSON_SUBFIELD_SIZE_IMAGE_NAME;
+                        strncpy(image_name, metadata_token_start+JSON_SUBFIELD_SIZE_IMAGE_NAME, metadata_token_size);
+                        image_name[metadata_token_size] = '\0';
+                    }
+                    else {
+                        strncpy(image_name, "unknown", IMAGE_NAME_SIZE - 1);
+                        image_name[7] = '\0';
+                    }
 
                     flb_plg_trace(ctx->ins, "Found image name %s", image_name);
                     add_container_to_list(ctx, id, name, image_name);
@@ -225,10 +230,19 @@ static int create_counter(struct flb_in_metrics *ctx, struct cmt_counter **count
         return -1;
     }
 
-    if (strcmp(metric_name, COUNTER_CPU) == 0 || strcmp(metric_name, COUNTER_CPU_USER) == 0) {
-        fvalue = fvalue / 1000000000;
-        flb_plg_trace(ctx->ins, "Converting %s from nanoseconds to seconds (%lu -> %lu)", metric_name, value, fvalue);
-
+    if (strcmp(metric_name, COUNTER_CPU) == 0 ||
+        strcmp(metric_name, COUNTER_CPU_USER) == 0) {
+        if (ctx->cgroup_version == CGROUP_V2) {
+            /* cgroup v2 cpu.stat reports in microseconds */
+            fvalue = fvalue / 1000000;
+        }
+        else {
+            /* cgroup v1 cpuacct reports in nanoseconds */
+            fvalue = fvalue / 1000000000;
+        }
+        flb_plg_trace(ctx->ins,
+                      "Converting %s to seconds (%lu -> %lu)",
+                      metric_name, value, fvalue);
     }
 
     labels = (char *[]){id, name, image_name, interface};

--- a/plugins/in_podman_metrics/podman_metrics.c
+++ b/plugins/in_podman_metrics/podman_metrics.c
@@ -120,7 +120,7 @@ static int collect_container_data(struct flb_in_metrics *ctx)
                     }
                     else {
                         strncpy(image_name, "unknown", IMAGE_NAME_SIZE - 1);
-                        image_name[7] = '\0';
+                        image_name[sizeof("unknown") - 1] = '\0';
                     }
 
                     flb_plg_trace(ctx->ins, "Found image name %s", image_name);

--- a/plugins/in_podman_metrics/podman_metrics.c
+++ b/plugins/in_podman_metrics/podman_metrics.c
@@ -113,10 +113,15 @@ static int collect_container_data(struct flb_in_metrics *ctx)
                 metadata_token_start = strstr(metadata, JSON_SUBFIELD_IMAGE_NAME);
                 if (metadata_token_start) {
                     metadata_token_stop = strstr(metadata_token_start + JSON_SUBFIELD_SIZE_IMAGE_NAME+1, "\\\"");
-                    metadata_token_size = metadata_token_stop - metadata_token_start - JSON_SUBFIELD_SIZE_IMAGE_NAME;
-
-                    strncpy(image_name, metadata_token_start+JSON_SUBFIELD_SIZE_IMAGE_NAME, metadata_token_size);
-                    image_name[metadata_token_size] = '\0';
+                    if (metadata_token_stop) {
+                        metadata_token_size = metadata_token_stop - metadata_token_start - JSON_SUBFIELD_SIZE_IMAGE_NAME;
+                        strncpy(image_name, metadata_token_start+JSON_SUBFIELD_SIZE_IMAGE_NAME, metadata_token_size);
+                        image_name[metadata_token_size] = '\0';
+                    }
+                    else {
+                        strncpy(image_name, "unknown", IMAGE_NAME_SIZE - 1);
+                        image_name[7] = '\0';
+                    }
 
                     flb_plg_trace(ctx->ins, "Found image name %s", image_name);
                     add_container_to_list(ctx, id, name, image_name);
@@ -229,10 +234,19 @@ static int create_counter(struct flb_in_metrics *ctx, struct cmt_counter **count
         return -1;
     }
 
-    if (strcmp(metric_name, COUNTER_CPU) == 0 || strcmp(metric_name, COUNTER_CPU_USER) == 0) {
-        fvalue = fvalue / 1000000000;
-        flb_plg_trace(ctx->ins, "Converting %s from nanoseconds to seconds (%lu -> %lu)", metric_name, value, fvalue);
-
+    if (strcmp(metric_name, COUNTER_CPU) == 0 ||
+        strcmp(metric_name, COUNTER_CPU_USER) == 0) {
+        if (ctx->cgroup_version == CGROUP_V2) {
+            /* cgroup v2 cpu.stat reports in microseconds */
+            fvalue = fvalue / 1000000;
+        }
+        else {
+            /* cgroup v1 cpuacct reports in nanoseconds */
+            fvalue = fvalue / 1000000000;
+        }
+        flb_plg_trace(ctx->ins,
+                      "Converting %s to seconds (%lu -> %lu)",
+                      metric_name, value, fvalue);
     }
 
     labels = (char *[]){id, name, image_name, interface};

--- a/plugins/in_podman_metrics/podman_metrics_config.h
+++ b/plugins/in_podman_metrics/podman_metrics_config.h
@@ -83,6 +83,7 @@
 
 /* Key names in .stat files */
 #define STAT_KEY_RSS                    "rss"
+#define V2_STAT_KEY_RSS                 "anon"
 #define STAT_KEY_CPU                    "usage_usec"
 #define STAT_KEY_CPU_USER               "user_usec"
 
@@ -106,7 +107,7 @@
 #define V2_SYSFS_FILE_MEMORY_LIMIT     "memory.max"
 #define V2_SYSFS_FILE_CPU_STAT         "cpu.stat"
 #define V2_SYSFS_FILE_PIDS             "cgroup.procs"
-#define V2_SYSFS_FILE_PIDS_ALT         "containers/cgroup.procs"
+#define V2_SYSFS_FILE_PIDS_ALT         "container/cgroup.procs"
 
 /* Values used to construct counters/gauges names and descriptions */
 #define COUNTER_PREFIX                  "container"

--- a/plugins/in_podman_metrics/podman_metrics_config.h
+++ b/plugins/in_podman_metrics/podman_metrics_config.h
@@ -83,6 +83,7 @@
 
 /* Key names in .stat files */
 #define STAT_KEY_RSS                    "rss"
+#define V2_STAT_KEY_RSS                 "anon"
 #define STAT_KEY_CPU                    "usage_usec"
 #define STAT_KEY_CPU_USER               "user_usec"
 
@@ -112,7 +113,7 @@
 #define V2_SYSFS_FILE_MEMORY_LIMIT     "memory.max"
 #define V2_SYSFS_FILE_CPU_STAT         "cpu.stat"
 #define V2_SYSFS_FILE_PIDS             "cgroup.procs"
-#define V2_SYSFS_FILE_PIDS_ALT         "containers/cgroup.procs"
+#define V2_SYSFS_FILE_PIDS_ALT         "container/cgroup.procs"
 #define V2_SYSFS_FILE_IO_STAT          "io.stat"
 
 /* Values used to construct counters/gauges names and descriptions */

--- a/plugins/in_podman_metrics/podman_metrics_data.c
+++ b/plugins/in_podman_metrics/podman_metrics_data.c
@@ -369,20 +369,25 @@ static uint64_t read_from_sysfs_or_max(struct flb_in_metrics *ctx,
         return value;
     }
 
-    if (fgets(buf, sizeof(buf), fp) != NULL) {
-        /* cgroup v2 uses "max" to indicate unlimited */
-        if (strncmp(buf, "max", 3) == 0) {
-            flb_plg_debug(ctx->ins, "%s: max (unlimited)", path);
-            fclose(fp);
-            return 0;
-        }
-        c = sscanf(buf, "%lu", &value);
-        if (c != 1) {
-            flb_plg_warn(ctx->ins,
-                         "Failed to read a number from %s", path);
-            fclose(fp);
-            return UINT64_MAX;
-        }
+    if (fgets(buf, sizeof(buf), fp) == NULL) {
+        flb_plg_warn(ctx->ins, "Failed to read a value from %s", path);
+        fclose(fp);
+        return UINT64_MAX;
+    }
+
+    /* cgroup v2 uses "max" to indicate unlimited */
+    if (strncmp(buf, "max", 3) == 0) {
+        flb_plg_debug(ctx->ins, "%s: max (unlimited)", path);
+        fclose(fp);
+        return 0;
+    }
+
+    c = sscanf(buf, "%lu", &value);
+    if (c != 1) {
+        flb_plg_warn(ctx->ins,
+                     "Failed to read a number from %s", path);
+        fclose(fp);
+        return UINT64_MAX;
     }
 
     fclose(fp);

--- a/plugins/in_podman_metrics/podman_metrics_data.c
+++ b/plugins/in_podman_metrics/podman_metrics_data.c
@@ -343,6 +343,54 @@ int fill_counters_with_sysfs_data_v1(struct flb_in_metrics *ctx)
 }
 
 /*
+ * Read uint64_t value from sysfs file, with special handling for the "max"
+ * keyword used by cgroup v2 to indicate an unlimited resource.
+ * Returns 0 when file contains "max".
+ */
+static uint64_t read_from_sysfs_or_max(struct flb_in_metrics *ctx,
+                                        flb_sds_t dir,
+                                        flb_sds_t name)
+{
+    char path[SYSFS_FILE_PATH_SIZE];
+    char buf[32];
+    uint64_t value = UINT64_MAX;
+    FILE *fp;
+    int c;
+
+    if (dir == NULL) {
+        return value;
+    }
+
+    snprintf(path, sizeof(path), "%s/%s", dir, name);
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        flb_plg_warn(ctx->ins, "Failed to read %s", path);
+        return value;
+    }
+
+    if (fgets(buf, sizeof(buf), fp) != NULL) {
+        /* cgroup v2 uses "max" to indicate unlimited */
+        if (strncmp(buf, "max", 3) == 0) {
+            flb_plg_debug(ctx->ins, "%s: max (unlimited)", path);
+            fclose(fp);
+            return 0;
+        }
+        c = sscanf(buf, "%lu", &value);
+        if (c != 1) {
+            flb_plg_warn(ctx->ins,
+                         "Failed to read a number from %s", path);
+            fclose(fp);
+            return UINT64_MAX;
+        }
+    }
+
+    fclose(fp);
+    flb_plg_debug(ctx->ins, "%s: %lu", path, value);
+    return value;
+}
+
+/*
  * Iterate over previously created container list. For each entry, generate its
  * path in sysfs system directory. From this path, grab data about container metrics
  * and put it this entry.
@@ -363,8 +411,11 @@ int fill_counters_with_sysfs_data_v2(struct flb_in_metrics *ctx)
 
         cnt->memory_usage = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MEMORY, NULL);
         cnt->memory_max_usage = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MAX_MEMORY, NULL);
-        cnt->rss = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MEMORY_STAT, STAT_KEY_RSS);
-        cnt->memory_limit = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MEMORY_LIMIT, NULL);
+        cnt->rss = get_data_from_sysfs(ctx, path,
+                                       V2_SYSFS_FILE_MEMORY_STAT,
+                                       V2_STAT_KEY_RSS);
+        cnt->memory_limit = read_from_sysfs_or_max(ctx, path,
+                                                    V2_SYSFS_FILE_MEMORY_LIMIT);
         cnt->cpu_user = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_CPU_STAT, STAT_KEY_CPU_USER);
         cnt->cpu = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_CPU_STAT, STAT_KEY_CPU);
         pid = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_PIDS, NULL);

--- a/plugins/in_podman_metrics/podman_metrics_data.c
+++ b/plugins/in_podman_metrics/podman_metrics_data.c
@@ -410,6 +410,54 @@ int fill_counters_with_sysfs_data_v1(struct flb_in_metrics *ctx)
 }
 
 /*
+ * Read uint64_t value from sysfs file, with special handling for the "max"
+ * keyword used by cgroup v2 to indicate an unlimited resource.
+ * Returns 0 when file contains "max".
+ */
+static uint64_t read_from_sysfs_or_max(struct flb_in_metrics *ctx,
+                                        flb_sds_t dir,
+                                        flb_sds_t name)
+{
+    char path[SYSFS_FILE_PATH_SIZE];
+    char buf[32];
+    uint64_t value = UINT64_MAX;
+    FILE *fp;
+    int c;
+
+    if (dir == NULL) {
+        return value;
+    }
+
+    snprintf(path, sizeof(path), "%s/%s", dir, name);
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        flb_plg_warn(ctx->ins, "Failed to read %s", path);
+        return value;
+    }
+
+    if (fgets(buf, sizeof(buf), fp) != NULL) {
+        /* cgroup v2 uses "max" to indicate unlimited */
+        if (strncmp(buf, "max", 3) == 0) {
+            flb_plg_debug(ctx->ins, "%s: max (unlimited)", path);
+            fclose(fp);
+            return 0;
+        }
+        c = sscanf(buf, "%lu", &value);
+        if (c != 1) {
+            flb_plg_warn(ctx->ins,
+                         "Failed to read a number from %s", path);
+            fclose(fp);
+            return UINT64_MAX;
+        }
+    }
+
+    fclose(fp);
+    flb_plg_debug(ctx->ins, "%s: %lu", path, value);
+    return value;
+}
+
+/*
  * Iterate over previously created container list. For each entry, generate its
  * path in sysfs system directory. From this path, grab data about container metrics
  * and put it this entry.
@@ -430,8 +478,11 @@ int fill_counters_with_sysfs_data_v2(struct flb_in_metrics *ctx)
 
         cnt->memory_usage = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MEMORY, NULL);
         cnt->memory_max_usage = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MAX_MEMORY, NULL);
-        cnt->rss = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MEMORY_STAT, STAT_KEY_RSS);
-        cnt->memory_limit = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_MEMORY_LIMIT, NULL);
+        cnt->rss = get_data_from_sysfs(ctx, path,
+                                       V2_SYSFS_FILE_MEMORY_STAT,
+                                       V2_STAT_KEY_RSS);
+        cnt->memory_limit = read_from_sysfs_or_max(ctx, path,
+                                                    V2_SYSFS_FILE_MEMORY_LIMIT);
         cnt->cpu_user = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_CPU_STAT, STAT_KEY_CPU_USER);
         cnt->cpu = get_data_from_sysfs(ctx, path, V2_SYSFS_FILE_CPU_STAT, STAT_KEY_CPU);
         read_io_stat(ctx, path, V2_SYSFS_FILE_IO_STAT, cnt);


### PR DESCRIPTION
## Summary

Fix four cgroup v2 bugs in the `in_podman_metrics` input plugin that caused
most container metrics to be absent or incorrect on systems using cgroup v2
(unified hierarchy).

All four bugs are confirmed on an ARM64 embedded device running
Fluent Bit 4.2.0/5.0.2 with Podman and cgroup v2 unified hierarchy.

## Bugs fixed

### 1. CPU counter division (incorrect unit conversion)

`create_counter()` divides raw CPU values by 1,000,000,000 (nanoseconds)
unconditionally. This is correct for cgroup v1 (`cpuacct.usage` reports
nanoseconds) but wrong for cgroup v2 (`cpu.stat` reports `usage_usec`
and `user_usec` in **microseconds**).

On v2, integer division truncates all values below 1e9 usec (~16.7 min of
CPU time) to zero. In practice, `container_cpu_usage_seconds_total` and
`container_cpu_user_seconds_total` always read 0.

**Fix:** Check `ctx->cgroup_version` and use the correct divisor:
1e9 for v1 (nanoseconds), 1e6 for v2 (microseconds).

### 2. RSS memory key name (wrong key for v2)

`STAT_KEY_RSS` is defined as `"rss"`, which is correct for cgroup v1
`memory.stat`. However, cgroup v2 `memory.stat` does not have a `rss`
field; the equivalent is `anon` (anonymous memory pages).

**Result:** `container_memory_rss` gauge is never reported for any
container on v2, with a `[warn] rss not found in .../memory.stat` log
message emitted per container per scrape.

**Fix:** Add `V2_STAT_KEY_RSS "anon"` and use it in
`fill_counters_with_sysfs_data_v2()`.

### 3. memory.max "max" keyword (parse failure)

cgroup v2 `memory.max` contains the literal string `"max"` when the
memory limit is unlimited (no limit set). `read_from_file()` uses
`fscanf(fp, "%lu", &value)` which fails to parse `"max"`, returning
UINT64_MAX and logging a spurious warning per affected container per
scrape.

**Result:** `container_spec_memory_limit_bytes` is missing for
containers without an explicit memory limit. Warning spam in logs.

**Fix:** Add `read_from_sysfs_or_max()` helper that parses the "max"
keyword and returns 0 (unlimited), matching the convention used by
cAdvisor and other container metric exporters.

### 4. PID fallback path typo (singular vs. plural)

`V2_SYSFS_FILE_PIDS_ALT` is defined as `"containers/cgroup.procs"`
(plural), but the actual cgroup v2 subdirectory is
`"container/cgroup.procs"` (singular).

On v2, `cgroup.procs` at the scope level is empty for all containers.
Processes live only in the `container/cgroup.procs` subdirectory. The
plugin correctly tries the alt path, but the typo means it always fails.

**Result:** PID lookup fails for all containers, which prevents
`get_net_data_from_proc()` from being called. All four
`container_network_*` metrics are completely absent.

**Fix:** Change `"containers/cgroup.procs"` to `"container/cgroup.procs"`.

## Before/After (gw-cloud-connector container, ARM64 device)

| Metric | Before | After |
|--------|--------|-------|
| `container_cpu_usage_seconds_total` | 0 | 449 |
| `container_cpu_user_seconds_total` | 0 | 145 |
| `container_memory_rss` | MISSING | 12,472,320 |
| `container_spec_memory_limit_bytes` | MISSING | 1,048,576,000 |
| `container_network_receive_bytes_total` | MISSING | 3,229,233 |
| `container_network_transmit_bytes_total` | MISSING | 4,721,901 |

After the fix, all 10 metric types are successfully emitted for all 9
containers, with zero warnings in the log.

## Testing

Tested on:
- ARM64 (Cortex-A7) embedded device, 4-core, 4 GB RAM
- Yocto Scarthgap (kernel 6.6), cgroup v2 unified hierarchy
- Podman 5.x with 9 containers (3 infra, 3 service, 3 app)
- Fluent Bit 4.2.0 and verified patch applies cleanly to 5.0.2/5.0.3

Verified:
- All 10 metric types present in Prometheus output
- CPU values match raw `cpu.stat` divided by 1e6
- RSS values match `anon` field in `memory.stat`
- Memory limit correctly reports 0 for unlimited and real values for limited
- Network metrics present for all containers with non-loopback interfaces
- Zero warnings in journal log after fix (previously ~45 warnings per scrape)
- No regression: cgroup v1 code path is unchanged

Fixes #7769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CPU metrics now convert correctly for both cgroup v1 and v2, improving reported CPU-time accuracy.
  * cgroup v2 memory limits now correctly recognize unlimited values and handle read or parsing failures safely.
  * RSS metrics for cgroup v2 now use the appropriate memory statistic.
  * Container image names default to “unknown” when metadata is incomplete.
  * Improved discovery of container process information on cgroup v2 systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->