### PR TITLE
tests: prevent port binding failures in concurrent OTEL tests

### DIFF
--- a/tests/runtime/data/routing/otlp_comprehensive_routing_test.yaml
+++ b/tests/runtime/data/routing/otlp_comprehensive_routing_test.yaml
@@ -1,7 +1,7 @@
 pipeline:
   inputs:
     - name: opentelemetry
-      port: 4318
+      port: 4319
       routes:
         logs:
           # Route 1: Match by resource attribute - service_name

--- a/tests/runtime/in_opentelemetry_routing.c
+++ b/tests/runtime/in_opentelemetry_routing.c
@@ -38,7 +38,9 @@
 #include "../../plugins/in_opentelemetry/opentelemetry_logs.h"
 
 #define JSON_CONTENT_TYPE "application/json"
-#define PORT_OTEL 4318
+/* Pick a port that is not in use by other tests as well */
+/* Ensure you update data/routing/otlp_comprehensive_routing_test.yaml */
+#define PORT_OTEL 4319
 #define V1_ENDPOINT_LOGS "/v1/logs"
 #define MAX_ROUTES 32
 


### PR DESCRIPTION
When tests are run concurrently, the `flb-rt-in_opentelemetry` and `flb-rt-in_opentelemetry_routing` tests both try to bind to the same port so tweaked the test configuration to use different ports.

Discovered during downstream testing where we happen to run both tests at the same time which does not seem to happen here (but purely by chance): https://github.com/telemetryforge/agent/actions/runs/25921061604/job/76189906835?pr=277
```
...
        Start  10: flb-rt-in_opentelemetry
...
        Start  22: flb-rt-in_opentelemetry_routing
...
 10/164 Test  #22: flb-rt-in_opentelemetry_routing ............***Failed    5.08 sec
Test otlp_comprehensive_routing...              [2026/05/15 13:52:48.605050512] [ info] [telemetryforge agent] version=26.5.3, commit=23b4105f28, pid=19253
[2026/05/15 13:52:48.605236641] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/05/15 13:52:48.605244125] [ info] [simd    ] SSE2
[2026/05/15 13:52:48.605247000] [ info] [cmetrics] version=1.0.6
[2026/05/15 13:52:48.605251699] [ info] [ctraces ] version=0.6.6
[2026/05/15 13:52:48.605419293] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2026/05/15 13:52:48.605429192] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
Error: 5/15 13:52:48.606036158] [error] Error binding socket
[2026/05/15 13:52:48.606045656] [ warn] Cannot listen on 0.0.0.0 port 4318
Error: 5/15 13:52:48.606060865] [error] [downstream] could not bind address 0.0.0.0:4318. Aborting
Error: 5/15 13:52:48.606063870] [error] [input:opentelemetry:opentelemetry.0] could not start http server on 0.0.0.0:4318. Aborting
...
 20/164 Test  #10: flb-rt-in_opentelemetry ....................   Passed   21.31 sec
...
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
