### PR TITLE
in_process_exporter_metrics: Expire metrics for dead processes

### DIFF
--- a/plugins/in_process_exporter_metrics/pe_process.c
+++ b/plugins/in_process_exporter_metrics/pe_process.c
@@ -1175,6 +1175,13 @@ static int process_update(struct flb_pe *ctx)
 
     flb_slist_destroy(&procfs_list);
 
+    /*
+     * Purge metric label-sets for processes that were not seen in this
+     * collection pass.  Any cmt_metric whose timestamp is older than ts
+     * (captured before the scan) belongs to a process that no longer exists.
+     */
+    cmt_expire(ctx->cmt, ts);
+
     return 0;
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This add a generic expiration mechanism in cmetrics with cmt_expire(), based on a timestamp. This avoids publishing prometheus metrics for process which are not running anymore on the host.
Uses timestamp based comparison, and removes any metrics with timestamp older than the last collection.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes #9547 
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purges stale process and thread metrics when entities are not observed during a scan, improving metric accuracy.
  * Prevents unsafe deletions when activity detection is incomplete.

* **Improvements**
  * Adds a timestamp-based metric expiration mechanism to enable safe cleanup of orphaned label-sets.
  * More reliable gated purging to remove orphaned metrics only after tracking is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->