### PR TITLE
avro: Handle int64 values correctly

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -56,6 +56,7 @@ jobs:
           - "-DFLB_SIMD=Off"
           - "-DFLB_ARROW=On"
           - "-DFLB_COMPILER_STRICT_POINTER_TYPES=On"
+          - "-DFLB_AVRO_ENCODER=On -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
         cmake_version:
           - "3.31.6"
         compiler:
@@ -75,6 +76,10 @@ jobs:
               cc: clang
               cxx: clang++
           - flb_option: "-DFLB_COMPILER_STRICT_POINTER_TYPES=On"
+            compiler:
+              cc: clang
+              cxx: clang++
+          - flb_option: "-DFLB_AVRO_ENCODER=On -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             compiler:
               cc: clang
               cxx: clang++

--- a/src/flb_avro.c
+++ b/src/flb_avro.c
@@ -233,6 +233,10 @@ int msgpack2avro(avro_value_t *val, msgpack_object *o)
                 ret = flb_msgpack_to_avro(&element, &p->val);
 
                 flb_sds_destroy(key);
+
+                if (ret == FLB_FALSE) {
+                    goto msg2avro_end;
+                }
             }
         }
         break;

--- a/src/flb_avro.c
+++ b/src/flb_avro.c
@@ -18,6 +18,9 @@
  */
 
 #include <assert.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,12 +31,48 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_avro.h>
 
-static inline int do_avro(bool call, const char *msg) {
+static inline int do_avro(bool call, const char *msg)
+{
     if (call) {
-            flb_error("%s:\n  %s\n", msg, avro_strerror());
-            return FLB_FALSE;
+        flb_error("%s:\n  %s\n", msg, avro_strerror());
+        return FLB_FALSE;
     }
     return FLB_TRUE;
+}
+
+static int set_avro_integer(avro_value_t *val, int64_t i64, uint64_t u64, int positive)
+{
+    avro_type_t type;
+
+    type = avro_value_get_type(val);
+
+    if (type == AVRO_INT64) {
+        if (positive && u64 > INT64_MAX) {
+            flb_error("positive integer value exceeds Avro long range: %" PRIu64, u64);
+            return FLB_FALSE;
+        }
+
+        return do_avro(avro_value_set_long(val, positive ? (int64_t) u64 : i64),
+                       positive ? "failed on posint" : "failed on negint");
+    }
+
+    if (type == AVRO_INT32) {
+        if (positive && u64 > INT32_MAX) {
+            flb_error("positive integer value exceeds Avro int range: %" PRIu64, u64);
+            return FLB_FALSE;
+        }
+        else if (!positive && (i64 < INT32_MIN || i64 > INT32_MAX)) {
+            flb_error("negative integer value exceeds Avro int range: %" PRIi64, i64);
+            return FLB_FALSE;
+        }
+
+        return do_avro(avro_value_set_int(val, positive ? (int32_t) u64 : (int32_t) i64),
+                       positive ? "failed on posint" : "failed on negint");
+    }
+
+    flb_error("integer value cannot be assigned to Avro type %d", type);
+
+    return FLB_FALSE;
 }
 
 avro_value_iface_t  *flb_avro_init(avro_value_t *aobject, char *json, size_t json_len, avro_schema_t *aschema)
@@ -85,33 +124,20 @@ int msgpack2avro(avro_value_t *val, msgpack_object *o)
 #if defined(PRIu64)
         // msgpack_pack_fix_uint64
         flb_debug("got a posint: %" PRIu64 "\n", o->via.u64);
-        ret = do_avro(avro_value_set_int(val, o->via.u64), "failed on posint");
 #else
-        if (o.via.u64 > ULONG_MAX)
-            flb_warn("over \"%lu\"", ULONG_MAX);
-            ret = do_avro(avro_value_set_int(val, ULONG_MAX), "failed on posint");
-        else
-            flb_debug("got a posint: %lu\n", (unsigned long)o->via.u64);
-            ret = do_avro(avro_value_set_int(val, o->via.u64), "failed on posint");
+        flb_debug("got a posint: %lu\n", (unsigned long) o->via.u64);
 #endif
+        ret = set_avro_integer(val, 0, o->via.u64, FLB_TRUE);
 
         break;
 
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
 #if defined(PRIi64)
         flb_debug("got a negint: %" PRIi64 "\n", o->via.i64);
-        ret = do_avro(avro_value_set_int(val, o->via.i64), "failed on negint");
 #else
-        if (o->via.i64 > LONG_MAX)
-            flb_warn("over +\"%ld\"", LONG_MAX);
-            ret = do_avro(avro_value_set_int(val, LONG_MAX), "failed on negint");
-        else if (o->via.i64 < LONG_MIN)
-            flb_warn("under -\"%ld\"", LONG_MIN);
-            ret = do_avro(avro_value_set_int(val, LONG_MIN), "failed on negint");
-        else
-            flb_debug("got a negint: %ld\n", (signed long)o->via.i64);
-            ret = do_avro(avro_value_set_int(val, o->via.i64), "failed on negint");
+        flb_debug("got a negint: %ld\n", (signed long) o->via.i64);
 #endif
+        ret = set_avro_integer(val, o->via.i64, 0, FLB_FALSE);
         break;
 
     case MSGPACK_OBJECT_FLOAT32:

--- a/tests/internal/avro.c
+++ b/tests/internal/avro.c
@@ -25,38 +25,44 @@ const char  JSON_SINGLE_MAP_001_SCHEMA[] =
         {\"type\": \"array\", \"items\":\
              {\"type\": \"map\",\"values\": \"int\"}}}]}";
 
-msgpack_unpacked test_init(avro_value_t *aobject, avro_schema_t *aschema, const char *json_schema, const char *json_data) {
-    char *out_buf;
+msgpack_unpacked test_init(avro_value_t *aobject, avro_schema_t *aschema,
+                           const char *json_schema, const char *json_data,
+                           char **out_buf)
+{
     size_t out_size;
     int root_type;
+    size_t len;
+    char *data;
+    avro_value_iface_t  *aclass;
+    msgpack_unpacked msg;
 
-    avro_value_iface_t  *aclass = flb_avro_init(aobject, (char *)json_schema, strlen(json_schema), aschema);
+    aclass = flb_avro_init(aobject, (char *)json_schema, strlen(json_schema), aschema);
     TEST_CHECK(aclass != NULL);
 
-    char *data = mk_file_to_buffer(json_data);
+    data = mk_file_to_buffer(json_data);
     TEST_CHECK(data != NULL);
 
-    size_t len = strlen(data);
+    len = strlen(data);
 
-    TEST_CHECK(flb_pack_json(data, len, &out_buf, &out_size, &root_type, NULL) == 0);
+    TEST_CHECK(flb_pack_json(data, len, out_buf, &out_size, &root_type, NULL) == 0);
 
-    msgpack_unpacked msg;
     msgpack_unpacked_init(&msg);
-    TEST_CHECK(msgpack_unpack_next(&msg, out_buf, out_size, NULL) == MSGPACK_UNPACK_SUCCESS);
+    TEST_CHECK(msgpack_unpack_next(&msg, *out_buf, out_size, NULL) == MSGPACK_UNPACK_SUCCESS);
 
     avro_value_iface_decref(aclass);
     flb_free(data);
-    flb_free(out_buf);
 
     return msg;
 }
 /* Unpack msgpack per avro schema */
 void test_unpack_to_avro()
 {
+    char *out_buf = NULL;
     avro_value_t  aobject;
     avro_schema_t aschema;
+    msgpack_unpacked mp;
 
-    msgpack_unpacked mp = test_init(&aobject, &aschema, JSON_SINGLE_MAP_001_SCHEMA, AVRO_SINGLE_MAP1);
+    mp = test_init(&aobject, &aschema, JSON_SINGLE_MAP_001_SCHEMA, AVRO_SINGLE_MAP1, &out_buf);
 
     msgpack_object_print(stderr, mp.data);
     flb_msgpack_to_avro(&aobject, &mp.data);
@@ -142,6 +148,7 @@ void test_unpack_to_avro()
     avro_value_decref(&aobject);
     avro_schema_decref(aschema);
     msgpack_unpacked_destroy(&mp);
+    flb_free(out_buf);
 }
 
 void test_parse_reordered_schema()
@@ -155,11 +162,12 @@ void test_parse_reordered_schema()
 
     int i=0;
     for (i=0; schemas[i] != NULL ; i++) {
-
+        char *out_buf = NULL;
         avro_value_t  aobject = {0};
         avro_schema_t aschema = {0};
+        msgpack_unpacked msg;
 
-        msgpack_unpacked msg = test_init(&aobject, &aschema, schemas[i], AVRO_MULTILINE_JSON);
+        msg = test_init(&aobject, &aschema, schemas[i], AVRO_MULTILINE_JSON, &out_buf);
 
         msgpack_object_print(stderr, msg.data);
 
@@ -227,6 +235,7 @@ void test_parse_reordered_schema()
         avro_schema_decref(aschema);
         msgpack_unpacked_destroy(&msg);
         avro_value_decref(&aobject);
+        flb_free(out_buf);
     }
 
 }
@@ -428,10 +437,12 @@ const char  JSON_SINGLE_MAP_001_SCHEMA_WITH_UNION[] =
              {\"type\": \"map\",\"values\": \"int\"}}}]}";
 void test_union_type_sanity()
 {
+    char *out_buf = NULL;
     avro_value_t  aobject;
     avro_schema_t aschema;
+    msgpack_unpacked msg;
 
-    msgpack_unpacked msg = test_init(&aobject, &aschema, JSON_SINGLE_MAP_001_SCHEMA_WITH_UNION, AVRO_SINGLE_MAP1);
+    msg = test_init(&aobject, &aschema, JSON_SINGLE_MAP_001_SCHEMA_WITH_UNION, AVRO_SINGLE_MAP1, &out_buf);
 
     msgpack_object_print(stderr, msg.data);
     flb_msgpack_to_avro(&aobject, &msg.data);
@@ -487,14 +498,17 @@ void test_union_type_sanity()
     avro_value_decref(&aobject);
     avro_schema_decref(aschema);
     msgpack_unpacked_destroy(&msg);
+    flb_free(out_buf);
 }
 
 void test_union_type_branches()
 {
+    char *out_buf = NULL;
     avro_value_t  aobject;
     avro_schema_t aschema;
+    msgpack_unpacked mp;
     
-    msgpack_unpacked mp = test_init(&aobject, &aschema, JSON_SINGLE_MAP_001_SCHEMA_WITH_UNION, AVRO_SINGLE_MAP1);
+    mp = test_init(&aobject, &aschema, JSON_SINGLE_MAP_001_SCHEMA_WITH_UNION, AVRO_SINGLE_MAP1, &out_buf);
 
     flb_msgpack_to_avro(&aobject, &mp.data);
 
@@ -517,6 +531,7 @@ void test_union_type_branches()
     avro_value_decref(&aobject);
     avro_schema_decref(aschema);
     msgpack_unpacked_destroy(&mp);
+    flb_free(out_buf);
 }
 TEST_LIST = {
     /* Avro */

--- a/tests/internal/avro.c
+++ b/tests/internal/avro.c
@@ -274,6 +274,20 @@ const char JSON_INT64_SCHEMA[] =
 "{\"name\":\"positive\",\"type\":\"long\"},"
 "{\"name\":\"negative\",\"type\":\"long\"}]}";
 
+const char JSON_INT_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"IntRecord\","
+"\"fields\":["
+"{\"name\":\"bad\",\"type\":\"int\"}]}";
+
+const char JSON_INT_MULTI_FIELD_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"IntMultiFieldRecord\","
+"\"fields\":["
+"{\"name\":\"first\",\"type\":\"int\"},"
+"{\"name\":\"bad\",\"type\":\"int\"},"
+"{\"name\":\"last\",\"type\":\"string\"}]}";
+
 void test_msgpack_to_avro_int64()
 {
     int64_t positive_expected = 4294967296LL;
@@ -314,6 +328,81 @@ void test_msgpack_to_avro_int64()
     TEST_CHECK(avro_value_get_by_name(&aobject, "negative", &test_value, NULL) == 0);
     TEST_CHECK(avro_value_get_long(&test_value, &actual) == 0);
     TEST_CHECK(actual == negative_expected);
+
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+}
+
+void test_msgpack_to_avro_int_range()
+{
+    uint64_t too_big = 2147483648ULL;
+    avro_value_t aobject;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_INT_SCHEMA,
+                           strlen(JSON_INT_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&pk, 1);
+    msgpack_pack_str(&pk, 3);
+    msgpack_pack_str_body(&pk, "bad", 3);
+    msgpack_pack_uint64(&pk, too_big);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_FALSE);
+
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+}
+
+void test_msgpack_to_avro_int_range_multi_field()
+{
+    uint64_t too_big = 2147483648ULL;
+    avro_value_t aobject;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_INT_MULTI_FIELD_SCHEMA,
+                           strlen(JSON_INT_MULTI_FIELD_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&pk, 3);
+    msgpack_pack_str(&pk, 5);
+    msgpack_pack_str_body(&pk, "first", 5);
+    msgpack_pack_int(&pk, 1);
+    msgpack_pack_str(&pk, 3);
+    msgpack_pack_str_body(&pk, "bad", 3);
+    msgpack_pack_uint64(&pk, too_big);
+    msgpack_pack_str(&pk, 4);
+    msgpack_pack_str_body(&pk, "last", 4);
+    msgpack_pack_str(&pk, 1);
+    msgpack_pack_str_body(&pk, "x", 1);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_FALSE);
 
     msgpack_unpacked_destroy(&msg);
     msgpack_sbuffer_destroy(&sbuf);
@@ -434,6 +523,9 @@ TEST_LIST = {
     { "msgpack_to_avro_basic", test_unpack_to_avro},
     { "test_parse_reordered_schema", test_parse_reordered_schema},
     { "test_msgpack_to_avro_int64", test_msgpack_to_avro_int64},
+    { "test_msgpack_to_avro_int_range", test_msgpack_to_avro_int_range},
+    { "test_msgpack_to_avro_int_range_multi_field",
+      test_msgpack_to_avro_int_range_multi_field},
     { "test_union_type_sanity", test_union_type_sanity},
     { "test_union_type_branches", test_union_type_branches},
     { 0 }

--- a/tests/internal/avro.c
+++ b/tests/internal/avro.c
@@ -1,5 +1,6 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 #include <errno.h>
+#include <stdint.h>
 #include <string.h>
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_avro.h>
@@ -265,6 +266,62 @@ void test_msgpack2avro()
     msgpack_zone_destroy(&mempool);
     msgpack_sbuffer_destroy(&sbuf);
 }
+
+const char JSON_INT64_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"Int64Record\","
+"\"fields\":["
+"{\"name\":\"positive\",\"type\":\"long\"},"
+"{\"name\":\"negative\",\"type\":\"long\"}]}";
+
+void test_msgpack_to_avro_int64()
+{
+    int64_t positive_expected = 4294967296LL;
+    int64_t negative_expected = -2147483649LL;
+    int64_t actual = 0;
+    avro_value_t aobject;
+    avro_value_t test_value;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_INT64_SCHEMA,
+                           strlen(JSON_INT64_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&pk, 2);
+    msgpack_pack_str(&pk, 8);
+    msgpack_pack_str_body(&pk, "positive", 8);
+    msgpack_pack_uint64(&pk, (uint64_t) positive_expected);
+    msgpack_pack_str(&pk, 8);
+    msgpack_pack_str_body(&pk, "negative", 8);
+    msgpack_pack_int64(&pk, negative_expected);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_TRUE);
+
+    TEST_CHECK(avro_value_get_by_name(&aobject, "positive", &test_value, NULL) == 0);
+    TEST_CHECK(avro_value_get_long(&test_value, &actual) == 0);
+    TEST_CHECK(actual == positive_expected);
+
+    TEST_CHECK(avro_value_get_by_name(&aobject, "negative", &test_value, NULL) == 0);
+    TEST_CHECK(avro_value_get_long(&test_value, &actual) == 0);
+    TEST_CHECK(actual == negative_expected);
+
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+}
+
 const char  JSON_SINGLE_MAP_001_SCHEMA_WITH_UNION[] =
 "{\"type\":\"record\",\
   \"name\":\"Map001\",\
@@ -376,6 +433,7 @@ TEST_LIST = {
     /* Avro */
     { "msgpack_to_avro_basic", test_unpack_to_avro},
     { "test_parse_reordered_schema", test_parse_reordered_schema},
+    { "test_msgpack_to_avro_int64", test_msgpack_to_avro_int64},
     { "test_union_type_sanity", test_union_type_sanity},
     { "test_union_type_branches", test_union_type_branches},
     { 0 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
In the current master of code base for handling avro, it cannot process exceeding 32bit width of integers correctly.
This PR fixes this issue.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integer conversions now validate signed/unsigned ranges and types, preventing silent truncation and returning explicit errors when values are out of range.
  * Map conversions now stop immediately on value-conversion failures to avoid producing partially converted results.

* **Tests**
  * Added tests covering 64-bit integer conversions and asserting failures for out-of-range integer values; updated test helpers to support new checks.

* **Chores**
  * CI matrix extended to include an AVRO-enabled build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->