### PR TITLE
in_syslog: fix integer overflow in octet-counting length parser

### DIFF
--- a/plugins/in_syslog/syslog_prot.c
+++ b/plugins/in_syslog/syslog_prot.c
@@ -240,7 +240,7 @@ int syslog_prot_process(struct syslog_conn *conn)
                 char *sp = p;
                 size_t n = 0;
                 while (sp < end && *sp >= '0' && *sp <= '9') {
-                    if (n > SIZE_MAX / 10) {
+                    if (n >= SIZE_MAX / 10) {
                         n = SIZE_MAX;
                         break;
                     }


### PR DESCRIPTION
The overflow guard uses strict greater-than (n > SIZE_MAX / 10) which
misses the boundary case where n equals SIZE_MAX / 10 exactly. When
n = 1844674407370955161 (SIZE_MAX / 10 on 64-bit), the subsequent
n * 10 + digit overflows to a small value (0-5). This sets
frame_expected_len to 0, which permanently corrupts the connection
state: frame_have_len stays set while frame_expected_len is 0,
causing all subsequent messages to be silently discarded.

Change the guard to >= so that the boundary value is also clamped to
SIZE_MAX before the multiplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the boundary condition used during RFC 6587 octet-counting frame length parsing. This refines overflow handling for very large length values, improving stability and reducing the chance of incorrect length interpretation in extreme cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->