### PR TITLE
oauth: out_http: add user-agent option for oauth

### DIFF
--- a/include/fluent-bit/flb_oauth2.h
+++ b/include/fluent-bit/flb_oauth2.h
@@ -42,6 +42,7 @@ struct flb_oauth2_config {
     flb_sds_t token_url;
     flb_sds_t client_id;
     flb_sds_t client_secret;
+    flb_sds_t user_agent;
     flb_sds_t scope;
     flb_sds_t audience;
     flb_sds_t resource;

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -744,6 +744,11 @@ static struct flb_config_map config_map[] = {
      "OAuth2 client_secret"
     },
     {
+     FLB_CONFIG_MAP_STR, "oauth2.user_agent", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_http, oauth2_config.user_agent),
+     "Optional User-Agent header for OAuth2 token requests"
+    },
+    {
      FLB_CONFIG_MAP_STR, "oauth2.scope", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_http, oauth2_config.scope),
      "Optional OAuth2 scope"

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -1,4 +1,4 @@
-And /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*  Fluent Bit
  *  ==========

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+And /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*  Fluent Bit
  *  ==========
@@ -66,6 +66,11 @@ struct flb_config_map oauth2_config_map[] = {
      FLB_CONFIG_MAP_STR, "oauth2.client_secret", NULL,
      0, FLB_TRUE, offsetof(struct flb_oauth2_config, client_secret),
      "OAuth2 client_secret"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "oauth2.user_agent", NULL,
+     0, FLB_TRUE, offsetof(struct flb_oauth2_config, user_agent),
+     "Optional User-Agent header for OAuth2 token requests"
     },
     {
      FLB_CONFIG_MAP_STR, "oauth2.scope", NULL,
@@ -185,6 +190,7 @@ static void oauth2_apply_defaults(struct flb_oauth2_config *cfg)
     cfg->token_url = NULL;
     cfg->client_id = NULL;
     cfg->client_secret = NULL;
+    cfg->user_agent = NULL;
     cfg->scope = NULL;
     cfg->audience = NULL;
     cfg->resource = NULL;
@@ -237,6 +243,15 @@ static int oauth2_clone_config(struct flb_oauth2_config *dst,
     if (src->client_secret) {
         dst->client_secret = flb_sds_create(src->client_secret);
         if (!dst->client_secret) {
+            flb_errno();
+            flb_oauth2_config_destroy(dst);
+            return -1;
+        }
+    }
+
+    if (src->user_agent) {
+        dst->user_agent = flb_sds_create(src->user_agent);
+        if (!dst->user_agent) {
             flb_errno();
             flb_oauth2_config_destroy(dst);
             return -1;
@@ -324,6 +339,8 @@ void flb_oauth2_config_destroy(struct flb_oauth2_config *cfg)
     cfg->client_id = NULL;
     flb_sds_destroy(cfg->client_secret);
     cfg->client_secret = NULL;
+    flb_sds_destroy(cfg->user_agent);
+    cfg->user_agent = NULL;
     flb_sds_destroy(cfg->scope);
     cfg->scope = NULL;
     flb_sds_destroy(cfg->audience);
@@ -1113,6 +1130,14 @@ static int oauth2_http_request(struct flb_oauth2 *ctx, flb_sds_t body)
                         sizeof(FLB_HTTP_HEADER_CONTENT_TYPE) - 1,
                         FLB_OAUTH2_HTTP_ENCODING,
                         sizeof(FLB_OAUTH2_HTTP_ENCODING) - 1);
+
+    if (ctx->cfg.user_agent) {
+        flb_http_add_header(c,
+                            "User-Agent",
+                            10,
+                            ctx->cfg.user_agent,
+                            flb_sds_len(ctx->cfg.user_agent));
+    }
 
     if (ctx->cfg.auth_method == FLB_OAUTH2_AUTH_METHOD_BASIC &&
         ctx->cfg.client_id && ctx->cfg.client_secret) {

--- a/tests/internal/oauth2.c
+++ b/tests/internal/oauth2.c
@@ -92,6 +92,8 @@ struct oauth2_mock_server {
     int expires_in;
     char latest_token[64];
     char latest_token_request[MOCK_BODY_SIZE];
+    int token_user_agent_seen;
+    char token_user_agent[256];
     pthread_t thread;
 #ifdef _WIN32
     int wsa_initialized;
@@ -152,9 +154,45 @@ static int request_content_length(const char *request)
     return len;
 }
 
+static int request_header_value(const char *request, const char *header_name,
+                                char *out, size_t out_size)
+{
+    int header_len;
+    const char *end;
+    const char *start;
+    size_t value_len;
+
+    start = strstr(request, header_name);
+    if (!start) {
+        return -1;
+    }
+
+    header_len = strlen(header_name);
+    start += header_len;
+    while (*start == ' ') {
+        start++;
+    }
+
+    end = strstr(start, "\r\n");
+    if (!end) {
+        return -1;
+    }
+
+    value_len = end - start;
+    if (value_len >= out_size) {
+        return -1;
+    }
+
+    memcpy(out, start, value_len);
+    out[value_len] = '\0';
+
+    return 0;
+}
+
 static void handle_token_request(struct oauth2_mock_server *server, flb_sockfd_t fd,
                                  const char *request)
 {
+    int ret;
     char payload[MOCK_BODY_SIZE];
     char *body;
     size_t body_len;
@@ -162,6 +200,16 @@ static void handle_token_request(struct oauth2_mock_server *server, flb_sockfd_t
     server->token_requests++;
     snprintf(server->latest_token, sizeof(server->latest_token),
              "mock-token-%d", server->token_requests);
+
+    server->token_user_agent_seen = FLB_FALSE;
+    server->token_user_agent[0] = '\0';
+    ret = request_header_value(request,
+                               "User-Agent:",
+                               server->token_user_agent,
+                               sizeof(server->token_user_agent));
+    if (ret == 0) {
+        server->token_user_agent_seen = FLB_TRUE;
+    }
 
     body = strstr(request, "\r\n\r\n");
     if (body) {
@@ -464,11 +512,13 @@ static void oauth2_mock_server_stop(struct oauth2_mock_server *server)
 #endif
 }
 
-static struct flb_oauth2 *create_oauth_ctx(struct flb_config *config,
-                                           struct oauth2_mock_server *server,
-                                           int refresh_skew)
+static struct flb_oauth2 *create_oauth_ctx_with_user_agent(struct flb_config *config,
+                                                           struct oauth2_mock_server *server,
+                                                           int refresh_skew,
+                                                           const char *user_agent)
 {
     struct flb_oauth2_config cfg;
+    struct flb_oauth2 *ctx;
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.enabled = FLB_TRUE;
@@ -477,14 +527,75 @@ static struct flb_oauth2 *create_oauth_ctx(struct flb_config *config,
     cfg.refresh_skew = refresh_skew;
     cfg.client_id = flb_sds_create("id");
     cfg.client_secret = flb_sds_create("secret");
+    if (user_agent) {
+        cfg.user_agent = flb_sds_create(user_agent);
+    }
 
     flb_sds_printf(&cfg.token_url, "http://127.0.0.1:%d/token", server->port);
 
-    struct flb_oauth2 *ctx = flb_oauth2_create_from_config(config, &cfg);
+    ctx = flb_oauth2_create_from_config(config, &cfg);
 
     flb_oauth2_config_destroy(&cfg);
 
     return ctx;
+}
+
+static struct flb_oauth2 *create_oauth_ctx(struct flb_config *config,
+                                           struct oauth2_mock_server *server,
+                                           int refresh_skew)
+{
+    return create_oauth_ctx_with_user_agent(config, server, refresh_skew, NULL);
+}
+
+void test_user_agent_header_optional(void)
+{
+    int ret;
+    flb_sds_t token = NULL;
+    struct flb_config *config;
+    struct flb_oauth2 *ctx;
+    struct oauth2_mock_server server;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ctx = create_oauth_ctx(config, &server, 58);
+    TEST_CHECK(ctx != NULL);
+
+#ifdef FLB_SYSTEM_MACOS
+    ret = oauth2_mock_server_wait_ready(&server);
+    TEST_CHECK(ret == 0);
+#endif
+
+    ret = flb_oauth2_get_access_token(ctx, &token, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(server.token_user_agent_seen == FLB_FALSE);
+
+    flb_oauth2_destroy(ctx);
+    oauth2_mock_server_stop(&server);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ctx = create_oauth_ctx_with_user_agent(config, &server, 58,
+                                           "oauth2-agent-test/1.0");
+    TEST_CHECK(ctx != NULL);
+
+#ifdef FLB_SYSTEM_MACOS
+    ret = oauth2_mock_server_wait_ready(&server);
+    TEST_CHECK(ret == 0);
+#endif
+
+    ret = flb_oauth2_get_access_token(ctx, &token, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(server.token_user_agent_seen == FLB_TRUE);
+    TEST_CHECK(strcmp(server.token_user_agent, "oauth2-agent-test/1.0") == 0);
+
+    flb_oauth2_destroy(ctx);
+    oauth2_mock_server_stop(&server);
+    flb_config_exit(config);
 }
 
 static struct flb_oauth2 *create_legacy_oauth_ctx(struct flb_config *config,
@@ -1149,6 +1260,7 @@ TEST_LIST = {
      test_parse_rejects_missing_required_fields},
     {"parse_rejects_invalid_expires_in", test_parse_rejects_invalid_expires_in},
     {"caching_and_refresh", test_caching_and_refresh},
+    {"user_agent_header_optional", test_user_agent_header_optional},
     {"legacy_create_manual_payload_flow", test_legacy_create_manual_payload_flow},
     {"private_key_jwt_body", test_private_key_jwt_body},
     {"private_key_jwt_x5t_header", test_private_key_jwt_x5t_header},


### PR DESCRIPTION
<!-- Provide summary of changes -->
I added the ability to supply an optional User-Agent header to the HTTP OAuth call.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
Fixes feature request/issue #11826


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [y] Example configuration file for the change
  add this to any HTTP OAuth config:

[OUTPUT]
    oauth2.user_agent test-agent

- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [y] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional oauth2.user_agent setting to customize the User-Agent header sent with OAuth2 token requests; when unset, behavior is unchanged. Configured value is retained across configuration lifecycle operations.

* **Tests**
  * Added tests verifying the User-Agent is omitted by default and included when configured; test suite updated to cover both scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->