### PR TITLE
in_mqtt: fix OOB read from hardcoded remaining length overhead

### DIFF
--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -416,7 +416,7 @@ int mqtt_prot_parser(struct mqtt_conn *conn)
                     return MQTT_ERROR;
                 }
 
-                if (length + 2 > (conn->buf_len - pos)) {
+                if (length + (conn->buf_pos - pos + 1) > (conn->buf_len - pos)) {
                     conn->buf_pos = pos;
                     flb_plg_trace(ctx->ins, "[fd=%i] Need more data",
                                   conn->connection->fd);
@@ -424,7 +424,7 @@ int mqtt_prot_parser(struct mqtt_conn *conn)
                 }
 
                 if ((BUFC() & 128) == 0) {
-                    if (conn->buf_len - 2 < length) {
+                    if (conn->buf_len - (conn->buf_pos - pos + 1) < length) {
                         conn->buf_pos = pos;
                         flb_plg_trace(ctx->ins, "[fd=%i] Need more data",
                                       conn->connection->fd);


### PR DESCRIPTION
The MQTT packet parser used hardcoded +2/-2 to account for the fixed
header size (1 type byte + 1 remaining-length byte). This is only
correct when the remaining length fits in a single byte (0-127).
For remaining lengths 128+, the encoding uses 2-4 bytes, making the
actual overhead 3-5 bytes. Replace the constant with the computed
header size (buf_pos - pos + 1) so the bounds checks account for the
actual number of remaining-length bytes consumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT message parsing reliability by fixing buffer-availability checks used during length decoding.
  * Prevents premature parsing of incomplete packets and ensures the parser correctly requests more data for partial messages, reducing errors and stream-processing interruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->