### PR TITLE
filter_kubernetes: destroy upstream and TLS context on happy path exit

### DIFF
--- a/plugins/filter_kubernetes/kubernetes_aws.c
+++ b/plugins/filter_kubernetes/kubernetes_aws.c
@@ -283,6 +283,10 @@ int fetch_pod_service_map(struct flb_kube *ctx, char *api_server_url,
         flb_http_client_destroy(c);
         flb_upstream_conn_recycle(u_conn, FLB_FALSE);
         flb_upstream_conn_release(u_conn);
+        flb_upstream_destroy(ctx->aws_pod_association_upstream);
+        flb_tls_destroy(ctx->aws_pod_association_tls);
+        ctx->aws_pod_association_upstream = NULL;
+        ctx->aws_pod_association_tls = NULL;
     }
     return 0;
 }


### PR DESCRIPTION
**Summary**

Continuation of fixing filter_kubernetes - https://github.com/fluent/fluent-bit/pull/11730

Problem: 
`fetch_pod_service_map` creates a per-call upstream and TLS context each iteration of the background thread loop. The error and failure paths destroy them, but the happy path returned without calling `flb_upstream_destroy` / `flb_tls_destroy`, leaking both on every successful fetch.

Why this does not effect other plugins:

The following conditions have to be true for this to be a real leak:

1. Per-call upstream — a fresh upstream and TLS context created each invocation, not a long-lived pooled one
2. Called in a loop — runs repeatedly for the process lifetime, so each leak compounds
3. Background thread — the normal event loop that drains the destroy queue never runs in this thread

`fetch_pod_service_map` is the only place in the codebase where all are true.
- Other plugins uses a long-lived upstream that's created once at init and pooled — condition 1 doesn't apply.
- `out_calyptia` creates a per-call upstream but only calls it once at startup — condition 2 doesn't apply.
- `out_azure_blob` creates a per-call upstream in a loop but already correctly destroys both upstream and TLS context on every path.
- `filter_aws` assigns the upstream to ctx->aws_ec2_filter_client->upstream — it's stored on the context, not a per-call local, long-lived.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change - https://github.com/aws-observability/helm-charts/blob/main/charts/amazon-cloudwatch-observability/values.yaml
- [WIP] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [WIP] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

From the test data collected across two run durations on (master, no fix):

Heap (jemalloc profiling):
- +5.7 MB at 90 minutes
- +14.6 MB at 3.5 hours

Growth is linear and sustained — ~5 MB per 90-minute window

Source pinned to `update_pod_service_map` → `fetch_pod_service_map` → `flb_tls_session_create` / `BIO_ssl_copy_session_id` / `SSL_CTX_add_custom_ext`

RSS:
- +113 MB at 90 minutes (~1,279 KiB/min)
- +145 MB at 3.5 hours (~683 KiB/min, decelerating)

The majority of RSS growth (~82%) is the jemalloc retained page pool, not the leak itself
The leak contributes ~80 KiB/min to RSS growth (difference between master and filter_ssl-fix + filter-tls-fix post-warmup rates)

Master vs Fixes
<img width="1420" height="247" alt="image" src="https://github.com/user-attachments/assets/aaedd107-a022-4b9f-bdf1-0280f58b7e11" />

Fixes
<img width="1401" height="244" alt="image" src="https://github.com/user-attachments/assets/1c55f2df-70fc-436e-b1b8-94c90c05d03d" />

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource cleanup in the Kubernetes AWS plugin to ensure all connection and encryption resources are properly disposed during normal operations. This enhancement ensures consistency between success and error handling paths, preventing potential resource accumulation that could degrade system stability and performance over extended periods in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->