### PR TITLE
out_influxdb: plug tag keys failure on out influxdb [Backport to 4.2]

### DIFF
--- a/plugins/out_influxdb/influxdb.c
+++ b/plugins/out_influxdb/influxdb.c
@@ -686,7 +686,7 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "tag_keys", NULL,
+     FLB_CONFIG_MAP_STR, "tag_keys", NULL,
      0, FLB_FALSE, 0,
      "Space separated list of keys that needs to be tagged."
     },

--- a/tests/runtime/out_influxdb.c
+++ b/tests/runtime/out_influxdb.c
@@ -170,6 +170,61 @@ static void cb_check_negative_int_as_float_value(
     flb_free(out);
 }
 
+#define JSON_TAG_KEYS "[12345678, {\"ldap_server\":\"host1\", \"client_ip\":\"10.0.0.1\", \"dn\":\"uid=jdoe\", \"value\":1}]"
+static void cb_check_tag_keys(void *ctx, int ffd,
+                              int res_ret, void *res_data, size_t res_size,
+                              void *data)
+{
+    char *p;
+    flb_sds_t out = res_data;
+    char *tag_key_1 = ",ldap_server=host1";
+    char *tag_key_2 = ",client_ip=10.0.0.1";
+    char *tag_key_3 = ",dn=uid\\=jdoe";
+    char *field_key = "value=1";
+    char *missing_field_1 = "ldap_server=\"host1\"";
+    char *missing_field_2 = "client_ip=\"10.0.0.1\"";
+    char *missing_field_3 = "dn=\"uid\\=jdoe\"";
+
+    set_output_num(1);
+
+    p = strstr(out, tag_key_1);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    p = strstr(out, tag_key_2);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    p = strstr(out, tag_key_3);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    p = strstr(out, field_key);
+    if (!TEST_CHECK(p != NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    p = strstr(out, missing_field_1);
+    if (!TEST_CHECK(p == NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    p = strstr(out, missing_field_2);
+    if (!TEST_CHECK(p == NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    p = strstr(out, missing_field_3);
+    if (!TEST_CHECK(p == NULL)) {
+      TEST_MSG("Given:%s", out);
+    }
+
+    flb_free(out);
+}
+
 void flb_test_basic()
 {
     int ret;
@@ -470,6 +525,51 @@ void flb_test_negative_integer_as_float_value()
     flb_destroy(ctx);
 }
 
+void flb_test_tag_keys()
+{
+    int ret;
+    int size = sizeof(JSON_TAG_KEYS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    clear_output_num();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "influxdb", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "tag_keys", "ldap_server client_ip dn",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_tag_keys,
+                              NULL, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_TAG_KEYS, size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+
+    ret = get_output_num();
+    if (!TEST_CHECK(ret != 0)) {
+        TEST_MSG("no output");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"basic"                  , flb_test_basic },
@@ -478,5 +578,6 @@ TEST_LIST = {
     {"int_negative_integer"   , flb_test_negative_integer_value },
     {"int_integer_as_float"   , flb_test_integer_as_float_value },
     {"int_negative_integer_as_float" , flb_test_negative_integer_as_float_value },
+    {"tag_keys"               , flb_test_tag_keys },
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11722.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
