### PR TITLE
parser: Address wrong assignments of timezone at midnight [Backport to 4.2]

### DIFF
--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -1199,7 +1199,12 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
             time_now = now;
         }
 
-        gmtime_r(&time_now, &tmy);
+        if (parser->time_system_timezone == FLB_TRUE) {
+            localtime_r(&time_now, &tmy);
+        }
+        else {
+            gmtime_r(&time_now, &tmy);
+        }
 
         /* Make the timestamp default to today */
         tm->tm.tm_mon = tmy.tm_mon;

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -517,12 +517,84 @@ void test_mysql_unquoted()
 
 }
 
+void test_parser_time_system_timezone_midnight()
+{
+    int ret;
+    time_t now;
+    time_t epoch;
+    struct tm now_tm;
+    struct tm expected_tm;
+    struct flb_tm tm;
+    double ns;
+    char *orig_tz;
+    struct flb_parser *parser;
+    struct flb_config *config;
+
+    orig_tz = getenv("TZ");
+    if (orig_tz != NULL) {
+        orig_tz = flb_strdup(orig_tz);
+    }
+
+    setenv("TZ", "Europe/Stockholm", 1);
+    tzset();
+
+    memset(&now_tm, 0, sizeof(struct tm));
+    now_tm.tm_year = 2025 - 1900;
+    now_tm.tm_mon = 3;
+    now_tm.tm_mday = 15;
+    now_tm.tm_hour = 0;
+    now_tm.tm_min = 30;
+    now_tm.tm_sec = 0;
+    now_tm.tm_isdst = -1;
+    now = mktime(&now_tm);
+    TEST_CHECK(now != (time_t) -1);
+
+    config = flb_config_init();
+    parser = flb_parser_create("time_only_tz", "regex", "^(?<time>.*)$",
+                               FLB_FALSE, "%H:%M:%S", "time",
+                               NULL, FLB_FALSE, FLB_TRUE, FLB_TRUE,
+                               FLB_FALSE, NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    memset(&tm, 0, sizeof(struct flb_tm));
+    ret = flb_parser_time_lookup("00:01:00", strlen("00:01:00"), now,
+                                 parser, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(ns == 0);
+
+    memset(&expected_tm, 0, sizeof(struct tm));
+    expected_tm.tm_year = 2025 - 1900;
+    expected_tm.tm_mon = 3;
+    expected_tm.tm_mday = 15;
+    expected_tm.tm_hour = 0;
+    expected_tm.tm_min = 1;
+    expected_tm.tm_sec = 0;
+    expected_tm.tm_isdst = -1;
+    epoch = mktime(&expected_tm);
+    TEST_CHECK(epoch != (time_t) -1);
+    TEST_CHECK(epoch == flb_parser_tm2time(&tm, FLB_TRUE));
+
+    if (orig_tz != NULL) {
+        setenv("TZ", orig_tz, 1);
+        flb_free(orig_tz);
+    }
+    else {
+        unsetenv("TZ");
+    }
+    tzset();
+
+    flb_parser_destroy(parser);
+    flb_parser_exit(config);
+    flb_config_exit(config);
+}
+
 
 TEST_LIST = {
     { "tzone_offset", test_parser_tzone_offset},
     { "time_lookup", test_parser_time_lookup},
     { "json_time_lookup", test_json_parser_time_lookup},
     { "regex_time_lookup", test_regex_parser_time_lookup},
+    { "time_system_timezone_midnight", test_parser_time_system_timezone_midnight},
     { "mysql_unquoted" , test_mysql_unquoted },
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11677.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
