### PR TITLE
downstream: re-architect workers support

### DIFF
--- a/include/fluent-bit/flb_downstream_worker.h
+++ b/include/fluent-bit/flb_downstream_worker.h
@@ -1,0 +1,74 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_DOWNSTREAM_WORKER_H
+#define FLB_DOWNSTREAM_WORKER_H
+
+#include <fluent-bit/flb_socket.h>
+
+struct mk_event_loop;
+struct flb_downstream_worker;
+struct flb_downstream_worker_runtime;
+
+typedef int (*flb_downstream_worker_init_cb)(struct flb_downstream_worker *worker,
+                                             void *parent,
+                                             void **worker_context);
+
+typedef void (*flb_downstream_worker_exit_cb)(struct flb_downstream_worker *worker,
+                                              void *worker_context);
+
+typedef void (*flb_downstream_worker_maintenance_cb)(
+    struct flb_downstream_worker *worker,
+    void *worker_context);
+
+typedef void (*flb_downstream_worker_foreach_cb)(struct flb_downstream_worker *worker,
+                                                 void *worker_context,
+                                                 void *data);
+
+struct flb_downstream_worker_options {
+    int workers;
+    void *parent;
+    flb_downstream_worker_init_cb cb_init;
+    flb_downstream_worker_exit_cb cb_exit;
+    flb_downstream_worker_maintenance_cb cb_maintenance;
+};
+
+int flb_downstream_worker_runtime_start(struct flb_downstream_worker_runtime **out_runtime,
+                                        const struct flb_downstream_worker_options *options);
+
+/* Runtime operations must not be invoked from a worker callback. */
+int flb_downstream_worker_runtime_stop(struct flb_downstream_worker_runtime *runtime);
+
+/* The callback is run synchronously once on every worker thread. */
+int flb_downstream_worker_runtime_foreach(struct flb_downstream_worker_runtime *runtime,
+                                          flb_downstream_worker_foreach_cb callback,
+                                          void *data);
+
+struct mk_event_loop *flb_downstream_worker_event_loop_get(
+    struct flb_downstream_worker *worker);
+
+int flb_downstream_worker_id_get(struct flb_downstream_worker *worker);
+
+int flb_downstream_worker_count_get(struct flb_downstream_worker *worker);
+
+/* Register the listener created by cb_init for shared-endpoint validation. */
+int flb_downstream_worker_listener_fd_set(struct flb_downstream_worker *worker,
+                                          flb_sockfd_t listener_fd);
+
+#endif

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -873,19 +873,24 @@ int flb_input_ingress_enable(struct flb_input_instance *ins);
 int flb_input_ingress_queue_log(struct flb_input_instance *ins,
                                 const char *tag, size_t tag_len,
                                 const void *buf, size_t buf_size);
+/* The take and decoded-signal queue functions always consume their payload. */
 int flb_input_ingress_queue_log_take(struct flb_input_instance *ins,
                                      const char *tag, size_t tag_len,
                                      void *buf, size_t buf_size,
                                      size_t allocation_size);
 int flb_input_ingress_queue_metrics(struct flb_input_instance *ins,
                                     const char *tag, size_t tag_len,
-                                    struct cmt *cmt);
+                                    struct cmt *cmt, size_t payload_size);
+int flb_input_ingress_queue_metrics_list(struct flb_input_instance *ins,
+                                         const char *tag, size_t tag_len,
+                                         struct cfl_list *contexts,
+                                         size_t payload_size);
 int flb_input_ingress_queue_traces(struct flb_input_instance *ins,
                                    const char *tag, size_t tag_len,
-                                   struct ctrace *ctr);
+                                   struct ctrace *ctr, size_t payload_size);
 int flb_input_ingress_queue_profiles(struct flb_input_instance *ins,
                                      const char *tag, size_t tag_len,
-                                     struct cprof *profile);
+                                     struct cprof *profile, size_t payload_size);
 
 
 /* processors */

--- a/include/fluent-bit/http_server/flb_http_server.h
+++ b/include/fluent-bit/http_server/flb_http_server.h
@@ -59,7 +59,7 @@ typedef int (*flb_http_server_request_processor_callback)(
                  struct flb_http_response *response);
 
 struct flb_http_server;
-struct flb_http_server_runtime;
+struct flb_downstream_worker_runtime;
 
 typedef int (*flb_http_server_worker_callback)(struct flb_http_server *server,
                                                void *data);
@@ -98,6 +98,7 @@ struct flb_http_server_options {
     size_t                               buffer_max_size;
     size_t                               buffer_chunk_size;
     size_t                               max_connections;
+    uint64_t                            *connection_counter;
 
     /* Total number of worker listeners to spawn. */
     int                                  workers;
@@ -142,6 +143,8 @@ struct flb_http_server {
     size_t                              buffer_max_size;
     size_t                              buffer_chunk_size;
     size_t                              max_connections;
+    uint64_t                            active_connections;
+    uint64_t                           *connection_counter;
     int                                 workers;
     int                                 worker_id;
     int                                 use_caller_event_loop;
@@ -149,7 +152,7 @@ struct flb_http_server {
     int                                 tls_alpn_configured;
     flb_http_server_worker_callback     cb_worker_init;
     flb_http_server_worker_callback     cb_worker_exit;
-    struct flb_http_server_runtime     *runtime;
+    struct flb_downstream_worker_runtime *runtime;
 };
 
 struct flb_http_server_session {
@@ -166,6 +169,7 @@ struct flb_http_server_session {
 
     int                             releasable;
     int                             drop_pending;
+    int                             connection_slot_reserved;
 
     struct flb_connection          *connection;
     struct flb_http_server         *parent;
@@ -230,10 +234,6 @@ int flb_http_server_init_on_input(struct flb_http_server *session,
 void flb_http_server_set_buffer_max_size(struct flb_http_server *server, size_t size);
 
 size_t flb_http_server_get_buffer_max_size(struct flb_http_server *server);
-
-const struct flb_net_setup *
-flb_http_server_runtime_worker_net_setup_get(struct flb_http_server *server,
-                                             int worker_id);
 
 /* HTTP SESSION */
 

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_downstream.h>
+#include <fluent-bit/flb_downstream_worker.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
@@ -36,6 +37,13 @@
 #include "fw.h"
 #include "fw_conn.h"
 #include "fw_config.h"
+
+static int in_fw_collect(struct flb_input_instance *ins,
+                         struct flb_config *config, void *in_context);
+static int in_fw_collect_ctx(struct flb_in_fw_config *ctx);
+static void delete_users(struct flb_in_fw_config *ctx);
+static int setup_users(struct flb_in_fw_config *ctx,
+                       struct flb_input_instance *ins);
 
 #ifdef FLB_HAVE_UNIX_SOCKET
 static int remove_existing_socket_file(char *socket_path)
@@ -124,12 +132,17 @@ static int fw_unix_create(struct flb_in_fw_config *ctx)
 static int in_fw_collect(struct flb_input_instance *ins,
                          struct flb_config *config, void *in_context)
 {
+    (void) ins;
+    (void) config;
+
+    return in_fw_collect_ctx(in_context);
+}
+
+static int in_fw_collect_ctx(struct flb_in_fw_config *ctx)
+{
     int                      state_backup;
     struct flb_connection   *connection;
     struct fw_conn          *conn;
-    struct flb_in_fw_config *ctx;
-
-    ctx = in_context;
 
     state_backup = ctx->state;
     ctx->state = FW_INSTANCE_STATE_ACCEPTING_CLIENT;
@@ -143,22 +156,22 @@ static int in_fw_collect(struct flb_input_instance *ins,
         return -1;
     }
 
-    if (!config->is_ingestion_active) {
+    if (!ctx->ins->config->is_ingestion_active) {
         flb_downstream_conn_release(connection);
         ctx->state = state_backup;
 
         return -1;
     }
 
-    if(ctx->is_paused) {
+    if (ctx->is_paused) {
+        flb_plg_trace(ctx->ins, "TCP connection will be closed FD=%i", connection->fd);
         flb_downstream_conn_release(connection);
-        flb_plg_trace(ins, "TCP connection will be closed FD=%i", connection->fd);
         ctx->state = state_backup;
 
         return -1;
     }
 
-    flb_plg_trace(ins, "new TCP connection arrived FD=%i", connection->fd);
+    flb_plg_trace(ctx->ins, "new TCP connection arrived FD=%i", connection->fd);
 
     conn = fw_conn_add(connection, ctx);
     if (!conn) {
@@ -272,11 +285,217 @@ static int setup_users(struct flb_in_fw_config *ctx,
     return 0;
 }
 
+static int in_fw_worker_listener_event(void *data)
+{
+    struct mk_event *event;
+
+    event = data;
+
+    return in_fw_collect_ctx(event->data);
+}
+
+static int in_fw_start_tcp_listener(struct flb_in_fw_config *ctx,
+                                    struct flb_config *config,
+                                    struct flb_net_setup *net_setup,
+                                    struct mk_event_loop *event_loop,
+                                    int use_collector)
+{
+    int ret;
+    unsigned short int port;
+
+    port = (unsigned short int) strtoul(ctx->tcp_port, NULL, 10);
+
+    ctx->downstream = flb_downstream_create(FLB_TRANSPORT_TCP,
+                                            ctx->ins->flags,
+                                            ctx->listen,
+                                            port,
+                                            ctx->ins->tls,
+                                            config,
+                                            net_setup);
+
+    if (ctx->downstream == NULL) {
+        flb_plg_error(ctx->ins,
+                      "could not initialize downstream on %s:%s. Aborting",
+                      ctx->listen, ctx->tcp_port);
+        return -1;
+    }
+
+    flb_input_downstream_set(ctx->downstream, ctx->ins);
+    flb_net_socket_nonblocking(ctx->downstream->server_fd);
+
+    if (use_collector == FLB_TRUE) {
+        ret = flb_input_set_collector_socket(ctx->ins,
+                                             in_fw_collect,
+                                             ctx->downstream->server_fd,
+                                             config);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not set server socket collector");
+            return -1;
+        }
+
+        ctx->coll_fd = ret;
+    }
+    else {
+        ctx->event_loop = event_loop;
+        MK_EVENT_NEW(&ctx->listener_event);
+        ctx->listener_event.type = FLB_ENGINE_EV_CUSTOM;
+        ctx->listener_event.data = ctx;
+        ctx->listener_event.handler = in_fw_worker_listener_event;
+
+        ret = mk_event_add(event_loop,
+                           ctx->downstream->server_fd,
+                           FLB_ENGINE_EV_CUSTOM,
+                           MK_EVENT_READ,
+                           &ctx->listener_event);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not register forward worker listener");
+            return -1;
+        }
+
+        ctx->listener_registered = FLB_TRUE;
+    }
+
+    return 0;
+}
+
+static int in_fw_worker_init(struct flb_downstream_worker *worker,
+                             void *parent,
+                             void **worker_context)
+{
+    int ret;
+    struct flb_in_fw_config *ctx;
+    struct flb_in_fw_config *parent_ctx;
+
+    parent_ctx = parent;
+
+    ctx = fw_config_init(parent_ctx->ins);
+    if (ctx == NULL) {
+        return -1;
+    }
+
+    *worker_context = ctx;
+
+    ctx->state = FW_INSTANCE_STATE_RUNNING;
+    ctx->coll_fd = -1;
+    ctx->ins = parent_ctx->ins;
+    ctx->workers = parent_ctx->workers;
+    ctx->worker_id = flb_downstream_worker_id_get(worker);
+    ctx->use_ingress_queue = FLB_TRUE;
+    ctx->is_paused = FLB_FALSE;
+    ctx->net_setup = parent_ctx->ins->net_setup;
+    ctx->net_setup.share_port = FLB_TRUE;
+    mk_list_init(&ctx->connections);
+    mk_list_init(&ctx->users);
+
+    ret = setup_users(ctx, parent_ctx->ins);
+    if (ret == -1) {
+        return -1;
+    }
+
+    ret = in_fw_start_tcp_listener(ctx,
+                                   parent_ctx->ins->config,
+                                   &ctx->net_setup,
+                                   flb_downstream_worker_event_loop_get(worker),
+                                   FLB_FALSE);
+    if (ret == 0) {
+        flb_downstream_thread_safe(ctx->downstream);
+        ret = flb_downstream_worker_listener_fd_set(
+                  worker, ctx->downstream->server_fd);
+    }
+
+    return ret;
+}
+
+static void in_fw_worker_exit(struct flb_downstream_worker *worker,
+                              void *worker_context)
+{
+    struct flb_in_fw_config *ctx;
+
+    (void) worker;
+
+    ctx = worker_context;
+
+    delete_users(ctx);
+    fw_conn_del_all(ctx);
+    fw_config_destroy(ctx);
+}
+
+static void in_fw_worker_maintenance(struct flb_downstream_worker *worker,
+                                     void *worker_context)
+{
+    struct flb_in_fw_config *ctx;
+
+    (void) worker;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_conn_timeouts_stream(ctx->downstream);
+        flb_downstream_conn_pending_destroy(ctx->downstream);
+    }
+}
+
+static int in_fw_workers_start(struct flb_in_fw_config *ctx)
+{
+    struct flb_downstream_worker_options options;
+
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = ctx->workers;
+    options.parent = ctx;
+    options.cb_init = in_fw_worker_init;
+    options.cb_exit = in_fw_worker_exit;
+    options.cb_maintenance = in_fw_worker_maintenance;
+
+    return flb_downstream_worker_runtime_start(&ctx->runtime, &options);
+}
+
+static void in_fw_workers_stop(struct flb_in_fw_config *ctx)
+{
+    flb_downstream_worker_runtime_stop(ctx->runtime);
+    ctx->runtime = NULL;
+}
+
+static void in_fw_worker_pause(struct flb_downstream_worker *worker,
+                               void *worker_context,
+                               void *data)
+{
+    struct flb_in_fw_config *ctx;
+
+    (void) worker;
+    (void) data;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_pause(ctx->downstream);
+        ctx->is_paused = FLB_TRUE;
+        ctx->state = FW_INSTANCE_STATE_PAUSED;
+        fw_conn_del_all(ctx);
+    }
+}
+
+static void in_fw_worker_resume(struct flb_downstream_worker *worker,
+                                void *worker_context,
+                                void *data)
+{
+    struct flb_in_fw_config *ctx;
+
+    (void) worker;
+    (void) data;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_resume(ctx->downstream);
+        ctx->is_paused = FLB_FALSE;
+        ctx->state = FW_INSTANCE_STATE_RUNNING;
+    }
+}
+
 /* Initialize plugin */
 static int in_fw_init(struct flb_input_instance *ins,
                       struct flb_config *config, void *data)
 {
-    unsigned short int       port;
     int                      ret;
     struct flb_in_fw_config *ctx;
 
@@ -300,8 +519,18 @@ static int in_fw_init(struct flb_input_instance *ins,
     /* Set plugin ingestion to active */
     ctx->is_paused = FLB_FALSE;
 
+    if (ctx->workers <= 0) {
+        ctx->workers = 1;
+    }
+
     /* Unix Socket mode */
     if (ctx->unix_path) {
+        if (ctx->workers > 1) {
+            flb_plg_error(ctx->ins, "workers is not supported with unix_path");
+            fw_config_destroy(ctx);
+            return -1;
+        }
+
 #ifndef FLB_HAVE_UNIX_SOCKET
         flb_plg_error(ctx->ins, "unix address is not supported %s:%s. Aborting",
                       ctx->listen, ctx->tcp_port);
@@ -319,38 +548,7 @@ static int in_fw_init(struct flb_input_instance *ins,
 #endif
     }
     else {
-        port = (unsigned short int) strtoul(ctx->tcp_port, NULL, 10);
-
-        ctx->downstream = flb_downstream_create(FLB_TRANSPORT_TCP,
-                                                ctx->ins->flags,
-                                                ctx->listen,
-                                                port,
-                                                ctx->ins->tls,
-                                                config,
-                                                &ctx->ins->net_setup);
-
-        if (ctx->downstream == NULL) {
-            flb_plg_error(ctx->ins,
-                          "could not initialize downstream on unix://%s. Aborting",
-                          ctx->listen);
-
-            fw_config_destroy(ctx);
-
-            return -1;
-        }
-
-        if (ctx->downstream != NULL) {
-            flb_plg_info(ctx->ins, "listening on %s:%s",
-                         ctx->listen, ctx->tcp_port);
-        }
-        else {
-            flb_plg_error(ctx->ins, "could not bind address %s:%s. Aborting",
-                          ctx->listen, ctx->tcp_port);
-
-            fw_config_destroy(ctx);
-
-            return -1;
-        }
+        /* TCP listener startup happens after security.users validation. */
     }
 
     /* Load users */
@@ -370,24 +568,65 @@ static int in_fw_init(struct flb_input_instance *ins,
         return -1;
     }
 
-    flb_input_downstream_set(ctx->downstream, ctx->ins);
-
-    flb_net_socket_nonblocking(ctx->downstream->server_fd);
-
-    /* Collect upon data available on the standard input */
-    ret = flb_input_set_collector_socket(ins,
-                                         in_fw_collect,
-                                         ctx->downstream->server_fd,
-                                         config);
-    if (ret == -1) {
-        flb_plg_error(ctx->ins, "could not set server socket collector");
+    ret = pthread_mutex_init(&ctx->conn_mutex, NULL);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "could not initialize connection mutex");
+        delete_users(ctx);
         fw_config_destroy(ctx);
         return -1;
     }
+    ctx->conn_mutex_initialized = FLB_TRUE;
 
-    ctx->coll_fd = ret;
+    if (ctx->unix_path) {
+        flb_input_downstream_set(ctx->downstream, ctx->ins);
+        flb_net_socket_nonblocking(ctx->downstream->server_fd);
 
-    pthread_mutex_init(&ctx->conn_mutex, NULL);
+        ret = flb_input_set_collector_socket(ins,
+                                             in_fw_collect,
+                                             ctx->downstream->server_fd,
+                                             config);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not set server socket collector");
+            delete_users(ctx);
+            fw_config_destroy(ctx);
+            return -1;
+        }
+
+        ctx->coll_fd = ret;
+    }
+    else {
+        if (ctx->workers > 1) {
+            ret = flb_input_ingress_enable(ins);
+            if (ret != 0) {
+                delete_users(ctx);
+                fw_config_destroy(ctx);
+                return -1;
+            }
+
+            ret = in_fw_workers_start(ctx);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins,
+                              "could not start forward listener workers on %s:%s. Aborting",
+                              ctx->listen, ctx->tcp_port);
+                delete_users(ctx);
+                fw_config_destroy(ctx);
+                return -1;
+            }
+        }
+        else {
+            ret = in_fw_start_tcp_listener(ctx, config, &ins->net_setup, NULL, FLB_TRUE);
+            if (ret != 0) {
+                delete_users(ctx);
+                fw_config_destroy(ctx);
+                return -1;
+            }
+        }
+
+        flb_plg_info(ctx->ins,
+                     "listening on %s:%s with %i worker%s",
+                     ctx->listen, ctx->tcp_port, ctx->workers,
+                     ctx->workers == 1 ? "" : "s");
+    }
 
     return 0;
 }
@@ -404,7 +643,17 @@ static void in_fw_pause(void *data, struct flb_config *config)
          * pause the ingestion. The plugin should close all the connections
          * and wait for the ingestion to resume.
          */
-        flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+        if (ctx->runtime != NULL) {
+            ret = flb_downstream_worker_runtime_foreach(ctx->runtime,
+                                                        in_fw_worker_pause,
+                                                        NULL);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "could not pause all downstream workers");
+            }
+        }
+        else {
+            flb_input_collector_pause(ctx->coll_fd, ctx->ins);
+        }
 
         ret = pthread_mutex_lock(&ctx->conn_mutex);
         if (ret != 0) {
@@ -444,7 +693,17 @@ static void in_fw_resume(void *data, struct flb_config *config) {
     struct flb_in_fw_config *ctx = data;
 
     if (config->is_running == FLB_TRUE) {
-        flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+        if (ctx->runtime != NULL) {
+            ret = flb_downstream_worker_runtime_foreach(ctx->runtime,
+                                                        in_fw_worker_resume,
+                                                        NULL);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "could not resume all downstream workers");
+            }
+        }
+        else {
+            flb_input_collector_resume(ctx->coll_fd, ctx->ins);
+        }
 
         ret = pthread_mutex_lock(&ctx->conn_mutex);
         if (ret != 0) {
@@ -474,6 +733,7 @@ static int in_fw_exit(void *data, struct flb_config *config)
     }
 
     delete_users(ctx);
+    in_fw_workers_stop(ctx);
     fw_conn_del_all(ctx);
     fw_config_destroy(ctx);
     return 0;
@@ -525,6 +785,11 @@ static struct flb_config_map config_map[] = {
     FLB_CONFIG_MAP_BOOL, "empty_shared_key", "false",
     0, FLB_TRUE, offsetof(struct flb_in_fw_config, empty_shared_key),
     "Enable an empty string as the shared key for authentication."
+   },
+   {
+    FLB_CONFIG_MAP_INT, "workers", "1",
+    0, FLB_TRUE, offsetof(struct flb_in_fw_config, workers),
+    "Set the number of Forward listener workers"
    },
    {0}
 };

--- a/plugins/in_forward/fw.h
+++ b/plugins/in_forward/fw.h
@@ -22,6 +22,9 @@
 
 #include <msgpack.h>
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_metric.h>
+#include <fluent-bit/flb_input_trace.h>
+#include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
@@ -50,6 +53,8 @@ struct flb_in_fw_user {
     struct mk_list _head;
 };
 
+struct flb_downstream_worker_runtime;
+
 struct flb_in_fw_config {
     size_t buffer_max_size;         /* Max Buffer size             */
     size_t buffer_chunk_size;       /* Chunk allocation size       */
@@ -73,6 +78,13 @@ struct flb_in_fw_config {
     int empty_shared_key;        /* use an empty string as shared key */
 
     int coll_fd;
+    int workers;                    /* Listener worker count       */
+    int worker_id;                  /* Worker id                   */
+    int use_ingress_queue;          /* Queue records to main loop  */
+    int listener_registered;        /* Listener event registered   */
+    struct mk_event listener_event; /* Worker listener event       */
+    struct mk_event_loop *event_loop; /* Worker event loop          */
+    struct flb_net_setup net_setup; /* Worker network setup        */
     struct flb_downstream *downstream; /* Client manager          */
     struct mk_list connections;     /* List of active connections */
     struct flb_input_instance *ins; /* Input plugin instace       */
@@ -81,11 +93,49 @@ struct flb_in_fw_config {
     struct flb_log_event_encoder *log_encoder;
 
     pthread_mutex_t conn_mutex;
+    int conn_mutex_initialized;
 
     int state;
     
     /* Plugin is paused */
     int is_paused;
+
+    struct flb_downstream_worker_runtime *runtime;
 };
+
+static inline int fw_ingest_logs(struct flb_in_fw_config *ctx,
+                                 const char *tag, size_t tag_len,
+                                 const void *buf, size_t buf_size)
+{
+    if (ctx->use_ingress_queue == FLB_TRUE) {
+        return flb_input_ingress_queue_log(ctx->ins, tag, tag_len, buf, buf_size);
+    }
+
+    return flb_input_log_append(ctx->ins, tag, tag_len, buf, buf_size);
+}
+
+static inline int fw_ingest_metrics(struct flb_in_fw_config *ctx,
+                                    const char *tag, size_t tag_len,
+                                    struct cmt *cmt, size_t payload_size)
+{
+    if (ctx->use_ingress_queue == FLB_TRUE) {
+        return flb_input_ingress_queue_metrics(ctx->ins, tag, tag_len,
+                                               cmt, payload_size);
+    }
+
+    return flb_input_metrics_append(ctx->ins, tag, tag_len, cmt);
+}
+
+static inline int fw_ingest_traces(struct flb_in_fw_config *ctx,
+                                   const char *tag, size_t tag_len,
+                                   struct ctrace *ctr, size_t payload_size)
+{
+    if (ctx->use_ingress_queue == FLB_TRUE) {
+        return flb_input_ingress_queue_traces(ctx->ins, tag, tag_len,
+                                              ctr, payload_size);
+    }
+
+    return flb_input_trace_append(ctx->ins, tag, tag_len, ctr);
+}
 
 #endif

--- a/plugins/in_forward/fw_config.c
+++ b/plugins/in_forward/fw_config.c
@@ -68,6 +68,7 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
         return NULL;
     }
     config->coll_fd = -1;
+    config->workers = 1;
 
     config->log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
 
@@ -135,6 +136,11 @@ struct flb_in_fw_config *fw_config_init(struct flb_input_instance *i_ins)
 
 int fw_config_destroy(struct flb_in_fw_config *config)
 {
+    if (config->conn_mutex_initialized == FLB_TRUE) {
+        pthread_mutex_destroy(&config->conn_mutex);
+        config->conn_mutex_initialized = FLB_FALSE;
+    }
+
     if (config->log_encoder != NULL) {
         flb_log_event_encoder_destroy(config->log_encoder);
     }
@@ -147,6 +153,11 @@ int fw_config_destroy(struct flb_in_fw_config *config)
         flb_input_collector_delete(config->coll_fd, config->ins);
 
         config->coll_fd = -1;
+    }
+
+    if (config->listener_registered == FLB_TRUE && config->event_loop != NULL) {
+        mk_event_del(config->event_loop, &config->listener_event);
+        config->listener_registered = FLB_FALSE;
     }
 
     if (config->downstream != NULL) {

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -986,9 +986,9 @@ static int fw_process_forward_mode_entry(
     }
 
     if (result == FLB_EVENT_ENCODER_SUCCESS) {
-        flb_input_log_append(conn->ctx->ins, tag, tag_len,
-                             conn->ctx->log_encoder->output_buffer,
-                             conn->ctx->log_encoder->output_length);
+        result = fw_ingest_logs(conn->ctx, tag, tag_len,
+                                conn->ctx->log_encoder->output_buffer,
+                                conn->ctx->log_encoder->output_length);
     }
 
     flb_log_event_encoder_reset(conn->ctx->log_encoder);
@@ -1057,16 +1057,21 @@ static int fw_process_message_mode_entry(
     }
 
     if (result == FLB_EVENT_ENCODER_SUCCESS) {
-        flb_input_log_append(in, tag, tag_len,
-                             conn->ctx->log_encoder->output_buffer,
-                             conn->ctx->log_encoder->output_length);
+        result = fw_ingest_logs(conn->ctx, tag, tag_len,
+                                conn->ctx->log_encoder->output_buffer,
+                                conn->ctx->log_encoder->output_length);
     }
 
     flb_log_event_encoder_reset(conn->ctx->log_encoder);
 
-    if (chunk_id != -1) {
+    if (result == FLB_EVENT_ENCODER_SUCCESS && chunk_id != -1) {
         chunk = options.via.map.ptr[chunk_id].val;
         send_ack(in, conn, chunk);
+    }
+
+    if (result != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_plg_warn(conn->ctx->ins, "could not ingest Forward message: %d", result);
+        return -1;
     }
 
     return 0;
@@ -1128,9 +1133,9 @@ static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
     struct ctrace *ctr;
 
     if (event_type == FLB_EVENT_TYPE_LOGS) {
-        ret = flb_input_log_append(conn->in,
-                                   out_tag, flb_sds_len(out_tag),
-                                   data, len);
+        ret = fw_ingest_logs(conn->ctx,
+                             out_tag, flb_sds_len(out_tag),
+                             data, len);
         if (ret != 0) {
             flb_plg_error(ins, "could not append logs. ret=%d", ret);
             return -1;
@@ -1145,15 +1150,20 @@ static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
             return -1;
         }
 
-        ret = flb_input_metrics_append(conn->in,
-                                       out_tag, flb_sds_len(out_tag),
-                                       cmt);
+        ret = fw_ingest_metrics(conn->ctx,
+                                out_tag, flb_sds_len(out_tag),
+                                cmt, len);
         if (ret != 0) {
             flb_plg_error(ins, "could not append metrics. ret=%d", ret);
-            cmt_decode_msgpack_destroy(cmt);
+            if (conn->ctx->use_ingress_queue == FLB_FALSE) {
+                cmt_decode_msgpack_destroy(cmt);
+            }
             return -1;
         }
-        cmt_decode_msgpack_destroy(cmt);
+
+        if (conn->ctx->use_ingress_queue == FLB_FALSE) {
+            cmt_decode_msgpack_destroy(cmt);
+        }
     }
     else if (event_type == FLB_EVENT_TYPE_TRACES) {
         off = 0;
@@ -1163,12 +1173,14 @@ static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
             return -1;
         }
 
-        ret = flb_input_trace_append(ins,
-                                     out_tag, flb_sds_len(out_tag),
-                                     ctr);
+        ret = fw_ingest_traces(conn->ctx,
+                               out_tag, flb_sds_len(out_tag),
+                               ctr, len);
         if (ret != 0) {
             flb_plg_error(ins, "could not append traces. ret=%d", ret);
-            ctr_decode_msgpack_destroy(ctr);
+            if (conn->ctx->use_ingress_queue == FLB_FALSE) {
+                ctr_decode_msgpack_destroy(ctr);
+            }
             return -1;
         }
         /* Note: flb_input_trace_append takes ownership of ctr and destroys it on success */
@@ -1480,7 +1492,7 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                             chunk_id);
                 }
 
-                if (chunk_id != -1) {
+                if (ret == 0 && chunk_id != -1) {
                     msgpack_object options;
                     msgpack_object chunk;
 
@@ -1488,6 +1500,10 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                     chunk = options.via.map.ptr[chunk_id].val;
 
                     send_ack(conn->in, conn, chunk);
+                }
+
+                if (ret != 0) {
+                    goto cleanup_msgpack;
                 }
             }
             else if (entry.type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
@@ -1534,11 +1550,14 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                 }
 
                 /* Process map */
-                fw_process_message_mode_entry(
+                ret = fw_process_message_mode_entry(
                     conn->in, conn,
                     out_tag, flb_sds_len(out_tag),
                     &root, &entry, &map, chunk_id,
                     metadata_id);
+                if (ret != 0) {
+                    goto cleanup_msgpack;
+                }
             }
             else if (entry.type == MSGPACK_OBJECT_STR ||
                      entry.type == MSGPACK_OBJECT_BIN) {

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -90,10 +90,12 @@ static inline int opentelemetry_ingest_logs_take(struct flb_opentelemetry *ctx,
 static inline int opentelemetry_ingest_metrics(struct flb_opentelemetry *ctx,
                                                const char *tag,
                                                size_t tag_len,
-                                               struct cmt *cmt)
+                                               struct cmt *cmt,
+                                               size_t payload_size)
 {
     if (opentelemetry_uses_worker_ingress_queue(ctx)) {
-        return flb_input_ingress_queue_metrics(ctx->ins, tag, tag_len, cmt);
+        return flb_input_ingress_queue_metrics(ctx->ins, tag, tag_len,
+                                               cmt, payload_size);
     }
 
     return flb_input_metrics_append(ctx->ins, tag, tag_len, cmt);
@@ -102,10 +104,12 @@ static inline int opentelemetry_ingest_metrics(struct flb_opentelemetry *ctx,
 static inline int opentelemetry_ingest_traces(struct flb_opentelemetry *ctx,
                                               const char *tag,
                                               size_t tag_len,
-                                              struct ctrace *ctr)
+                                              struct ctrace *ctr,
+                                              size_t payload_size)
 {
     if (opentelemetry_uses_worker_ingress_queue(ctx)) {
-        return flb_input_ingress_queue_traces(ctx->ins, tag, tag_len, ctr);
+        return flb_input_ingress_queue_traces(ctx->ins, tag, tag_len,
+                                              ctr, payload_size);
     }
 
     return flb_input_trace_append(ctx->ins, tag, tag_len, ctr);
@@ -114,10 +118,12 @@ static inline int opentelemetry_ingest_traces(struct flb_opentelemetry *ctx,
 static inline int opentelemetry_ingest_profiles(struct flb_opentelemetry *ctx,
                                                 const char *tag,
                                                 size_t tag_len,
-                                                struct cprof *profile)
+                                                struct cprof *profile,
+                                                size_t payload_size)
 {
     if (opentelemetry_uses_worker_ingress_queue(ctx)) {
-        return flb_input_ingress_queue_profiles(ctx->ins, tag, tag_len, profile);
+        return flb_input_ingress_queue_profiles(ctx->ins, tag, tag_len,
+                                                profile, payload_size);
     }
 
     return flb_input_profiles_append(ctx->ins, tag, tag_len, profile);

--- a/plugins/in_opentelemetry/opentelemetry_logs.c
+++ b/plugins/in_opentelemetry/opentelemetry_logs.c
@@ -857,9 +857,7 @@ int opentelemetry_process_logs(struct flb_opentelemetry *ctx,
                                                  encoder->output_buffer,
                                                  encoder->output_length,
                                                  allocation_size);
-            if (ret == 0 || ret == FLB_INPUT_INGRESS_BUSY) {
-                flb_log_event_encoder_claim_internal_buffer_ownership(encoder);
-            }
+            flb_log_event_encoder_claim_internal_buffer_ownership(encoder);
         }
         else {
             ret = opentelemetry_ingest_logs(ctx,

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -537,26 +537,38 @@ static int process_payload_metrics_ng(struct flb_opentelemetry *ctx,
     }
 
     if (result == CMT_DECODE_OPENTELEMETRY_SUCCESS) {
+        if (opentelemetry_uses_worker_ingress_queue(ctx)) {
+            result = flb_input_ingress_queue_metrics_list(ctx->ins,
+                                                          tag,
+                                                          cfl_sds_len(tag),
+                                                          &decoded_contexts,
+                                                          payload_size);
+            if (result == FLB_INPUT_INGRESS_BUSY) {
+                return FLB_INPUT_INGRESS_BUSY;
+            }
+            else if (result != 0) {
+                flb_plg_debug(ctx->ins,
+                              "could not queue metrics contexts : %d", result);
+                return -1;
+            }
+
+            return 0;
+        }
+
         cfl_list_foreach_safe(iterator, tmp, &decoded_contexts) {
             context = cfl_list_entry(iterator, struct cmt, _head);
-
-            if (opentelemetry_uses_worker_ingress_queue(ctx)) {
-                cfl_list_del(&context->_head);
-            }
 
             result = opentelemetry_ingest_metrics(ctx,
                                                   tag,
                                                   cfl_sds_len(tag),
-                                                  context);
+                                                  context,
+                                                  payload_size);
 
             if (result == FLB_INPUT_INGRESS_BUSY) {
                 cmt_decode_opentelemetry_destroy(&decoded_contexts);
                 return FLB_INPUT_INGRESS_BUSY;
             }
             else if (result != 0) {
-                if (opentelemetry_uses_worker_ingress_queue(ctx)) {
-                    cmt_destroy(context);
-                }
                 flb_plg_debug(ctx->ins, "could not ingest metrics context : %d", result);
             }
         }
@@ -644,9 +656,7 @@ static int ingest_profiles_context_as_log_entry(struct flb_opentelemetry *ctx,
                                              encoder->output_buffer,
                                              encoder->output_length,
                                              allocation_size);
-        if (ret == 0 || ret == FLB_INPUT_INGRESS_BUSY) {
-            flb_log_event_encoder_claim_internal_buffer_ownership(encoder);
-        }
+        flb_log_event_encoder_claim_internal_buffer_ownership(encoder);
     }
     else {
         ret = opentelemetry_ingest_logs(ctx,
@@ -717,10 +727,10 @@ static int process_payload_profiles_ng(struct flb_opentelemetry *ctx,
             ret = opentelemetry_ingest_profiles(ctx,
                                                 tag,
                                                 flb_sds_len(tag),
-                                                profiles_context);
+                                                profiles_context,
+                                                payload_size);
 
-            if (ret != FLB_INPUT_INGRESS_BUSY &&
-                (ret != 0 || !opentelemetry_uses_worker_ingress_queue(ctx))) {
+            if (!opentelemetry_uses_worker_ingress_queue(ctx)) {
                 cprof_decode_opentelemetry_destroy(profiles_context);
             }
         }

--- a/plugins/in_opentelemetry/opentelemetry_traces.c
+++ b/plugins/in_opentelemetry/opentelemetry_traces.c
@@ -43,8 +43,10 @@ int opentelemetry_traces_process_protobuf(struct flb_opentelemetry *ctx,
                                              data, size,
                                              &offset);
     if (result == 0) {
-        result = opentelemetry_ingest_traces(ctx, tag, tag_len, decoded_context);
-        if (result == -1) {
+        result = opentelemetry_ingest_traces(ctx, tag, tag_len,
+                                             decoded_context, size);
+        if (result == -1 &&
+            !opentelemetry_uses_worker_ingress_queue(ctx)) {
             ctr_destroy(decoded_context);
         }
     }
@@ -67,8 +69,9 @@ static int process_json(struct flb_opentelemetry *ctx,
     /* Use the new centralized API for JSON to ctrace conversion */
     ctr = flb_opentelemetry_json_traces_to_ctrace(body, len, &error_status);
     if (ctr) {
-        result = opentelemetry_ingest_traces(ctx, tag, tag_len, ctr);
-        if (result == -1) {
+        result = opentelemetry_ingest_traces(ctx, tag, tag_len, ctr, len);
+        if (result == -1 &&
+            !opentelemetry_uses_worker_ingress_queue(ctx)) {
             ctr_destroy(ctr);
         }
     }

--- a/plugins/in_prometheus_remote_write/prom_rw.h
+++ b/plugins/in_prometheus_remote_write/prom_rw.h
@@ -52,10 +52,12 @@ static inline int prom_rw_uses_worker_ingress_queue(
 static inline int prom_rw_ingest_metrics(struct flb_prom_remote_write *ctx,
                                          const char *tag,
                                          size_t tag_len,
-                                         struct cmt *cmt)
+                                         struct cmt *cmt,
+                                         size_t payload_size)
 {
     if (prom_rw_uses_worker_ingress_queue(ctx)) {
-        return flb_input_ingress_queue_metrics(ctx->ins, tag, tag_len, cmt);
+        return flb_input_ingress_queue_metrics(ctx->ins, tag, tag_len,
+                                               cmt, payload_size);
     }
 
     return flb_input_metrics_append(ctx->ins, tag, tag_len, cmt);

--- a/plugins/in_prometheus_remote_write/prom_rw_prot.c
+++ b/plugins/in_prometheus_remote_write/prom_rw_prot.c
@@ -74,14 +74,10 @@ static int process_payload_metrics_ng(struct flb_prom_remote_write *ctx,
         return 400;
     }
 
-    result = prom_rw_ingest_metrics(ctx, NULL, 0, context);
+    result = prom_rw_ingest_metrics(ctx, NULL, 0, context,
+                                    cfl_sds_len(request->body));
 
-    if (prom_rw_uses_worker_ingress_queue(ctx)) {
-        if (result != 0 && result != FLB_INPUT_INGRESS_BUSY) {
-            cmt_decode_prometheus_remote_write_destroy(context);
-        }
-    }
-    else {
+    if (!prom_rw_uses_worker_ingress_queue(ctx)) {
         cmt_decode_prometheus_remote_write_destroy(context);
     }
 

--- a/plugins/in_tcp/tcp.c
+++ b/plugins/in_tcp/tcp.c
@@ -18,12 +18,241 @@
  */
 
 #include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_downstream.h>
+#include <fluent-bit/flb_downstream_worker.h>
 #include <msgpack.h>
 
 #include "tcp.h"
 #include "tcp_conn.h"
 #include "tcp_config.h"
+
+static int in_tcp_collect_ctx(struct flb_in_tcp_config *ctx);
+static int in_tcp_collect(struct flb_input_instance *in,
+                          struct flb_config *config, void *in_context);
+
+static void in_tcp_connections_destroy(struct flb_in_tcp_config *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct tcp_conn *conn;
+
+    mk_list_foreach_safe(head, tmp, &ctx->connections) {
+        conn = mk_list_entry(head, struct tcp_conn, _head);
+        tcp_conn_del(conn);
+    }
+}
+
+static void in_tcp_connections_pause(struct flb_in_tcp_config *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct tcp_conn *conn;
+
+    mk_list_foreach_safe(head, tmp, &ctx->connections) {
+        conn = mk_list_entry(head, struct tcp_conn, _head);
+        if (conn->busy) {
+            conn->pending_close = FLB_TRUE;
+            continue;
+        }
+
+        tcp_conn_del(conn);
+    }
+}
+
+static int in_tcp_worker_listener_event(void *data)
+{
+    struct mk_event *event;
+
+    event = data;
+
+    return in_tcp_collect_ctx(event->data);
+}
+
+static int in_tcp_start_listener(struct flb_in_tcp_config *ctx,
+                                 struct flb_config *config,
+                                 struct flb_net_setup *net_setup,
+                                 struct mk_event_loop *event_loop,
+                                 int use_collector)
+{
+    int ret;
+    unsigned short int port;
+
+    port = (unsigned short int) strtoul(ctx->tcp_port, NULL, 10);
+
+    ctx->downstream = flb_downstream_create(FLB_TRANSPORT_TCP,
+                                            ctx->ins->flags,
+                                            ctx->listen,
+                                            port,
+                                            ctx->ins->tls,
+                                            config,
+                                            net_setup);
+
+    if (ctx->downstream == NULL) {
+        flb_plg_error(ctx->ins,
+                      "could not initialize downstream on %s:%s. Aborting",
+                      ctx->listen, ctx->tcp_port);
+        return -1;
+    }
+
+    flb_input_downstream_set(ctx->downstream, ctx->ins);
+
+    if (use_collector == FLB_TRUE) {
+        ret = flb_input_set_collector_socket(ctx->ins,
+                                             in_tcp_collect,
+                                             ctx->downstream->server_fd,
+                                             config);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "Could not set collector for IN_TCP input plugin");
+            return -1;
+        }
+
+        ctx->collector_id = ret;
+    }
+    else {
+        ctx->event_loop = event_loop;
+        MK_EVENT_NEW(&ctx->listener_event);
+        ctx->listener_event.type = FLB_ENGINE_EV_CUSTOM;
+        ctx->listener_event.data = ctx;
+        ctx->listener_event.handler = in_tcp_worker_listener_event;
+
+        ret = mk_event_add(event_loop,
+                           ctx->downstream->server_fd,
+                           FLB_ENGINE_EV_CUSTOM,
+                           MK_EVENT_READ,
+                           &ctx->listener_event);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not register TCP worker listener");
+            return -1;
+        }
+
+        ctx->listener_registered = FLB_TRUE;
+    }
+
+    return 0;
+}
+
+static int in_tcp_worker_init(struct flb_downstream_worker *worker,
+                              void *parent,
+                              void **worker_context)
+{
+    int ret;
+    struct flb_in_tcp_config *ctx;
+    struct flb_in_tcp_config *parent_ctx;
+
+    parent_ctx = parent;
+
+    ctx = tcp_config_init(parent_ctx->ins);
+    if (ctx == NULL) {
+        return -1;
+    }
+
+    *worker_context = ctx;
+
+    ctx->collector_id = -1;
+    ctx->ins = parent_ctx->ins;
+    ctx->workers = parent_ctx->workers;
+    ctx->worker_id = flb_downstream_worker_id_get(worker);
+    ctx->use_ingress_queue = FLB_TRUE;
+    ctx->net_setup = parent_ctx->ins->net_setup;
+    ctx->net_setup.share_port = FLB_TRUE;
+    mk_list_init(&ctx->connections);
+
+    ret = in_tcp_start_listener(ctx,
+                                parent_ctx->ins->config,
+                                &ctx->net_setup,
+                                flb_downstream_worker_event_loop_get(worker),
+                                FLB_FALSE);
+    if (ret == 0) {
+        flb_downstream_thread_safe(ctx->downstream);
+        ret = flb_downstream_worker_listener_fd_set(
+                  worker, ctx->downstream->server_fd);
+    }
+
+    return ret;
+}
+
+static void in_tcp_worker_exit(struct flb_downstream_worker *worker,
+                               void *worker_context)
+{
+    struct flb_in_tcp_config *ctx;
+
+    (void) worker;
+
+    ctx = worker_context;
+
+    in_tcp_connections_destroy(ctx);
+    tcp_config_destroy(ctx);
+}
+
+static void in_tcp_worker_maintenance(struct flb_downstream_worker *worker,
+                                      void *worker_context)
+{
+    struct flb_in_tcp_config *ctx;
+
+    (void) worker;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_conn_timeouts_stream(ctx->downstream);
+        flb_downstream_conn_pending_destroy(ctx->downstream);
+    }
+}
+
+static int in_tcp_workers_start(struct flb_in_tcp_config *ctx)
+{
+    struct flb_downstream_worker_options options;
+
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = ctx->workers;
+    options.parent = ctx;
+    options.cb_init = in_tcp_worker_init;
+    options.cb_exit = in_tcp_worker_exit;
+    options.cb_maintenance = in_tcp_worker_maintenance;
+
+    return flb_downstream_worker_runtime_start(&ctx->runtime, &options);
+}
+
+static void in_tcp_workers_stop(struct flb_in_tcp_config *ctx)
+{
+    flb_downstream_worker_runtime_stop(ctx->runtime);
+    ctx->runtime = NULL;
+}
+
+static void in_tcp_worker_pause(struct flb_downstream_worker *worker,
+                                void *worker_context,
+                                void *data)
+{
+    struct flb_in_tcp_config *ctx;
+
+    (void) worker;
+    (void) data;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_pause(ctx->downstream);
+    }
+    in_tcp_connections_pause(ctx);
+}
+
+static void in_tcp_worker_resume(struct flb_downstream_worker *worker,
+                                 void *worker_context,
+                                 void *data)
+{
+    struct flb_in_tcp_config *ctx;
+
+    (void) worker;
+    (void) data;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_resume(ctx->downstream);
+    }
+}
 
 /*
  * For a server event, the collection event means a new client have arrived, we
@@ -33,11 +262,16 @@
 static int in_tcp_collect(struct flb_input_instance *in,
                           struct flb_config *config, void *in_context)
 {
+    (void) in;
+    (void) config;
+
+    return in_tcp_collect_ctx(in_context);
+}
+
+static int in_tcp_collect_ctx(struct flb_in_tcp_config *ctx)
+{
     struct flb_connection    *connection;
     struct tcp_conn          *conn;
-    struct flb_in_tcp_config *ctx;
-
-    ctx = in_context;
 
     connection = flb_downstream_conn_get(ctx->downstream);
 
@@ -65,7 +299,6 @@ static int in_tcp_collect(struct flb_input_instance *in,
 static int in_tcp_init(struct flb_input_instance *in,
                       struct flb_config *config, void *data)
 {
-    unsigned short int        port;
     int                       ret;
     struct flb_in_tcp_config *ctx;
 
@@ -83,61 +316,52 @@ static int in_tcp_init(struct flb_input_instance *in,
     /* Set the context */
     flb_input_set_context(in, ctx);
 
-    port = (unsigned short int) strtoul(ctx->tcp_port, NULL, 10);
-
-    ctx->downstream = flb_downstream_create(FLB_TRANSPORT_TCP,
-                                            in->flags,
-                                            ctx->listen,
-                                            port,
-                                            in->tls,
-                                            config,
-                                            &in->net_setup);
-
-    if (ctx->downstream == NULL) {
-        flb_plg_error(ctx->ins,
-                      "could not initialize downstream on %s:%s. Aborting",
-                      ctx->listen, ctx->tcp_port);
-
-        tcp_config_destroy(ctx);
-
-        return -1;
+    if (ctx->workers <= 0) {
+        ctx->workers = 1;
     }
 
-    flb_input_downstream_set(ctx->downstream, ctx->ins);
+    if (ctx->workers > 1) {
+        ret = flb_input_ingress_enable(in);
+        if (ret != 0) {
+            tcp_config_destroy(ctx);
+            return -1;
+        }
 
-    /* Collect upon data available on the standard input */
-    ret = flb_input_set_collector_socket(in,
-                                         in_tcp_collect,
-                                         ctx->downstream->server_fd,
-                                         config);
-    if (ret == -1) {
-        flb_plg_error(ctx->ins, "Could not set collector for IN_TCP input plugin");
-        tcp_config_destroy(ctx);
-
-        return -1;
+        ret = in_tcp_workers_start(ctx);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "could not start TCP listener workers on %s:%s. Aborting",
+                          ctx->listen, ctx->tcp_port);
+            tcp_config_destroy(ctx);
+            return -1;
+        }
+    }
+    else {
+        ret = in_tcp_start_listener(ctx, config, &in->net_setup, NULL, FLB_TRUE);
+        if (ret != 0) {
+            tcp_config_destroy(ctx);
+            return -1;
+        }
     }
 
-    ctx->collector_id = ret;
+    flb_plg_info(ctx->ins,
+                 "listening on %s:%s with %i worker%s",
+                 ctx->listen, ctx->tcp_port, ctx->workers,
+                 ctx->workers == 1 ? "" : "s");
 
     return 0;
 }
 
 static int in_tcp_exit(void *data, struct flb_config *config)
 {
-    struct mk_list *tmp;
-    struct mk_list *head;
     struct flb_in_tcp_config *ctx;
-    struct tcp_conn *conn;
 
     (void) *config;
 
     ctx = data;
 
-    mk_list_foreach_safe(head, tmp, &ctx->connections) {
-        conn = mk_list_entry(head, struct tcp_conn, _head);
-
-        tcp_conn_del(conn);
-    }
+    in_tcp_workers_stop(ctx);
+    in_tcp_connections_destroy(ctx);
 
     tcp_config_destroy(ctx);
 
@@ -146,31 +370,42 @@ static int in_tcp_exit(void *data, struct flb_config *config)
 
 static void in_tcp_pause(void *data, struct flb_config *config)
 {
+    int ret;
     struct flb_in_tcp_config *ctx = data;
-    struct mk_list *head;
-    struct mk_list *tmp;
-    struct tcp_conn *conn;
 
     (void) config;
 
+    if (ctx->runtime != NULL) {
+        ret = flb_downstream_worker_runtime_foreach(ctx->runtime,
+                                                    in_tcp_worker_pause,
+                                                    NULL);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "could not pause all downstream workers");
+        }
+        return;
+    }
+
     flb_downstream_pause(ctx->downstream);
 
-    mk_list_foreach_safe(head, tmp, &ctx->connections) {
-        conn = mk_list_entry(head, struct tcp_conn, _head);
-        if (conn->busy) {
-            conn->pending_close = FLB_TRUE;
-            continue;
-        }
-
-        tcp_conn_del(conn);
-    }
+    in_tcp_connections_pause(ctx);
 }
 
 static void in_tcp_resume(void *data, struct flb_config *config)
 {
+    int ret;
     struct flb_in_tcp_config *ctx = data;
 
     (void) config;
+
+    if (ctx->runtime != NULL) {
+        ret = flb_downstream_worker_runtime_foreach(ctx->runtime,
+                                                    in_tcp_worker_resume,
+                                                    NULL);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "could not resume all downstream workers");
+        }
+        return;
+    }
 
     flb_downstream_resume(ctx->downstream);
 }
@@ -205,6 +440,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "source_address_key", (char *) NULL,
       0, FLB_TRUE, offsetof(struct flb_in_tcp_config, source_address_key),
       "Key where the source address will be injected"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "workers", "1",
+      0, FLB_TRUE, offsetof(struct flb_in_tcp_config, workers),
+      "Set the number of TCP listener workers"
     },
     /* EOF */
     {0}

--- a/plugins/in_tcp/tcp.h
+++ b/plugins/in_tcp/tcp.h
@@ -27,10 +27,13 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_network.h>
 #ifdef FLB_HAVE_PARSER
 #include <fluent-bit/flb_parser.h>
 #endif
 #include <msgpack.h>
+
+struct flb_downstream_worker_runtime;
 
 struct flb_in_tcp_config {
     flb_sds_t format_name;             /* Data format name */
@@ -51,10 +54,28 @@ struct flb_in_tcp_config {
     void *parser;
 #endif
     int collector_id;                  /* Listener collector id       */
+    int workers;                       /* Listener worker count       */
+    int worker_id;                     /* Worker id                   */
+    int use_ingress_queue;             /* Queue records to main loop  */
+    int listener_registered;           /* Listener event registered   */
+    struct mk_event listener_event;    /* Worker listener event       */
+    struct mk_event_loop *event_loop;  /* Worker event loop           */
+    struct flb_net_setup net_setup;    /* Worker network setup        */
     struct flb_downstream *downstream; /* Client manager */
     struct mk_list connections;        /* List of active connections  */
     struct flb_input_instance *ins;    /* Input plugin instace        */
     struct flb_log_event_encoder *log_encoder;
+    struct flb_downstream_worker_runtime *runtime;
 };
+
+static inline int tcp_ingest_logs(struct flb_in_tcp_config *ctx,
+                                  const void *buf, size_t buf_size)
+{
+    if (ctx->use_ingress_queue == FLB_TRUE) {
+        return flb_input_ingress_queue_log(ctx->ins, NULL, 0, buf, buf_size);
+    }
+
+    return flb_input_log_append(ctx->ins, NULL, 0, buf, buf_size);
+}
 
 #endif

--- a/plugins/in_tcp/tcp_config.c
+++ b/plugins/in_tcp/tcp_config.c
@@ -43,6 +43,7 @@ struct flb_in_tcp_config *tcp_config_init(struct flb_input_instance *ins)
     }
     ctx->ins = ins;
     ctx->format = FLB_TCP_FMT_JSON;
+    ctx->workers = 1;
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *)ctx);
@@ -166,6 +167,11 @@ int tcp_config_destroy(struct flb_in_tcp_config *ctx)
         flb_input_collector_delete(ctx->collector_id, ctx->ins);
 
         ctx->collector_id = -1;
+    }
+
+    if (ctx->listener_registered == FLB_TRUE && ctx->event_loop != NULL) {
+        mk_event_del(ctx->event_loop, &ctx->listener_event);
+        ctx->listener_registered = FLB_FALSE;
     }
 
     if (ctx->downstream != NULL) {

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -54,6 +54,7 @@ static inline int process_pack(struct tcp_conn *conn,
     char   *source_address;
 
     ctx = conn->ctx;
+    ret = FLB_EVENT_ENCODER_SUCCESS;
 
     flb_log_event_encoder_reset(ctx->log_encoder);
 
@@ -140,9 +141,15 @@ static inline int process_pack(struct tcp_conn *conn,
 
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
         if (ctx->log_encoder->output_length > 0) {
-            flb_input_log_append(conn->ins, NULL, 0,
-                                 ctx->log_encoder->output_buffer,
-                                 ctx->log_encoder->output_length);
+            ret = tcp_ingest_logs(ctx,
+                                  ctx->log_encoder->output_buffer,
+                                  ctx->log_encoder->output_length);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins,
+                              "could not append TCP logs for %s:%s. ret=%d",
+                              ctx->listen, ctx->tcp_port, ret);
+                return -1;
+            }
         }
         ret = 0;
     }
@@ -384,9 +391,15 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
 
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
         if (ctx->log_encoder->output_length > 0) {
-            flb_input_log_append(conn->ins, NULL, 0,
-                                 ctx->log_encoder->output_buffer,
-                                 ctx->log_encoder->output_length);
+            ret = tcp_ingest_logs(ctx,
+                                  ctx->log_encoder->output_buffer,
+                                  ctx->log_encoder->output_length);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins,
+                              "could not append TCP logs for %s:%s. ret=%d",
+                              ctx->listen, ctx->tcp_port, ret);
+                return -1;
+            }
         }
     }
     else {

--- a/plugins/in_udp/udp.c
+++ b/plugins/in_udp/udp.c
@@ -18,21 +18,222 @@
  */
 
 #include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_downstream.h>
+#include <fluent-bit/flb_downstream_worker.h>
 #include <msgpack.h>
 
 #include "udp.h"
 #include "udp_conn.h"
 #include "udp_config.h"
 
+static int in_udp_collect_ctx(struct flb_in_udp_config *ctx);
+static int in_udp_collect(struct flb_input_instance *in,
+                          struct flb_config *config,
+                          void *in_context);
+
+static int in_udp_worker_listener_event(void *data)
+{
+    struct mk_event *event;
+
+    event = data;
+
+    return in_udp_collect_ctx(event->data);
+}
+
+static void in_udp_dummy_conn_destroy(struct flb_in_udp_config *ctx)
+{
+    if (ctx->dummy_conn != NULL) {
+        udp_conn_del(ctx->dummy_conn);
+        ctx->dummy_conn = NULL;
+    }
+}
+
+static int in_udp_start_listener(struct flb_in_udp_config *ctx,
+                                 struct flb_config *config,
+                                 struct flb_net_setup *net_setup,
+                                 struct mk_event_loop *event_loop,
+                                 int use_collector)
+{
+    int ret;
+    unsigned short int port;
+    struct flb_connection *connection;
+
+    port = (unsigned short int) strtoul(ctx->port, NULL, 10);
+
+    ctx->downstream = flb_downstream_create(FLB_TRANSPORT_UDP,
+                                            ctx->ins->flags,
+                                            ctx->listen,
+                                            port,
+                                            ctx->ins->tls,
+                                            config,
+                                            net_setup);
+
+    if (ctx->downstream == NULL) {
+        flb_plg_error(ctx->ins,
+                      "could not initialize downstream on %s:%s. Aborting",
+                      ctx->listen, ctx->port);
+        return -1;
+    }
+
+    flb_input_downstream_set(ctx->downstream, ctx->ins);
+
+    connection = flb_downstream_conn_get(ctx->downstream);
+    if (connection == NULL) {
+        flb_plg_error(ctx->ins, "could not get UDP server dummy connection");
+        return -1;
+    }
+
+    ctx->dummy_conn = udp_conn_add(connection, ctx);
+    if (ctx->dummy_conn == NULL) {
+        flb_plg_error(ctx->ins, "could not track UDP server dummy connection");
+        return -1;
+    }
+
+    if (use_collector == FLB_TRUE) {
+        ret = flb_input_set_collector_socket(ctx->ins,
+                                             in_udp_collect,
+                                             ctx->downstream->server_fd,
+                                             config);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "Could not set collector for IN_UDP input plugin");
+            in_udp_dummy_conn_destroy(ctx);
+            return -1;
+        }
+
+        ctx->collector_id = ret;
+        ctx->collector_event = flb_input_collector_get_event(ret, ctx->ins);
+
+        if (ctx->collector_event == NULL) {
+            flb_plg_error(ctx->ins, "Could not get collector event");
+            in_udp_dummy_conn_destroy(ctx);
+            return -1;
+        }
+    }
+    else {
+        ctx->event_loop = event_loop;
+        MK_EVENT_NEW(&ctx->listener_event);
+        ctx->listener_event.type = FLB_ENGINE_EV_CUSTOM;
+        ctx->listener_event.data = ctx;
+        ctx->listener_event.handler = in_udp_worker_listener_event;
+
+        ret = mk_event_add(event_loop,
+                           ctx->downstream->server_fd,
+                           FLB_ENGINE_EV_CUSTOM,
+                           MK_EVENT_READ,
+                           &ctx->listener_event);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not register UDP worker listener");
+            in_udp_dummy_conn_destroy(ctx);
+            return -1;
+        }
+
+        ctx->listener_registered = FLB_TRUE;
+    }
+
+    return 0;
+}
+
+static int in_udp_worker_init(struct flb_downstream_worker *worker,
+                              void *parent,
+                              void **worker_context)
+{
+    int ret;
+    struct flb_in_udp_config *ctx;
+    struct flb_in_udp_config *parent_ctx;
+
+    parent_ctx = parent;
+
+    ctx = udp_config_init(parent_ctx->ins);
+    if (ctx == NULL) {
+        return -1;
+    }
+
+    *worker_context = ctx;
+
+    ctx->collector_id = -1;
+    ctx->ins = parent_ctx->ins;
+    ctx->workers = parent_ctx->workers;
+    ctx->worker_id = flb_downstream_worker_id_get(worker);
+    ctx->use_ingress_queue = FLB_TRUE;
+    ctx->net_setup = parent_ctx->ins->net_setup;
+    ctx->net_setup.share_port = FLB_TRUE;
+
+    ret = in_udp_start_listener(ctx,
+                                parent_ctx->ins->config,
+                                &ctx->net_setup,
+                                flb_downstream_worker_event_loop_get(worker),
+                                FLB_FALSE);
+    if (ret == 0) {
+        flb_downstream_thread_safe(ctx->downstream);
+        ret = flb_downstream_worker_listener_fd_set(
+                  worker, ctx->downstream->server_fd);
+    }
+
+    return ret;
+}
+
+static void in_udp_worker_exit(struct flb_downstream_worker *worker,
+                               void *worker_context)
+{
+    struct flb_in_udp_config *ctx;
+
+    (void) worker;
+
+    ctx = worker_context;
+
+    in_udp_dummy_conn_destroy(ctx);
+    udp_config_destroy(ctx);
+}
+
+static void in_udp_worker_maintenance(struct flb_downstream_worker *worker,
+                                      void *worker_context)
+{
+    struct flb_in_udp_config *ctx;
+
+    (void) worker;
+
+    ctx = worker_context;
+
+    if (ctx->downstream != NULL) {
+        flb_downstream_conn_pending_destroy(ctx->downstream);
+    }
+}
+
+static int in_udp_workers_start(struct flb_in_udp_config *ctx)
+{
+    struct flb_downstream_worker_options options;
+
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = ctx->workers;
+    options.parent = ctx;
+    options.cb_init = in_udp_worker_init;
+    options.cb_exit = in_udp_worker_exit;
+    options.cb_maintenance = in_udp_worker_maintenance;
+
+    return flb_downstream_worker_runtime_start(&ctx->runtime, &options);
+}
+
+static void in_udp_workers_stop(struct flb_in_udp_config *ctx)
+{
+    flb_downstream_worker_runtime_stop(ctx->runtime);
+    ctx->runtime = NULL;
+}
+
 static int in_udp_collect(struct flb_input_instance *in,
                           struct flb_config *config,
                           void *in_context)
 {
-    struct flb_connection    *connection;
-    struct flb_in_udp_config *ctx;
+    (void) in;
+    (void) config;
 
-    ctx = in_context;
+    return in_udp_collect_ctx(in_context);
+}
+
+static int in_udp_collect_ctx(struct flb_in_udp_config *ctx)
+{
+    struct flb_connection    *connection;
 
     connection = flb_downstream_conn_get(ctx->downstream);
 
@@ -49,8 +250,6 @@ static int in_udp_collect(struct flb_input_instance *in,
 static int in_udp_init(struct flb_input_instance *in,
                        struct flb_config *config, void *data)
 {
-    struct flb_connection    *connection;
-    unsigned short int        port;
     int                       ret;
     struct flb_in_udp_config *ctx;
 
@@ -69,69 +268,38 @@ static int in_udp_init(struct flb_input_instance *in,
     /* Set the context */
     flb_input_set_context(in, ctx);
 
-    port = (unsigned short int) strtoul(ctx->port, NULL, 10);
-
-    ctx->downstream = flb_downstream_create(FLB_TRANSPORT_UDP,
-                                            in->flags,
-                                            ctx->listen,
-                                            port,
-                                            in->tls,
-                                            config,
-                                            &in->net_setup);
-
-    if (ctx->downstream == NULL) {
-        flb_plg_error(ctx->ins,
-                      "could not initialize downstream on %s:%s. Aborting",
-                      ctx->listen, ctx->port);
-
-        udp_config_destroy(ctx);
-
-        return -1;
+    if (ctx->workers <= 0) {
+        ctx->workers = 1;
     }
 
-    flb_input_downstream_set(ctx->downstream, ctx->ins);
+    if (ctx->workers > 1) {
+        ret = flb_input_ingress_enable(in);
+        if (ret != 0) {
+            udp_config_destroy(ctx);
+            return -1;
+        }
 
-    connection = flb_downstream_conn_get(ctx->downstream);
-
-    if (connection == NULL) {
-        flb_plg_error(ctx->ins, "could not get UDP server dummy connection");
-
-        udp_config_destroy(ctx);
-
-        return -1;
+        ret = in_udp_workers_start(ctx);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "could not start UDP listener workers on %s:%s. Aborting",
+                          ctx->listen, ctx->port);
+            udp_config_destroy(ctx);
+            return -1;
+        }
+    }
+    else {
+        ret = in_udp_start_listener(ctx, config, &in->net_setup, NULL, FLB_TRUE);
+        if (ret != 0) {
+            udp_config_destroy(ctx);
+            return -1;
+        }
     }
 
-    ctx->dummy_conn = udp_conn_add(connection, ctx);
-
-    if (ctx->dummy_conn == NULL) {
-        flb_plg_error(ctx->ins, "could not track UDP server dummy connection");
-
-        udp_config_destroy(ctx);
-
-        return -1;
-    }
-
-    /* Collect upon data available on the standard input */
-    ret = flb_input_set_collector_socket(in,
-                                         in_udp_collect,
-                                         ctx->downstream->server_fd,
-                                         config);
-    if (ret == -1) {
-        flb_plg_error(ctx->ins, "Could not set collector for IN_UDP input plugin");
-        udp_config_destroy(ctx);
-
-        return -1;
-    }
-
-    ctx->collector_id = ret;
-    ctx->collector_event = flb_input_collector_get_event(ret, in);
-
-    if (ret == -1) {
-        flb_plg_error(ctx->ins, "Could not get collector event");
-        udp_config_destroy(ctx);
-
-        return -1;
-    }
+    flb_plg_info(ctx->ins,
+                 "listening on %s:%s with %i worker%s",
+                 ctx->listen, ctx->port, ctx->workers,
+                 ctx->workers == 1 ? "" : "s");
 
     return 0;
 }
@@ -144,9 +312,8 @@ static int in_udp_exit(void *data, struct flb_config *config)
 
     ctx = data;
 
-    if (ctx->dummy_conn != NULL) {
-        udp_conn_del(ctx->dummy_conn);
-    }
+    in_udp_workers_stop(ctx);
+    in_udp_dummy_conn_destroy(ctx);
 
     udp_config_destroy(ctx);
 
@@ -183,6 +350,11 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "source_address_key", (char *) NULL,
       0, FLB_TRUE, offsetof(struct flb_in_udp_config, source_address_key),
       "Key where the source address will be injected"
+    },
+    {
+      FLB_CONFIG_MAP_INT, "workers", "1",
+      0, FLB_TRUE, offsetof(struct flb_in_udp_config, workers),
+      "Set the number of UDP listener workers"
     },
     /* EOF */
     {0}

--- a/plugins/in_udp/udp.h
+++ b/plugins/in_udp/udp.h
@@ -27,12 +27,14 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_network.h>
 #ifdef FLB_HAVE_PARSER
 #include <fluent-bit/flb_parser.h>
 #endif
 #include <msgpack.h>
 
 struct udp_conn;
+struct flb_downstream_worker_runtime;
 
 struct flb_in_udp_config {
     struct mk_event *collector_event;
@@ -54,10 +56,28 @@ struct flb_in_udp_config {
     void *parser;
 #endif
     int collector_id;                  /* Listener collector id       */
+    int workers;                       /* Listener worker count       */
+    int worker_id;                     /* Worker id                   */
+    int use_ingress_queue;             /* Queue records to main loop  */
+    int listener_registered;           /* Listener event registered   */
+    struct mk_event listener_event;    /* Worker listener event       */
+    struct mk_event_loop *event_loop;  /* Worker event loop           */
+    struct flb_net_setup net_setup;    /* Worker network setup        */
     struct flb_downstream *downstream; /* Client manager              */
     struct udp_conn *dummy_conn;       /* Datagram dummy connection   */
     struct flb_input_instance *ins;    /* Input plugin instace        */
     struct flb_log_event_encoder *log_encoder;
+    struct flb_downstream_worker_runtime *runtime;
 };
+
+static inline int udp_ingest_logs(struct flb_in_udp_config *ctx,
+                                  const void *buf, size_t buf_size)
+{
+    if (ctx->use_ingress_queue == FLB_TRUE) {
+        return flb_input_ingress_queue_log(ctx->ins, NULL, 0, buf, buf_size);
+    }
+
+    return flb_input_log_append(ctx->ins, NULL, 0, buf, buf_size);
+}
 
 #endif

--- a/plugins/in_udp/udp_config.c
+++ b/plugins/in_udp/udp_config.c
@@ -43,6 +43,7 @@ struct flb_in_udp_config *udp_config_init(struct flb_input_instance *ins)
     }
     ctx->ins = ins;
     ctx->format = FLB_UDP_FMT_JSON;
+    ctx->workers = 1;
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *)ctx);
@@ -166,6 +167,11 @@ int udp_config_destroy(struct flb_in_udp_config *ctx)
         flb_input_collector_delete(ctx->collector_id, ctx->ins);
 
         ctx->collector_id = -1;
+    }
+
+    if (ctx->listener_registered == FLB_TRUE && ctx->event_loop != NULL) {
+        mk_event_del(ctx->event_loop, &ctx->listener_event);
+        ctx->listener_registered = FLB_FALSE;
     }
 
     if (ctx->downstream != NULL) {

--- a/plugins/in_udp/udp_conn.c
+++ b/plugins/in_udp/udp_conn.c
@@ -114,6 +114,7 @@ static inline int process_pack(struct udp_conn *conn,
     int len;
 
     ctx = conn->ctx;
+    ret = FLB_EVENT_ENCODER_SUCCESS;
 
     flb_log_event_encoder_reset(ctx->log_encoder);
 
@@ -210,10 +211,19 @@ static inline int process_pack(struct udp_conn *conn,
     msgpack_unpacked_destroy(&result);
 
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-        flb_input_log_append(conn->ins, NULL, 0,
-                             ctx->log_encoder->output_buffer,
-                             ctx->log_encoder->output_length);
-        ret = 0;
+        if (ctx->log_encoder->output_length > 0) {
+            ret = udp_ingest_logs(ctx,
+                                  ctx->log_encoder->output_buffer,
+                                  ctx->log_encoder->output_length);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins,
+                              "could not append UDP logs for %s:%s. ret=%d",
+                              ctx->listen, ctx->port, ret);
+                return -1;
+            }
+        }
+
+        return 0;
     }
     else {
         flb_plg_error(ctx->ins, "log event encoding error : %d", ret);
@@ -248,8 +258,12 @@ static ssize_t parse_payload_json(struct udp_conn *conn)
     }
 
     /* Process the packaged JSON and return the last byte used */
-    process_pack(conn, pack, out_size);
+    ret = process_pack(conn, pack, out_size);
     flb_free(pack);
+
+    if (ret != 0) {
+        return -1;
+    }
 
     return conn->pack_state.last_byte;
 }
@@ -441,9 +455,17 @@ static ssize_t parse_payload_none(struct udp_conn *conn)
     }
 
     if (ret == FLB_EVENT_ENCODER_SUCCESS) {
-        flb_input_log_append(conn->ins, NULL, 0,
-                             ctx->log_encoder->output_buffer,
-                             ctx->log_encoder->output_length);
+        if (ctx->log_encoder->output_length > 0) {
+            ret = udp_ingest_logs(ctx,
+                                  ctx->log_encoder->output_buffer,
+                                  ctx->log_encoder->output_length);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins,
+                              "could not append UDP logs for %s:%s. ret=%d",
+                              ctx->listen, ctx->port, ret);
+                return -1;
+            }
+        }
     }
     else {
         flb_plg_error(ctx->ins, "log event encoding error : %d", ret);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(src
   flb_storage.c
   flb_connection.c
   flb_downstream.c
+  flb_downstream_worker.c
   flb_upstream.c
   flb_upstream_ha.c
   flb_upstream_node.c

--- a/src/flb_downstream_worker.c
+++ b/src/flb_downstream_worker.c
@@ -1,0 +1,635 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cfl/cfl_atomic.h>
+
+#include <fluent-bit/flb_downstream_worker.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_network.h>
+#include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_pthread.h>
+
+#include <monkey/mk_core.h>
+
+#include <string.h>
+
+struct flb_downstream_worker {
+    struct flb_downstream_worker_runtime *runtime;
+    struct mk_event_loop *event_loop;
+    struct mk_event control_event;
+    flb_pipefd_t control_channel[2];
+    flb_sockfd_t listener_fd;
+    void *context;
+    int worker_id;
+    int worker_count;
+    pthread_t thread;
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    uint64_t should_exit;
+    flb_downstream_worker_foreach_cb control_callback;
+    void *control_data;
+    int initialized;
+    int thread_created;
+    int control_channel_created;
+    int control_done;
+    int control_result;
+    int startup_result;
+};
+
+struct flb_downstream_worker_runtime {
+    struct flb_downstream_worker *workers;
+    int worker_count;
+    int active_workers;
+    void *parent;
+    flb_downstream_worker_init_cb cb_init;
+    flb_downstream_worker_exit_cb cb_exit;
+    flb_downstream_worker_maintenance_cb cb_maintenance;
+    pthread_mutex_t lifecycle_mutex;
+    pthread_cond_t lifecycle_condition;
+    pthread_mutex_t foreach_mutex;
+    int active_operations;
+    int stopping;
+    int listener_address_set;
+    struct sockaddr_storage listener_address;
+};
+
+static int downstream_worker_context_reset(struct flb_downstream_worker *worker)
+{
+    int ret;
+
+    memset(worker, 0, sizeof(struct flb_downstream_worker));
+    worker->listener_fd = FLB_INVALID_SOCKET;
+
+    ret = pthread_mutex_init(&worker->mutex, NULL);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = pthread_cond_init(&worker->condition, NULL);
+    if (ret != 0) {
+        pthread_mutex_destroy(&worker->mutex);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int downstream_worker_listener_validate(
+    struct flb_downstream_worker_runtime *runtime,
+    struct flb_downstream_worker *worker)
+{
+    int result;
+    socklen_t address_length;
+    int addresses_match;
+    struct sockaddr_in *address_ipv4;
+    struct sockaddr_in *runtime_address_ipv4;
+    struct sockaddr_in6 *address_ipv6;
+    struct sockaddr_in6 *runtime_address_ipv6;
+    struct sockaddr_storage address;
+
+    if (worker->listener_fd == FLB_INVALID_SOCKET) {
+        return 0;
+    }
+
+    memset(&address, 0, sizeof(struct sockaddr_storage));
+    address_length = sizeof(struct sockaddr_storage);
+    result = getsockname(worker->listener_fd,
+                         (struct sockaddr *) &address,
+                         &address_length);
+    if (result != 0) {
+        return -1;
+    }
+
+    if (runtime->listener_address_set == FLB_FALSE) {
+        memcpy(&runtime->listener_address, &address,
+               sizeof(struct sockaddr_storage));
+        runtime->listener_address_set = FLB_TRUE;
+        return 0;
+    }
+
+    addresses_match = FLB_FALSE;
+    if (runtime->listener_address.ss_family == AF_INET &&
+        address.ss_family == AF_INET) {
+        runtime_address_ipv4 = (struct sockaddr_in *) &runtime->listener_address;
+        address_ipv4 = (struct sockaddr_in *) &address;
+        if (runtime_address_ipv4->sin_port == address_ipv4->sin_port &&
+            memcmp(&runtime_address_ipv4->sin_addr,
+                   &address_ipv4->sin_addr,
+                   sizeof(struct in_addr)) == 0) {
+            addresses_match = FLB_TRUE;
+        }
+    }
+    else if (runtime->listener_address.ss_family == AF_INET6 &&
+             address.ss_family == AF_INET6) {
+        runtime_address_ipv6 = (struct sockaddr_in6 *) &runtime->listener_address;
+        address_ipv6 = (struct sockaddr_in6 *) &address;
+        if (runtime_address_ipv6->sin6_port == address_ipv6->sin6_port &&
+            runtime_address_ipv6->sin6_scope_id == address_ipv6->sin6_scope_id &&
+            memcmp(&runtime_address_ipv6->sin6_addr,
+                   &address_ipv6->sin6_addr,
+                   sizeof(struct in6_addr)) == 0) {
+            addresses_match = FLB_TRUE;
+        }
+    }
+
+    if (addresses_match == FLB_FALSE) {
+        flb_error("[downstream worker] listeners did not bind the same endpoint");
+        return -1;
+    }
+
+    return 0;
+}
+
+static void downstream_worker_context_cleanup(struct flb_downstream_worker *worker)
+{
+    pthread_mutex_destroy(&worker->mutex);
+    pthread_cond_destroy(&worker->condition);
+}
+
+static int downstream_worker_control_event(struct flb_downstream_worker *worker)
+{
+    ssize_t bytes;
+    char signal;
+    flb_downstream_worker_foreach_cb callback;
+    void *data;
+
+    bytes = flb_pipe_r(worker->control_channel[0], &signal, sizeof(signal));
+    if (bytes != sizeof(signal)) {
+        pthread_mutex_lock(&worker->mutex);
+        worker->control_callback = NULL;
+        worker->control_data = NULL;
+        worker->control_result = -1;
+        worker->control_done = FLB_TRUE;
+        pthread_cond_broadcast(&worker->condition);
+        pthread_mutex_unlock(&worker->mutex);
+        return -1;
+    }
+
+    pthread_mutex_lock(&worker->mutex);
+    callback = worker->control_callback;
+    data = worker->control_data;
+    pthread_mutex_unlock(&worker->mutex);
+
+    if (callback != NULL && worker->context != NULL) {
+        callback(worker, worker->context, data);
+    }
+
+    pthread_mutex_lock(&worker->mutex);
+    worker->control_callback = NULL;
+    worker->control_data = NULL;
+    worker->control_result = 0;
+    worker->control_done = FLB_TRUE;
+    pthread_cond_signal(&worker->condition);
+    pthread_mutex_unlock(&worker->mutex);
+
+    return 0;
+}
+
+static void *downstream_worker_thread(void *data)
+{
+    int ret;
+    struct mk_event *event;
+    struct flb_net_dns dns_ctx = {0};
+    struct flb_downstream_worker *worker;
+    struct flb_downstream_worker_runtime *runtime;
+
+    worker = data;
+    runtime = worker->runtime;
+    flb_net_ctx_init(&dns_ctx);
+
+    worker->event_loop = mk_event_loop_create(256);
+    if (worker->event_loop == NULL) {
+        ret = -1;
+        goto signal_and_exit;
+    }
+
+    MK_EVENT_NEW(&worker->control_event);
+    ret = mk_event_channel_create(worker->event_loop,
+                                  &worker->control_channel[0],
+                                  &worker->control_channel[1],
+                                  &worker->control_event);
+    if (ret != 0) {
+        ret = -1;
+        goto signal_and_exit;
+    }
+    worker->control_channel_created = FLB_TRUE;
+
+    flb_engine_evl_init();
+    flb_engine_evl_set(worker->event_loop);
+    flb_net_dns_ctx_set(&dns_ctx);
+
+    ret = runtime->cb_init(worker, runtime->parent, &worker->context);
+
+signal_and_exit:
+    pthread_mutex_lock(&worker->mutex);
+    worker->startup_result = ret;
+    worker->initialized = FLB_TRUE;
+    pthread_cond_signal(&worker->condition);
+    pthread_mutex_unlock(&worker->mutex);
+
+    if (ret != 0) {
+        goto cleanup;
+    }
+
+    while (cfl_atomic_load(&worker->should_exit) == FLB_FALSE) {
+        ret = mk_event_wait_2(worker->event_loop, 250);
+        if (ret < 0) {
+            flb_error("[downstream worker %i] event loop wait failed",
+                      worker->worker_id);
+            pthread_mutex_lock(&worker->mutex);
+            worker->startup_result = -1;
+            pthread_mutex_unlock(&worker->mutex);
+            break;
+        }
+
+        if (cfl_atomic_load(&worker->should_exit) == FLB_TRUE) {
+            break;
+        }
+
+        {
+            mk_event_foreach(event, worker->event_loop) {
+                if (event->type == FLB_ENGINE_EV_CUSTOM) {
+                    event->handler(event);
+                }
+            }
+        }
+
+        {
+            mk_event_foreach(event, worker->event_loop) {
+                if (event == &worker->control_event) {
+                    downstream_worker_control_event(worker);
+                }
+            }
+        }
+
+        if (runtime->cb_maintenance != NULL) {
+            runtime->cb_maintenance(worker, worker->context);
+        }
+
+        flb_net_dns_lookup_context_cleanup(&dns_ctx);
+    }
+
+cleanup:
+    flb_net_dns_lookup_context_cleanup(&dns_ctx);
+
+    if (runtime->cb_exit != NULL && worker->context != NULL) {
+        runtime->cb_exit(worker, worker->context);
+    }
+
+    pthread_mutex_lock(&worker->mutex);
+    if (worker->context != NULL) {
+        worker->context = NULL;
+    }
+
+    if (worker->control_done == FLB_FALSE &&
+        worker->control_callback != NULL) {
+        worker->control_callback = NULL;
+        worker->control_data = NULL;
+        worker->control_result = -1;
+        worker->control_done = FLB_TRUE;
+        pthread_cond_broadcast(&worker->condition);
+    }
+
+    if (worker->control_channel_created == FLB_TRUE) {
+        mk_event_channel_destroy(worker->event_loop,
+                                 worker->control_channel[0],
+                                 worker->control_channel[1],
+                                 &worker->control_event);
+        worker->control_channel_created = FLB_FALSE;
+    }
+    pthread_mutex_unlock(&worker->mutex);
+
+    if (worker->event_loop != NULL) {
+        flb_engine_evl_set(NULL);
+        flb_net_dns_ctx_set(NULL);
+        mk_event_loop_destroy(worker->event_loop);
+        worker->event_loop = NULL;
+    }
+
+    return NULL;
+}
+
+int flb_downstream_worker_runtime_start(struct flb_downstream_worker_runtime **out_runtime,
+                                        const struct flb_downstream_worker_options *options)
+{
+    int i;
+    int ret;
+    struct flb_downstream_worker_runtime *runtime;
+
+    if (out_runtime == NULL) {
+        return -1;
+    }
+
+    *out_runtime = NULL;
+
+    if (options == NULL || options->workers <= 0 || options->cb_init == NULL) {
+        return -1;
+    }
+
+    runtime = flb_calloc(1, sizeof(struct flb_downstream_worker_runtime));
+    if (runtime == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = pthread_mutex_init(&runtime->lifecycle_mutex, NULL);
+    if (ret != 0) {
+        flb_free(runtime);
+        return -1;
+    }
+
+    ret = pthread_cond_init(&runtime->lifecycle_condition, NULL);
+    if (ret != 0) {
+        pthread_mutex_destroy(&runtime->lifecycle_mutex);
+        flb_free(runtime);
+        return -1;
+    }
+
+    ret = pthread_mutex_init(&runtime->foreach_mutex, NULL);
+    if (ret != 0) {
+        pthread_cond_destroy(&runtime->lifecycle_condition);
+        pthread_mutex_destroy(&runtime->lifecycle_mutex);
+        flb_free(runtime);
+        return -1;
+    }
+    runtime->workers = flb_calloc(options->workers,
+                                  sizeof(struct flb_downstream_worker));
+    if (runtime->workers == NULL) {
+        flb_errno();
+        pthread_mutex_destroy(&runtime->foreach_mutex);
+        pthread_cond_destroy(&runtime->lifecycle_condition);
+        pthread_mutex_destroy(&runtime->lifecycle_mutex);
+        flb_free(runtime);
+        return -1;
+    }
+
+    runtime->worker_count = options->workers;
+    runtime->parent = options->parent;
+    runtime->cb_init = options->cb_init;
+    runtime->cb_exit = options->cb_exit;
+    runtime->cb_maintenance = options->cb_maintenance;
+
+    *out_runtime = runtime;
+
+    for (i = 0; i < runtime->worker_count; i++) {
+        ret = downstream_worker_context_reset(&runtime->workers[i]);
+        if (ret != 0) {
+            break;
+        }
+
+        runtime->active_workers++;
+        runtime->workers[i].runtime = runtime;
+        runtime->workers[i].worker_id = i;
+        runtime->workers[i].worker_count = runtime->worker_count;
+
+        ret = pthread_create(&runtime->workers[i].thread,
+                             NULL,
+                             downstream_worker_thread,
+                             &runtime->workers[i]);
+        if (ret != 0) {
+            runtime->workers[i].startup_result = -1;
+            break;
+        }
+
+        runtime->workers[i].thread_created = FLB_TRUE;
+        pthread_mutex_lock(&runtime->workers[i].mutex);
+        while (runtime->workers[i].initialized == FLB_FALSE) {
+            ret = pthread_cond_wait(&runtime->workers[i].condition,
+                                    &runtime->workers[i].mutex);
+            if (ret != 0) {
+                break;
+            }
+        }
+        if (ret == 0) {
+            ret = runtime->workers[i].startup_result;
+        }
+        pthread_mutex_unlock(&runtime->workers[i].mutex);
+
+        if (ret == 0) {
+            ret = downstream_worker_listener_validate(runtime,
+                                                      &runtime->workers[i]);
+        }
+
+        if (ret != 0) {
+            break;
+        }
+    }
+
+    if (i != runtime->worker_count) {
+        flb_downstream_worker_runtime_stop(runtime);
+        *out_runtime = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
+static int downstream_worker_runtime_is_worker_thread(
+    struct flb_downstream_worker_runtime *runtime)
+{
+    int i;
+
+    for (i = 0; i < runtime->active_workers; i++) {
+        if (runtime->workers[i].thread_created == FLB_TRUE &&
+            pthread_equal(runtime->workers[i].thread, pthread_self())) {
+            return FLB_TRUE;
+        }
+    }
+
+    return FLB_FALSE;
+}
+
+int flb_downstream_worker_runtime_stop(struct flb_downstream_worker_runtime *runtime)
+{
+    int i;
+    char signal;
+
+    if (runtime == NULL) {
+        return 0;
+    }
+
+    if (downstream_worker_runtime_is_worker_thread(runtime) == FLB_TRUE) {
+        return -1;
+    }
+
+    signal = 1;
+
+    pthread_mutex_lock(&runtime->lifecycle_mutex);
+    runtime->stopping = FLB_TRUE;
+    while (runtime->active_operations > 0) {
+        pthread_cond_wait(&runtime->lifecycle_condition,
+                          &runtime->lifecycle_mutex);
+    }
+    pthread_mutex_unlock(&runtime->lifecycle_mutex);
+
+    /* Wake every worker before joining so shutdown latency is not cumulative. */
+    for (i = 0; i < runtime->active_workers; i++) {
+        cfl_atomic_store(&runtime->workers[i].should_exit, FLB_TRUE);
+
+        pthread_mutex_lock(&runtime->workers[i].mutex);
+        if (runtime->workers[i].startup_result == 0 &&
+            runtime->workers[i].control_channel_created == FLB_TRUE) {
+            flb_pipe_w(runtime->workers[i].control_channel[1],
+                       &signal, sizeof(signal));
+        }
+        pthread_mutex_unlock(&runtime->workers[i].mutex);
+    }
+
+    for (i = 0; i < runtime->active_workers; i++) {
+        if (runtime->workers[i].thread_created == FLB_TRUE) {
+            pthread_join(runtime->workers[i].thread, NULL);
+        }
+        downstream_worker_context_cleanup(&runtime->workers[i]);
+    }
+
+    pthread_mutex_destroy(&runtime->foreach_mutex);
+    pthread_cond_destroy(&runtime->lifecycle_condition);
+    pthread_mutex_destroy(&runtime->lifecycle_mutex);
+    flb_free(runtime->workers);
+    flb_free(runtime);
+
+    return 0;
+}
+
+int flb_downstream_worker_runtime_foreach(struct flb_downstream_worker_runtime *runtime,
+                                          flb_downstream_worker_foreach_cb callback,
+                                          void *data)
+{
+    int i;
+    int result;
+    int wait_result;
+    ssize_t bytes;
+    char signal;
+    struct flb_downstream_worker *worker;
+
+    if (runtime == NULL || callback == NULL) {
+        return -1;
+    }
+
+    if (downstream_worker_runtime_is_worker_thread(runtime) == FLB_TRUE) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&runtime->lifecycle_mutex);
+    if (runtime->stopping == FLB_TRUE) {
+        pthread_mutex_unlock(&runtime->lifecycle_mutex);
+        return -1;
+    }
+    runtime->active_operations++;
+    pthread_mutex_unlock(&runtime->lifecycle_mutex);
+
+    pthread_mutex_lock(&runtime->foreach_mutex);
+
+    result = 0;
+    signal = 1;
+
+    for (i = 0; i < runtime->worker_count; i++) {
+        worker = &runtime->workers[i];
+
+        pthread_mutex_lock(&worker->mutex);
+        if (worker->context == NULL || worker->thread_created != FLB_TRUE ||
+            worker->control_channel_created != FLB_TRUE) {
+            pthread_mutex_unlock(&worker->mutex);
+            result = -1;
+            continue;
+        }
+
+        worker->control_callback = callback;
+        worker->control_data = data;
+        worker->control_done = FLB_FALSE;
+        worker->control_result = 0;
+
+        bytes = flb_pipe_w(worker->control_channel[1], &signal, sizeof(signal));
+        if (bytes != sizeof(signal)) {
+            worker->control_callback = NULL;
+            worker->control_data = NULL;
+            worker->control_done = FLB_TRUE;
+            pthread_mutex_unlock(&worker->mutex);
+            result = -1;
+            continue;
+        }
+
+        while (worker->control_done == FLB_FALSE) {
+            wait_result = pthread_cond_wait(&worker->condition, &worker->mutex);
+            if (wait_result != 0) {
+                worker->control_callback = NULL;
+                worker->control_data = NULL;
+                worker->control_result = -1;
+                worker->control_done = FLB_TRUE;
+                break;
+            }
+        }
+        if (worker->control_result != 0) {
+            result = -1;
+        }
+        pthread_mutex_unlock(&worker->mutex);
+    }
+    pthread_mutex_unlock(&runtime->foreach_mutex);
+
+    pthread_mutex_lock(&runtime->lifecycle_mutex);
+    runtime->active_operations--;
+    if (runtime->active_operations == 0) {
+        pthread_cond_signal(&runtime->lifecycle_condition);
+    }
+    pthread_mutex_unlock(&runtime->lifecycle_mutex);
+
+    return result;
+}
+
+struct mk_event_loop *flb_downstream_worker_event_loop_get(
+    struct flb_downstream_worker *worker)
+{
+    if (worker == NULL) {
+        return NULL;
+    }
+
+    return worker->event_loop;
+}
+
+int flb_downstream_worker_id_get(struct flb_downstream_worker *worker)
+{
+    if (worker == NULL) {
+        return -1;
+    }
+
+    return worker->worker_id;
+}
+
+int flb_downstream_worker_count_get(struct flb_downstream_worker *worker)
+{
+    if (worker == NULL) {
+        return -1;
+    }
+
+    return worker->worker_count;
+}
+
+int flb_downstream_worker_listener_fd_set(struct flb_downstream_worker *worker,
+                                          flb_sockfd_t listener_fd)
+{
+    if (worker == NULL || listener_fd == FLB_INVALID_SOCKET) {
+        return -1;
+    }
+
+    worker->listener_fd = listener_fd;
+
+    return 0;
+}

--- a/src/flb_input_ingest.c
+++ b/src/flb_input_ingest.c
@@ -52,16 +52,20 @@ struct flb_input_ingress_event {
             void   *buf;
             size_t  size;
         } log;
-        struct cmt    *metrics;
         struct ctrace *traces;
         struct cprof  *profiles;
     } data;
 
+    struct cfl_list metrics;
     struct mk_list _head;
 };
 
 static void flb_input_ingress_event_destroy(struct flb_input_ingress_event *event)
 {
+    struct cfl_list *iterator;
+    struct cfl_list *tmp;
+    struct cmt *context;
+
     if (event == NULL) {
         return;
     }
@@ -80,8 +84,10 @@ static void flb_input_ingress_event_destroy(struct flb_input_ingress_event *even
         }
     }
     else if (event->type == FLB_INPUT_INGRESS_METRICS) {
-        if (event->data.metrics != NULL) {
-            cmt_destroy(event->data.metrics);
+        cfl_list_foreach_safe(iterator, tmp, &event->metrics) {
+            context = cfl_list_entry(iterator, struct cmt, _head);
+            cfl_list_del(&context->_head);
+            cmt_destroy(context);
         }
     }
     else if (event->type == FLB_INPUT_INGRESS_TRACES) {
@@ -107,42 +113,14 @@ static size_t flb_input_ingress_event_size(struct flb_input_ingress_event *event
     return event->size;
 }
 
-static size_t flb_input_ingress_estimate_metrics_size(struct cmt *cmt)
+static size_t flb_input_ingress_signal_size(size_t payload_size)
 {
-    if (cmt == NULL) {
-        return 0;
+    if (payload_size > 0) {
+        return payload_size;
     }
 
-    /* Deferred worker ingress must not touch complex decoded signal objects
-     * beyond ownership transfer. Conservative accounting is safer here than
-     * re-encoding on the worker thread. 64 KiB is an intentionally coarse
-     * upper-bound for typical decoded signal objects; tune it only after
-     * profiling real workloads shows that this safety margin is too strict or
-     * too loose for queue backpressure.
-     */
-    return 64 * 1024;
-}
-
-static size_t flb_input_ingress_estimate_traces_size(struct ctrace *ctr)
-{
-    if (ctr == NULL) {
-        return 0;
-    }
-
-    /* Keep trace accounting aligned with the conservative signal estimate
-     * used for metrics/profiles to avoid worker-side re-encoding.
-     */
-    return 64 * 1024;
-}
-
-static size_t flb_input_ingress_estimate_profiles_size(struct cprof *profile)
-{
-    if (profile == NULL) {
-        return 0;
-    }
-
-    /* Keep profile accounting aligned with the conservative signal estimate
-     * used for metrics/traces to avoid worker-side re-encoding.
+    /* Callers should provide the source payload size. Keep a non-zero fallback
+     * for producers that legitimately build a signal without a wire payload.
      */
     return 64 * 1024;
 }
@@ -185,6 +163,29 @@ static void flb_input_ingress_update_metrics(struct flb_input_instance *ins)
     }
 }
 
+static int flb_input_ingress_busy(struct flb_input_instance *ins,
+                                  struct flb_input_ingress_event *event)
+{
+    struct cmt_counter *counter;
+    flb_sds_t input_name;
+
+    counter = ins->cmt_ingress_queue_busy;
+    input_name = NULL;
+
+    if (counter != NULL) {
+        input_name = flb_sds_create(flb_input_name(ins));
+    }
+
+    if (counter != NULL && input_name != NULL) {
+        cmt_counter_add(counter, cfl_time_now(), 1, 1, (char *[]) {input_name});
+        flb_sds_destroy(input_name);
+    }
+
+    flb_input_ingress_event_destroy(event);
+
+    return FLB_INPUT_INGRESS_BUSY;
+}
+
 static int flb_input_ingress_enqueue(struct flb_input_instance *ins,
                                      struct flb_input_ingress_event *event)
 {
@@ -193,8 +194,6 @@ static int flb_input_ingress_enqueue(struct flb_input_instance *ins,
     int should_signal;
     int wait_result;
     struct timespec deadline;
-    struct cmt_counter *cmt_ingress_queue_busy;
-    flb_sds_t input_name;
 
     if (ins == NULL || event == NULL || ins->ingress_queue_enabled != FLB_TRUE) {
         flb_input_ingress_event_destroy(event);
@@ -206,6 +205,12 @@ static int flb_input_ingress_enqueue(struct flb_input_instance *ins,
 
     pthread_mutex_lock(&ins->ingress_queue_lock);
 
+    if (ins->ingress_queue_byte_limit > 0 &&
+        event_size > ins->ingress_queue_byte_limit) {
+        pthread_mutex_unlock(&ins->ingress_queue_lock);
+        return flb_input_ingress_busy(ins, event);
+    }
+
     while (ins->ingress_queue_enabled == FLB_TRUE) {
         queue_is_full = FLB_FALSE;
 
@@ -214,9 +219,12 @@ static int flb_input_ingress_enqueue(struct flb_input_instance *ins,
             queue_is_full = FLB_TRUE;
         }
 
-        if (ins->ingress_queue_byte_limit > 0 &&
-            ins->ingress_queue_pending_bytes + event_size > ins->ingress_queue_byte_limit) {
-            queue_is_full = FLB_TRUE;
+        if (ins->ingress_queue_byte_limit > 0) {
+            if (event_size > ins->ingress_queue_byte_limit ||
+                ins->ingress_queue_pending_bytes >
+                    ins->ingress_queue_byte_limit - event_size) {
+                queue_is_full = FLB_TRUE;
+            }
         }
 
         if (queue_is_full == FLB_FALSE) {
@@ -240,26 +248,13 @@ static int flb_input_ingress_enqueue(struct flb_input_instance *ins,
                                              &ins->ingress_queue_lock,
                                              &deadline);
         if (wait_result == ETIMEDOUT) {
-            cmt_ingress_queue_busy = ins->cmt_ingress_queue_busy;
-            input_name = NULL;
-
-            if (cmt_ingress_queue_busy != NULL) {
-                input_name = flb_sds_create(flb_input_name(ins));
-            }
-
             pthread_mutex_unlock(&ins->ingress_queue_lock);
-
-            if (cmt_ingress_queue_busy != NULL && input_name != NULL) {
-                cmt_counter_add(cmt_ingress_queue_busy,
-                                cfl_time_now(),
-                                1,
-                                1, (char *[]) {input_name});
-                flb_sds_destroy(input_name);
-            }
-
+            return flb_input_ingress_busy(ins, event);
+        }
+        else if (wait_result != 0) {
+            pthread_mutex_unlock(&ins->ingress_queue_lock);
             flb_input_ingress_event_destroy(event);
-
-            return FLB_INPUT_INGRESS_BUSY;
+            return -1;
         }
     }
 
@@ -304,6 +299,7 @@ static struct flb_input_ingress_event *flb_input_ingress_event_create(
     }
 
     event->type = type;
+    cfl_list_init(&event->metrics);
     mk_list_entry_init(&event->_head);
 
     if (tag != NULL && tag_len > 0) {
@@ -334,13 +330,16 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
                                        struct flb_config *config,
                                        void *context)
 {
+    int append_result;
     int result;
-    int queue_was_full;
     size_t pending_events;
     size_t pending_bytes;
     struct mk_list *head;
     struct mk_list *tmp;
     struct mk_list queue;
+    struct cfl_list *iterator;
+    struct cfl_list *list_tmp;
+    struct cmt *metrics_context;
     struct flb_input_ingress_event *event;
 
     (void) config;
@@ -360,15 +359,6 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
 
         pending_events = ins->ingress_queue_pending_events;
         pending_bytes = ins->ingress_queue_pending_bytes;
-        queue_was_full = FLB_FALSE;
-
-        if ((ins->ingress_queue_event_limit > 0 &&
-             pending_events >= ins->ingress_queue_event_limit) ||
-            (ins->ingress_queue_byte_limit > 0 &&
-             pending_bytes >= ins->ingress_queue_byte_limit)) {
-            queue_was_full = FLB_TRUE;
-        }
-
         mk_list_foreach_safe(head, tmp, &ins->ingress_queue) {
             mk_list_del(head);
             mk_list_add(head, &queue);
@@ -379,7 +369,7 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
         ins->ingress_queue_signal_pending = FLB_FALSE;
         flb_input_ingress_update_metrics(ins);
 
-        if (queue_was_full == FLB_TRUE) {
+        if (pending_events > 0 || pending_bytes > 0) {
             pthread_cond_broadcast(&ins->ingress_queue_space_available);
         }
 
@@ -398,10 +388,20 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
                                               event->data.log.size);
             }
             else if (event->type == FLB_INPUT_INGRESS_METRICS) {
-                result = flb_input_metrics_append(ins,
-                                                  event->tag,
-                                                  event->tag != NULL ? flb_sds_len(event->tag) : 0,
-                                                  event->data.metrics);
+                result = 0;
+                cfl_list_foreach_safe(iterator, list_tmp, &event->metrics) {
+                    metrics_context = cfl_list_entry(iterator, struct cmt, _head);
+                    cfl_list_del(&metrics_context->_head);
+                    append_result = flb_input_metrics_append(
+                                        ins,
+                                        event->tag,
+                                        event->tag != NULL ? flb_sds_len(event->tag) : 0,
+                                        metrics_context);
+                    cmt_destroy(metrics_context);
+                    if (append_result != 0) {
+                        result = append_result;
+                    }
+                }
             }
             else if (event->type == FLB_INPUT_INGRESS_TRACES) {
                 result = flb_input_trace_append(ins,
@@ -565,6 +565,9 @@ int flb_input_ingress_queue_log_take(struct flb_input_instance *ins,
     struct flb_input_ingress_event *event;
 
     if (buf == NULL || buf_size == 0) {
+        if (buf != NULL) {
+            flb_free(buf);
+        }
         return -1;
     }
 
@@ -587,7 +590,8 @@ int flb_input_ingress_queue_log_take(struct flb_input_instance *ins,
 int flb_input_ingress_queue_metrics(struct flb_input_instance *ins,
                                     const char *tag,
                                     size_t tag_len,
-                                    struct cmt *cmt)
+                                    struct cmt *cmt,
+                                    size_t payload_size)
 {
     struct flb_input_ingress_event *event;
 
@@ -595,14 +599,54 @@ int flb_input_ingress_queue_metrics(struct flb_input_instance *ins,
         return -1;
     }
 
-    /* Ownership of 'cmt' is transferred to the ingress queue on success. */
+    /* The ingress queue consumes 'cmt' on every return path. */
     event = flb_input_ingress_event_create(FLB_INPUT_INGRESS_METRICS, tag, tag_len);
     if (event == NULL) {
+        cmt_destroy(cmt);
         return -1;
     }
 
-    event->data.metrics = cmt;
-    event->size = flb_input_ingress_estimate_metrics_size(cmt);
+    if (!cfl_list_entry_is_orphan(&cmt->_head)) {
+        cfl_list_del(&cmt->_head);
+    }
+    cfl_list_add(&cmt->_head, &event->metrics);
+    event->size = flb_input_ingress_signal_size(payload_size);
+
+    return flb_input_ingress_enqueue(ins, event);
+}
+
+int flb_input_ingress_queue_metrics_list(struct flb_input_instance *ins,
+                                         const char *tag,
+                                         size_t tag_len,
+                                         struct cfl_list *contexts,
+                                         size_t payload_size)
+{
+    struct cfl_list *iterator;
+    struct cfl_list *tmp;
+    struct cmt *context;
+    struct flb_input_ingress_event *event;
+
+    if (contexts == NULL || cfl_list_is_empty(contexts)) {
+        return -1;
+    }
+
+    event = flb_input_ingress_event_create(FLB_INPUT_INGRESS_METRICS,
+                                           tag, tag_len);
+    if (event == NULL) {
+        cfl_list_foreach_safe(iterator, tmp, contexts) {
+            context = cfl_list_entry(iterator, struct cmt, _head);
+            cfl_list_del(&context->_head);
+            cmt_destroy(context);
+        }
+        return -1;
+    }
+
+    cfl_list_foreach_safe(iterator, tmp, contexts) {
+        context = cfl_list_entry(iterator, struct cmt, _head);
+        cfl_list_del(&context->_head);
+        cfl_list_add(&context->_head, &event->metrics);
+    }
+    event->size = flb_input_ingress_signal_size(payload_size);
 
     return flb_input_ingress_enqueue(ins, event);
 }
@@ -610,7 +654,8 @@ int flb_input_ingress_queue_metrics(struct flb_input_instance *ins,
 int flb_input_ingress_queue_traces(struct flb_input_instance *ins,
                                    const char *tag,
                                    size_t tag_len,
-                                   struct ctrace *ctr)
+                                   struct ctrace *ctr,
+                                   size_t payload_size)
 {
     struct flb_input_ingress_event *event;
 
@@ -618,14 +663,15 @@ int flb_input_ingress_queue_traces(struct flb_input_instance *ins,
         return -1;
     }
 
-    /* Ownership of 'ctr' is transferred to the ingress queue on success. */
+    /* The ingress queue consumes 'ctr' on every return path. */
     event = flb_input_ingress_event_create(FLB_INPUT_INGRESS_TRACES, tag, tag_len);
     if (event == NULL) {
+        ctr_destroy(ctr);
         return -1;
     }
 
     event->data.traces = ctr;
-    event->size = flb_input_ingress_estimate_traces_size(ctr);
+    event->size = flb_input_ingress_signal_size(payload_size);
 
     return flb_input_ingress_enqueue(ins, event);
 }
@@ -633,7 +679,8 @@ int flb_input_ingress_queue_traces(struct flb_input_instance *ins,
 int flb_input_ingress_queue_profiles(struct flb_input_instance *ins,
                                      const char *tag,
                                      size_t tag_len,
-                                     struct cprof *profile)
+                                     struct cprof *profile,
+                                     size_t payload_size)
 {
     struct flb_input_ingress_event *event;
 
@@ -641,14 +688,15 @@ int flb_input_ingress_queue_profiles(struct flb_input_instance *ins,
         return -1;
     }
 
-    /* Ownership of 'profile' is transferred to the ingress queue on success. */
+    /* The ingress queue consumes 'profile' on every return path. */
     event = flb_input_ingress_event_create(FLB_INPUT_INGRESS_PROFILES, tag, tag_len);
     if (event == NULL) {
+        cprof_destroy(profile);
         return -1;
     }
 
     event->data.profiles = profile;
-    event->size = flb_input_ingress_estimate_profiles_size(profile);
+    event->size = flb_input_ingress_signal_size(payload_size);
 
     return flb_input_ingress_enqueue(ins, event);
 }

--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -239,6 +239,8 @@ int flb_net_socket_share_port(flb_sockfd_t fd)
     }
 #else
     (void) fd;
+    flb_error("shared listener ports are not supported on this platform");
+    return -1;
 #endif
 
     return 0;
@@ -1689,8 +1691,9 @@ flb_sockfd_t flb_net_server(const char *port, const char *listen_addr,
             continue;
         }
 
-        if (share_port) {
-            flb_net_socket_share_port(fd);
+        if (share_port && flb_net_socket_share_port(fd) == -1) {
+            flb_socket_close(fd);
+            continue;
         }
 
         flb_net_socket_tcp_nodelay(fd);
@@ -1763,8 +1766,9 @@ flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr, int s
             continue;
         }
 
-        if (share_port) {
-            flb_net_socket_share_port(fd);
+        if (share_port && flb_net_socket_share_port(fd) == -1) {
+            flb_socket_close(fd);
+            continue;
         }
 
         ret = flb_net_bind_udp(fd, rp->ai_addr, rp->ai_addrlen);
@@ -1820,8 +1824,9 @@ flb_sockfd_t flb_net_server_unix(const char *listen_path,
 
         strncpy(address.sun_path, listen_path, sizeof(address.sun_path));
 
-        if (share_port) {
-            flb_net_socket_share_port(fd);
+        if (share_port && flb_net_socket_share_port(fd) == -1) {
+            flb_socket_close(fd);
+            return -1;
         }
 
         if (stream_mode) {

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_pthread.h>
+#include <fluent-bit/flb_downstream_worker.h>
 #include <string.h>
 
 #include <fluent-bit/http_server/flb_http_server.h>
@@ -34,70 +35,11 @@
 /* PRIVATE */
 
 struct flb_http_server_worker_context {
-    struct flb_http_server parent;
     struct flb_http_server server;
     struct flb_net_setup net_setup;
-    struct mk_event_loop *event_loop;
-    pthread_t thread;
-    pthread_mutex_t mutex;
-    pthread_cond_t condition;
-    int worker_id;
-    uint64_t should_exit;
-    int initialized;
-    int thread_created;
-    int startup_result;
 };
 
-struct flb_http_server_runtime {
-    struct flb_http_server_worker_context *workers;
-    int worker_count;
-};
-
-const struct flb_net_setup *
-flb_http_server_runtime_worker_net_setup_get(struct flb_http_server *server,
-                                             int worker_id)
-{
-    if (server == NULL ||
-        server->runtime == NULL ||
-        worker_id < 0 ||
-        worker_id >= server->runtime->worker_count) {
-        return NULL;
-    }
-
-    return &server->runtime->workers[worker_id].net_setup;
-}
-
-static void flb_http_server_runtime_stop(struct flb_http_server *session,
-                                         struct flb_http_server_runtime *runtime);
-
-static int flb_http_server_worker_context_reset(
-    struct flb_http_server_worker_context *worker)
-{
-    int result;
-
-    memset(worker, 0, sizeof(struct flb_http_server_worker_context));
-
-    result = pthread_mutex_init(&worker->mutex, NULL);
-    if (result != 0) {
-        return result;
-    }
-
-    result = pthread_cond_init(&worker->condition, NULL);
-    if (result != 0) {
-        pthread_mutex_destroy(&worker->mutex);
-        return result;
-    }
-
-    return 0;
-}
-
-static void flb_http_server_worker_context_cleanup(
-    struct flb_http_server_worker_context *worker)
-{
-    pthread_mutex_destroy(&worker->mutex);
-    pthread_cond_destroy(&worker->condition);
-}
-
+static void flb_http_server_runtime_stop(struct flb_http_server *session);
 static int flb_http_server_running_on_caller_context(
     struct flb_http_server *session)
 {
@@ -167,9 +109,50 @@ static void flb_http_server_reap_stale_sessions(struct flb_http_server *server)
     }
 }
 
-static size_t flb_http_server_client_count(struct flb_http_server *server)
+static int flb_http_server_connection_slot_reserve(struct flb_http_server *server)
 {
-    return cfl_list_size(&server->clients);
+    uint64_t connection_count;
+
+    if (server->max_connections == 0) {
+        return FLB_TRUE;
+    }
+
+    while (FLB_TRUE) {
+        connection_count = cfl_atomic_load(server->connection_counter);
+
+        if (connection_count >= server->max_connections) {
+            return FLB_FALSE;
+        }
+
+        if (cfl_atomic_compare_exchange(server->connection_counter,
+                                        connection_count,
+                                        connection_count + 1)) {
+            return FLB_TRUE;
+        }
+    }
+}
+
+static void flb_http_server_connection_slot_release(struct flb_http_server *server)
+{
+    uint64_t connection_count;
+
+    if (server->max_connections == 0) {
+        return;
+    }
+
+    while (FLB_TRUE) {
+        connection_count = cfl_atomic_load(server->connection_counter);
+
+        if (connection_count == 0) {
+            return;
+        }
+
+        if (cfl_atomic_compare_exchange(server->connection_counter,
+                                        connection_count,
+                                        connection_count - 1)) {
+            return;
+        }
+    }
 }
 
 static int flb_http_server_apply_options(struct flb_http_server *session,
@@ -198,6 +181,13 @@ static int flb_http_server_apply_options(struct flb_http_server *session,
     session->buffer_max_size = options->buffer_max_size;
     session->buffer_chunk_size = options->buffer_chunk_size;
     session->max_connections = options->max_connections;
+    cfl_atomic_store(&session->active_connections, 0);
+    if (options->connection_counter != NULL) {
+        session->connection_counter = options->connection_counter;
+    }
+    else {
+        session->connection_counter = &session->active_connections;
+    }
     session->workers = options->workers;
     session->worker_id = 0;
     session->use_caller_event_loop = options->use_caller_event_loop;
@@ -489,17 +479,18 @@ static int flb_http_server_client_connection_event_handler(void *data)
 
     if (server->max_connections > 0) {
         flb_http_server_reap_stale_sessions(server);
+    }
 
-        if (flb_http_server_client_count(server) >= server->max_connections) {
-            flb_downstream_conn_release(connection);
+    if (!flb_http_server_connection_slot_reserve(server)) {
+        flb_downstream_conn_release(connection);
 
-            return -5;
-        }
+        return -5;
     }
 
     session = flb_http_server_session_create(server->protocol_version);
 
     if (session == NULL) {
+        flb_http_server_connection_slot_release(server);
         flb_downstream_conn_release(connection);
 
         return -2;
@@ -507,6 +498,7 @@ static int flb_http_server_client_connection_event_handler(void *data)
 
     session->parent = server;
     session->connection = connection;
+    session->connection_slot_reserved = FLB_TRUE;
 
     if (session->version <= HTTP_PROTOCOL_VERSION_11) {
         session->http1.stream.user_data = server->user_data;
@@ -544,148 +536,131 @@ static int flb_http_server_client_connection_event_handler(void *data)
     return 0;
 }
 
-static void flb_http_server_worker_maintenance(struct flb_config *config,
-                                               void *data)
+static void flb_http_server_worker_maintenance(struct flb_downstream_worker *worker,
+                                               void *worker_context)
 {
-    struct flb_http_server_worker_context *worker;
+    struct flb_http_server_worker_context *context;
 
-    (void) config;
+    (void) worker;
 
-    worker = data;
+    context = worker_context;
 
-    if (worker->server.downstream != NULL) {
-        flb_downstream_conn_timeouts_stream(worker->server.downstream);
+    if (context->server.downstream != NULL) {
+        flb_downstream_conn_timeouts_stream(context->server.downstream);
+        flb_downstream_conn_pending_destroy(context->server.downstream);
     }
 
-    flb_http_server_reap_stale_sessions(&worker->server);
+    flb_http_server_reap_stale_sessions(&context->server);
 }
 
-static int flb_http_server_worker_initialize(
-    struct flb_http_server_worker_context *worker)
+static int flb_http_server_worker_initialize(struct flb_downstream_worker *worker,
+                                             struct flb_http_server *parent,
+                                             struct flb_http_server_worker_context *context)
 {
     int result;
     struct flb_http_server_options options;
 
+    memcpy(&context->net_setup,
+           parent->networking_setup,
+           sizeof(struct flb_net_setup));
+    context->net_setup.share_port = FLB_TRUE;
+
     flb_http_server_options_init(&options);
 
-    options.protocol_version = worker->parent.protocol_version;
-    options.flags = worker->parent.flags;
-    options.request_callback = worker->parent.request_callback;
-    options.user_data = worker->parent.user_data;
-    options.address = worker->parent.address;
-    options.port = worker->parent.port;
-    options.tls_provider = worker->parent.tls_provider;
-    options.networking_flags = worker->parent.networking_flags;
-    options.networking_setup = &worker->net_setup;
-    options.event_loop = worker->event_loop;
-    options.system_context = worker->parent.system_context;
-    options.idle_timeout = worker->parent.idle_timeout;
-    options.buffer_max_size = worker->parent.buffer_max_size;
+    options.protocol_version = parent->protocol_version;
+    options.flags = parent->flags;
+    options.request_callback = parent->request_callback;
+    options.user_data = parent->user_data;
+    options.address = parent->address;
+    options.port = parent->port;
+    options.tls_provider = parent->tls_provider;
+    options.networking_flags = parent->networking_flags;
+    options.networking_setup = &context->net_setup;
+    options.event_loop = flb_downstream_worker_event_loop_get(worker);
+    options.system_context = parent->system_context;
+    options.idle_timeout = parent->idle_timeout;
+    options.buffer_max_size = parent->buffer_max_size;
+    options.buffer_chunk_size = parent->buffer_chunk_size;
+    options.max_connections = parent->max_connections;
+    options.connection_counter = parent->connection_counter;
     options.workers = 1;
     options.use_caller_event_loop = FLB_TRUE;
-    options.reuse_port = worker->parent.reuse_port;
-    options.cb_worker_init = worker->parent.cb_worker_init;
-    options.cb_worker_exit = worker->parent.cb_worker_exit;
+    options.reuse_port = FLB_TRUE;
+    options.cb_worker_init = parent->cb_worker_init;
+    options.cb_worker_exit = parent->cb_worker_exit;
 
-    result = flb_http_server_init_with_options(&worker->server, &options);
+    result = flb_http_server_init_with_options(&context->server, &options);
     if (result != 0) {
         return result;
     }
 
-    result = flb_http_server_start(&worker->server);
+    result = flb_http_server_start(&context->server);
     if (result != 0) {
+        flb_http_server_destroy(&context->server);
         return result;
     }
 
-    flb_downstream_thread_safe(worker->server.downstream);
+    flb_downstream_thread_safe(context->server.downstream);
 
-    worker->server.worker_id = worker->worker_id;
-    worker->server.workers = worker->parent.workers;
+    context->server.worker_id = flb_downstream_worker_id_get(worker);
+    context->server.workers = parent->workers;
 
     return 0;
 }
 
-static void *flb_http_server_worker_thread(void *data)
+static int flb_http_server_worker_init(struct flb_downstream_worker *worker,
+                                       void *parent,
+                                       void **worker_context)
 {
-    int result;
-    uint64_t should_exit;
-    struct mk_event *event;
-    struct flb_net_dns dns_ctx = {0};
-    struct flb_http_server_worker_context *worker;
+    int ret;
+    struct flb_http_server *parent_server;
+    struct flb_http_server_worker_context *context;
 
-    worker = data;
+    parent_server = parent;
 
-    worker->event_loop = mk_event_loop_create(256);
-    if (worker->event_loop == NULL) {
-        result = -1;
-        goto signal_and_exit;
+    context = flb_calloc(1, sizeof(struct flb_http_server_worker_context));
+    if (context == NULL) {
+        flb_errno();
+        return -1;
     }
 
-    flb_engine_evl_init();
-    flb_engine_evl_set(worker->event_loop);
-
-    flb_net_dns_ctx_init();
-    flb_net_ctx_init(&dns_ctx);
-    flb_net_dns_ctx_set(&dns_ctx);
-
-    result = flb_http_server_worker_initialize(worker);
-
-signal_and_exit:
-    pthread_mutex_lock(&worker->mutex);
-    worker->startup_result = result;
-    worker->initialized = FLB_TRUE;
-    pthread_cond_signal(&worker->condition);
-    pthread_mutex_unlock(&worker->mutex);
-
-    if (result != 0) {
-        goto cleanup;
+    ret = flb_http_server_worker_initialize(worker, parent_server, context);
+    if (ret != 0) {
+        flb_free(context);
+        return ret;
     }
 
-    while ((should_exit = cfl_atomic_load(&worker->should_exit)) == FLB_FALSE) {
-        mk_event_wait_2(worker->event_loop, 250);
-
-        mk_event_foreach(event, worker->event_loop) {
-            if (event->type == FLB_ENGINE_EV_CUSTOM) {
-                event->handler(event);
-            }
-        }
-
-        flb_http_server_worker_maintenance(worker->parent.system_context,
-                                           worker);
-        flb_downstream_conn_pending_destroy(worker->server.downstream);
+    ret = flb_downstream_worker_listener_fd_set(
+              worker, context->server.downstream->server_fd);
+    if (ret != 0) {
+        flb_http_server_destroy(&context->server);
+        flb_free(context);
+        return ret;
     }
 
-cleanup:
-    if (worker->server.status == HTTP_SERVER_RUNNING &&
-        worker->server.cb_worker_exit != NULL) {
-        worker->server.cb_worker_exit(&worker->server,
-                                      worker->server.user_data);
-        worker->server.cb_worker_exit = NULL;
-    }
+    *worker_context = context;
 
-    return NULL;
+    return 0;
+}
+
+static void flb_http_server_worker_exit(struct flb_downstream_worker *worker,
+                                        void *worker_context)
+{
+    struct flb_http_server_worker_context *context;
+
+    (void) worker;
+
+    context = worker_context;
+
+    flb_http_server_destroy(&context->server);
+    flb_free(context);
 }
 
 static int flb_http_server_runtime_start(struct flb_http_server *session)
 {
     const char *alpn;
-    int index;
     int result;
-    struct flb_http_server_runtime *runtime;
-
-    runtime = flb_calloc(1, sizeof(struct flb_http_server_runtime));
-    if (runtime == NULL) {
-        flb_errno();
-        return -1;
-    }
-
-    runtime->workers = flb_calloc(session->workers,
-                                  sizeof(struct flb_http_server_worker_context));
-    if (runtime->workers == NULL) {
-        flb_errno();
-        flb_free(runtime);
-        return -1;
-    }
+    struct flb_downstream_worker_options options;
 
     if (session->tls_provider != NULL &&
         session->tls_alpn_configured == FLB_FALSE) {
@@ -693,115 +668,33 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
         result = flb_tls_set_alpn(session->tls_provider, alpn);
 
         if (result != 0) {
-            flb_free(runtime->workers);
-            flb_free(runtime);
-
             return -1;
         }
 
         session->tls_alpn_configured = FLB_TRUE;
     }
 
-    for (index = 0; index < session->workers; index++) {
-        result = flb_http_server_worker_context_reset(&runtime->workers[index]);
-        if (result != 0) {
-            while (index > 0) {
-                index--;
-                flb_http_server_worker_context_cleanup(&runtime->workers[index]);
-            }
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = session->workers;
+    options.parent = session;
+    options.cb_init = flb_http_server_worker_init;
+    options.cb_exit = flb_http_server_worker_exit;
+    options.cb_maintenance = flb_http_server_worker_maintenance;
 
-            flb_free(runtime->workers);
-            flb_free(runtime);
-
-            return -1;
-        }
-    }
-
-    runtime->worker_count = session->workers;
-
-    for (index = 0; index < runtime->worker_count; index++) {
-        memcpy(&runtime->workers[index].parent,
-               session,
-               sizeof(struct flb_http_server));
-        memcpy(&runtime->workers[index].net_setup,
-               session->networking_setup,
-               sizeof(struct flb_net_setup));
-
-        runtime->workers[index].net_setup.share_port = FLB_TRUE;
-        runtime->workers[index].worker_id = index;
-        runtime->workers[index].parent.reuse_port = FLB_TRUE;
-        runtime->workers[index].parent.runtime = NULL;
-        runtime->workers[index].parent.workers = session->workers;
-
-        result = pthread_create(&runtime->workers[index].thread,
-                                NULL,
-                                flb_http_server_worker_thread,
-                                &runtime->workers[index]);
-        if (result != 0) {
-            runtime->workers[index].startup_result = -1;
-            break;
-        }
-        runtime->workers[index].thread_created = FLB_TRUE;
-
-        pthread_mutex_lock(&runtime->workers[index].mutex);
-        while (runtime->workers[index].initialized == FLB_FALSE) {
-            pthread_cond_wait(&runtime->workers[index].condition,
-                              &runtime->workers[index].mutex);
-        }
-        result = runtime->workers[index].startup_result;
-        pthread_mutex_unlock(&runtime->workers[index].mutex);
-
-        if (result != 0) {
-            break;
-        }
-    }
-
-    if (index != runtime->worker_count) {
-        flb_http_server_runtime_stop(session, runtime);
+    result = flb_downstream_worker_runtime_start(&session->runtime, &options);
+    if (result != 0) {
         return -1;
     }
 
-    session->runtime = runtime;
     session->status = HTTP_SERVER_RUNNING;
 
     return 0;
 }
 
-static void flb_http_server_runtime_stop(struct flb_http_server *session,
-                                         struct flb_http_server_runtime *runtime)
+static void flb_http_server_runtime_stop(struct flb_http_server *session)
 {
-    int index;
-    int published;
-
-    if (runtime == NULL) {
-        return;
-    }
-
-    published = (session->runtime == runtime);
-
-    for (index = 0; index < runtime->worker_count; index++) {
-        cfl_atomic_store(&runtime->workers[index].should_exit, FLB_TRUE);
-
-        if (runtime->workers[index].thread_created == FLB_TRUE) {
-            pthread_join(runtime->workers[index].thread, NULL);
-
-            flb_http_server_destroy(&runtime->workers[index].server);
-
-            if (runtime->workers[index].event_loop != NULL) {
-                mk_event_loop_destroy(runtime->workers[index].event_loop);
-                runtime->workers[index].event_loop = NULL;
-            }
-        }
-
-        flb_http_server_worker_context_cleanup(&runtime->workers[index]);
-    }
-
-    if (published == FLB_TRUE) {
-        session->runtime = NULL;
-    }
-
-    flb_free(runtime->workers);
-    flb_free(runtime);
+    flb_downstream_worker_runtime_stop(session->runtime);
+    session->runtime = NULL;
 }
 
 /* HTTP SERVER */
@@ -1069,7 +962,7 @@ int flb_http_server_stop(struct flb_http_server *server)
     struct flb_http_server_session *session;
 
     if (server->runtime != NULL) {
-        flb_http_server_runtime_stop(server, server->runtime);
+        flb_http_server_runtime_stop(server);
         server->status = HTTP_SERVER_STOPPED;
         return 0;
     }
@@ -1259,6 +1152,11 @@ void flb_http_server_session_destroy(struct flb_http_server_session *session)
 
         if (!cfl_list_entry_is_orphan(&session->_head)) {
             cfl_list_del(&session->_head);
+        }
+
+        if (session->connection_slot_reserved) {
+            flb_http_server_connection_slot_release(session->parent);
+            session->connection_slot_reserved = FLB_FALSE;
         }
 
         if (session->incoming_data != NULL) {

--- a/tests/integration/scenarios/in_forward/config/in_forward_tls_workers.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_tls_workers.yaml
@@ -7,16 +7,17 @@ service:
 
 pipeline:
   inputs:
-    - name: http
+    - name: forward
       listen: 127.0.0.1
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
-      http_server.idle_timeout: 2s
-      http_server.max_connections: 1
-      http_server.workers: 2
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      workers: 4
 
   outputs:
     - name: http
-      match: "*"
+      match: test
       host: 127.0.0.1
       port: ${TEST_SUITE_HTTP_PORT}
       uri: /data

--- a/tests/integration/scenarios/in_forward/config/in_forward_workers.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_workers.yaml
@@ -7,16 +7,14 @@ service:
 
 pipeline:
   inputs:
-    - name: http
+    - name: forward
       listen: 127.0.0.1
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
-      http_server.idle_timeout: 2s
-      http_server.max_connections: 1
-      http_server.workers: 2
+      workers: 4
 
   outputs:
     - name: http
-      match: "*"
+      match: test
       host: 127.0.0.1
       port: ${TEST_SUITE_HTTP_PORT}
       uri: /data

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import opentelemetry
@@ -104,6 +105,7 @@ class Service:
 
     def start(self):
         self.service.start()
+        self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
 
     def stop(self):
@@ -135,6 +137,9 @@ class Service:
             interval=0.5,
             description=f"log text {text!r}",
         )
+
+    def wait_for_log_message(self, pattern, timeout=10):
+        return self.wait_for_log_contains(pattern, timeout)
 
 
 class StorageLimitService(Service):
@@ -842,6 +847,62 @@ def test_in_forward_forward_mode_multiple_entries():
     assert [record["message"] for record in records[:2]] == ["entry-1", "entry-2"]
 
 
+def test_in_forward_workers_concurrent_message_mode_records():
+    total_records = 16
+    service = Service("in_forward_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        payloads = [
+            _message_mode_payload(TEST_TAG, {"message": f"worker-{i}", "value": i})
+            for i in range(total_records)
+        ]
+        with ThreadPoolExecutor(max_workers=total_records) as executor:
+            list(executor.map(
+                lambda payload: _send_tcp_payload(service.flb_listener_port, payload),
+                payloads,
+            ))
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(total_records))
+
+
+def test_in_forward_workers_drop_partial_connections_and_continue():
+    dropped_connections = 8
+    valid_records = 8
+    service = Service("in_forward_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        # Send partial MessagePack bytes and close to exercise drop cleanup.
+        with ThreadPoolExecutor(max_workers=dropped_connections) as executor:
+            list(executor.map(
+                lambda _: _send_tcp_payload(service.flb_listener_port, b"\x93\xa4test"),
+                range(dropped_connections),
+            ))
+
+        payloads = [
+            _message_mode_payload(TEST_TAG, {"message": f"valid-{i}", "value": i})
+            for i in range(valid_records)
+        ]
+        with ThreadPoolExecutor(max_workers=valid_records) as executor:
+            list(executor.map(
+                lambda payload: _send_tcp_payload(service.flb_listener_port, payload),
+                payloads,
+            ))
+        records = service.wait_for_record_count(valid_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(valid_records))
+
+
 def test_in_forward_packed_forward_gzip():
     service = Service("in_forward.yaml")
     service.start()
@@ -1077,6 +1138,65 @@ def test_in_forward_tls_idle_connection_timeout_churn(monkeypatch):
         service.stop()
 
     assert any(record.get("message") == "after-churn" for record in records)
+
+
+def test_in_forward_tls_workers_concurrent_message_mode_records():
+    total_records = 16
+    service = Service("in_forward_tls_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=total_records) as executor:
+            list(executor.map(
+                lambda i: _send_tls_payload(service.flb_listener_port,
+                                            _message_mode_payload(
+                                                TEST_TAG,
+                                                {"message": f"tls-worker-{i}",
+                                                 "value": i}),
+                                            service.tls_crt_file),
+                range(total_records),
+            ))
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(total_records))
+
+
+def test_in_forward_tls_workers_drop_bad_handshakes_and_continue():
+    dropped_connections = 8
+    valid_records = 8
+    service = Service("in_forward_tls_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        # Send raw non-TLS bytes and close to exercise handshake cleanup.
+        with ThreadPoolExecutor(max_workers=dropped_connections) as executor:
+            list(executor.map(
+                lambda i: _send_tcp_payload(service.flb_listener_port,
+                                            f"not-tls-{i}".encode("utf-8")),
+                range(dropped_connections),
+            ))
+
+        with ThreadPoolExecutor(max_workers=valid_records) as executor:
+            list(executor.map(
+                lambda i: _send_tls_payload(service.flb_listener_port,
+                                            _message_mode_payload(
+                                                TEST_TAG,
+                                                {"message": f"valid-tls-{i}",
+                                                 "value": i}),
+                                            service.tls_crt_file),
+                range(valid_records),
+            ))
+        records = service.wait_for_record_count(valid_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(valid_records))
 
 
 def test_in_forward_secure_forward_auth_success():

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -1565,3 +1565,37 @@ def test_in_opentelemetry_http_workers_respect_ingress_queue_byte_limit():
         "fluentbit_input_http_server_ingress_queue_pending_bytes",
         "opentelemetry.0",
     ) == 0
+
+
+def test_in_opentelemetry_http_workers_account_metrics_payload_bytes():
+    service = Service(IN_OPENTELEMETRY_TINY_INGRESS_QUEUE_BYTE_LIMIT_CONFIG)
+    small_payload = service.build_otel_payload("test_metrics_001.in.json", "metrics")
+
+    small_request = ExportMetricsServiceRequest()
+    small_request.ParseFromString(small_payload)
+
+    large_request = ExportMetricsServiceRequest()
+    for _ in range(16):
+        large_request.resource_metrics.extend(small_request.resource_metrics)
+
+    large_payload = large_request.SerializeToString()
+
+    assert len(small_payload) < 2000
+    assert len(large_payload) > 2000
+
+    service.start()
+    service.wait_for_log_message("with 4 workers", timeout=10)
+    metrics_before = len(data_storage["metrics"])
+
+    try:
+        success_response = service.send_raw_request("/v1/metrics", small_payload)
+        assert success_response.status_code == 201
+        service.wait_for_signal_count("metrics", metrics_before + 1, timeout=10)
+
+        failure_response = service.send_raw_request("/v1/metrics", large_payload)
+        assert failure_response.status_code == 503
+        assert "deferred ingress queue is full" in failure_response.text
+    finally:
+        service.stop()
+
+    assert len(data_storage["metrics"]) == metrics_before + 1

--- a/tests/integration/scenarios/in_tcp/config/in_tcp_parser_json_tls_workers.yaml
+++ b/tests/integration/scenarios/in_tcp/config/in_tcp_parser_json_tls_workers.yaml
@@ -4,19 +4,25 @@ service:
   log_level: info
   http_server: on
   http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
 
 pipeline:
   inputs:
-    - name: http
+    - name: tcp
+      tag: target_input
       listen: 127.0.0.1
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
-      http_server.idle_timeout: 2s
-      http_server.max_connections: 1
-      http_server.workers: 2
+      format: none
+      separator: "\\n"
+      parser: json
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      workers: 4
 
   outputs:
     - name: http
-      match: "*"
+      match: target_input
       host: 127.0.0.1
       port: ${TEST_SUITE_HTTP_PORT}
       uri: /data

--- a/tests/integration/scenarios/in_tcp/config/in_tcp_parser_json_workers.yaml
+++ b/tests/integration/scenarios/in_tcp/config/in_tcp_parser_json_workers.yaml
@@ -4,19 +4,22 @@ service:
   log_level: info
   http_server: on
   http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
 
 pipeline:
   inputs:
-    - name: http
+    - name: tcp
+      tag: target_input
       listen: 127.0.0.1
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
-      http_server.idle_timeout: 2s
-      http_server.max_connections: 1
-      http_server.workers: 2
+      format: none
+      separator: "\\n"
+      parser: json
+      workers: 4
 
   outputs:
     - name: http
-      match: "*"
+      match: target_input
       host: 127.0.0.1
       port: ${TEST_SUITE_HTTP_PORT}
       uri: /data

--- a/tests/integration/scenarios/in_tcp/tests/test_in_tcp_001.py
+++ b/tests/integration/scenarios/in_tcp/tests/test_in_tcp_001.py
@@ -1,5 +1,8 @@
 import os
 import socket
+import ssl
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
@@ -14,12 +17,17 @@ class Service:
         self.parsers_file = os.environ.get("FLUENT_BIT_PARSERS_FILE") or os.path.abspath(
             os.path.join(test_path, "../../../../../conf/parsers.conf")
         )
+        cert_dir = os.path.abspath(os.path.join(test_path, "../../in_splunk/certificate"))
+        self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
+        self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
             data_keys=["payloads"],
             extra_env={
                 "PARSERS_FILE_TEST": self.parsers_file,
+                "CERTIFICATE_TEST": self.tls_crt_file,
+                "PRIVATE_KEY_TEST": self.tls_key_file,
             },
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
@@ -41,6 +49,7 @@ class Service:
 
     def start(self):
         self.service.start()
+        self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
 
     def stop(self):
@@ -60,11 +69,56 @@ class Service:
 
         return payloads[0][0]
 
+    def flattened_records(self):
+        records = []
+        for payload in data_storage["payloads"]:
+            if isinstance(payload, list):
+                records.extend(payload)
+            elif payload is not None:
+                records.append(payload)
+        return records
+
+    def wait_for_record_count(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: self.flattened_records() if len(self.flattened_records()) >= minimum_count else None,
+            timeout=timeout,
+            interval=0.2,
+            description=f"{minimum_count} forwarded TCP payloads",
+        )
+
+    def wait_for_log_message(self, pattern, timeout=10, interval=0.25):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.flb and self.flb.log_file and os.path.exists(self.flb.log_file):
+                with open(self.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+                    if pattern in log_file.read():
+                        return True
+            time.sleep(interval)
+        raise TimeoutError(f"Timed out waiting for log pattern: {pattern}")
+
 
 def _send_line(port, line):
     with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
         sock.sendall(line.encode("utf-8"))
         sock.shutdown(socket.SHUT_WR)
+
+
+def _drop_partial_connection(port, payload):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(payload.encode("utf-8"))
+
+
+def _send_tls_line(port, line, cafile):
+    context = ssl.create_default_context(cafile=cafile)
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname="localhost") as tls_sock:
+            tls_sock.sendall(line.encode("utf-8"))
+            tls_sock.shutdown(socket.SHUT_WR)
+
+
+def _drop_raw_tls_connection(port, payload):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(payload)
 
 
 def test_in_tcp_parser_json_success():
@@ -93,3 +147,105 @@ def test_in_tcp_parser_json_fallback_to_log():
 
     assert "log" in record
     assert record["log"].strip() == "not-json"
+
+
+def test_in_tcp_parser_json_workers_concurrent_records():
+    total_records = 16
+    service = Service("in_tcp_parser_json_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=total_records) as executor:
+            list(executor.map(
+                lambda i: _send_line(service.flb_listener_port,
+                                     f'{{"message":"worker-{i}","value":{i}}}\n'),
+                range(total_records),
+            ))
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(total_records))
+
+
+def test_in_tcp_workers_drop_partial_connections_and_continue():
+    dropped_connections = 8
+    valid_records = 8
+    service = Service("in_tcp_parser_json_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=dropped_connections) as executor:
+            list(executor.map(
+                lambda i: _drop_partial_connection(service.flb_listener_port,
+                                                   f'{{"message":"partial-{i}"'),
+                range(dropped_connections),
+            ))
+
+        with ThreadPoolExecutor(max_workers=valid_records) as executor:
+            list(executor.map(
+                lambda i: _send_line(service.flb_listener_port,
+                                     f'{{"message":"valid-{i}","value":{i}}}\n'),
+                range(valid_records),
+            ))
+        records = service.wait_for_record_count(valid_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(valid_records))
+
+
+def test_in_tcp_tls_workers_concurrent_records():
+    total_records = 16
+    service = Service("in_tcp_parser_json_tls_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=total_records) as executor:
+            list(executor.map(
+                lambda i: _send_tls_line(service.flb_listener_port,
+                                         f'{{"message":"tls-worker-{i}","value":{i}}}\n',
+                                         service.tls_crt_file),
+                range(total_records),
+            ))
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(total_records))
+
+
+def test_in_tcp_tls_workers_drop_bad_handshakes_and_continue():
+    dropped_connections = 8
+    valid_records = 8
+    service = Service("in_tcp_parser_json_tls_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=dropped_connections) as executor:
+            list(executor.map(
+                lambda i: _drop_raw_tls_connection(service.flb_listener_port,
+                                                   f"not-tls-{i}".encode("utf-8")),
+                range(dropped_connections),
+            ))
+
+        with ThreadPoolExecutor(max_workers=valid_records) as executor:
+            list(executor.map(
+                lambda i: _send_tls_line(service.flb_listener_port,
+                                         f'{{"message":"valid-tls-{i}","value":{i}}}\n',
+                                         service.tls_crt_file),
+                range(valid_records),
+            ))
+        records = service.wait_for_record_count(valid_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(valid_records))

--- a/tests/integration/scenarios/in_udp/config/in_udp_json_workers.yaml
+++ b/tests/integration/scenarios/in_udp/config/in_udp_json_workers.yaml
@@ -7,16 +7,16 @@ service:
 
 pipeline:
   inputs:
-    - name: http
+    - name: udp
+      tag: target_input
       listen: 127.0.0.1
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
-      http_server.idle_timeout: 2s
-      http_server.max_connections: 1
-      http_server.workers: 2
+      format: json
+      workers: 4
 
   outputs:
     - name: http
-      match: "*"
+      match: target_input
       host: 127.0.0.1
       port: ${TEST_SUITE_HTTP_PORT}
       uri: /data

--- a/tests/integration/scenarios/in_udp/config/in_udp_parser_json_workers.yaml
+++ b/tests/integration/scenarios/in_udp/config/in_udp_parser_json_workers.yaml
@@ -4,19 +4,22 @@ service:
   log_level: info
   http_server: on
   http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${PARSERS_FILE_TEST}
 
 pipeline:
   inputs:
-    - name: http
+    - name: udp
+      tag: target_input
       listen: 127.0.0.1
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
-      http_server.idle_timeout: 2s
-      http_server.max_connections: 1
-      http_server.workers: 2
+      format: none
+      separator: "\\n"
+      parser: json
+      workers: 4
 
   outputs:
     - name: http
-      match: "*"
+      match: target_input
       host: 127.0.0.1
       port: ${TEST_SUITE_HTTP_PORT}
       uri: /data

--- a/tests/integration/scenarios/in_udp/tests/test_in_udp_001.py
+++ b/tests/integration/scenarios/in_udp/tests/test_in_udp_001.py
@@ -1,5 +1,7 @@
 import os
 import socket
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
@@ -41,6 +43,7 @@ class Service:
 
     def start(self):
         self.service.start()
+        self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
 
     def stop(self):
@@ -59,6 +62,39 @@ class Service:
         assert len(payloads[0]) == 1
 
         return payloads[0][0]
+
+    def flattened_records(self):
+        records = []
+        for payload in data_storage["payloads"]:
+            if isinstance(payload, list):
+                records.extend(payload)
+            elif payload is not None:
+                records.append(payload)
+        return records
+
+    def wait_for_record_count(self, minimum_count, timeout=10):
+        def records_ready():
+            records = self.flattened_records()
+            if len(records) >= minimum_count:
+                return records
+            return None
+
+        return self.service.wait_for_condition(
+            records_ready,
+            timeout=timeout,
+            interval=0.2,
+            description=f"{minimum_count} forwarded UDP payloads",
+        )
+
+    def wait_for_log_message(self, pattern, timeout=10, interval=0.25):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.flb and self.flb.log_file and os.path.exists(self.flb.log_file):
+                with open(self.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+                    if pattern in log_file.read():
+                        return True
+            time.sleep(interval)
+        raise TimeoutError(f"Timed out waiting for log pattern: {pattern}")
 
 
 def _send_datagram(port, payload):
@@ -92,3 +128,54 @@ def test_in_udp_parser_json_fallback_to_log():
 
     assert "log" in record
     assert record["log"].strip() == "not-json"
+
+
+def test_in_udp_parser_json_workers_concurrent_records():
+    total_records = 16
+    service = Service("in_udp_parser_json_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=total_records) as executor:
+            list(executor.map(
+                lambda i: _send_datagram(service.flb_listener_port,
+                                         f'{{"message":"worker-{i}","value":{i}}}\n'),
+                range(total_records),
+            ))
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(total_records))
+
+
+def test_in_udp_workers_drop_malformed_datagrams_and_continue():
+    malformed_datagrams = 8
+    valid_records = 8
+    service = Service("in_udp_json_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        with ThreadPoolExecutor(max_workers=malformed_datagrams) as executor:
+            list(executor.map(
+                lambda i: _send_datagram(service.flb_listener_port,
+                                         f'{{"message":"malformed-{i}"'),
+                range(malformed_datagrams),
+            ))
+
+        with ThreadPoolExecutor(max_workers=valid_records) as executor:
+            list(executor.map(
+                lambda i: _send_datagram(service.flb_listener_port,
+                                         f'{{"message":"valid-{i}","value":{i}}}'),
+                range(valid_records),
+            ))
+        records = service.wait_for_record_count(valid_records, timeout=20)
+        assert len(records) == valid_records
+    finally:
+        service.stop()
+
+    values = sorted(record["value"] for record in records)
+    assert values == list(range(valid_records))

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -35,6 +35,7 @@ set(UNIT_TESTS_FILES
   typecast.c
   base64.c
   bucket_queue.c
+  downstream_worker.c
   flb_event_loop.c
   ring_buffer.c
   regex.c

--- a/tests/internal/downstream_worker.c
+++ b/tests/internal/downstream_worker.c
@@ -1,0 +1,510 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_downstream_worker.h>
+#include <fluent-bit/flb_pthread.h>
+#include <fluent-bit/flb_time.h>
+#ifdef FLB_SYSTEM_WINDOWS
+#include <fluent-bit/flb_compat.h>
+#endif
+
+#include <string.h>
+
+#include "flb_tests_internal.h"
+
+struct downstream_worker_test_context {
+    pthread_mutex_t mutex;
+    struct flb_downstream_worker_runtime *runtime;
+    int init_calls;
+    int exit_calls;
+    int foreach_calls;
+    int worker_ids;
+    int accessor_failures;
+    int nested_foreach_failures;
+    int nested_stop_failures;
+    int fail_worker_id;
+};
+
+struct downstream_worker_foreach_call {
+    struct flb_downstream_worker_runtime *runtime;
+    int callback_calls;
+    int result;
+};
+
+struct downstream_worker_stop_context {
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    struct flb_downstream_worker_runtime *runtime;
+    int callback_entered;
+    int callback_released;
+    int foreach_result;
+    int stop_result;
+};
+
+static int downstream_worker_test_network_init(void)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    int ret;
+    WSADATA wsa_data;
+
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    TEST_CHECK(ret == 0);
+    return ret;
+#else
+    return 0;
+#endif
+}
+
+static void downstream_worker_test_network_cleanup(void)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    WSACleanup();
+#endif
+}
+
+static void downstream_worker_test_context_init(
+    struct downstream_worker_test_context *context)
+{
+    memset(context, 0, sizeof(struct downstream_worker_test_context));
+    pthread_mutex_init(&context->mutex, NULL);
+    context->fail_worker_id = -1;
+}
+
+static void downstream_worker_test_context_destroy(
+    struct downstream_worker_test_context *context)
+{
+    pthread_mutex_destroy(&context->mutex);
+}
+
+static int downstream_worker_test_init(struct flb_downstream_worker *worker,
+                                       void *parent,
+                                       void **worker_context)
+{
+    int worker_id;
+    struct downstream_worker_test_context *context;
+
+    context = parent;
+    worker_id = flb_downstream_worker_id_get(worker);
+    *worker_context = context;
+
+    pthread_mutex_lock(&context->mutex);
+    context->init_calls++;
+    pthread_mutex_unlock(&context->mutex);
+
+    if (worker_id == context->fail_worker_id) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static void downstream_worker_test_exit(struct flb_downstream_worker *worker,
+                                        void *worker_context)
+{
+    struct downstream_worker_test_context *context;
+
+    (void) worker;
+    context = worker_context;
+
+    pthread_mutex_lock(&context->mutex);
+    context->exit_calls++;
+    pthread_mutex_unlock(&context->mutex);
+}
+
+static void downstream_worker_test_noop(struct flb_downstream_worker *worker,
+                                        void *worker_context,
+                                        void *data)
+{
+    (void) worker;
+    (void) worker_context;
+    (void) data;
+}
+
+static void downstream_worker_test_count(struct flb_downstream_worker *worker,
+                                         void *worker_context,
+                                         void *data)
+{
+    struct downstream_worker_foreach_call *call;
+
+    (void) worker;
+    (void) worker_context;
+
+    call = data;
+    call->callback_calls++;
+}
+
+static void *downstream_worker_test_foreach_thread(void *data)
+{
+    struct downstream_worker_foreach_call *call;
+
+    call = data;
+    call->result = flb_downstream_worker_runtime_foreach(
+        call->runtime, downstream_worker_test_count, call);
+
+    return NULL;
+}
+
+static void downstream_worker_test_block(struct flb_downstream_worker *worker,
+                                         void *worker_context,
+                                         void *data)
+{
+    struct downstream_worker_stop_context *stop_context;
+
+    (void) worker;
+    (void) worker_context;
+
+    stop_context = data;
+    pthread_mutex_lock(&stop_context->mutex);
+    stop_context->callback_entered = FLB_TRUE;
+    pthread_cond_broadcast(&stop_context->condition);
+    while (stop_context->callback_released == FLB_FALSE) {
+        pthread_cond_wait(&stop_context->condition, &stop_context->mutex);
+    }
+    pthread_mutex_unlock(&stop_context->mutex);
+}
+
+static void *downstream_worker_test_stop_thread(void *data)
+{
+    struct downstream_worker_stop_context *stop_context;
+
+    stop_context = data;
+    stop_context->stop_result = flb_downstream_worker_runtime_stop(
+        stop_context->runtime);
+
+    return NULL;
+}
+
+static void *downstream_worker_test_blocking_foreach_thread(void *data)
+{
+    struct downstream_worker_stop_context *stop_context;
+
+    stop_context = data;
+    stop_context->foreach_result = flb_downstream_worker_runtime_foreach(
+        stop_context->runtime, downstream_worker_test_block, stop_context);
+
+    return NULL;
+}
+
+static void downstream_worker_test_foreach(struct flb_downstream_worker *worker,
+                                           void *worker_context,
+                                           void *data)
+{
+    int worker_count;
+    int worker_id;
+    int nested_foreach_result;
+    int nested_stop_result;
+    struct downstream_worker_test_context *context;
+
+    (void) data;
+    context = worker_context;
+    worker_id = flb_downstream_worker_id_get(worker);
+    worker_count = flb_downstream_worker_count_get(worker);
+
+    nested_foreach_result = flb_downstream_worker_runtime_foreach(
+        context->runtime, downstream_worker_test_noop, NULL);
+    nested_stop_result = flb_downstream_worker_runtime_stop(context->runtime);
+
+    pthread_mutex_lock(&context->mutex);
+    context->foreach_calls++;
+
+    if (worker_id < 0 || worker_id >= worker_count || worker_count != 2 ||
+        flb_downstream_worker_event_loop_get(worker) == NULL) {
+        context->accessor_failures++;
+    }
+    else {
+        context->worker_ids |= (1 << worker_id);
+    }
+
+    if (nested_foreach_result != -1) {
+        context->nested_foreach_failures++;
+    }
+
+    if (nested_stop_result != -1) {
+        context->nested_stop_failures++;
+    }
+    pthread_mutex_unlock(&context->mutex);
+}
+
+void test_downstream_worker_validation()
+{
+    int ret;
+    struct flb_downstream_worker_options options;
+    struct flb_downstream_worker_runtime *runtime;
+
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    runtime = (struct flb_downstream_worker_runtime *) 0x1;
+
+    ret = flb_downstream_worker_runtime_start(&runtime, &options);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(runtime == NULL);
+    TEST_CHECK(flb_downstream_worker_runtime_start(NULL, &options) == -1);
+    TEST_CHECK(flb_downstream_worker_runtime_foreach(NULL,
+                                                     downstream_worker_test_noop,
+                                                     NULL) == -1);
+    TEST_CHECK(flb_downstream_worker_runtime_stop(NULL) == 0);
+    TEST_CHECK(flb_downstream_worker_event_loop_get(NULL) == NULL);
+    TEST_CHECK(flb_downstream_worker_id_get(NULL) == -1);
+    TEST_CHECK(flb_downstream_worker_count_get(NULL) == -1);
+    TEST_CHECK(flb_downstream_worker_listener_fd_set(NULL,
+                                                     FLB_INVALID_SOCKET) == -1);
+}
+
+void test_downstream_worker_lifecycle()
+{
+    int ret;
+    struct downstream_worker_test_context context;
+    struct flb_downstream_worker_options options;
+    struct flb_downstream_worker_runtime *runtime;
+
+    ret = downstream_worker_test_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    downstream_worker_test_context_init(&context);
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = 2;
+    options.parent = &context;
+    options.cb_init = downstream_worker_test_init;
+    options.cb_exit = downstream_worker_test_exit;
+
+    runtime = NULL;
+    ret = flb_downstream_worker_runtime_start(&runtime, &options);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(runtime != NULL);
+    if (ret != 0) {
+        downstream_worker_test_context_destroy(&context);
+        downstream_worker_test_network_cleanup();
+        return;
+    }
+
+    context.runtime = runtime;
+    ret = flb_downstream_worker_runtime_foreach(runtime,
+                                                downstream_worker_test_foreach,
+                                                NULL);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(context.init_calls == 2);
+    TEST_CHECK(context.foreach_calls == 2);
+    TEST_CHECK(context.worker_ids == 3);
+    TEST_CHECK(context.accessor_failures == 0);
+    TEST_CHECK(context.nested_foreach_failures == 0);
+    TEST_CHECK(context.nested_stop_failures == 0);
+
+    ret = flb_downstream_worker_runtime_stop(runtime);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(context.exit_calls == 2);
+
+    downstream_worker_test_context_destroy(&context);
+    downstream_worker_test_network_cleanup();
+}
+
+void test_downstream_worker_startup_rollback()
+{
+    int ret;
+    struct downstream_worker_test_context context;
+    struct flb_downstream_worker_options options;
+    struct flb_downstream_worker_runtime *runtime;
+
+    ret = downstream_worker_test_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    downstream_worker_test_context_init(&context);
+    context.fail_worker_id = 1;
+
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = 3;
+    options.parent = &context;
+    options.cb_init = downstream_worker_test_init;
+    options.cb_exit = downstream_worker_test_exit;
+
+    runtime = (struct flb_downstream_worker_runtime *) 0x1;
+    ret = flb_downstream_worker_runtime_start(&runtime, &options);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(runtime == NULL);
+    TEST_CHECK(context.init_calls == 2);
+    TEST_CHECK(context.exit_calls == 2);
+
+    downstream_worker_test_context_destroy(&context);
+    downstream_worker_test_network_cleanup();
+}
+
+void test_downstream_worker_concurrent_foreach()
+{
+    int i;
+    int ret;
+    int threads_created;
+    pthread_t threads[4];
+    struct downstream_worker_foreach_call calls[4];
+    struct downstream_worker_test_context context;
+    struct flb_downstream_worker_options options;
+    struct flb_downstream_worker_runtime *runtime;
+
+    ret = downstream_worker_test_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    downstream_worker_test_context_init(&context);
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = 2;
+    options.parent = &context;
+    options.cb_init = downstream_worker_test_init;
+    options.cb_exit = downstream_worker_test_exit;
+
+    runtime = NULL;
+    ret = flb_downstream_worker_runtime_start(&runtime, &options);
+    if (!TEST_CHECK(ret == 0)) {
+        downstream_worker_test_context_destroy(&context);
+        downstream_worker_test_network_cleanup();
+        return;
+    }
+
+    memset(calls, 0, sizeof(calls));
+    threads_created = 0;
+    for (i = 0; i < 4; i++) {
+        calls[i].runtime = runtime;
+        ret = pthread_create(&threads[i], NULL,
+                             downstream_worker_test_foreach_thread,
+                             &calls[i]);
+        if (!TEST_CHECK(ret == 0)) {
+            break;
+        }
+        threads_created++;
+    }
+
+    for (i = 0; i < threads_created; i++) {
+        ret = pthread_join(threads[i], NULL);
+        TEST_CHECK(ret == 0);
+        TEST_CHECK(calls[i].result == 0);
+        TEST_CHECK(calls[i].callback_calls == 2);
+    }
+
+    ret = flb_downstream_worker_runtime_stop(runtime);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(context.exit_calls == 2);
+    downstream_worker_test_context_destroy(&context);
+    downstream_worker_test_network_cleanup();
+}
+
+void test_downstream_worker_stop_waits_for_foreach()
+{
+    int ret;
+    pthread_t foreach_thread;
+    pthread_t queued_foreach_thread;
+    pthread_t stop_thread;
+    struct downstream_worker_foreach_call queued_call;
+    struct downstream_worker_stop_context stop_context;
+    struct downstream_worker_test_context context;
+    struct flb_downstream_worker_options options;
+    struct flb_downstream_worker_runtime *runtime;
+
+    ret = downstream_worker_test_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    downstream_worker_test_context_init(&context);
+    memset(&options, 0, sizeof(struct flb_downstream_worker_options));
+    options.workers = 1;
+    options.parent = &context;
+    options.cb_init = downstream_worker_test_init;
+    options.cb_exit = downstream_worker_test_exit;
+
+    runtime = NULL;
+    ret = flb_downstream_worker_runtime_start(&runtime, &options);
+    if (!TEST_CHECK(ret == 0)) {
+        downstream_worker_test_context_destroy(&context);
+        downstream_worker_test_network_cleanup();
+        return;
+    }
+
+    memset(&stop_context, 0, sizeof(stop_context));
+    pthread_mutex_init(&stop_context.mutex, NULL);
+    pthread_cond_init(&stop_context.condition, NULL);
+    stop_context.runtime = runtime;
+
+    ret = pthread_create(&foreach_thread, NULL,
+                         downstream_worker_test_blocking_foreach_thread,
+                         &stop_context);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_downstream_worker_runtime_stop(runtime);
+        goto cleanup;
+    }
+
+    pthread_mutex_lock(&stop_context.mutex);
+    while (stop_context.callback_entered == FLB_FALSE) {
+        pthread_cond_wait(&stop_context.condition, &stop_context.mutex);
+    }
+    pthread_mutex_unlock(&stop_context.mutex);
+
+    memset(&queued_call, 0, sizeof(queued_call));
+    queued_call.runtime = runtime;
+    ret = pthread_create(&queued_foreach_thread, NULL,
+                         downstream_worker_test_foreach_thread,
+                         &queued_call);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        pthread_mutex_lock(&stop_context.mutex);
+        stop_context.callback_released = FLB_TRUE;
+        pthread_cond_broadcast(&stop_context.condition);
+        pthread_mutex_unlock(&stop_context.mutex);
+        pthread_join(foreach_thread, NULL);
+        flb_downstream_worker_runtime_stop(runtime);
+        goto cleanup;
+    }
+
+    /* Give the second operation time to enter admission and queue behind the
+     * blocking foreach call before shutdown begins.
+     */
+    flb_time_msleep(50);
+
+    ret = pthread_create(&stop_thread, NULL,
+                         downstream_worker_test_stop_thread, &stop_context);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        pthread_mutex_lock(&stop_context.mutex);
+        stop_context.callback_released = FLB_TRUE;
+        pthread_cond_broadcast(&stop_context.condition);
+        pthread_mutex_unlock(&stop_context.mutex);
+        pthread_join(foreach_thread, NULL);
+        pthread_join(queued_foreach_thread, NULL);
+        flb_downstream_worker_runtime_stop(runtime);
+        goto cleanup;
+    }
+
+    pthread_mutex_lock(&stop_context.mutex);
+    stop_context.callback_released = FLB_TRUE;
+    pthread_cond_broadcast(&stop_context.condition);
+    pthread_mutex_unlock(&stop_context.mutex);
+
+    ret = pthread_join(foreach_thread, NULL);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(stop_context.foreach_result == 0);
+
+    ret = pthread_join(queued_foreach_thread, NULL);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(queued_call.result == 0);
+    TEST_CHECK(queued_call.callback_calls == 1);
+
+    ret = pthread_join(stop_thread, NULL);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(stop_context.stop_result == 0);
+    TEST_CHECK(context.exit_calls == 1);
+
+cleanup:
+    pthread_cond_destroy(&stop_context.condition);
+    pthread_mutex_destroy(&stop_context.mutex);
+    downstream_worker_test_context_destroy(&context);
+    downstream_worker_test_network_cleanup();
+}
+
+TEST_LIST = {
+    { "downstream_worker_validation", test_downstream_worker_validation },
+    { "downstream_worker_lifecycle", test_downstream_worker_lifecycle },
+    { "downstream_worker_startup_rollback", test_downstream_worker_startup_rollback },
+    { "downstream_worker_concurrent_foreach", test_downstream_worker_concurrent_foreach },
+    { "downstream_worker_stop_waits_for_foreach", test_downstream_worker_stop_waits_for_foreach },
+    { 0 }
+};

--- a/tests/internal/http_server.c
+++ b/tests/internal/http_server.c
@@ -22,6 +22,8 @@ struct test_http_server_context {
     int exit_calls;
     int request_calls;
     int exit_thread_mismatches;
+    int expected_idle_timeout;
+    int idle_timeout_mismatches;
     struct flb_http_server *initialized_servers[TEST_HTTP_SERVER_WORKERS];
     pthread_t initialized_threads[TEST_HTTP_SERVER_WORKERS];
 };
@@ -45,6 +47,11 @@ static int test_http_server_worker_init(struct flb_http_server *server, void *da
     context = data;
 
     pthread_mutex_lock(&context->lock);
+
+    if (server->networking_setup == NULL ||
+        server->networking_setup->io_timeout != context->expected_idle_timeout) {
+        context->idle_timeout_mismatches++;
+    }
 
     if (context->init_calls < TEST_HTTP_SERVER_WORKERS) {
         context->initialized_servers[context->init_calls] = server;
@@ -127,6 +134,30 @@ static void test_http_server_network_cleanup(void)
 #ifdef FLB_SYSTEM_WINDOWS
     WSACleanup();
 #endif
+}
+
+static int test_http_server_reserve_port(void)
+{
+    int ret;
+    socklen_t address_length;
+    flb_sockfd_t socket_fd;
+    struct sockaddr_in address;
+
+    socket_fd = flb_net_server("0", TEST_HTTP_SERVER_HOST,
+                               FLB_NETWORK_DEFAULT_BACKLOG_SIZE, FLB_FALSE);
+    if (socket_fd == FLB_INVALID_SOCKET) {
+        return -1;
+    }
+
+    memset(&address, 0, sizeof(address));
+    address_length = sizeof(address);
+    ret = getsockname(socket_fd, (struct sockaddr *) &address, &address_length);
+    flb_socket_close(socket_fd);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return ntohs(address.sin_port);
 }
 
 void test_http_server_options_defaults()
@@ -250,6 +281,7 @@ void test_http_server_managed_worker_contract()
 
 void test_http_server_worker_exit_runs_on_worker_thread()
 {
+    int port;
     int ret;
     struct flb_config *config;
     struct flb_net_setup net_setup;
@@ -269,6 +301,15 @@ void test_http_server_worker_exit_runs_on_worker_thread()
     }
 
     test_http_server_context_init(&context);
+    context.expected_idle_timeout = HTTP_SERVER_DEFAULT_IDLE_TIMEOUT;
+
+    port = test_http_server_reserve_port();
+    if (!TEST_CHECK(port > 0)) {
+        test_http_server_context_destroy(&context);
+        flb_config_exit(config);
+        test_http_server_network_cleanup();
+        return;
+    }
 
     flb_net_setup_init(&net_setup);
     flb_http_server_options_init(&options);
@@ -277,7 +318,7 @@ void test_http_server_worker_exit_runs_on_worker_thread()
     options.request_callback = test_http_server_request_handler;
     options.user_data = &context;
     options.address = (char *) TEST_HTTP_SERVER_HOST;
-    options.port = 0;
+    options.port = port;
     options.networking_flags = FLB_IO_TCP;
     options.networking_setup = &net_setup;
     options.system_context = config;
@@ -289,6 +330,7 @@ void test_http_server_worker_exit_runs_on_worker_thread()
     TEST_CHECK(ret == 0);
     if (ret == 0) {
         ret = flb_http_server_start(&server);
+#if defined(SO_REUSEPORT) && !defined(FLB_SYSTEM_WINDOWS)
         TEST_CHECK(ret == 0);
 
         if (ret == 0) {
@@ -298,13 +340,61 @@ void test_http_server_worker_exit_runs_on_worker_thread()
 
             TEST_CHECK(context.exit_calls == TEST_HTTP_SERVER_WORKERS);
             TEST_CHECK(context.exit_thread_mismatches == 0);
+            TEST_CHECK(context.idle_timeout_mismatches == 0);
         }
         else {
             flb_http_server_destroy(&server);
         }
+#else
+        TEST_CHECK(ret != 0);
+        flb_http_server_destroy(&server);
+#endif
     }
 
     test_http_server_context_destroy(&context);
+    flb_config_exit(config);
+    test_http_server_network_cleanup();
+}
+
+void test_http_server_workers_reject_distinct_ephemeral_ports()
+{
+    int ret;
+    struct flb_config *config;
+    struct flb_net_setup net_setup;
+    struct flb_http_server server;
+    struct flb_http_server_options options;
+
+    ret = test_http_server_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        test_http_server_network_cleanup();
+        return;
+    }
+
+    flb_net_setup_init(&net_setup);
+    flb_http_server_options_init(&options);
+
+    options.protocol_version = HTTP_PROTOCOL_VERSION_AUTODETECT;
+    options.request_callback = test_http_server_request_handler;
+    options.address = (char *) TEST_HTTP_SERVER_HOST;
+    options.port = 0;
+    options.networking_flags = FLB_IO_TCP;
+    options.networking_setup = &net_setup;
+    options.system_context = config;
+    options.workers = 2;
+
+    ret = flb_http_server_init_with_options(&server, &options);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        ret = flb_http_server_start(&server);
+        TEST_CHECK(ret != 0);
+        flb_http_server_destroy(&server);
+    }
+
     flb_config_exit(config);
     test_http_server_network_cleanup();
 }
@@ -391,13 +481,12 @@ void test_http_server_explicit_network_timeout_is_preserved()
 
 void test_http_server_multi_worker_disabled_idle_timeout_is_preserved()
 {
+    int port;
     struct flb_config *config;
     struct flb_net_setup net_setup;
     struct flb_http_server server;
     struct flb_http_server_options options;
-    const struct flb_net_setup *worker0_net_setup;
-    const struct flb_net_setup *worker1_net_setup;
-    const struct flb_net_setup *worker2_net_setup;
+    struct test_http_server_context context;
     int ret;
 
     ret = test_http_server_network_init();
@@ -413,20 +502,34 @@ void test_http_server_multi_worker_disabled_idle_timeout_is_preserved()
 
     flb_net_setup_init(&net_setup);
     flb_http_server_options_init(&options);
+    test_http_server_context_init(&context);
+    context.expected_idle_timeout = 0;
+
+    port = test_http_server_reserve_port();
+    if (!TEST_CHECK(port > 0)) {
+        test_http_server_context_destroy(&context);
+        flb_config_exit(config);
+        test_http_server_network_cleanup();
+        return;
+    }
 
     options.protocol_version = HTTP_PROTOCOL_VERSION_AUTODETECT;
     options.request_callback = test_http_server_request_handler;
     options.address = (char *) TEST_HTTP_SERVER_HOST;
-    options.port = 0;
+    options.port = port;
     options.networking_flags = FLB_IO_TCP;
     options.networking_setup = &net_setup;
     options.system_context = config;
     options.workers = 2;
     options.idle_timeout = 0;
+    options.user_data = &context;
+    options.cb_worker_init = test_http_server_worker_init;
+    options.cb_worker_exit = test_http_server_worker_exit;
 
     ret = flb_http_server_init_with_options(&server, &options);
     TEST_CHECK(ret == 0);
     if (ret != 0) {
+        test_http_server_context_destroy(&context);
         flb_config_exit(config);
         test_http_server_network_cleanup();
         return;
@@ -436,6 +539,7 @@ void test_http_server_multi_worker_disabled_idle_timeout_is_preserved()
     TEST_CHECK(net_setup.io_timeout == 0);
 
     ret = flb_http_server_start(&server);
+#if defined(SO_REUSEPORT) && !defined(FLB_SYSTEM_WINDOWS)
     TEST_CHECK(ret == 0);
     if (ret != 0) {
         flb_http_server_destroy(&server);
@@ -444,18 +548,17 @@ void test_http_server_multi_worker_disabled_idle_timeout_is_preserved()
         return;
     }
 
-    worker0_net_setup = flb_http_server_runtime_worker_net_setup_get(&server, 0);
-    worker1_net_setup = flb_http_server_runtime_worker_net_setup_get(&server, 1);
-    worker2_net_setup = flb_http_server_runtime_worker_net_setup_get(&server, 2);
-
-    if (TEST_CHECK(worker0_net_setup != NULL) &&
-        TEST_CHECK(worker1_net_setup != NULL) &&
-        TEST_CHECK(worker2_net_setup == NULL)) {
-        TEST_CHECK(worker0_net_setup->io_timeout == 0);
-        TEST_CHECK(worker1_net_setup->io_timeout == 0);
-    }
+    TEST_CHECK(context.init_calls == TEST_HTTP_SERVER_WORKERS);
+    TEST_CHECK(context.idle_timeout_mismatches == 0);
 
     flb_http_server_destroy(&server);
+    TEST_CHECK(context.exit_calls == TEST_HTTP_SERVER_WORKERS);
+    TEST_CHECK(context.exit_thread_mismatches == 0);
+#else
+    TEST_CHECK(ret != 0);
+    flb_http_server_destroy(&server);
+#endif
+    test_http_server_context_destroy(&context);
     flb_config_exit(config);
     test_http_server_network_cleanup();
 }
@@ -513,6 +616,8 @@ TEST_LIST = {
     { "http_server_managed_worker_contract", test_http_server_managed_worker_contract },
     { "http_server_worker_exit_runs_on_worker_thread",
       test_http_server_worker_exit_runs_on_worker_thread },
+    { "http_server_workers_reject_distinct_ephemeral_ports",
+      test_http_server_workers_reject_distinct_ephemeral_ports },
     { "http_server_idle_timeout_applies_to_networking_setup",
       test_http_server_idle_timeout_applies_to_networking_setup },
     { "http_server_explicit_network_timeout_is_preserved",


### PR DESCRIPTION
fixes https://github.com/fluent/fluent-bit/issues/11757

Adds shared downstream worker support and enables workers for downstream-based inputs:

  - in_tcp
  - in_udp
  - in_forward

  Also refactors flb_http_server to use the same shared downstream worker runtime, avoiding
  duplicated worker lifecycle code across HTTP and non-HTTP downstream listeners.

  Scope

  - Adds flb_downstream_worker helper for worker lifecycle:
      - thread startup/shutdown
      - per-worker event loop
      - DNS context setup
      - custom event dispatch
      - startup synchronization
      - safe join/cleanup
      - maintenance callbacks
  - Adds workers config option to:
      - in_tcp
      - in_udp
      - in_forward
  - Keeps default behavior unchanged:
      - workers defaults to 1
  - Adds integration coverage for:
      - concurrent TCP workers
      - concurrent UDP workers
      - concurrent Forward workers
      - dropped/partial connections
      - malformed UDP datagrams
      - TCP TLS workers
      - Forward TLS workers
      - bad TLS handshakes followed by valid traffic

  Compatibility Notes

  - Default behavior remains single listener worker.
  - in_forward workers are supported for TCP listeners; Unix socket mode still runs without worker
    fan-out.
  - in_udp has no TLS worker test because the plugin does not expose TLS support.
  ----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TCP, UDP and Forward inputs now support configurable multi‑worker listeners with a shared downstream worker runtime and optional ingress routing for improved concurrency; HTTP server adopts the same worker model.
* **Tests**
  * New integration scenarios and tests covering multi‑worker concurrency, TLS/non‑TLS, malformed/partial connections, and recovery.
* **Documentation**
  * Added contributor guidelines and refreshed library README.
* **Chores**
  * CI workflow updates and new public atomic/container APIs in the CFL library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->