### PR TITLE
pack: Use lowercase string for binary format string

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1346,6 +1346,11 @@ static int flb_pack_msgpack_binary_to_hex(msgpack_packer *pck, msgpack_object *o
     input = (const unsigned char *) obj->via.bin.ptr;
     hex_len = (size_t) obj->via.bin.size * 2;
 
+    if (hex_len == 0) {
+        msgpack_pack_str(pck, 0);
+        return 0;
+    }
+
     hex = flb_malloc(hex_len);
     if (!hex) {
         flb_errno();
@@ -1401,7 +1406,10 @@ static int flb_pack_msgpack_append_json_metadata(msgpack_packer *pck, msgpack_ob
                 if ((msgpack_object_eq_str(&nested_kv->key, "trace_id") ||
                      msgpack_object_eq_str(&nested_kv->key, "span_id")) &&
                     nested_kv->val.type == MSGPACK_OBJECT_BIN) {
-                    flb_pack_msgpack_binary_to_hex(pck, &nested_kv->val);
+                    if (flb_pack_msgpack_binary_to_hex(pck, &nested_kv->val) != 0) {
+                        /* keep the map well-formed if hex conversion fails */
+                        msgpack_pack_str(pck, 0);
+                    }
                 }
                 else {
                     msgpack_pack_object(pck, nested_kv->val);

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1317,6 +1317,109 @@ static int msgpack_pack_formatted_datetime(flb_sds_t out_buf, char time_formatte
     return 0;
 }
 
+static int msgpack_object_eq_str(msgpack_object *obj, const char *str)
+{
+    size_t len;
+
+    len = strlen(str);
+
+    if (obj->type != MSGPACK_OBJECT_STR || obj->via.str.size != len) {
+        return FLB_FALSE;
+    }
+
+    return (memcmp(obj->via.str.ptr, str, len) == 0);
+}
+
+static int flb_pack_msgpack_binary_to_hex(msgpack_packer *pck, msgpack_object *obj)
+{
+    uint32_t index;
+    uint8_t byte;
+    char *hex;
+    static const char table[] = "0123456789abcdef";
+    const unsigned char *input;
+    size_t hex_len;
+
+    if (obj->type != MSGPACK_OBJECT_BIN) {
+        return -1;
+    }
+
+    input = (const unsigned char *) obj->via.bin.ptr;
+    hex_len = (size_t) obj->via.bin.size * 2;
+
+    hex = flb_malloc(hex_len);
+    if (!hex) {
+        flb_errno();
+        return -1;
+    }
+
+    for (index = 0; index < obj->via.bin.size; index++) {
+        byte = input[index];
+        hex[index * 2]     = table[(byte >> 4) & 0x0f];
+        hex[index * 2 + 1] = table[byte & 0x0f];
+    }
+
+    msgpack_pack_str(pck, hex_len);
+    msgpack_pack_str_body(pck, hex, hex_len);
+
+    flb_free(hex);
+    return 0;
+}
+
+static int flb_pack_msgpack_append_json_metadata(msgpack_packer *pck, msgpack_object *metadata)
+{
+    int index;
+    int nested_index;
+    msgpack_object_kv *kv;
+    msgpack_object_kv *nested_kv;
+    msgpack_object *value;
+    struct flb_mp_map_header metadata_mh;
+    struct flb_mp_map_header otlp_mh;
+
+    if (metadata == NULL || metadata->type != MSGPACK_OBJECT_MAP) {
+        return -1;
+    }
+
+    flb_mp_map_header_init(&metadata_mh, pck);
+
+    for (index = 0; index < metadata->via.map.size; index++) {
+        kv = &metadata->via.map.ptr[index];
+        value = &kv->val;
+
+        flb_mp_map_header_append(&metadata_mh);
+        msgpack_pack_object(pck, kv->key);
+
+        if (msgpack_object_eq_str(&kv->key, "otlp") &&
+            value->type == MSGPACK_OBJECT_MAP) {
+            flb_mp_map_header_init(&otlp_mh, pck);
+
+            for (nested_index = 0; nested_index < value->via.map.size; nested_index++) {
+                nested_kv = &value->via.map.ptr[nested_index];
+
+                flb_mp_map_header_append(&otlp_mh);
+                msgpack_pack_object(pck, nested_kv->key);
+
+                if ((msgpack_object_eq_str(&nested_kv->key, "trace_id") ||
+                     msgpack_object_eq_str(&nested_kv->key, "span_id")) &&
+                    nested_kv->val.type == MSGPACK_OBJECT_BIN) {
+                    flb_pack_msgpack_binary_to_hex(pck, &nested_kv->val);
+                }
+                else {
+                    msgpack_pack_object(pck, nested_kv->val);
+                }
+            }
+
+            flb_mp_map_header_end(&otlp_mh);
+        }
+        else {
+            msgpack_pack_object(pck, *value);
+        }
+    }
+
+    flb_mp_map_header_end(&metadata_mh);
+
+    return 0;
+}
+
 flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
                                           int json_format, int date_format,
                                           flb_sds_t date_key, int escape_unicode)
@@ -1467,7 +1570,12 @@ flb_sds_t flb_pack_msgpack_to_json_format(const char *data, uint64_t bytes,
                 flb_mp_map_header_append(&mh_internal);
                 msgpack_pack_str(&tmp_pck, 12);
                 msgpack_pack_str_body(&tmp_pck, "log_metadata", 12);
-                msgpack_pack_object(&tmp_pck, *log_event.metadata);
+                if (log_event.metadata->type == MSGPACK_OBJECT_MAP) {
+                    flb_pack_msgpack_append_json_metadata(&tmp_pck, log_event.metadata);
+                }
+                else {
+                    msgpack_pack_object(&tmp_pck, *log_event.metadata);
+                }
             }
 
             /* finalize the internal map */

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -644,6 +644,54 @@ def test_in_opentelemetry_stdout_otlp_json_logs():
     assert records[0]["resource_attributes"]["service.name"] == "example-service"
 
 
+def test_in_opentelemetry_stdout_otlp_json_logs_preserve_trace_and_span_id_hex():
+    service = Service("003-stdout-otlp-json.yaml")
+    service.start()
+
+    payload = {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "my.service"}}
+                    ]
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {"name": "my.library", "version": "1.0.0"},
+                        "logRecords": [
+                            {
+                                "timeUnixNano": "1774877764000000000",
+                                "observedTimeUnixNano": "1774877764000000000",
+                                "severityNumber": 2,
+                                "severityText": "INFO",
+                                "traceId": "c413d5b5fea3657325ff663320c7fd10",
+                                "spanId": "77651bbd5ce0ce99",
+                                "body": {"stringValue": "trace/span id repro payload"},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    response = service.send_raw_request(
+        "/v1/logs",
+        json.dumps(payload).encode("utf-8"),
+        content_type="application/json",
+    )
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceLogs")
+    service.stop()
+
+    records = list(iter_log_records(output))
+    assert len(records) >= 1
+    assert records[0]["record"]["traceId"] == "c413d5b5fea3657325ff663320c7fd10"
+    assert records[0]["record"]["spanId"] == "77651bbd5ce0ce99"
+
+
 def test_in_opentelemetry_stdout_otlp_json_metrics():
     service = Service("003-stdout-otlp-json.yaml")
     service.start()

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -5,6 +5,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_pack_json.h>
 #include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_log_event_encoder.h>
 #include <fluent-bit/flb_str.h>
 #include <monkey/mk_core.h>
 
@@ -1287,6 +1288,68 @@ void test_json_pack_token_count_overflow()
     flb_pack_state_reset(&state);
 }
 
+void test_json_otlp_trace_span_id_hex_encoding()
+{
+    int ret;
+    char trace_id[] = {
+        '\xc4', '\x13', '\xd5', '\xb5', '\xfe', '\xa3', '\x65', '\x73',
+        '\x25', '\xff', '\x66', '\x33', '\x20', '\xc7', '\xfd', '\x10'
+    };
+    char span_id[] = {
+        '\x77', '\x65', '\x1b', '\xbd', '\x5c', '\xe0', '\xce', '\x99'
+    };
+    flb_sds_t json;
+    struct flb_log_event_encoder encoder;
+
+    ret = flb_log_event_encoder_init(&encoder, FLB_LOG_EVENT_FORMAT_FLUENT_BIT_V2);
+    if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+        TEST_MSG("flb_log_event_encoder_init failed");
+        return;
+    }
+
+    ret = flb_log_event_encoder_begin_record(&encoder);
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+    ret = flb_log_event_encoder_set_current_timestamp(&encoder);
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+
+    ret = flb_log_event_encoder_append_metadata_values(&encoder,
+                                                       FLB_LOG_EVENT_CSTRING_VALUE("otlp"));
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+    ret = flb_log_event_encoder_begin_map(&encoder, FLB_LOG_EVENT_METADATA);
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+
+    ret = flb_log_event_encoder_append_metadata_values(&encoder,
+                                                       FLB_LOG_EVENT_CSTRING_VALUE("trace_id"),
+                                                       FLB_LOG_EVENT_BINARY_VALUE(trace_id, 16),
+                                                       FLB_LOG_EVENT_CSTRING_VALUE("span_id"),
+                                                       FLB_LOG_EVENT_BINARY_VALUE(span_id, 8));
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+
+    ret = flb_log_event_encoder_commit_map(&encoder, FLB_LOG_EVENT_METADATA);
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+
+    ret = flb_log_event_encoder_append_body_values(&encoder,
+                                                   FLB_LOG_EVENT_CSTRING_VALUE("message"),
+                                                   FLB_LOG_EVENT_CSTRING_VALUE("test"));
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+
+    ret = flb_log_event_encoder_commit_record(&encoder);
+    TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS);
+
+    json = flb_pack_msgpack_to_json_format((char *) encoder.output_buffer,
+                                           encoder.output_length,
+                                           FLB_PACK_JSON_FORMAT_LINES,
+                                           FLB_PACK_JSON_DATE_DOUBLE,
+                                           NULL,
+                                           FLB_TRUE);
+    TEST_CHECK(json != NULL);
+    TEST_CHECK(strstr(json, "\"trace_id\":\"c413d5b5fea3657325ff663320c7fd10\"") != NULL);
+    TEST_CHECK(strstr(json, "\"span_id\":\"77651bbd5ce0ce99\"") != NULL);
+
+    flb_sds_destroy(json);
+    flb_log_event_encoder_destroy(&encoder);
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "json_pack"          , test_json_pack },
@@ -1318,5 +1381,6 @@ TEST_LIST = {
     { "json_pack_surrogate_pairs", test_json_pack_surrogate_pairs},
     { "json_pack_surrogate_pairs_with_replacement", test_json_pack_surrogate_pairs_with_replacement},
     { "json_pack_token_count_overflow", test_json_pack_token_count_overflow},
+    { "json_otlp_trace_span_id_hex_encoding", test_json_otlp_trace_span_id_hex_encoding},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
For human readable encoding, we need to encode trace_id and span_id for sending as JSON payloads.
Without this hex encoding, we have to handle binary tofu-ed character to search relative traces and logs.

So, we need to use hex format encoding before sending as JSON.
For just peek the contents of otel's payloads, we don't need do that.

Closes https://github.com/fluent/fluent-bit/issues/11630.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry: when present in log metadata, trace_id and span_id are emitted as lowercase hexadecimal strings in JSON logs (preserving other metadata entries).

* **Tests**
  * Added an integration test validating OTLP JSON logs retain hex trace and span IDs.
  * Added a unit test verifying metadata trace/span ID hex encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->