### PR TITLE
cmake: kafka: enable zstd compression using bundled library

### DIFF
--- a/cmake/kafka.cmake
+++ b/cmake/kafka.cmake
@@ -77,6 +77,51 @@ if (FLB_SYSTEM_MACOS)
   FLB_OPTION(WITH_CURL Off)
 endif()
 
+# Enable zstd compression for librdkafka using the library already resolved
+# by the top-level zstd detection block (LIBZSTD_LIBRARIES is set for all
+# cases: bundled, system CMake config, and system pkg-config fallback).
+if(LIBZSTD_LIBRARIES)
+  if(TARGET libzstd_static)
+    # Bundled: force-inject vars — librdkafka's find_package(ZSTD) cannot
+    # discover an in-tree target on its own.
+    set(ZSTD_FOUND TRUE CACHE BOOL "" FORCE)
+    set(ZSTD_INCLUDE_DIR "${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_ZSTD}/lib" CACHE PATH "" FORCE)
+    set(ZSTD_LIBRARY_DEBUG libzstd_static CACHE STRING "" FORCE)
+    set(ZSTD_LIBRARY_RELEASE libzstd_static CACHE STRING "" FORCE)
+    set(ZSTD_LIBRARY libzstd_static CACHE STRING "" FORCE)
+    FLB_OPTION(WITH_ZSTD ON)
+    set(FLB_KAFKA_ZSTD_SOURCE "bundled")
+  else()
+    # System: clear stale bundled-sentinel entries and WITH_ZSTD so librdkafka
+    # re-runs find_package(ZSTD) fresh and its option() sets its own default.
+    # Preserve explicit caller overrides such as -DZSTD_LIBRARY=/custom/path.
+    if(ZSTD_LIBRARY STREQUAL "libzstd_static")
+      unset(ZSTD_FOUND CACHE)
+      unset(ZSTD_INCLUDE_DIR CACHE)
+      unset(ZSTD_LIBRARY CACHE)
+      unset(ZSTD_LIBRARY_DEBUG CACHE)
+      unset(ZSTD_LIBRARY_RELEASE CACHE)
+      unset(WITH_ZSTD CACHE)
+    endif()
+    set(FLB_KAFKA_ZSTD_SOURCE "system")
+  endif()
+else()
+  # FLB didn't find zstd. Clear stale bundled entries so librdkafka's
+  # find_package/option() runs fresh and defaults to OFF.
+  # Preserve user-supplied custom paths (ZSTD_LIBRARY != sentinel).
+  if(ZSTD_LIBRARY STREQUAL "libzstd_static")
+    unset(ZSTD_FOUND CACHE)
+    unset(ZSTD_INCLUDE_DIR CACHE)
+    unset(ZSTD_LIBRARY CACHE)
+    unset(ZSTD_LIBRARY_DEBUG CACHE)
+    unset(ZSTD_LIBRARY_RELEASE CACHE)
+    unset(WITH_ZSTD CACHE)
+  elseif(NOT ZSTD_LIBRARY)
+    unset(WITH_ZSTD CACHE)
+  endif()
+  set(FLB_KAFKA_ZSTD_SOURCE "disabled")
+endif()
+
 include_directories(${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_RDKAFKA}/src/)
 
 add_subdirectory(${FLB_PATH_LIB_RDKAFKA} EXCLUDE_FROM_ALL)
@@ -88,4 +133,5 @@ message(STATUS "=== Kafka Feature Summary ===")
 message(STATUS "SASL Auth:     ${FLB_SASL_ENABLED}")
 message(STATUS "OAuth Bearer:  ${FLB_SASL_OAUTHBEARER_ENABLED}")
 message(STATUS "MSK IAM:       ${FLB_KAFKA_MSK_IAM_ENABLED}")
+message(STATUS "ZSTD:          ${FLB_KAFKA_ZSTD_SOURCE}")
 message(STATUS "===============================")


### PR DESCRIPTION
Configure librdkafka to use Fluent Bit's bundled zstd library for compression support. This avoids external dependency on system zstd while enabling zstd compression in Kafka producers/consumers.

The CACHE FORCE flags ensure the bundled library takes precedence over any system find_package(ZSTD) results.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[OUTPUT]
  Name        kafka
  Match       *
  Brokers     192.168.1.3:9092
  Topics      test
  rdkafka.compression.codec  zstd
```
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kafka feature summary now shows ZSTD status, indicating whether zstd compression is used, bundled, system-provided, or disabled.

* **Chores**
  * Build configuration refined to automatically enable zstd compression when available (bundled or system), clear stale settings when absent, and preserve explicit caller overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->