### PR TITLE
out_azure_blob: add service principal auth

### DIFF
--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -1247,6 +1247,7 @@ static int create_container(struct flb_azure_blob *ctx, char *name)
                         NULL, 0, NULL, 0, NULL, 0);
     if (!c) {
         flb_plg_error(ctx->ins, "cannot create HTTP client context");
+        flb_sds_destroy(uri);
         flb_upstream_conn_release(u_conn);
         return FLB_FALSE;
     }
@@ -1346,6 +1347,7 @@ static int ensure_container(struct flb_azure_blob *ctx)
                         NULL, 0, NULL, 0, NULL, 0);
     if (!c) {
         flb_plg_error(ctx->ins, "cannot create HTTP client context");
+        flb_sds_destroy(uri);
         flb_upstream_conn_release(u_conn);
         return FLB_FALSE;
     }
@@ -1435,14 +1437,17 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         /* validate 'total_file_size' */
         if (ctx->file_size <= 0) {
             flb_plg_error(ctx->ins, "Failed to parse upload_file_size");
+            azure_blob_store_exit(ctx);
             return -1;
         }
         if (ctx->file_size < 1000000) {
             flb_plg_error(ctx->ins, "upload_file_size must be at least 1MB");
+            azure_blob_store_exit(ctx);
             return -1;
         }
         if (ctx->file_size > MAX_FILE_SIZE) {
             flb_plg_error(ctx->ins, "Max total_file_size must be lower than %ld bytes", MAX_FILE_SIZE);
+            azure_blob_store_exit(ctx);
             return -1;
         }
         ctx->has_old_buffers = azure_blob_store_has_data(ctx);
@@ -1456,6 +1461,9 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         ret = pthread_mutex_init(&ctx->token_mutex, NULL);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "failed to initialize token mutex");
+            if (ctx->buffering_enabled == FLB_TRUE) {
+                azure_blob_store_exit(ctx);
+            }
             flb_azure_blob_conf_destroy(ctx);
             return -1;
         }
@@ -1466,6 +1474,9 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         if (!token_url) {
             flb_plg_error(ctx->ins, "failed to allocate token URL");
             pthread_mutex_destroy(&ctx->token_mutex);
+            if (ctx->buffering_enabled == FLB_TRUE) {
+                azure_blob_store_exit(ctx);
+            }
             flb_azure_blob_conf_destroy(ctx);
             return -1;
         }
@@ -1477,6 +1488,9 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
             flb_plg_error(ctx->ins, "failed to build token URL");
             flb_sds_destroy(token_url);
             pthread_mutex_destroy(&ctx->token_mutex);
+            if (ctx->buffering_enabled == FLB_TRUE) {
+                azure_blob_store_exit(ctx);
+            }
             flb_azure_blob_conf_destroy(ctx);
             return -1;
         }
@@ -1487,6 +1501,9 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         if (!ctx->o) {
             flb_plg_error(ctx->ins, "failed to create OAuth2 context");
             pthread_mutex_destroy(&ctx->token_mutex);
+            if (ctx->buffering_enabled == FLB_TRUE) {
+                azure_blob_store_exit(ctx);
+            }
             flb_azure_blob_conf_destroy(ctx);
             return -1;
         }

--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -738,8 +738,13 @@ static int create_blob(struct flb_azure_blob *ctx, const char *path_prefix, char
     }
 
     /* Prepare headers and authentication */
-    azb_http_client_setup(ctx, c, -1, FLB_TRUE,
-                          AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    ret = azb_http_client_setup(ctx, c, -1, FLB_TRUE,
+                                AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to setup HTTP client");
+        status = FLB_RETRY;
+        goto cleanup_create;
+    }
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
@@ -817,8 +822,13 @@ static int delete_blob(struct flb_azure_blob *ctx,
     }
 
     /* Prepare headers and authentication */
-    azb_http_client_setup(ctx, c, -1, FLB_TRUE,
-                          AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    ret = azb_http_client_setup(ctx, c, -1, FLB_TRUE,
+                                AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to setup HTTP client");
+        status = FLB_RETRY;
+        goto cleanup_delete;
+    }
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
@@ -1000,8 +1010,17 @@ static int http_send_blob(struct flb_config *config, struct flb_azure_blob *ctx,
     }
 
     /* Prepare headers and authentication */
-    azb_http_client_setup(ctx, c, (ssize_t) payload_size, FLB_FALSE,
-                          content_type, content_encoding);
+    ret = azb_http_client_setup(ctx, c, (ssize_t) payload_size, FLB_FALSE,
+                                content_type, content_encoding);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to setup HTTP client");
+        if (compressed == FLB_TRUE) {
+            flb_free(payload_buf);
+        }
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        return FLB_RETRY;
+    }
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
@@ -1233,8 +1252,15 @@ static int create_container(struct flb_azure_blob *ctx, char *name)
     }
 
     /* Prepare headers and authentication */
-    azb_http_client_setup(ctx, c, -1, FLB_FALSE,
-                          AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    ret = azb_http_client_setup(ctx, c, -1, FLB_FALSE,
+                                AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to setup HTTP client");
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        flb_sds_destroy(uri);
+        return FLB_FALSE;
+    }
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
@@ -1326,8 +1352,15 @@ static int ensure_container(struct flb_azure_blob *ctx)
     flb_http_strip_port_from_host(c);
 
     /* Prepare headers and authentication */
-    azb_http_client_setup(ctx, c, -1, FLB_FALSE,
-                          AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    ret = azb_http_client_setup(ctx, c, -1, FLB_FALSE,
+                                AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to setup HTTP client");
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        flb_sds_destroy(uri);
+        return FLB_FALSE;
+    }
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);
@@ -1425,6 +1458,8 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         token_url = flb_sds_create_size(256);
         if (!token_url) {
             flb_plg_error(ctx->ins, "failed to allocate token URL");
+            pthread_mutex_destroy(&ctx->token_mutex);
+            flb_azure_blob_conf_destroy(ctx);
             return -1;
         }
 
@@ -1434,6 +1469,8 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         if (ret < 0) {
             flb_plg_error(ctx->ins, "failed to build token URL");
             flb_sds_destroy(token_url);
+            pthread_mutex_destroy(&ctx->token_mutex);
+            flb_azure_blob_conf_destroy(ctx);
             return -1;
         }
 
@@ -1443,6 +1480,7 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         if (!ctx->o) {
             flb_plg_error(ctx->ins, "failed to create OAuth2 context");
             pthread_mutex_destroy(&ctx->token_mutex);
+            flb_azure_blob_conf_destroy(ctx);
             return -1;
         }
     }

--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -1368,6 +1368,7 @@ static int ensure_container(struct flb_azure_blob *ctx)
 
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error requesting container properties");
+        flb_http_client_destroy(c);
         flb_upstream_conn_release(u_conn);
         return FLB_FALSE;
     }
@@ -1452,7 +1453,13 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
 
     /* Initialize OAuth2 context for service principal auth */
     if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
-        pthread_mutex_init(&ctx->token_mutex, NULL);
+        ret = pthread_mutex_init(&ctx->token_mutex, NULL);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed to initialize token mutex");
+            flb_azure_blob_conf_destroy(ctx);
+            return -1;
+        }
+
         flb_sds_t token_url;
 
         token_url = flb_sds_create_size(256);
@@ -1761,7 +1768,7 @@ static void cb_azb_blob_file_upload(struct flb_config *config, void *out_context
         const char *commit_prefix = azb_commit_prefix_with_fallback(ctx, path_prefix);
 
         ret = azb_block_blob_commit_file_parts(ctx, file_id, file_path, part_ids, commit_prefix);
-        if (ret == -1) {
+        if (ret != FLB_OK) {
             flb_plg_error(ctx->ins, "cannot commit blob file parts for file id=%" PRIu64 " path=%s",
                           file_id, file_path);
         }

--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -1372,6 +1372,7 @@ static int ensure_container(struct flb_azure_blob *ctx)
 static int cb_azure_blob_init(struct flb_output_instance *ins,
                               struct flb_config *config, void *data)
 {
+    int ret;
     struct flb_azure_blob *ctx = NULL;
     (void) ins;
     (void) config;
@@ -1384,8 +1385,9 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         return -1;
     }
 
+    ctx->ins = ins;
+
     if (ctx->buffering_enabled == FLB_TRUE) {
-        ctx->ins = ins;
         ctx->retry_time = 0;
 
         /* Initialize local storage */
@@ -1413,6 +1415,36 @@ static int cb_azure_blob_init(struct flb_output_instance *ins,
         ctx->timer_created = FLB_FALSE;
         ctx->timer_ms = (int) (ctx->upload_timeout / 6) * 1000;
         flb_plg_info(ctx->ins, "Using upload size %lu bytes", ctx->file_size);
+    }
+
+    /* Initialize OAuth2 context for service principal auth */
+    if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
+        pthread_mutex_init(&ctx->token_mutex, NULL);
+        flb_sds_t token_url;
+
+        token_url = flb_sds_create_size(256);
+        if (!token_url) {
+            flb_plg_error(ctx->ins, "failed to allocate token URL");
+            return -1;
+        }
+
+        ret = flb_sds_snprintf(&token_url, flb_sds_alloc(token_url),
+                              "%s/%s/oauth2/v2.0/token",
+                              AZURE_BLOB_DEFAULT_AUTHORITY_HOST, ctx->tenant_id);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "failed to build token URL");
+            flb_sds_destroy(token_url);
+            return -1;
+        }
+
+        ctx->o = flb_oauth2_create(ctx->config, token_url, AZURE_BLOB_TOKEN_REFRESH);
+        flb_sds_destroy(token_url);
+
+        if (!ctx->o) {
+            flb_plg_error(ctx->ins, "failed to create OAuth2 context");
+            pthread_mutex_destroy(&ctx->token_mutex);
+            return -1;
+        }
     }
 
     flb_output_set_context(ins, ctx);
@@ -2390,6 +2422,11 @@ static int cb_azure_blob_exit(void *data, struct flb_config *config)
         ctx->u = NULL;
     }
 
+    /* Destroy token mutex for service principal auth */
+    if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
+        pthread_mutex_destroy(&ctx->token_mutex);
+    }
+
     flb_azure_blob_conf_destroy(ctx);
     return 0;
 }
@@ -2514,13 +2551,31 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "auth_type", "key",
      0, FLB_TRUE, offsetof(struct flb_azure_blob, auth_type),
-     "Set the auth type: key or sas"
+     "Set the auth type: key, sas, or service_principal"
     },
 
     {
      FLB_CONFIG_MAP_STR, "sas_token", NULL,
      0, FLB_TRUE, offsetof(struct flb_azure_blob, sas_token),
      "Azure Blob SAS token"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "tenant_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_azure_blob, tenant_id),
+     "Azure AD tenant ID (required for service_principal auth)"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "client_id", NULL,
+     0, FLB_TRUE, offsetof(struct flb_azure_blob, client_id),
+     "Azure AD client ID (required for service_principal auth)"
+    },
+
+    {
+     FLB_CONFIG_MAP_STR, "client_secret", NULL,
+     0, FLB_TRUE, offsetof(struct flb_azure_blob, client_secret),
+     "Azure AD client secret (required for service_principal auth)"
     },
 
     {

--- a/plugins/out_azure_blob/azure_blob.h
+++ b/plugins/out_azure_blob/azure_blob.h
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_oauth2.h>
 
 /* Content-Type */
 #define AZURE_BLOB_CT          "Content-Type"
@@ -53,6 +54,12 @@
 
 #define AZURE_BLOB_AUTH_KEY 0
 #define AZURE_BLOB_AUTH_SAS 1
+#define AZURE_BLOB_AUTH_SERVICE_PRINCIPAL 2
+
+/* OAuth2 defaults for service principal authentication */
+#define AZURE_BLOB_DEFAULT_AUTHORITY_HOST "https://login.microsoftonline.com"
+#define AZURE_BLOB_OAUTH_SCOPE "https://storage.azure.com/.default"
+#define AZURE_BLOB_TOKEN_REFRESH 3000  /* refresh token every 50 minutes */
 
 struct flb_azure_blob {
     int auto_create_container;
@@ -69,6 +76,11 @@ struct flb_azure_blob {
     flb_sds_t date_key;
     flb_sds_t auth_type;
     flb_sds_t sas_token;
+
+    /* Service Principal authentication fields */
+    flb_sds_t tenant_id;
+    flb_sds_t client_id;
+    flb_sds_t client_secret;
     flb_sds_t database_file;
     size_t part_size;
     time_t upload_parts_timeout;
@@ -124,6 +136,10 @@ struct flb_azure_blob {
     /* Shared key */
     unsigned char *decoded_sk;        /* decoded shared key */
     size_t decoded_sk_size;           /* size of decoded shared key */
+
+    /* Service Principal OAuth2 context */
+    struct flb_oauth2 *o;
+    pthread_mutex_t token_mutex;
 
 #ifdef FLB_HAVE_SQLDB
     /*

--- a/plugins/out_azure_blob/azure_blob_blockblob.c
+++ b/plugins/out_azure_blob/azure_blob_blockblob.c
@@ -310,9 +310,15 @@ int azb_block_blob_put_block_list(struct flb_azure_blob *ctx, flb_sds_t uri, flb
     }
 
     /* Prepare headers and authentication */
-    azb_http_client_setup(ctx, c, flb_sds_len(payload),
-                          FLB_FALSE,
-                          AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    ret = azb_http_client_setup(ctx, c, flb_sds_len(payload),
+                                FLB_FALSE,
+                                AZURE_BLOB_CT_NONE, AZURE_BLOB_CE_NONE);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to setup HTTP client");
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        return FLB_RETRY;
+    }
 
     /* Send HTTP request */
     ret = flb_http_do(c, &b_sent);

--- a/plugins/out_azure_blob/azure_blob_blockblob.c
+++ b/plugins/out_azure_blob/azure_blob_blockblob.c
@@ -326,6 +326,8 @@ int azb_block_blob_put_block_list(struct flb_azure_blob *ctx, flb_sds_t uri, flb
     /* Validate HTTP status */
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error sending block_blob");
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
         return FLB_RETRY;
     }
 

--- a/plugins/out_azure_blob/azure_blob_conf.c
+++ b/plugins/out_azure_blob/azure_blob_conf.c
@@ -574,6 +574,27 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
         return NULL;
     }
 
+    /* Set Auth type - must be parsed before remote configuration */
+    tmp = (char *) flb_output_get_property("auth_type", ins);
+    if (!tmp) {
+        ctx->atype = AZURE_BLOB_AUTH_KEY;
+    }
+    else {
+        if (strcasecmp(tmp, "key") == 0) {
+            ctx->atype = AZURE_BLOB_AUTH_KEY;
+        }
+        else if (strcasecmp(tmp, "sas") == 0) {
+            ctx->atype = AZURE_BLOB_AUTH_SAS;
+        }
+        else if (strcasecmp(tmp, "service_principal") == 0) {
+            ctx->atype = AZURE_BLOB_AUTH_SERVICE_PRINCIPAL;
+        }
+        else {
+            flb_plg_error(ctx->ins, "invalid auth_type value '%s'", tmp);
+            return NULL;
+        }
+    }
+
     if (ctx->configuration_endpoint_url != NULL) {
         ret = flb_azure_blob_apply_remote_configuration(ctx);
 
@@ -605,27 +626,6 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
         return NULL;
     }
 
-    /* Set Auth type */
-    tmp = (char *) flb_output_get_property("auth_type", ins);
-    if (!tmp) {
-        ctx->atype = AZURE_BLOB_AUTH_KEY;
-    }
-    else {
-        if (strcasecmp(tmp, "key") == 0) {
-            ctx->atype = AZURE_BLOB_AUTH_KEY;
-        }
-        else if (strcasecmp(tmp, "sas") == 0) {
-            ctx->atype = AZURE_BLOB_AUTH_SAS;
-        }
-        else if (strcasecmp(tmp, "service_principal") == 0) {
-            ctx->atype = AZURE_BLOB_AUTH_SERVICE_PRINCIPAL;
-        }
-        else {
-            flb_plg_error(ctx->ins, "invalid auth_type value '%s'", tmp);
-            return NULL;
-        }
-    }
-
     /* Validate auth-specific required fields */
     if (ctx->atype == AZURE_BLOB_AUTH_KEY &&
         ctx->shared_key == NULL) {
@@ -644,15 +644,15 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
     }
 
     if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
-        if (ctx->tenant_id == NULL) {
+        if (ctx->tenant_id == NULL || flb_sds_len(ctx->tenant_id) == 0) {
             flb_plg_error(ctx->ins, "'tenant_id' is required for service_principal auth");
             return NULL;
         }
-        if (ctx->client_id == NULL) {
+        if (ctx->client_id == NULL || flb_sds_len(ctx->client_id) == 0) {
             flb_plg_error(ctx->ins, "'client_id' is required for service_principal auth");
             return NULL;
         }
-        if (ctx->client_secret == NULL) {
+        if (ctx->client_secret == NULL || flb_sds_len(ctx->client_secret) == 0) {
             flb_plg_error(ctx->ins, "'client_secret' is required for service_principal auth");
             return NULL;
         }

--- a/plugins/out_azure_blob/azure_blob_conf.c
+++ b/plugins/out_azure_blob/azure_blob_conf.c
@@ -21,6 +21,7 @@
 #include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_compression.h>
+#include <fluent-bit/flb_oauth2.h>
 
 #include "azure_blob.h"
 #include "azure_blob_conf.h"
@@ -616,11 +617,16 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
         else if (strcasecmp(tmp, "sas") == 0) {
             ctx->atype = AZURE_BLOB_AUTH_SAS;
         }
+        else if (strcasecmp(tmp, "service_principal") == 0) {
+            ctx->atype = AZURE_BLOB_AUTH_SERVICE_PRINCIPAL;
+        }
         else {
             flb_plg_error(ctx->ins, "invalid auth_type value '%s'", tmp);
             return NULL;
         }
     }
+
+    /* Validate auth-specific required fields */
     if (ctx->atype == AZURE_BLOB_AUTH_KEY &&
         ctx->shared_key == NULL) {
         flb_plg_error(ctx->ins, "'shared_key' has not been set");
@@ -634,6 +640,21 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
         }
         if (ctx->sas_token[0] == '?') {
             ctx->sas_token++;
+        }
+    }
+
+    if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
+        if (ctx->tenant_id == NULL) {
+            flb_plg_error(ctx->ins, "'tenant_id' is required for service_principal auth");
+            return NULL;
+        }
+        if (ctx->client_id == NULL) {
+            flb_plg_error(ctx->ins, "'client_id' is required for service_principal auth");
+            return NULL;
+        }
+        if (ctx->client_secret == NULL) {
+            flb_plg_error(ctx->ins, "'client_secret' is required for service_principal auth");
+            return NULL;
         }
     }
 
@@ -693,6 +714,17 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
         flb_plg_error(ctx->ins,
                       "the option 'compress_blob' is not compatible with 'appendblob' "
                       "blob_type");
+        return NULL;
+    }
+
+    /*
+     * Service principal authentication requires TLS for Azure Storage API
+     * requests. Validate that TLS is explicitly enabled.
+     */
+    if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL &&
+        ins->use_tls != FLB_TRUE) {
+        flb_plg_error(ctx->ins,
+                      "service_principal auth requires TLS; set 'tls On'");
         return NULL;
     }
 
@@ -795,7 +827,8 @@ struct flb_azure_blob *flb_azure_blob_conf_create(struct flb_output_instance *in
                  ctx->btype == AZURE_BLOB_APPENDBLOB ? "appendblob" : "blockblob",
                  ctx->emulator_mode ? "yes" : "no",
                  ctx->real_endpoint ? ctx->real_endpoint : "no",
-                 ctx->atype == AZURE_BLOB_AUTH_KEY ? "key" : "sas");
+                 ctx->atype == AZURE_BLOB_AUTH_KEY ? "key" :
+                 (ctx->atype == AZURE_BLOB_AUTH_SAS ? "sas" : "service_principal"));
     return ctx;
 }
 
@@ -838,6 +871,14 @@ void flb_azure_blob_conf_destroy(struct flb_azure_blob *ctx)
 
     if (ctx->shared_key_prefix) {
         flb_sds_destroy(ctx->shared_key_prefix);
+    }
+
+    /* Cleanup service principal resources */
+    if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
+        if (ctx->o) {
+            flb_oauth2_destroy(ctx->o);
+            ctx->o = NULL;
+        }
     }
 
     if (ctx->u) {

--- a/plugins/out_azure_blob/azure_blob_http.c
+++ b/plugins/out_azure_blob/azure_blob_http.c
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_hmac.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_kv.h>
+#include <fluent-bit/flb_oauth2.h>
 
 #include "azure_blob.h"
 #include "azure_blob_uri.h"
@@ -36,6 +37,111 @@ static int hmac_sha256_sign(unsigned char out[32],
                            key, key_len,
                            msg, msg_len,
                            out, 32);
+}
+
+static int azb_get_oauth2_token(struct flb_azure_blob *ctx)
+{
+    int ret;
+    char *token;
+
+    flb_oauth2_payload_clear(ctx->o);
+
+    ret = flb_oauth2_payload_append(ctx->o,
+                                    "grant_type", 10,
+                                    "client_credentials", 18);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "failed to append OAuth2 grant type");
+        return -1;
+    }
+
+    ret = flb_oauth2_payload_append(ctx->o,
+                                    "scope", 5,
+                                    AZURE_BLOB_OAUTH_SCOPE, -1);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "failed to append OAuth2 scope");
+        return -1;
+    }
+
+    ret = flb_oauth2_payload_append(ctx->o,
+                                    "client_id", 9,
+                                    ctx->client_id, -1);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "failed to append OAuth2 client ID");
+        return -1;
+    }
+
+    ret = flb_oauth2_payload_append(ctx->o,
+                                    "client_secret", 13,
+                                    ctx->client_secret, -1);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "failed to append OAuth2 client secret");
+        return -1;
+    }
+
+    token = flb_oauth2_token_get(ctx->o);
+    if (!token) {
+        flb_plg_error(ctx->ins, "failed to retrieve OAuth2 access token");
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * Get the current Azure Blob bearer token as a formatted string.
+ * Acquires the token mutex, refreshes the token if expired, and returns
+ * a copy of the token string in the format "<token_type> <access_token>".
+ * The caller must destroy the returned flb_sds_t.
+ */
+static int azb_get_oauth2_authorization_header(struct flb_azure_blob *ctx,
+                                               flb_sds_t *out_auth_header)
+{
+    int ret;
+    flb_sds_t auth_header = NULL;
+
+    if (!out_auth_header) {
+        return -1;
+    }
+
+    /* Acquire token mutex */
+    ret = pthread_mutex_lock(&ctx->token_mutex);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to lock token mutex");
+        return -1;
+    }
+
+    /* Check if token needs refresh */
+    if (flb_oauth2_token_expired(ctx->o) == FLB_TRUE) {
+        ret = azb_get_oauth2_token(ctx);
+        if (ret != 0) {
+            pthread_mutex_unlock(&ctx->token_mutex);
+            flb_plg_error(ctx->ins, "failed to refresh OAuth2 token");
+            return -1;
+        }
+    }
+
+    /* Build Authorization header while holding lock */
+    auth_header = flb_sds_create_size(flb_sds_len(ctx->o->token_type) +
+                                      flb_sds_len(ctx->o->access_token) + 2);
+    if (!auth_header) {
+        pthread_mutex_unlock(&ctx->token_mutex);
+        flb_plg_error(ctx->ins, "failed to allocate authorization header");
+        return -1;
+    }
+
+    ret = flb_sds_snprintf(&auth_header, flb_sds_alloc(auth_header),
+                          "%s %s", ctx->o->token_type, ctx->o->access_token);
+    if (ret < 0) {
+        flb_sds_destroy(auth_header);
+        pthread_mutex_unlock(&ctx->token_mutex);
+        flb_plg_error(ctx->ins, "failed to format authorization header");
+        return -1;
+    }
+
+    pthread_mutex_unlock(&ctx->token_mutex);
+
+    *out_auth_header = auth_header;
+    return 0;
 }
 
 static flb_sds_t canonical_headers(struct flb_http_client *c)
@@ -300,6 +406,7 @@ int azb_http_client_setup(struct flb_azure_blob *ctx, struct flb_http_client *c,
                           ssize_t content_length, int blob_type,
                           int content_type, int content_encoding)
 {
+    int ret;
     int len;
     time_t now;
     struct tm tm;
@@ -358,6 +465,7 @@ int azb_http_client_setup(struct flb_azure_blob *ctx, struct flb_http_client *c,
     /* Azure header: x-ms-version */
     flb_http_add_header(c, "x-ms-version", 12, "2019-12-12", 10);
 
+
     if (ctx->atype == AZURE_BLOB_AUTH_KEY) {
         can_req = azb_http_canonical_request(ctx, c, content_length, content_type,
                                              content_encoding);
@@ -372,6 +480,20 @@ int azb_http_client_setup(struct flb_azure_blob *ctx, struct flb_http_client *c,
 
         /* Release buffers */
         flb_sds_destroy(can_req);
+        flb_sds_destroy(auth);
+    }
+    else if (ctx->atype == AZURE_BLOB_AUTH_SERVICE_PRINCIPAL) {
+        /* Get OAuth2 authorization header (thread-safe) */
+        ret = azb_get_oauth2_authorization_header(ctx, &auth);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed to get OAuth2 authorization header");
+            return -1;
+        }
+
+        /* Azure header: authorization */
+        flb_http_add_header(c, "Authorization", 13, auth, flb_sds_len(auth));
+
+        /* Release buffer */
         flb_sds_destroy(auth);
     }
 

--- a/plugins/out_azure_blob/azure_blob_http.c
+++ b/plugins/out_azure_blob/azure_blob_http.c
@@ -39,7 +39,7 @@ static int hmac_sha256_sign(unsigned char out[32],
                            out, 32);
 }
 
-static int azb_get_oauth2_token(struct flb_azure_blob *ctx)
+static int azb_get_service_principal_token(struct flb_azure_blob *ctx)
 {
     int ret;
     char *token;
@@ -112,10 +112,10 @@ static int azb_get_oauth2_authorization_header(struct flb_azure_blob *ctx,
 
     /* Check if token needs refresh */
     if (flb_oauth2_token_expired(ctx->o) == FLB_TRUE) {
-        ret = azb_get_oauth2_token(ctx);
+        ret = azb_get_service_principal_token(ctx);
         if (ret != 0) {
             pthread_mutex_unlock(&ctx->token_mutex);
-            flb_plg_error(ctx->ins, "failed to refresh OAuth2 token");
+            flb_plg_error(ctx->ins, "failed to refresh Service Principal OAuth2 token");
             return -1;
         }
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->
## Summary

This PR adds focused service principal authentication support for the Azure Blob output plugin.

It supports Microsoft Entra ID client credentials authentication for Azure public cloud using the default authority host:

`https://login.microsoftonline.com`


## Related

- Docs PR: https://github.com/fluent/fluent-bit-docs/pull/2592

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    debug

[INPUT]
    Name   dummy
    Tag    test
    Dummy  {"message": "hello from azure service principal test"}
    Rate   1

[OUTPUT]
    Name                  azure_blob
    Match                 *
    account_name           <redacted>
    container_name        <redacted>
    auth_type             service_principal
    tenant_id             <redacted>
    client_id             <redacted>
    client_secret         <redacted>
    tls                   On
    auto_create_container Off



```
- [x] Debug log output from testing the change

```
/01 15:36:18.533] [debug] [output:azure_blob:azure_blob.0] http_send_blob()=1
[2026/06/01 15:36:18.533] [debug] [out flush] cb_destroy coro_id=261
[2026/06/01 15:36:18.533] [debug] [task] destroy task=0x1348042f0 (task_id=0)
[2026/06/01 15:36:19.253] [debug] [task] created task=0x14472f690 id=0 OK
[2026/06/01 15:36:19.253] [debug] [output:azure_blob:azure_blob.0] task_id=0 assigned to thread #0
[2026/06/01 15:36:19.253] [ info] [output:azure_blob:azure_blob.0] auto_create_container is disabled, assuming container '<redacted>' already exists
[2026/06/01 15:36:19.253] [debug] [output:azure_blob:azure_blob.0] generated blob uri ::: /<redacted>/test?comp=appendblock
[2026/06/01 15:36:19.253] [debug] [upstream] KA connection #47 to <redacted>:443 has been assigned (recycled)
[2026/06/01 15:36:19.254] [debug] [http_client] not using http_proxy for header
[2026/06/01 15:36:19.532] [ info] [output:azure_blob:azure_blob.0] content uploaded successfully: 
[2026/06/01 15:36:19.532] [debug] [upstream] KA connection #47 to <redacted>:443 is now available
[2026/06/01 15:36:19.532] [debug] [output:azure_blob:azure_blob.0] http_send_blob()=1
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
valgrind \
  --tool=memcheck \
  --leak-check=full \
  --show-leak-kinds=all \
  --track-origins=yes \
  --num-callers=30 \
  --log-file=/src/valgrind-azure-blob-test.log \
  ./bin/fluent-bit -c /tmp/azure-blob-test.conf
 ```
  
Result:
```
HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
  total heap usage: 36,391 allocs, 36,391 frees, 21,674,540 bytes allocated

All heap blocks were freed -- no leaks are possible

ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/2592
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service Principal authentication for Azure Blob output (tenant_id, client_id, client_secret)
  * OAuth2 token management with automatic refresh; TLS is required for this auth mode

* **Bug Fixes**
  * Improved HTTP setup and upload error handling with explicit cleanup and safer startup/shutdown

* **Documentation**
  * auth_type help text updated to include service_principal and stronger validation messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->