### PR TITLE
in_elasticsearch: check map size before accessing first entry

### DIFF
--- a/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
+++ b/plugins/in_elasticsearch/in_elasticsearch_bulk_prot.c
@@ -73,6 +73,10 @@ static int get_write_op(struct flb_in_elasticsearch *ctx, msgpack_object *map, f
     msgpack_object key;
     int check = FLB_FALSE;
 
+    if (map->via.map.size == 0) {
+        return FLB_FALSE;
+    }
+
     kv = map->via.map.ptr;
     key = kv[0].key;
     if (key.type == MSGPACK_OBJECT_BIN) {


### PR DESCRIPTION
get_write_op() accesses kv[0] without checking that the map has at
least one entry. When the bulk API receives an empty JSON object {}
as the meta line, msgpack unpacks it as a map with size 0 and the
kv[0] access reads past the map allocation.

Add an early return when map size is zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or malformed data in the Elasticsearch plugin to prevent errors during processing.
  * Reduces risk of crashes or failed writes when encountering unexpected empty inputs, improving overall stability and reliability.
  * Enhances robustness of data ingestion so operations continue smoothly when edge-case payloads are received.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->