### PR TITLE
crypto: fix build with OPENSSL_NO_ENGINE

### DIFF
--- a/include/fluent-bit/flb_crypto.h
+++ b/include/fluent-bit/flb_crypto.h
@@ -24,7 +24,9 @@
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 #include <fluent-bit/flb_crypto_constants.h>
 
 

--- a/include/fluent-bit/flb_hash.h
+++ b/include/fluent-bit/flb_hash.h
@@ -51,7 +51,9 @@
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 #include <fluent-bit/flb_crypto_constants.h>
 
 

--- a/include/fluent-bit/flb_hmac.h
+++ b/include/fluent-bit/flb_hmac.h
@@ -23,7 +23,9 @@
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 #include <fluent-bit/flb_crypto_constants.h>
 
 struct flb_hmac {


### PR DESCRIPTION
ENGINE was deprecated in openssl 3.0 (and disabled in RHEL 10), and completely removed in 4.0.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation failures when OpenSSL is built without engine support enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->