### PR TITLE
aws: catch auth errors on XML responses

### DIFF
--- a/src/aws/flb_aws_util.c
+++ b/src/aws/flb_aws_util.c
@@ -346,16 +346,16 @@ int flb_aws_is_auth_error(char *payload, size_t payload_size)
         return FLB_FALSE;
     }
 
-    /* Fluent Bit calls the STS API which returns XML */
-    if (strcasestr(payload, "InvalidClientTokenId") != NULL) {
-        return FLB_TRUE;
-    }
-
-    if (strcasestr(payload, "AccessDenied") != NULL) {
-        return FLB_TRUE;
-    }
-
-    if (strcasestr(payload, "Expired") != NULL) {
+    /* STS, S3, and other AWS APIs return XML error responses */
+    if (strcasestr(payload, "InvalidClientTokenId") != NULL ||
+        strcasestr(payload, "AccessDenied") != NULL ||
+        strcasestr(payload, "Expired") != NULL ||
+        strcasestr(payload, "InvalidAccessKeyId") != NULL ||
+        strcasestr(payload, "SignatureDoesNotMatch") != NULL ||
+        strcasestr(payload, "InvalidToken") != NULL ||
+        strcasestr(payload, "InvalidSecurity") != NULL ||
+        strcasestr(payload, "TokenRefreshRequired") != NULL ||
+        strcasestr(payload, "InvalidSignature") != NULL) {
         return FLB_TRUE;
     }
 
@@ -372,6 +372,9 @@ int flb_aws_is_auth_error(char *payload, size_t payload_size)
             strcmp(error, "InvalidClientTokenId") == 0 ||
             strcmp(error, "InvalidToken") == 0 ||
             strcmp(error, "InvalidAccessKeyId") == 0 ||
+            strcmp(error, "InvalidSecurity") == 0 ||
+            strcmp(error, "TokenRefreshRequired") == 0 ||
+            strcmp(error, "InvalidSignature") == 0 ||
             strcmp(error, "UnrecognizedClientException") == 0) {
                 flb_sds_destroy(error);
             return FLB_TRUE;

--- a/tests/internal/aws_util.c
+++ b/tests/internal/aws_util.c
@@ -144,6 +144,36 @@ static void test_flb_aws_error()
     flb_sds_destroy(error_type);
 }
 
+static void test_flb_aws_is_auth_error()
+{
+    char *payload;
+
+    initialization_crutch();
+
+    payload = "<Error><Code>InvalidAccessKeyId</Code><Message>The AWS Access Key Id you provided does not exist in our records.</Message>"
+              "<AWSAccessKeyId>AKIATRANDOMKEY12345678</AWSAccessKeyId>"
+              "<RequestId>XZ4Y38XBV54B7GKT</RequestId>"
+              "<HostId>PEH4YGxFyd7aiREqx47Xj1SEztmklUp/9rzwrLz4A1LIWp8jQRhybogym3KhlfpCC4JD4FaRYxU=</HostId></Error>";
+    TEST_CHECK(flb_aws_is_auth_error(payload, strlen(payload)) == FLB_TRUE);
+
+    payload = "<Error>"
+              "<Code>NoSuchKey</Code>"
+              "<Message>The resource you requested does not exist</Message>"
+              "<Resource>/mybucket/myfoto.jpg</Resource>"
+              "<RequestId>4442587FB7D0A2F9</RequestId>"
+              "</Error>";
+    TEST_CHECK(flb_aws_is_auth_error(payload, strlen(payload)) == FLB_FALSE);
+
+    payload = "{\"__type\":\"ExpiredToken\",\"message\":\"The security token included in the request is expired.\"}";
+    TEST_CHECK(flb_aws_is_auth_error(payload, strlen(payload)) == FLB_TRUE);
+
+    payload = "{\"__type\":\"ValidationError\",\"message\":\"Input validation failed.\"}";
+    TEST_CHECK(flb_aws_is_auth_error(payload, strlen(payload)) == FLB_FALSE);
+
+    payload = "";
+    TEST_CHECK(flb_aws_is_auth_error(payload, strlen(payload)) == FLB_FALSE);
+}
+
 static void test_flb_aws_endpoint()
 {
     char *endpoint;
@@ -418,6 +448,7 @@ static void test_flb_get_s3_key_mixed_timestamp()
 
 TEST_LIST = {
     { "parse_api_error" , test_flb_aws_error},
+    { "flb_aws_is_auth_error", test_flb_aws_is_auth_error},
     { "flb_aws_endpoint" , test_flb_aws_endpoint},
     {"flb_get_s3_key_multi_tag_exists", test_flb_get_s3_key_multi_tag_exists},
     {"flb_get_s3_key_full_tag", test_flb_get_s3_key_full_tag},


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

## Problem

When AWS credentials are rotated (e.g. a new key pair written to `~/.aws/credentials`), the S3 output plugin fails to detect the authentication error and trigger a credential refresh.

The root cause is in `flb_aws_is_auth_error()` (`src/aws/flb_aws_util.c`): S3 returns error responses in **XML** format, but several auth-related error codes — `InvalidAccessKeyId`, `SignatureDoesNotMatch`, `InvalidToken`, `InvalidSecurity`, `TokenRefreshRequired`, and `InvalidSignature` — were only checked via the **JSON** path (using `flb_aws_error()`, which parses the `__type` field). The XML path only covered `InvalidClientTokenId`, `AccessDenied`, and `Expired`.

As a result, `flb_aws_client_request()` never called `provider->refresh()` on S3 auth failures, so stale credentials were used indefinitely despite an updated credentials file on disk.

## Fix

The missing error codes are added to the XML `strcasestr` check block in `flb_aws_is_auth_error()`. When `flb_aws_client_request()` receives a 4xx response, it calls `flb_aws_is_auth_error()` on the response body. If the function returns `FLB_TRUE`, the client calls `provider->refresh()`, which re-reads the credentials file from disk and picks up the rotated keys. The next upload attempt — triggered by the S3 timer callback — then uses the fresh credentials and succeeds. With this fix, that detection now works correctly for S3's XML responses, not just JSON-based APIs like Kinesis.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened detection of AWS authentication errors to include additional XML and JSON error identifiers (e.g., InvalidSecurity, TokenRefreshRequired, InvalidSignature), improving recognition of token/signature/security issues and resulting error handling.
* **Tests**
  * Added unit coverage verifying detection behavior across representative AWS XML/JSON error payloads (including empty responses).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->