### PR TITLE
snappy: fix OOB reads in framed data parser

### DIFF
--- a/src/flb_snappy.c
+++ b/src/flb_snappy.c
@@ -175,8 +175,9 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
 
         frame_type    = *((uint8_t *) &frame_buffer[0]);
 
-        frame_length  = *((uint32_t *) &frame_buffer[1]);
-        frame_length &= 0x00FFFFFF;
+        frame_length  = ((uint32_t)((unsigned char) frame_buffer[1]))       |
+                        ((uint32_t)((unsigned char) frame_buffer[2]) << 8)  |
+                        ((uint32_t)((unsigned char) frame_buffer[3]) << 16);
 
         frame_body    = &frame_buffer[4];
 

--- a/src/flb_snappy.c
+++ b/src/flb_snappy.c
@@ -166,6 +166,11 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
     offset = 0;
 
     while (offset < in_len && result == 0) {
+        if (offset + 4 > in_len) {
+            result = -2;
+            break;
+        }
+
         frame_buffer = &in_data[offset];
 
         frame_type    = *((uint8_t *) &frame_buffer[0]);
@@ -176,6 +181,9 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
         frame_body    = &frame_buffer[4];
 
         if (frame_length > FLB_SNAPPY_FRAME_SIZE_LIMIT) {
+            result = -2;
+        }
+        else if (offset + 4 + frame_length > in_len) {
             result = -2;
         }
         else if (frame_type == FLB_SNAPPY_FRAME_TYPE_STREAM_IDENTIFIER) {
@@ -192,6 +200,11 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
             }
         }
         else if (frame_type == FLB_SNAPPY_FRAME_TYPE_COMPRESSED_DATA) {
+            if (frame_length < sizeof(uint32_t)) {
+                result = -2;
+                break;
+            }
+
             chunk = (struct flb_snappy_data_chunk * ) \
                         flb_calloc(1, sizeof(struct flb_snappy_data_chunk));
 
@@ -234,6 +247,11 @@ int flb_snappy_uncompress_framed_data(char *in_data, size_t in_len,
             }
         }
         else if (frame_type == FLB_SNAPPY_FRAME_TYPE_UNCOMPRESSED_DATA) {
+            if (frame_length < sizeof(uint32_t)) {
+                result = -2;
+                break;
+            }
+
             chunk = (struct flb_snappy_data_chunk *) \
                         flb_calloc(1, sizeof(struct flb_snappy_data_chunk));
 


### PR DESCRIPTION
The snappy framed data parser has two issues:

1. The loop reads a 4-byte frame header without checking that 4 bytes
   are available. When 1-3 bytes remain after the last valid frame,
   the uint32_t read at frame_buffer[1] extends past the buffer.
   Also missing a check that the full frame body (offset + 4 +
   frame_length) fits within the input.

2. Both compressed and uncompressed data paths subtract sizeof(uint32_t)
   from frame_length for the checksum without checking frame_length >= 4.
   When frame_length < 4, the subtraction wraps to a huge size_t value
   on 64-bit, causing flb_snappy_uncompress() or memcpy() to read far
   past the buffer.

Add bounds checks for the frame header read, total frame extent, and
minimum frame_length before the checksum subtraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when reading framed compressed data to avoid crashes or incorrect behavior with malformed or truncated inputs; the parser now detects incomplete or undersized frames (including missing checksum/header) and stops parsing, returning an error to prevent unsafe reads and improve stability when handling compressed payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->