### PR TITLE
kafka: use rd_kafka_conf_destroy in flb_kafka_conf_create error path

### DIFF
--- a/src/flb_kafka.c
+++ b/src/flb_kafka.c
@@ -95,7 +95,7 @@ rd_kafka_conf_t *flb_kafka_conf_create(struct flb_kafka *kafka,
 
 err:
     if (kafka_cfg) {
-        flb_free(kafka_cfg);
+        rd_kafka_conf_destroy(kafka_cfg);
     }
     return NULL;
 }


### PR DESCRIPTION
`flb_kafka_conf_create` leaks memory when it hits the error path (e.g. missing `brokers` config). code calls `flb_free(kafka_cfg)` on the `rd_kafka_conf_t*` from `rd_kafka_conf_new()`, which skips `rd_kafka_anyconf_destroy()` and leaves all internal strings (default props, client.id, group.id) hanging in memory.

one-line fix: swap `flb_free` for `rd_kafka_conf_destroy`. every other caller in the codebase already does this (`in_kafka.c:459`, `out_kafka/kafka_config.c:255,320`).

How to repro: configure a kafka output without brokers and run under valgrind:

```
[OUTPUT]
    name  kafka
    topic test
```

valgrind will show leaks from rd_kafka_conf_set allocations that never get freed on teardown.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change (above)
- [N/A] Debug log output from testing the change
- [ ] Attached Valgrind output that shows no leaks or memory corruption was found

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error handling in Kafka initialization to ensure proper cleanup of configuration resources when startup fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->