### PR TITLE
out_chronicle: Support label and namespace mapping [Backport to 4.2]

### DIFF
--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -838,7 +838,11 @@ static int chronicle_metadata_resolve(struct flb_chronicle *ctx,
         *namespace = flb_ra_translate_check(ctx->namespace_ra,
                                             tag, tag_len,
                                             map, NULL, FLB_TRUE);
-        if (!*namespace) {
+        if (!*namespace || flb_sds_len(*namespace) == 0) {
+            if (*namespace) {
+                flb_sds_destroy(*namespace);
+                *namespace = NULL;
+            }
             if (ctx->namespace) {
                 *namespace = flb_sds_create(ctx->namespace);
             }

--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -674,6 +674,218 @@ struct chronicle_entry {
     struct cfl_list _head;
 };
 
+static void chronicle_entries_destroy(struct cfl_list *entry_list)
+{
+    struct cfl_list *head;
+    struct cfl_list *tmp;
+    struct chronicle_entry *entry;
+
+    cfl_list_foreach_safe(head, tmp, entry_list) {
+        entry = cfl_list_entry(head, struct chronicle_entry, _head);
+        flb_sds_destroy(entry->log_text);
+        cfl_list_del(&entry->_head);
+        flb_free(entry);
+    }
+}
+
+struct chronicle_resolved_label {
+    flb_sds_t key;
+    flb_sds_t value;
+    struct mk_list _head;
+};
+
+static void chronicle_resolved_labels_destroy(struct mk_list *labels)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct chronicle_resolved_label *label;
+
+    mk_list_foreach_safe(head, tmp, labels) {
+        label = mk_list_entry(head, struct chronicle_resolved_label, _head);
+        mk_list_del(&label->_head);
+        flb_sds_destroy(label->key);
+        flb_sds_destroy(label->value);
+        flb_free(label);
+    }
+}
+
+static int chronicle_resolved_label_add(struct mk_list *labels,
+                                        flb_sds_t key, flb_sds_t value)
+{
+    struct chronicle_resolved_label *label;
+
+    label = flb_calloc(1, sizeof(struct chronicle_resolved_label));
+    if (!label) {
+        flb_errno();
+        return -1;
+    }
+
+    label->key = flb_sds_create(key);
+    if (!label->key) {
+        flb_free(label);
+        return -1;
+    }
+
+    label->value = flb_sds_create(value);
+    if (!label->value) {
+        flb_sds_destroy(label->key);
+        flb_free(label);
+        return -1;
+    }
+
+    mk_list_add(&label->_head, labels);
+    return 0;
+}
+
+static int chronicle_sds_equal(flb_sds_t left, flb_sds_t right)
+{
+    size_t left_len;
+    size_t right_len;
+
+    if (left == NULL && right == NULL) {
+        return FLB_TRUE;
+    }
+
+    if (left == NULL || right == NULL) {
+        return FLB_FALSE;
+    }
+
+    left_len = flb_sds_len(left);
+    right_len = flb_sds_len(right);
+
+    if (left_len != right_len) {
+        return FLB_FALSE;
+    }
+
+    if (strncmp(left, right, left_len) != 0) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+}
+
+static int chronicle_resolved_labels_match(struct mk_list *left,
+                                           struct mk_list *right)
+{
+    struct mk_list *left_head;
+    struct mk_list *right_head;
+    struct chronicle_resolved_label *left_label;
+    struct chronicle_resolved_label *right_label;
+
+    if (mk_list_size(left) != mk_list_size(right)) {
+        return FLB_FALSE;
+    }
+
+    right_head = right->next;
+    mk_list_foreach(left_head, left) {
+        if (right_head == right) {
+            return FLB_FALSE;
+        }
+
+        left_label = mk_list_entry(left_head, struct chronicle_resolved_label, _head);
+        right_label = mk_list_entry(right_head, struct chronicle_resolved_label, _head);
+
+        if (chronicle_sds_equal(left_label->key, right_label->key) == FLB_FALSE ||
+            chronicle_sds_equal(left_label->value, right_label->value) == FLB_FALSE) {
+            return FLB_FALSE;
+        }
+
+        right_head = right_head->next;
+    }
+
+    return FLB_TRUE;
+}
+
+static void chronicle_resolved_labels_move(struct mk_list *dst,
+                                           struct mk_list *src)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+
+    mk_list_foreach_safe(head, tmp, src) {
+        mk_list_del(head);
+        mk_list_add(head, dst);
+    }
+}
+
+static int chronicle_metadata_match(flb_sds_t left_namespace,
+                                    struct mk_list *left_labels,
+                                    flb_sds_t right_namespace,
+                                    struct mk_list *right_labels)
+{
+    if (chronicle_sds_equal(left_namespace, right_namespace) == FLB_FALSE) {
+        return FLB_FALSE;
+    }
+
+    return chronicle_resolved_labels_match(left_labels, right_labels);
+}
+
+static int chronicle_metadata_resolve(struct flb_chronicle *ctx,
+                                      char *tag, int tag_len,
+                                      msgpack_object map,
+                                      flb_sds_t *namespace,
+                                      struct mk_list *labels,
+                                      int *label_count)
+{
+    int ret;
+    struct mk_list *head;
+    struct flb_chronicle_label *label;
+    flb_sds_t value;
+
+    *label_count = 0;
+
+    if (ctx->namespace_ra) {
+        *namespace = flb_ra_translate_check(ctx->namespace_ra,
+                                            tag, tag_len,
+                                            map, NULL, FLB_TRUE);
+        if (!*namespace) {
+            if (ctx->namespace) {
+                *namespace = flb_sds_create(ctx->namespace);
+            }
+            else {
+                flb_plg_warn(ctx->ins,
+                             "namespace_key '%s' did not resolve for this batch",
+                             ctx->namespace_key);
+            }
+        }
+    }
+    else if (ctx->namespace) {
+        *namespace = flb_sds_create(ctx->namespace);
+    }
+
+    mk_list_foreach(head, &ctx->labels) {
+        label = mk_list_entry(head, struct flb_chronicle_label, _head);
+
+        if (label->ra) {
+            value = flb_ra_translate_check(label->ra,
+                                           tag, tag_len,
+                                           map, NULL, FLB_TRUE);
+            if (!value) {
+                flb_plg_warn(ctx->ins,
+                             "label '%s' did not resolve for this batch",
+                             label->key);
+                continue;
+            }
+        }
+        else {
+            value = label->value;
+        }
+
+        ret = chronicle_resolved_label_add(labels, label->key, value);
+        if (label->ra) {
+            flb_sds_destroy(value);
+        }
+
+        if (ret != 0) {
+            return -1;
+        }
+
+        (*label_count)++;
+    }
+
+    return 0;
+}
+
 static int chronicle_format(const void *data, size_t bytes,
                             const char *tag, size_t tag_len,
                             char **out_data, size_t *out_size,
@@ -687,7 +899,7 @@ static int chronicle_format(const void *data, size_t bytes,
     int ret;
     int array_size = 0;
     size_t off = 0;
-    size_t last_off = 0;
+    size_t last_off = last_offset;
     size_t alloc_size = 0;
     size_t s;
     char time_formatted[255];
@@ -702,10 +914,32 @@ static int chronicle_format(const void *data, size_t bytes,
     char *json_str;
     struct cfl_list entry_list;
     struct chronicle_entry *entry;
-    struct cfl_list *tmp;
     struct cfl_list *head;
+    struct mk_list resolved_labels;
+    struct mk_list record_labels;
+    struct mk_list *label_head;
+    struct chronicle_resolved_label *label;
+    flb_sds_t namespace = NULL;
+    flb_sds_t record_namespace = NULL;
+    int label_count = 0;
+    int record_label_count = 0;
+    int map_size = 3;
+    int metadata_resolved = FLB_FALSE;
+    size_t record_start;
+
+    if (out_data) {
+        *out_data = NULL;
+    }
+    if (out_size) {
+        *out_size = 0;
+    }
+    if (out_offset) {
+        *out_offset = last_offset;
+    }
 
     cfl_list_init(&entry_list);
+    mk_list_init(&resolved_labels);
+    mk_list_init(&record_labels);
 
     array_size = count_mp_with_threshold(last_offset, threshold, log_decoder, ctx);
 
@@ -717,13 +951,14 @@ static int chronicle_format(const void *data, size_t bytes,
     if (last_offset != 0) {
         log_decoder->offset = last_offset;
     }
+    off = last_offset;
 
     while ((ret = flb_log_event_decoder_next(
                     log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+        record_start = off;
         off = log_decoder->offset;
-        alloc_size = (off - last_off) + 128; /* JSON is larger than msgpack */
-        last_off = off;
+        alloc_size = (off - record_start) + 128; /* JSON is larger than msgpack */
 
         if (ctx->log_key != NULL) {
             log_text = flb_pack_msgpack_extract_log_key(ctx, bytes, log_event, config);
@@ -757,8 +992,49 @@ static int chronicle_format(const void *data, size_t bytes,
             return -1;
         }
 
+        mk_list_init(&record_labels);
+        record_namespace = NULL;
+        record_label_count = 0;
+        ret = chronicle_metadata_resolve(ctx,
+                                         (char *) tag, tag_len,
+                                         *log_event.body,
+                                         &record_namespace,
+                                         &record_labels,
+                                         &record_label_count);
+        if (ret != 0) {
+            flb_sds_destroy(log_text);
+            chronicle_resolved_labels_destroy(&record_labels);
+            flb_sds_destroy(record_namespace);
+            chronicle_resolved_labels_destroy(&resolved_labels);
+            flb_sds_destroy(namespace);
+            chronicle_entries_destroy(&entry_list);
+            return -1;
+        }
+
+        if (metadata_resolved == FLB_FALSE) {
+            namespace = record_namespace;
+            record_namespace = NULL;
+            chronicle_resolved_labels_move(&resolved_labels, &record_labels);
+            label_count = record_label_count;
+            metadata_resolved = FLB_TRUE;
+        }
+        else if (chronicle_metadata_match(namespace, &resolved_labels,
+                                          record_namespace, &record_labels) == FLB_FALSE) {
+            flb_plg_debug(ctx->ins,
+                          "splitting Chronicle batch due to namespace or label change");
+            flb_sds_destroy(log_text);
+            chronicle_resolved_labels_destroy(&record_labels);
+            flb_sds_destroy(record_namespace);
+            last_off = record_start;
+            break;
+        }
+
+        chronicle_resolved_labels_destroy(&record_labels);
+        flb_sds_destroy(record_namespace);
+
         entry = flb_malloc(sizeof(struct chronicle_entry));
         if (!entry) {
+            flb_sds_destroy(log_text);
             continue;
         }
 
@@ -767,6 +1043,7 @@ static int chronicle_format(const void *data, size_t bytes,
         entry->timestamp = log_event.timestamp;
 
         cfl_list_add(&entry->_head, &entry_list);
+        last_off = off;
 
         if (off >= (threshold + last_offset)) {
             flb_plg_debug(ctx->ins,
@@ -780,6 +1057,8 @@ static int chronicle_format(const void *data, size_t bytes,
 
     /* If the list is empty, no records were valid. */
     if (cfl_list_is_empty(&entry_list)) {
+        chronicle_resolved_labels_destroy(&resolved_labels);
+        flb_sds_destroy(namespace);
         return -1;
     }
 
@@ -808,7 +1087,15 @@ static int chronicle_format(const void *data, size_t bytes,
      *   ]
      * }
      */
-    msgpack_pack_map(&mp_pck, 3);
+    if (namespace) {
+        map_size++;
+    }
+
+    if (label_count > 0) {
+        map_size++;
+    }
+
+    msgpack_pack_map(&mp_pck, map_size);
 
     msgpack_pack_str(&mp_pck, 11);
     msgpack_pack_str_body(&mp_pck, "customer_id", 11);
@@ -822,6 +1109,37 @@ static int chronicle_format(const void *data, size_t bytes,
     msgpack_pack_str(&mp_pck, strlen(ctx->log_type));
     msgpack_pack_str_body(&mp_pck, ctx->log_type, strlen(ctx->log_type));
 
+    if (namespace) {
+        msgpack_pack_str(&mp_pck, 9);
+        msgpack_pack_str_body(&mp_pck, "namespace", 9);
+
+        msgpack_pack_str(&mp_pck, flb_sds_len(namespace));
+        msgpack_pack_str_body(&mp_pck, namespace, flb_sds_len(namespace));
+    }
+
+    if (label_count > 0) {
+        msgpack_pack_str(&mp_pck, 6);
+        msgpack_pack_str_body(&mp_pck, "labels", 6);
+
+        msgpack_pack_array(&mp_pck, label_count);
+
+        mk_list_foreach(label_head, &resolved_labels) {
+            label = mk_list_entry(label_head, struct chronicle_resolved_label, _head);
+
+            msgpack_pack_map(&mp_pck, 2);
+
+            msgpack_pack_str(&mp_pck, 3);
+            msgpack_pack_str_body(&mp_pck, "key", 3);
+            msgpack_pack_str(&mp_pck, flb_sds_len(label->key));
+            msgpack_pack_str_body(&mp_pck, label->key, flb_sds_len(label->key));
+
+            msgpack_pack_str(&mp_pck, 5);
+            msgpack_pack_str_body(&mp_pck, "value", 5);
+            msgpack_pack_str(&mp_pck, flb_sds_len(label->value));
+            msgpack_pack_str_body(&mp_pck, label->value, flb_sds_len(label->value));
+        }
+    }
+
     msgpack_pack_str(&mp_pck, 7);
     msgpack_pack_str_body(&mp_pck, "entries", 7);
 
@@ -829,7 +1147,7 @@ static int chronicle_format(const void *data, size_t bytes,
     msgpack_pack_array(&mp_pck, cfl_list_size(&entry_list));
 
     /* Iterate the list of valid entries and pack them */
-    cfl_list_foreach_safe(head, tmp, &entry_list) {
+    cfl_list_foreach(head, &entry_list) {
         entry = cfl_list_entry(head, struct chronicle_entry, _head);
         /*
          * Pack entries
@@ -863,16 +1181,15 @@ static int chronicle_format(const void *data, size_t bytes,
         msgpack_pack_str(&mp_pck, s);
         msgpack_pack_str_body(&mp_pck, time_formatted, s);
 
-        /* Clean up the entry now that it's packed */
-        flb_sds_destroy(entry->log_text);
-        cfl_list_del(&entry->_head);
-        flb_free(entry);
     }
 
     /* Convert from msgpack to JSON */
     out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size,
                                           config->json_escape_unicode);
     msgpack_sbuffer_destroy(&mp_sbuf);
+    chronicle_resolved_labels_destroy(&resolved_labels);
+    flb_sds_destroy(namespace);
+    chronicle_entries_destroy(&entry_list);
 
     if (!out_buf) {
         flb_plg_error(ctx->ins, "error formatting JSON payload");
@@ -1161,6 +1478,21 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_STR, "log_key", NULL,
       0, FLB_TRUE, offsetof(struct flb_chronicle, log_key),
       "Set the log key"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "namespace", NULL,
+      0, FLB_TRUE, offsetof(struct flb_chronicle, namespace),
+      "Set the Chronicle namespace"
+    },
+    {
+      FLB_CONFIG_MAP_STR, "namespace_key", NULL,
+      0, FLB_TRUE, offsetof(struct flb_chronicle, namespace_key),
+      "Record accessor for the Chronicle namespace. Falls back to namespace"
+    },
+    {
+      FLB_CONFIG_MAP_SLIST_1, "label", NULL,
+      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_chronicle, label_properties),
+      "Add a Chronicle label key/value pair. Multiple labels can be set"
     },
     /* EOF */
     {0}

--- a/plugins/out_chronicle/chronicle.h
+++ b/plugins/out_chronicle/chronicle.h
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_oauth2.h>
+#include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_sds.h>
 
 /* refresh token every 50 minutes */
@@ -56,6 +57,13 @@ struct flb_chronicle_oauth_credentials {
     flb_sds_t token_uri;
 };
 
+struct flb_chronicle_label {
+    flb_sds_t key;
+    flb_sds_t value;
+    struct flb_record_accessor *ra;
+    struct mk_list _head;
+};
+
 struct flb_chronicle {
     /* credentials */
     flb_sds_t credentials_file;
@@ -72,6 +80,11 @@ struct flb_chronicle {
     flb_sds_t endpoint;
     flb_sds_t region;
     flb_sds_t log_key;
+    flb_sds_t namespace;
+    flb_sds_t namespace_key;
+    struct flb_record_accessor *namespace_ra;
+    struct mk_list *label_properties;
+    struct mk_list labels;
 
     int json_date_format;
     flb_sds_t json_date_key;

--- a/plugins/out_chronicle/chronicle_conf.c
+++ b/plugins/out_chronicle/chronicle_conf.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_aws_credentials.h>
+#include <fluent-bit/flb_slist.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -38,6 +39,105 @@ static inline int key_cmp(char *str, int len, char *cmp) {
     }
 
     return strncasecmp(str, cmp, len);
+}
+
+static void chronicle_labels_destroy(struct flb_chronicle *ctx)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct flb_chronicle_label *label;
+
+    mk_list_foreach_safe(head, tmp, &ctx->labels) {
+        label = mk_list_entry(head, struct flb_chronicle_label, _head);
+        mk_list_del(&label->_head);
+
+        flb_sds_destroy(label->key);
+        flb_sds_destroy(label->value);
+
+        if (label->ra) {
+            flb_ra_destroy(label->ra);
+        }
+
+        flb_free(label);
+    }
+}
+
+static int chronicle_label_add(struct flb_chronicle *ctx,
+                               char *key, size_t key_len,
+                               char *value, size_t value_len)
+{
+    struct flb_chronicle_label *label;
+
+    if (key == NULL || key_len == 0 || value == NULL) {
+        flb_plg_error(ctx->ins, "label requires a non-empty key and value");
+        return -1;
+    }
+
+    label = flb_calloc(1, sizeof(struct flb_chronicle_label));
+    if (!label) {
+        flb_errno();
+        return -1;
+    }
+
+    label->key = flb_sds_create_len(key, key_len);
+    if (!label->key) {
+        flb_free(label);
+        return -1;
+    }
+
+    label->value = flb_sds_create_len(value, value_len);
+    if (!label->value) {
+        flb_sds_destroy(label->key);
+        flb_free(label);
+        return -1;
+    }
+
+    if (memchr(value, '$', value_len) != NULL) {
+        label->ra = flb_ra_create(label->value, FLB_FALSE);
+        if (!label->ra) {
+            flb_plg_error(ctx->ins, "invalid label record accessor '%s'",
+                          label->value);
+            flb_sds_destroy(label->key);
+            flb_sds_destroy(label->value);
+            flb_free(label);
+            return -1;
+        }
+    }
+
+    mk_list_add(&label->_head, &ctx->labels);
+    return 0;
+}
+
+static int chronicle_configure_labels(struct flb_chronicle *ctx)
+{
+    int ret;
+    struct mk_list *head;
+    struct flb_config_map_val *mv;
+    struct flb_slist_entry *key;
+    struct flb_slist_entry *val;
+
+    if (ctx->label_properties) {
+        flb_config_map_foreach(head, mv, ctx->label_properties) {
+            if (mk_list_size(mv->val.list) != 2) {
+                flb_plg_error(ctx->ins, "'label' expects a key and a value");
+                return -1;
+            }
+
+            key = mk_list_entry_first(mv->val.list,
+                                      struct flb_slist_entry, _head);
+            val = mk_list_entry_last(mv->val.list,
+                                     struct flb_slist_entry, _head);
+
+            ret = chronicle_label_add(ctx,
+                                      key->str, flb_sds_len(key->str),
+                                      val->str, flb_sds_len(val->str));
+            if (ret != 0) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
 }
 
 static int flb_chronicle_read_credentials_file(struct flb_chronicle *ctx,
@@ -187,6 +287,7 @@ struct flb_chronicle *flb_chronicle_conf_create(struct flb_output_instance *ins,
     }
     ctx->ins = ins;
     ctx->config = config;
+    mk_list_init(&ctx->labels);
 
     ret = flb_output_config_map_set(ins, (void *)ctx);
     if (ret == -1) {
@@ -298,6 +399,28 @@ struct flb_chronicle *flb_chronicle_conf_create(struct flb_output_instance *ins,
     /* config: 'log_type' */
     if (ctx->log_type == NULL) {
         flb_plg_error(ctx->ins, "property 'log_type' is not defined");
+        flb_chronicle_conf_destroy(ctx);
+        return NULL;
+    }
+
+    if (ctx->namespace && flb_sds_len(ctx->namespace) == 0) {
+        flb_plg_error(ctx->ins, "property 'namespace' cannot be empty");
+        flb_chronicle_conf_destroy(ctx);
+        return NULL;
+    }
+
+    if (ctx->namespace_key) {
+        ctx->namespace_ra = flb_ra_create(ctx->namespace_key, FLB_FALSE);
+        if (!ctx->namespace_ra) {
+            flb_plg_error(ctx->ins, "invalid namespace_key record accessor '%s'",
+                          ctx->namespace_key);
+            flb_chronicle_conf_destroy(ctx);
+            return NULL;
+        }
+    }
+
+    ret = chronicle_configure_labels(ctx);
+    if (ret != 0) {
         flb_chronicle_conf_destroy(ctx);
         return NULL;
     }
@@ -417,6 +540,12 @@ int flb_chronicle_conf_destroy(struct flb_chronicle *ctx)
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);
     }
+
+    if (ctx->namespace_ra) {
+        flb_ra_destroy(ctx->namespace_ra);
+    }
+
+    chronicle_labels_destroy(ctx);
 
     flb_free(ctx);
     return 0;

--- a/tests/runtime/out_chronicle.c
+++ b/tests/runtime/out_chronicle.c
@@ -131,6 +131,129 @@ static void cb_check_format_partially_succeeded_records(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_format_namespace_and_labels(void *ctx, int ffd,
+                                                 int res_ret, void *res_data,
+                                                 size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p;
+
+    set_output_invoked(1);
+
+    p = strstr(out_json, "\"namespace\":\"tenant-a\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected namespace not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"labels\":[");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected labels array not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"key\":\"env\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected static label key not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"value\":\"production\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected static label value not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"key\":\"cluster_name\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected dynamic label key not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"value\":\"blue\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected dynamic label value not found. Got: %s", out_json);
+    }
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_format_namespace_fallback_and_missing_label(void *ctx, int ffd,
+                                                                 int res_ret, void *res_data,
+                                                                 size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p;
+
+    set_output_invoked(1);
+
+    p = strstr(out_json, "\"namespace\":\"fallback-namespace\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected fallback namespace not found. Got: %s", out_json);
+    }
+
+    p = strstr(out_json, "\"key\":\"missing\"");
+    TEST_CHECK(p == NULL);
+
+    p = strstr(out_json, "\"log_text\":\"{\\\"message\\\":\\\"hello world\\\"}\"");
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Expected log_text not found. Got: %s", out_json);
+    }
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_format_split_on_metadata_change(void *ctx, int ffd,
+                                                     int res_ret, void *res_data,
+                                                     size_t res_size, void *data)
+{
+    char *out_json = res_data;
+    char *p;
+    int invocation;
+
+    invocation = get_output_invoked() + 1;
+    set_output_invoked(invocation);
+
+    if (invocation == 1) {
+        p = strstr(out_json, "\"namespace\":\"tenant-a\"");
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected first namespace not found. Got: %s", out_json);
+        }
+
+        p = strstr(out_json, "\"value\":\"blue\"");
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected first dynamic label value not found. Got: %s", out_json);
+        }
+
+        p = strstr(out_json, "\"log_text\":\"{\\\"message\\\":\\\"record one\\\"");
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected first record not found. Got: %s", out_json);
+        }
+
+        p = strstr(out_json, "tenant-b");
+        TEST_CHECK(p == NULL);
+
+        p = strstr(out_json, "green");
+        TEST_CHECK(p == NULL);
+
+        p = strstr(out_json, "record two");
+        TEST_CHECK(p == NULL);
+    }
+    else if (invocation == 2) {
+        p = strstr(out_json, "\"namespace\":\"tenant-b\"");
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected second namespace not found. Got: %s", out_json);
+        }
+
+        p = strstr(out_json, "\"value\":\"green\"");
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected second dynamic label value not found. Got: %s", out_json);
+        }
+
+        p = strstr(out_json, "\"log_text\":\"{\\\"message\\\":\\\"record two\\\"");
+        if (!TEST_CHECK(p != NULL)) {
+            TEST_MSG("Expected second record not found. Got: %s", out_json);
+        }
+    }
+
+    flb_sds_destroy(res_data);
+}
+
 void test_format_no_log_key()
 {
     flb_ctx_t *ctx;
@@ -322,6 +445,139 @@ void test_format_partially_suceeded_records()
     flb_destroy(ctx);
 }
 
+void test_format_namespace_and_labels()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record[1024];
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   "namespace_key", "$tenant_namespace",
+                   "namespace", "fallback-namespace",
+                   "label", "env production",
+                   "label", "cluster_name $cluster['name']",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter",
+                        cb_check_format_namespace_and_labels, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record, sizeof(record) - 1,
+             "[%ld, {\"message\": \"hello world\", \"tenant_namespace\": \"tenant-a\", "
+             "\"cluster\": {\"name\": \"blue\"}}]",
+             (long) time(NULL));
+    flb_lib_push(ctx, in_ffd, record, strlen(record));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void test_format_namespace_fallback_and_missing_label()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record[1024];
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   "namespace", "fallback-namespace",
+                   "namespace_key", "$tenant_namespace",
+                   "label", "missing $cluster['name']",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter",
+                        cb_check_format_namespace_fallback_and_missing_label, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record, sizeof(record) - 1,
+             "[%ld, {\"message\": \"hello world\"}]",
+             (long) time(NULL));
+    flb_lib_push(ctx, in_ffd, record, strlen(record));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void test_format_split_on_metadata_change()
+{
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+    char record1[1024];
+    char record2[1024];
+    time_t now = time(NULL);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "chronicle", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "customer_id", "test-customer",
+                   "project_id", "TESTING_FORMAT",
+                   "log_type", "TEST_LOG",
+                   "namespace_key", "$tenant_namespace",
+                   "label", "cluster_name $cluster['name']",
+                   NULL);
+
+    flb_output_set_test(ctx, out_ffd, "formatter",
+                        cb_check_format_split_on_metadata_change, NULL, NULL);
+
+    flb_start(ctx);
+    clear_output_invoked();
+
+    snprintf(record1, sizeof(record1) - 1,
+             "[%ld, {\"message\": \"record one\", \"tenant_namespace\": \"tenant-a\", "
+             "\"cluster\": {\"name\": \"blue\"}}]",
+             (long) now);
+    snprintf(record2, sizeof(record2) - 1,
+             "[%ld, {\"message\": \"record two\", \"tenant_namespace\": \"tenant-b\", "
+             "\"cluster\": {\"name\": \"green\"}}]",
+             (long) now + 1);
+
+    flb_lib_push(ctx, in_ffd, record1, strlen(record1));
+    flb_lib_push(ctx, in_ffd, record2, strlen(record2));
+
+    sleep(1);
+
+    TEST_CHECK(get_output_invoked() == 1);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 
 TEST_LIST = {
     { "format_no_log_key",           test_format_no_log_key },
@@ -329,5 +585,9 @@ TEST_LIST = {
     { "format_with_log_key_not_found", test_format_with_log_key_not_found },
     { "format_multiple_records",     test_format_multiple_records },
     { "format_partially_suceeded_records", test_format_partially_suceeded_records },
+    { "format_namespace_and_labels", test_format_namespace_and_labels },
+    { "format_namespace_fallback_and_missing_label",
+      test_format_namespace_fallback_and_missing_label },
+    { "format_split_on_metadata_change", test_format_split_on_metadata_change },
     { NULL, NULL }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11836.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
