### PR TITLE
aws: update support for additional regions

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -35,8 +35,34 @@
 
 #define AWS_SERVICE_ENDPOINT_FORMAT            "%s.%s%s"
 #define AWS_SERVICE_ENDPOINT_SUFFIX_COM        ".amazonaws.com"
-#define AWS_SERVICE_ENDPOINT_SUFFIX_COM_CN     ".amazonaws.com.cn"
+#define AWS_SERVICE_ENDPOINT_SUFFIX_SC2S       ".sc2s.sgov.gov"
+#define AWS_SERVICE_ENDPOINT_SUFFIX_CSP        ".csp.hci.ic.gov"
+#define AWS_SERVICE_ENDPOINT_SUFFIX_C2S        ".c2s.ic.gov"
+#define AWS_SERVICE_ENDPOINT_SUFFIX_ADC_E      ".cloud.adc-e.uk"
 #define AWS_SERVICE_ENDPOINT_SUFFIX_EU         ".amazonaws.eu"
+#define AWS_SERVICE_ENDPOINT_SUFFIX_COM_CN     ".amazonaws.com.cn"
+
+/* Maps a region name prefix to its endpoint domain suffix. */
+struct flb_aws_endpoint_suffix {
+    const char *prefix;
+    const char *suffix;
+};
+
+/*
+ * Region prefix to domain suffix mapping for non-standard AWS region families.
+ * Matched via strncmp against the region string, so entries must be ordered
+ * most-specific first to prevent a shorter prefix (e.g. "us-iso-") from
+ * matching before a longer one (e.g. "us-isob-", "us-isof-").
+ */
+static const struct flb_aws_endpoint_suffix endpoint_suffixes[] = {
+    { "us-isob-", AWS_SERVICE_ENDPOINT_SUFFIX_SC2S },
+    { "us-isof-", AWS_SERVICE_ENDPOINT_SUFFIX_CSP },
+    { "us-iso-",  AWS_SERVICE_ENDPOINT_SUFFIX_C2S },
+    { "eu-isoe-", AWS_SERVICE_ENDPOINT_SUFFIX_ADC_E },
+    { "eusc-", AWS_SERVICE_ENDPOINT_SUFFIX_EU },
+    { "cn-", AWS_SERVICE_ENDPOINT_SUFFIX_COM_CN },
+    { NULL, NULL }
+};
 
 #define TAG_PART_DESCRIPTOR "$TAG[%d]"
 #define TAG_DESCRIPTOR "$TAG"
@@ -73,7 +99,8 @@ struct flb_http_client *request_do(struct flb_aws_client *aws_client,
                                    size_t dynamic_headers_len);
 
 /*
- * https://service.region.amazonaws.[com(.cn)|eu]
+ * Constructs an AWS service endpoint of the form: service.region.<domain-suffix>
+ * The domain suffix is resolved via endpoint_suffixes[], defaulting to .amazonaws.com.
  */
 char *flb_aws_endpoint(char* service, char* region)
 {
@@ -81,15 +108,19 @@ char *flb_aws_endpoint(char* service, char* region)
     const char *domain_suffix = AWS_SERVICE_ENDPOINT_SUFFIX_COM;
     size_t len;
     int bytes;
+    int i;
 
-
-    /* China regions end with amazonaws.com.cn */
-    if (strcmp("cn-north-1", region) == 0 ||
-        strcmp("cn-northwest-1", region) == 0) {
-        domain_suffix = AWS_SERVICE_ENDPOINT_SUFFIX_COM_CN;
+    if (!service || !region) {
+        return NULL;
     }
-    else if (strncmp(region, "eusc-", 5) == 0) {
-        domain_suffix = AWS_SERVICE_ENDPOINT_SUFFIX_EU;
+
+    /* Walk the prefix table; first match wins */
+    for (i = 0; endpoint_suffixes[i].prefix != NULL; i++) {
+        if (strncmp(region, endpoint_suffixes[i].prefix,
+                    strlen(endpoint_suffixes[i].prefix)) == 0) {
+            domain_suffix = endpoint_suffixes[i].suffix;
+            break;
+        }
     }
 
     len = strlen(service);

--- a/tests/internal/aws_util.c
+++ b/tests/internal/aws_util.c
@@ -150,26 +150,59 @@ static void test_flb_aws_endpoint()
 
     initialization_crutch();
 
+    /* NULL inputs should return NULL */
+    endpoint = flb_aws_endpoint(NULL, "us-east-1");
+    TEST_CHECK(endpoint == NULL);
+
+    endpoint = flb_aws_endpoint("s3", NULL);
+    TEST_CHECK(endpoint == NULL);
+
+    /* Standard commercial region */
     endpoint = flb_aws_endpoint("cloudwatch", "ap-south-1");
-
-    TEST_CHECK(strcmp("cloudwatch.ap-south-1.amazonaws.com",
-                      endpoint) == 0);
+    TEST_CHECK(strcmp("cloudwatch.ap-south-1.amazonaws.com", endpoint) == 0);
     flb_free(endpoint);
 
-    /* China regions have a different TLD */
+    /* China regions (.amazonaws.com.cn) */
     endpoint = flb_aws_endpoint("cloudwatch", "cn-north-1");
-
-    TEST_CHECK(strcmp("cloudwatch.cn-north-1.amazonaws.com.cn",
-                      endpoint) == 0);
+    TEST_CHECK(strcmp("cloudwatch.cn-north-1.amazonaws.com.cn", endpoint) == 0);
     flb_free(endpoint);
 
-    /* EU Sovereign Cloud regions have a different domain */
+    endpoint = flb_aws_endpoint("cloudwatch", "cn-northwest-1");
+    TEST_CHECK(strcmp("cloudwatch.cn-northwest-1.amazonaws.com.cn", endpoint) == 0);
+    flb_free(endpoint);
+
+    /* EU Sovereign Cloud (.amazonaws.eu) */
     endpoint = flb_aws_endpoint("cloudwatch", "eusc-de-east-1");
-
-    TEST_CHECK(strcmp("cloudwatch.eusc-de-east-1.amazonaws.eu",
-                      endpoint) == 0);
+    TEST_CHECK(strcmp("cloudwatch.eusc-de-east-1.amazonaws.eu", endpoint) == 0);
     flb_free(endpoint);
 
+    /* C2S isolated regions (.c2s.ic.gov) */
+    endpoint = flb_aws_endpoint("s3", "us-iso-east-1");
+    TEST_CHECK(strcmp("s3.us-iso-east-1.c2s.ic.gov", endpoint) == 0);
+    flb_free(endpoint);
+
+    endpoint = flb_aws_endpoint("s3", "us-iso-west-1");
+    TEST_CHECK(strcmp("s3.us-iso-west-1.c2s.ic.gov", endpoint) == 0);
+    flb_free(endpoint);
+
+    /* SC2S isolated regions (.sc2s.sgov.gov) */
+    endpoint = flb_aws_endpoint("s3", "us-isob-east-1");
+    TEST_CHECK(strcmp("s3.us-isob-east-1.sc2s.sgov.gov", endpoint) == 0);
+    flb_free(endpoint);
+
+    endpoint = flb_aws_endpoint("s3", "us-isob-west-1");
+    TEST_CHECK(strcmp("s3.us-isob-west-1.sc2s.sgov.gov", endpoint) == 0);
+    flb_free(endpoint);
+
+    /* CSP isolated regions (.csp.hci.ic.gov) */
+    endpoint = flb_aws_endpoint("s3", "us-isof-south-1");
+    TEST_CHECK(strcmp("s3.us-isof-south-1.csp.hci.ic.gov", endpoint) == 0);
+    flb_free(endpoint);
+
+    /* ADC-E isolated regions (.cloud.adc-e.uk) */
+    endpoint = flb_aws_endpoint("s3", "eu-isoe-west-1");
+    TEST_CHECK(strcmp("s3.eu-isoe-west-1.cloud.adc-e.uk", endpoint) == 0);
+    flb_free(endpoint);
 }
 
 static void test_flb_get_s3_key_multi_tag_exists()


### PR DESCRIPTION
**Summary**

AWS region mapping handles existing regions, China, GovCloud, and recently was updated to support EU sovereign cloud, but lacks dedicated cloud. This set of changes aims to update the existing regions supported to cover a wider selection by adding missing mappings. Customers can currently override the `ENDPOINT` parameter to work around this limitation, but it would be nicer to just handle it based on the supplied `REGION` parameter.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/2552

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when AWS service or region inputs are missing, preventing invalid endpoint generation

* **New Features**
  * Broadened endpoint resolution to support China regions, EU Sovereign Cloud, and multiple isolated/sovereign regional endpoints

* **Tests**
  * Expanded tests covering many region formats and domain suffix mappings, with added null-input assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->