### PR TITLE
in_ebpf: Implement dns trace

### DIFF
--- a/plugins/in_ebpf/in_ebpf.c
+++ b/plugins/in_ebpf/in_ebpf.c
@@ -262,7 +262,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "Trace", NULL,
      FLB_CONFIG_MAP_MULT, FLB_FALSE, 0,
-     "Set the eBPF trace to enable (for example, bind, exec, malloc, signal, vfs, tcp). Can be set multiple times"
+     "Set the eBPF trace to enable (for example, bind, dns, exec, malloc, signal, vfs, tcp). Can be set multiple times"
     },
     /* EOF */
     {0}

--- a/plugins/in_ebpf/traces/dns/bpf.c
+++ b/plugins/in_ebpf/traces/dns/bpf.c
@@ -18,6 +18,9 @@
 #ifndef AF_INET
 #define AF_INET 2
 #endif
+#ifndef AF_INET6
+#define AF_INET6 10
+#endif
 
 #ifndef DNS_PORT
 #define DNS_PORT 53
@@ -51,12 +54,12 @@ struct dns_recv_args {
 
 struct dns_connect_args {
     int fd;
-    const struct sockaddr *addr;
-    __u32 addrlen;
+    __u16 family;
+    __u16 port;
 };
 
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, 16384);
     __type(key, struct dns_query_key);
     __type(value, struct dns_query_state);
@@ -157,16 +160,38 @@ static __always_inline int parse_dns_response(const void *payload, __u64 len,
 static __always_inline int is_dns_destination(const struct sockaddr *addr, __u32 addrlen)
 {
     struct sockaddr_in dst;
+    struct sockaddr_in6 dst6;
 
-    if (!addr || addrlen < sizeof(struct sockaddr_in)) {
+    if (!addr) {
         return 0;
     }
 
-    if (bpf_probe_read_user(&dst, sizeof(dst), addr) != 0) {
+    if (addrlen >= sizeof(struct sockaddr_in)) {
+        if (bpf_probe_read_user(&dst, sizeof(dst), addr) == 0) {
+            if (dst.sin_family == AF_INET && bpf_ntohs(dst.sin_port) == DNS_PORT) {
+                return 1;
+            }
+        }
+    }
+
+    if (addrlen < sizeof(struct sockaddr_in6)) {
         return 0;
     }
 
-    if (dst.sin_family != AF_INET || bpf_ntohs(dst.sin_port) != DNS_PORT) {
+    if (bpf_probe_read_user(&dst6, sizeof(dst6), addr) != 0) {
+        return 0;
+    }
+
+    if (dst6.sin6_family != AF_INET6 || bpf_ntohs(dst6.sin6_port) != DNS_PORT) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static __always_inline int is_dns_family_port(__u16 family, __u16 port)
+{
+    if ((family != AF_INET && family != AF_INET6) || port != DNS_PORT) {
         return 0;
     }
 
@@ -179,14 +204,38 @@ int trace_dns_connect_enter(struct syscall_trace_enter *ctx)
     __u32 tid;
     __u64 pid_tgid;
     struct dns_connect_args args;
+    __u16 family;
+    __u16 port;
+    struct sockaddr sa;
+    struct sockaddr_in sa4;
+    struct sockaddr_in6 sa6;
 
     args.fd = (int) ctx->args[0];
-    args.addr = (const struct sockaddr *) ctx->args[1];
-    args.addrlen = (__u32) ctx->args[2];
+    family = 0;
+    port = 0;
 
-    if (!args.addr) {
+    if (!ctx->args[1]) {
         return 0;
     }
+
+    if (bpf_probe_read_user(&sa, sizeof(sa), (const void *) ctx->args[1]) != 0) {
+        return 0;
+    }
+
+    family = sa.sa_family;
+    if (family == AF_INET && (__u32) ctx->args[2] >= sizeof(struct sockaddr_in)) {
+        if (bpf_probe_read_user(&sa4, sizeof(sa4), (const void *) ctx->args[1]) == 0) {
+            port = bpf_ntohs(sa4.sin_port);
+        }
+    }
+    else if (family == AF_INET6 && (__u32) ctx->args[2] >= sizeof(struct sockaddr_in6)) {
+        if (bpf_probe_read_user(&sa6, sizeof(sa6), (const void *) ctx->args[1]) == 0) {
+            port = bpf_ntohs(sa6.sin6_port);
+        }
+    }
+
+    args.family = family;
+    args.port = port;
 
     pid_tgid = bpf_get_current_pid_tgid();
     tid = (__u32) pid_tgid;
@@ -217,16 +266,38 @@ int trace_dns_connect_exit(struct syscall_trace_exit *ctx)
     }
 
     ret = ctx->ret;
-    if (ret == 0 && is_dns_destination(args->addr, args->addrlen)) {
+    key.pid = pid;
+    key.fd = args->fd;
+
+    if (ret == 0 && is_dns_family_port(args->family, args->port)) {
         mntns_id = gadget_get_mntns_id();
         if (!gadget_should_discard_mntns_id(mntns_id)) {
-            key.pid = pid;
-            key.fd = args->fd;
             bpf_map_update_elem(&dns_sockets, &key, &mntns_id, BPF_ANY);
         }
     }
+    else {
+        bpf_map_delete_elem(&dns_sockets, &key);
+    }
 
     bpf_map_delete_elem(&dns_connect_pending, &tid);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_close")
+int trace_dns_close_enter(struct syscall_trace_enter *ctx)
+{
+    __u64 pid_tgid;
+    __u32 pid;
+    struct dns_socket_key key;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32) (pid_tgid >> 32);
+
+    key.pid = pid;
+    key.fd = (__s32) ((int) ctx->args[0]);
+
+    bpf_map_delete_elem(&dns_sockets, &key);
 
     return 0;
 }

--- a/plugins/in_ebpf/traces/dns/bpf.c
+++ b/plugins/in_ebpf/traces/dns/bpf.c
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+#include <vmlinux.h>
+
+#define _LINUX_TYPES_H
+#define _LINUX_POSIX_TYPES_H
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns_filter.h>
+#include <gadget/types.h>
+
+#include "common/events.h"
+
+#ifndef AF_INET
+#define AF_INET 2
+#endif
+
+#ifndef DNS_PORT
+#define DNS_PORT 53
+#endif
+
+#define DNS_HEADER_SIZE 12
+
+struct dns_query_key {
+    __u32 pid;
+    __s32 fd;
+    __u16 txid;
+};
+
+struct dns_socket_key {
+    __u32 pid;
+    __s32 fd;
+};
+
+struct dns_query_state {
+    __u64 start_ns;
+    __u64 mntns_id;
+    __u16 txid;
+    __u16 query_raw_len;
+    __u8 query_raw[DNS_QUERY_RAW_MAX];
+};
+
+struct dns_recv_args {
+    int fd;
+    const void *buf;
+};
+
+struct dns_connect_args {
+    int fd;
+    const struct sockaddr *addr;
+    __u32 addrlen;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, struct dns_query_key);
+    __type(value, struct dns_query_state);
+} dns_queries SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, __u32);
+    __type(value, struct dns_recv_args);
+} dns_recv SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, __u32);
+    __type(value, struct dns_connect_args);
+} dns_connect_pending SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, struct dns_socket_key);
+    __type(value, __u64);
+} dns_sockets SEC(".maps");
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+
+static __always_inline void fill_common(struct event *event, __u64 mntns_id)
+{
+    __u64 pid_tgid;
+    __u64 uid_gid;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    uid_gid = bpf_get_current_uid_gid();
+
+    event->common.timestamp_raw = bpf_ktime_get_boot_ns();
+    event->common.pid = (__u32) (pid_tgid >> 32);
+    event->common.tid = (__u32) pid_tgid;
+    event->common.uid = (__u32) uid_gid;
+    event->common.gid = (__u32) (uid_gid >> 32);
+    event->common.mntns_id = mntns_id;
+    bpf_get_current_comm(event->common.comm, sizeof(event->common.comm));
+}
+
+static __always_inline int parse_dns_query_header(const void *payload, __u64 len,
+                                                  __u16 *txid)
+{
+    __u8 header[DNS_HEADER_SIZE];
+    __u16 flags;
+    __u16 qdcount;
+
+    if (len < DNS_HEADER_SIZE) {
+        return -1;
+    }
+
+    if (bpf_probe_read_user(header, sizeof(header), payload) != 0) {
+        return -1;
+    }
+
+    *txid = ((__u16) header[0] << 8) | header[1];
+    flags = ((__u16) header[2] << 8) | header[3];
+    qdcount = ((__u16) header[4] << 8) | header[5];
+
+    if ((flags & 0x8000) != 0 || qdcount == 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static __always_inline int parse_dns_response(const void *payload, __u64 len,
+                                              __u16 *txid, __u8 *rcode)
+{
+    __u8 header[DNS_HEADER_SIZE];
+    __u16 flags;
+
+    if (len < DNS_HEADER_SIZE) {
+        return -1;
+    }
+
+    if (bpf_probe_read_user(header, sizeof(header), payload) != 0) {
+        return -1;
+    }
+
+    *txid = ((__u16) header[0] << 8) | header[1];
+    flags = ((__u16) header[2] << 8) | header[3];
+
+    if ((flags & 0x8000) == 0) {
+        return -1;
+    }
+
+    *rcode = (__u8) (flags & 0x000f);
+
+    return 0;
+}
+
+static __always_inline int is_dns_destination(const struct sockaddr *addr, __u32 addrlen)
+{
+    struct sockaddr_in dst;
+
+    if (!addr || addrlen < sizeof(struct sockaddr_in)) {
+        return 0;
+    }
+
+    if (bpf_probe_read_user(&dst, sizeof(dst), addr) != 0) {
+        return 0;
+    }
+
+    if (dst.sin_family != AF_INET || bpf_ntohs(dst.sin_port) != DNS_PORT) {
+        return 0;
+    }
+
+    return 1;
+}
+
+SEC("tracepoint/syscalls/sys_enter_connect")
+int trace_dns_connect_enter(struct syscall_trace_enter *ctx)
+{
+    __u32 tid;
+    __u64 pid_tgid;
+    struct dns_connect_args args;
+
+    args.fd = (int) ctx->args[0];
+    args.addr = (const struct sockaddr *) ctx->args[1];
+    args.addrlen = (__u32) ctx->args[2];
+
+    if (!args.addr) {
+        return 0;
+    }
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+
+    bpf_map_update_elem(&dns_connect_pending, &tid, &args, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_connect")
+int trace_dns_connect_exit(struct syscall_trace_exit *ctx)
+{
+    __u32 tid;
+    __u32 pid;
+    __u64 pid_tgid;
+    __u64 mntns_id;
+    __s64 ret;
+    struct dns_connect_args *args;
+    struct dns_socket_key key;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+    pid = (__u32) (pid_tgid >> 32);
+
+    args = bpf_map_lookup_elem(&dns_connect_pending, &tid);
+    if (!args) {
+        return 0;
+    }
+
+    ret = ctx->ret;
+    if (ret == 0 && is_dns_destination(args->addr, args->addrlen)) {
+        mntns_id = gadget_get_mntns_id();
+        if (!gadget_should_discard_mntns_id(mntns_id)) {
+            key.pid = pid;
+            key.fd = args->fd;
+            bpf_map_update_elem(&dns_sockets, &key, &mntns_id, BPF_ANY);
+        }
+    }
+
+    bpf_map_delete_elem(&dns_connect_pending, &tid);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_sendto")
+int trace_dns_sendto_enter(struct syscall_trace_enter *ctx)
+{
+    __u64 pid_tgid;
+    __u32 pid;
+    __u16 txid;
+    __u16 raw_len;
+    __u64 mntns_id;
+    __u64 len;
+    int fd;
+    __u32 addrlen;
+    const struct sockaddr *addr;
+    const void *payload;
+    struct dns_query_key key;
+    struct dns_socket_key socket_key;
+    __u64 *socket_mntns_id;
+    struct dns_query_state state = {0};
+    struct event *event;
+
+    mntns_id = gadget_get_mntns_id();
+    if (gadget_should_discard_mntns_id(mntns_id)) {
+        return 0;
+    }
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    pid = (__u32) (pid_tgid >> 32);
+
+    fd = (int) ctx->args[0];
+    payload = (const void *) ctx->args[1];
+    len = (__u64) ctx->args[2];
+    addr = (const struct sockaddr *) ctx->args[4];
+    addrlen = (__u32) ctx->args[5];
+
+    if (!payload || len < DNS_HEADER_SIZE) {
+        return 0;
+    }
+
+    socket_key.pid = pid;
+    socket_key.fd = fd;
+    socket_mntns_id = bpf_map_lookup_elem(&dns_sockets, &socket_key);
+
+    if (!is_dns_destination(addr, addrlen) && !socket_mntns_id) {
+        return 0;
+    }
+
+    if (parse_dns_query_header(payload, len, &txid) != 0) {
+        return 0;
+    }
+
+    key.pid = pid;
+    key.fd = fd;
+    key.txid = txid;
+
+    state.start_ns = bpf_ktime_get_ns();
+    if (socket_mntns_id) {
+        state.mntns_id = *socket_mntns_id;
+    }
+    else {
+        state.mntns_id = mntns_id;
+    }
+    state.txid = txid;
+
+    raw_len = (__u16) (len > DNS_QUERY_RAW_MAX ? DNS_QUERY_RAW_MAX : len);
+    state.query_raw_len = raw_len;
+
+    if (raw_len > 0) {
+        if (bpf_probe_read_user(state.query_raw, raw_len, payload) != 0) {
+            return 0;
+        }
+    }
+
+    bpf_map_update_elem(&dns_queries, &key, &state, BPF_ANY);
+
+    event = gadget_reserve_buf(&events, sizeof(*event));
+    if (!event) {
+        return 0;
+    }
+
+    fill_common(event, state.mntns_id);
+    event->type = EVENT_TYPE_DNS;
+    event->details.dns.txid = txid;
+    event->details.dns.query_type = 0;
+    event->details.dns.rcode = 0;
+    event->details.dns.response = 0;
+    event->details.dns.latency_ns = 0;
+    event->details.dns.error_raw = 0;
+    event->details.dns.query_raw_len = state.query_raw_len;
+    __builtin_memcpy(event->details.dns.query_raw,
+                     state.query_raw,
+                     sizeof(event->details.dns.query_raw));
+
+    gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_recvfrom")
+int trace_dns_recvfrom_enter(struct syscall_trace_enter *ctx)
+{
+    __u32 tid;
+    __u64 pid_tgid;
+    struct dns_recv_args args;
+
+    args.fd = (int) ctx->args[0];
+    args.buf = (const void *) ctx->args[1];
+
+    if (!args.buf) {
+        return 0;
+    }
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+
+    bpf_map_update_elem(&dns_recv, &tid, &args, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_recvfrom")
+int trace_dns_recvfrom_exit(struct syscall_trace_exit *ctx)
+{
+    __u32 tid;
+    __u32 pid;
+    __u64 now_ns;
+    __u64 pid_tgid;
+    __s64 ret;
+    __u16 txid;
+    __u8 rcode;
+    struct dns_recv_args *args;
+    struct dns_query_key key;
+    struct dns_query_state *state;
+    struct event *event;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    tid = (__u32) pid_tgid;
+    pid = (__u32) (pid_tgid >> 32);
+
+    args = bpf_map_lookup_elem(&dns_recv, &tid);
+    if (!args) {
+        return 0;
+    }
+
+    ret = ctx->ret;
+    if (ret <= 0) {
+        bpf_map_delete_elem(&dns_recv, &tid);
+        return 0;
+    }
+
+    if (parse_dns_response(args->buf, (__u64) ret, &txid, &rcode) != 0) {
+        bpf_map_delete_elem(&dns_recv, &tid);
+        return 0;
+    }
+
+    key.pid = pid;
+    key.fd = args->fd;
+    key.txid = txid;
+
+    state = bpf_map_lookup_elem(&dns_queries, &key);
+    if (!state) {
+        bpf_map_delete_elem(&dns_recv, &tid);
+        return 0;
+    }
+
+    event = gadget_reserve_buf(&events, sizeof(*event));
+    if (!event) {
+        bpf_map_delete_elem(&dns_queries, &key);
+        bpf_map_delete_elem(&dns_recv, &tid);
+        return 0;
+    }
+
+    now_ns = bpf_ktime_get_ns();
+
+    fill_common(event, state->mntns_id);
+    event->type = EVENT_TYPE_DNS;
+    event->details.dns.txid = txid;
+    event->details.dns.query_type = 0;
+    event->details.dns.rcode = rcode;
+    event->details.dns.response = 1;
+    event->details.dns.latency_ns = now_ns - state->start_ns;
+    event->details.dns.error_raw = 0;
+    event->details.dns.query_raw_len = state->query_raw_len;
+    __builtin_memcpy(event->details.dns.query_raw,
+                     state->query_raw,
+                     sizeof(event->details.dns.query_raw));
+
+    gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+    bpf_map_delete_elem(&dns_queries, &key);
+    bpf_map_delete_elem(&dns_recv, &tid);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/plugins/in_ebpf/traces/dns/handler.c
+++ b/plugins/in_ebpf/traces/dns/handler.c
@@ -204,17 +204,17 @@ int trace_dns_handler(void *ctx, void *data, size_t data_sz)
         return 0;
     }
     if (ret != 0) {
+        flb_log_event_encoder_reset(encoder);
         return -1;
     }
 
     ret = flb_input_log_append(event_ctx->ins, NULL, 0,
                                encoder->output_buffer,
                                encoder->output_length);
+    flb_log_event_encoder_reset(encoder);
     if (ret == -1) {
         return -1;
     }
-
-    flb_log_event_encoder_reset(encoder);
 
     return 0;
 }

--- a/plugins/in_ebpf/traces/dns/handler.c
+++ b/plugins/in_ebpf/traces/dns/handler.c
@@ -1,0 +1,220 @@
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "common/events.h"
+#include "common/event_context.h"
+#include "common/encoder.h"
+
+#include "handler.h"
+
+#define DNS_HEADER_SIZE 12
+
+static int decode_dns_query_name(const uint8_t *raw, size_t raw_len, char *out, size_t out_len,
+                                 uint16_t *query_type)
+{
+    size_t cursor;
+    size_t out_i;
+    size_t label_end;
+    uint8_t label_len;
+
+    if (!raw || raw_len < DNS_HEADER_SIZE || !out || out_len == 0) {
+        return -1;
+    }
+
+    cursor = DNS_HEADER_SIZE;
+    out_i = 0;
+
+    while (cursor < raw_len) {
+        label_len = raw[cursor++];
+
+        if (label_len == 0) {
+            break;
+        }
+
+        if ((label_len & 0xc0) != 0 || cursor + label_len > raw_len) {
+            return -1;
+        }
+
+        if (out_i > 0) {
+            if (out_i + 1 >= out_len) {
+                return -1;
+            }
+            out[out_i++] = '.';
+        }
+
+        label_end = cursor + label_len;
+        while (cursor < label_end) {
+            if (out_i + 1 >= out_len) {
+                return -1;
+            }
+            out[out_i++] = (char) raw[cursor++];
+        }
+    }
+
+    if (out_i == 0) {
+        if (out_len < 2) {
+            return -1;
+        }
+        out[out_i++] = '.';
+    }
+
+    out[out_i] = '\0';
+
+    if (cursor + 4 > raw_len) {
+        return -1;
+    }
+
+    if (query_type) {
+        *query_type = (uint16_t) ((raw[cursor] << 8) | raw[cursor + 1]);
+    }
+
+    return 0;
+}
+
+int encode_dns_event(struct flb_input_instance *ins,
+                     struct flb_log_event_encoder *log_encoder,
+                     const struct event *ev)
+{
+    char query_name[DNS_NAME_MAX];
+    uint16_t query_type;
+    int ret;
+    (void) ins;
+
+    query_name[0] = '\0';
+    query_type = ev->details.dns.query_type;
+
+    if (ev->details.dns.query_raw_len > 0 &&
+        ev->details.dns.query_raw_len <= DNS_QUERY_RAW_MAX) {
+        if (decode_dns_query_name(ev->details.dns.query_raw,
+                                  ev->details.dns.query_raw_len,
+                                  query_name,
+                                  sizeof(query_name),
+                                  &query_type) != 0) {
+            if (ev->details.dns.response == 0) {
+                return -2;
+            }
+
+            memcpy(query_name, "<unknown>", 9);
+            query_name[9] = '\0';
+        }
+    }
+    else {
+        if (ev->details.dns.response == 0) {
+            return -2;
+        }
+
+        memcpy(query_name, "<unknown>", 9);
+        query_name[9] = '\0';
+    }
+
+    if (ev->details.dns.response == 0 && query_type == 0) {
+        return -2;
+    }
+
+    ret = flb_log_event_encoder_begin_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    ret = encode_common_fields(log_encoder, ev);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "query");
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, query_name);
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "query_type");
+    }
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_uint16(log_encoder, query_type);
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "txid");
+    }
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_uint16(log_encoder, ev->details.dns.txid);
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "response");
+    }
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_uint8(log_encoder, ev->details.dns.response);
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "rcode");
+    }
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_uint8(log_encoder, ev->details.dns.rcode);
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "latency_ns");
+    }
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_uint64(log_encoder, ev->details.dns.latency_ns);
+    }
+
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "error_raw");
+    }
+    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+        ret = flb_log_event_encoder_append_body_int32(log_encoder, ev->details.dns.error_raw);
+    }
+
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_commit_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int trace_dns_handler(void *ctx, void *data, size_t data_sz)
+{
+    struct trace_event_context *event_ctx;
+    struct event *ev;
+    struct flb_log_event_encoder *encoder;
+    int ret;
+
+    event_ctx = (struct trace_event_context *) ctx;
+    ev = (struct event *) data;
+    encoder = event_ctx->log_encoder;
+
+    if (data_sz < sizeof(struct event) || ev->type != EVENT_TYPE_DNS) {
+        return -1;
+    }
+
+    ret = encode_dns_event(event_ctx->ins, encoder, ev);
+    if (ret == -2) {
+        return 0;
+    }
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = flb_input_log_append(event_ctx->ins, NULL, 0,
+                               encoder->output_buffer,
+                               encoder->output_length);
+    if (ret == -1) {
+        return -1;
+    }
+
+    flb_log_event_encoder_reset(encoder);
+
+    return 0;
+}

--- a/plugins/in_ebpf/traces/dns/handler.h
+++ b/plugins/in_ebpf/traces/dns/handler.h
@@ -1,0 +1,12 @@
+#ifndef TRACE_DNS_HANDLER_H
+#define TRACE_DNS_HANDLER_H
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+int trace_dns_handler(void *ctx, void *data, size_t data_sz);
+int encode_dns_event(struct flb_input_instance *ins,
+                     struct flb_log_event_encoder *log_encoder,
+                     const struct event *ev);
+
+#endif

--- a/plugins/in_ebpf/traces/includes/common/encoder.h
+++ b/plugins/in_ebpf/traces/includes/common/encoder.h
@@ -25,6 +25,8 @@ static inline char *event_type_to_string(enum event_type type) {
             return "accept";
         case EVENT_TYPE_CONNECT:
             return "connect";
+        case EVENT_TYPE_DNS:
+            return "dns";
         default:
             return "unknown";
     }

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -8,6 +8,8 @@
 #define VFS_PATH_MAX 256
 #define EXECVE_ARG_MAX 3
 #define EXECVE_ARG_LEN 256
+#define DNS_NAME_MAX 128
+#define DNS_QUERY_RAW_MAX 96
 
 enum event_type {
     EVENT_TYPE_EXECVE,
@@ -18,6 +20,7 @@ enum event_type {
     EVENT_TYPE_LISTEN,
     EVENT_TYPE_ACCEPT,
     EVENT_TYPE_CONNECT,
+    EVENT_TYPE_DNS,
 };
 
 enum vfs_op {
@@ -130,6 +133,18 @@ struct connect_event {
     int error_raw;
 };
 
+struct dns_event {
+    __u16 txid;
+    __u16 query_type;
+    __u8 rcode;
+    __u8 response;
+    __u16 query_raw_len;
+    __u64 latency_ns;
+    int error_raw;
+    char query[DNS_NAME_MAX];
+    __u8 query_raw[DNS_QUERY_RAW_MAX];
+};
+
 struct event {
     enum event_type type;           // Type of event (execve, signal, mem, bind)
     struct event_common common;     // Common fields for all events
@@ -142,6 +157,7 @@ struct event {
         struct listen_event listen;
         struct accept_event accept;
         struct connect_event connect;
+        struct dns_event dns;
     } details;
 };
 

--- a/plugins/in_ebpf/traces/traces.h
+++ b/plugins/in_ebpf/traces/traces.h
@@ -9,6 +9,7 @@
 #include "generated/trace_vfs.skel.h"
 #include "generated/trace_tcp.skel.h"
 #include "generated/trace_exec.skel.h"
+#include "generated/trace_dns.skel.h"
 
 #include "bind/handler.h"
 #include "signal/handler.h"  // Include signal handler
@@ -16,6 +17,7 @@
 #include "vfs/handler.h"
 #include "tcp/handler.h"
 #include "exec/handler.h"
+#include "dns/handler.h"
 
 /* Skeleton function pointer types */
 typedef void *(*trace_skel_open_func_t)(void);
@@ -69,6 +71,7 @@ DEFINE_GET_BPF_OBJECT(trace_bind)
 DEFINE_GET_BPF_OBJECT(trace_vfs)
 DEFINE_GET_BPF_OBJECT(trace_tcp)
 DEFINE_GET_BPF_OBJECT(trace_exec)
+DEFINE_GET_BPF_OBJECT(trace_dns)
 
 static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_signal, trace_signal_handler),
@@ -77,6 +80,7 @@ static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_vfs, trace_vfs_handler),
     REGISTER_TRACE(trace_tcp, trace_tcp_handler),
     REGISTER_TRACE(trace_exec, trace_exec_handler),
+    REGISTER_TRACE(trace_dns, trace_dns_handler),
 };
 
 #endif // TRACE_TRACES_H


### PR DESCRIPTION
<!-- Provide summary of changes -->
In this PR, I implemented DNS query eBPF trace.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
sudo bin/fluent-bit -i ebpf -ptrace=trace_dns -o stdout -v
```
- [x] Debug log output from testing the change

```
Fluent Bit v5.0.4
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/22 13:08:57.904] [ info] Configuration:
[2026/04/22 13:08:57.925] [ info]  flush time     | 1.000000 seconds
[2026/04/22 13:08:57.930] [ info]  grace          | 5 seconds
[2026/04/22 13:08:57.931] [ info]  daemon         | 0
[2026/04/22 13:08:57.931] [ info] ___________
[2026/04/22 13:08:57.931] [ info]  inputs:
[2026/04/22 13:08:57.931] [ info]      ebpf
[2026/04/22 13:08:57.932] [ info] ___________
[2026/04/22 13:08:57.932] [ info]  filters:
[2026/04/22 13:08:57.932] [ info] ___________
[2026/04/22 13:08:57.932] [ info]  outputs:
[2026/04/22 13:08:57.932] [ info]      stdout.0
[2026/04/22 13:08:57.933] [ info] ___________
[2026/04/22 13:08:57.933] [ info]  collectors:
[2026/04/22 13:08:58.002] [ info] [fluent bit] version=5.0.4, commit=dfdc57cc69, pid=355581
[2026/04/22 13:08:58.011] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/04/22 13:08:58.016] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/22 13:08:58.017] [ info] [simd    ] SSE2
[2026/04/22 13:08:58.017] [ info] [cmetrics] version=2.1.2
[2026/04/22 13:08:58.017] [ info] [ctraces ] version=0.7.1
[2026/04/22 13:08:58.033] [ info] [input:ebpf:ebpf.0] initializing
[2026/04/22 13:08:58.034] [ info] [input:ebpf:ebpf.0] storage_strategy='memory' (memory only)
[2026/04/22 13:08:58.035] [debug] [ebpf:ebpf.0] created event channels: read=21 write=22
[2026/04/22 13:08:58.036] [debug] [input:ebpf:ebpf.0] initializing eBPF input plugin
[2026/04/22 13:08:58.041] [debug] [input:ebpf:ebpf.0] processing trace: trace_dns
[2026/04/22 13:08:58.041] [debug] [input:ebpf:ebpf.0] setting up trace configuration for: trace_dns
[2026/04/22 13:09:03.453] [debug] [input:ebpf:ebpf.0] attaching BPF program for trace: trace_dns
[2026/04/22 13:09:03.463] [debug] [input:ebpf:ebpf.0] registering trace handler for: trace_dns
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: dns_connect_pending
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: dns_sockets
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: dns_queries
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: events
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: dns_recv
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: gadget_heap
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: gadget_mntns_filter_map
[2026/04/22 13:09:03.464] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: trace_dn.rodata
[2026/04/22 13:09:03.465] [trace] [input:ebpf:ebpf.0 at /home/cosmo/GitHub/fluent-bit/plugins/in_ebpf/in_ebpf.c:49] found BPF map: trace_dn.bss
[2026/04/22 13:09:03.468] [ info] [input:ebpf:ebpf.0] registered trace handler for: trace_dns
[2026/04/22 13:09:03.468] [ info] [input:ebpf:ebpf.0] trace configuration completed for: trace_dns
[2026/04/22 13:09:03.469] [debug] [input:ebpf:ebpf.0] setting up collector with poll interval: 1000 ms
[2026/04/22 13:09:03.471] [ info] [input:ebpf:ebpf.0] eBPF input plugin initialized successfully
[2026/04/22 13:09:03.475] [debug] [stdout:stdout.0] created event channels: read=49 write=50
[2026/04/22 13:09:03.512] [ info] [sp] stream processor started
[2026/04/22 13:09:03.514] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/22 13:09:03.520] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:03.527] [ info] [output:stdout:stdout.0] worker #0 started
[2026/04/22 13:09:03.664] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:03.924] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:03.936] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/22 13:09:03.937] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_dns
[2026/04/22 13:09:03.938] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_dns
[2026/04/22 13:09:03.939] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:04.164] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:04.414] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:04.664] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:04.914] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/22 13:09:04.915] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_dns
[2026/04/22 13:09:04.964] [trace] [input chunk] update output instances with new chunk size diff=186, records=1, input=ebpf.0
[2026/04/22 13:09:04.968] [trace] [input chunk] update output instances with new chunk size diff=190, records=1, input=ebpf.0
[2026/04/22 13:09:04.968] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_dns
[2026/04/22 13:09:04.968] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:05.164] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:05.414] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:05.414] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:05.664] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:05.923] [trace] [task 0x6653660] created (id=0)
[2026/04/22 13:09:05.929] [debug] [task] created task=0x6653660 id=0 OK
[2026/04/22 13:09:05.930] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] ebpf.0: [[1776830944.927134652, {}], {"event_type"=>"dns", "pid"=>4719, "tid"=>343834, "comm"=>"DNS Res~ver #52", "query"=>"sync-1-us-west1-g.sync.services.mozilla.com", "query_type"=>1, "txid"=>11237, "response"=>0, "rcode"=>0, "latency_ns"=>0, "error_raw"=>0}]
[1] ebpf.0: [[1776830944.966563667, {}], {"event_type"=>"dns", "pid"=>4719, "tid"=>343834, "comm"=>"DNS Res~ver #52", "query"=>"sync-1-us-west1-g.sync.services.mozilla.com", "query_type"=>1, "txid"=>11237, "response"=>1, "rcode"=>0, "latency_ns"=>10443380, "error_raw"=>0}]
[2026/04/22 13:09:05.945] [debug] [out flush] cb_destroy coro_id=0
[2026/04/22 13:09:05.946] [trace] [coro] destroy coroutine=0x833dbf0 data=0x833dc10
[2026/04/22 13:09:05.946] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:05.931] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/04/22 13:09:05.946] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_dns
[2026/04/22 13:09:05.947] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_dns
[2026/04/22 13:09:05.948] [trace] [engine] [task event] task_id=0 out_id=0 return=OK
[2026/04/22 13:09:05.954] [debug] [task] destroy task=0x6653660 (task_id=0)
[2026/04/22 13:09:05.958] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:06.164] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:06.414] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:06.664] [trace] [sched] 0 timer coroutines destroyed
^C[2026/04/22 13:09:06] [engine] caught signal (SIGINT)
[2026/04/22 13:09:06.819] [trace] [engine] flush enqueued data
[2026/04/22 13:09:06.819] [ warn] [engine] service will shutdown in max 5 seconds
[2026/04/22 13:09:06.820] [ info] [engine] pausing all inputs..
[2026/04/22 13:09:06.821] [ info] [input] pausing ebpf.0
[2026/04/22 13:09:06.822] [debug] [input:ebpf:ebpf.0] collector paused
[2026/04/22 13:09:06.823] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:06.914] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:06.920] [ info] [engine] service has stopped (0 pending tasks)
[2026/04/22 13:09:06.920] [ info] [input] pausing ebpf.0
[2026/04/22 13:09:06.921] [debug] [input:ebpf:ebpf.0] collector paused
[2026/04/22 13:09:06.923] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/04/22 13:09:06.923] [trace] [sched] 0 timer coroutines destroyed
[2026/04/22 13:09:06.930] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/04/22 13:09:07.144] [ info] [input:ebpf:ebpf.0] eBPF input plugin exited

```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==355581== 
==355581== HEAP SUMMARY:
==355581==     in use at exit: 0 bytes in 0 blocks
==355581==   total heap usage: 3,784 allocs, 3,784 frees, 17,106,722 bytes allocated
==355581== 
==355581== All heap blocks were freed -- no leaks are possible
==355581== 
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS tracing: correlates queries and responses, measures latency, records response codes and query type, captures raw query data, and automatically tracks socket lifecycle for accurate pairing.
* **Chores**
  * Updated the "Trace" configuration description to list supported trace examples (dns, exec, malloc, signal, vfs, tcp) and note multi-use support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->