### PR TITLE
out_forward: fix retain_metadata_in_forward_mode default value (true)

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1739,7 +1739,7 @@ static struct flb_config_map config_map[] = {
      "Set timestamp in integer format (compat mode for old Fluentd v0.12)"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "retain_metadata_in_forward_mode", "false",
+     FLB_CONFIG_MAP_BOOL, "retain_metadata_in_forward_mode", "true",
      0, FLB_TRUE, offsetof(struct flb_forward_config, fwd_retain_metadata),
      "Retain metadata when operating in forward mode"
     },

--- a/tests/integration/scenarios/out_forward/config/out_forward_metadata_receiver.yaml
+++ b/tests/integration/scenarios/out_forward/config/out_forward_metadata_receiver.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FORWARD_METADATA_RECEIVER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_METADATA_CAPTURE_PORT}
+      send_options: true
+      require_ack_response: true
+      retain_metadata_in_forward_mode: true

--- a/tests/integration/scenarios/out_forward/config/out_forward_metadata_sender_default.yaml
+++ b/tests/integration/scenarios/out_forward/config/out_forward_metadata_sender_default.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FORWARD_METADATA_SENDER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_METADATA_RECEIVER_PORT}
+      send_options: true
+      require_ack_response: true

--- a/tests/integration/scenarios/out_forward/config/out_forward_metadata_sender_false.yaml
+++ b/tests/integration/scenarios/out_forward/config/out_forward_metadata_sender_false.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FORWARD_METADATA_SENDER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_METADATA_RECEIVER_PORT}
+      send_options: true
+      require_ack_response: true
+      retain_metadata_in_forward_mode: false

--- a/tests/integration/scenarios/out_forward/config/out_forward_metadata_sender_true.yaml
+++ b/tests/integration/scenarios/out_forward/config/out_forward_metadata_sender_true.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FORWARD_METADATA_SENDER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_METADATA_RECEIVER_PORT}
+      send_options: true
+      require_ack_response: true
+      retain_metadata_in_forward_mode: true

--- a/tests/integration/scenarios/out_forward/tests/test_out_forward_metadata_001.py
+++ b/tests/integration/scenarios/out_forward/tests/test_out_forward_metadata_001.py
@@ -1,0 +1,200 @@
+import os
+import socket
+import time
+
+import pytest
+
+from server.forward_server import (
+    data_storage as forward_data_storage,
+    forward_server_run,
+    forward_server_stop,
+)
+from utils.fluent_bit_manager import FluentBitManager
+from utils.network import find_available_port, wait_for_port_to_be_free
+
+
+TEST_TAG = "test"
+TEST_TS = 1234567890
+TEST_METADATA = {"source": "suite", "scope": "out_forward"}
+
+
+class FluentBitForwardChain:
+    def __init__(self, sender_config_file):
+        self.config_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config"))
+        self.sender_config_file = os.path.join(self.config_dir, sender_config_file)
+        self.receiver_config_file = os.path.join(self.config_dir, "out_forward_metadata_receiver.yaml")
+        self.sender = None
+        self.receiver = None
+        self.previous_env = {}
+
+    def _set_env(self, key, value):
+        self.previous_env.setdefault(key, os.environ.get(key))
+        os.environ[key] = str(value)
+
+    def _restore_env(self):
+        for key, value in self.previous_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        self.previous_env.clear()
+
+    def start(self):
+        self.sender_port = find_available_port()
+        self.receiver_port = find_available_port()
+        self.capture_port = find_available_port()
+
+        self._set_env("FORWARD_METADATA_SENDER_PORT", self.sender_port)
+        self._set_env("FORWARD_METADATA_RECEIVER_PORT", self.receiver_port)
+        self._set_env("FORWARD_METADATA_CAPTURE_PORT", self.capture_port)
+
+        forward_server_run(self.capture_port)
+
+        self.receiver = FluentBitManager(self.receiver_config_file)
+        self.receiver.start()
+
+        time.sleep(1)
+
+        self.sender = FluentBitManager(self.sender_config_file)
+        self.sender.start()
+
+    def stop(self):
+        try:
+            if self.sender:
+                self.sender.stop()
+            if self.receiver:
+                self.receiver.stop()
+        finally:
+            forward_server_stop()
+            wait_for_port_to_be_free(self.capture_port, timeout=10 if os.environ.get("VALGRIND") else 5)
+            self._restore_env()
+
+    def wait_for_forward_messages(self, minimum_count, timeout=10):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            messages = forward_data_storage["messages"]
+            if len(messages) >= minimum_count:
+                return messages
+            time.sleep(0.2)
+        raise TimeoutError(f"Timed out waiting for {minimum_count} captured forward messages")
+
+
+def _pack_uint(value):
+    if value < 0x80:
+        return bytes([value])
+    if value <= 0xFF:
+        return b"\xCC" + bytes([value])
+    if value <= 0xFFFF:
+        return b"\xCD" + value.to_bytes(2, "big")
+    if value <= 0xFFFFFFFF:
+        return b"\xCE" + value.to_bytes(4, "big")
+    return b"\xCF" + value.to_bytes(8, "big")
+
+
+def _pack_str(value):
+    data = value.encode()
+    length = len(data)
+    if length <= 31:
+        return bytes([0xA0 | length]) + data
+    if length <= 0xFF:
+        return b"\xD9" + bytes([length]) + data
+    if length <= 0xFFFF:
+        return b"\xDA" + length.to_bytes(2, "big") + data
+    return b"\xDB" + length.to_bytes(4, "big") + data
+
+
+def _pack_array(items):
+    length = len(items)
+    if length <= 15:
+        prefix = bytes([0x90 | length])
+    elif length <= 0xFFFF:
+        prefix = b"\xDC" + length.to_bytes(2, "big")
+    else:
+        prefix = b"\xDD" + length.to_bytes(4, "big")
+    return prefix + b"".join(_pack_obj(item) for item in items)
+
+
+def _pack_map(mapping):
+    items = list(mapping.items())
+    length = len(items)
+    if length <= 15:
+        prefix = bytes([0x80 | length])
+    elif length <= 0xFFFF:
+        prefix = b"\xDE" + length.to_bytes(2, "big")
+    else:
+        prefix = b"\xDF" + length.to_bytes(4, "big")
+
+    encoded = []
+    for key, value in items:
+        encoded.append(_pack_obj(key))
+        encoded.append(_pack_obj(value))
+    return prefix + b"".join(encoded)
+
+
+def _pack_obj(value):
+    if isinstance(value, int):
+        return _pack_uint(value)
+    if isinstance(value, str):
+        return _pack_str(value)
+    if isinstance(value, list):
+        return _pack_array(value)
+    if isinstance(value, dict):
+        return _pack_map(value)
+    raise TypeError(f"Unsupported value type {type(value)!r}")
+
+
+def _send_log_event_with_metadata(port, message):
+    payload = _pack_obj(
+        [
+            TEST_TAG,
+            TEST_TS,
+            {"message": message},
+            {"metadata": TEST_METADATA, "chunk": f"{message}-chunk"},
+        ]
+    )
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(payload)
+
+
+def _capture_record(sender_config_file, message):
+    service = FluentBitForwardChain(sender_config_file)
+    service.start()
+
+    try:
+        _send_log_event_with_metadata(service.sender_port, message)
+        messages = service.wait_for_forward_messages(1, timeout=20 if os.environ.get("VALGRIND") else 10)
+    finally:
+        service.stop()
+
+    assert messages[0]["mode"] == "forward"
+    assert messages[0]["tag"] == TEST_TAG
+    assert messages[0]["options"]["fluent_signal"] == 0
+    assert messages[0]["options"]["size"] == 1
+    return messages[0]["records"][0]
+
+
+@pytest.mark.parametrize(
+    "sender_config_file",
+    [
+        "out_forward_metadata_sender_default.yaml",
+        "out_forward_metadata_sender_true.yaml",
+    ],
+)
+def test_out_forward_fluent_bit_to_fluent_bit_preserves_metadata(sender_config_file):
+    record = _capture_record(sender_config_file, sender_config_file)
+
+    assert record["body"]["message"] == sender_config_file
+    assert record["metadata"] == TEST_METADATA
+    assert len(record["raw"]) == 2
+    assert len(record["raw"][0]) == 2
+    assert record["raw"][0][1] == TEST_METADATA
+
+
+def test_out_forward_fluent_bit_to_fluent_bit_opt_out_drops_metadata():
+    record = _capture_record("out_forward_metadata_sender_false.yaml", "metadata-opt-out")
+
+    assert record["body"]["message"] == "metadata-opt-out"
+    assert not record["metadata"]
+    assert len(record["raw"]) == 2
+    assert not record["raw"][0][1]
+    assert record["raw"][1] == {"message": "metadata-opt-out"}

--- a/tests/runtime/group_counter_semantics.c
+++ b/tests/runtime/group_counter_semantics.c
@@ -658,6 +658,42 @@ static void flb_test_forward_group_size_default()
     TEST_CHECK(ret == 0);
 
     run_group_count_test(ctx);
+    TEST_CHECK(get_forward_size() == 3);
+
+    flb_destroy(ctx);
+}
+
+static void flb_test_forward_group_size_opt_out_metadata()
+{
+    int out_ffd;
+    int in_ffd;
+    int ret;
+    flb_ctx_t *ctx;
+
+    reset_results();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "Flush", "0.2", "Grace", "1", "Log_Level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "tag", "new.tag",
+                   "send_options", "true",
+                   "retain_metadata_in_forward_mode", "false",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_forward_size_check,
+                              NULL, NULL);
+    TEST_CHECK(ret == 0);
+
+    run_group_count_test(ctx);
     TEST_CHECK(get_forward_size() == 1);
 
     flb_destroy(ctx);
@@ -837,6 +873,7 @@ static void flb_test_forward_output_processor_mixed_payload_smoke()
 
 TEST_LIST = {
     {"forward_group_size_default", flb_test_forward_group_size_default},
+    {"forward_group_size_opt_out_metadata", flb_test_forward_group_size_opt_out_metadata},
     {"forward_group_size_retain_metadata", flb_test_forward_group_size_retain_metadata},
     {"loki_group_values_count", flb_test_loki_group_values_count},
     {"stackdriver_group_entries_count", flb_test_stackdriver_group_entries_count},


### PR DESCRIPTION
This fixes a gap in Fluent Bit-to-Fluent Bit forwarding where log event metadata could be silently dropped by default in out_forward forward mode.

Fluent Bit’s current log event model includes metadata, so forwarding between Fluent Bit instances should preserve that metadata unless the user explicitly opts out for strict Forward-compatible records. This change updates   `retain_metadata_in_forward_mode` to default to `true` while preserving the existing opt-out behavior with `retain_metadata_in_forward_mode` `false`.

The integration coverage adds a Fluent Bit sender and receiver chain and verifies that metadata is preserved by default, preserved when explicitly enabled, and dropped when explicitly disabled.

__Tests__:
  - tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_forward/tests/
  test_out_forward_metadata_001.py -q
  - VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/
  scenarios/out_forward/tests/test_out_forward_metadata_001.py -q
  
  ----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Forward output plugin default now retains metadata in Forward mode; can be explicitly disabled to revert prior behavior.

* **Tests**
  * Added multiple integration scenarios and an end-to-end test covering metadata retention and opt-out behavior.
  * Updated runtime grouping tests and expectations to reflect metadata retention semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->