### PR TITLE
out_kinesis_streams: increase PUT_RECORDS_PAYLOAD_SIZE to 10MB

### DIFF
--- a/plugins/out_kinesis_streams/kinesis_api.h
+++ b/plugins/out_kinesis_streams/kinesis_api.h
@@ -20,7 +20,7 @@
 #ifndef FLB_OUT_KINESIS_API
 #define FLB_OUT_KINESIS_API
 
-#define PUT_RECORDS_PAYLOAD_SIZE         5242880
+#define PUT_RECORDS_PAYLOAD_SIZE         10485760
 #define MAX_EVENTS_PER_PUT               500
 #define MAX_EVENT_SIZE                   1048556 /* 1048576 - 20 bytes for partition key */
 #define MAX_B64_EVENT_SIZE               1398076 /* ceil(1048556 / 3) * 4 */

--- a/tests/runtime/out_kinesis.c
+++ b/tests/runtime/out_kinesis.c
@@ -5,6 +5,9 @@
 /* Test data */
 #include "data/td/json_td.h" /* JSON_TD */
 
+/* Kinesis Streams API constants */
+#include "../../plugins/out_kinesis_streams/kinesis_api.h"
+
 #define ERROR_THROUGHPUT "{\"__type\":\"ServiceUnavailableException\"}"
 /* not a real error code, but tests that the code can respond to any error */
 #define ERROR_UNKNOWN "{\"__type\":\"UNKNOWN\"}"
@@ -595,6 +598,159 @@ void flb_test_kinesis_compression_snappy_with_aggregation(void)
     flb_destroy(ctx);
 }
 
+/*
+ * Helper function to create a log-event record in [timestamp, {"message":"..."}]
+ * format with a message payload of the specified target_json_size.
+ * target_json_size is the desired size of the inner JSON object {"message":"..."}.
+ * Returns a malloc'd string the caller must free, and sets *out_len.
+ */
+static char* create_large_log_event(size_t target_json_size, size_t *out_len)
+{
+    const char *prefix = "[1, {\"message\":\"";
+    const char *suffix = "\"}]";
+    size_t prefix_len = strlen(prefix);
+    size_t suffix_len = strlen(suffix);
+    size_t json_prefix_len = strlen("{\"message\":\"");
+    size_t json_suffix_len = strlen("\"}");
+    size_t json_overhead = json_prefix_len + json_suffix_len;
+    size_t fill_size;
+    size_t total_len;
+    char *record;
+
+    if (target_json_size < json_overhead + 1) {
+        return NULL;
+    }
+
+    fill_size = target_json_size - json_overhead;
+    total_len = prefix_len + fill_size + suffix_len;
+
+    record = flb_malloc(total_len + 1);
+    if (!record) {
+        return NULL;
+    }
+
+    memcpy(record, prefix, prefix_len);
+    memset(record + prefix_len, 'A', fill_size);
+    memcpy(record + prefix_len + fill_size, suffix, suffix_len);
+    record[total_len] = '\0';
+
+    *out_len = total_len;
+    return record;
+}
+
+/* Helper to setup and run a Kinesis Streams test with custom record data */
+static void run_kinesis_test_with_data(char *data, size_t data_len)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    setenv("FLB_KINESIS_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "kinesis_streams", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd, "stream", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "Retry_Limit", "1", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    if (data) {
+        flb_lib_push(ctx, in_ffd, data, data_len);
+    }
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Test event size just under the maximum allowed limit (should succeed).
+ * MAX_EVENT_SIZE is 1048556 (1 MiB - 20 bytes for partition key).
+ * The plugin discards when (written + 1) >= MAX_EVENT_SIZE, so the maximum
+ * accepted JSON size is MAX_EVENT_SIZE - 2.
+ */
+void flb_test_kinesis_event_size_at_limit(void)
+{
+    char *record;
+    size_t record_len;
+
+    record = create_large_log_event(MAX_EVENT_SIZE - 2, &record_len);
+    TEST_CHECK(record != NULL);
+
+    if (record) {
+        run_kinesis_test_with_data(record, record_len);
+        flb_free(record);
+    }
+}
+
+/*
+ * Test event size exceeding limit (should be discarded by the plugin).
+ * The plugin logs a warning and drops the record without crashing.
+ */
+void flb_test_kinesis_event_size_over_limit(void)
+{
+    char *record;
+    size_t record_len;
+
+    record = create_large_log_event(MAX_EVENT_SIZE + 100, &record_len);
+    TEST_CHECK(record != NULL);
+
+    if (record) {
+        run_kinesis_test_with_data(record, record_len);
+        flb_free(record);
+    }
+}
+
+/*
+ * Test event with backslash escape sequences near the size boundary.
+ * Validates the plugin handles special characters correctly when the
+ * record exceeds the limit.
+ */
+void flb_test_kinesis_event_size_with_backslash(void)
+{
+    char *record;
+    size_t record_len;
+    size_t prefix_len = strlen("[1, {\"message\":\"");
+    size_t suffix_len = strlen("\"}]");
+    size_t fill_size;
+    size_t boundary;
+    size_t i;
+
+    record = create_large_log_event(MAX_EVENT_SIZE + 100, &record_len);
+    TEST_CHECK(record != NULL);
+
+    if (record) {
+        fill_size = record_len - prefix_len - suffix_len;
+
+        /* Replace pairs of characters with valid escape sequence "\\" */
+        for (i = 98; i < fill_size - 1; i += 100) {
+            record[prefix_len + i] = '\\';
+            record[prefix_len + i + 1] = '\\';
+        }
+
+        /* Ensure a backslash pair is near the MAX_EVENT_SIZE boundary */
+        boundary = MAX_EVENT_SIZE - 1;
+        if (boundary + 1 < record_len - suffix_len) {
+            record[boundary] = '\\';
+            record[boundary + 1] = '\\';
+        }
+
+        run_kinesis_test_with_data(record, record_len);
+        flb_free(record);
+    }
+}
+
 /* Test list */
 TEST_LIST = {
     {"success", flb_test_firehose_success },
@@ -613,5 +769,8 @@ TEST_LIST = {
     {"compression_zstd", flb_test_kinesis_compression_zstd },
     {"compression_snappy", flb_test_kinesis_compression_snappy },
     {"compression_snappy_with_aggregation", flb_test_kinesis_compression_snappy_with_aggregation },
+    {"event_size_at_limit", flb_test_kinesis_event_size_at_limit },
+    {"event_size_over_limit", flb_test_kinesis_event_size_over_limit },
+    {"event_size_with_backslash", flb_test_kinesis_event_size_with_backslash },
     {NULL, NULL}
 };


### PR DESCRIPTION
- Increase size from 5MB -> 10MB to match recent changes with PutRecords API

Kinesis Streams [PutRecords API](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html) change in 2025 to support events up to 10MB ([ref](https://aws.amazon.com/blogs/big-data/amazon-kinesis-data-streams-now-supports-10x-larger-record-sizes-simplifying-real-time-data-processing/)) while our defaults reflect the older value 1MB.

Add runtime tests to validate the new limit:

event_size_near_limit: Validates events just under 10MB are accepted
event_size_at_aws_max: Validates events near AWS max are discarded (existing behavior)
event_truncation_with_backslash: Validates backslash handling at truncation boundary

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Logs: https://gist.github.com/ShelbyZ/0c8d005d39ddc8759cf6b77d7dc90dc5

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased Kinesis output plugin maximum payload size from 5 MB to 10 MB.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->