### PR TITLE
in_tail: fix offset_key value multiplied by 8 on Windows 64-bit

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -462,9 +462,12 @@ int flb_tail_pack_line_map(struct flb_time *time, char **data,
         if (result == FLB_EVENT_ENCODER_SUCCESS) {
             result = flb_log_event_encoder_append_body_values(
                         file->sl_log_event_encoder,
-                        FLB_LOG_EVENT_CSTRING_VALUE(file->config->offset_key),
-                        FLB_LOG_EVENT_UINT64_VALUE(file->stream_offset +
-                                                   processed_bytes));
+                        FLB_LOG_EVENT_CSTRING_VALUE(file->config->offset_key));
+        }
+        if (result == FLB_EVENT_ENCODER_SUCCESS) {
+            result = flb_log_event_encoder_append_body_uint64(
+                        file->sl_log_event_encoder,
+                        (uint64_t)(file->stream_offset + processed_bytes));
         }
     }
 
@@ -512,9 +515,12 @@ int flb_tail_file_pack_line(struct flb_time *time, char *data, size_t data_size,
         if (result == FLB_EVENT_ENCODER_SUCCESS) {
             result = flb_log_event_encoder_append_body_values(
                         file->sl_log_event_encoder,
-                        FLB_LOG_EVENT_CSTRING_VALUE(file->config->offset_key),
-                        FLB_LOG_EVENT_UINT64_VALUE(file->stream_offset +
-                                                   processed_bytes));
+                        FLB_LOG_EVENT_CSTRING_VALUE(file->config->offset_key));
+        }
+        if (result == FLB_EVENT_ENCODER_SUCCESS) {
+            result = flb_log_event_encoder_append_body_uint64(
+                        file->sl_log_event_encoder,
+                        (uint64_t)(file->stream_offset + processed_bytes));
         }
     }
 


### PR DESCRIPTION
On Win64, FLB_LOG_EVENT_UINT64_VALUE() casts its argument to size_t * (a pointer type) to work around an MSVC varargs type-promotion bug with small constant integers. When the argument is a runtime size_t expression (stream_offset + processed_bytes), MSVC may treat the resulting size_t * differently from a plain uint64_t during varargs passing, causing the received value to be 8x the correct offset.

Fix by splitting the combined append_body_values() call into two steps: use the existing FLB_LOG_EVENT_CSTRING_VALUE macro for the key, then call flb_log_event_encoder_append_body_uint64() directly with an explicit (uint64_t) cast for the value. This avoids the variadic path entirely for the numeric offset, eliminating the Win64 MSVC issue.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal encoding of file offset data in the tail plugin for more consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->