### PR TITLE
in_forward: handle retain metadata in upstream conf

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -840,6 +840,11 @@ static int config_set_properties(struct flb_upstream_node *node,
         fc->send_options = flb_utils_bool(tmp);
     }
 
+    tmp = config_get_property("retain_metadata_in_forward_mode", node, ctx);
+    if (tmp) {
+        fc->fwd_retain_metadata = flb_utils_bool(tmp);
+    }
+
     /* add_option -> extra_options: if the user has defined 'add_option'
      * we need to enable the 'send_options' flag
      */

--- a/tests/integration/scenarios/in_forward/config/in_opentelemetry_to_forward_receiver_retain_metadata.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_opentelemetry_to_forward_receiver_retain_metadata.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+      profiles_support: true
+
+  outputs:
+    - name: forward
+      match: '*'
+      host: 127.0.0.1
+      port: ${FORWARD_RECEIVER_PORT}
+      send_options: true
+      retain_metadata_in_forward_mode: true
+      require_ack_response: true

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -924,6 +924,50 @@ def test_out_forward_logs_signal_e2e_with_forward_receiver():
     assert "This is another example log message." in log_bodies
 
 
+def test_out_forward_logs_signal_e2e_with_forward_receiver_retain_metadata():
+    service = ForwardReceiverService(
+        "in_opentelemetry_to_forward_receiver_retain_metadata.yaml"
+    )
+    service.start()
+
+    try:
+        service.send_json_as_otel_protobuf("test_logs_001.in.json", "logs")
+        messages = service.wait_for_forward_messages(1)
+    finally:
+        service.stop()
+
+    message = messages[0]
+    _assert_forward_signal_message(message, expected_tag="v1_logs", expected_signal=0)
+    assert len(message["records"]) > 0
+
+    schema_metadata_count = 0
+    otlp_metadata_count = 0
+    empty_metadata_count = 0
+
+    for record in message["records"]:
+        metadata = record["metadata"]
+
+        assert isinstance(metadata, dict)
+
+        if "schema" in metadata:
+            assert metadata["schema"] == "otlp"
+            assert metadata["resource_id"] in (0, 1)
+            assert metadata["scope_id"] in (0, 1)
+            schema_metadata_count += 1
+        elif "otlp" in metadata:
+            assert metadata["otlp"]["severity_number"] == 9
+            assert metadata["otlp"]["severity_text"] == "INFO"
+            assert metadata["otlp"]["attributes"]["example_key"] == "example_value"
+            otlp_metadata_count += 1
+        else:
+            assert metadata == {}
+            empty_metadata_count += 1
+
+    assert schema_metadata_count > 0
+    assert otlp_metadata_count > 0
+    assert empty_metadata_count > 0
+
+
 def test_out_forward_metrics_signal_e2e_with_forward_receiver():
     service = ForwardReceiverService("in_opentelemetry_to_forward_receiver.yaml")
     service.start()

--- a/tests/runtime/data/forward/upstream_retain_metadata.conf
+++ b/tests/runtime/data/forward/upstream_retain_metadata.conf
@@ -1,0 +1,9 @@
+[UPSTREAM]
+    name test_upstream
+
+[NODE]
+    name node-1
+    host 127.0.0.1
+    port 24224
+    send_options true
+    retain_metadata_in_forward_mode true

--- a/tests/runtime/group_counter_semantics.c
+++ b/tests/runtime/group_counter_semantics.c
@@ -699,6 +699,42 @@ static void flb_test_forward_group_size_retain_metadata()
     flb_destroy(ctx);
 }
 
+static void flb_test_forward_group_size_retain_metadata_upstream_node()
+{
+    int ret;
+    int out_ffd;
+    int in_ffd;
+    flb_ctx_t *ctx;
+
+    reset_results();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "0.2", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "tag", "new.tag",
+                   "upstream",
+                   FLB_TESTS_DATA_PATH "/data/forward/upstream_retain_metadata.conf",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_forward_size_check,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+
+    run_group_count_test(ctx);
+    TEST_CHECK(get_forward_size() == 3);
+
+    flb_destroy(ctx);
+}
+
 static void flb_test_loki_group_values_count()
 {
     int out_ffd;
@@ -838,6 +874,8 @@ static void flb_test_forward_output_processor_mixed_payload_smoke()
 TEST_LIST = {
     {"forward_group_size_default", flb_test_forward_group_size_default},
     {"forward_group_size_retain_metadata", flb_test_forward_group_size_retain_metadata},
+    {"forward_group_size_retain_metadata_upstream_node",
+     flb_test_forward_group_size_retain_metadata_upstream_node},
     {"loki_group_values_count", flb_test_loki_group_values_count},
     {"stackdriver_group_entries_count", flb_test_stackdriver_group_entries_count},
     {"forward_output_processor_mixed_payload_smoke",


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixes https://github.com/fluent/fluent-bit/issues/11617.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `retain_metadata_in_forward_mode` configuration option to control metadata preservation during forward operations. When enabled (default: disabled), metadata including schema information and event attributes is retained when forwarding logs and signal events.

* **Tests**
  * Added comprehensive integration and runtime test scenarios to validate metadata retention behavior in forward mode, including upstream node configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->