### PR TITLE
github: workflows: Restore ok-package-test trigger behavior

### DIFF
--- a/.github/workflows/pr-package-tests.yaml
+++ b/.github/workflows/pr-package-tests.yaml
@@ -1,6 +1,9 @@
 name: PR - packaging tests run on-demand via label
 on:
-  pull_request:
+  # This workflow is label-gated and should be triggerable by maintainers on
+  # PRs where the default pull_request event cannot access the required
+  # repository permissions.
+  pull_request_target:
     types:
       - labeled
       - opened
@@ -11,14 +14,16 @@ on:
 
 # Cancel any running on push
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   # This job provides this metadata for the other jobs to use.
   pr-package-test-build-get-meta:
     # This is a long test to run so only on-demand for certain PRs
-    if: contains(github.event.pull_request.labels.*.name, 'ok-package-test')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'ok-package-test') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     name: Get metadata to add to build
     runs-on: ubuntu-latest
     outputs:
@@ -41,8 +46,8 @@ jobs:
       - pr-package-test-build-generate-matrix
     uses: ./.github/workflows/call-build-images.yaml
     with:
-      version: pr-${{ github.event.number }}
-      ref: ${{ github.ref }}
+      version: pr-${{ github.event.pull_request.number }}
+      ref: ${{ github.event.pull_request.head.sha }}
       registry: ghcr.io
       username: ${{ github.actor }}
       image: ${{ github.repository }}/pr
@@ -80,8 +85,8 @@ jobs:
       - pr-package-test-build-generate-matrix
     uses: ./.github/workflows/call-build-linux-packages.yaml
     with:
-      version: pr-${{ github.event.number }}
-      ref: ${{ github.ref }}
+      version: pr-${{ github.event.pull_request.number }}
+      ref: ${{ github.event.pull_request.head.sha }}
       build_matrix: ${{ needs.pr-package-test-build-generate-matrix.outputs.build-matrix }}
       unstable: ${{ needs.pr-package-test-build-get-meta.outputs.date }}
     secrets:
@@ -93,8 +98,8 @@ jobs:
       - pr-package-test-build-get-meta
     uses: ./.github/workflows/call-build-windows.yaml
     with:
-      version: pr-${{ github.event.number }}
-      ref: ${{ github.ref }}
+      version: pr-${{ github.event.pull_request.number }}
+      ref: ${{ github.event.pull_request.head.sha }}
       unstable: ${{ needs.pr-package-test-build-get-meta.outputs.date }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
@@ -105,8 +110,8 @@ jobs:
       - pr-package-test-build-get-meta
     uses: ./.github/workflows/call-build-macos.yaml
     with:
-      version: pr-${{ github.event.number }}
-      ref: ${{ github.ref }}
+      version: pr-${{ github.event.pull_request.number }}
+      ref: ${{ github.event.pull_request.head.sha }}
       unstable: ${{ needs.pr-package-test-build-get-meta.outputs.date }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-package-tests.yaml
+++ b/.github/workflows/pr-package-tests.yaml
@@ -44,6 +44,9 @@ jobs:
     needs:
       - pr-package-test-build-get-meta
       - pr-package-test-build-generate-matrix
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/call-build-images.yaml
     with:
       version: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- Provide summary of changes -->

On this patch, `ok-package-test` works as the maintainer-controlled switch for the full package workflow.

When someone adds the `ok-package-test` label to a PR, GitHub fires the `pull_request_target` workflow from the base repository. The first job checks two things before anything expensive runs:

```yaml
contains(github.event.pull_request.labels.*.name, 'ok-package-test') &&
github.event.pull_request.head.repo.full_name == github.repository
```

So the workflow only proceeds when the label is present, and only for same-repository PR branches. That restores the label-triggered behavior while avoiding privileged execution for fork-controlled code.

The actual build jobs then pass:

```yaml
ref: ${{ github.event.pull_request.head.sha }}
```

to the reusable Linux, Windows, macOS, and container build workflows. That detail matters: because `pull_request_target` runs in the base-repo context, `github.ref` would point at the target/base side, not the PR code. Using the PR head SHA makes the package builders check out and build the exact commit from the labeled PR.

Finally, the concurrency group is now:

```yaml
${{ github.workflow }}-${{ github.event.pull_request.number }}
```

so reruns or new commits for the same PR cancel older package runs for that PR, but package builds for different PRs no longer cancel each other just because they all target `master`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now uses a maintainer-gated pull request trigger and includes inline controls for maintainer execution when standard triggers lack permissions.
  * Concurrency tightened to a per-workflow/per-PR group with in-progress runs cancelled.
  * Downstream reusable build workflows now receive explicit PR number and head SHA and invoke builds with explicit package write permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->