### PR TITLE
filter_log_to_metrics: retry timer metric append

### DIFF
--- a/plugins/filter_log_to_metrics/log_to_metrics.c
+++ b/plugins/filter_log_to_metrics/log_to_metrics.c
@@ -621,6 +621,7 @@ static int set_buckets(struct log_to_metrics_ctx *ctx,
 static void cb_send_metric_chunk(struct flb_config *config, void *data)
 {
     int ret;
+    int appended = FLB_FALSE;
     struct log_to_metrics_ctx *ctx = data;
 
     /* Check that metric context is not empty */
@@ -630,9 +631,12 @@ static void cb_send_metric_chunk(struct flb_config *config, void *data)
 
     if (ctx->new_data) {
         ret = flb_input_metrics_append(ctx->input_ins, ctx->tag,
-            strlen(ctx->tag), ctx->cmt);
+                                       strlen(ctx->tag), ctx->cmt);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "could not append metrics");
+        }
+        else {
+            appended = FLB_TRUE;
         }
     }
 
@@ -643,7 +647,9 @@ static void cb_send_metric_chunk(struct flb_config *config, void *data)
             flb_sched_timer_cb_disable(ctx->timer);
         }
     }
-    ctx->new_data = FLB_FALSE;
+    if (appended) {
+        ctx->new_data = FLB_FALSE;
+    }
 }
 
 static int cb_log_to_metrics_init(struct flb_filter_instance *f_ins,
@@ -1124,7 +1130,9 @@ static int cb_log_to_metrics_filter(const void *data, size_t bytes,
                 }
             }
             else {
-                ctx->new_data = FLB_TRUE;
+                if (ret == 0) {
+                    ctx->new_data = FLB_TRUE;
+                }
             }
         }
         else if (ret == GREP_RET_EXCLUDE) {

--- a/tests/integration/scenarios/filter_log_to_metrics/config/counter_timer_prometheus.yaml
+++ b/tests/integration/scenarios/filter_log_to_metrics/config/counter_timer_prometheus.yaml
@@ -9,8 +9,8 @@ pipeline:
   inputs:
     - name: dummy
       tag: nginx.b2b.access
-      rate: 1
-      samples: 5
+      rate: 25
+      samples: 100
       dummy: '{"request_method":"GET","status":"200","host":"example.com","endpoint":"/","hostname":"host-a","upstream_response_time":"0.125"}'
 
   filters:
@@ -20,7 +20,7 @@ pipeline:
       emitter_name: em_status_code
       flush_interval_sec: 1
       metric_mode: counter
-      metric_name: nginx_request_status_code_total
+      metric_name: status_code_total
       metric_description: Counts nginx request status codes
       metric_namespace: nginx
       metric_subsystem: request

--- a/tests/integration/scenarios/filter_log_to_metrics/config/counter_timer_prometheus.yaml
+++ b/tests/integration/scenarios/filter_log_to_metrics/config/counter_timer_prometheus.yaml
@@ -1,0 +1,38 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: nginx.b2b.access
+      rate: 1
+      samples: 5
+      dummy: '{"request_method":"GET","status":"200","host":"example.com","endpoint":"/","hostname":"host-a","upstream_response_time":"0.125"}'
+
+  filters:
+    - name: log_to_metrics
+      match: nginx.b2b.access
+      tag: metrics.nginx
+      emitter_name: em_status_code
+      flush_interval_sec: 1
+      metric_mode: counter
+      metric_name: nginx_request_status_code_total
+      metric_description: Counts nginx request status codes
+      metric_namespace: nginx
+      metric_subsystem: request
+      label_field:
+        - request_method
+        - status
+        - host
+        - endpoint
+        - hostname
+
+  outputs:
+    - name: prometheus_exporter
+      match: metrics.nginx
+      host: 127.0.0.1
+      port: ${EXPORTER_PORT}

--- a/tests/integration/scenarios/filter_log_to_metrics/tests/test_filter_log_to_metrics_001.py
+++ b/tests/integration/scenarios/filter_log_to_metrics/tests/test_filter_log_to_metrics_001.py
@@ -1,11 +1,10 @@
 import os
-import time
 
 from utils.http_matrix import run_curl_request
 from utils.test_service import FluentBitTestService
 
 
-COUNTER_NAME = "nginx_request_nginx_request_status_code_total"
+COUNTER_NAME = "nginx_request_status_code_total"
 COUNTER_LABELS = (
     'request_method="GET"',
     'status="200"',
@@ -13,6 +12,7 @@ COUNTER_LABELS = (
     'endpoint="/"',
     'hostname="host-a"',
 )
+EXPECTED_SAMPLE_COUNT = 100
 
 
 class Service:
@@ -41,15 +41,20 @@ def _counter_value(metrics_text):
         if not line.startswith(f"{COUNTER_NAME}{{"):
             continue
         if all(label in line for label in COUNTER_LABELS):
-            return float(line.rsplit(" ", 1)[1])
+            fields = line.split()
+            if len(fields) < 2:
+                continue
+            value_field = fields[-2] if len(fields) > 2 else fields[-1]
+            return float(value_field)
     return None
 
 
 def test_log_to_metrics_counter_timer_emits_repeated_metric_chunks():
     service = Service("counter_timer_prometheus.yaml")
-    service.start()
 
     try:
+        service.start()
+
         first_value = service.service.wait_for_condition(
             lambda: _counter_value(service.scrape_metrics()["body"]),
             timeout=15,
@@ -57,7 +62,7 @@ def test_log_to_metrics_counter_timer_emits_repeated_metric_chunks():
             description="initial log_to_metrics counter scrape",
         )
 
-        second_value = service.service.wait_for_condition(
+        service.service.wait_for_condition(
             lambda: (
                 value
                 if (value := _counter_value(service.scrape_metrics()["body"])) is not None
@@ -69,7 +74,16 @@ def test_log_to_metrics_counter_timer_emits_repeated_metric_chunks():
             description="increasing log_to_metrics counter scrape",
         )
 
-        assert second_value > first_value
-        time.sleep(3)
+        service.service.wait_for_condition(
+            lambda: (
+                value
+                if (value := _counter_value(service.scrape_metrics()["body"])) is not None
+                and value >= EXPECTED_SAMPLE_COUNT
+                else None
+            ),
+            timeout=15,
+            interval=1,
+            description="complete log_to_metrics counter scrape",
+        )
     finally:
         service.stop()

--- a/tests/integration/scenarios/filter_log_to_metrics/tests/test_filter_log_to_metrics_001.py
+++ b/tests/integration/scenarios/filter_log_to_metrics/tests/test_filter_log_to_metrics_001.py
@@ -1,0 +1,75 @@
+import os
+import time
+
+from utils.http_matrix import run_curl_request
+from utils.test_service import FluentBitTestService
+
+
+COUNTER_NAME = "nginx_request_nginx_request_status_code_total"
+COUNTER_LABELS = (
+    'request_method="GET"',
+    'status="200"',
+    'host="example.com"',
+    'endpoint="/"',
+    'hostname="host-a"',
+)
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config", config_file)
+        )
+        self.service = FluentBitTestService(self.config_file, pre_start=self._pre_start)
+
+    def _pre_start(self, service):
+        self.exporter_port = service.allocate_port_env("EXPORTER_PORT")
+
+    def start(self):
+        self.service.start()
+        self.base_url = f"http://127.0.0.1:{self.exporter_port}"
+
+    def stop(self):
+        self.service.stop()
+
+    def scrape_metrics(self):
+        return run_curl_request(f"{self.base_url}/metrics", method="GET", http_mode="http1.1")
+
+
+def _counter_value(metrics_text):
+    for line in metrics_text.splitlines():
+        if not line.startswith(f"{COUNTER_NAME}{{"):
+            continue
+        if all(label in line for label in COUNTER_LABELS):
+            return float(line.rsplit(" ", 1)[1])
+    return None
+
+
+def test_log_to_metrics_counter_timer_emits_repeated_metric_chunks():
+    service = Service("counter_timer_prometheus.yaml")
+    service.start()
+
+    try:
+        first_value = service.service.wait_for_condition(
+            lambda: _counter_value(service.scrape_metrics()["body"]),
+            timeout=15,
+            interval=1,
+            description="initial log_to_metrics counter scrape",
+        )
+
+        second_value = service.service.wait_for_condition(
+            lambda: (
+                value
+                if (value := _counter_value(service.scrape_metrics()["body"])) is not None
+                and value > first_value
+                else None
+            ),
+            timeout=15,
+            interval=1,
+            description="increasing log_to_metrics counter scrape",
+        )
+
+        assert second_value > first_value
+        time.sleep(3)
+    finally:
+        service.stop()


### PR DESCRIPTION
It can potentially fix https://github.com/fluent/fluent-bit/issues/11772 ....

Fixes `timer-mode emission so pending metric data is not marked as consumed unless the internal metrics append succeeds.

Previously, `cb_send_metric_chunk()` cleared `ctx->new_data` unconditionally after each timer callback. If `flb_input_metrics_append()` failed, the pending counter state could be dropped from the timer path, causing subsequent emissions to stall until new data reset the flag. The fix only clears `ctx->new_data` after a successful append.

Also adds an integration test that runs `log_to_metrics` in counter timer mode and verifies Prometheus-exported counter values continue increasing.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loss of pending metrics by only clearing pending state after a successful append, improving reliability in timer-mode metric emission.

* **Tests**
  * Added an integration scenario and automated test that exercises the metric export path and verifies Prometheus counters increase across repeated scrapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->