### PR TITLE
in_collectd: reject parts with length < 4 and fix null-terminator OOB [Backport to 4.2]

### DIFF
--- a/plugins/in_collectd/netprot.c
+++ b/plugins/in_collectd/netprot.c
@@ -247,8 +247,9 @@ int netprot_to_msgpack(char *buf, int len, struct mk_list *tdb,
         part_type = be16read(buf);
         part_len = be16read((unsigned char *) buf + 2);
 
-        if (len < part_len) {
-            flb_error("[in_collectd] data truncated (%i < %i)", len, part_len);
+        if (part_len < 4 || len < part_len) {
+            flb_error("[in_collectd] invalid part length (%i, remaining %i)",
+                      part_len, len);
             return -1;
         }
 
@@ -268,7 +269,7 @@ int netprot_to_msgpack(char *buf, int len, struct mk_list *tdb,
 
         switch (part_type) {
             case PART_HOST:
-                if (ptr[size] == '\0') {
+                if (size > 0 && ptr[size - 1] == '\0') {
                     hdr.host = ptr;
                 }
                 break;
@@ -279,22 +280,22 @@ int netprot_to_msgpack(char *buf, int len, struct mk_list *tdb,
                 hdr.time = hr2time(be64read(ptr));
                 break;
             case PART_PLUGIN:
-                if (ptr[size] == '\0') {
+                if (size > 0 && ptr[size - 1] == '\0') {
                     hdr.plugin = ptr;
                 }
                 break;
             case PART_PLUGIN_INSTANCE:
-                if (ptr[size] == '\0') {
+                if (size > 0 && ptr[size - 1] == '\0') {
                     hdr.plugin_instance = ptr;
                 }
                 break;
             case PART_TYPE:
-                if (ptr[size] == '\0') {
+                if (size > 0 && ptr[size - 1] == '\0') {
                     hdr.type = ptr;
                 }
                 break;
             case PART_TYPE_INSTANCE:
-                if (ptr[size] == '\0') {
+                if (size > 0 && ptr[size - 1] == '\0') {
                     hdr.type_instance = ptr;
                 }
                 break;


### PR DESCRIPTION
Backporting of https://github.com/fluent/fluent-bit/pull/11849.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
