### PR TITLE
in_dummy: Use pre_run callback to fix crash path

### DIFF
--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -446,10 +446,6 @@ static int in_dummy_init(struct flb_input_instance *in,
 
     flb_input_set_context(in, ctx);
 
-    if (ctx->flush_on_startup) {
-        in_dummy_collect(in, config, ctx);
-    }
-
     ret = flb_input_set_collector_time(in,
                                        in_dummy_collect,
                                        tm.tv_sec,
@@ -463,6 +459,20 @@ static int in_dummy_init(struct flb_input_instance *in,
     ctx->coll_fd = ret;
 
     flb_time_get(&ctx->base_timestamp);
+
+    return 0;
+}
+
+static int in_dummy_pre_run(struct flb_input_instance *in,
+                            struct flb_config *config, void *in_context)
+{
+    struct flb_dummy *ctx;
+
+    ctx = (struct flb_dummy *) in_context;
+
+    if (ctx != NULL && ctx->flush_on_startup) {
+        in_dummy_collect(in, config, in_context);
+    }
 
     return 0;
 }
@@ -570,7 +580,7 @@ struct flb_input_plugin in_dummy_plugin = {
     .name         = "dummy",
     .description  = "Generate dummy data",
     .cb_init      = in_dummy_init,
-    .cb_pre_run   = NULL,
+    .cb_pre_run   = in_dummy_pre_run,
     .cb_collect   = in_dummy_collect,
     .cb_flush_buf = NULL,
     .config_map   = config_map,

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -637,6 +637,70 @@ void flb_test_helloworld(void)
     flb_destroy(ctx);
 }
 
+void flb_test_dummy_flush_on_startup(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    record[\"check\"] = \"checkval\"\n"
+      "    return 2, timestamp, record\n"
+      "end\n";
+
+    clear_output();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
+
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "script", TMP_LUA_PATH,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "flush_on_startup", "true", NULL);
+    flb_input_set(ctx, in_ffd, "samples", "1", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    wait_with_timeout(2000, &output);
+    TEST_CHECK(output != NULL);
+    result = strstr(output, "\"check\":\"checkval\"");
+    TEST_CHECK(result != NULL);
+
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 // https://github.com/fluent/fluent-bit/issues/3343
 void flb_test_type_array_key(void)
 {
@@ -1614,6 +1678,7 @@ void flb_test_group_lua_drop(void)
 
 TEST_LIST = {
     {"hello_world",  flb_test_helloworld},
+    {"dummy_flush_on_startup", flb_test_dummy_flush_on_startup},
     {"append_tag",   flb_test_append_tag},
     {"type_int_key", flb_test_type_int_key},
     {"type_int_key_multi", flb_test_type_int_key_multi},


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed the root cause in dummy plugin. This ensures startup emissions on in_dummy with flush_on_startup=true do not cause SEGV crash.

Closes https://github.com/fluent/fluent-bit/issues/11751.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change

The previously repro and fixed SEGV config is:
https://github.com/fluent/fluent-bit/issues/11751#issue-4339019516


- [x] Debug log output from testing the change

```
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/04/28 15:17:50.365] [ info] Configuration:
[2026/04/28 15:17:50.365] [ info]  flush time     | 1.000000 seconds
[2026/04/28 15:17:50.365] [ info]  grace          | 5 seconds
[2026/04/28 15:17:50.365] [ info]  daemon         | 0
[2026/04/28 15:17:50.365] [ info] ___________
[2026/04/28 15:17:50.365] [ info]  inputs:
[2026/04/28 15:17:50.365] [ info]      dummy
[2026/04/28 15:17:50.365] [ info] ___________
[2026/04/28 15:17:50.365] [ info]  filters:
[2026/04/28 15:17:50.365] [ info]      lua.0
[2026/04/28 15:17:50.365] [ info] ___________
[2026/04/28 15:17:50.365] [ info]  outputs:
[2026/04/28 15:17:50.365] [ info]      stdout.0
[2026/04/28 15:17:50.365] [ info] ___________
[2026/04/28 15:17:50.365] [ info]  collectors:
[2026/04/28 15:17:50.365] [ info] [fluent bit] version=5.0.4, commit=8c0880a8d8, pid=89166
[2026/04/28 15:17:50.365] [debug] [engine] coroutine stack size: 36864 bytes (36.0K)
[2026/04/28 15:17:50.365] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/04/28 15:17:50.365] [ info] [simd    ] NEON
[2026/04/28 15:17:50.365] [ info] [cmetrics] version=2.1.2
[2026/04/28 15:17:50.365] [ info] [ctraces ] version=0.7.1
[2026/04/28 15:17:50.365] [ info] [input:dummy:dummy.0] initializing
[2026/04/28 15:17:50.365] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/04/28 15:17:50.365] [debug] [dummy:dummy.0] created event channels: read=21 write=22
[2026/04/28 15:17:50.366] [debug] [stdout:stdout.0] created event channels: read=23 write=24
[2026/04/28 15:17:50.366] [ info] [output:stdout:stdout.0] worker #0 started
[2026/04/28 15:17:50.366] [ info] [sp] stream processor started
[2026/04/28 15:17:50.366] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/04/28 15:17:51.370] [debug] [task] created task=0x105a0c080 id=0 OK
[2026/04/28 15:17:51.370] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.0: [[1777357070.366138000, {}], {"message"=>"dummy", "check"=>"checkval"}]
[2026/04/28 15:17:51.370] [debug] [out flush] cb_destroy coro_id=0
[2026/04/28 15:17:51.370] [debug] [task] destroy task=0x105a0c080 (task_id=0)
[2026/04/28 15:17:56.370] [debug] [task] created task=0x105a0c180 id=0 OK
[2026/04/28 15:17:56.370] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.0: [[1777357075.370458000, {}], {"message"=>"dummy", "check"=>"checkval"}]
[2026/04/28 15:17:56.370] [debug] [out flush] cb_destroy coro_id=1
[2026/04/28 15:17:56.370] [debug] [task] destroy task=0x105a0c180 (task_id=0)
^C[2026/04/28 15:17:56] [engine] caught signal (SIGINT)
[2026/04/28 15:17:56.861] [ info] [input] pausing dummy.0
[2026/04/28 15:17:56.861] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/04/28 15:17:56.861] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
Process 78573 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [78573]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x1042b8000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [78572]
Target Type:     live task

Date/Time:       2026-04-28 14:58:14.693 +0900
Launch Time:     2026-04-28 14:58:04.631 +0900
OS Version:      macOS 26.4.1 (25E253)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         7601K
Physical footprint (peak):  7729K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 78573: 1332 nodes malloced for 203 KB
Process 78573: 0 leaks for 0 total leaked bytes.

[2026/04/28 14:58:16] [engine] caught signal (SIGCONT)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of plugin initialization error messages to correctly identify whether filter or input initialization failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->