### PR TITLE
backport: env: add bash-style default value operator :-

### DIFF
--- a/src/flb_env.c
+++ b/src/flb_env.c
@@ -201,6 +201,9 @@ const char *flb_env_get(struct flb_env *env, const char *key)
 /*
  * Given a 'value', lookup for variables, if found, return a new composed
  * sds string.
+ *
+ * Supports bash-style default substitution inside ${...}:
+ *   ${name:-word}  — if unset or empty, expand word; do not assign.
  */
 flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
 {
@@ -211,6 +214,9 @@ flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
     int pre_var;
     int have_var = FLB_FALSE;
     const char *env_var = NULL;
+    char *v_sep;
+    const char *def_val;
+    int def_len;
     char *v_start = NULL;
     char *v_end = NULL;
     char tmp[4096];
@@ -248,6 +254,18 @@ flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
         strncpy(tmp, v_start, v_len);
         tmp[v_len] = '\0';
         have_var = FLB_TRUE;
+        
+        /* Bash-style default value expansion :- */
+        v_sep = strstr(tmp, ":");
+        def_val = NULL;
+        def_len = 0;
+
+        if (v_sep && (v_sep[1] == '-')) {
+            def_val = v_sep + 2;
+            def_len = strlen(def_val);
+            *v_sep = '\0';
+        }
+
 
         /* Append pre-variable content */
         pre_var = (v_start - 2) - (value + i);
@@ -264,7 +282,8 @@ flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
 
         /* Lookup the variable in our env-hash */
         env_var = flb_env_get(env, tmp);
-        if (env_var) {
+        /* Skip env if it's empty and have a fallback defined */ 
+        if (env_var && !(def_val && strlen(env_var) == 0)) {
             e_len = strlen(env_var);
             s = buf_append(buf, env_var, e_len);
             if (!s) {
@@ -272,6 +291,16 @@ flb_sds_t flb_env_var_translate(struct flb_env *env, const char *value)
                 return NULL;
             }
             if (s != buf) {
+                buf = s;
+            }
+        }
+        else if (def_val) {
+            if (def_len > 0) {
+                s = buf_append(buf, def_val, def_len);
+                if (!s) {
+                    flb_sds_destroy(buf);
+                    return NULL;
+                }
                 buf = s;
             }
         }

--- a/tests/internal/env.c
+++ b/tests/internal/env.c
@@ -85,7 +85,163 @@ void test_translate_long_env()
 }
 
 
+/* ${name:-word} when unset or empty */
+void test_expand_default_hyphen()
+{
+    struct flb_env *env;
+    flb_sds_t buf = NULL;
+    const char *v;
+    int ret;
+
+    env = flb_env_create();
+    if (!TEST_CHECK(env != NULL)) {
+        TEST_MSG("flb_env_create failed");
+        return;
+    }
+
+    buf = flb_env_var_translate(env, "${FLB_IT_DEFHYPH_Z:-fallback}");
+    if (!TEST_CHECK(buf != NULL)) {
+        TEST_MSG("translate failed");
+        flb_env_destroy(env);
+        return;
+    }
+    if (!TEST_CHECK(strcmp(buf, "fallback") == 0)) {
+        TEST_MSG("expected fallback, got=%s", buf);
+    }
+    flb_sds_destroy(buf);
+
+    v = flb_env_get(env, "FLB_IT_DEFHYPH_Z");
+    if (!TEST_CHECK(v == NULL)) {
+        TEST_MSG(":- must not assign locally");
+    }
+
+    ret = flb_env_set(env, "FLB_IT_DEFHYPH_Z", "");
+    if (!TEST_CHECK(ret >= 0)) {
+        TEST_MSG("flb_env_set empty failed");
+        flb_env_destroy(env);
+        return;
+    }
+    buf = flb_env_var_translate(env, "${FLB_IT_DEFHYPH_Z:-empty_fallback}");
+    if (!TEST_CHECK(buf != NULL)) {
+        TEST_MSG("translate empty failed");
+        flb_env_destroy(env);
+        return;
+    }
+    if (!TEST_CHECK(strcmp(buf, "empty_fallback") == 0)) {
+        TEST_MSG("empty local should use default, got=%s", buf);
+    }
+    flb_sds_destroy(buf);
+    flb_env_destroy(env);
+}
+
+
+/* ${name:-} should return an empty string if name is unset or empty */
+void test_expand_empty_default()
+{
+    struct flb_env *env;
+    flb_sds_t buf = NULL;
+    int ret;
+
+    env = flb_env_create();
+    if (!TEST_CHECK(env != NULL)) {
+        TEST_MSG("flb_env_create failed");
+        return;
+    }
+
+    /* Case 1: Variable is unset */
+    buf = flb_env_var_translate(env, "val=${VAR_NOT_SET:-}");
+    if (!TEST_CHECK(buf != NULL)) {
+        TEST_MSG("translate failed");
+        flb_env_destroy(env);
+        return;
+    }
+    if (!TEST_CHECK(strcmp(buf, "val=") == 0)) {
+        TEST_MSG("expected 'val=', got='%s'", buf);
+    }
+    flb_sds_destroy(buf);
+
+    /* Case 2: Variable is explicitly set to empty string */
+    ret = flb_env_set(env, "VAR_EMPTY", "");
+    if (!TEST_CHECK(ret >= 0)) {
+        TEST_MSG("flb_env_set failed");
+        flb_env_destroy(env);
+        return;
+    }
+
+    buf = flb_env_var_translate(env, "${VAR_EMPTY:-}");
+    if (!TEST_CHECK(buf != NULL)) {
+        TEST_MSG("translate failed");
+        flb_env_destroy(env);
+        return;
+    }
+    
+    /* Result should be length 0 */
+    if (!TEST_CHECK(strlen(buf) == 0)) {
+        TEST_MSG("expected empty string, got='%s'", buf);
+    }
+
+    flb_sds_destroy(buf);
+    flb_env_destroy(env);
+}
+
+
+void test_expand_default_hyphen_from_os()
+{
+    struct flb_env *env;
+    flb_sds_t buf = NULL;
+    char *var_name = "FLB_IT_DEFHYPH_OS";
+    char *var_val = "from_process";
+    int ret;
+
+    /* Set OS environment inline */
+    #ifdef FLB_SYSTEM_WINDOWS
+        ret = _putenv_s(var_name, var_val);
+    #else
+        ret = setenv(var_name, var_val, 1);
+    #endif
+
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("putenv failed");
+        return;
+    }
+
+    env = flb_env_create();
+    if (!TEST_CHECK(env != NULL)) {
+        TEST_MSG("flb_env_create failed");
+        #ifdef FLB_SYSTEM_WINDOWS
+            _putenv_s(var_name, "");
+        #else
+            unsetenv(var_name);
+        #endif
+        return;
+    }
+
+    buf = flb_env_var_translate(env, "${FLB_IT_DEFHYPH_OS:-fallback}");
+    if (!TEST_CHECK(buf != NULL)) {
+        TEST_MSG("translate failed");
+    }
+    else {
+        if (!TEST_CHECK(strcmp(buf, var_val) == 0)) {
+            TEST_MSG("expected from_process, got=%s", buf);
+        }
+        flb_sds_destroy(buf);
+    }
+
+    flb_env_destroy(env);
+
+    /* Unset OS environment inline */
+    #ifdef FLB_SYSTEM_WINDOWS
+        _putenv_s(var_name, "");
+    #else
+        unsetenv(var_name);
+    #endif
+}
+
+
 TEST_LIST = {
     { "translate_long_env"           , test_translate_long_env},
+    { "expand_default_hyphen"        , test_expand_default_hyphen},
+    { "expand_empty_default", test_expand_empty_default},
+    { "expand_default_hyphen_from_os", test_expand_default_hyphen_from_os},
     { NULL, NULL }
 };


### PR DESCRIPTION
### **Backport to 4.2 of https://github.com/fluent/fluent-bit/pull/11787**

The below description is a copy from that PR, however, test output has been reran on this 4.2 backport.

---
Adds the familiar bash-style default value operator `:-`. 
Now inside configuration files `${VALUE:-default}` will resolve to `default` if VALUE variable is not set (os or locally) or is empty ''. 

Addresses https://github.com/fluent/fluent-bit/issues/5517

### Configuration example
<details>
<summary>Expand</summary>

```ini
[SERVICE]
    flush        1
    log_level    info
[INPUT]
    name         cpu
    tag          cpu.local
    interval_sec 1
[FILTER]
    name         record_modifier
    match        *
    record       env_check ${TEST_ZONE:-default-region}
[OUTPUT]
    name         stdout
    match        *
    format       json_lines
```

</details>

---
### Checklist (maintainers)
- [x] **Debug log output from testing the change**
<details>
<summary>Debug / stdout </summary>

**Unset `TEST_ZONE`**

```
{"date":1778797137.454888,"cpu_p":0.3,"user_p":0.2,"system_p":0.1,"cpu0.p_cpu":0.0,"cpu0.p_user":0.0,"cpu0.p_system":0.0,"cpu1.p_cpu":0.0,"cpu1.p_user":0.0,"cpu1.p_system":0.0,"env_check":"default-region"}
{"date":1778797138.457873,"cpu_p":0.0,"user_p":0.0,"system_p":0.0,"cpu0.p_cpu":0.0,"cpu0.p_user":0.0,"cpu0.p_system":0.0,"cpu1.p_cpu":0.0,"cpu1.p_user":0.0,"cpu1.p_system":0.0,"env_check":"default-region"}
```
**Set `TEST_ZONE=eu-east-1`:**

```
{"date":1778797312.487864,"cpu_p":0.4,"user_p":0.3,"system_p":0.1,"cpu0.p_cpu":0.0,"cpu0.p_user":0.0,"cpu0.p_system":0.0,"cpu1.p_cpu":0.0,"cpu1.p_user":0.0,"cpu1.p_system":0.0,"env_check":"us-east-1"}
{"date":1778797313.490645,"cpu_p":0.0,"user_p":0.0,"system_p":0.0,"cpu0.p_cpu":0.0,"cpu0.p_user":0.0,"cpu0.p_system":0.0,"cpu1.p_cpu":0.0,"cpu1.p_user":0.0,"cpu1.p_system":0.0,"env_check":"us-east-1"}

```

**Unit tests**

```
$ ctest --test-dir build -L internal --output-on-failure
```
```
[...]
      Start 39: flb-it-env
39/77 Test #39: flb-it-env .......................   Passed    0.01 sec
[...]

100% tests passed, 0 tests failed out of 77

Label Time Summary:
internal    =  84.93 sec*proc (77 tests)

Total Test time (real) =  85.01 sec

```
</details>

- [x] Attached Valgrind output that shows no leaks or memory corruption

<details>
<summary>Valgrind summary / log tail</summary>

**Command:**

```
$ valgrind --leak-check=full --error-exitcode=1 ./build/bin/flb-it-env
```
**Valgrind tail:**
```
==1== Memcheck, a memory error detector
==1== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==1== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==1== Command: ./bin/flb-it-env
==1== 
Test translate_long_env...                      ==1== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test expand_default_hyphen...                   ==1== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test expand_empty_default...                    ==1== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
Test expand_default_hyphen_from_os...           ==1== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
SUCCESS: All unit tests have passed.
==1== 
==1== HEAP SUMMARY:
==1==     in use at exit: 0 bytes in 0 blocks
==1==   total heap usage: 3,697 allocs, 3,697 frees, 474,156 bytes allocated
==1== 
==1== All heap blocks were freed -- no leaks are possible
==1== 
==1== For lists of detected and suppressed errors, rerun with: -s
==1== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
</details>

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/2568


**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

