### PR TITLE
tests: runtime: Stabilize out_lib test case

### DIFF
--- a/tests/runtime/out_lib.c
+++ b/tests/runtime/out_lib.c
@@ -80,7 +80,7 @@ void wait_with_timeout(uint32_t timeout_ms, int *output_num)
 
         if (elapsed_time_flb > timeout_ms) {
             flb_warn("[timeout] elapsed_time: %ld", elapsed_time_flb);
-            // Reached timeout.
+            /* Reached timeout. */
             break;
         }
     }
@@ -437,6 +437,10 @@ static void test_max_records(void)
 {
     struct flb_lib_out_cb cb_data;
     struct test_ctx *ctx;
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb = 0;
     int ret;
     int num;
     char *input_json = "[1,{\"hoge\":\"moge\", \"bool\":true, \"int\":100, \"float\":-2.0}]";
@@ -475,7 +479,25 @@ static void test_max_records(void)
     }
 
     /* waiting to flush */
-    wait_with_timeout(1000, &num);
+    flb_time_get(&start_time);
+
+    while (true) {
+        num = get_output_num();
+        if (num >= expected) {
+            break;
+        }
+
+        flb_time_msleep(100);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+
+        if (elapsed_time_flb > 1000) {
+            flb_warn("[timeout] elapsed_time: %ld", elapsed_time_flb);
+            /* Reached timeout. */
+            break;
+        }
+    }
 
     if (!TEST_CHECK(num == expected /* max_records */))  {
         TEST_MSG("max_records error. got=%d, expected=%d", num, expected);


### PR DESCRIPTION
<!-- Provide summary of changes -->
In our CI environments, some of the out_lib tests are flaky. So, we need to stabilize it.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timeout measurement and polling logic in testing suite for more robust timeout validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->