### PR TITLE
packaging: add support for Ubuntu 26.04 (backport to 4.2)

### DIFF
--- a/packaging/build-config.json
+++ b/packaging/build-config.json
@@ -145,6 +145,14 @@
           "type": "deb"
         },
         {
+          "target": "ubuntu/26.04",
+          "type": "deb"
+        },
+        {
+          "target": "ubuntu/26.04.arm64v8",
+          "type": "deb"
+        },
+        {
           "target": "raspbian/bookworm",
           "type": "deb"
         }

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -257,6 +257,56 @@ RUN apt-get update && \
 
 ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
+# ubuntu/26.04 base image
+FROM ubuntu:26.04 AS ubuntu-26.04-base
+ENV DEBIAN_FRONTEND="noninteractive" \
+    CMAKE_HOME="/opt/cmake"
+
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates build-essential libsystemd-dev \
+    make bash wget unzip nano vim valgrind dh-make flex bison \
+    libpq-dev postgresql-server-dev-all libpq5 \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev \
+    tar gzip && \
+    apt-get install -y --reinstall lsb-base lsb-release && \
+    mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
+# ubuntu/26.04.arm64v8 base image
+FROM arm64v8/ubuntu:26.04 AS ubuntu-26.04.arm64v8-base
+ENV DEBIAN_FRONTEND="noninteractive" \
+    CMAKE_HOME="/opt/cmake"
+
+COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates build-essential libsystemd-dev \
+    make bash wget unzip nano vim valgrind dh-make flex bison \
+    libpq-dev postgresql-server-dev-all libpq5 \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
+    libyaml-dev pkg-config zlib1g-dev \
+    tar gzip && \
+    apt-get install -y --reinstall lsb-base lsb-release && \
+    mkdir -p "${CMAKE_HOME}" && \
+    cmake_download_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" && \
+    echo "Downloading CMake ${CMAKE_VERSION}: ${cmake_download_url} -> ${CMAKE_HOME}" && \
+    curl -jksSL "${cmake_download_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
+
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
+
 # Common build for all distributions now
 # hadolint ignore=DL3006
 FROM $BASE_BUILDER AS builder

--- a/packaging/update-repos.sh
+++ b/packaging/update-repos.sh
@@ -65,6 +65,7 @@ DEB_REPO_PATHS=( "debian/bookworm"
                  "debian/trixie"
                  "ubuntu/jammy"
                  "ubuntu/noble"
+                 "ubuntu/resolute"
                  "raspbian/bookworm"
                 )
 


### PR DESCRIPTION
Backport of #11802 for 4.2 releses to provide Ubuntu 26.04 support.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
