### PR TITLE
kv: add `flb_kv_get_all_key_values` function for `mk_list`

### DIFF
--- a/include/fluent-bit/flb_kv.h
+++ b/include/fluent-bit/flb_kv.h
@@ -30,6 +30,11 @@ struct flb_kv {
   struct mk_list _head;
 };
 
+struct flb_kv_pair {
+  flb_sds_t key;
+  flb_sds_t val;
+};
+
 void flb_kv_init(struct mk_list *list);
 struct flb_kv *flb_kv_item_create_len(struct mk_list *list,
                                       char *k_buf, size_t k_len,
@@ -41,5 +46,6 @@ struct flb_kv *flb_kv_item_set(struct mk_list *list,
 void flb_kv_item_destroy(struct flb_kv *kv);
 void flb_kv_release(struct mk_list *list);
 const char *flb_kv_get_key_value(const char *key, struct mk_list *list);
+struct flb_kv_pair **flb_kv_get_all_key_values(struct mk_list *list);
 
 #endif

--- a/include/fluent-bit/flb_kv.h
+++ b/include/fluent-bit/flb_kv.h
@@ -30,11 +30,6 @@ struct flb_kv {
   struct mk_list _head;
 };
 
-struct flb_kv_pair {
-  flb_sds_t key;
-  flb_sds_t val;
-};
-
 void flb_kv_init(struct mk_list *list);
 struct flb_kv *flb_kv_item_create_len(struct mk_list *list,
                                       char *k_buf, size_t k_len,
@@ -46,6 +41,6 @@ struct flb_kv *flb_kv_item_set(struct mk_list *list,
 void flb_kv_item_destroy(struct flb_kv *kv);
 void flb_kv_release(struct mk_list *list);
 const char *flb_kv_get_key_value(const char *key, struct mk_list *list);
-struct flb_kv_pair **flb_kv_get_all_key_values(struct mk_list *list);
+struct flb_kv **flb_kv_get_all_key_values(struct mk_list *list);
 
 #endif

--- a/src/flb_kv.c
+++ b/src/flb_kv.c
@@ -161,13 +161,13 @@ const char *flb_kv_get_key_value(const char *key, struct mk_list *list)
     return NULL;
 }
 
-struct flb_kv_pair **flb_kv_get_all_key_values(struct mk_list *list)
+struct flb_kv **flb_kv_get_all_key_values(struct mk_list *list)
 {
     int count;
     int i = 0;
     struct mk_list *head;
     struct flb_kv *kv;
-    struct flb_kv_pair **arr;
+    struct flb_kv **arr;
 
     if (!list) {
         return NULL;
@@ -186,8 +186,7 @@ struct flb_kv_pair **flb_kv_get_all_key_values(struct mk_list *list)
 
     mk_list_foreach(head, list) {
         kv = mk_list_entry(head, struct flb_kv, _head);
-        arr[i]->key = kv->key;
-        arr[i]->val = kv->val;
+        arr[i] = kv;
         i++;
     }
 

--- a/src/flb_kv.c
+++ b/src/flb_kv.c
@@ -178,7 +178,7 @@ struct flb_kv **flb_kv_get_all_key_values(struct mk_list *list)
         return NULL;
     }
 
-    arr = flb_calloc(count, sizeof(struct flb_kv_pair *));
+    arr = flb_calloc(count, sizeof(struct flb_kv *));
     if (!arr) {
         flb_errno();
         return NULL;

--- a/src/flb_kv.c
+++ b/src/flb_kv.c
@@ -160,3 +160,36 @@ const char *flb_kv_get_key_value(const char *key, struct mk_list *list)
 
     return NULL;
 }
+
+struct flb_kv_pair **flb_kv_get_all_key_values(struct mk_list *list)
+{
+    int count;
+    int i = 0;
+    struct mk_list *head;
+    struct flb_kv *kv;
+    struct flb_kv_pair **arr;
+
+    if (!list) {
+        return NULL;
+    }
+
+    count = mk_list_size(list);
+    if (count == 0) {
+        return NULL;
+    }
+
+    arr = flb_calloc(count, sizeof(struct flb_kv_pair *));
+    if (!arr) {
+        flb_errno();
+        return NULL;
+    }
+
+    mk_list_foreach(head, list) {
+        kv = mk_list_entry(head, struct flb_kv, _head);
+        arr[i]->key = kv->key;
+        arr[i]->val = kv->val;
+        i++;
+    }
+
+    return arr;
+}

--- a/tests/internal/kv.c
+++ b/tests/internal/kv.c
@@ -32,7 +32,7 @@ static void test_kv_item_set_duplicate()
 static void test_kv_get_all_key_values()
 {
     struct mk_list list;
-    struct flb_kv_pair **pairs;
+    struct flb_kv **pairs;
 
     flb_kv_init(&list);
 

--- a/tests/internal/kv.c
+++ b/tests/internal/kv.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_mem.h>
 #include "flb_tests_internal.h"
 
 static void test_kv_item_set_duplicate()
@@ -28,7 +29,42 @@ static void test_kv_item_set_duplicate()
     flb_kv_release(&list);
 }
 
+static void test_kv_get_all_key_values()
+{
+    struct mk_list list;
+    struct flb_kv_pair **pairs;
+
+    flb_kv_init(&list);
+
+    pairs = flb_kv_get_all_key_values(&list);
+    TEST_CHECK(pairs == NULL);
+
+    flb_kv_item_set(&list, "host", "localhost");
+    flb_kv_item_set(&list, "port", "8080");
+    flb_kv_item_set(&list, "path", "/api");
+
+    pairs = flb_kv_get_all_key_values(&list);
+    TEST_CHECK(pairs != NULL);
+
+    if (pairs) {
+        TEST_CHECK(pairs[0] != NULL);
+        TEST_CHECK(strcmp(pairs[0]->key, "host") == 0);
+        TEST_CHECK(strcmp(pairs[0]->val, "localhost") == 0);
+
+        TEST_CHECK(pairs[1] != NULL);
+        TEST_CHECK(strcmp(pairs[1]->key, "port") == 0);
+        TEST_CHECK(strcmp(pairs[1]->val, "8080") == 0);
+
+        TEST_CHECK(pairs[2] != NULL);
+        TEST_CHECK(strcmp(pairs[2]->key, "path") == 0);
+        TEST_CHECK(strcmp(pairs[2]->val, "/api") == 0);
+    }
+
+    flb_kv_release(&list);
+}
+
 TEST_LIST = {
     {"kv_item_set_duplicate", test_kv_item_set_duplicate},
+    {"kv_get_all_key_values", test_kv_get_all_key_values},
     {0}
 };

--- a/tests/internal/kv.c
+++ b/tests/internal/kv.c
@@ -61,6 +61,7 @@ static void test_kv_get_all_key_values()
     }
 
     flb_kv_release(&list);
+    flb_free(pairs);
 }
 
 TEST_LIST = {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add `flb_kv_get_all_key_values` function for `mk_list`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Addresses #11776 (1/3 sub-task)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ ] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new public API function that retrieves multiple key-value pairs in bulk from existing lists. The function includes proper validation for null inputs and handles memory allocation appropriately.

* **Tests**
  * Added comprehensive test coverage for the bulk key-value retrieval functionality, validating correct retrieval of pair data and appropriate behavior with empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->