### PR TITLE
chore(tests): fix duplicated "the" in filter_throttle_size comments

### DIFF
--- a/tests/runtime/filter_throttle_size.c
+++ b/tests/runtime/filter_throttle_size.c
@@ -147,7 +147,7 @@ void flb_test_simple_log(void)
 
     /*  Verify that the size throttle plugin differentiates logs by a non nested name_field.
        We put 9 logs 32 bytes long which is 288 bytes of total or rate of 9.6.
-       If all logs passed this means that the the plugin sees them as two seperates tipes or
+       If all logs passed this means that the plugin sees them as two seperates tipes or
        does now work at all.Or each logs is seen as different group of logs. */
     for (i = 0; i < 9; i++) {
         /*Make message with sream: stdout */
@@ -276,7 +276,7 @@ void test_nestest_name_fields(void)
 
     /*  Verify that the size throttle plugin differentiates logs by a nested name_field and nested log_field.
        We put 9 logs 32 bytes long which is 288 bytes of total or rate of 9.6.
-       If all logs passed this means that the the plugin sees them as two seperates tipes or
+       If all logs passed this means that the plugin sees them as two seperates tipes or
        does now work at all.Or each logs is seen as different group of logs. */
     for (i = 0; i < 9; i++) {
         /*Make message with sream: stdout */
@@ -429,7 +429,7 @@ void test_default_name_field(void)
 
     /*  Verify that the size throttle plugin do not differentiates logs by name_field.
        We put 8 logs 32 bytes long which is 256 bytes of total or rate of 8.53.
-       If all logs passed this means that the the plugin sees them as one or
+       If all logs passed this means that the plugin sees them as one or
        does now work at all.Or each logs is seen as different group of logs. */
     for (i = 0; i < 4; i++) {
         /*Make message with sream: stdout */


### PR DESCRIPTION
Removes a doubled `the the` from three comment lines in `tests/runtime/filter_throttle_size.c`. Comment-only, no test behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comment text in test files for clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11801)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->