### PR TITLE
mp: fixed count when empty data

### DIFF
--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -47,27 +47,29 @@ int flb_mp_count(const void *data, size_t bytes)
 
 int flb_mp_count_remaining(const void *data, size_t bytes, size_t *remaining_bytes)
 {
-    size_t remaining;
+    size_t remaining = 0;
     int count = 0;
     mpack_reader_t reader;
 
-    mpack_reader_init_data(&reader, (const char *) data, bytes);
-    for (;;) {
-        remaining = mpack_reader_remaining(&reader, NULL);
-        if (!remaining) {
-            break;
+    if (data) {
+        mpack_reader_init_data(&reader, (const char *) data, bytes);
+        for (;;) {
+            remaining = mpack_reader_remaining(&reader, NULL);
+            if (!remaining) {
+                break;
+            }
+            mpack_discard(&reader);
+            if (mpack_reader_error(&reader)) {
+                break;
+            }
+            count++;
         }
-        mpack_discard(&reader);
-        if (mpack_reader_error(&reader)) {
-            break;
-        }
-        count++;
+        mpack_reader_destroy(&reader);
     }
 
     if (remaining_bytes) {
         *remaining_bytes = remaining;
     }
-    mpack_reader_destroy(&reader);
     return count;
 }
 


### PR DESCRIPTION
(cherry picked from commit 644ced926b64d40924e28f45f01ef5fb0d984581)

Backports the msgpack empty-buffer count fix to 4.2.

When an output processor drops every log record, the processed buffer can be NULL/0. Without this guard, flb_mp_count_remaining() can call mpack_reader_init_data() with null data and crash. This patch skips msgpack reader initialization for null buffers and returns zero records.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
