### PR TITLE
zstd: add 100 MB decompression size limit

### DIFF
--- a/src/flb_zstd.c
+++ b/src/flb_zstd.c
@@ -28,7 +28,8 @@ struct flb_zstd_decompression_context {
     ZSTD_DCtx *dctx;
 };
 
-#define FLB_ZSTD_DEFAULT_CHUNK 64 * 1024  /* 64 KB buffer */
+#define FLB_ZSTD_DEFAULT_CHUNK      (64 * 1024)       /* 64 KB buffer */
+#define FLB_ZSTD_DECOMPRESS_MAX     (100 * 1024 * 1024)  /* 100 MB limit */
 
 int flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len)
 {
@@ -105,6 +106,12 @@ static int zstd_uncompress_unknown_size(void *in_data, size_t in_len, void **out
         /* check if we need more space */
         if (output.pos == out_size) {
             out_size *= 2;
+            if (out_size > FLB_ZSTD_DECOMPRESS_MAX) {
+                flb_error("[zstd] maximum decompression size reached (~100 MB)");
+                flb_free(buf);
+                ZSTD_freeDCtx(dctx);
+                return -1;
+            }
             tmp = flb_realloc(buf, out_size);
             if (!tmp) {
                 flb_errno();
@@ -144,6 +151,12 @@ int flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *o
     else if (size == ZSTD_CONTENTSIZE_UNKNOWN) {
         ret = zstd_uncompress_unknown_size(in_data, in_len, out_data, out_len);
         return ret;
+    }
+
+    if (size > FLB_ZSTD_DECOMPRESS_MAX) {
+        flb_error("[zstd] maximum decompression size is %d bytes",
+                  FLB_ZSTD_DECOMPRESS_MAX);
+        return -1;
     }
 
     buf = flb_malloc(size);

--- a/src/flb_zstd.c
+++ b/src/flb_zstd.c
@@ -105,12 +105,15 @@ static int zstd_uncompress_unknown_size(void *in_data, size_t in_len, void **out
 
         /* check if we need more space */
         if (output.pos == out_size) {
-            out_size *= 2;
-            if (out_size > FLB_ZSTD_DECOMPRESS_MAX) {
+            if (out_size >= FLB_ZSTD_DECOMPRESS_MAX) {
                 flb_error("[zstd] maximum decompression size reached (~100 MB)");
                 flb_free(buf);
                 ZSTD_freeDCtx(dctx);
                 return -1;
+            }
+            out_size *= 2;
+            if (out_size > FLB_ZSTD_DECOMPRESS_MAX) {
+                out_size = FLB_ZSTD_DECOMPRESS_MAX;
             }
             tmp = flb_realloc(buf, out_size);
             if (!tmp) {


### PR DESCRIPTION
The gzip decompressor limits output to 100 MB but the zstd
decompressor has no such cap. A small zstd-compressed payload with
a high compression ratio can expand to gigabytes, exhausting memory
and causing the process to be OOM-killed.

Add FLB_ZSTD_DECOMPRESS_MAX (100 MB) matching the gzip limit,
checked in both the known-size path (ZSTD_getFrameContentSize) and
the streaming path (zstd_uncompress_unknown_size).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 100 MB maximum decompression size to ZSTD handling to prevent excessive memory use.
  * Decompression now rejects inputs that declare or would expand beyond the size limit.
  * Both streaming and frame-based decompression paths enforce this cap for improved stability and safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->