### PR TITLE
in_tail: reconcile files after missed inotify events

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -169,6 +169,18 @@ int flb_tail_file_offset_marker_matches(struct flb_tail_file *file)
     return FLB_TRUE;
 }
 
+static void update_resumable_offset_state(struct flb_tail_file *file)
+{
+#ifdef FLB_HAVE_SQLDB
+    if (file->config->db) {
+        flb_tail_db_file_offset(file, file->config);
+        return;
+    }
+#endif
+
+    flb_tail_file_update_offset_marker(file);
+}
+
 static uint64_t stat_get_st_dev(struct stat *st)
 {
 #ifdef FLB_SYSTEM_WINDOWS
@@ -1705,12 +1717,7 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
         file->offset = offset;
         file->buf_len = 0;
 
-        /* Update offset in the database file */
-#ifdef FLB_HAVE_SQLDB
-        if (ctx->db) {
-            flb_tail_db_file_offset(file, ctx);
-        }
-#endif
+        update_resumable_offset_state(file);
     }
     else {
         // Avoid negative pending_bytes when fstat() has stale data and size < offset
@@ -1766,11 +1773,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
                 file->buf_len -= processed_bytes;
                 file->buf_data[file->buf_len] = '\0';
 
-#ifdef FLB_HAVE_SQLDB
-                if (file->config->db) {
-                    flb_tail_db_file_offset(file, file->config);
-                }
-#endif
+                update_resumable_offset_state(file);
                 return adjust_counters(ctx, file);
             }
         }
@@ -1954,11 +1957,7 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
         file->buf_len -= processed_bytes;
         file->buf_data[file->buf_len] = '\0';
 
-#ifdef FLB_HAVE_SQLDB
-        if (file->config->db) {
-            flb_tail_db_file_offset(file, file->config);
-        }
-#endif
+        update_resumable_offset_state(file);
 
         /* adjust file counters, returns FLB_TAIL_OK or FLB_TAIL_ERROR */
         ret = adjust_counters(ctx, file);

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -181,6 +181,32 @@ static void update_resumable_offset_state(struct flb_tail_file *file)
     flb_tail_file_update_offset_marker(file);
 }
 
+int flb_tail_file_reset_on_truncate(struct flb_tail_file *file,
+                                    int64_t size_delta,
+                                    const char *caller)
+{
+    int64_t offset;
+    struct flb_tail_config *ctx = file->config;
+
+    offset = lseek(file->fd, 0, SEEK_SET);
+    if (offset == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    flb_plg_debug(ctx->ins,
+                  "%s: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
+                  caller, file->inode, file->name, size_delta);
+
+    file->offset = offset;
+    file->stream_offset = offset;
+    file->last_processed_bytes = 0;
+    file->buf_len = 0;
+
+    update_resumable_offset_state(file);
+    return 0;
+}
+
 static uint64_t stat_get_st_dev(struct stat *st)
 {
 #ifdef FLB_SYSTEM_WINDOWS
@@ -1690,8 +1716,9 @@ int flb_tail_file_remove_all(struct flb_tail_config *ctx)
 static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *file)
 {
     int ret;
-    int64_t offset;
     struct stat st;
+
+    (void) ctx;
 
     ret = fstat(file->fd, &st);
     if (ret == -1) {
@@ -1706,18 +1733,10 @@ static int adjust_counters(struct flb_tail_config *ctx, struct flb_tail_file *fi
 
     /* Check if the file was truncated by comparing current size with previous size */
     if (size_delta < 0) {
-        offset = lseek(file->fd, 0, SEEK_SET);
-        if (offset == -1) {
-            flb_errno();
+        if (flb_tail_file_reset_on_truncate(file, size_delta,
+                                            "adjust_counters") == -1) {
             return FLB_TAIL_ERROR;
         }
-
-        flb_plg_debug(ctx->ins, "adjust_counters: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
-                      file->inode, file->name, size_delta);
-        file->offset = offset;
-        file->buf_len = 0;
-
-        update_resumable_offset_state(file);
     }
     else {
         // Avoid negative pending_bytes when fstat() has stale data and size < offset

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -155,5 +155,8 @@ static inline off_t flb_tail_file_db_offset(struct flb_tail_file *file)
 
 int flb_tail_file_update_offset_marker(struct flb_tail_file *file);
 int flb_tail_file_offset_marker_matches(struct flb_tail_file *file);
+int flb_tail_file_reset_on_truncate(struct flb_tail_file *file,
+                                    int64_t size_delta,
+                                    const char *caller);
 
 #endif

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -31,6 +31,7 @@
 #include "tail_config.h"
 #include "tail_file.h"
 #include "tail_db.h"
+#include "tail_scan.h"
 #include "tail_signal.h"
 
 #include <limits.h>
@@ -163,22 +164,177 @@ static int flb_tail_fs_add_rotated(struct flb_tail_file *file)
     return tail_fs_add(file, FLB_FALSE);
 }
 
+static int reset_file_on_truncate(struct flb_tail_config *ctx,
+                                  struct flb_tail_file *file,
+                                  int64_t size_delta,
+                                  const char *caller)
+{
+    int64_t offset;
+
+    offset = lseek(file->fd, 0, SEEK_SET);
+    if (offset == -1) {
+        flb_errno();
+        return -1;
+    }
+
+    flb_plg_debug(ctx->ins,
+                  "%s: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
+                  caller, file->inode, file->name, size_delta);
+
+    file->offset = offset;
+    file->stream_offset = offset;
+    file->last_processed_bytes = 0;
+    file->buf_len = 0;
+    file->pending_bytes = file->size;
+
+#ifdef FLB_HAVE_SQLDB
+    if (ctx->db) {
+        flb_tail_db_file_offset(file, ctx);
+    }
+#endif
+
+    return 0;
+}
+
+static int reconcile_file_state(struct flb_tail_config *ctx,
+                                struct flb_tail_file *file,
+                                const char *caller,
+                                int *pending_data_detected)
+{
+    int ret;
+    int64_t size_delta;
+    struct stat st;
+
+    *pending_data_detected = FLB_FALSE;
+
+    ret = fstat(file->fd, &st);
+    if (ret == -1) {
+        flb_plg_debug(ctx->ins, "inode=%"PRIu64" error stat(2) %s, removing",
+                      file->inode, file->name);
+        flb_tail_file_remove(file);
+        return -1;
+    }
+
+    size_delta = st.st_size - file->size;
+    if (size_delta != 0) {
+        file->size = st.st_size;
+    }
+
+    if (size_delta < 0 || st.st_size < file->offset ||
+        flb_tail_file_offset_marker_matches(file) != FLB_TRUE) {
+        ret = reset_file_on_truncate(ctx, file, size_delta, caller);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
+    if (file->offset < st.st_size) {
+        file->pending_bytes = (st.st_size - file->offset);
+        *pending_data_detected = FLB_TRUE;
+    }
+    else {
+        file->pending_bytes = 0;
+    }
+
+    if (st.st_nlink == 0) {
+        if (*pending_data_detected == FLB_TRUE) {
+            return 0;
+        }
+
+        if (file->buf_len > 0) {
+            return 0;
+        }
+
+        flb_plg_debug(ctx->ins, "inode=%"PRIu64" file has been deleted: %s",
+                      file->inode, file->name);
+
+#ifdef FLB_HAVE_SQLDB
+        if (ctx->db) {
+            flb_tail_db_file_delete(file, ctx);
+        }
+#endif
+        flb_tail_file_remove(file);
+        return -1;
+    }
+
+    ret = flb_tail_file_is_rotated(ctx, file);
+    if (ret == FLB_TRUE) {
+        ret = flb_tail_file_rotated(file);
+        if (ret == -1) {
+            return -1;
+        }
+
+        ret = flb_tail_fs_remove(ctx, file);
+        if (ret == -1) {
+            return -1;
+        }
+
+        ret = flb_tail_fs_add_rotated(file);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    else if (ret == -1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int reconcile_all_files(struct flb_tail_config *ctx)
+{
+    int ret;
+    int pending;
+    int pending_data_detected;
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct flb_tail_file *file;
+
+    pending_data_detected = FLB_FALSE;
+
+    mk_list_foreach_safe(head, tmp, &ctx->files_event) {
+        file = mk_list_entry(head, struct flb_tail_file, _head);
+        ret = reconcile_file_state(ctx, file, "inotify_reconcile", &pending);
+        if (ret == -1) {
+            continue;
+        }
+
+        if (pending == FLB_TRUE) {
+            pending_data_detected = FLB_TRUE;
+        }
+    }
+
+    if (pending_data_detected == FLB_TRUE) {
+        tail_signal_pending(ctx);
+    }
+
+    return pending_data_detected;
+}
+
 static int tail_fs_event(struct flb_input_instance *ins,
                          struct flb_config *config, void *in_context)
 {
     int ret;
-    int64_t offset;
     struct mk_list *head;
     struct mk_list *tmp;
     struct flb_tail_config *ctx = in_context;
     struct flb_tail_file *file = NULL;
     struct inotify_event ev;
-    struct stat st;
+    int pending_data_detected;
 
     /* Read the event */
     ret = read(ctx->fd_notify, &ev, sizeof(struct inotify_event));
     if (ret < 1) {
         return -1;
+    }
+
+    if (ev.mask & IN_Q_OVERFLOW) {
+        debug_event_mask(ctx, NULL, ev.mask);
+        flb_plg_warn(ctx->ins, "inotify event queue overflow, reconciling files");
+
+        reconcile_all_files(ctx);
+        flb_tail_scan(ctx->path_list, ctx);
+        return 0;
     }
 
     /* Lookup watched file */
@@ -210,71 +366,25 @@ static int tail_fs_event(struct flb_input_instance *ins,
                       file->inode, file->name);
 
         /* A rotated file must be re-registered */
-        flb_tail_file_rotated(file);
-        flb_tail_fs_remove(ctx, file);
-        flb_tail_fs_add_rotated(file);
+        ret = flb_tail_file_rotated(file);
+        if (ret == -1) {
+            return -1;
+        }
+
+        ret = flb_tail_fs_remove(ctx, file);
+        if (ret == -1) {
+            return -1;
+        }
+
+        ret = flb_tail_fs_add_rotated(file);
+        if (ret == -1) {
+            return -1;
+        }
     }
 
-    ret = fstat(file->fd, &st);
+    ret = reconcile_file_state(ctx, file, "tail_fs_event", &pending_data_detected);
     if (ret == -1) {
-        flb_plg_debug(ins, "inode=%"PRIu64" error stat(2) %s, removing",
-                      file->inode, file->name);
-        flb_tail_file_remove(file);
         return 0;
-    }
-
-    /* Check if the file was truncated */
-    int64_t size_delta = st.st_size - file->size;
-    if (size_delta != 0) {
-        file->size = st.st_size;
-    }
-
-    file->pending_bytes = (st.st_size > file->offset) ? (st.st_size - file->offset) : 0;
-
-    /* File was removed ? */
-    if (ev.mask & IN_ATTRIB) {
-        /* Check if the file have been deleted */
-        if (st.st_nlink == 0) {
-            flb_plg_debug(ins, "inode=%"PRIu64" file has been deleted: %s",
-                          file->inode, file->name);
-
-#ifdef FLB_HAVE_SQLDB
-            if (ctx->db) {
-                /* Remove file entry from the database */
-                flb_tail_db_file_delete(file, ctx);
-            }
-#endif
-            /* Remove file from the monitored list */
-            flb_tail_file_remove(file);
-            return 0;
-        }
-    }
-
-    if (ev.mask & IN_MODIFY) {
-        /*
-         * The file was modified, check how many new bytes do
-         * we have.
-         */
-
-        if (size_delta < 0) {
-            offset = lseek(file->fd, 0, SEEK_SET);
-            if (offset == -1) {
-                flb_errno();
-                return -1;
-            }
-
-            flb_plg_debug(ctx->ins, "tail_fs_event: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
-                          file->inode, file->name, size_delta);
-            file->offset = offset;
-            file->buf_len = 0;
-
-            /* Update offset in the database file */
-#ifdef FLB_HAVE_SQLDB
-            if (ctx->db) {
-                flb_tail_db_file_offset(file, ctx);
-            }
-#endif
-        }
     }
 
     /* Collect the data */
@@ -307,44 +417,32 @@ static int in_tail_progress_check_callback(struct flb_input_instance *ins,
                                            struct flb_config *config, void *context)
 {
     int ret = 0;
+    int pending;
     struct mk_list *tmp;
     struct mk_list *head;
     struct flb_tail_config *ctx = context;
     struct flb_tail_file *file;
     int pending_data_detected;
-    struct stat st;
 
     (void) config;
+    (void) ins;
 
     pending_data_detected = FLB_FALSE;
 
     mk_list_foreach_safe(head, tmp, &ctx->files_event) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
-
-        if (file->offset < file->size) {
-            pending_data_detected = FLB_TRUE;
-
-            continue;
-        }
-
-        ret = fstat(file->fd, &st);
+        ret = reconcile_file_state(ctx, file, "in_tail_progress_check", &pending);
         if (ret == -1) {
-            flb_errno();
-            flb_plg_error(ins, "fstat error");
-
             continue;
         }
 
-        if (file->offset < st.st_size) {
-            file->size = st.st_size;
-            file->pending_bytes = (file->size - file->offset);
-
+        if (pending == FLB_TRUE) {
             pending_data_detected = FLB_TRUE;
         }
     }
 
     if (pending_data_detected) {
-       tail_signal_pending(ctx);
+        tail_signal_pending(ctx);
     }
 
     return 0;

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -164,38 +164,6 @@ static int flb_tail_fs_add_rotated(struct flb_tail_file *file)
     return tail_fs_add(file, FLB_FALSE);
 }
 
-static int reset_file_on_truncate(struct flb_tail_config *ctx,
-                                  struct flb_tail_file *file,
-                                  int64_t size_delta,
-                                  const char *caller)
-{
-    int64_t offset;
-
-    offset = lseek(file->fd, 0, SEEK_SET);
-    if (offset == -1) {
-        flb_errno();
-        return -1;
-    }
-
-    flb_plg_debug(ctx->ins,
-                  "%s: inode=%"PRIu64" file truncated %s (diff: %"PRId64" bytes)",
-                  caller, file->inode, file->name, size_delta);
-
-    file->offset = offset;
-    file->stream_offset = offset;
-    file->last_processed_bytes = 0;
-    file->buf_len = 0;
-    file->pending_bytes = file->size;
-
-#ifdef FLB_HAVE_SQLDB
-    if (ctx->db) {
-        flb_tail_db_file_offset(file, ctx);
-    }
-#endif
-
-    return 0;
-}
-
 static int reconcile_file_state(struct flb_tail_config *ctx,
                                 struct flb_tail_file *file,
                                 const char *caller,
@@ -205,7 +173,9 @@ static int reconcile_file_state(struct flb_tail_config *ctx,
     int64_t size_delta;
     struct stat st;
 
-    *pending_data_detected = FLB_FALSE;
+    if (pending_data_detected != NULL) {
+        *pending_data_detected = FLB_FALSE;
+    }
 
     ret = fstat(file->fd, &st);
     if (ret == -1) {
@@ -222,7 +192,7 @@ static int reconcile_file_state(struct flb_tail_config *ctx,
 
     if (size_delta < 0 || st.st_size < file->offset ||
         flb_tail_file_offset_marker_matches(file) != FLB_TRUE) {
-        ret = reset_file_on_truncate(ctx, file, size_delta, caller);
+        ret = flb_tail_file_reset_on_truncate(file, size_delta, caller);
         if (ret == -1) {
             return -1;
         }
@@ -230,14 +200,16 @@ static int reconcile_file_state(struct flb_tail_config *ctx,
 
     if (file->offset < st.st_size) {
         file->pending_bytes = (st.st_size - file->offset);
-        *pending_data_detected = FLB_TRUE;
+        if (pending_data_detected != NULL) {
+            *pending_data_detected = FLB_TRUE;
+        }
     }
     else {
         file->pending_bytes = 0;
     }
 
     if (st.st_nlink == 0) {
-        if (*pending_data_detected == FLB_TRUE) {
+        if (file->pending_bytes > 0) {
             return 0;
         }
 
@@ -268,14 +240,16 @@ static int reconcile_file_state(struct flb_tail_config *ctx,
         if (ret == -1) {
             return -1;
         }
+    }
+    else if (ret == -1) {
+        return -1;
+    }
 
+    if (file->rotated != 0 && file->watch_fd == -1) {
         ret = flb_tail_fs_add_rotated(file);
         if (ret == -1) {
             return -1;
         }
-    }
-    else if (ret == -1) {
-        return -1;
     }
 
     return 0;
@@ -320,7 +294,8 @@ static int tail_fs_event(struct flb_input_instance *ins,
     struct flb_tail_config *ctx = in_context;
     struct flb_tail_file *file = NULL;
     struct inotify_event ev;
-    int pending_data_detected;
+
+    (void) ins;
 
     /* Read the event */
     ret = read(ctx->fd_notify, &ev, sizeof(struct inotify_event));
@@ -360,29 +335,12 @@ static int tail_fs_event(struct flb_input_instance *ins,
         return -1;
     }
 
-    /* Check file rotation (only if it has not been rotated before) */
-    if (ev.mask & IN_MOVE_SELF && file->rotated == 0) {
-        flb_plg_debug(ins, "inode=%"PRIu64" rotated IN_MOVE SELF '%s'",
-                      file->inode, file->name);
-
-        /* A rotated file must be re-registered */
-        ret = flb_tail_file_rotated(file);
-        if (ret == -1) {
-            return -1;
-        }
-
-        ret = flb_tail_fs_remove(ctx, file);
-        if (ret == -1) {
-            return -1;
-        }
-
-        ret = flb_tail_fs_add_rotated(file);
-        if (ret == -1) {
-            return -1;
-        }
-    }
-
-    ret = reconcile_file_state(ctx, file, "tail_fs_event", &pending_data_detected);
+    /*
+     * IN_MOVE_SELF rotation is handled inside reconcile_file_state via
+     * flb_tail_file_is_rotated, which detects the inode/name divergence and
+     * re-registers the watch through the same retry path.
+     */
+    ret = reconcile_file_state(ctx, file, "tail_fs_event", NULL);
     if (ret == -1) {
         return 0;
     }

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -400,7 +400,7 @@ static int in_tail_progress_check_callback(struct flb_input_instance *ins,
     }
 
     if (pending_data_detected) {
-        tail_signal_pending(ctx);
+       tail_signal_pending(ctx);
     }
 
     return 0;


### PR DESCRIPTION
This makes the inotify tail backend recover from missed events instead of waiting for the next modify event to happen to the same file. That matters when the inotify queue overflows, or when a truncate/copytruncate/delete/rotation event is missed while a file still has readable data.

What changed:

- handle `IN_Q_OVERFLOW` by reconciling tracked files and rescanning paths
- share truncate, delete, rotation, and pending-byte checks through one reconcile helper
- catch missed truncate/copytruncate during progress checks, not only on `IN_MODIFY`
- keep unlinked files around while they still have pending or buffered bytes
- use the no-DB offset marker path so copytruncate detection still works without a SQL DB
- return watch re-registration failures instead of ignoring them

Testing:

- Linux Docker build: `cmake -S . -B /build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On -DFLB_EXAMPLES=Off && cmake --build /build --target fluent-bit-bin -j"$(nproc)"`
- Linux Docker normal integration: `FLUENT_BIT_BINARY=/build/bin/fluent-bit /tmp/flb-it-venv/bin/python -m pytest tests/integration/scenarios/in_tail/tests/test_in_tail_001.py -q -k "copytruncate_with_stale_writer or follows_rename_rotation or handles_multiple_rename_rotations or multi_file_rapid_rotation or rotate_wait_keeps_old_inode_then_purges_it"`
- Linux Docker valgrind integration: `FLUENT_BIT_BINARY=/build/bin/fluent-bit VALGRIND=1 VALGRIND_STRICT=1 /tmp/flb-it-venv/bin/python -m pytest tests/integration/scenarios/in_tail/tests/test_in_tail_001.py -q -k "copytruncate_with_stale_writer or follows_rename_rotation or handles_multiple_rename_rotations or multi_file_rapid_rotation or rotate_wait_keeps_old_inode_then_purges_it"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized resumable-offset persistence for consistent progress tracking.
  * Consolidated truncate-recovery into a single reusable routine for clearer behavior.
  * Reworked event handling to use a shared reconciliation path for file state and rotation management.

* **Bug Fixes**
  * Overflow events now trigger full reconciliation to avoid missed activity.
  * More reliable detection and cleanup of deleted/rotated files and pending-data accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->