### PR TITLE
tests: internal: fuzzers: avoid destroying active input fuzzer tasks

### DIFF
--- a/tests/internal/fuzzers/input_fuzzer.c
+++ b/tests/internal/fuzzers/input_fuzzer.c
@@ -56,8 +56,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data3, size_t size3)
         return 0;
     }
     /* Set fuzzer-malloc chance of failure */
+#ifdef FLB_HAVE_TESTS_OSSFUZZ
     flb_malloc_p = 0;
     flb_malloc_mod = 25000;
+#endif
     char *input_buffer1 = get_null_terminated(30, &data3, &size3);
     if (input_buffer1 == NULL) {
         return 0;
@@ -66,15 +68,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *data3, size_t size3)
 
     char *input_buffer2 = get_null_terminated(10, &data3, &size3);
     if (input_buffer2 == NULL) {
+        flb_free(input_buffer1);
         return 0;
     }
-    size_t input_buffer_len2 = strlen(input_buffer2);
 
     char *input_buffer3 = get_null_terminated(10, &data3, &size3);
     if (input_buffer3 == NULL) {
+        flb_free(input_buffer1);
+        flb_free(input_buffer2);
         return 0;
     }
-    size_t input_buffer_len3 = strlen(input_buffer3);       
+
     /* Create context, flush every second (some checks omitted here) */
     ctx = flb_create();
 
@@ -145,6 +149,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data3, size_t size3)
     /* FORCE clean up test tasks */
     mk_list_foreach_safe(head, tmp, &i_ins->tasks) {
         task = mk_list_entry(head, struct flb_task, _head);
+        if (task->users != 0 ||
+            mk_list_size(&task->retries) != 0 ||
+            mk_list_size(&task->routes) != 0) {
+            continue;
+        }
+
         flb_info("[task] cleanup test task");
         flb_task_destroy(task, FLB_TRUE);
     }
@@ -152,6 +162,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data3, size_t size3)
     /* clean up test chunks */
     mk_list_foreach_safe(head, tmp, &i_ins->chunks) {
         ic = mk_list_entry(head, struct flb_input_chunk, _head);
+        if (ic->task != NULL) {
+            continue;
+        }
+
         flb_input_chunk_destroy(ic, FLB_TRUE);
     }
     flb_free(input_buffer1);
@@ -161,4 +175,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data3, size_t size3)
     flb_time_msleep(200);
     flb_stop(ctx);
     flb_destroy(ctx);
+
+    return 0;
 }


### PR DESCRIPTION
Fix the input fuzzer teardown path so it does not force-destroy tasks or chunks that are still owned by the engine.

The OSS-Fuzz crash was caused by the harness destroying active tasks while output completion events were still pending. That cleared the task map entry, and the engine later dereferenced the missing task from `handle_output_event()`.

This keeps the forced cleanup limited to idle test tasks with no users, retries, or routes, and skips chunks still attached to a task.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Conditional failure simulation now only enabled in the OSS-Fuzz test build.
  * Added allocation and validation for an additional fuzz-derived input buffer.
  * Safer cleanup: skip destroying tasks or chunks that are still in use or referenced.
  * Ensure the fuzz entry point returns a defined success value after teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->