### PR TITLE
in_exec: run collector in threaded mode

### DIFF
--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -482,6 +482,7 @@ static struct flb_config_map config_map[] = {
 struct flb_input_plugin in_exec_plugin = {
     .name         = "exec",
     .description  = "Exec Input",
+    .flags        = FLB_INPUT_THREADED,
     .cb_init      = in_exec_init,
     .cb_pre_run   = in_exec_prerun,
     .cb_collect   = in_exec_collect,

--- a/tests/integration/scenarios/internal_http_server/config/internal_http_server_exec_deadlock.yaml
+++ b/tests/integration/scenarios/internal_http_server/config/internal_http_server_exec_deadlock.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_listen: 127.0.0.1
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: exec
+      tag: test
+      command: curl -s http://127.0.0.1:${FLUENT_BIT_HTTP_MONITORING_PORT}/api/v1/metrics/prometheus
+      interval_sec: 1
+      buf_size: 128k
+
+  outputs:
+    - name: "null"
+      match: "*"

--- a/tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_exec_deadlock_001.py
+++ b/tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_exec_deadlock_001.py
@@ -1,0 +1,64 @@
+import os
+import time
+
+from utils.http_matrix import run_curl_request
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self):
+        self.config_file = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../config/internal_http_server_exec_deadlock.yaml",
+            )
+        )
+        self.service = FluentBitTestService(self.config_file)
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+        self.base_url = f"http://127.0.0.1:{self.flb.http_monitoring_port}"
+
+    def stop(self):
+        self.service.stop()
+
+    def request(self, path, *, method="GET", http_mode="http1.1"):
+        return run_curl_request(
+            f"{self.base_url}{path}",
+            method=method,
+            http_mode=http_mode,
+        )
+
+
+def test_http_server_responsive_after_exec_self_request():
+    """The built-in HTTP server must remain responsive after the exec input
+    plugin makes an HTTP request to it. Before the fix, the exec child
+    process (curl) and the HTTP server shared the same event loop, causing
+    a deadlock that made the server permanently unresponsive."""
+
+    service = Service()
+
+    try:
+        service.start()
+
+        result = service.request("/api/v1/uptime")
+        assert result["status_code"] == 200
+        assert "uptime_sec" in result["body"]
+
+        time.sleep(2)
+
+        result = service.service.wait_for_condition(
+            lambda: (
+                response
+                if response["status_code"] == 200 and "uptime_sec" in response["body"]
+                else None
+            ) if (response := service.request("/api/v1/uptime")) else None,
+            timeout=10,
+            interval=1,
+            description="HTTP server responsive after exec self-request",
+        )
+        assert result["status_code"] == 200
+        assert "uptime_sec" in result["body"]
+    finally:
+        service.stop()


### PR DESCRIPTION
Fixes an internal HTTP server self-request deadlock by running the `exec` input collector on Fluent Bit's existing threaded input path. This keeps blocking  `popen()`/read work out of the engine event loop while leaving the monitoring HTTP server on its original event loop.

Adds an integration regression test where `exec` runs `curl` against `/api/v1/metrics/prometheus` and verifies the internal HTTP server remains responsive.

  ## Validation

  - Confirmed the regression test fails on the original baseline with an HTTP read
  timeout.
  - `cmake --build build -j8`
  - `tests/integration/run_tests.py --quiet scenarios/internal_http_server/tests/
  test_internal_http_server_exec_deadlock_001.py::test_http_server_responsive_afte
  r_exec_self_request`
  - `tests/integration/run_tests.py --valgrind --valgrind-strict --quiet
  scenarios/internal_http_server/tests/
  test_internal_http_server_exec_deadlock_001.py::test_http_server_responsive_afte
  r_exec_self_request`
  - `tests/integration/run_tests.py --quiet scenarios/internal_http_server`
  - `ctest --test-dir build -R flb-it-http_server --output-on-failure`
  - `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/
  integration/.venv/bin/python .github/scripts/commit_prefix_check.py`
  
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a deadlock that caused the internal HTTP server to become unresponsive when executing metric collection that includes self-referential requests.

* **Tests**
  * Added integration test scenario to verify the HTTP server remains responsive after exec inputs make self-targeted metric requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->