### PR TITLE
out_s3: Provide options for inactive chunks behavior

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -82,6 +82,9 @@ static struct multipart_upload *create_upload(struct flb_s3 *ctx,
                                               time_t file_first_log_time);
 
 static void remove_from_queue(struct upload_queue *entry);
+static void s3_chunk_retry_exhausted_cleanup(struct flb_s3 *ctx,
+                                             struct s3_file *chunk_file);
+static int s3_get_retry_exhausted_action(const char *value);
 
 static int blob_initialize_authorization_endpoint_upstream(struct flb_s3 *context);
 
@@ -97,21 +100,21 @@ static struct flb_aws_header *get_content_encoding_header(int compression_type)
         .val = "gzip",
         .val_len = 4,
     };
-    
+
     static struct flb_aws_header zstd_header = {
         .key = "Content-Encoding",
         .key_len = 16,
         .val = "zstd",
         .val_len = 4,
     };
-    
+
     static struct flb_aws_header snappy_header = {
         .key = "Content-Encoding",
         .key_len = 16,
         .val = "snappy",
         .val_len = 6,
     };
-    
+
     switch (compression_type) {
         case FLB_AWS_COMPRESS_GZIP:
             return &gzip_header;
@@ -196,7 +199,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
     if (ctx->content_type != NULL) {
         headers_len++;
     }
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP || 
+    if (ctx->compression == FLB_AWS_COMPRESS_GZIP ||
         ctx->compression == FLB_AWS_COMPRESS_ZSTD ||
         ctx->compression == FLB_AWS_COMPRESS_SNAPPY) {
         headers_len++;
@@ -228,7 +231,7 @@ int create_headers(struct flb_s3 *ctx, char *body_md5,
         s3_headers[n].val_len = strlen(ctx->content_type);
         n++;
     }
-    if (ctx->compression == FLB_AWS_COMPRESS_GZIP || 
+    if (ctx->compression == FLB_AWS_COMPRESS_GZIP ||
         ctx->compression == FLB_AWS_COMPRESS_ZSTD ||
         ctx->compression == FLB_AWS_COMPRESS_SNAPPY) {
         encoding_header = get_content_encoding_header(ctx->compression);
@@ -628,6 +631,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
                       struct flb_config *config, void *data)
 {
     int ret;
+    int action;
     flb_sds_t tmp_sds;
     char *role_arn = NULL;
     char *session_name;
@@ -680,6 +684,15 @@ static int cb_s3_init(struct flb_output_instance *ins,
     if (ret == -1) {
         return -1;
     }
+
+    action = s3_get_retry_exhausted_action(ctx->retry_exhausted_action_str);
+    if (action == -1) {
+        flb_plg_error(ctx->ins,
+                      "invalid retry_exhausted_action value '%s'",
+                      ctx->retry_exhausted_action_str ? ctx->retry_exhausted_action_str : "(null)");
+        return -1;
+    }
+    ctx->retry_exhausted_action = action;
 
     /* the check against -1 is works here because size_t is unsigned
      * and (int) -1 == unsigned max value
@@ -834,7 +847,7 @@ static int cb_s3_init(struct flb_output_instance *ins,
                          "total_file_size is less than 10 MB, will use PutObject API");
             ctx->use_put_object = FLB_TRUE;
     }
-    
+
     if (ctx->use_put_object == FLB_FALSE) {
         /* upload_chunk_size */
         if (ctx->upload_chunk_size <= 0) {
@@ -1446,6 +1459,9 @@ static int put_all_chunks(struct flb_s3 *ctx)
         if (fs_stream == ctx->stream_upload) {
             continue;
         }
+        if (fs_stream == ctx->stream_quarantine) {
+            continue;
+        }
         /* skip metadata stream */
         if (fs_stream == ctx->stream_metadata) {
             continue;
@@ -1464,8 +1480,7 @@ static int put_all_chunks(struct flb_s3 *ctx)
                 flb_plg_warn(ctx->ins,
                              "Chunk for tag %s failed to send %d/%d times, will not retry",
                              (char *) fsf->meta_buf, chunk->failures, ctx->ins->retry_limit);
-                flb_free(chunk);
-                flb_fstore_file_inactive(ctx->fs, fsf);
+                s3_chunk_retry_exhausted_cleanup(ctx, chunk);
                 continue;
             }
 
@@ -1946,6 +1961,72 @@ static int buffer_chunk(void *out_context, struct s3_file *upload_file,
     return 0;
 }
 
+/*
+ * Terminal retry exhaustion must permanently remove local buffer files.
+ * Unlike inactive state (recoverable/restart-resumable), terminal cleanup
+ * must release store_dir_limit_size accounting and delete on-disk state.
+ */
+static void s3_chunk_retry_exhausted_cleanup(struct flb_s3 *ctx,
+                                             struct s3_file *chunk_file)
+{
+    size_t reclaim_size;
+    int ret;
+
+    if (chunk_file == NULL) {
+        return;
+    }
+
+    if (ctx->retry_exhausted_action == S3_RETRY_EXHAUSTED_QUARANTINE) {
+        reclaim_size = chunk_file->size;
+
+        if (ctx->quarantine_dir_limit_size > 0 &&
+            ctx->quarantine_buffer_size + reclaim_size > ctx->quarantine_dir_limit_size) {
+            flb_plg_warn(ctx->ins,
+                         "quarantine limit reached, deleting retry-exhausted chunk");
+            s3_store_file_delete(ctx, chunk_file);
+            return;
+        }
+
+        ret = s3_store_file_quarantine(ctx, chunk_file);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins,
+                          "could not quarantine, deleting retry-exhausted chunk");
+            s3_store_file_delete(ctx, chunk_file);
+            return;
+        }
+
+        if (ctx->current_buffer_size >= reclaim_size) {
+            ctx->current_buffer_size -= reclaim_size;
+        }
+        else {
+            ctx->current_buffer_size = 0;
+        }
+        ctx->quarantine_buffer_size += reclaim_size;
+
+        flb_plg_warn(ctx->ins,
+                     "retry-exhausted chunk moved to quarantine");
+        return;
+    }
+
+    s3_store_file_delete(ctx, chunk_file);
+}
+
+static int s3_get_retry_exhausted_action(const char *value)
+{
+    if (value == NULL) {
+        return S3_RETRY_EXHAUSTED_QUARANTINE;
+    }
+
+    if (strcasecmp(value, "delete") == 0) {
+        return S3_RETRY_EXHAUSTED_DELETE;
+    }
+    if (strcasecmp(value, "quarantine") == 0) {
+        return S3_RETRY_EXHAUSTED_QUARANTINE;
+    }
+
+    return -1;
+}
+
 /* Uploads all chunk files in queue synchronously */
 static void s3_upload_queue(struct flb_config *config, void *out_context)
 {
@@ -1998,7 +2079,7 @@ static void s3_upload_queue(struct flb_config *config, void *out_context)
             if (upload_contents->retry_counter > ctx->ins->retry_limit) {
                 flb_plg_warn(ctx->ins, "Chunk file failed to send %d times, will not "
                              "retry", upload_contents->retry_counter);
-                s3_store_file_inactive(ctx, upload_contents->upload_file);
+                s3_chunk_retry_exhausted_cleanup(ctx, upload_contents->upload_file);
                 if (upload_contents->m_upload_file) {
                     mk_list_del(&upload_contents->m_upload_file->_head);
                 }
@@ -3403,8 +3484,7 @@ static void cb_s3_upload(struct flb_config *config, void *data)
                 flb_plg_warn(ctx->ins,
                              "Chunk for tag %s failed to send %d/%d times, will not retry",
                              (char *) fsf->meta_buf, chunk->failures, ctx->ins->retry_limit);
-                flb_free(chunk);
-                flb_fstore_file_inactive(ctx->fs, fsf);
+                s3_chunk_retry_exhausted_cleanup(ctx, chunk);
                 continue;
             }
         }
@@ -3937,7 +4017,7 @@ static void cb_s3_flush(struct flb_event_chunk *event_chunk,
     if (upload_file != NULL && upload_file->failures > ctx->ins->retry_limit) {
         flb_plg_warn(ctx->ins, "File with tag %s failed to send %d/%d times, will not retry",
                      event_chunk->tag, upload_file->failures, ctx->ins->retry_limit);
-        s3_store_file_inactive(ctx, upload_file);
+        s3_chunk_retry_exhausted_cleanup(ctx, upload_file);
         upload_file = NULL;
     }
 
@@ -4177,6 +4257,13 @@ static struct flb_config_map config_map[] = {
      "the `store_dir` to limit disk usage. If the limit is reached, "
      "data will be discarded. Default is 0 which means unlimited."
     },
+    {
+     FLB_CONFIG_MAP_SIZE, "quarantine_dir_limit_size", "0",
+     0, FLB_TRUE, offsetof(struct flb_s3, quarantine_dir_limit_size),
+     "Limit size for retry-exhausted quarantined chunks. Applies when "
+     "retry_exhausted_action is set to 'quarantine'. If limit is reached, "
+     "retry-exhausted chunks are deleted. Default is 0 (unlimited)."
+    },
 
     {
      FLB_CONFIG_MAP_STR, "s3_key_format", "/fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S",
@@ -4228,6 +4315,13 @@ static struct flb_config_map config_map[] = {
      "Normally, when an upload request fails, there is a high chance for the last "
      "received chunk to be swapped with a later chunk, resulting in data shuffling. "
      "This feature prevents this shuffling by using a queue logic for uploads."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "retry_exhausted_action", "quarantine",
+     0, FLB_TRUE, offsetof(struct flb_s3, retry_exhausted_action_str),
+     "Action for chunks that exceeded retry_limit. Supported values are "
+     "'delete' (remove permanently) and 'quarantine' (move to quarantine and "
+     "remove from active buffer accounting)."
     },
 
     {

--- a/plugins/out_s3/s3.h
+++ b/plugins/out_s3/s3.h
@@ -49,6 +49,8 @@
 #define DEFAULT_UPLOAD_TIMEOUT 3600
 
 #define MAX_UPLOAD_ERRORS 5
+#define S3_RETRY_EXHAUSTED_DELETE     0
+#define S3_RETRY_EXHAUSTED_QUARANTINE 1
 
 /*
  * If we see repeated errors on an upload/chunk, we will discard it
@@ -113,6 +115,7 @@ struct flb_s3 {
     char *sts_endpoint;
     char *canned_acl;
     char *content_type;
+    char *retry_exhausted_action_str;
     char *storage_class;
     char *log_key;
     char *external_id;
@@ -122,10 +125,12 @@ struct flb_s3 {
     int use_put_object;
     int send_content_md5;
     int static_file_path;
+    int retry_exhausted_action;
     int compression;
     int port;
     int insecure;
     size_t store_dir_limit_size;
+    size_t quarantine_dir_limit_size;
 
     struct flb_blob_db blob_db;
     flb_sds_t blob_database_file;
@@ -143,6 +148,7 @@ struct flb_s3 {
 
     /* track the total amount of buffered data */
     size_t current_buffer_size;
+    size_t quarantine_buffer_size;
 
     struct flb_aws_provider *provider;
     struct flb_aws_provider *base_provider;
@@ -164,6 +170,7 @@ struct flb_s3 {
     struct flb_fstore *fs;
     struct flb_fstore_stream *stream_active;  /* default active stream */
     struct flb_fstore_stream *stream_upload;  /* multipart upload stream */
+    struct flb_fstore_stream *stream_quarantine; /* retry-exhausted stream */
     struct flb_fstore_stream *stream_metadata; /* s3 metadata stream */
 
     /*

--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -215,6 +215,7 @@ static int set_files_context(struct flb_s3 *ctx)
     struct flb_fstore_stream *fs_stream;
     struct flb_fstore_file *fsf;
     struct s3_file *s3_file;
+    ssize_t file_size;
 
     mk_list_foreach(head, &ctx->fs->streams) {
         fs_stream = mk_list_entry(head, struct flb_fstore_stream, _head);
@@ -245,6 +246,11 @@ static int set_files_context(struct flb_s3 *ctx)
             s3_file->fsf = fsf;
             s3_file->first_log_time = time(NULL);
             s3_file->create_time = time(NULL);
+
+            file_size = cio_chunk_get_real_size(fsf->chunk);
+            if (file_size > 0) {
+                s3_file->size = (size_t) file_size;
+            }
 
             /* Use fstore opaque 'data' reference to keep our context */
             fsf->data = s3_file;
@@ -321,6 +327,16 @@ int s3_store_init(struct flb_s3 *ctx)
     }
     ctx->stream_upload = fs_stream;
 
+    /* Terminal quarantine stream */
+    fs_stream = flb_fstore_stream_create(ctx->fs, "quarantine");
+    if (!fs_stream) {
+        flb_plg_error(ctx->ins, "could not initialize quarantine stream");
+        flb_fstore_destroy(fs);
+        ctx->fs = NULL;
+        return -1;
+    }
+    ctx->stream_quarantine = fs_stream;
+
     set_files_context(ctx);
     return 0;
 }
@@ -376,7 +392,8 @@ int s3_store_has_data(struct flb_s3 *ctx)
     mk_list_foreach(head, &ctx->fs->streams) {
         /* skip multi upload stream */
         fs_stream = mk_list_entry(head, struct flb_fstore_stream, _head);
-        if (fs_stream == ctx->stream_upload) {
+        if (fs_stream == ctx->stream_upload ||
+            fs_stream == ctx->stream_quarantine) {
             continue;
         }
 
@@ -411,6 +428,47 @@ int s3_store_file_inactive(struct flb_s3 *ctx, struct s3_file *s3_file)
     ret = flb_fstore_file_inactive(ctx->fs, fsf);
 
     return ret;
+}
+
+int s3_store_file_quarantine(struct flb_s3 *ctx, struct s3_file *s3_file)
+{
+    struct flb_fstore_file *fsf;
+    struct flb_fstore_file *qfsf;
+    void *buf;
+    size_t size;
+    int ret;
+
+    fsf = s3_file->fsf;
+    ret = flb_fstore_file_content_copy(ctx->fs, fsf, &buf, &size);
+    if (ret < 0) {
+        return -1;
+    }
+
+    qfsf = flb_fstore_file_create(ctx->fs, ctx->stream_quarantine, fsf->name, size);
+    if (qfsf == NULL) {
+        flb_free(buf);
+        return -1;
+    }
+
+    if (fsf->meta_buf != NULL && fsf->meta_size > 0) {
+        ret = flb_fstore_file_meta_set(ctx->fs, qfsf, fsf->meta_buf, fsf->meta_size);
+        if (ret < 0) {
+            flb_free(buf);
+            flb_fstore_file_delete(ctx->fs, qfsf);
+            return -1;
+        }
+    }
+
+    ret = flb_fstore_file_append(qfsf, buf, size);
+    flb_free(buf);
+    if (ret < 0) {
+        flb_fstore_file_delete(ctx->fs, qfsf);
+        return -1;
+    }
+
+    flb_fstore_file_delete(ctx->fs, fsf);
+    flb_free(s3_file);
+    return 0;
 }
 
 int s3_store_file_delete(struct flb_s3 *ctx, struct s3_file *s3_file)

--- a/plugins/out_s3/s3_store.h
+++ b/plugins/out_s3/s3_store.h
@@ -45,6 +45,7 @@ int s3_store_has_data(struct flb_s3 *ctx);
 int s3_store_has_uploads(struct flb_s3 *ctx);
 
 int s3_store_file_inactive(struct flb_s3 *ctx, struct s3_file *s3_file);
+int s3_store_file_quarantine(struct flb_s3 *ctx, struct s3_file *s3_file);
 struct s3_file *s3_store_file_get(struct flb_s3 *ctx, const char *tag,
                                   int tag_len);
 int s3_store_file_delete(struct flb_s3 *ctx, struct s3_file *s3_file);

--- a/tests/integration/scenarios/out_s3/config/out_s3_retry_exhausted_default_quarantine.yaml
+++ b/tests/integration/scenarios/out_s3/config/out_s3_retry_exhausted_default_quarantine.yaml
@@ -1,0 +1,28 @@
+service:
+  flush: 1
+  grace: 3
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_s3_retry_exhausted
+      dummy: '{"message":"retry exhausted default quarantine","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: s3
+      match: out_s3_retry_exhausted
+      bucket: test-bucket
+      region: us-east-1
+      endpoint: http://127.0.0.1:1
+      use_put_object: true
+      retry_limit: 1
+      total_file_size: 1M
+      upload_timeout: 1s
+      s3_key_format: /payloads/$TAG/$UUID
+      content_type: application/x-ndjson
+      store_dir: /tmp/fluent-bit-test-suite-s3-retry-exhausted
+      store_dir_limit_size: 20M

--- a/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
+++ b/tests/integration/scenarios/out_s3/tests/test_out_s3_001.py
@@ -1,6 +1,9 @@
 import gzip
 import json
 import os
+import glob
+import time
+import shutil
 
 import requests
 import pytest
@@ -218,3 +221,23 @@ def test_out_s3_otlp_json_uploads_signal_payloads(signal_type, json_file, root_k
 
     rendered = json.dumps(payload)
     assert expected_value in rendered
+
+
+def test_out_s3_default_retry_exhausted_action_quarantines_file():
+    store_dir = "/tmp/fluent-bit-test-suite-s3-retry-exhausted"
+    if os.path.exists(store_dir):
+        shutil.rmtree(store_dir)
+    os.makedirs(store_dir, exist_ok=True)
+
+    service = Service("out_s3_retry_exhausted_default_quarantine.yaml")
+    service.start()
+    timeout = time.time() + 10
+    files = []
+    while time.time() < timeout:
+        files = [p for p in glob.glob(f"{store_dir}/**", recursive=True) if os.path.isfile(p)]
+        if len(files) > 0:
+            break
+        time.sleep(0.2)
+    service.stop()
+
+    assert len(files) > 0

--- a/tests/runtime/out_s3.c
+++ b/tests/runtime/out_s3.c
@@ -1,6 +1,15 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 #include <fluent-bit.h>
 #include "flb_tests_runtime.h"
+#include "../include/flb_tests_tmpdir.h"
+#include <errno.h>
+
+#ifdef FLB_SYSTEM_WINDOWS
+#include <windows.h>
+#else
+#include <dirent.h>
+#include <sys/stat.h>
+#endif
 
 /* Test data */
 #include "data/td/json_td.h" /* JSON_TD */
@@ -13,6 +22,102 @@
                             <RequestId>656c76696e6727732072657175657374</RequestId>\
                             <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>\
                             </Error>"
+
+static int count_files_recursive(const char *path)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    WIN32_FIND_DATAA data;
+    HANDLE handle;
+    char pattern[2048];
+    char child[2048];
+    int total = 0;
+
+    snprintf(pattern, sizeof(pattern), "%s\\*", path);
+    handle = FindFirstFileA(pattern, &data);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+
+    do {
+        if (strcmp(data.cFileName, ".") == 0 || strcmp(data.cFileName, "..") == 0) {
+            continue;
+        }
+
+        snprintf(child, sizeof(child), "%s\\%s", path, data.cFileName);
+        if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            total += count_files_recursive(child);
+        }
+        else {
+            total++;
+        }
+    } while (FindNextFileA(handle, &data) != 0);
+
+    FindClose(handle);
+    return total;
+#else
+    DIR *dir;
+    struct dirent *entry;
+    struct stat st;
+    char child[2048];
+    int total = 0;
+
+    dir = opendir(path);
+    if (dir == NULL) {
+        return 0;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        snprintf(child, sizeof(child), "%s/%s", path, entry->d_name);
+        if (stat(child, &st) != 0) {
+            continue;
+        }
+
+        if (S_ISDIR(st.st_mode)) {
+            total += count_files_recursive(child);
+        }
+        else if (S_ISREG(st.st_mode)) {
+            total++;
+        }
+    }
+
+    closedir(dir);
+    return total;
+#endif
+}
+
+static int ensure_test_directory(const char *path)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    WIN32_FILE_ATTRIBUTE_DATA attributes;
+
+    if (flb_utils_mkdir(path, 0777) == 0) {
+        return 0;
+    }
+
+    if (GetFileAttributesExA(path, GetFileExInfoStandard, &attributes) != 0 &&
+        (attributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        return 0;
+    }
+
+    return -1;
+#else
+    struct stat st;
+
+    if (flb_utils_mkdir(path, 0777) == 0) {
+        return 0;
+    }
+
+    if (errno == EEXIST && stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
+        return 0;
+    }
+
+    return -1;
+#endif
+}
 
 void flb_test_s3_multipart_success(void)
 {
@@ -800,6 +905,65 @@ void flb_test_s3_default_retry_limit(void)
     unsetenv("TEST_PutObject_CALL_COUNT");
 }
 
+void flb_test_s3_default_retry_exhausted_action_quarantine(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int file_count;
+    char postfix[128];
+    char *store_dir;
+
+    snprintf(postfix, sizeof(postfix),
+             "/flb-s3-test-default-action-%u", (unsigned) rand());
+    store_dir = flb_test_tmpdir_cat(postfix);
+    TEST_CHECK(store_dir != NULL);
+    TEST_CHECK(ensure_test_directory(store_dir) == 0);
+
+    setenv("FLB_S3_PLUGIN_UNDER_TEST", "true", 1);
+    setenv("TEST_PUT_OBJECT_ERROR", ERROR_ACCESS_DENIED, 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "s3", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "use_put_object", "true", NULL);
+    flb_output_set(ctx, out_ffd, "total_file_size", "5M", NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "6s", NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    flb_output_set(ctx, out_ffd, "Retry_Limit", "1", NULL);
+    /* do not set retry_exhausted_action to validate default behavior */
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    unsetenv("TEST_PutObject_CALL_COUNT");
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+    sleep(10);
+
+    file_count = count_files_recursive(store_dir);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    TEST_CHECK_(file_count > 0,
+                "Expected quarantined file(s) in store_dir, got %d",
+                file_count);
+
+    unsetenv("FLB_S3_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_PUT_OBJECT_ERROR");
+    unsetenv("TEST_PutObject_CALL_COUNT");
+
+    flb_free(store_dir);
+}
+
 /* Test list */
 TEST_LIST = {
     {"multipart_success", flb_test_s3_multipart_success },
@@ -807,6 +971,7 @@ TEST_LIST = {
     {"putobject_error", flb_test_s3_putobject_error },
     {"putobject_retry_limit_semantics", flb_test_s3_putobject_retry_limit_semantics },
     {"default_retry_limit", flb_test_s3_default_retry_limit },
+    {"default_retry_exhausted_action_quarantine", flb_test_s3_default_retry_exhausted_action_quarantine },
     {"create_upload_error", flb_test_s3_create_upload_error },
     {"upload_part_error", flb_test_s3_upload_part_error },
     {"complete_upload_error", flb_test_s3_complete_upload_error },


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the current behavior of inactive files, out_s3 just persists to leave as-is and nop for the quaratined files.
In this PR, we provide options to change behavior of these quarantined files.
The default behavior of inactive files should be set up as quarantine and the limit of quarantine size of files are also provided.

Closes https://github.com/fluent/fluent-bit/issues/11759.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry_exhausted_action setting to control local buffer handling when uploads permanently fail (delete or quarantine; default: quarantine). Invalid values now fail initialization.
  * Added quarantine storage handling with directory size limits and enforcement; quarantined buffers tracked and managed.

* **Bug Fixes**
  * Initialize buffered file sizes from actual chunk sizes.

* **Tests**
  * Added integration and runtime tests covering default quarantine and retry-exhaustion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->