### PR TITLE
in_ebpf: Implement sched trace

### DIFF
--- a/plugins/in_ebpf/traces/includes/common/encoder.h
+++ b/plugins/in_ebpf/traces/includes/common/encoder.h
@@ -27,6 +27,8 @@ static inline char *event_type_to_string(enum event_type type) {
             return "connect";
         case EVENT_TYPE_DNS:
             return "dns";
+        case EVENT_TYPE_SCHED:
+            return "sched";
         default:
             return "unknown";
     }

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -157,6 +157,12 @@ struct sched_event {
     __u8 wakeup_tracked;
 };
 
+struct sched_sample {
+    enum event_type type;
+    struct event_common common;
+    struct sched_event details;
+};
+
 struct event {
     enum event_type type;           // Type of event (execve, signal, mem, bind)
     struct event_common common;     // Common fields for all events

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -21,6 +21,7 @@ enum event_type {
     EVENT_TYPE_ACCEPT,
     EVENT_TYPE_CONNECT,
     EVENT_TYPE_DNS,
+    EVENT_TYPE_SCHED,
 };
 
 enum vfs_op {
@@ -145,6 +146,17 @@ struct dns_event {
     __u8 query_raw[DNS_QUERY_RAW_MAX];
 };
 
+struct sched_event {
+    __u32 prev_pid;
+    int prev_prio;
+    long prev_state;
+    __u32 next_pid;
+    int next_prio;
+    __u32 cpu;
+    __u64 runq_latency_ns;
+    __u8 wakeup_tracked;
+};
+
 struct event {
     enum event_type type;           // Type of event (execve, signal, mem, bind)
     struct event_common common;     // Common fields for all events
@@ -158,6 +170,7 @@ struct event {
         struct accept_event accept;
         struct connect_event connect;
         struct dns_event dns;
+        struct sched_event sched;
     } details;
 };
 

--- a/plugins/in_ebpf/traces/sched/bpf.c
+++ b/plugins/in_ebpf/traces/sched/bpf.c
@@ -65,6 +65,7 @@ int BPF_PROG(trace_sched_switch, bool preempt, struct task_struct *prev,
     struct wakeup_info *wakeup;
     __u64 now_ns;
     __u32 next_pid = 0;
+    __u32 next_tid = 0;
     __u32 prev_pid = 0;
     int prev_prio = 0;
     int next_prio = 0;
@@ -73,7 +74,8 @@ int BPF_PROG(trace_sched_switch, bool preempt, struct task_struct *prev,
     __u32 uid = 0;
     __u32 gid = 0;
 
-    bpf_core_read(&next_pid, sizeof(next_pid), &next->pid);
+    bpf_core_read(&next_pid, sizeof(next_pid), &next->tgid);
+    bpf_core_read(&next_tid, sizeof(next_tid), &next->pid);
     bpf_core_read(&prev_pid, sizeof(prev_pid), &prev->pid);
     bpf_core_read(&prev_prio, sizeof(prev_prio), &prev->prio);
     bpf_core_read(&next_prio, sizeof(next_prio), &next->prio);
@@ -102,7 +104,7 @@ int BPF_PROG(trace_sched_switch, bool preempt, struct task_struct *prev,
     event->type = EVENT_TYPE_SCHED;
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = next_pid;
-    event->common.tid = next_pid;
+    event->common.tid = next_tid;
     event->common.uid = uid;
     event->common.gid = gid;
     event->common.mntns_id = mntns_id;
@@ -117,13 +119,13 @@ int BPF_PROG(trace_sched_switch, bool preempt, struct task_struct *prev,
     event->details.wakeup_tracked = 0;
     event->details.runq_latency_ns = 0;
 
-    wakeup = bpf_map_lookup_elem(&wakeup_by_pid, &next_pid);
+    wakeup = bpf_map_lookup_elem(&wakeup_by_pid, &next_tid);
     if (wakeup) {
         event->details.wakeup_tracked = 1;
         if (now_ns > wakeup->wakeup_ns) {
             event->details.runq_latency_ns = now_ns - wakeup->wakeup_ns;
         }
-        bpf_map_delete_elem(&wakeup_by_pid, &next_pid);
+        bpf_map_delete_elem(&wakeup_by_pid, &next_tid);
     }
 
     gadget_submit_buf(ctx, &events, event, sizeof(*event));

--- a/plugins/in_ebpf/traces/sched/bpf.c
+++ b/plugins/in_ebpf/traces/sched/bpf.c
@@ -8,6 +8,7 @@
 
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
 
 #include <gadget/buffer.h>
 #include <gadget/mntns_filter.h>
@@ -56,33 +57,41 @@ int trace_sched_wakeup_new(struct trace_event_raw_sched_wakeup_template *ctx)
     return track_wakeup((__u32) ctx->pid);
 }
 
-SEC("tracepoint/sched/sched_switch")
-int trace_sched_switch(struct trace_event_raw_sched_switch *ctx)
+SEC("tp_btf/sched_switch")
+int BPF_PROG(trace_sched_switch, bool preempt, struct task_struct *prev,
+             struct task_struct *next, unsigned int prev_state)
 {
-    struct event *event;
+    struct sched_sample *event;
     struct wakeup_info *wakeup;
     __u64 now_ns;
     __u32 next_pid = 0;
     __u32 prev_pid = 0;
     int prev_prio = 0;
-    long prev_state = 0;
     int next_prio = 0;
-    __u64 uid_gid;
     __u64 mntns_id;
+    const struct cred *next_cred;
+    __u32 uid = 0;
+    __u32 gid = 0;
 
-    bpf_core_read(&next_pid, sizeof(next_pid), &ctx->next_pid);
-    bpf_core_read(&prev_pid, sizeof(prev_pid), &ctx->prev_pid);
-    bpf_core_read(&prev_prio, sizeof(prev_prio), &ctx->prev_prio);
-    bpf_core_read(&prev_state, sizeof(prev_state), &ctx->prev_state);
-    bpf_core_read(&next_prio, sizeof(next_prio), &ctx->next_prio);
+    bpf_core_read(&next_pid, sizeof(next_pid), &next->pid);
+    bpf_core_read(&prev_pid, sizeof(prev_pid), &prev->pid);
+    bpf_core_read(&prev_prio, sizeof(prev_prio), &prev->prio);
+    bpf_core_read(&next_prio, sizeof(next_prio), &next->prio);
 
-    mntns_id = gadget_get_mntns_id();
+    if (next_pid == 0) {
+        return 0;
+    }
+
+    mntns_id = BPF_CORE_READ(next, nsproxy, mnt_ns, ns.inum);
     if (gadget_should_discard_mntns_id(mntns_id)) {
         return 0;
     }
 
-    if (next_pid == 0) {
-        return 0;
+    now_ns = bpf_ktime_get_ns();
+    next_cred = BPF_CORE_READ(next, real_cred);
+    if (next_cred) {
+        uid = BPF_CORE_READ(next_cred, uid.val);
+        gid = BPF_CORE_READ(next_cred, gid.val);
     }
 
     event = gadget_reserve_buf(&events, sizeof(*event));
@@ -90,32 +99,29 @@ int trace_sched_switch(struct trace_event_raw_sched_switch *ctx)
         return 0;
     }
 
-    now_ns = bpf_ktime_get_ns();
-    uid_gid = bpf_get_current_uid_gid();
-
     event->type = EVENT_TYPE_SCHED;
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = next_pid;
     event->common.tid = next_pid;
-    event->common.uid = (u32) uid_gid;
-    event->common.gid = (u32) (uid_gid >> 32);
+    event->common.uid = uid;
+    event->common.gid = gid;
     event->common.mntns_id = mntns_id;
-    bpf_core_read(event->common.comm, sizeof(event->common.comm), &ctx->next_comm);
+    bpf_core_read(event->common.comm, sizeof(event->common.comm), &next->comm);
 
-    event->details.sched.prev_pid = prev_pid;
-    event->details.sched.prev_prio = prev_prio;
-    event->details.sched.prev_state = prev_state;
-    event->details.sched.next_pid = next_pid;
-    event->details.sched.next_prio = next_prio;
-    event->details.sched.cpu = bpf_get_smp_processor_id();
-    event->details.sched.wakeup_tracked = 0;
-    event->details.sched.runq_latency_ns = 0;
+    event->details.prev_pid = prev_pid;
+    event->details.prev_prio = prev_prio;
+    event->details.prev_state = prev_state;
+    event->details.next_pid = next_pid;
+    event->details.next_prio = next_prio;
+    event->details.cpu = bpf_get_smp_processor_id();
+    event->details.wakeup_tracked = 0;
+    event->details.runq_latency_ns = 0;
 
     wakeup = bpf_map_lookup_elem(&wakeup_by_pid, &next_pid);
     if (wakeup) {
-        event->details.sched.wakeup_tracked = 1;
+        event->details.wakeup_tracked = 1;
         if (now_ns > wakeup->wakeup_ns) {
-            event->details.sched.runq_latency_ns = now_ns - wakeup->wakeup_ns;
+            event->details.runq_latency_ns = now_ns - wakeup->wakeup_ns;
         }
         bpf_map_delete_elem(&wakeup_by_pid, &next_pid);
     }

--- a/plugins/in_ebpf/traces/sched/bpf.c
+++ b/plugins/in_ebpf/traces/sched/bpf.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+#define __TARGET_ARCH_x86_64
+
+#include <vmlinux.h>
+
+#define _LINUX_TYPES_H
+#define _LINUX_POSIX_TYPES_H
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+#include <gadget/buffer.h>
+#include <gadget/mntns_filter.h>
+
+#include "common/events.h"
+
+struct wakeup_info {
+    __u64 wakeup_ns;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 65536);
+    __type(key, __u32);
+    __type(value, struct wakeup_info);
+} wakeup_by_pid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 20);
+} events SEC(".maps");
+
+static __always_inline int track_wakeup(__u32 pid)
+{
+    struct wakeup_info info = {0};
+
+    if (pid == 0) {
+        return 0;
+    }
+
+    info.wakeup_ns = bpf_ktime_get_ns();
+    bpf_map_update_elem(&wakeup_by_pid, &pid, &info, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_wakeup")
+int trace_sched_wakeup(struct trace_event_raw_sched_wakeup_template *ctx)
+{
+    return track_wakeup((__u32) ctx->pid);
+}
+
+SEC("tracepoint/sched/sched_wakeup_new")
+int trace_sched_wakeup_new(struct trace_event_raw_sched_wakeup_template *ctx)
+{
+    return track_wakeup((__u32) ctx->pid);
+}
+
+SEC("tracepoint/sched/sched_switch")
+int trace_sched_switch(struct trace_event_raw_sched_switch *ctx)
+{
+    struct event *event;
+    struct wakeup_info *wakeup;
+    __u64 now_ns;
+    __u32 next_pid = 0;
+    __u32 prev_pid = 0;
+    int prev_prio = 0;
+    long prev_state = 0;
+    int next_prio = 0;
+    __u64 uid_gid;
+    __u64 mntns_id;
+
+    bpf_core_read(&next_pid, sizeof(next_pid), &ctx->next_pid);
+    bpf_core_read(&prev_pid, sizeof(prev_pid), &ctx->prev_pid);
+    bpf_core_read(&prev_prio, sizeof(prev_prio), &ctx->prev_prio);
+    bpf_core_read(&prev_state, sizeof(prev_state), &ctx->prev_state);
+    bpf_core_read(&next_prio, sizeof(next_prio), &ctx->next_prio);
+
+    mntns_id = gadget_get_mntns_id();
+    if (gadget_should_discard_mntns_id(mntns_id)) {
+        return 0;
+    }
+
+    if (next_pid == 0) {
+        return 0;
+    }
+
+    event = gadget_reserve_buf(&events, sizeof(*event));
+    if (!event) {
+        return 0;
+    }
+
+    now_ns = bpf_ktime_get_ns();
+    uid_gid = bpf_get_current_uid_gid();
+
+    event->type = EVENT_TYPE_SCHED;
+    event->common.timestamp_raw = bpf_ktime_get_boot_ns();
+    event->common.pid = next_pid;
+    event->common.tid = next_pid;
+    event->common.uid = (u32) uid_gid;
+    event->common.gid = (u32) (uid_gid >> 32);
+    event->common.mntns_id = mntns_id;
+    bpf_core_read(event->common.comm, sizeof(event->common.comm), &ctx->next_comm);
+
+    event->details.sched.prev_pid = prev_pid;
+    event->details.sched.prev_prio = prev_prio;
+    event->details.sched.prev_state = prev_state;
+    event->details.sched.next_pid = next_pid;
+    event->details.sched.next_prio = next_prio;
+    event->details.sched.cpu = bpf_get_smp_processor_id();
+    event->details.sched.wakeup_tracked = 0;
+    event->details.sched.runq_latency_ns = 0;
+
+    wakeup = bpf_map_lookup_elem(&wakeup_by_pid, &next_pid);
+    if (wakeup) {
+        event->details.sched.wakeup_tracked = 1;
+        if (now_ns > wakeup->wakeup_ns) {
+            event->details.sched.runq_latency_ns = now_ns - wakeup->wakeup_ns;
+        }
+        bpf_map_delete_elem(&wakeup_by_pid, &next_pid);
+    }
+
+    gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/plugins/in_ebpf/traces/sched/handler.c
+++ b/plugins/in_ebpf/traces/sched/handler.c
@@ -1,0 +1,155 @@
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "common/events.h"
+#include "common/event_context.h"
+#include "common/encoder.h"
+
+#include "handler.h"
+
+int encode_sched_event(struct flb_log_event_encoder *log_encoder,
+                       const struct event *e)
+{
+    int ret;
+
+    ret = flb_log_event_encoder_begin_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    ret = encode_common_fields(log_encoder, e);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "cpu");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.sched.cpu);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "prev_pid");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.sched.prev_pid);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "prev_prio");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, e->details.sched.prev_prio);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "prev_state");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int64(log_encoder, e->details.sched.prev_state);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "next_pid");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.sched.next_pid);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "next_prio");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, e->details.sched.next_prio);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "runq_latency_ns");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint64(log_encoder, e->details.sched.runq_latency_ns);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "wakeup_tracked");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_boolean(log_encoder, e->details.sched.wakeup_tracked);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_commit_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int trace_sched_handler(void *ctx, void *data, size_t data_sz)
+{
+    struct trace_event_context *event_ctx;
+    struct flb_log_event_encoder *encoder;
+    struct event *e;
+    int ret;
+
+    event_ctx = (struct trace_event_context *) ctx;
+    e = (struct event *) data;
+
+    if (data_sz < sizeof(struct event) || e->type != EVENT_TYPE_SCHED) {
+        return -1;
+    }
+
+    encoder = event_ctx->log_encoder;
+
+    ret = encode_sched_event(encoder, e);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = flb_input_log_append(event_ctx->ins,
+                               NULL,
+                               0,
+                               encoder->output_buffer,
+                               encoder->output_length);
+    if (ret == -1) {
+        return -1;
+    }
+
+    flb_log_event_encoder_reset(encoder);
+
+    return 0;
+}

--- a/plugins/in_ebpf/traces/sched/handler.c
+++ b/plugins/in_ebpf/traces/sched/handler.c
@@ -8,8 +8,9 @@
 #include "handler.h"
 
 int encode_sched_event(struct flb_log_event_encoder *log_encoder,
-                       const struct event *e)
+                       const struct sched_sample *e)
 {
+    struct event ev;
     int ret;
 
     ret = flb_log_event_encoder_begin_record(log_encoder);
@@ -17,7 +18,10 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         return -1;
     }
 
-    ret = encode_common_fields(log_encoder, e);
+    ev.type = e->type;
+    ev.common = e->common;
+
+    ret = encode_common_fields(log_encoder, &ev);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -28,7 +32,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.sched.cpu);
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.cpu);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -39,7 +43,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.sched.prev_pid);
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.prev_pid);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -50,7 +54,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_int32(log_encoder, e->details.sched.prev_prio);
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, e->details.prev_prio);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -61,7 +65,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_int64(log_encoder, e->details.sched.prev_state);
+    ret = flb_log_event_encoder_append_body_int64(log_encoder, e->details.prev_state);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -72,7 +76,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.sched.next_pid);
+    ret = flb_log_event_encoder_append_body_uint32(log_encoder, e->details.next_pid);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -83,7 +87,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_int32(log_encoder, e->details.sched.next_prio);
+    ret = flb_log_event_encoder_append_body_int32(log_encoder, e->details.next_prio);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -94,7 +98,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_uint64(log_encoder, e->details.sched.runq_latency_ns);
+    ret = flb_log_event_encoder_append_body_uint64(log_encoder, e->details.runq_latency_ns);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -105,7 +109,7 @@ int encode_sched_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
-    ret = flb_log_event_encoder_append_body_boolean(log_encoder, e->details.sched.wakeup_tracked);
+    ret = flb_log_event_encoder_append_body_boolean(log_encoder, e->details.wakeup_tracked);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -123,13 +127,13 @@ int trace_sched_handler(void *ctx, void *data, size_t data_sz)
 {
     struct trace_event_context *event_ctx;
     struct flb_log_event_encoder *encoder;
-    struct event *e;
+    struct sched_sample *e;
     int ret;
 
     event_ctx = (struct trace_event_context *) ctx;
-    e = (struct event *) data;
+    e = (struct sched_sample *) data;
 
-    if (data_sz < sizeof(struct event) || e->type != EVENT_TYPE_SCHED) {
+    if (data_sz < sizeof(struct sched_sample) || e->type != EVENT_TYPE_SCHED) {
         return -1;
     }
 
@@ -137,6 +141,7 @@ int trace_sched_handler(void *ctx, void *data, size_t data_sz)
 
     ret = encode_sched_event(encoder, e);
     if (ret != 0) {
+        flb_log_event_encoder_reset(encoder);
         return -1;
     }
 
@@ -146,6 +151,7 @@ int trace_sched_handler(void *ctx, void *data, size_t data_sz)
                                encoder->output_buffer,
                                encoder->output_length);
     if (ret == -1) {
+        flb_log_event_encoder_reset(encoder);
         return -1;
     }
 

--- a/plugins/in_ebpf/traces/sched/handler.h
+++ b/plugins/in_ebpf/traces/sched/handler.h
@@ -7,7 +7,7 @@
 #include "common/events.h"
 
 int encode_sched_event(struct flb_log_event_encoder *log_encoder,
-                       const struct event *e);
+                       const struct sched_sample *e);
 int trace_sched_handler(void *ctx, void *data, size_t data_sz);
 
 #endif

--- a/plugins/in_ebpf/traces/sched/handler.h
+++ b/plugins/in_ebpf/traces/sched/handler.h
@@ -1,0 +1,13 @@
+#ifndef SCHED_HANDLER_H
+#define SCHED_HANDLER_H
+
+#include <fluent-bit/flb_log_event_encoder.h>
+#include <stddef.h>
+
+#include "common/events.h"
+
+int encode_sched_event(struct flb_log_event_encoder *log_encoder,
+                       const struct event *e);
+int trace_sched_handler(void *ctx, void *data, size_t data_sz);
+
+#endif

--- a/plugins/in_ebpf/traces/traces.h
+++ b/plugins/in_ebpf/traces/traces.h
@@ -10,6 +10,7 @@
 #include "generated/trace_tcp.skel.h"
 #include "generated/trace_exec.skel.h"
 #include "generated/trace_dns.skel.h"
+#include "generated/trace_sched.skel.h"
 
 #include "bind/handler.h"
 #include "signal/handler.h"  // Include signal handler
@@ -18,6 +19,7 @@
 #include "tcp/handler.h"
 #include "exec/handler.h"
 #include "dns/handler.h"
+#include "sched/handler.h"
 
 /* Skeleton function pointer types */
 typedef void *(*trace_skel_open_func_t)(void);
@@ -72,6 +74,7 @@ DEFINE_GET_BPF_OBJECT(trace_vfs)
 DEFINE_GET_BPF_OBJECT(trace_tcp)
 DEFINE_GET_BPF_OBJECT(trace_exec)
 DEFINE_GET_BPF_OBJECT(trace_dns)
+DEFINE_GET_BPF_OBJECT(trace_sched)
 
 static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_signal, trace_signal_handler),
@@ -81,6 +84,7 @@ static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_tcp, trace_tcp_handler),
     REGISTER_TRACE(trace_exec, trace_exec_handler),
     REGISTER_TRACE(trace_dns, trace_dns_handler),
+    REGISTER_TRACE(trace_sched, trace_sched_handler),
 };
 
 #endif // TRACE_TRACES_H

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -181,11 +181,18 @@ if(FLB_IN_EBPF)
         "../../plugins/in_ebpf/traces/exec/handler.c"
     )
 
+    add_ebpf_handler_test(
+        "sched"
+        "in_ebpf_sched_handler.c"
+        "../../plugins/in_ebpf/traces/sched/handler.c"
+    )
+
     add_dependencies(flb-rt-in_ebpf_bind_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_signal_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_malloc_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_tcp_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_exec_handler fluent-bit-static)
+    add_dependencies(flb-rt-in_ebpf_sched_handler fluent-bit-static)
 
 endif()
 

--- a/tests/runtime/in_ebpf_sched_handler.c
+++ b/tests/runtime/in_ebpf_sched_handler.c
@@ -1,0 +1,164 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "flb_tests_runtime.h"
+
+#include "../../plugins/in_ebpf/traces/includes/common/event_context.h"
+#include "../../plugins/in_ebpf/traces/includes/common/events.h"
+#include "../../plugins/in_ebpf/traces/sched/handler.h"
+
+struct test_context {
+    struct trace_event_context event_ctx;
+    struct flb_input_instance *ins;
+    struct flb_log_event_decoder *decoder;
+};
+
+static struct test_context *init_test_context()
+{
+    struct test_context *ctx;
+
+    ctx = flb_calloc(1, sizeof(struct test_context));
+    if (!ctx) {
+        return NULL;
+    }
+
+    ctx->ins = flb_calloc(1, sizeof(struct flb_input_instance));
+    if (!ctx->ins) {
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->event_ctx.log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!ctx->event_ctx.log_encoder) {
+        flb_free(ctx->ins);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->decoder = flb_log_event_decoder_create(NULL, 0);
+    if (!ctx->decoder) {
+        flb_log_event_encoder_destroy(ctx->event_ctx.log_encoder);
+        flb_free(ctx->ins);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->ins->context = &ctx->event_ctx;
+    ctx->event_ctx.ins = ctx->ins;
+
+    return ctx;
+}
+
+static void cleanup_test_context(struct test_context *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    if (ctx->decoder) {
+        flb_log_event_decoder_destroy(ctx->decoder);
+    }
+
+    if (ctx->event_ctx.log_encoder) {
+        flb_log_event_encoder_destroy(ctx->event_ctx.log_encoder);
+    }
+
+    if (ctx->ins) {
+        flb_free(ctx->ins);
+    }
+
+    flb_free(ctx);
+}
+
+static int key_matches(msgpack_object key, const char *str)
+{
+    if (key.type != MSGPACK_OBJECT_STR) {
+        return 0;
+    }
+
+    return strncmp(key.via.str.ptr, str, key.via.str.size) == 0 &&
+           strlen(str) == key.via.str.size;
+}
+
+static void verify_decoded_values(struct flb_log_event *event,
+                                  const struct event *original)
+{
+    msgpack_object_kv *kv;
+    int i;
+
+    TEST_CHECK(event != NULL);
+    TEST_CHECK(event->body->type == MSGPACK_OBJECT_MAP);
+
+    for (i = 0; i < event->body->via.map.size; i++) {
+        kv = &event->body->via.map.ptr[i];
+
+        if (key_matches(kv->key, "event_type")) {
+            TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
+            TEST_CHECK(strncmp(kv->val.via.str.ptr, "sched", kv->val.via.str.size) == 0);
+        }
+        else if (key_matches(kv->key, "cpu")) {
+            TEST_CHECK(kv->val.via.u64 == original->details.sched.cpu);
+        }
+        else if (key_matches(kv->key, "prev_pid")) {
+            TEST_CHECK(kv->val.via.u64 == original->details.sched.prev_pid);
+        }
+        else if (key_matches(kv->key, "next_pid")) {
+            TEST_CHECK(kv->val.via.u64 == original->details.sched.next_pid);
+        }
+        else if (key_matches(kv->key, "runq_latency_ns")) {
+            TEST_CHECK(kv->val.via.u64 == original->details.sched.runq_latency_ns);
+        }
+    }
+}
+
+void test_sched_event_encoding()
+{
+    struct test_context *ctx;
+    struct flb_log_event log_event;
+    struct event test_event;
+    int ret;
+
+    ctx = init_test_context();
+    TEST_CHECK(ctx != NULL);
+
+    memset(&test_event, 0, sizeof(struct event));
+    test_event.type = EVENT_TYPE_SCHED;
+    test_event.common.pid = 4321;
+    test_event.common.tid = 4321;
+    memcpy(test_event.common.comm, "sched_test", strlen("sched_test"));
+
+    test_event.details.sched.prev_pid = 1111;
+    test_event.details.sched.prev_prio = 120;
+    test_event.details.sched.prev_state = 1;
+    test_event.details.sched.next_pid = 4321;
+    test_event.details.sched.next_prio = 90;
+    test_event.details.sched.cpu = 3;
+    test_event.details.sched.runq_latency_ns = 125000;
+    test_event.details.sched.wakeup_tracked = 1;
+
+    ret = encode_sched_event(ctx->event_ctx.log_encoder, &test_event);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(ctx->event_ctx.log_encoder->output_length > 0);
+
+    ret = flb_log_event_decoder_init(ctx->decoder,
+                                     ctx->event_ctx.log_encoder->output_buffer,
+                                     ctx->event_ctx.log_encoder->output_length);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_log_event_decoder_next(ctx->decoder, &log_event);
+    TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS);
+
+    verify_decoded_values(&log_event, &test_event);
+
+    cleanup_test_context(ctx);
+}
+
+TEST_LIST = {
+    {"sched_event_encoding", test_sched_event_encoding},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

In this PR, I implemented sched eBPF trace.



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
% sudo bin/fluent-bit -i ebpf -ptrace=trace_sched -o stdout -v 
```
- [x] Debug log output from testing the change
```
Fluent Bit v5.0.8
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/06/16 13:54:15.334] [ info] Configuration:
[2026/06/16 13:54:15.356] [ info]  flush time     | 1.000000 seconds
[2026/06/16 13:54:15.361] [ info]  grace          | 5 seconds
[2026/06/16 13:54:15.361] [ info]  daemon         | 0
[2026/06/16 13:54:15.361] [ info] ___________
[2026/06/16 13:54:15.361] [ info]  inputs:
[2026/06/16 13:54:15.362] [ info]      ebpf
[2026/06/16 13:54:15.362] [ info] ___________
[2026/06/16 13:54:15.362] [ info]  filters:
[2026/06/16 13:54:15.362] [ info] ___________
[2026/06/16 13:54:15.362] [ info]  outputs:
[2026/06/16 13:54:15.363] [ info]      stdout.0
[2026/06/16 13:54:15.363] [ info] ___________
[2026/06/16 13:54:15.363] [ info]  collectors:
[2026/06/16 13:54:15.426] [ info] [fluent bit] version=5.0.8, commit=93e00a7309, pid=191057
[2026/06/16 13:54:15.436] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/06/16 13:54:15.441] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/06/16 13:54:15.442] [ info] [simd    ] SSE2
[2026/06/16 13:54:15.442] [ info] [cmetrics] version=2.1.4
[2026/06/16 13:54:15.442] [ info] [ctraces ] version=0.7.1
[2026/06/16 13:54:15.457] [ info] [input:ebpf:ebpf.0] initializing
[2026/06/16 13:54:15.457] [ info] [input:ebpf:ebpf.0] storage_strategy='memory' (memory only)
[2026/06/16 13:54:15.459] [debug] [ebpf:ebpf.0] created event channels: read=21 write=22
[2026/06/16 13:54:15.459] [debug] [input:ebpf:ebpf.0] initializing eBPF input plugin
[2026/06/16 13:54:15.464] [debug] [input:ebpf:ebpf.0] processing trace: trace_sched
[2026/06/16 13:54:15.464] [debug] [input:ebpf:ebpf.0] setting up trace configuration for: trace_sched
[2026/06/16 13:54:20.383] [debug] [input:ebpf:ebpf.0] attaching BPF program for trace: trace_sched
[2026/06/16 13:54:20.396] [debug] [input:ebpf:ebpf.0] registering trace handler for: trace_sched
[2026/06/16 13:54:20.400] [ info] [input:ebpf:ebpf.0] registered trace handler for: trace_sched
[2026/06/16 13:54:20.401] [ info] [input:ebpf:ebpf.0] trace configuration completed for: trace_sched
[2026/06/16 13:54:20.402] [debug] [input:ebpf:ebpf.0] setting up collector with poll interval: 1000 ms
[2026/06/16 13:54:20.404] [ info] [input:ebpf:ebpf.0] eBPF input plugin initialized successfully
[2026/06/16 13:54:20.409] [debug] [stdout:stdout.0] created event channels: read=38 write=39
[2026/06/16 13:54:20.447] [ info] [sp] stream processor started
[2026/06/16 13:54:20.449] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/06/16 13:54:20.458] [ info] [output:stdout:stdout.0] worker #0 started
[2026/06/16 13:54:21.149] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/16 13:54:21.149] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_sched
[2026/06/16 13:54:21.254] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_sched
[2026/06/16 13:54:22.150] [debug] [task] created task=0x7a62b90 id=0 OK
[2026/06/16 13:54:22.152] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/16 13:54:22.153] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/16 13:54:22.153] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_sched
[2026/06/16 13:54:22.216] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_sched
[0] ebpf.0: [[1781585661.153101206, {}], {"event_type"=>"sched", "pid"=>182312, "tid"=>182312, "comm"=>"kworker/u48:37", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>182312, "next_prio"=>120, "runq_latency_ns"=>4142, "wakeup_tracked"=>true}]
[1] ebpf.0: [[1781585661.184334297, {}], {"event_type"=>"sched", "pid"=>191055, "tid"=>191055, "comm"=>"sudo", "cpu"=>7, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191055, "next_prio"=>120, "runq_latency_ns"=>1673, "wakeup_tracked"=>true}]
[2] ebpf.0: [[1781585661.185261201, {}], {"event_type"=>"sched", "pid"=>182312, "tid"=>182312, "comm"=>"kworker/u48:37", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>182312, "next_prio"=>120, "runq_latency_ns"=>573, "wakeup_tracked"=>true}]
[3] ebpf.0: [[1781585661.185435407, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>2000, "wakeup_tracked"=>true}]
[4] ebpf.0: [[1781585661.185582407, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>2, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>10106, "wakeup_tracked"=>true}]
[5] ebpf.0: [[1781585661.185902025, {}], {"event_type"=>"sched", "pid"=>3905, "tid"=>3905, "comm"=>"gnome-terminal-", "cpu"=>0, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>3905, "next_prio"=>120, "runq_latency_ns"=>16919, "wakeup_tracked"=>true}]
[6] ebpf.0: [[1781585661.186042958, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>911, "wakeup_tracked"=>true}]
[7] ebpf.0: [[1781585661.186180045, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>902, "wakeup_tracked"=>true}]
[8] ebpf.0: [[1781585661.186326172, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>750, "wakeup_tracked"=>true}]
[9] ebpf.0: [[1781585661.186462778, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>702, "wakeup_tracked"=>true}]
[10] ebpf.0: [[1781585661.186612450, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>1017, "wakeup_tracked"=>true}]
[11] ebpf.0: [[1781585661.186748056, {}], {"event_type"=>"sched", "pid"=>114161, "tid"=>114161, "comm"=>"kworker/0:2", "cpu"=>0, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>114161, "next_prio"=>120, "runq_latency_ns"=>2394, "wakeup_tracked"=>true}]
[12] ebpf.0: [[1781585661.186883401, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>779, "wakeup_tracked"=>true}]
[13] ebpf.0: [[1781585661.187026272, {}], {"event_type"=>"sched", "pid"=>37, "tid"=>37, "comm"=>"migration/5", "cpu"=>5, "prev_pid"=>191058, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>37, "next_prio"=>0, "runq_latency_ns"=>4154, "wakeup_tracked"=>true}]
[14] ebpf.0: [[1781585661.187164388, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191058, "comm"=>"flb-pipeline", "cpu"=>2, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>11312811, "wakeup_tracked"=>true}]
[15] ebpf.0: [[1781585661.187507879, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>3720, "wakeup_tracked"=>true}]
[16] ebpf.0: [[1781585661.187671687, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>1450, "wakeup_tracked"=>true}]
[17] ebpf.0: [[1781585661.187810012, {}], {"event_type"=>"sched", "pid"=>162963, "tid"=>162963, "comm"=>"kworker/u49:3", "cpu"=>7, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>162963, "next_prio"=>100, "runq_latency_ns"=>993, "wakeup_tracked"=>true}]
[18] ebpf.0: [[1781585661.187956038, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2948, "comm"=>"KMS thread", "cpu"=>3, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>79, "runq_latency_ns"=>2909, "wakeup_tracked"=>true}]
[19] ebpf.0: [[1781585661.188091020, {}], {"event_type"=>"sched", "pid"=>204, "tid"=>204, "comm"=>"kworker/7:1H", "cpu"=>7, "prev_pid"=>162963, "prev_prio"=>100, "prev_state"=>1026, "next_pid"=>204, "next_prio"=>100, "runq_latency_ns"=>2715, "wakeup_tracked"=>true}]
[20] ebpf.0: [[1781585661.188580396, {}], {"event_type"=>"sched", "pid"=>25, "tid"=>25, "comm"=>"migration/2", "cpu"=>2, "prev_pid"=>191058, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>25, "next_prio"=>0, "runq_latency_ns"=>1976, "wakeup_tracked"=>true}]
[21] ebpf.0: [[1781585661.188790502, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>1633, "wakeup_tracked"=>true}]
[22] ebpf.0: [[1781585661.188932113, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191058, "comm"=>"flb-pipeline", "cpu"=>7, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>0, "wakeup_tracked"=>false}]
[23] ebpf.0: [[1781585661.189386685, {}], {"event_type"=>"sched", "pid"=>182312, "tid"=>182312, "comm"=>"kworker/u48:37", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>182312, "next_prio"=>120, "runq_latency_ns"=>1310, "wakeup_tracked"=>true}]
[24] ebpf.0: [[1781585661.189909187, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>1148, "wakeup_tracked"=>true}]
[25] ebpf.0: [[1781585661.190062880, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>1691, "wakeup_tracked"=>true}]
[26] ebpf.0: [[1781585661.190214704, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>2135, "wakeup_tracked"=>true}]
[27] ebpf.0: [[1781585661.190354331, {}], {"event_type"=>"sched", "pid"=>49, "tid"=>49, "comm"=>"migration/7", "cpu"=>7, "prev_pid"=>191058, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>49, "next_prio"=>0, "runq_latency_ns"=>2826, "wakeup_tracked"=>true}]
[28] ebpf.0: [[1781585661.190490954, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191058, "comm"=>"flb-pipeline", "cpu"=>2, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>0, "wakeup_tracked"=>false}]
[29] ebpf.0: [[1781585661.190647010, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>2971, "wakeup_tracked"=>true}]
[30] ebpf.0: [[1781585661.190784685, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2948, "comm"=>"KMS thread", "cpu"=>3, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>79, "runq_latency_ns"=>2324, "wakeup_tracked"=>true}]
[31] ebpf.0: [[1781585661.190931511, {}], {"event_type"=>"sched", "pid"=>3905, "tid"=>3905, "comm"=>"gnome-terminal-", "cpu"=>5, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>3905, "next_prio"=>120, "runq_latency_ns"=>2208, "wakeup_tracked"=>true}]
[32] ebpf.0: [[1781585661.191068394, {}], {"event_type"=>"sched", "pid"=>162963, "tid"=>162963, "comm"=>"kworker/u49:3", "cpu"=>7, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>162963, "next_prio"=>100, "runq_latency_ns"=>1454, "wakeup_tracked"=>true}]
[33] ebpf.0: [[1781585661.191203469, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>1605, "wakeup_tracked"=>true}]
[34] ebpf.0: [[1781585661.191348661, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191060, "comm"=>"flb-logger", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>7155, "wakeup_tracked"=>true}]
[35] ebpf.0: [[1781585661.191483572, {}], {"event_type"=>"sched", "pid"=>162963, "tid"=>162963, "comm"=>"kworker/u49:3", "cpu"=>7, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>162963, "next_prio"=>100, "runq_latency_ns"=>2475, "wakeup_tracked"=>true}]
[36] ebpf.0: [[1781585661.191621755, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2948, "comm"=>"KMS thread", "cpu"=>3, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>79, "runq_latency_ns"=>4133, "wakeup_tracked"=>true}]
[37] ebpf.0: [[1781585661.191766596, {}], {"event_type"=>"sched", "pid"=>162963, "tid"=>162963, "comm"=>"kworker/u49:3", "cpu"=>7, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>162963, "next_prio"=>100, "runq_latency_ns"=>2603, "wakeup_tracked"=>true}]
[38] ebpf.0: [[1781585661.191902416, {}], {"event_type"=>"sched", "pid"=>204, "tid"=>204, "comm"=>"kworker/7:1H", "cpu"=>7, "prev_pid"=>162963, "prev_prio"=>100, "prev_state"=>1026, "next_pid"=>204, "next_prio"=>100, "runq_latency_ns"=>4181, "wakeup_tracked"=>true}]
[39] ebpf.0: [[1781585661.192049347, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>2610, "wakeup_tracked"=>true}]
[40] ebpf.0: [[1781585661.192184228, {}], {"event_type"=>"sched", "pid"=>182312, "tid"=>182312, "comm"=>"kworker/u48:37", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>182312, "next_prio"=>120, "runq_latency_ns"=>2321, "wakeup_tracked"=>true}]
[41] ebpf.0: [[1781585661.192318677, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>4156, "wakeup_tracked"=>true}]
[42] ebpf.0: [[1781585661.192462993, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>3552, "wakeup_tracked"=>true}]
[43] ebpf.0: [[1781585661.192600763, {}], {"event_type"=>"sched", "pid"=>182312, "tid"=>182312, "comm"=>"kworker/u48:37", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>182312, "next_prio"=>120, "runq_latency_ns"=>2775, "wakeup_tracked"=>true}]
[44] ebpf.0: [[1781585661.192736946, {}], {"event_type"=>"sched", "pid"=>3905, "tid"=>3905, "comm"=>"gnome-terminal-", "cpu"=>5, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>3905, "next_prio"=>120, "runq_latency_ns"=>4560, "wakeup_tracked"=>true}]
[45] ebpf.0: [[1781585661.192879801, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>16451, "wakeup_tracked"=>true}]
[46] ebpf.0: [[1781585661.193014721, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>6270, "wakeup_tracked"=>true}]
[47] ebpf.0: [[1781585661.193155737, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>9536, "wakeup_tracked"=>true}]
[48] ebpf.0: [[1781585661.193288763, {}], {"event_type"=>"sched", "pid"=>17, "tid"=>17, "comm"=>"rcu_preempt", "cpu"=>6, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>17, "next_prio"=>120, "runq_latency_ns"=>8038, "wakeup_tracked"=>true}]
[49] ebpf.0: [[1781585661.193427863, {}], {"event_type"=>"sched", "pid"=>31, "tid"=>31, "comm"=>"migration/4", "cpu"=>4, "prev_pid"=>2914, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>31, "next_prio"=>0, "runq_latency_ns"=>3595, "wakeup_tracked"=>true}]
[50] ebpf.0: [[1781585661.193577381, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2914, "comm"=>"gnome-shell", "cpu"=>0, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>120, "runq_latency_ns"=>0, "wakeup_tracked"=>false}]
[51] ebpf.0: [[1781585661.193720766, {}], {"event_type"=>"sched", "pid"=>2914, "tid"=>2948, "comm"=>"KMS thread", "cpu"=>3, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>2914, "next_prio"=>79, "runq_latency_ns"=>3313, "wakeup_tracked"=>true}]
[52] ebpf.0: [[1781585661.193866135, {}], {"event_type"=>"sched", "pid"=>25, "tid"=>25, "comm"=>"migration/2", "cpu"=>2, "prev_pid"=>191058, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>25, "next_prio"=>0, "runq_latency_ns"=>3542, "wakeup_tracked"=>true}]
[53] ebpf.0: [[1781585661.193998853, {}], {"event_type"=>"sched", "pid"=>191057, "tid"=>191058, "comm"=>"flb-pipeline", "cpu"=>4, "prev_pid"=>0, "prev_prio"=>120, "prev_state"=>0, "next_pid"=>191057, "next_prio"=>120, "runq_latency_ns"=>0, "wakeup_tracked"=>false}]
<snip>
[2026/06/16 13:54:22.272] [debug] [out flush] cb_destroy coro_id=0
[2026/06/16 13:54:22.280] [debug] [task] destroy task=0x7a62b90 (task_id=0)
^C[2026/06/16 13:54:22] [engine] caught signal (SIGINT)
[2026/06/16 13:54:22.688] [debug] [task] created task=0x6683e80 id=0 OK
[2026/06/16 13:54:22.689] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/16 13:54:22.689] [ warn] [engine] service will shutdown in max 5 seconds
[2026/06/16 13:54:22.690] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/06/16 13:54:22.690] [ info] [engine] pausing all inputs..
[2026/06/16 13:54:22.691] [ info] [input] pausing ebpf.0
[2026/06/16 13:54:22.693] [debug] [input:ebpf:ebpf.0] collector paused
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==191057== 
==191057== HEAP SUMMARY:
==191057==     in use at exit: 0 bytes in 0 blocks
==191057==   total heap usage: 12,965 allocs, 12,965 frees, 47,959,419 bytes allocated
==191057== 
==191057== All heap blocks were freed -- no leaks are possible
==191057== 
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduler trace support for capturing scheduling transitions, including CPU context, previous/next process metadata, and run-queue latency derived from wakeup timing.
  * Extended the unified event schema with a new scheduler (`sched`) event type and payload fields, and improved string rendering for the scheduler event type.
* **Tests**
  * Added runtime coverage to verify scheduler event encoding and decoding, including validation of scheduler-specific fields (event type, CPU, PIDs, and run-queue latency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->