### PR TITLE
engine: ignore duplicate STOP to prevent shutdown spin

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -688,6 +688,16 @@ static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
     /* Flush all remaining data */
     if (type == 1) {                  /* Engine type */
         if (key == FLB_ENGINE_STOP) {
+            /*
+             * Re-entering the STOP handler in flb_engine_start() would reset
+             * config->event_shutdown.status while the shutdown timerfd is
+             * still registered, so the dispatcher drops the timer and the
+             * pipeline thread busy-loops on epoll.
+             */
+            if (config->is_shutting_down) {
+                flb_debug("[engine] duplicate STOP ignored");
+                return 0;
+            }
             flb_trace("[engine] flush enqueued data");
             flb_engine_flush(config, NULL);
             return FLB_ENGINE_STOP;

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -27,6 +27,10 @@ endmacro()
 FLB_RT_CORE_TEST(FLB_COROUTINE_TIMEOUT    "core-timeout.c")
 FLB_RT_CORE_TEST(FLB_INTERNAL_LOGGER      "core_internal_logger.c")
 FLB_RT_CORE_TEST(FLB_DOWNSTREAM_ACCEPT_TIMEOUT "core_accept_timeout.c")
+# Uses POSIX alarm()/sigaction() for a watchdog; skip on Windows.
+if(NOT FLB_SYSTEM_WINDOWS)
+  FLB_RT_CORE_TEST(FLB_CORE_SHUTDOWN_SPIN   "core_shutdown_spin.c")
+endif()
 FLB_RT_CORE_TEST(1 "http_client_chunked.c")
 
 FLB_RT_TEST(FLB_CHUNK_TRACE "core_chunk_trace.c")

--- a/tests/runtime/core_shutdown_spin.c
+++ b/tests/runtime/core_shutdown_spin.c
@@ -1,0 +1,110 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_engine.h>
+#include <signal.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "flb_tests_runtime.h"
+
+#define SHUTDOWN_TIME_LIMIT_SEC 5   /* grace=2 + safety margin */
+#define SHUTDOWN_WATCHDOG_SEC   10
+
+/* Async-signal-safe abort used when flb_stop() hangs on a regression. */
+static void timeout_abort(int sig)
+{
+    static const char msg[] =
+        "\nFAIL: flb_test_duplicate_stop_no_spin timed out; "
+        "shutdown spin regression likely present.\n";
+    (void) sig;
+    (void) write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    _exit(1);
+}
+
+/* Regression: two back-to-back STOPs must not cause a shutdown busy-loop. */
+void flb_test_duplicate_stop_no_spin(void)
+{
+    flb_ctx_t        *ctx;
+    int               in_ffd;
+    int               out_ffd;
+    int64_t           ret;
+    time_t            start;
+    time_t            elapsed;
+    struct sigaction  sa;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    TEST_CHECK(flb_service_set(ctx,
+                               "Flush",     "1",
+                               "Grace",     "2",
+                               "Log_Level", "info",
+                               NULL) == 0);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    TEST_CHECK(flb_input_set(ctx, in_ffd, "tag", "test", NULL) == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "*", NULL) == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret == 0, "starting engine");
+
+    /* Let the engine enter its main event loop. */
+    sleep(1);
+
+    TEST_CHECK(flb_engine_exit(ctx->config) >= 0);
+
+    /* Let the first STOP be processed before the second arrives. */
+    usleep(100 * 1000);
+
+    TEST_CHECK(flb_engine_exit(ctx->config) >= 0);
+
+    /* Bound flb_stop() so a regression fails fast. */
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = timeout_abort;
+    sigaction(SIGALRM, &sa, NULL);
+    alarm(SHUTDOWN_WATCHDOG_SEC);
+
+    start = time(NULL);
+    ret = flb_stop(ctx);
+    elapsed = time(NULL) - start;
+
+    alarm(0);
+
+    TEST_CHECK_(ret == 0, "flb_stop returned %lld", (long long) ret);
+    TEST_CHECK_(elapsed <= SHUTDOWN_TIME_LIMIT_SEC,
+                "shutdown took %lds; expected <= %ds (shutdown spin?)",
+                (long) elapsed, SHUTDOWN_TIME_LIMIT_SEC);
+
+    if (ctx) {
+        flb_destroy(ctx);
+    }
+}
+
+/* Test list */
+TEST_LIST = {
+    {"duplicate_stop_no_spin", flb_test_duplicate_stop_no_spin},
+    {NULL, NULL}
+};


### PR DESCRIPTION
Fix a shutdown spin where duplicate `FLB_ENGINE_STOP` messages (e.g. an input plugin's internal `flb_engine_exit()` followed by an external SIGTERM, or any path that writes STOP twice to `ch_manager`) cause the pipeline thread to busy-loop at 100% CPU and the process fails to terminate.

The second STOP re-enters the handler block in `flb_engine_start()` and resets `config->event_shutdown->status` to `MK_EVENT_NONE` while the shutdown timerfd is still registered in epoll. The dispatcher then drops the timer event via the `status != MK_EVENT_NONE` guard in `flb_event_load_bucket_queue()`, but the level-triggered timerfd keeps reporting EPOLLIN — busy-loop, `grace_count` never advances, `flb_engine_shutdown()` unreachable.

Fix: swallow duplicate STOP at the `flb_engine_manager()` boundary when `config->is_shutting_down` is already set (first STOP sets it via `flb_engine_stop_ingestion()`). Periodic shutdown work (flush, task drain, grace counter) is already driven by the 1s tick in the `FLB_ENGINE_SHUTDOWN` branch, so swallowing the duplicate is safe.

I considered putting the guard at each `flb_engine_exit()` call site or inside `flb_engine_exit()` itself, but chose to place it in `flb_engine_manager()` for the following reasons. I'd be happy to move it if maintainers prefer a different layer.

- `flb_engine_exit()` has 12+ call sites (in_tail, in_exec, in_stdin, out_exit, filter_expect, flb_lib, winsvc, ...) that look like independent shutdown triggers, so a caller-side check looked prone to races: `config->is_shutting_down` is set by the engine loop rather than by `flb_engine_exit()`, so two producers could both observe `FALSE` and each send a STOP.
- The engine loop is a single-threaded consumer, which seemed like a natural serialization point to make STOP handling idempotent without introducing new locks or atomics.
- From what I can tell, the timerfd creation was already guarded (`if (shutdown_fd <= 0)`), so extending the same idempotency to the `event_shutdown` reset seemed consistent with that existing pattern.

Fixes #11744

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Shutdown timing race — not reproducible via configuration, so a regression test is included instead:

- `tests/runtime/core_shutdown_spin.c` reproduces the duplicate-STOP race via two back-to-back `flb_engine_exit()` calls and asserts `flb_stop()` returns within the grace period.
- A SIGALRM watchdog (10s) bounds the wait so the regression surfaces quickly instead of hanging for the 1500s CTest default.
- Verified: **PASS in ~1.9s with fix, FAIL in ~11s without fix** (watchdog fires).

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate shutdown handling to avoid a busy-loop or hang when stop/exit is triggered multiple times, ensuring graceful shutdown.

* **Tests**
  * Added a regression test (non-Windows) that verifies rapid consecutive stop/exit calls are handled without spinning and complete within a watchdog time limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->