### PR TITLE
utils: fix integer divide-by-zero on Windows x64 in bytes_to_human_readable_size [Backport to 4.2]

### DIFF
--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -812,8 +812,8 @@ int flb_utils_time_split(const char *time, int *sec, long *nsec)
 void flb_utils_bytes_to_human_readable_size(size_t bytes,
                                             char *out_buf, size_t size)
 {
-    unsigned long i;
-    unsigned long u = 1024;
+    uint64_t i;
+    uint64_t u = 1024;
     static const char *__units[] = {
         "b", "K", "M", "G",
         "T", "P", "E", "Z", "Y", NULL


### PR DESCRIPTION
Backporting of https://github.com/fluent/fluent-bit/pull/11727.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
