### PR TITLE
in_node_exporter_metrics: Skip ipv6 metrics collection when disabled

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_sockstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_sockstat_linux.c
@@ -20,6 +20,9 @@
 #define _GNU_SOURCE
 
 #include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <limits.h>
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input_plugin.h>
@@ -168,6 +171,9 @@ static int sockstat_update(struct flb_ne *ctx)
     int i;
     struct flb_slist_entry *key;
     struct flb_slist_entry *val;
+    int path_len;
+    char ipv6_proc_path[PATH_MAX];
+    struct stat st;
 
     mk_list_init(&list);
     ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/sockstat", &list);
@@ -296,7 +302,16 @@ static int sockstat_update(struct flb_ne *ctx)
 
     flb_slist_destroy(&list);
 
-    /* Parse IPv6 statistics */
+    /* Parse IPv6 statistics (if enabled) */
+    path_len = snprintf(ipv6_proc_path, sizeof(ipv6_proc_path), "%s%s", ctx->path_procfs, "/net/sockstat6");
+    if (path_len < 0 || path_len >= (int) sizeof(ipv6_proc_path)) {
+        return -1;
+    }
+    ret = stat(ipv6_proc_path, &st);
+    if (ret == -1 && errno == ENOENT) {
+        flb_plg_debug(ctx->ins, "cannot read %s, skip ipv6 metrics collection", ipv6_proc_path);
+        return 0;
+    }
     mk_list_init(&list);
     ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/sockstat6", &list);
     if (ret != -1) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
The stat() pre-check on /proc/net/sockstat6 will avoid having lots of "no such file or directory" errors when trying to collect ipv6 metrics on hosts where ipv6 is disabled.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and error handling when IPv6 socket statistics are unavailable, avoiding erroneous failures on systems without IPv6 metrics.
  * Added safer path validation to prevent malformed IPv6 proc paths from causing errors and to skip missing files gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->