### PR TITLE
out_stackdriver: fix multiple memory leaks and potential corruption

### DIFF
--- a/plugins/out_stackdriver/gce_metadata.c
+++ b/plugins/out_stackdriver/gce_metadata.c
@@ -33,7 +33,7 @@
 
 static int fetch_metadata(struct flb_stackdriver *ctx,
                           struct flb_upstream *upstream, char *uri,
-                          char *payload)
+                          flb_sds_t *payload)
 {
     int ret;
     int ret_code;
@@ -44,21 +44,30 @@ static int fetch_metadata(struct flb_stackdriver *ctx,
     /* If runtime test mode is enabled, add test data */
     if (ctx->ins->test_mode == FLB_TRUE) {
         if (strcmp(uri, FLB_STD_METADATA_PROJECT_ID_URI) == 0) {
-            if (!flb_sds_cat(payload, "fluent-bit-test", 15)) {
+            flb_sds_t tmp;
+            tmp = flb_sds_cat(*payload, "fluent-bit-test", 15);
+            if (!tmp) {
                 return -1;
             }
+            *payload = tmp;
             return 0;
         }
         else if (strcmp(uri, FLB_STD_METADATA_ZONE_URI) == 0) {
-            if (!flb_sds_cat(payload, "projects/0123456789/zones/fluent", 32)) {
+            flb_sds_t tmp;
+            tmp = flb_sds_cat(*payload, "projects/0123456789/zones/fluent", 32);
+            if (!tmp) {
                 return -1;
             }
+            *payload = tmp;
             return 0;
         }
         else if (strcmp(uri, FLB_STD_METADATA_INSTANCE_ID_URI) == 0) {
-            if (!flb_sds_cat(payload, "333222111", 9)) {
+            flb_sds_t tmp;
+            tmp = flb_sds_cat(*payload, "333222111", 9);
+            if (!tmp) {
                 return -1;
             }
+            *payload = tmp;
             return 0;
         }
         return -1;
@@ -93,8 +102,15 @@ static int fetch_metadata(struct flb_stackdriver *ctx,
         /* The request was issued successfully, validate the 'error' field */
         flb_plg_debug(ctx->ins, "HTTP Status=%i", c->resp.status);
         if (c->resp.status == 200) {
-            ret_code = 0;
-            flb_sds_copy(payload, c->resp.payload, c->resp.payload_size);
+            flb_sds_t tmp;
+            tmp = flb_sds_copy(*payload, c->resp.payload, c->resp.payload_size);
+            if (!tmp) {
+                ret_code = -1;
+            }
+            else {
+                *payload = tmp;
+                ret_code = 0;
+            }
         }
         else {
             if (c->resp.payload_size > 0) {
@@ -150,7 +166,7 @@ int gce_metadata_read_token(struct flb_stackdriver *ctx)
     }
     uri = tmp;
 
-    ret = fetch_metadata(ctx, ctx->metadata_u, uri, payload);
+    ret = fetch_metadata(ctx, ctx->metadata_u, uri, &payload);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "can't fetch token from the metadata server");
         flb_sds_destroy(payload);
@@ -180,7 +196,7 @@ int gce_metadata_read_zone(struct flb_stackdriver *ctx)
     flb_sds_t zone = NULL;
 
     ret = fetch_metadata(ctx, ctx->metadata_u, FLB_STD_METADATA_ZONE_URI,
-                         payload);
+                         &payload);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "can't fetch zone from the metadata server");
         flb_sds_destroy(payload);
@@ -226,7 +242,7 @@ int gce_metadata_read_project_id(struct flb_stackdriver *ctx)
     flb_sds_t payload = flb_sds_create_size(4096);
 
     ret = fetch_metadata(ctx, ctx->metadata_u,
-                         FLB_STD_METADATA_PROJECT_ID_URI, payload);
+                         FLB_STD_METADATA_PROJECT_ID_URI, &payload);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "can't fetch project id from the metadata server");
         flb_sds_destroy(payload);
@@ -243,7 +259,7 @@ int gce_metadata_read_instance_id(struct flb_stackdriver *ctx)
     flb_sds_t payload = flb_sds_create_size(4096);
 
     ret = fetch_metadata(ctx, ctx->metadata_u,
-                         FLB_STD_METADATA_INSTANCE_ID_URI, payload);
+                         FLB_STD_METADATA_INSTANCE_ID_URI, &payload);
     if (ret != 0) {
         flb_plg_error(ctx->ins, "can't fetch instance id from the metadata server");
         flb_sds_destroy(payload);

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1164,6 +1164,9 @@ static int pack_resource_labels(struct flb_stackdriver *ctx,
                 } else {
                     flb_plg_warn(ctx->ins, "failed to find a corresponding entry for "
                         "resource label entry [%s=%s]", label_kv->key, label_kv->val);
+                    if (rval) {
+                        flb_ra_key_value_destroy(rval);
+                    }
                 }
                 flb_ra_destroy(ra);
             } else {
@@ -2509,6 +2512,8 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
             if (log_name_extracted == FLB_TRUE) {
                 flb_sds_destroy(log_name);
             }
+
+            destroy_http_request(&http_request);
 
             flb_log_event_decoder_destroy(&log_decoder);
             msgpack_sbuffer_destroy(&mp_sbuf);

--- a/plugins/out_stackdriver/stackdriver_conf.c
+++ b/plugins/out_stackdriver/stackdriver_conf.c
@@ -134,6 +134,9 @@ static int read_credentials_file(const char *cred_file, struct flb_stackdriver *
             ctx->creds->type = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "project_id") == 0) {
+            if (ctx->project_id) {
+                flb_sds_destroy(ctx->project_id);
+            }
             ctx->project_id = flb_sds_create_len(val, val_len);
         }
         else if (key_cmp(key, key_len, "private_key_id") == 0) {


### PR DESCRIPTION
This pull request addresses several memory management issues in the Stackdriver output plugin, fixing potential memory leaks and invalid pointer usage due to SDS string reallocation.

### Changes:

**plugins/out_stackdriver/gce_metadata.c**
*   Updated the `fetch_metadata` function signature to accept a pointer to `flb_sds_t` (`flb_sds_t *payload`). This ensures that if the SDS string is reallocated during `flb_sds_cat` or `flb_sds_copy`, the caller's pointer is correctly updated, preventing the use of invalid pointers.
*   Updated all calls to `fetch_metadata` to pass the address of the payload.
*   Added proper assignment of `flb_sds_cat` and `flb_sds_copy` results back to the payload pointer, including error checks.

**plugins/out_stackdriver/stackdriver.c**
*   **`pack_resource_labels`**: Added missing `flb_ra_key_value_destroy(rval)` when the extracted value object is valid but not of string type, fixing a memory leak.
*   **`stackdriver_format`**: Added missing `destroy_http_request(&http_request)` in an early return path (error case) to prevent leaking resources associated with the HTTP request.

**plugins/out_stackdriver/stackdriver_conf.c**
*   **`read_credentials_file`**: Added cleanup for `ctx->project_id` before it gets overwritten if it was already initialized, preventing a memory leak if duplicate keys exist in the configuration.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory handling in metadata payload assembly to prevent null/invalid writes and ensure fetched metadata is stored reliably.
  * Ensured HTTP request state is cleaned up on error paths to avoid resource leaks.
  * Prevented stale project ID data from persisting across credential reloads by replacing prior values during parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit/pull/11879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->