### PR TITLE
scripts: enable working runtime tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -113,8 +113,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: mabrarov/fluent-bit-ci
-          ref: feat/enable_tests
+          repository: calyptia/fluent-bit-ci
           path: ci
       - name: Setup Apache Arrow libraries for parquet (-DFLB_ARROW=On Only)
         if: matrix.flb_option == '-DFLB_ARROW=On'
@@ -170,8 +169,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/checkout@v6
         with:
-          repository: mabrarov/fluent-bit-ci
-          ref: feat/enable_tests
+          repository: calyptia/fluent-bit-ci
           path: ci
 
       - name: ${{ matrix.flb_option }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -113,7 +113,8 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: calyptia/fluent-bit-ci
+          repository: mabrarov/fluent-bit-ci
+          ref: feat/enable_tests
           path: ci
       - name: Setup Apache Arrow libraries for parquet (-DFLB_ARROW=On Only)
         if: matrix.flb_option == '-DFLB_ARROW=On'
@@ -169,7 +170,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/checkout@v6
         with:
-          repository: calyptia/fluent-bit-ci
+          repository: mabrarov/fluent-bit-ci
+          ref: feat/enable_tests
           path: ci
 
       - name: ${{ matrix.flb_option }}

--- a/run_code_analysis.sh
+++ b/run_code_analysis.sh
@@ -14,7 +14,7 @@ FLB_CMAKE_OPTIONS=${FLB_CMAKE_OPTIONS:--DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off 
 ADDITIONAL_DEPS=${ADDITIONAL_DEPS:-libssl-dev libsasl2-dev pkg-config libsystemd-dev zlib1g-dev libpq-dev postgresql-server-dev-all flex bison libyaml-dev netcat}
 
 # From the Unit Tests script
-SKIP_TESTS=${SKIP_TESTS:-flb-it-network flb-it-fstore flb-rt-out_td flb-rt-out_forward flb-rt-in_disk flb-rt-in_proc}
+SKIP_TESTS=${SKIP_TESTS:-flb-it-network flb-it-fstore flb-rt-out_td flb-rt-in_disk flb-rt-in_proc}
 
 SKIP=""
 for skip in $SKIP_TESTS

--- a/run_code_analysis.sh
+++ b/run_code_analysis.sh
@@ -14,7 +14,7 @@ FLB_CMAKE_OPTIONS=${FLB_CMAKE_OPTIONS:--DFLB_BACKTRACE=Off -DFLB_SHARED_LIB=Off 
 ADDITIONAL_DEPS=${ADDITIONAL_DEPS:-libssl-dev libsasl2-dev pkg-config libsystemd-dev zlib1g-dev libpq-dev postgresql-server-dev-all flex bison libyaml-dev netcat}
 
 # From the Unit Tests script
-SKIP_TESTS=${SKIP_TESTS:-flb-rt-out_elasticsearch flb-it-network flb-it-fstore flb-rt-out_elasticsearch flb-rt-out_td flb-rt-out_forward flb-rt-in_disk flb-rt-in_proc}
+SKIP_TESTS=${SKIP_TESTS:-flb-it-network flb-it-fstore flb-rt-out_td flb-rt-out_forward flb-rt-in_disk flb-rt-in_proc}
 
 SKIP=""
 for skip in $SKIP_TESTS


### PR DESCRIPTION
**Summary**

~Fixed support of runtime tests in HTTP client. Refer to https://github.com/fluent/fluent-bit/pull/11686#discussion_r3094999665.~ This change was already done / merged into master branch in #11710 and was removed from this PR.

Enabled runtime tests for Elasticsearch and Forward output plugins in dev script.

The enabled tests were successfully executed on CI within e37d1f3cc3d1211447eeedc7a5846116caaf61ee temporary commit using https://github.com/fluent/fluent-bit-ci/pull/153 - refer to https://github.com/fluent/fluent-bit/actions/runs/25181471509?pr=11724.

----

**Testing**

- [N/A] Example configuration file for the change.
- [N/A] Debug log output from testing the change.
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found - refer to [flb_run_code_analysis.log](https://drive.google.com/file/d/1slW0ISvguiToPLbLDJ4Q2gAA2SdQJ4kr/view?usp=sharing) for the output of command
    ```bash
    TEST_PRESET=valgrind ./run_code_analysis.sh
    ```
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature

**Backporting**

- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a null-pointer safety check to HTTP client connection setup.

* **Tests**
  * Reduced the default test skip list so Elasticsearch and forward outputs are included in default test runs.

* **Chores**
  * CI unit-test workflow updated to source reusable test scripts from a different repository reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->