### PR TITLE
utils: fix integer divide-by-zero on Windows x64 in bytes_to_human_readable_size

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -812,8 +812,8 @@ int flb_utils_time_split(const char *time, int *sec, long *nsec)
 void flb_utils_bytes_to_human_readable_size(size_t bytes,
                                             char *out_buf, size_t size)
 {
-    unsigned long i;
-    unsigned long u = 1024;
+    uint64_t i;
+    uint64_t u = 1024;
     static const char *__units[] = {
         "b", "K", "M", "G",
         "T", "P", "E", "Z", "Y", NULL


### PR DESCRIPTION
## Summary

Fix an `INTEGER_DIVIDE_BY_ZERO` crash (exception `0xC0000094`) on Windows x64 in
`flb_utils_bytes_to_human_readable_size()`.

## Root Cause

On Windows x64, the LLP64 data model makes `unsigned long` 32 bits (unlike LP64 on
Linux where it is 64 bits). The divisor variable `u` starts at 1024 and is multiplied
by 1024 each loop iteration. After three iterations (reaching the GB unit boundary),
the next multiplication (`1024^4 = 1,099,511,627,776`) overflows a 32-bit unsigned
long to **zero**, causing a divide-by-zero crash on the next `bytes / u` operation.

This is triggered every 5 seconds by the storage metrics timer
(`cb_storage_metrics_collect` in `flb_storage.c`) whenever any input buffer exceeds ~1 GB,
which is common with high-volume inputs using filesystem-backed storage.

## Fix

Change `unsigned long` to `uint64_t` for both the loop counter `i` and divisor `u`,
guaranteeing 64-bit arithmetic on all platforms.

## Testing

- Verified on Windows x64 with a `winevtlog` input producing >1 GB of buffered data.
  Before the fix, Fluent Bit crashes every ~5 seconds at the metrics timer. After the
  fix, the formatter correctly displays sizes in GB/TB without overflow.

Signed-off-by: Amit Shinde <ashinde@databahn.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal variable types within a utility function to improve type consistency and reliability. No functional or user-visible behavior changes; existing formatting and output remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->