### PR TITLE
filter_kubernetes: make memory growth rigidly on filter k8s

### DIFF
--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -48,6 +48,7 @@
 #define FLB_KUBE_META_INIT_CONTAINER_STATUSES_KEY_LEN \
     (sizeof(FLB_KUBE_META_INIT_CONTAINER_STATUSES_KEY) - 1)
 #define FLB_KUBE_TOKEN_BUF_SIZE 8192       /* 8KB */
+#define FLB_KUBE_TOKEN_MAX_SIZE (1024 * 1024) /* 1MB */
 
 static int file_to_buffer(const char *path,
                           char **out_buf, size_t *out_size)
@@ -100,6 +101,9 @@ static int get_token_with_command(const char *command,
     char buf[FLB_KUBE_TOKEN_BUF_SIZE];
     char *temp;
     char *res;
+    size_t capacity = FLB_KUBE_TOKEN_BUF_SIZE;
+    size_t required_size;
+    size_t new_capacity;
     size_t size = 0;
     size_t len = 0;
 
@@ -108,7 +112,7 @@ static int get_token_with_command(const char *command,
         return -1;
     }
 
-    res = flb_calloc(1, FLB_KUBE_TOKEN_BUF_SIZE);
+    res = flb_calloc(1, capacity);
     if (!res) {
         flb_errno();
         pclose(fp);
@@ -117,21 +121,39 @@ static int get_token_with_command(const char *command,
 
     while (fgets(buf, sizeof(buf), fp) != NULL) {
         len = strlen(buf);
-        if (len >= FLB_KUBE_TOKEN_BUF_SIZE - 1) {
-            temp = flb_realloc(res, (FLB_KUBE_TOKEN_BUF_SIZE + size) * 2);
+
+        if (len > FLB_KUBE_TOKEN_MAX_SIZE - size - 1) {
+            flb_free(res);
+            pclose(fp);
+            return -1;
+        }
+        required_size = size + len + 1;
+
+        if (required_size > capacity) {
+            new_capacity = capacity;
+
+            while (new_capacity < required_size) {
+                new_capacity *= 2;
+            }
+
+            temp = flb_realloc(res, new_capacity);
             if (temp == NULL) {
                 flb_errno();
                 flb_free(res);
                 pclose(fp);
                 return -1;
             }
+
             res = temp;
+            capacity = new_capacity;
         }
-        strcpy(res + size, buf);
+
+        memcpy(res + size, buf, len);
         size += len;
+        res[size] = '\0';
     }
 
-    if (strlen(res) < 1) {
+    if (size < 1) {
         flb_free(res);
         pclose(fp);
         return -1;
@@ -140,7 +162,7 @@ static int get_token_with_command(const char *command,
     pclose(fp);
 
     *out_buf = res;
-    *out_size = strlen(res);
+    *out_size = size;
 
     return 0;
 }
@@ -169,8 +191,13 @@ static int get_http_auth_header(struct flb_kube *ctx)
         if (ret == -1) {
             flb_plg_warn(ctx->ins, "cannot open %s", FLB_KUBE_TOKEN);
         }
-        flb_plg_info(ctx->ins, " token updated");
     }
+
+    if (ret == -1 || tk == NULL) {
+        return -1;
+    }
+
+    flb_plg_info(ctx->ins, " token updated");
     ctx->kube_token_create = time(NULL);
 
     /* Token */

--- a/tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py
+++ b/tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py
@@ -1,0 +1,148 @@
+import contextlib
+import http.server
+import os
+import shlex
+import sys
+import threading
+
+import pytest
+
+from utils.data_utils import read_file
+from utils.test_service import FluentBitTestService
+
+
+class _KubeApiHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = b"{}"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, fmt, *args):
+        return
+
+
+@contextlib.contextmanager
+def _run_kube_api_server():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _KubeApiHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(config_file)
+        self.service = FluentBitTestService(self.config_file)
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_log_contains(self, text, timeout=20):
+        return self.service.wait_for_condition(
+            lambda: read_file(self.flb.log_file) if text in read_file(self.flb.log_file) else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"log text {text!r}",
+        )
+
+    def read_log(self):
+        return read_file(self.flb.log_file)
+
+
+def _write_script(tmp_path, name, line_count):
+    script_file = tmp_path / name
+    script_file.write_text(
+        f"import sys\nsys.stdout.write('tkn\\n' * {line_count})\n",
+        encoding="utf-8",
+    )
+    return script_file
+
+
+def _write_config(tmp_path, name, script_file, kube_api_port):
+    docker_id = "a" * 64
+    token_command = "{} {}".format(
+        shlex.quote(sys.executable),
+        shlex.quote(str(script_file)),
+    )
+
+    config_file = tmp_path / name
+    config_file.write_text(
+        "\n".join(
+            [
+                "[SERVICE]",
+                "    Flush 1",
+                "    Grace 1",
+                "    Log_Level info",
+                "    HTTP_Server On",
+                "    HTTP_Port ${FLUENT_BIT_HTTP_MONITORING_PORT}",
+                "",
+                "[INPUT]",
+                "    Name dummy",
+                "    Dummy {\"message\":\"kube token command test\"}",
+                f"    Tag kube.var.log.containers.testpod_default_testcontainer-{docker_id}.log",
+                "    Samples 1",
+                "",
+                "[FILTER]",
+                "    Name kubernetes",
+                "    Match kube.*",
+                f"    Kube_URL http://127.0.0.1:{kube_api_port}",
+                "    Kube_Tag_Prefix kube.var.log.containers.",
+                "    tls.verify Off",
+                f"    Kube_Token_Command {token_command}",
+                "",
+                "[OUTPUT]",
+                "    Name stdout",
+                "    Match *",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_file
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Kube_Token_Command test is Linux-only")
+def test_filter_kubernetes_token_command_accepts_multiline_output_over_8kb(tmp_path):
+    script_file = _write_script(tmp_path, "token_large.py", 3000)
+    with _run_kube_api_server() as kube_api_port:
+        config_file = _write_config(tmp_path, "token_large.conf", script_file, kube_api_port)
+
+        service = Service(str(config_file))
+        service.start()
+        log_text = service.wait_for_log_contains("kube token command test", timeout=25)
+        service.stop()
+
+    assert "failed to run command" not in log_text
+    assert "kube token command test" in log_text
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Kube_Token_Command test is Linux-only")
+def test_filter_kubernetes_token_command_rejects_multiline_output_over_limit(tmp_path):
+    script_file = _write_script(tmp_path, "token_huge.py", 270000)
+    with _run_kube_api_server() as kube_api_port:
+        config_file = _write_config(tmp_path, "token_huge.conf", script_file, kube_api_port)
+
+        service = Service(str(config_file))
+        log_text = None
+        service.start()
+        try:
+            log_text = service.wait_for_log_contains("failed to run command", timeout=25)
+            log_text = service.wait_for_log_contains("kube token command test", timeout=25)
+        finally:
+            service.stop()
+
+    assert "failed to run command" in log_text
+    assert "kube token command test" in log_text


### PR DESCRIPTION
<!-- Provide summary of changes -->
When using get_token_with_command, this mechanism really referring of the limit of memory.
So, we need to refer it carefully before executing flb_realloc to allocate heap memory.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes filter token handling with a strict 1MB limit to prevent oversized command outputs and related memory issues.
  * Enhanced buffering and error handling to fail early on excessive token output and to reliably report token load failures.

* **Tests**
  * Added Linux-only integration tests that verify acceptance of large-but-valid token output and rejection of oversized multiline command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->