### PR TITLE
http_server: serialize worker teardown to prevent race conditions

### DIFF
--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -158,7 +158,18 @@ int flb_downstream_setup(struct flb_downstream *stream,
         return -2;
     }
 
-    mk_list_add(&stream->base._head, &config->downstreams);
+    if (config != NULL) {
+        /*
+         * flb_downstream_setup can be called concurrently by multiple HTTP
+         * server worker threads, so we must protect the shared list.
+         * Since there is no explicit mutex for downstreams, and we only
+         * do this at startup, we will just lock the collectors_mutex as
+         * a workaround to prevent the data race on aarch64.
+         */
+        pthread_mutex_lock(&config->collectors_mutex);
+        mk_list_add(&stream->base._head, &config->downstreams);
+        pthread_mutex_unlock(&config->collectors_mutex);
+    }
 
     return 0;
 }
@@ -426,8 +437,16 @@ void flb_downstream_destroy(struct flb_downstream *stream)
             flb_socket_close(stream->server_fd);
         }
 
+        if (stream->base.config != NULL) {
+            pthread_mutex_lock(&stream->base.config->collectors_mutex);
+        }
+
         if (mk_list_entry_orphan(&stream->base._head) == 0) {
             mk_list_del(&stream->base._head);
+        }
+
+        if (stream->base.config != NULL) {
+            pthread_mutex_unlock(&stream->base.config->collectors_mutex);
         }
 
         if (stream->base.dynamically_allocated) {

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -67,7 +67,8 @@ flb_http_server_runtime_worker_net_setup_get(struct flb_http_server *server,
     return &server->runtime->workers[worker_id].net_setup;
 }
 
-static void flb_http_server_runtime_stop(struct flb_http_server *session);
+static void flb_http_server_runtime_stop(struct flb_http_server *session,
+                                         struct flb_http_server_runtime *runtime);
 
 static int flb_http_server_worker_context_reset(
     struct flb_http_server_worker_context *worker)
@@ -728,7 +729,6 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
     }
 
     runtime->worker_count = session->workers;
-    session->runtime = runtime;
 
     for (index = 0; index < runtime->worker_count; index++) {
         memcpy(&runtime->workers[index].parent,
@@ -768,24 +768,27 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
     }
 
     if (index != runtime->worker_count) {
-        flb_http_server_runtime_stop(session);
+        flb_http_server_runtime_stop(session, runtime);
         return -1;
     }
 
+    session->runtime = runtime;
     session->status = HTTP_SERVER_RUNNING;
 
     return 0;
 }
 
-static void flb_http_server_runtime_stop(struct flb_http_server *session)
+static void flb_http_server_runtime_stop(struct flb_http_server *session,
+                                         struct flb_http_server_runtime *runtime)
 {
     int index;
-    struct flb_http_server_runtime *runtime;
+    int published;
 
-    runtime = session->runtime;
     if (runtime == NULL) {
         return;
     }
+
+    published = (session->runtime == runtime);
 
     for (index = 0; index < runtime->worker_count; index++) {
         cfl_atomic_store(&runtime->workers[index].should_exit, FLB_TRUE);
@@ -804,10 +807,12 @@ static void flb_http_server_runtime_stop(struct flb_http_server *session)
         flb_http_server_worker_context_cleanup(&runtime->workers[index]);
     }
 
+    if (published == FLB_TRUE) {
+        session->runtime = NULL;
+    }
+
     flb_free(runtime->workers);
     flb_free(runtime);
-
-    session->runtime = NULL;
 }
 
 /* HTTP SERVER */
@@ -1075,7 +1080,7 @@ int flb_http_server_stop(struct flb_http_server *server)
     struct flb_http_server_session *session;
 
     if (server->runtime != NULL) {
-        flb_http_server_runtime_stop(server);
+        flb_http_server_runtime_stop(server, server->runtime);
         server->status = HTTP_SERVER_STOPPED;
         return 0;
     }

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -69,12 +69,25 @@ flb_http_server_runtime_worker_net_setup_get(struct flb_http_server *server,
 
 static void flb_http_server_runtime_stop(struct flb_http_server *session);
 
-static void flb_http_server_worker_context_reset(
+static int flb_http_server_worker_context_reset(
     struct flb_http_server_worker_context *worker)
 {
+    int result;
+
     memset(worker, 0, sizeof(struct flb_http_server_worker_context));
-    pthread_mutex_init(&worker->mutex, NULL);
-    pthread_cond_init(&worker->condition, NULL);
+
+    result = pthread_mutex_init(&worker->mutex, NULL);
+    if (result != 0) {
+        return result;
+    }
+
+    result = pthread_cond_init(&worker->condition, NULL);
+    if (result != 0) {
+        pthread_mutex_destroy(&worker->mutex);
+        return result;
+    }
+
+    return 0;
 }
 
 static void flb_http_server_worker_context_cleanup(
@@ -676,14 +689,11 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
         return -1;
     }
 
-    session->runtime = runtime;
-    runtime->worker_count = session->workers;
-    runtime->workers = flb_calloc(runtime->worker_count,
+    runtime->workers = flb_calloc(session->workers,
                                   sizeof(struct flb_http_server_worker_context));
     if (runtime->workers == NULL) {
         flb_errno();
         flb_free(runtime);
-        session->runtime = NULL;
         return -1;
     }
 
@@ -695,7 +705,6 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
         if (result != 0) {
             flb_free(runtime->workers);
             flb_free(runtime);
-            session->runtime = NULL;
 
             return -1;
         }
@@ -703,8 +712,25 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
         session->tls_alpn_configured = FLB_TRUE;
     }
 
+    for (index = 0; index < session->workers; index++) {
+        result = flb_http_server_worker_context_reset(&runtime->workers[index]);
+        if (result != 0) {
+            while (index > 0) {
+                index--;
+                flb_http_server_worker_context_cleanup(&runtime->workers[index]);
+            }
+
+            flb_free(runtime->workers);
+            flb_free(runtime);
+
+            return -1;
+        }
+    }
+
+    runtime->worker_count = session->workers;
+    session->runtime = runtime;
+
     for (index = 0; index < runtime->worker_count; index++) {
-        flb_http_server_worker_context_reset(&runtime->workers[index]);
         memcpy(&runtime->workers[index].parent,
                session,
                sizeof(struct flb_http_server));

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -609,6 +609,12 @@ static void *flb_http_server_worker_thread(void *data)
 
     worker = data;
 
+    /* 
+     * Ensure worker TLS is zeroed for this thread so logging macros
+     * do not read garbage memory on architectures like aarch64.
+     */
+    FLB_TLS_SET(flb_worker_ctx, NULL);
+
     worker->event_loop = mk_event_loop_create(256);
     if (worker->event_loop == NULL) {
         result = -1;
@@ -647,6 +653,13 @@ signal_and_exit:
     }
 
 cleanup:
+    if (worker->server.status == HTTP_SERVER_RUNNING &&
+        worker->server.cb_worker_exit != NULL) {
+        worker->server.cb_worker_exit(&worker->server,
+                                      worker->server.user_data);
+        worker->server.cb_worker_exit = NULL;
+    }
+
     return NULL;
 }
 

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -645,13 +645,6 @@ signal_and_exit:
     }
 
 cleanup:
-    flb_http_server_destroy(&worker->server);
-
-    if (worker->event_loop != NULL) {
-        mk_event_loop_destroy(worker->event_loop);
-        worker->event_loop = NULL;
-    }
-
     return NULL;
 }
 
@@ -758,6 +751,13 @@ static void flb_http_server_runtime_stop(struct flb_http_server *session)
 
         if (runtime->workers[index].thread_created == FLB_TRUE) {
             pthread_join(runtime->workers[index].thread, NULL);
+
+            flb_http_server_destroy(&runtime->workers[index].server);
+
+            if (runtime->workers[index].event_loop != NULL) {
+                mk_event_loop_destroy(runtime->workers[index].event_loop);
+                runtime->workers[index].event_loop = NULL;
+            }
         }
 
         flb_http_server_worker_context_cleanup(&runtime->workers[index]);

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -623,19 +623,16 @@ static void *flb_http_server_worker_thread(void *data)
 
     worker = data;
 
-    /* 
-     * Ensure worker TLS is zeroed for this thread so logging macros
-     * do not read garbage memory on architectures like aarch64.
-     */
-    FLB_TLS_SET(flb_worker_ctx, NULL);
-
     worker->event_loop = mk_event_loop_create(256);
     if (worker->event_loop == NULL) {
         result = -1;
         goto signal_and_exit;
     }
 
+    flb_engine_evl_init();
     flb_engine_evl_set(worker->event_loop);
+
+    flb_net_dns_ctx_init();
     flb_net_ctx_init(&dns_ctx);
     flb_net_dns_ctx_set(&dns_ctx);
 

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -661,16 +661,16 @@ static int flb_http_server_runtime_start(struct flb_http_server *session)
         return -1;
     }
 
-    runtime->workers = flb_calloc(session->workers,
+    session->runtime = runtime;
+    runtime->worker_count = session->workers;
+    runtime->workers = flb_calloc(runtime->worker_count,
                                   sizeof(struct flb_http_server_worker_context));
     if (runtime->workers == NULL) {
         flb_errno();
         flb_free(runtime);
+        session->runtime = NULL;
         return -1;
     }
-
-    runtime->worker_count = session->workers;
-    session->runtime = runtime;
 
     if (session->tls_provider != NULL &&
         session->tls_alpn_configured == FLB_FALSE) {

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -29,6 +29,7 @@
 
 #include <fluent-bit/flb_snappy.h>
 #include <fluent-bit/flb_gzip.h>
+#include <cfl/cfl_atomic.h>
 
 /* PRIVATE */
 
@@ -41,7 +42,7 @@ struct flb_http_server_worker_context {
     pthread_mutex_t mutex;
     pthread_cond_t condition;
     int worker_id;
-    int should_exit;
+    uint64_t should_exit;
     int initialized;
     int thread_created;
     int startup_result;
@@ -601,6 +602,7 @@ static int flb_http_server_worker_initialize(
 static void *flb_http_server_worker_thread(void *data)
 {
     int result;
+    uint64_t should_exit;
     struct mk_event *event;
     struct flb_net_dns dns_ctx = {0};
     struct flb_http_server_worker_context *worker;
@@ -630,7 +632,7 @@ signal_and_exit:
         goto cleanup;
     }
 
-    while (worker->should_exit == FLB_FALSE) {
+    while ((should_exit = cfl_atomic_load(&worker->should_exit)) == FLB_FALSE) {
         mk_event_wait_2(worker->event_loop, 250);
 
         mk_event_foreach(event, worker->event_loop) {
@@ -747,7 +749,7 @@ static void flb_http_server_runtime_stop(struct flb_http_server *session)
     }
 
     for (index = 0; index < runtime->worker_count; index++) {
-        runtime->workers[index].should_exit = FLB_TRUE;
+        cfl_atomic_store(&runtime->workers[index].should_exit, FLB_TRUE);
 
         if (runtime->workers[index].thread_created == FLB_TRUE) {
             pthread_join(runtime->workers[index].thread, NULL);

--- a/tests/internal/http_server.c
+++ b/tests/internal/http_server.c
@@ -14,12 +14,16 @@
 #include "flb_tests_internal.h"
 
 #define TEST_HTTP_SERVER_HOST "127.0.0.1"
+#define TEST_HTTP_SERVER_WORKERS 2
 
 struct test_http_server_context {
     pthread_mutex_t lock;
     int init_calls;
     int exit_calls;
     int request_calls;
+    int exit_thread_mismatches;
+    struct flb_http_server *initialized_servers[TEST_HTTP_SERVER_WORKERS];
+    pthread_t initialized_threads[TEST_HTTP_SERVER_WORKERS];
 };
 
 
@@ -38,11 +42,15 @@ static int test_http_server_worker_init(struct flb_http_server *server, void *da
 {
     struct test_http_server_context *context;
 
-    (void) server;
-
     context = data;
 
     pthread_mutex_lock(&context->lock);
+
+    if (context->init_calls < TEST_HTTP_SERVER_WORKERS) {
+        context->initialized_servers[context->init_calls] = server;
+        context->initialized_threads[context->init_calls] = pthread_self();
+    }
+
     context->init_calls++;
     pthread_mutex_unlock(&context->lock);
 
@@ -51,13 +59,28 @@ static int test_http_server_worker_init(struct flb_http_server *server, void *da
 
 static int test_http_server_worker_exit(struct flb_http_server *server, void *data)
 {
+    int index;
+    int matching_thread;
     struct test_http_server_context *context;
 
-    (void) server;
-
     context = data;
+    matching_thread = FLB_FALSE;
 
     pthread_mutex_lock(&context->lock);
+
+    for (index = 0; index < context->init_calls &&
+                    index < TEST_HTTP_SERVER_WORKERS; index++) {
+        if (context->initialized_servers[index] == server &&
+            pthread_equal(context->initialized_threads[index], pthread_self())) {
+            matching_thread = FLB_TRUE;
+            break;
+        }
+    }
+
+    if (matching_thread == FLB_FALSE) {
+        context->exit_thread_mismatches++;
+    }
+
     context->exit_calls++;
     pthread_mutex_unlock(&context->lock);
 
@@ -223,6 +246,67 @@ void test_http_server_managed_worker_contract()
     flb_http_server_destroy(&server);
     test_http_server_context_destroy(&context);
     flb_config_exit(config);
+}
+
+void test_http_server_worker_exit_runs_on_worker_thread()
+{
+    int ret;
+    struct flb_config *config;
+    struct flb_net_setup net_setup;
+    struct flb_http_server server;
+    struct flb_http_server_options options;
+    struct test_http_server_context context;
+
+    ret = test_http_server_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        test_http_server_network_cleanup();
+        return;
+    }
+
+    test_http_server_context_init(&context);
+
+    flb_net_setup_init(&net_setup);
+    flb_http_server_options_init(&options);
+
+    options.protocol_version = HTTP_PROTOCOL_VERSION_AUTODETECT;
+    options.request_callback = test_http_server_request_handler;
+    options.user_data = &context;
+    options.address = (char *) TEST_HTTP_SERVER_HOST;
+    options.port = 0;
+    options.networking_flags = FLB_IO_TCP;
+    options.networking_setup = &net_setup;
+    options.system_context = config;
+    options.workers = TEST_HTTP_SERVER_WORKERS;
+    options.cb_worker_init = test_http_server_worker_init;
+    options.cb_worker_exit = test_http_server_worker_exit;
+
+    ret = flb_http_server_init_with_options(&server, &options);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        ret = flb_http_server_start(&server);
+        TEST_CHECK(ret == 0);
+
+        if (ret == 0) {
+            TEST_CHECK(context.init_calls == TEST_HTTP_SERVER_WORKERS);
+
+            flb_http_server_destroy(&server);
+
+            TEST_CHECK(context.exit_calls == TEST_HTTP_SERVER_WORKERS);
+            TEST_CHECK(context.exit_thread_mismatches == 0);
+        }
+        else {
+            flb_http_server_destroy(&server);
+        }
+    }
+
+    test_http_server_context_destroy(&context);
+    flb_config_exit(config);
+    test_http_server_network_cleanup();
 }
 
 void test_http_server_idle_timeout_applies_to_networking_setup()
@@ -431,6 +515,8 @@ TEST_LIST = {
     { "http_server_options_defaults", test_http_server_options_defaults },
     { "http_server_options_multi_worker_magic", test_http_server_options_multi_worker_magic },
     { "http_server_managed_worker_contract", test_http_server_managed_worker_contract },
+    { "http_server_worker_exit_runs_on_worker_thread",
+      test_http_server_worker_exit_runs_on_worker_thread },
     { "http_server_idle_timeout_applies_to_networking_setup",
       test_http_server_idle_timeout_applies_to_networking_setup },
     { "http_server_explicit_network_timeout_is_preserved",


### PR DESCRIPTION
<!-- Provide summary of changes -->
In our Ci environment, http_server related tasks are sometimes failed with flaky in these days.
So, we need to plug these failures.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for downstream registration/removal by adding proper synchronization to avoid races during startup/shutdown.
  * Hardened HTTP server worker lifecycle: atomic shutdown signaling, safer startup/shutdown ordering, and more robust cleanup to prevent race conditions and leaks.

* **Tests**
  * Added a test ensuring worker exit callbacks run on the same thread that performed worker initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->