### PR TITLE
aws: compression: arrow: Set up proper block size [Backport to 4.2]

### DIFF
--- a/src/aws/compression/arrow/compress.c
+++ b/src/aws/compression/arrow/compress.c
@@ -15,6 +15,20 @@
 #include <fluent-bit/flb_mem.h>
 #include <inttypes.h>
 
+static int choose_block_size(size_t size)
+{
+    int block_size = 8 * 1024 * 1024;
+
+    while ((size_t) block_size <= size) {
+        block_size *= 2;
+        if (block_size > 64 * 1024 * 1024) {
+            return 64 * 1024 * 1024;
+        }
+    }
+
+    return block_size;
+}
+
 /*
  * GArrowTable is the central structure that represents "table" (a.k.a.
  * data frame).
@@ -45,6 +59,10 @@ static GArrowTable* parse_json(uint8_t *json, int size)
             g_object_unref(input);
             return NULL;
         }
+
+        g_object_set(options,
+                     "block-size", choose_block_size(size),
+                     NULL);
 
         reader = garrow_json_reader_new(GARROW_INPUT_STREAM(input), options, &error);
         if (reader == NULL) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11640.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
