### PR TITLE
in_forward: handle unpacker allocation failure [Backport to 4.2]

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1089,21 +1089,22 @@ static size_t receiver_recv(struct fw_conn *conn, char *buf, size_t try_size) {
     return actual_size;
 }
 
-static size_t receiver_to_unpacker(struct fw_conn *conn, size_t request_size,
-                                   msgpack_unpacker *unpacker)
+static int receiver_to_unpacker(struct fw_conn *conn, size_t request_size,
+                                msgpack_unpacker *unpacker, size_t *recv_len)
 {
-    size_t recv_len;
+    *recv_len = 0;
 
     /* make sure there's enough room, or expand the unpacker accordingly */
     if (msgpack_unpacker_buffer_capacity(unpacker) < request_size) {
-        msgpack_unpacker_reserve_buffer(unpacker, request_size);
-        assert(msgpack_unpacker_buffer_capacity(unpacker) >= request_size);
+        if (!msgpack_unpacker_reserve_buffer(unpacker, request_size)) {
+            return -1;
+        }
     }
-    recv_len = receiver_recv(conn, msgpack_unpacker_buffer(unpacker),
-                             request_size);
-    msgpack_unpacker_buffer_consumed(unpacker, recv_len);
+    *recv_len = receiver_recv(conn, msgpack_unpacker_buffer(unpacker),
+                              request_size);
+    msgpack_unpacker_buffer_consumed(unpacker, *recv_len);
 
-    return recv_len;
+    return 0;
 }
 
 static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
@@ -1284,11 +1285,26 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
     }
 
     unp = msgpack_unpacker_new(1024);
+    if (!unp) {
+        flb_plg_error(ctx->ins, "could not allocate msgpack unpacker");
+        flb_sds_destroy(out_tag);
+        return -1;
+    }
+
     msgpack_unpacked_init(&result);
     conn->rest = conn->buf_len;
 
     while (1) {
-        recv_len = receiver_to_unpacker(conn, EACH_RECV_SIZE, unp);
+        ret = receiver_to_unpacker(conn, EACH_RECV_SIZE, unp, &recv_len);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "could not allocate msgpack unpacker buffer");
+            msgpack_unpacked_destroy(&result);
+            msgpack_unpacker_free(unp);
+            flb_sds_destroy(out_tag);
+
+            return -1;
+        }
+
         if (recv_len == 0) {
             /* No more data */
             msgpack_unpacker_free(unp);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Partially backporting of https://github.com/fluent/fluent-bit/pull/11809. 
(Excluded to import an integration testing commit)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
