### PR TITLE
network: Handle braketed ipv6 addresses [backport to 4.2]

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -1648,18 +1648,38 @@ flb_sockfd_t flb_net_server(const char *port, const char *listen_addr,
 {
     flb_sockfd_t fd = -1;
     int ret;
+    size_t listen_addr_len;
     struct addrinfo hints;
     struct addrinfo *res, *rp;
+    const char *normalized_listen_addr;
+    char *listen_addr_copy;
+
+    listen_addr_copy = NULL;
+    normalized_listen_addr = listen_addr;
+
+    if (listen_addr != NULL && listen_addr[0] == '[') {
+        listen_addr_len = strlen(listen_addr);
+
+        if (listen_addr_len >= 3 && listen_addr[listen_addr_len - 1] == ']') {
+            listen_addr_copy = flb_strndup(listen_addr + 1, listen_addr_len - 2);
+            if (listen_addr_copy != NULL) {
+                normalized_listen_addr = listen_addr_copy;
+            }
+        }
+    }
 
     memset(&hints, 0, sizeof hints);
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = AI_PASSIVE;
 
-    ret = getaddrinfo(listen_addr, port, &hints, &res);
+    ret = getaddrinfo(normalized_listen_addr, port, &hints, &res);
     if (ret != 0) {
         flb_warn("net_server: getaddrinfo(listen='%s:%s'): %s",
                  listen_addr, port, gai_strerror(ret));
+        if (listen_addr_copy != NULL) {
+            flb_free(listen_addr_copy);
+        }
         return -1;
     }
 
@@ -1687,6 +1707,10 @@ flb_sockfd_t flb_net_server(const char *port, const char *listen_addr,
     }
     freeaddrinfo(res);
 
+    if (listen_addr_copy != NULL) {
+        flb_free(listen_addr_copy);
+    }
+
     if (rp == NULL) {
         return -1;
     }
@@ -1698,18 +1722,38 @@ flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr, int s
 {
     flb_sockfd_t fd = -1;
     int ret;
+    size_t listen_addr_len;
     struct addrinfo hints;
     struct addrinfo *res, *rp;
+    const char *normalized_listen_addr;
+    char *listen_addr_copy;
+
+    listen_addr_copy = NULL;
+    normalized_listen_addr = listen_addr;
+
+    if (listen_addr != NULL && listen_addr[0] == '[') {
+        listen_addr_len = strlen(listen_addr);
+
+        if (listen_addr_len >= 3 && listen_addr[listen_addr_len - 1] == ']') {
+            listen_addr_copy = flb_strndup(listen_addr + 1, listen_addr_len - 2);
+            if (listen_addr_copy != NULL) {
+                normalized_listen_addr = listen_addr_copy;
+            }
+        }
+    }
 
     memset(&hints, 0, sizeof hints);
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags = AI_PASSIVE;
 
-    ret = getaddrinfo(listen_addr, port, &hints, &res);
+    ret = getaddrinfo(normalized_listen_addr, port, &hints, &res);
     if (ret != 0) {
         flb_warn("net_server_udp: getaddrinfo(listen='%s:%s'): %s",
                  listen_addr, port, gai_strerror(ret));
+        if (listen_addr_copy != NULL) {
+            flb_free(listen_addr_copy);
+        }
         return -1;
     }
 
@@ -1733,6 +1777,10 @@ flb_sockfd_t flb_net_server_udp(const char *port, const char *listen_addr, int s
         break;
     }
     freeaddrinfo(res);
+
+    if (listen_addr_copy != NULL) {
+        flb_free(listen_addr_copy);
+    }
 
     if (rp == NULL) {
         return -1;

--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -13,6 +13,7 @@
 
 #define TEST_HOSTv4           "127.0.0.1"
 #define TEST_HOSTv6           "::1"
+#define TEST_HOSTv6_BRACKETED "[::1]"
 #define TEST_PORT             "41322"
 
 #define TEST_EV_CLIENT        MK_EVENT_NOTIFICATION
@@ -159,8 +160,30 @@ void test_ipv6_client_server()
     test_client_server(FLB_TRUE);
 }
 
+void test_ipv6_bracketed_listen()
+{
+    flb_sockfd_t fd_server;
+
+    errno = 0;
+    fd_server = flb_net_server(TEST_PORT, TEST_HOSTv6_BRACKETED,
+                               FLB_NETWORK_DEFAULT_BACKLOG_SIZE,
+                               FLB_FALSE);
+
+    if (fd_server == -1 && errno == EAFNOSUPPORT) {
+        TEST_MSG("This protocol is not supported in this platform");
+        return;
+    }
+
+    TEST_CHECK(fd_server != -1);
+
+    if (fd_server != -1) {
+        flb_socket_close(fd_server);
+    }
+}
+
 TEST_LIST = {
     { "ipv4_client_server", test_ipv4_client_server},
     { "ipv6_client_server", test_ipv6_client_server},
+    { "ipv6_bracketed_listen", test_ipv6_bracketed_listen},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

backporting of https://github.com/fluent/fluent-bit/pull/11676.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
