### PR TITLE
in_forward: validate array size before accessing message mode fields

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1488,6 +1488,14 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                 /*
                  * Forward format 2 (message mode) : [tag, time, map, ...]
                  */
+                if (root.via.array.size < 3) {
+                    flb_plg_warn(ctx->ins,
+                                 "message mode requires at least 3 elements");
+                    msgpack_unpacked_destroy(&result);
+                    msgpack_unpacker_free(unp);
+                    flb_sds_destroy(out_tag);
+                    return -1;
+                }
                 map = root.via.array.ptr[2];
                 if (map.type != MSGPACK_OBJECT_MAP) {
                     flb_plg_warn(ctx->ins, "invalid data format, map expected");


### PR DESCRIPTION
The forward protocol parser accesses root.via.array.ptr[2] when the
second element is a positive integer or EXT type (message mode), but
only checks that the array has at least 2 elements. A 2-element array
[tag, integer] passes the size check but causes an out-of-bounds heap
read when accessing index 2.

Add a size >= 3 check before the message mode branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message validation and error handling to gracefully detect and reject malformed or too-short incoming messages, log a warning, release parsing resources, and avoid out-of-bounds processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->