### PR TITLE
in_node_exporter_metrics: add netdev ignore regex

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -526,6 +526,12 @@ static struct flb_config_map config_map[] = {
      "ignore regular expression for disk devices"
     },
 
+    {
+     FLB_CONFIG_MAP_STR, "netdev.ignore_device_regex", NULL,
+     0, FLB_TRUE, offsetof(struct flb_ne, netdev_regex_skip_devices_text),
+     "ignore regular expression for network devices"
+    },
+
     /* hwmon specific settings */
     {
      FLB_CONFIG_MAP_STR, "collector.hwmon.chip-include", NULL,

--- a/plugins/in_node_exporter_metrics/ne.c
+++ b/plugins/in_node_exporter_metrics/ne.c
@@ -154,6 +154,10 @@ static int activate_collector(struct flb_ne *ctx, struct flb_config *config,
 
     ret = coll->cb_init(ctx);
     if (ret != 0) {
+        if (coll->cb_update && coll->coll_fd >= 0) {
+            flb_input_collector_delete(coll->coll_fd, ctx->ins);
+            coll->coll_fd = -1;
+        }
         flb_plg_error(ctx->ins, "%s init failed", name);
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -125,6 +125,8 @@ struct flb_ne {
 
     /* netdev */
     struct flb_hash_table *netdev_ht;
+    struct flb_regex *netdev_regex_skip_devices;
+    flb_sds_t netdev_regex_skip_devices_text;
 
 #ifdef FLB_SYSTEM_MACOS
     /* netdev_darwin */

--- a/plugins/in_node_exporter_metrics/ne_netdev_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_netdev_linux.c
@@ -63,6 +63,17 @@ static struct cmt_counter *netdev_hash_get(struct flb_ne *ctx,
     return c;
 }
 
+static int netdev_skip_device(struct flb_ne *ctx, flb_sds_t device)
+{
+    if (!ctx->netdev_regex_skip_devices) {
+        return FLB_FALSE;
+    }
+
+    return flb_regex_match(ctx->netdev_regex_skip_devices,
+                           (unsigned char *) device,
+                           flb_sds_len(device));
+}
+
 static int netdev_configure(struct flb_ne *ctx)
 {
     int ret;
@@ -291,8 +302,13 @@ static int netdev_update(struct flb_ne *ctx)
         /* sanitize device name */
         len = flb_sds_len(dev->str);
         len--;
-        flb_sds_len_set(dev->str, len - 1);
+        flb_sds_len_set(dev->str, len);
         dev->str[len] = '\0';
+
+        if (netdev_skip_device(ctx, dev->str)) {
+            flb_slist_destroy(&split_list);
+            continue;
+        }
 
         /* iterate line fields */
         n = 0;
@@ -344,8 +360,19 @@ static int netdev_update(struct flb_ne *ctx)
 
 static int ne_netdev_init(struct flb_ne *ctx)
 {
-    netdev_configure(ctx);
-    return 0;
+    if (ctx->netdev_regex_skip_devices_text) {
+        ctx->netdev_regex_skip_devices =
+            flb_regex_create(ctx->netdev_regex_skip_devices_text);
+        if (!ctx->netdev_regex_skip_devices) {
+            flb_plg_error(ctx->ins,
+                          "could not initialize regex pattern for ignored "
+                          "network devices: '%s'",
+                          ctx->netdev_regex_skip_devices_text);
+            return -1;
+        }
+    }
+
+    return netdev_configure(ctx);
 }
 
 static int ne_netdev_update(struct flb_input_instance *ins, struct flb_config *config, void *in_context)
@@ -361,6 +388,11 @@ static int ne_netdev_exit(struct flb_ne *ctx)
     if (ctx->netdev_ht) {
         flb_hash_table_destroy(ctx->netdev_ht);
     }
+
+    if (ctx->netdev_regex_skip_devices) {
+        flb_regex_destroy(ctx->netdev_regex_skip_devices);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Add `netdev.ignore_device_regex` to the `node_exporter_metrics` input so Linux network device metrics can be filtered by regular expression before samples are emitted.

This mirrors the existing regex filtering model used by the diskstats and filesystem collectors, and covers dynamic interface names such as `veth0`, `veth1`, etc. Exact label deletion after collection is not enough for this case because the interface names are runtime-generated.

## Example configuration

```ini
[INPUT]
    Name                       node_exporter_metrics
    Tag                        node.metrics
    Scrape_Interval            1
    Metrics                    netdev
    netdev.ignore_device_regex ^(lo|podman|veth.*)$
```

With this configuration, `node_network_*{device="lo"}`, `device="podman"`, and dynamic `device="veth*"` series are skipped while physical or host-relevant interfaces continue to be emitted.

## Testing

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [N/A] Attached Valgrind output that shows no leaks or memory corruption was found

Build verification:

```sh
cmake -S . -B build -DFLB_CONFIG_YAML=Off -DFLB_TESTS_RUNTIME=Off -DFLB_TESTS_INTERNAL=Off -DFLB_EXAMPLES=Off
cmake --build build -j8 --target flb-plugin-in_node_exporter_metrics fluent-bit-bin
```

Local runtime smoke test on Linux:

```ini
[SERVICE]
    Flush     1
    Log_Level info

[INPUT]
    Name                       node_exporter_metrics
    Tag                        node.metrics
    Scrape_Interval            1
    Metrics                    netdev
    netdev.ignore_device_regex ^lo$

[OUTPUT]
    Name  prometheus_exporter
    Match *
    Host  127.0.0.1
    Port  9927
```

Smoke test result from `http://127.0.0.1:9927/metrics`:

```text
node_network_total=32
lo_count=0
```

Sample retained host interfaces:

```text
node_network_receive_bytes_total{device="wlp0s20f3"} 2269105625
node_network_receive_bytes_total{device="zcctun0"} 3550762101
node_network_receive_packets_total{device="wlp0s20f3"} 2971213
node_network_receive_packets_total{device="zcctun0"} 5405127
```

Log excerpt from the same smoke test:

```text
[ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.rootfs = /
[ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
```

Embedded-device validation was also done with a downstream Yocto build on an ARM64 Linux device. With `netdev.ignore_device_regex: "^(lo|podman|veth.*)$"`:

```text
node_network_total=80
lo_count=0
podman_count=0
veth_count=0
eth0_count=16
wan0_count=16
br_lan_count=16
```

## Documentation

- [x] Documentation required for this feature

The plugin documentation is maintained in `fluent/fluent-bit-docs`. I can open a follow-up docs PR for this new option if the feature shape is accepted.

## Backporting

- [ ] Backport to latest stable release.

No backport requested yet. This is a small additive configuration option and should be low risk if maintainers want it on a stable branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added netdev.ignore_device_regex option to filter out network device metrics via a regex.

* **Bug Fixes**
  * Fixed cleanup on collector activation failures to remove leftover registrations and reset state when initialization fails.
  * Ensure ignored-device patterns are compiled and released cleanly during plugin init/exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->