### PR TITLE
out_loki: fix 'occured' -> 'occurred' in comment

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -2001,7 +2001,7 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
                             ctx->tcp_host, ctx->tcp_port, c->resp.status);
             }
             /*
-             * Server-side error occured, do not reuse this connection for retry.
+             * Server-side error occurred, do not reuse this connection for retry.
              * This could be an issue of Loki gateway.
              * Rather initiate new connection.
              */


### PR DESCRIPTION
Comment in `plugins/out_loki/loki.c` line 2004 reads `Server-side error occured`. Fixed to `occurred`. Comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected spelling in internal documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->