### PR TITLE
in_dummy: Use pre_run callback to fix crash path [Backport to 4.2]

### DIFF
--- a/plugins/in_dummy/in_dummy.c
+++ b/plugins/in_dummy/in_dummy.c
@@ -353,10 +353,6 @@ static int in_dummy_init(struct flb_input_instance *in,
 
     flb_input_set_context(in, ctx);
 
-    if (ctx->flush_on_startup) {
-        in_dummy_collect(in, config, ctx);
-    }
-
     ret = flb_input_set_collector_time(in,
                                        in_dummy_collect,
                                        tm.tv_sec,
@@ -370,6 +366,20 @@ static int in_dummy_init(struct flb_input_instance *in,
     ctx->coll_fd = ret;
 
     flb_time_get(&ctx->base_timestamp);
+
+    return 0;
+}
+
+static int in_dummy_pre_run(struct flb_input_instance *in,
+                            struct flb_config *config, void *in_context)
+{
+    struct flb_dummy *ctx;
+
+    ctx = (struct flb_dummy *) in_context;
+
+    if (ctx != NULL && ctx->flush_on_startup) {
+        in_dummy_collect(in, config, in_context);
+    }
 
     return 0;
 }
@@ -475,7 +485,7 @@ struct flb_input_plugin in_dummy_plugin = {
     .name         = "dummy",
     .description  = "Generate dummy data",
     .cb_init      = in_dummy_init,
-    .cb_pre_run   = NULL,
+    .cb_pre_run   = in_dummy_pre_run,
     .cb_collect   = in_dummy_collect,
     .cb_flush_buf = NULL,
     .config_map   = config_map,

--- a/tests/runtime/filter_lua.c
+++ b/tests/runtime/filter_lua.c
@@ -637,6 +637,70 @@ void flb_test_helloworld(void)
     flb_destroy(ctx);
 }
 
+void flb_test_dummy_flush_on_startup(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    int filter_ffd;
+    char *result;
+    struct flb_lib_out_cb cb_data;
+
+    char *script_body = ""
+      "function lua_main(tag, timestamp, record)\n"
+      "    record[\"check\"] = \"checkval\"\n"
+      "    return 2, timestamp, record\n"
+      "end\n";
+
+    clear_output();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", FLUSH_INTERVAL, "grace", "1", NULL);
+
+    cb_data.cb = callback_test;
+    cb_data.data = NULL;
+
+    ret = create_script(script_body, strlen(script_body));
+    TEST_CHECK(ret == 0);
+
+    filter_ffd = flb_filter(ctx, (char *) "lua", NULL);
+    TEST_CHECK(filter_ffd >= 0);
+    ret = flb_filter_set(ctx, filter_ffd,
+                         "Match", "*",
+                         "call", "lua_main",
+                         "script", TMP_LUA_PATH,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+    flb_input_set(ctx, in_ffd, "flush_on_startup", "true", NULL);
+    flb_input_set(ctx, in_ffd, "samples", "1", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "format", "json",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    wait_with_timeout(2000, &output);
+    TEST_CHECK(output != NULL);
+    result = strstr(output, "\"check\":\"checkval\"");
+    TEST_CHECK(result != NULL);
+
+    flb_lib_free(output);
+    delete_script();
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 // https://github.com/fluent/fluent-bit/issues/3343
 void flb_test_type_array_key(void)
 {
@@ -1614,6 +1678,7 @@ void flb_test_group_lua_drop(void)
 
 TEST_LIST = {
     {"hello_world",  flb_test_helloworld},
+    {"dummy_flush_on_startup", flb_test_dummy_flush_on_startup},
     {"append_tag",   flb_test_append_tag},
     {"type_int_key", flb_test_type_int_key},
     {"type_int_key_multi", flb_test_type_int_key_multi},


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backpotring of https://github.com/fluent/fluent-bit/pull/11753.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
