### PR TITLE
storage: discard checksum corrupt chunks on startup

### DIFF
--- a/lib/chunkio/src/cio_scan.c
+++ b/lib/chunkio/src/cio_scan.c
@@ -106,7 +106,8 @@ static int cio_scan_stream_files(struct cio_ctx *ctx, struct cio_stream *st,
 
         if (ctx->options.flags & CIO_DELETE_IRRECOVERABLE) {
             if (err == CIO_CORRUPTED) {
-                if (ctx->last_chunk_error == CIO_ERR_BAD_FILE_SIZE ||
+                if (ctx->last_chunk_error == CIO_ERR_BAD_CHECKSUM ||
+                    ctx->last_chunk_error == CIO_ERR_BAD_FILE_SIZE ||
                     ctx->last_chunk_error == CIO_ERR_BAD_LAYOUT)
                 {
                     cio_log_error(ctx, "[cio scan] discarding irrecoverable chunk");

--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -391,7 +391,8 @@ int sb_segregate_chunks(struct flb_config *config)
                     if (config->storage_del_bad_chunks) {
                         chunk_error = cio_error_get(chunk);
 
-                        if (chunk_error == CIO_ERR_BAD_FILE_SIZE ||
+                        if (chunk_error == CIO_ERR_BAD_CHECKSUM ||
+                            chunk_error == CIO_ERR_BAD_FILE_SIZE ||
                             chunk_error == CIO_ERR_BAD_LAYOUT)
                         {
                             flb_plg_error(context->ins, "discarding irrecoverable chunk %s/%s", stream->name, chunk->name);

--- a/tests/integration/scenarios/in_tail/config/tail_storage_corrupt_chunk.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_storage_corrupt_chunk.yaml
@@ -1,0 +1,36 @@
+service:
+  flush: 60
+  grace: 1
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  storage.path: ${TAIL_STORAGE_PATH}
+  storage.sync: normal
+  storage.checksum: on
+  storage.delete_irrecoverable_chunks: on
+  storage.max_chunks_up: 128
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: tail.storage
+      path: ${TAIL_TEST_PATH}
+      read_from_head: true
+      read_newly_discovered_files_from_head: true
+      refresh_interval: 1
+      watcher_interval: 1
+      progress_check_interval: 1
+      db: ${TAIL_TEST_DB}
+      db.sync: full
+      db.journal_mode: DELETE
+      storage.type: filesystem
+
+  outputs:
+    - name: http
+      match: tail.storage
+      host: 127.0.0.1
+      port: ${TAIL_STORAGE_OUTPUT_PORT}
+      uri: /data
+      format: json
+      json_date_key: false
+      retry_limit: false

--- a/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
+++ b/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
@@ -106,6 +106,53 @@ class Service:
             time.sleep(0.5)
 
 
+class StorageFailureService:
+    def __init__(self, config_file, *, tail_path, db_path, storage_path):
+        self.config_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config", config_file)
+        )
+        self.service = FluentBitTestService(
+            self.config_file,
+            extra_env={
+                "TAIL_TEST_PATH": tail_path,
+                "TAIL_TEST_DB": db_path,
+                "TAIL_STORAGE_PATH": storage_path,
+            },
+            pre_start=self._set_closed_output_port,
+        )
+
+    def _set_closed_output_port(self, service):
+        service.allocate_port_env("TAIL_STORAGE_OUTPUT_PORT")
+
+    def start(self):
+        self.service.start()
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_log_line(self, needle, timeout=20):
+        def has_log_line():
+            log_file = self.service.flb.log_file
+
+            if not log_file or not os.path.exists(log_file):
+                return None
+
+            with open(log_file, "r", encoding="utf-8") as handle:
+                content = handle.read()
+
+            if needle in content:
+                return content
+
+            return None
+
+        return self.service.wait_for_condition(
+            has_log_line,
+            timeout=timeout,
+            interval=0.5,
+            description=f"log line containing {needle!r}",
+        )
+
+
 def flatten_records(payloads):
     records = []
 
@@ -150,10 +197,71 @@ def assert_log_set(records, expected_logs):
         assert logs.count(expected) == 1
 
 
+def wait_for_path_absent(path, timeout=20):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not path.exists():
+            return
+
+        time.sleep(0.5)
+
+    raise TimeoutError(f"Timed out waiting for {path} to be deleted")
+
+
+def write_checksum_corrupted_chunk(storage_path):
+    stream_path = storage_path / "tail.0"
+    chunk_path = stream_path / "1-177560529.168611552.flb"
+    data = bytearray(25)
+
+    stream_path.mkdir()
+
+    data[0] = 0xC1
+    data[1] = 0x00
+    data[10] = 0x00
+    data[11] = 0x00
+    data[12] = 0x00
+    data[13] = 0x01
+    data[22] = 0x00
+    data[23] = 0x00
+    data[24] = 0x91
+
+    with open(chunk_path, "wb") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    return chunk_path
+
+
 @pytest.fixture
 def workspace():
     with tempfile.TemporaryDirectory(prefix="flb-tail-it-") as tmpdir:
         yield Path(tmpdir)
+
+
+def test_in_tail_storage_deletes_checksum_corrupted_chunk_on_startup(workspace):
+    log_file = workspace / "checksum-corrupt.log"
+    db_path = workspace / "tail.db"
+    storage_path = workspace / "storage"
+
+    storage_path.mkdir()
+    log_file.write_text("", encoding="utf-8")
+    corrupted_chunk = write_checksum_corrupted_chunk(storage_path)
+
+    service = StorageFailureService(
+        "tail_storage_corrupt_chunk.yaml",
+        tail_path=log_file,
+        db_path=db_path,
+        storage_path=storage_path,
+    )
+
+    try:
+        service.start()
+        service.wait_for_log_line("invalid crc32")
+        wait_for_path_absent(corrupted_chunk)
+    finally:
+        service.stop()
 
 
 def test_in_tail_discovers_new_files_from_head(workspace):


### PR DESCRIPTION
Fixes #11847.

Upgrade to chunkio v1.5.5 and fix interfaces:

When filesystem storage finds a chunk with a bad checksum during startup scan/backlog loading, treat it as irrecoverable when `storage.delete_irrecoverable_chunks` is enabled.

This updates the storage backlog path to discard checksum-corrupt chunks, matching ChunkIO's irrecoverable-chunk handling, and adds an in_tail integration test covering startup cleanup.



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
