### PR TITLE
in_ebpf: Implement openssl trace

### DIFF
--- a/plugins/in_ebpf/CMakeLists.txt
+++ b/plugins/in_ebpf/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(gadget INTERFACE)
 target_include_directories(gadget INTERFACE ${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/includes/external/gadget)
 
 set(LIBC_PATH "/lib64/libc.so.6")
+set(LIBSSL_PATH "/lib64/libssl.so.3")
 
 find_program(LSB_RELEASE_EXEC lsb_release)
 if (LSB_RELEASE_EXEC)
@@ -42,10 +43,13 @@ if (LSB_RELEASE_EXEC)
     # Just added for the future enhancement
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)")
       set(LIBC_PATH "/usr/lib/aarch64-linux-gnu/libc.so.6")
+      set(LIBSSL_PATH "/usr/lib/aarch64-linux-gnu/libssl.so.3")
     elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
       set(LIBC_PATH "/usr/lib/x86_64-linux-gnu/libc.so.6")
+      set(LIBSSL_PATH "/usr/lib/x86_64-linux-gnu/libssl.so.3")
     elseif (CMAKE_SIZEOF_VOID_P EQUAL 4)
       set(LIBC_PATH "/usr/lib/i386-linux-gnu/libc.so.6")
+      set(LIBSSL_PATH "/usr/lib/i386-linux-gnu/libssl.so.3")
     endif()
   endif()
 endif()
@@ -54,6 +58,11 @@ endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/malloc/bpf.c.in"
   "${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/malloc/bpf.c"
+  )
+
+configure_file(
+  "${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/openssl/bpf.c.in"
+  "${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/openssl/bpf.c"
   )
 
 # Find all bpf.c files in the traces directory

--- a/plugins/in_ebpf/CMakeLists.txt
+++ b/plugins/in_ebpf/CMakeLists.txt
@@ -26,7 +26,38 @@ add_library(gadget INTERFACE)
 target_include_directories(gadget INTERFACE ${CMAKE_SOURCE_DIR}/plugins/in_ebpf/traces/includes/external/gadget)
 
 set(LIBC_PATH "/lib64/libc.so.6")
-set(LIBSSL_PATH "/lib64/libssl.so.3")
+
+set(FLB_IN_EBPF_LIBSSL_PATH "" CACHE FILEPATH
+    "Path to libssl shared object used by eBPF OpenSSL uprobes")
+
+if (FLB_IN_EBPF_LIBSSL_PATH)
+  set(LIBSSL_PATH "${FLB_IN_EBPF_LIBSSL_PATH}")
+else()
+  find_package(OpenSSL QUIET)
+
+  if (OPENSSL_SSL_LIBRARY)
+    set(LIBSSL_PATH "${OPENSSL_SSL_LIBRARY}")
+  elseif (TARGET OpenSSL::SSL)
+    get_target_property(_libssl_path OpenSSL::SSL IMPORTED_LOCATION)
+    if (_libssl_path)
+      set(LIBSSL_PATH "${_libssl_path}")
+    endif()
+  endif()
+
+  if (NOT LIBSSL_PATH)
+    find_library(LIBSSL_PATH NAMES ssl libssl.so libssl.so.3 libssl.so.1.1)
+  endif()
+
+  if (NOT LIBSSL_PATH)
+    set(LIBSSL_PATH "/lib64/libssl.so.3")
+  endif()
+endif()
+
+if (LIBSSL_PATH MATCHES "\\.(a|lib)$")
+  message(WARNING
+          "eBPF OpenSSL uprobes resolved a static OpenSSL library: ${LIBSSL_PATH}. "
+          "Set FLB_IN_EBPF_LIBSSL_PATH to the target host libssl shared object.")
+endif()
 
 find_program(LSB_RELEASE_EXEC lsb_release)
 if (LSB_RELEASE_EXEC)
@@ -43,16 +74,15 @@ if (LSB_RELEASE_EXEC)
     # Just added for the future enhancement
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)")
       set(LIBC_PATH "/usr/lib/aarch64-linux-gnu/libc.so.6")
-      set(LIBSSL_PATH "/usr/lib/aarch64-linux-gnu/libssl.so.3")
     elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
       set(LIBC_PATH "/usr/lib/x86_64-linux-gnu/libc.so.6")
-      set(LIBSSL_PATH "/usr/lib/x86_64-linux-gnu/libssl.so.3")
     elseif (CMAKE_SIZEOF_VOID_P EQUAL 4)
       set(LIBC_PATH "/usr/lib/i386-linux-gnu/libc.so.6")
-      set(LIBSSL_PATH "/usr/lib/i386-linux-gnu/libssl.so.3")
     endif()
   endif()
 endif()
+
+message(STATUS "eBPF OpenSSL uprobes libssl path: ${LIBSSL_PATH}")
 
 # Generate the malloc trace from the template
 configure_file(

--- a/plugins/in_ebpf/traces/includes/common/encoder.h
+++ b/plugins/in_ebpf/traces/includes/common/encoder.h
@@ -29,6 +29,14 @@ static inline char *event_type_to_string(enum event_type type) {
             return "dns";
         case EVENT_TYPE_SCHED:
             return "sched";
+        case EVENT_TYPE_TLS_HANDSHAKE:
+            return "tls_handshake";
+        case EVENT_TYPE_TLS_READ:
+            return "tls_read";
+        case EVENT_TYPE_TLS_WRITE:
+            return "tls_write";
+        case EVENT_TYPE_TLS_SHUTDOWN:
+            return "tls_shutdown";
         default:
             return "unknown";
     }

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -22,6 +22,10 @@ enum event_type {
     EVENT_TYPE_CONNECT,
     EVENT_TYPE_DNS,
     EVENT_TYPE_SCHED,
+    EVENT_TYPE_TLS_HANDSHAKE,
+    EVENT_TYPE_TLS_READ,
+    EVENT_TYPE_TLS_WRITE,
+    EVENT_TYPE_TLS_SHUTDOWN,
 };
 
 enum vfs_op {
@@ -163,6 +167,18 @@ struct sched_sample {
     struct sched_event details;
 };
 
+struct tls_handshake_event {
+    __u64 ssl_ptr;
+    __s64 latency_ns;
+    int ret;
+};
+
+struct tls_io_event {
+    __u64 ssl_ptr;
+    __s64 latency_ns;
+    int ret;
+};
+
 struct event {
     enum event_type type;           // Type of event (execve, signal, mem, bind)
     struct event_common common;     // Common fields for all events
@@ -177,6 +193,8 @@ struct event {
         struct connect_event connect;
         struct dns_event dns;
         struct sched_event sched;
+        struct tls_handshake_event tls_handshake;
+        struct tls_io_event tls_io;
     } details;
 };
 

--- a/plugins/in_ebpf/traces/openssl/bpf.c.in
+++ b/plugins/in_ebpf/traces/openssl/bpf.c.in
@@ -24,6 +24,7 @@
 struct tls_state {
     __u64 ssl_ptr;
     __u64 start_ns;
+    __u64 bytes_ptr;
     __u32 type;
 };
 
@@ -71,6 +72,45 @@ static __always_inline int trace_tls_entry(void *ssl, __u32 type)
     return 0;
 }
 
+static __always_inline int trace_tls_entry_ex(void *ssl, __u32 type,
+                                              size_t *bytes_ptr)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct tls_state state = {};
+
+    state.ssl_ptr = (__u64) ssl;
+    state.start_ns = bpf_ktime_get_ns();
+    state.bytes_ptr = (__u64) bytes_ptr;
+    state.type = type;
+
+    bpf_map_update_elem(&tls_start, &pid_tgid, &state, BPF_ANY);
+    return 0;
+}
+
+static __always_inline int get_openssl_ex_ret(int ret, __u64 bytes_ptr)
+{
+    size_t byte_count = 0;
+
+    if (ret <= 0) {
+        return ret;
+    }
+
+    if (bytes_ptr == 0) {
+        return -1;
+    }
+
+    if (bpf_probe_read_user(&byte_count, sizeof(byte_count),
+                            (const void *) bytes_ptr) != 0) {
+        return -1;
+    }
+
+    if (byte_count > 0x7fffffffULL) {
+        return 0x7fffffff;
+    }
+
+    return (int) byte_count;
+}
+
 static __always_inline int trace_tls_return(struct pt_regs *ctx)
 {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -78,6 +118,7 @@ static __always_inline int trace_tls_return(struct pt_regs *ctx)
     __u64 now_ns;
     __s64 latency_ns;
     struct event *eventp;
+    int ret;
 
     state = bpf_map_lookup_elem(&tls_start, &pid_tgid);
     if (!state) {
@@ -99,19 +140,24 @@ static __always_inline int trace_tls_return(struct pt_regs *ctx)
         eventp->details.tls_handshake.ssl_ptr = state->ssl_ptr;
         eventp->details.tls_handshake.latency_ns = latency_ns;
 #if defined(__TARGET_ARCH_arm64)
-        eventp->details.tls_handshake.ret = (int) ctx->regs[0];
+        ret = (int) ctx->regs[0];
 #else
-        eventp->details.tls_handshake.ret = (int)PT_REGS_RC(ctx);
+        ret = (int) PT_REGS_RC(ctx);
 #endif
+        eventp->details.tls_handshake.ret = ret;
     }
     else {
         eventp->details.tls_io.ssl_ptr = state->ssl_ptr;
         eventp->details.tls_io.latency_ns = latency_ns;
 #if defined(__TARGET_ARCH_arm64)
-        eventp->details.tls_io.ret = (int) ctx->regs[0];
+        ret = (int) ctx->regs[0];
 #else
-        eventp->details.tls_io.ret = (int)PT_REGS_RC(ctx);
+        ret = (int) PT_REGS_RC(ctx);
 #endif
+        if (state->bytes_ptr != 0) {
+            ret = get_openssl_ex_ret(ret, state->bytes_ptr);
+        }
+        eventp->details.tls_io.ret = ret;
     }
 
     gadget_submit_buf(ctx, &events, eventp, sizeof(*eventp));
@@ -143,6 +189,19 @@ int trace_uretprobe_ssl_read(struct pt_regs *ctx)
     return trace_tls_return(ctx);
 }
 
+SEC("uprobe/@LIBSSL_PATH@:SSL_read_ex")
+int BPF_UPROBE(trace_uprobe_ssl_read_ex, void *ssl, void *buf, size_t num,
+               size_t *readbytes)
+{
+    return trace_tls_entry_ex(ssl, TLS_EVENT_READ, readbytes);
+}
+
+SEC("uretprobe/@LIBSSL_PATH@:SSL_read_ex")
+int trace_uretprobe_ssl_read_ex(struct pt_regs *ctx)
+{
+    return trace_tls_return(ctx);
+}
+
 SEC("uprobe/@LIBSSL_PATH@:SSL_write")
 int BPF_UPROBE(trace_uprobe_ssl_write, void *ssl)
 {
@@ -151,6 +210,19 @@ int BPF_UPROBE(trace_uprobe_ssl_write, void *ssl)
 
 SEC("uretprobe/@LIBSSL_PATH@:SSL_write")
 int trace_uretprobe_ssl_write(struct pt_regs *ctx)
+{
+    return trace_tls_return(ctx);
+}
+
+SEC("uprobe/@LIBSSL_PATH@:SSL_write_ex")
+int BPF_UPROBE(trace_uprobe_ssl_write_ex, void *ssl, const void *buf, size_t num,
+               size_t *written)
+{
+    return trace_tls_entry_ex(ssl, TLS_EVENT_WRITE, written);
+}
+
+SEC("uretprobe/@LIBSSL_PATH@:SSL_write_ex")
+int trace_uretprobe_ssl_write_ex(struct pt_regs *ctx)
 {
     return trace_tls_return(ctx);
 }

--- a/plugins/in_ebpf/traces/openssl/bpf.c.in
+++ b/plugins/in_ebpf/traces/openssl/bpf.c.in
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+#include <vmlinux.h>
+
+#define _LINUX_TYPES_H
+#define _LINUX_POSIX_TYPES_H
+
+#if defined(__TARGET_ARCH_x86_64) && !defined(__TARGET_ARCH_x86)
+#define __TARGET_ARCH_x86
+#endif
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include <gadget/buffer.h>
+#include <gadget/macros.h>
+#include <gadget/mntns_filter.h>
+#include <gadget/types.h>
+
+#include "common/events.h"
+
+#define MAX_ENTRIES 10240
+
+struct tls_state {
+    __u64 ssl_ptr;
+    __u64 start_ns;
+    __u32 type;
+};
+
+#define TLS_EVENT_HANDSHAKE EVENT_TYPE_TLS_HANDSHAKE
+#define TLS_EVENT_READ      EVENT_TYPE_TLS_READ
+#define TLS_EVENT_WRITE     EVENT_TYPE_TLS_WRITE
+#define TLS_EVENT_SHUTDOWN  EVENT_TYPE_TLS_SHUTDOWN
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, __u64);              /* pid_tgid */
+    __type(value, struct tls_state);
+} tls_start SEC(".maps");
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+
+static __always_inline void fill_common(struct event *event)
+{
+    __u64 pid_tgid;
+    __u64 uid_gid;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    uid_gid = bpf_get_current_uid_gid();
+
+    event->common.timestamp_raw = bpf_ktime_get_boot_ns();
+    event->common.pid = (__u32) (pid_tgid >> 32);
+    event->common.tid = (__u32) pid_tgid;
+    event->common.uid = (__u32) uid_gid;
+    event->common.gid = (__u32) (uid_gid >> 32);
+    event->common.mntns_id = 0;
+    bpf_get_current_comm(event->common.comm, sizeof(event->common.comm));
+}
+
+static __always_inline int trace_tls_entry(void *ssl, __u32 type)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct tls_state state = {};
+
+    state.ssl_ptr = (__u64) ssl;
+    state.start_ns = bpf_ktime_get_ns();
+    state.type = type;
+
+    bpf_map_update_elem(&tls_start, &pid_tgid, &state, BPF_ANY);
+    return 0;
+}
+
+static __always_inline int trace_tls_return(struct pt_regs *ctx)
+{
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct tls_state *state;
+    __u64 now_ns;
+    __s64 latency_ns;
+    struct event *eventp;
+
+    state = bpf_map_lookup_elem(&tls_start, &pid_tgid);
+    if (!state) {
+        return 0;
+    }
+
+    now_ns = bpf_ktime_get_ns();
+    latency_ns = (__s64)(now_ns - state->start_ns);
+
+    eventp = gadget_reserve_buf(&events, sizeof(*eventp));
+    if (!eventp) {
+        bpf_map_delete_elem(&tls_start, &pid_tgid);
+        return 0;
+    }
+
+    fill_common(eventp);
+    eventp->type = state->type;
+    if (state->type == TLS_EVENT_HANDSHAKE) {
+        eventp->details.tls_handshake.ssl_ptr = state->ssl_ptr;
+        eventp->details.tls_handshake.latency_ns = latency_ns;
+#if defined(__TARGET_ARCH_arm64)
+        eventp->details.tls_handshake.ret = (int) ctx->regs[0];
+#else
+        eventp->details.tls_handshake.ret = (int)PT_REGS_RC(ctx);
+#endif
+    }
+    else {
+        eventp->details.tls_io.ssl_ptr = state->ssl_ptr;
+        eventp->details.tls_io.latency_ns = latency_ns;
+#if defined(__TARGET_ARCH_arm64)
+        eventp->details.tls_io.ret = (int) ctx->regs[0];
+#else
+        eventp->details.tls_io.ret = (int)PT_REGS_RC(ctx);
+#endif
+    }
+
+    gadget_submit_buf(ctx, &events, eventp, sizeof(*eventp));
+    bpf_map_delete_elem(&tls_start, &pid_tgid);
+    return 0;
+}
+
+SEC("uprobe/@LIBSSL_PATH@:SSL_do_handshake")
+int BPF_UPROBE(trace_uprobe_ssl_do_handshake, void *ssl)
+{
+    return trace_tls_entry(ssl, TLS_EVENT_HANDSHAKE);
+}
+
+SEC("uretprobe/@LIBSSL_PATH@:SSL_do_handshake")
+int trace_uretprobe_ssl_do_handshake(struct pt_regs *ctx)
+{
+    return trace_tls_return(ctx);
+}
+
+SEC("uprobe/@LIBSSL_PATH@:SSL_read")
+int BPF_UPROBE(trace_uprobe_ssl_read, void *ssl)
+{
+    return trace_tls_entry(ssl, TLS_EVENT_READ);
+}
+
+SEC("uretprobe/@LIBSSL_PATH@:SSL_read")
+int trace_uretprobe_ssl_read(struct pt_regs *ctx)
+{
+    return trace_tls_return(ctx);
+}
+
+SEC("uprobe/@LIBSSL_PATH@:SSL_write")
+int BPF_UPROBE(trace_uprobe_ssl_write, void *ssl)
+{
+    return trace_tls_entry(ssl, TLS_EVENT_WRITE);
+}
+
+SEC("uretprobe/@LIBSSL_PATH@:SSL_write")
+int trace_uretprobe_ssl_write(struct pt_regs *ctx)
+{
+    return trace_tls_return(ctx);
+}
+
+SEC("uprobe/@LIBSSL_PATH@:SSL_shutdown")
+int BPF_UPROBE(trace_uprobe_ssl_shutdown, void *ssl)
+{
+    return trace_tls_entry(ssl, TLS_EVENT_SHUTDOWN);
+}
+
+SEC("uretprobe/@LIBSSL_PATH@:SSL_shutdown")
+int trace_uretprobe_ssl_shutdown(struct pt_regs *ctx)
+{
+    return trace_tls_return(ctx);
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/plugins/in_ebpf/traces/openssl/handler.c
+++ b/plugins/in_ebpf/traces/openssl/handler.c
@@ -7,11 +7,27 @@
 
 #include "handler.h"
 
+static int is_openssl_tls_event(enum event_type type)
+{
+    if (type == EVENT_TYPE_TLS_HANDSHAKE ||
+        type == EVENT_TYPE_TLS_READ ||
+        type == EVENT_TYPE_TLS_WRITE ||
+        type == EVENT_TYPE_TLS_SHUTDOWN) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 int encode_openssl_event(struct flb_log_event_encoder *log_encoder,
                          const struct event *ev)
 {
     int ret;
     const char *trace_name;
+
+    if (!is_openssl_tls_event(ev->type)) {
+        return -1;
+    }
 
     ret = flb_log_event_encoder_begin_record(log_encoder);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
@@ -29,18 +45,25 @@ int encode_openssl_event(struct flb_log_event_encoder *log_encoder,
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
     }
+
     if (ev->type == EVENT_TYPE_TLS_READ) {
-        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_read");
+        trace_name = "openssl_tls_read";
     }
     else if (ev->type == EVENT_TYPE_TLS_WRITE) {
-        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_write");
+        trace_name = "openssl_tls_write";
     }
     else if (ev->type == EVENT_TYPE_TLS_SHUTDOWN) {
-        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_shutdown");
+        trace_name = "openssl_tls_shutdown";
+    }
+    else if (ev->type == EVENT_TYPE_TLS_HANDSHAKE) {
+        trace_name = "openssl_tls_handshake";
     }
     else {
-        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_handshake");
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
     }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, trace_name);
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {
         flb_log_event_encoder_rollback_record(log_encoder);
         return -1;
@@ -124,10 +147,7 @@ int trace_openssl_handler(void *ctx, void *data, size_t data_sz)
         return -1;
     }
 
-    if (ev->type != EVENT_TYPE_TLS_HANDSHAKE &&
-        ev->type != EVENT_TYPE_TLS_READ &&
-        ev->type != EVENT_TYPE_TLS_WRITE &&
-        ev->type != EVENT_TYPE_TLS_SHUTDOWN) {
+    if (!is_openssl_tls_event(ev->type)) {
         return -1;
     }
 

--- a/plugins/in_ebpf/traces/openssl/handler.c
+++ b/plugins/in_ebpf/traces/openssl/handler.c
@@ -1,0 +1,147 @@
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_log_event_encoder.h>
+
+#include "common/events.h"
+#include "common/event_context.h"
+#include "common/encoder.h"
+
+#include "handler.h"
+
+int encode_openssl_event(struct flb_log_event_encoder *log_encoder,
+                         const struct event *ev)
+{
+    int ret;
+    const char *trace_name;
+
+    ret = flb_log_event_encoder_begin_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
+    ret = encode_common_fields(log_encoder, ev);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "trace");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    if (ev->type == EVENT_TYPE_TLS_READ) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_read");
+    }
+    else if (ev->type == EVENT_TYPE_TLS_WRITE) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_write");
+    }
+    else if (ev->type == EVENT_TYPE_TLS_SHUTDOWN) {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_shutdown");
+    }
+    else {
+        ret = flb_log_event_encoder_append_body_cstring(log_encoder, "openssl_tls_handshake");
+    }
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "ssl_ptr");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    if (ev->type == EVENT_TYPE_TLS_HANDSHAKE) {
+        ret = flb_log_event_encoder_append_body_uint64(log_encoder,
+                                                       ev->details.tls_handshake.ssl_ptr);
+    }
+    else {
+        ret = flb_log_event_encoder_append_body_uint64(log_encoder,
+                                                       ev->details.tls_io.ssl_ptr);
+    }
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "latency_ns");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    if (ev->type == EVENT_TYPE_TLS_HANDSHAKE) {
+        ret = flb_log_event_encoder_append_body_int64(log_encoder,
+                                                      ev->details.tls_handshake.latency_ns);
+    }
+    else {
+        ret = flb_log_event_encoder_append_body_int64(log_encoder,
+                                                      ev->details.tls_io.latency_ns);
+    }
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "ret");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+    if (ev->type == EVENT_TYPE_TLS_HANDSHAKE) {
+        ret = flb_log_event_encoder_append_body_int32(log_encoder,
+                                                      ev->details.tls_handshake.ret);
+    }
+    else {
+        ret = flb_log_event_encoder_append_body_int32(log_encoder,
+                                                      ev->details.tls_io.ret);
+    }
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    ret = flb_log_event_encoder_commit_record(log_encoder);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        flb_log_event_encoder_rollback_record(log_encoder);
+        return -1;
+    }
+
+    return 0;
+}
+
+int trace_openssl_handler(void *ctx, void *data, size_t data_sz)
+{
+    struct trace_event_context *event_ctx;
+    struct event *ev;
+    struct flb_log_event_encoder *encoder;
+    int ret;
+
+    event_ctx = (struct trace_event_context *) ctx;
+    ev = (struct event *) data;
+    encoder = event_ctx->log_encoder;
+
+    if (data_sz < sizeof(struct event)) {
+        return -1;
+    }
+
+    if (ev->type != EVENT_TYPE_TLS_HANDSHAKE &&
+        ev->type != EVENT_TYPE_TLS_READ &&
+        ev->type != EVENT_TYPE_TLS_WRITE &&
+        ev->type != EVENT_TYPE_TLS_SHUTDOWN) {
+        return -1;
+    }
+
+    ret = encode_openssl_event(encoder, ev);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = flb_input_log_append(event_ctx->ins, NULL, 0,
+                               encoder->output_buffer, encoder->output_length);
+    flb_log_event_encoder_reset(encoder);
+    if (ret == -1) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/plugins/in_ebpf/traces/openssl/handler.h
+++ b/plugins/in_ebpf/traces/openssl/handler.h
@@ -1,0 +1,13 @@
+#ifndef TRACE_OPENSSL_HANDLER_H
+#define TRACE_OPENSSL_HANDLER_H
+
+#include <stddef.h>
+
+struct event;
+struct flb_log_event_encoder;
+
+int encode_openssl_event(struct flb_log_event_encoder *log_encoder,
+                         const struct event *ev);
+int trace_openssl_handler(void *ctx, void *data, size_t data_sz);
+
+#endif

--- a/plugins/in_ebpf/traces/traces.h
+++ b/plugins/in_ebpf/traces/traces.h
@@ -11,6 +11,7 @@
 #include "generated/trace_exec.skel.h"
 #include "generated/trace_dns.skel.h"
 #include "generated/trace_sched.skel.h"
+#include "generated/trace_openssl.skel.h"
 
 #include "bind/handler.h"
 #include "signal/handler.h"  // Include signal handler
@@ -20,6 +21,7 @@
 #include "exec/handler.h"
 #include "dns/handler.h"
 #include "sched/handler.h"
+#include "openssl/handler.h"
 
 /* Skeleton function pointer types */
 typedef void *(*trace_skel_open_func_t)(void);
@@ -75,6 +77,7 @@ DEFINE_GET_BPF_OBJECT(trace_tcp)
 DEFINE_GET_BPF_OBJECT(trace_exec)
 DEFINE_GET_BPF_OBJECT(trace_dns)
 DEFINE_GET_BPF_OBJECT(trace_sched)
+DEFINE_GET_BPF_OBJECT(trace_openssl)
 
 static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_signal, trace_signal_handler),
@@ -85,6 +88,7 @@ static struct trace_registration trace_table[] = {
     REGISTER_TRACE(trace_exec, trace_exec_handler),
     REGISTER_TRACE(trace_dns, trace_dns_handler),
     REGISTER_TRACE(trace_sched, trace_sched_handler),
+    REGISTER_TRACE(trace_openssl, trace_openssl_handler),
 };
 
 #endif // TRACE_TRACES_H

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -182,6 +182,12 @@ if(FLB_IN_EBPF)
     )
 
     add_ebpf_handler_test(
+        "openssl"
+        "in_ebpf_openssl_handler.c"
+        "../../plugins/in_ebpf/traces/openssl/handler.c"
+    )
+
+    add_ebpf_handler_test(
         "sched"
         "in_ebpf_sched_handler.c"
         "../../plugins/in_ebpf/traces/sched/handler.c"
@@ -192,6 +198,7 @@ if(FLB_IN_EBPF)
     add_dependencies(flb-rt-in_ebpf_malloc_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_tcp_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_exec_handler fluent-bit-static)
+    add_dependencies(flb-rt-in_ebpf_openssl_handler fluent-bit-static)
     add_dependencies(flb-rt-in_ebpf_sched_handler fluent-bit-static)
 
 endif()

--- a/tests/runtime/in_ebpf_openssl_handler.c
+++ b/tests/runtime/in_ebpf_openssl_handler.c
@@ -93,7 +93,30 @@ void test_openssl_event_encoding(void)
     cleanup_test_context(ctx);
 }
 
+void test_openssl_event_encoding_rejects_unknown_type(void)
+{
+    struct test_context *ctx;
+    struct event ev = {0};
+    int ret;
+
+    ctx = init_test_context();
+    TEST_CHECK(ctx != NULL);
+
+    ev.type = EVENT_TYPE_SCHED;
+    ev.common.pid = 101;
+    ev.common.tid = 202;
+    strncpy(ev.common.comm, "openssl", sizeof(ev.common.comm));
+
+    ret = encode_openssl_event(ctx->event_ctx.log_encoder, &ev);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(ctx->event_ctx.log_encoder->output_length == 0);
+
+    cleanup_test_context(ctx);
+}
+
 TEST_LIST = {
     {"openssl_event_encoding", test_openssl_event_encoding},
+    {"openssl_event_encoding_rejects_unknown_type",
+     test_openssl_event_encoding_rejects_unknown_type},
     {NULL, NULL}
 };

--- a/tests/runtime/in_ebpf_openssl_handler.c
+++ b/tests/runtime/in_ebpf_openssl_handler.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <fluent-bit/flb_log_event_encoder.h>
+#include <fluent-bit/flb_input_plugin.h>
+
+#include "flb_tests_runtime.h"
+
+#include "../../plugins/in_ebpf/traces/includes/common/event_context.h"
+#include "../../plugins/in_ebpf/traces/includes/common/events.h"
+#include "../../plugins/in_ebpf/traces/openssl/handler.h"
+
+struct test_context {
+    struct trace_event_context event_ctx;
+    struct flb_input_instance *ins;
+};
+
+static struct test_context *init_test_context(void)
+{
+    struct test_context *ctx;
+
+    ctx = flb_calloc(1, sizeof(struct test_context));
+    if (!ctx) {
+        return NULL;
+    }
+
+    ctx->ins = flb_calloc(1, sizeof(struct flb_input_instance));
+    if (!ctx->ins) {
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->event_ctx.log_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!ctx->event_ctx.log_encoder) {
+        flb_free(ctx->ins);
+        flb_free(ctx);
+        return NULL;
+    }
+
+    ctx->ins->context = &ctx->event_ctx;
+    ctx->event_ctx.ins = ctx->ins;
+
+    return ctx;
+}
+
+static void cleanup_test_context(struct test_context *ctx)
+{
+    if (!ctx) {
+        return;
+    }
+
+    if (ctx->event_ctx.log_encoder) {
+        flb_log_event_encoder_destroy(ctx->event_ctx.log_encoder);
+    }
+
+    if (ctx->ins) {
+        flb_free(ctx->ins);
+    }
+
+    flb_free(ctx);
+}
+
+void test_openssl_event_encoding(void)
+{
+    struct test_context *ctx;
+    struct event ev = {0};
+    int ret;
+    int i;
+    int types[] = {
+        EVENT_TYPE_TLS_HANDSHAKE,
+        EVENT_TYPE_TLS_READ,
+        EVENT_TYPE_TLS_WRITE,
+        EVENT_TYPE_TLS_SHUTDOWN
+    };
+
+    ctx = init_test_context();
+    TEST_CHECK(ctx != NULL);
+
+    for (i = 0; i < (int) (sizeof(types) / sizeof(types[0])); i++) {
+        memset(&ev, 0, sizeof(ev));
+        ev.type = types[i];
+        ev.common.pid = 101;
+        ev.common.tid = 202;
+        strncpy(ev.common.comm, "openssl", sizeof(ev.common.comm));
+        ev.details.tls_io.ssl_ptr = 0x1234;
+        ev.details.tls_io.latency_ns = 5000;
+        ev.details.tls_io.ret = 1;
+
+        ret = encode_openssl_event(ctx->event_ctx.log_encoder, &ev);
+        TEST_CHECK(ret == 0);
+    }
+
+    cleanup_test_context(ctx);
+}
+
+TEST_LIST = {
+    {"openssl_event_encoding", test_openssl_event_encoding},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
In this PR, I implemented OpenSSL's uprobe traces for read, write, handshake, and shutdown.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
$ sudo bin/fluent-bit -i ebpf -ptrace=trace_openssl -o stdout -v
```
- [x] Debug log output from testing the change
```
Fluent Bit v5.0.8
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/06/25 11:34:25.878] [ info] Configuration:
[2026/06/25 11:34:25.899] [ info]  flush time     | 1.000000 seconds
[2026/06/25 11:34:25.904] [ info]  grace          | 5 seconds
[2026/06/25 11:34:25.904] [ info]  daemon         | 0
[2026/06/25 11:34:25.904] [ info] ___________
[2026/06/25 11:34:25.905] [ info]  inputs:
[2026/06/25 11:34:25.905] [ info]      ebpf
[2026/06/25 11:34:25.905] [ info] ___________
[2026/06/25 11:34:25.905] [ info]  filters:
[2026/06/25 11:34:25.906] [ info] ___________
[2026/06/25 11:34:25.906] [ info]  outputs:
[2026/06/25 11:34:25.906] [ info]      stdout.0
[2026/06/25 11:34:25.906] [ info] ___________
[2026/06/25 11:34:25.907] [ info]  collectors:
[2026/06/25 11:34:25.969] [ info] [fluent bit] version=5.0.8, commit=3028035a28, pid=224738
[2026/06/25 11:34:25.980] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/06/25 11:34:25.985] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/06/25 11:34:25.985] [ info] [simd    ] SSE2
[2026/06/25 11:34:25.986] [ info] [cmetrics] version=2.1.5
[2026/06/25 11:34:25.986] [ info] [ctraces ] version=0.7.1
[2026/06/25 11:34:26.001] [ info] [input:ebpf:ebpf.0] initializing
[2026/06/25 11:34:26.001] [ info] [input:ebpf:ebpf.0] storage_strategy='memory' (memory only)
[2026/06/25 11:34:26.003] [debug] [ebpf:ebpf.0] created event channels: read=21 write=22
[2026/06/25 11:34:26.003] [debug] [input:ebpf:ebpf.0] initializing eBPF input plugin
[2026/06/25 11:34:26.008] [debug] [input:ebpf:ebpf.0] processing trace: trace_openssl
[2026/06/25 11:34:26.008] [debug] [input:ebpf:ebpf.0] setting up trace configuration for: trace_openssl
[2026/06/25 11:34:30.926] [debug] [input:ebpf:ebpf.0] attaching BPF program for trace: trace_openssl
[2026/06/25 11:34:30.978] [debug] [input:ebpf:ebpf.0] registering trace handler for: trace_openssl
[2026/06/25 11:34:30.980] [ info] [input:ebpf:ebpf.0] registered trace handler for: trace_openssl
[2026/06/25 11:34:30.981] [ info] [input:ebpf:ebpf.0] trace configuration completed for: trace_openssl
[2026/06/25 11:34:30.981] [debug] [input:ebpf:ebpf.0] setting up collector with poll interval: 1000 ms
[2026/06/25 11:34:30.983] [ info] [input:ebpf:ebpf.0] eBPF input plugin initialized successfully
[2026/06/25 11:34:30.989] [debug] [stdout:stdout.0] created event channels: read=67 write=68
[2026/06/25 11:34:31.026] [ info] [sp] stream processor started
[2026/06/25 11:34:31.028] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/06/25 11:34:31.040] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:31.041] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:31.042] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 11:34:31.048] [ info] [output:stdout:stdout.0] worker #0 started
[2026/06/25 11:34:32.028] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:32.036] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:32.036] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 11:34:33.028] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:33.029] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:33.029] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 11:34:34.028] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:34.029] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:34.029] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 11:34:35.040] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:35.041] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:35.084] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[0] ebpf.0: [[1782354875.044002408, {}], {"event_type"=>"tls_handshake", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>99681321833392, "latency_ns"=>14253782, "ret"=>-1}]
[1] ebpf.0: [[1782354875.075568726, {}], {"event_type"=>"tls_handshake", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>99681321833392, "latency_ns"=>1103621, "ret"=>1}]
[2] ebpf.0: [[1782354875.076574457, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4124, "ret"=>-1}]
[3] ebpf.0: [[1782354875.077565174, {}], {"event_type"=>"tls_write", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>99681321833392, "latency_ns"=>7742, "ret"=>64}]
[4] ebpf.0: [[1782354875.077764874, {}], {"event_type"=>"tls_write", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>99681321833392, "latency_ns"=>2374, "ret"=>40}]
[5] ebpf.0: [[1782354875.077898029, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>54618, "ret"=>49}]
[6] ebpf.0: [[1782354875.078046849, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>1936, "ret"=>-1}]
[7] ebpf.0: [[1782354875.078172600, {}], {"event_type"=>"tls_write", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>99681321833392, "latency_ns"=>25927, "ret"=>9}]
[8] ebpf.0: [[1782354875.078297267, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>48446, "ret"=>710}]
[2026/06/25 11:34:36.034] [debug] [task] created task=0x85015e0 id=0 OK
[2026/06/25 11:34:36.036] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/25 11:34:36.037] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:36.037] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:36.039] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[9] ebpf.0: [[1782354875.078655149, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>9062, "ret"=>1369}]
[10] ebpf.0: [[1782354875.078812956, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6603, "ret"=>1369}]
[11] ebpf.0: [[1782354875.078983494, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6958, "ret"=>1369}]
[12] ebpf.0: [[1782354875.079109857, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7115, "ret"=>1369}]
[13] ebpf.0: [[1782354875.079235732, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6552, "ret"=>1369}]
[14] ebpf.0: [[1782354875.079368946, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6897, "ret"=>1369}]
[15] ebpf.0: [[1782354875.079492852, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6811, "ret"=>1369}]
[16] ebpf.0: [[1782354875.079617759, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6871, "ret"=>1369}]
[17] ebpf.0: [[1782354875.079749702, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7102, "ret"=>1369}]
[18] ebpf.0: [[1782354875.079877371, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6830, "ret"=>1369}]
[19] ebpf.0: [[1782354875.080013210, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6659, "ret"=>1369}]
[20] ebpf.0: [[1782354875.080137693, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6837, "ret"=>1369}]
[21] ebpf.0: [[1782354875.080306809, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6908, "ret"=>1369}]
[22] ebpf.0: [[1782354875.080458720, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7884, "ret"=>1369}]
[23] ebpf.0: [[1782354875.080584101, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6610, "ret"=>1369}]
[24] ebpf.0: [[1782354875.080719381, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6831, "ret"=>1369}]
[25] ebpf.0: [[1782354875.080842613, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6767, "ret"=>1369}]
[26] ebpf.0: [[1782354875.080971530, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6814, "ret"=>1369}]
[27] ebpf.0: [[1782354875.081104068, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7249, "ret"=>-1}]
[28] ebpf.0: [[1782354875.081229038, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>13168, "ret"=>-1}]
[29] ebpf.0: [[1782354875.081723379, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>41278, "ret"=>1369}]
[30] ebpf.0: [[1782354875.081882873, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>11724, "ret"=>1369}]
[31] ebpf.0: [[1782354875.082037480, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7038, "ret"=>1369}]
[32] ebpf.0: [[1782354875.082173833, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6469, "ret"=>1369}]
[33] ebpf.0: [[1782354875.082300212, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7403, "ret"=>1369}]
[34] ebpf.0: [[1782354875.082425524, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>8199, "ret"=>1369}]
[35] ebpf.0: [[1782354875.082557585, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7297, "ret"=>1369}]
[36] ebpf.0: [[1782354875.082681848, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>10173, "ret"=>-1}]
[37] ebpf.0: [[1782354875.082816721, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>5695, "ret"=>-1}]
[38] ebpf.0: [[1782354875.082945716, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>37099, "ret"=>1369}]
[39] ebpf.0: [[1782354875.083072414, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6305, "ret"=>1369}]
[40] ebpf.0: [[1782354875.083204854, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4472, "ret"=>1369}]
[41] ebpf.0: [[1782354875.083328894, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4496, "ret"=>1369}]
[42] ebpf.0: [[1782354875.083452936, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4553, "ret"=>1369}]
[43] ebpf.0: [[1782354875.083588323, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6398, "ret"=>-1}]
[44] ebpf.0: [[1782354875.083716822, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>2364, "ret"=>-1}]
[45] ebpf.0: [[1782354875.083870634, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>37285, "ret"=>1369}]
[46] ebpf.0: [[1782354875.084031360, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>6053, "ret"=>1369}]
[47] ebpf.0: [[1782354875.084178579, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4848, "ret"=>1369}]
[48] ebpf.0: [[1782354875.084335977, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4487, "ret"=>1369}]
[49] ebpf.0: [[1782354875.084485041, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>4484, "ret"=>1369}]
[2026/06/25 11:34:36.065] [debug] [out flush] cb_destroy coro_id=0
[2026/06/25 11:34:36.074] [debug] [task] destroy task=0x85015e0 (task_id=0)
[0] ebpf.0: [[1782354876.037907195, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>82109, "ret"=>7735}]
[1] ebpf.0: [[1782354876.038522645, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>20994, "ret"=>9}]
[2] ebpf.0: [[1782354876.038742331, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>10308, "ret"=>-1}]
[2026/06/25 11:34:37.028] [debug] [task] created task=0x85d8b30 id=0 OK
[2026/06/25 11:34:37.030] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/25 11:34:37.031] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:37.034] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:37.034] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[3] ebpf.0: [[1782354876.038965932, {}], {"event_type"=>"tls_shutdown", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_shutdown", "ssl_ptr"=>99681321833392, "latency_ns"=>77185, "ret"=>0}]
[4] ebpf.0: [[1782354876.039239655, {}], {"event_type"=>"tls_read", "pid"=>224816, "tid"=>224816, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>99681321833392, "latency_ns"=>7038, "ret"=>-1}]
[2026/06/25 11:34:37.036] [debug] [out flush] cb_destroy coro_id=1
[2026/06/25 11:34:37.037] [debug] [task] destroy task=0x85d8b30 (task_id=0)
[2026/06/25 11:34:38.029] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:38.029] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:38.029] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 11:34:39.029] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:39.029] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:39.035] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[0] ebpf.0: [[1782354879.030887095, {}], {"event_type"=>"tls_handshake", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>97406730863264, "latency_ns"=>19365082, "ret"=>-1}]
[1] ebpf.0: [[1782354879.032086925, {}], {"event_type"=>"tls_handshake", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>97406730863264, "latency_ns"=>747307, "ret"=>1}]
[2] ebpf.0: [[1782354879.032749684, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>3805, "ret"=>-1}]
[3] ebpf.0: [[1782354879.033390483, {}], {"event_type"=>"tls_write", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>97406730863264, "latency_ns"=>13914, "ret"=>64}]
[2026/06/25 11:34:40.029] [debug] [task] created task=0x8f02550 id=0 OK
[2026/06/25 11:34:40.029] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/25 11:34:40.029] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:40.029] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:40.031] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[4] ebpf.0: [[1782354879.033575149, {}], {"event_type"=>"tls_write", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>97406730863264, "latency_ns"=>2497, "ret"=>36}]
[5] ebpf.0: [[1782354879.033756987, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>49529, "ret"=>40}]
[6] ebpf.0: [[1782354879.033979816, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>1925, "ret"=>-1}]
[7] ebpf.0: [[1782354879.034392584, {}], {"event_type"=>"tls_write", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>97406730863264, "latency_ns"=>17683, "ret"=>9}]
[8] ebpf.0: [[1782354879.034580680, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>26393, "ret"=>9}]
[9] ebpf.0: [[1782354879.034970875, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>1809, "ret"=>-1}]
[2026/06/25 11:34:40.033] [debug] [out flush] cb_destroy coro_id=2
[2026/06/25 11:34:40.033] [debug] [task] destroy task=0x8f02550 (task_id=0)
[2026/06/25 11:34:41.029] [debug] [task] created task=0x8f932c0 id=0 OK
[2026/06/25 11:34:41.030] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] ebpf.0: [[1782354880.029452975, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>63046, "ret"=>406}]
[1] ebpf.0: [[1782354880.029801636, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>11146, "ret"=>239}]
[2] ebpf.0: [[1782354880.030242881, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>7497, "ret"=>17}]
[3] ebpf.0: [[1782354880.030405016, {}], {"event_type"=>"tls_write", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>97406730863264, "latency_ns"=>67030, "ret"=>17}]
[4] ebpf.0: [[1782354880.030568978, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>6554, "ret"=>-1}]
[5] ebpf.0: [[1782354880.030718590, {}], {"event_type"=>"tls_shutdown", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_shutdown", "ssl_ptr"=>97406730863264, "latency_ns"=>13064, "ret"=>0}]
[6] ebpf.0: [[1782354880.030868421, {}], {"event_type"=>"tls_read", "pid"=>224881, "tid"=>224881, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>97406730863264, "latency_ns"=>8486, "ret"=>-1}]
[2026/06/25 11:34:41.034] [debug] [out flush] cb_destroy coro_id=3
[2026/06/25 11:34:41.031] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 11:34:41.034] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 11:34:41.035] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 11:34:41.035] [debug] [task] destroy task=0x8f932c0 (task_id=0)
^C[2026/06/25 11:34:41] [engine] caught signal (SIGINT)
[2026/06/25 11:34:41.643] [ warn] [engine] service will shutdown in max 5 seconds
[2026/06/25 11:34:41.644] [ info] [engine] pausing all inputs..
[2026/06/25 11:34:41.646] [ info] [input] pausing ebpf.0
[2026/06/25 11:34:41.648] [debug] [input:ebpf:ebpf.0] collector paused
[2026/06/25 11:34:42.032] [ info] [engine] service has stopped (0 pending tasks)
[2026/06/25 11:34:42.033] [ info] [input] pausing ebpf.0
[2026/06/25 11:34:42.033] [debug] [input:ebpf:ebpf.0] collector paused
[2026/06/25 11:34:42.035] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/06/25 11:34:42.043] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/06/25 11:34:42.528] [ info] [input:ebpf:ebpf.0] eBPF input plugin exited
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found


```
==224738== 
==224738== HEAP SUMMARY:
==224738==     in use at exit: 0 bytes in 0 blocks
==224738==   total heap usage: 4,798 allocs, 4,798 frees, 21,307,333 bytes allocated
==224738== 
==224738== All heap blocks were freed -- no leaks are possible
==224738==
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Extended OpenSSL/TLS tracing to emit additional event types for TLS handshake, read, write, and shutdown.
  * Events now include TLS-specific details such as the SSL pointer, operation latency, and operation return/byte counts.

* **Configuration/Compatibility**
  * Improved OpenSSL library detection for eBPF uprobes, with support for overriding the resolved `libssl` path.

* **Tests**
  * Added runtime coverage for OpenSSL TLS event encoding across supported event types, including validation for unknown types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->