### PR TITLE
mem: input_chunk: Make heap memory based backpressure

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -333,6 +333,9 @@ struct flb_config {
 
     int dry_run;
 
+    /* Heap limit configuration */
+    size_t heap_mem_limit;
+
     /* New Router Configuration */
     struct cfl_list input_routes;
 };
@@ -365,6 +368,7 @@ enum conf_type {
     FLB_CONF_TYPE_DOUBLE,
     FLB_CONF_TYPE_BOOL,
     FLB_CONF_TYPE_STR,
+    FLB_CONF_TYPE_SIZE,
     FLB_CONF_TYPE_OTHER,
 };
 
@@ -378,6 +382,7 @@ enum conf_type {
 #define FLB_CONF_STR_STREAMS_FILE "Streams_File"
 #define FLB_CONF_STR_STREAMS_STR_CONV "sp.convert_from_str_to_num"
 #define FLB_CONF_STR_CONV_NAN     "json.convert_nan_to_null"
+#define FLB_CONF_STR_HEAP_MEM_LIMIT "heap.mem_limit"
 
 /* FLB_HAVE_HTTP_SERVER */
 #ifdef FLB_HAVE_HTTP_SERVER

--- a/include/fluent-bit/flb_mem.h
+++ b/include/fluent-bit/flb_mem.h
@@ -63,8 +63,28 @@ static inline int flb_fuzz_get_probability(int val) {
 }
 #endif
 
+FLB_EXPORT extern void flb_mem_account_add(size_t size);
+FLB_EXPORT extern void flb_mem_account_sub(size_t size);
+FLB_EXPORT extern size_t flb_mem_usage_get(void);
+
+#ifdef FLB_HAVE_JEMALLOC
+    #define FLB_MEM_SIZE(ptr) malloc_usable_size((void *)ptr)
+#elif defined(_WIN32)
+    #include <malloc.h>
+    #define FLB_MEM_SIZE(ptr) _msize((void *)ptr)
+#elif defined(__APPLE__)
+    #include <malloc/malloc.h>
+    #define FLB_MEM_SIZE(ptr) malloc_size((void *)ptr)
+#else
+    #include <malloc.h>
+    #define FLB_MEM_SIZE(ptr) malloc_usable_size((void *)ptr)
+#endif
+
+static inline void flb_free(void *ptr);
+
 static inline FLB_ALLOCSZ_ATTR(1)
 void *flb_malloc(const size_t size) {
+    void *ptr;
 
 #ifdef FLB_HAVE_TESTS_OSSFUZZ
    // 1% chance of failure
@@ -73,18 +93,19 @@ void *flb_malloc(const size_t size) {
    }
 #endif
 
-    if (size == 0) {
+    ptr = malloc(size);
+    if (!ptr) {
         return NULL;
     }
-
-    return malloc(size);
+    
+    flb_mem_account_add(FLB_MEM_SIZE(ptr));
+    return ptr;
 }
 
 static inline FLB_ALLOCSZ_ATTR(1, 2)
 void *flb_calloc(size_t n, const size_t size) {
-    if (size == 0) {
-        return NULL;
-    }
+    void *ptr;
+
 #ifdef FLB_HAVE_TESTS_OSSFUZZ
    // Add chance of failure. Used by fuzzing to test error-handling code.
    if (flb_fuzz_get_probability(1)) {
@@ -92,13 +113,40 @@ void *flb_calloc(size_t n, const size_t size) {
    }
 #endif
 
-    return calloc(n, size);
+    ptr = calloc(n, size);
+    if (!ptr) {
+        return NULL;
+    }
+
+    flb_mem_account_add(FLB_MEM_SIZE(ptr));
+    return ptr;
 }
 
 static inline FLB_ALLOCSZ_ATTR(2)
 void *flb_realloc(void *ptr, const size_t size)
 {
-    return realloc(ptr, size);
+    void *new_ptr;
+    size_t old_size = 0;
+
+    if (!ptr) {
+        return flb_malloc(size);
+    }
+    
+    if (size == 0) {
+        flb_free(ptr);
+        return NULL;
+    }
+
+    old_size = FLB_MEM_SIZE(ptr);
+    new_ptr = realloc(ptr, size);
+    if (!new_ptr) {
+        return NULL;
+    }
+
+    flb_mem_account_sub(old_size);
+    flb_mem_account_add(FLB_MEM_SIZE(new_ptr));
+
+    return new_ptr;
 }
 
 static inline FLB_ALLOCSZ_ATTR(3)
@@ -124,8 +172,14 @@ void *flb_realloc_z(void *ptr, const size_t old_size, const size_t new_size)
 
 
 static inline void flb_free(void *ptr) {
+    if (!ptr) {
+        return;
+    }
+    
+    flb_mem_account_sub(FLB_MEM_SIZE(ptr));
     free(ptr);
 }
+
 
 #undef FLB_ALLOCSZ_ATTR
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -229,6 +229,10 @@ struct flb_service_config service_configs[] = {
      FLB_CONF_TYPE_INT,
      offsetof(struct flb_config, hot_reload_watchdog_timeout_seconds)},
 
+    {FLB_CONF_STR_HEAP_MEM_LIMIT,
+     FLB_CONF_TYPE_SIZE,
+     offsetof(struct flb_config, heap_mem_limit)},
+
     {NULL, FLB_CONF_TYPE_OTHER, 0} /* end of array */
 };
 
@@ -744,6 +748,7 @@ int flb_config_set_property(struct flb_config *config,
     int *i_val;
     double *d_val;
     char **s_val;
+    size_t *sz_val;
     size_t len = strnlen(k, 256);
     char *key = service_configs[0].key;
     flb_sds_t tmp = NULL;
@@ -807,6 +812,11 @@ int flb_config_set_property(struct flb_config *config,
                     }
 
                     *s_val = flb_strdup(tmp);
+                    flb_sds_destroy(tmp);
+                    break;
+                case FLB_CONF_TYPE_SIZE:
+                    sz_val = (size_t*)((char*)config+service_configs[i].offset);
+                    *sz_val = flb_utils_size_to_bytes(tmp);
                     flb_sds_destroy(tmp);
                     break;
                 default:

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -2401,6 +2401,16 @@ static inline int flb_input_chunk_is_mem_overlimit(struct flb_input_instance *i)
     return FLB_FALSE;
 }
 
+static inline int flb_input_chunk_is_global_heap_overlimit(struct flb_input_instance *i)
+{
+    if (i->config->heap_mem_limit > 0 &&
+        flb_mem_usage_get() >= i->config->heap_mem_limit) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 static inline int flb_input_chunk_is_storage_overlimit(struct flb_input_instance *i)
 {
     struct flb_storage_input *storage = (struct flb_storage_input *)i->storage;
@@ -2452,16 +2462,15 @@ size_t flb_input_chunk_set_limits(struct flb_input_instance *in)
      * and perform further adjustments.
      */
     if (flb_input_chunk_is_mem_overlimit(in) == FLB_FALSE &&
+        flb_input_chunk_is_global_heap_overlimit(in) == FLB_FALSE &&
         in->config->is_running == FLB_TRUE &&
         in->config->is_ingestion_active == FLB_TRUE &&
         in->mem_buf_status == FLB_INPUT_PAUSED) {
         in->mem_buf_status = FLB_INPUT_RUNNING;
         if (in->p->cb_resume) {
             flb_input_resume(in);
-            flb_info("[input] %s resume (mem buf overlimit - buf size %zuB now below limit %zuB)",
-                      flb_input_name(in),
-                      in->mem_chunks_size,
-                      in->mem_buf_limit);
+            flb_info("[input] %s resume (mem buf overlimit / global heap - limits not exceeded)",
+                      flb_input_name(in));
         }
     }
     if (flb_input_chunk_is_storage_overlimit(in) == FLB_FALSE &&
@@ -2501,6 +2510,21 @@ static inline int flb_input_chunk_protect(struct flb_input_instance *i, size_t j
 
     if (storage->type == FLB_STORAGE_FS) {
         return FLB_FALSE;
+    }
+
+    if (flb_input_chunk_is_global_heap_overlimit(i) == FLB_TRUE) {
+        if (i->storage_type == FLB_STORAGE_MEMRB) {
+            return FLB_FALSE;
+        }
+
+        flb_warn("[input] %s paused (global heap mem overlimit - usage %zuB exceeded limit %zuB)",
+                 flb_input_name(i),
+                 flb_mem_usage_get(),
+                 i->config->heap_mem_limit
+                );
+        flb_input_pause(i);
+        i->mem_buf_status = FLB_INPUT_PAUSED;
+        return FLB_TRUE;
     }
 
     if (flb_input_chunk_is_mem_overlimit(i) == FLB_TRUE) {
@@ -2551,7 +2575,7 @@ int flb_input_chunk_set_up_down(struct flb_input_chunk *ic)
     /* Register the total into the context variable */
     in->mem_chunks_size = total;
 
-    if (flb_input_chunk_is_mem_overlimit(in) == FLB_TRUE) {
+    if (flb_input_chunk_is_mem_overlimit(in) == FLB_TRUE || flb_input_chunk_is_global_heap_overlimit(in) == FLB_TRUE) {
         if (cio_chunk_is_up(ic->chunk) == CIO_TRUE) {
             cio_chunk_down(ic->chunk);
 

--- a/src/flb_mem.c
+++ b/src/flb_mem.c
@@ -18,8 +18,71 @@
  */
 
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <stdlib.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 #ifdef FLB_HAVE_TESTS_OSSFUZZ
 int flb_malloc_p;
 int flb_malloc_mod;
 #endif
+
+static size_t flb_global_heap_usage = 0;
+
+FLB_EXPORT void flb_mem_account_add(size_t size) {
+#if defined(__GNUC__) || defined(__clang__)
+    __atomic_fetch_add(&flb_global_heap_usage, size, __ATOMIC_RELAXED);
+#elif defined(_WIN32)
+    InterlockedExchangeAdd64((LONG64*)&flb_global_heap_usage, size);
+#else
+    flb_global_heap_usage += size;
+#endif
+}
+
+FLB_EXPORT void flb_mem_account_sub(size_t size) {
+#if defined(__GNUC__) || defined(__clang__)
+    size_t current;
+    size_t updated;
+
+    current = __atomic_load_n(&flb_global_heap_usage, __ATOMIC_RELAXED);
+
+    do {
+        updated = current > size ? current - size : 0;
+    } while (!__atomic_compare_exchange_n(&flb_global_heap_usage, &current,
+                                           updated, 0, __ATOMIC_RELAXED,
+                                           __ATOMIC_RELAXED));
+#elif defined(_WIN32)
+    LONG64 current;
+    LONG64 updated;
+
+    current = InterlockedCompareExchange64((LONG64 *) &flb_global_heap_usage,
+                                           0, 0);
+
+    do {
+        updated = (LONG64) ((size_t) current > size ? (size_t) current - size : 0);
+    } while (InterlockedCompareExchange64((LONG64 *) &flb_global_heap_usage,
+                                          updated, current) != current);
+#else
+    if (flb_global_heap_usage > size) {
+        flb_global_heap_usage -= size;
+    }
+    else {
+        flb_global_heap_usage = 0;
+    }
+#endif
+}
+
+FLB_EXPORT size_t flb_mem_usage_get(void)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return (size_t) __atomic_load_n(&flb_global_heap_usage, __ATOMIC_RELAXED);
+#elif defined(_WIN32)
+    return (size_t) InterlockedCompareExchange64(
+            (LONG64 *) &flb_global_heap_usage, 0, 0);
+#else
+    return (size_t) flb_global_heap_usage;
+#endif
+}

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -347,6 +347,24 @@ static int attach_hot_reload_info(struct flb_config *ctx, struct cmt *cmt, uint6
     return 0;
 }
 
+static int attach_heap_usage(struct flb_config *ctx, struct cmt *cmt, uint64_t ts,
+                             char *hostname)
+{
+    double val;
+    struct cmt_gauge *g;
+
+    g = cmt_gauge_create(cmt, "fluentbit", "", "heap_usage_bytes",
+                         "Total heap memory usage in bytes.",
+                         1, (char *[]) {"hostname"});
+    if (!g) {
+        return -1;
+    }
+
+    val = (double) flb_mem_usage_get();
+    cmt_gauge_set(g, ts, val, 1, (char *[]) {hostname});
+    return 0;
+}
+
 /* Append internal Fluent Bit metrics to context */
 int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt)
 {
@@ -368,6 +386,7 @@ int flb_metrics_fluentbit_add(struct flb_config *ctx, struct cmt *cmt)
     attach_process_start_time_seconds(ctx, cmt, ts, hostname);
     attach_build_info(ctx, cmt, ts, hostname);
     attach_hot_reload_info(ctx, cmt, ts, hostname);
+    attach_heap_usage(ctx, cmt, ts, hostname);
 
     return 0;
 }

--- a/src/flb_metrics.c
+++ b/src/flb_metrics.c
@@ -243,8 +243,15 @@ int flb_metrics_dump_values(char **out_buf, size_t *out_size,
         msgpack_pack_uint64(&mp_pck, m->val);
     }
 
-    *out_buf  = mp_sbuf.data;
+    *out_buf = flb_malloc(mp_sbuf.size);
+    if (!*out_buf) {
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        return -1;
+    }
+    memcpy(*out_buf, mp_sbuf.data, mp_sbuf.size);
     *out_size = mp_sbuf.size;
+
+    msgpack_sbuffer_destroy(&mp_sbuf);
 
     return 0;
 }

--- a/src/flb_task.c
+++ b/src/flb_task.c
@@ -930,6 +930,22 @@ void flb_task_destroy(struct flb_task *task, int del)
 
     if (task->i_ins != NULL) {
         flb_input_chunk_set_limits(task->i_ins);
+
+        if (task->i_ins->config->heap_mem_limit > 0) {
+            struct mk_list *i_head;
+            struct flb_input_instance *ins;
+
+            /* 
+             * If the global heap limit is configured, freeing memory from this task
+             * might allow OTHER globally-paused inputs to resume. We must evaluate them.
+             */
+            mk_list_foreach(i_head, &task->i_ins->config->inputs) {
+                ins = mk_list_entry(i_head, struct flb_input_instance, _head);
+                if (ins != task->i_ins && ins->mem_buf_status == FLB_INPUT_PAUSED) {
+                    flb_input_chunk_set_limits(ins);
+                }
+            }
+        }
     }
 
     if (task->event_chunk != NULL) {

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -2166,7 +2166,7 @@ int flb_utils_read_file_offset(char *path, off_t offset_start, off_t offset_end,
             }
             if (ferror(fp)) {
                 flb_errno();
-                free(buf);
+                flb_free(buf);
                 fclose(fp);
                 return -1;
             }

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -1202,7 +1202,7 @@ void flb_deduplication_list_purge(struct cfl_list *deduplication_list)
 
         cfl_list_del(&entry->_head);
 
-        free(entry);
+        flb_free(entry);
     }
 }
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -16,6 +16,7 @@ set(UNIT_TESTS_FILES
   router_config.c
   network.c
   unit_sizes.c
+  mem.c
   hashtable.c
   http_client.c
   utils.c

--- a/tests/internal/mem.c
+++ b/tests/internal/mem.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+
+#include "flb_tests_internal.h"
+
+void test_heap_mem_accounting(void)
+{
+    size_t baseline;
+    size_t calloc_size;
+    void *buffer;
+    void *zeroed;
+    void *resized;
+
+    baseline = flb_mem_usage_get();
+
+    buffer = flb_malloc(32);
+    TEST_CHECK(buffer != NULL);
+    if (!buffer) {
+        return;
+    }
+    TEST_CHECK(flb_mem_usage_get() == baseline + FLB_MEM_SIZE(buffer));
+
+    zeroed = flb_calloc(4, 16);
+    TEST_CHECK(zeroed != NULL);
+    if (!zeroed) {
+        flb_free(buffer);
+        return;
+    }
+    calloc_size = FLB_MEM_SIZE(zeroed);
+    TEST_CHECK(flb_mem_usage_get() == baseline + FLB_MEM_SIZE(buffer) + calloc_size);
+
+    resized = flb_realloc(buffer, 256);
+    TEST_CHECK(resized != NULL);
+    if (!resized) {
+        flb_free(buffer);
+        flb_free(zeroed);
+        return;
+    }
+    buffer = resized;
+    TEST_CHECK(flb_mem_usage_get() == baseline + FLB_MEM_SIZE(buffer) + calloc_size);
+
+    flb_free(buffer);
+    flb_free(zeroed);
+    TEST_CHECK(flb_mem_usage_get() == baseline);
+}
+
+void test_heap_mem_accounting_underflow(void)
+{
+    size_t baseline;
+
+    baseline = flb_mem_usage_get();
+
+    flb_mem_account_sub(baseline + 1);
+    TEST_CHECK(flb_mem_usage_get() == 0);
+
+    flb_mem_account_add(baseline);
+    TEST_CHECK(flb_mem_usage_get() == baseline);
+}
+
+TEST_LIST = {
+    {"heap_mem_accounting", test_heap_mem_accounting},
+    {"heap_mem_accounting_underflow", test_heap_mem_accounting_underflow},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR is still under-constructions.

---

**Problem**
In memory-constrained environments like Kubernetes, downstream network latency or destination outages can cause input plugins to buffer logs indefinitely into the heap, resulting in sudden OOMKills. While `mem_buf_limit` exists on a per-input basis, it is difficult to manage and scale dynamically across dozens of plugins to prevent overall container memory exhaustion.

**Solution**
This PR introduces a new global `heap.mem_limit` service configuration. This acts as a unified, cross-plugin backpressure mechanism. When the total allocated heap memory across the engine exceeds this limit, all data-ingesting plugins are temporarily paused. As output plugins successfully flush data and free memory, the engine automatically resuscitates all globally paused inputs.

**Performance & Overhead Impact**
To safely track global memory without causing heap corruption in 3rd-party libraries, this PR overrides `flb_malloc`/`flb_calloc`/`flb_free` to leverage OS-native allocator metrics (`malloc_usable_size` for glibc, `je_malloc_usable_size` for jemalloc, `_msize` for Windows, and `malloc_size` for macOS) instead of injecting custom memory headers. 

This tracking design introduces **near-zero performance overhead** to the pipeline throughput:
* **Function Call Overhead**: Memory wrappers are `static inline`, eliminating stack frame and branching costs.
* **Size Querying**: Resolves in `O(1)`. Modern allocators natively store block sizes immediately preceding the allocated pointer. Querying `malloc_usable_size` executes a fast, constant-time memory read to retrieve this integer.
* **Accounting**: The global counter updates via a single `__ATOMIC_RELAXED` CPU instruction per allocation/free. Because Fluent Bit relies primarily on a single-threaded event loop, cross-core cache-line contention on the global counter is virtually non-existent.

### Related Issues
- Addresses global memory bounding and OOM prevention strategies.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
