### PR TITLE
http_server: fix libevent crash on connection drop

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -231,16 +231,15 @@ int flb_net_socket_share_port(flb_sockfd_t fd)
     int on = 1;
     int ret;
 
-#ifdef SO_REUSEPORT
+#if defined(SO_REUSEPORT) && !defined(FLB_SYSTEM_WINDOWS)
     ret = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on));
-#else
-    ret = -1;
-#endif
-
     if (ret == -1) {
         flb_errno();
         return -1;
     }
+#else
+    (void) fd;
+#endif
 
     return 0;
 }

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -125,7 +125,7 @@ static void flb_http_server_connection_drop(struct flb_connection *connection)
     if (session != NULL &&
         session->connection == connection) {
         session->connection = NULL;
-        session->drop_pending = FLB_TRUE;
+        session->drop_pending = FLB_FALSE;
     }
 
     connection->user_data = NULL;

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -126,10 +126,6 @@ static void flb_http_server_connection_drop(struct flb_connection *connection)
         session->connection == connection) {
         session->connection = NULL;
         session->drop_pending = FLB_TRUE;
-        connection->event.data = session;
-    }
-    else {
-        connection->event.data = NULL;
     }
 
     connection->user_data = NULL;
@@ -387,15 +383,13 @@ static int flb_http_server_client_activity_event_handler(void *data)
 
     session = (struct flb_http_server_session *) connection->user_data;
     if (session == NULL) {
-        session = (struct flb_http_server_session *) event->data;
-        if (session != NULL &&
-            (session->connection == NULL ||
-             session->connection->fd == FLB_INVALID_SOCKET)) {
-            event->data = NULL;
-            session->drop_pending = FLB_FALSE;
-            flb_http_server_session_destroy(session);
-        }
+        return -1;
+    }
 
+    if (session->connection == NULL ||
+        session->connection->fd == FLB_INVALID_SOCKET) {
+        session->drop_pending = FLB_FALSE;
+        flb_http_server_session_destroy(session);
         return -1;
     }
 
@@ -507,7 +501,6 @@ static int flb_http_server_client_connection_event_handler(void *data)
     MK_EVENT_NEW(&connection->event);
 
     connection->user_data     = (void *) session;
-    connection->event.data    = (void *) session;
     connection->drop_notification_callback = flb_http_server_connection_drop;
     connection->event.type    = FLB_ENGINE_EV_CUSTOM;
     connection->event.handler = flb_http_server_client_activity_event_handler;
@@ -1214,7 +1207,6 @@ void flb_http_server_session_destroy(struct flb_http_server_session *session)
 
         if (connection != NULL) {
             connection->user_data = NULL;
-            connection->event.data = NULL;
             connection->drop_notification_callback = NULL;
             session->drop_pending = FLB_FALSE;
 

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -128,7 +128,6 @@ static void flb_http_server_connection_drop(struct flb_connection *connection)
         session->drop_pending = FLB_FALSE;
     }
 
-    connection->user_data = NULL;
     connection->drop_notification_callback = NULL;
 }
 

--- a/tests/internal/http_server.c
+++ b/tests/internal/http_server.c
@@ -391,12 +391,10 @@ void test_http_server_session_destroy_with_closed_connection()
 
     session->connection = &connection;
     connection.user_data = session;
-    connection.event.data = session;
 
     flb_http_server_session_destroy(session);
 
     TEST_CHECK(connection.user_data == NULL);
-    TEST_CHECK(connection.event.data == NULL);
 }
 
 void test_http_server_session_destroy_clears_drop_pending()
@@ -416,12 +414,10 @@ void test_http_server_session_destroy_clears_drop_pending()
     session->drop_pending = FLB_TRUE;
     session->releasable = FLB_FALSE;
     connection.user_data = session;
-    connection.event.data = session;
 
     flb_http_server_session_destroy(session);
 
     TEST_CHECK(connection.user_data == NULL);
-    TEST_CHECK(connection.event.data == NULL);
     TEST_CHECK(session->drop_pending == FLB_FALSE);
 
     flb_free(session);


### PR DESCRIPTION
Removes dangerous connection->event.data assignments (which crash the libevent backend on Windows)
and instead preserves connection->user_data
so the event handler can safely find and clean up the session.


Closes https://github.com/fluent/fluent-bit/issues/11842.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
PS> bin/fluent-bit -i dummy -o stdout -H -P 2021 -v
```

- [x] Debug log output from testing the change

After applying this patch, Fluent Bit now starts to process HTTP requests with internal HTTP server again on Windows:
```
Fluent Bit v5.0.7
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/05/26 17:25:02.564] [ info] Configuration:
[2026/05/26 17:25:02.564] [ info]  flush time     | 1.000000 seconds
[2026/05/26 17:25:02.564] [ info]  grace          | 5 seconds
[2026/05/26 17:25:02.564] [ info]  daemon         | 0
[2026/05/26 17:25:02.564] [ info] ___________
[2026/05/26 17:25:02.564] [ info]  inputs:
[2026/05/26 17:25:02.564] [ info]      dummy
[2026/05/26 17:25:02.565] [ info] ___________
[2026/05/26 17:25:02.565] [ info]  filters:
[2026/05/26 17:25:02.565] [ info] ___________
[2026/05/26 17:25:02.565] [ info]  outputs:
[2026/05/26 17:25:02.565] [ info]      stdout.0
[2026/05/26 17:25:02.565] [ info] ___________
[2026/05/26 17:25:02.565] [ info]  collectors:
[2026/05/26 17:25:02.566] [ info] [fluent bit] version=5.0.7, commit=7a494fbb56, pid=43020
[2026/05/26 17:25:02.566] [debug] [engine] maxstdio set: 512
[2026/05/26 17:25:02.566] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2026/05/26 17:25:02.566] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/05/26 17:25:02.566] [ info] [simd    ] disabled
[2026/05/26 17:25:02.566] [ info] [cmetrics] version=2.1.4
[2026/05/26 17:25:02.566] [ info] [ctraces ] version=0.7.1
[2026/05/26 17:25:02.567] [ info] [input:dummy:dummy.0] initializing
[2026/05/26 17:25:02.567] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/05/26 17:25:02.567] [debug] [dummy:dummy.0] created event channels: read=804 write=808
[2026/05/26 17:25:02.567] [debug] [stdout:stdout.0] created event channels: read=812 write=816
[2026/05/26 17:25:02.568] [ info] [output:stdout:stdout.0] worker #0 started
[2026/05/26 17:25:02.569] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2021
[2026/05/26 17:25:02.569] [ info] [sp] stream processor started
[2026/05/26 17:25:02.569] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/05/26 17:25:04.564] [debug] [task] created task=000001CE46DE2890 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:04.564] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783903.558790900, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:04.564] [debug] [out flush] cb_destroy coro_id=0
[2026/05/26 17:25:04.565] [debug] [task] destroy task=000001CE46DE2890 (task_id=0)
[2026/05/26 17:25:05.578] [debug] [task] created task=000001CE46DE27F0 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:05.578] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783904.564420700, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:05.579] [debug] [out flush] cb_destroy coro_id=1
[2026/05/26 17:25:05.579] [debug] [task] destroy task=000001CE46DE27F0 (task_id=0)
[2026/05/26 17:25:06.568] [debug] [task] created task=000001CE46DE1CB0 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:06.568] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783905.578922100, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:06.569] [debug] [out flush] cb_destroy coro_id=2
[2026/05/26 17:25:06.569] [debug] [task] destroy task=000001CE46DE1CB0 (task_id=0)
[2026/05/26 17:25:07.570] [debug] [task] created task=000001CE46DE1B70 id=0 OK
[0] dummy.0: [[1779783906.569488100, {[2026/05/26 17:25:07.570] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
}], {"message"=>"dummy"}]
[2026/05/26 17:25:07.571] [debug] [out flush] cb_destroy coro_id=3
[2026/05/26 17:25:07.571] [debug] [task] destroy task=000001CE46DE1B70 (task_id=0)
[2026/05/26 17:25:08.570] [debug] [task] created task=000001CE46DE1D50 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:08.570] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783907.571000000, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:08.570] [debug] [out flush] cb_destroy coro_id=4
[2026/05/26 17:25:08.570] [debug] [task] destroy task=000001CE46DE1D50 (task_id=0)
[2026/05/26 17:25:09.564] [debug] [task] created task=000001CE46DE1A30 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:09.564] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783908.570760100, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:09.564] [debug] [out flush] cb_destroy coro_id=5
[2026/05/26 17:25:09.564] [debug] [task] destroy task=000001CE46DE1A30 (task_id=0)
[2026/05/26 17:25:10.570] [debug] [task] created task=000001CE46DE27F0 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:10.570] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783909.564631900, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:10.570] [debug] [out flush] cb_destroy coro_id=6
[2026/05/26 17:25:10.570] [debug] [task] destroy task=000001CE46DE27F0 (task_id=0)
[2026/05/26 17:25:11.570] [debug] [task] created task=000001CE46DE2110 id=0 OK
[2026/05/26 17:25:11.570] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.0: [[1779783910.570571300, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:11.570] [debug] [out flush] cb_destroy coro_id=7
[2026/05/26 17:25:11.570] [debug] [task] destroy task=000001CE46DE2110 (task_id=0)
[2026/05/26 17:25:12.562] [debug] [task] created task=000001CE46DE2890 id=0 OK
[2026/05/26 17:25:12.562] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] dummy.0: [[1779783911.570632300, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:12.562] [debug] [out flush] cb_destroy coro_id=8
[2026/05/26 17:25:12.562] [debug] [task] destroy task=000001CE46DE2890 (task_id=0)
[2026/05/26 17:25:12] [engine] caught signal (SIGINT)
[2026/05/26 17:25:13.560] [debug] [task] created task=000001CE46DE27F0 id=0 OK
[0] dummy.0: [[[2026/05/26 17:25:13.560] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
1779783912.562228400, {}], {"message"=>"dummy"}]
[2026/05/26 17:25:13.560] [debug] [out flush] cb_destroy coro_id=9
[2026/05/26 17:25:13.560] [debug] [task] destroy task=000001CE46DE27F0 (task_id=0)
[2026/05/26 17:25:13.683] [debug] [task] created task=000001CE46DE2750 id=0 OK
[0] dummy.0: [[1779783913.560587200, [2026/05/26 17:25:13.683] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/05/26 17:25:13.683] [ warn] [engine] service will shutdown in max 5 seconds
[2026/05/26 17:25:13.683] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/05/26 17:25:13.683] [ info] [engine] pausing all inputs..
{}], [2026/05/26 17:25:13.683] [ info] [input] pausing dummy.0
{"message"=>"dummy"}]
[2026/05/26 17:25:13.684] [debug] [out flush] cb_destroy coro_id=10
[2026/05/26 17:25:13.684] [debug] [task] destroy task=000001CE46DE2750 (task_id=0)
[2026/05/26 17:25:14.698] [ info] [engine] service has stopped (0 pending tasks)
[2026/05/26 17:25:14.698] [ info] [input] pausing dummy.0
[2026/05/26 17:25:14.698] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/05/26 17:25:14.699] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved server connection and session lifecycle handling for greater reliability.
  * More robust session teardown and cleanup to prevent stale or lingering session links.
  * Streamlined client activity and connection event handling to reduce unexpected disconnects and improve stability.

* **Bug Fixes**
  * Safer socket port-sharing behavior on platforms without specific socket option support to avoid unnecessary errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->