### PR TITLE
zstd: cap buffer at max instead of aborting on overshoot [Backport to 4.2]

### DIFF
--- a/src/flb_zstd.c
+++ b/src/flb_zstd.c
@@ -28,7 +28,8 @@ struct flb_zstd_decompression_context {
     ZSTD_DCtx *dctx;
 };
 
-#define FLB_ZSTD_DEFAULT_CHUNK 64 * 1024  /* 64 KB buffer */
+#define FLB_ZSTD_DEFAULT_CHUNK      (64 * 1024)       /* 64 KB buffer */
+#define FLB_ZSTD_DECOMPRESS_MAX     (100 * 1024 * 1024)  /* 100 MB limit */
 
 int flb_zstd_compress(void *in_data, size_t in_len, void **out_data, size_t *out_len)
 {
@@ -104,7 +105,16 @@ static int zstd_uncompress_unknown_size(void *in_data, size_t in_len, void **out
 
         /* check if we need more space */
         if (output.pos == out_size) {
+            if (out_size >= FLB_ZSTD_DECOMPRESS_MAX) {
+                flb_error("[zstd] maximum decompression size reached (~100 MB)");
+                flb_free(buf);
+                ZSTD_freeDCtx(dctx);
+                return -1;
+            }
             out_size *= 2;
+            if (out_size > FLB_ZSTD_DECOMPRESS_MAX) {
+                out_size = FLB_ZSTD_DECOMPRESS_MAX;
+            }
             tmp = flb_realloc(buf, out_size);
             if (!tmp) {
                 flb_errno();
@@ -144,6 +154,12 @@ int flb_zstd_uncompress(void *in_data, size_t in_len, void **out_data, size_t *o
     else if (size == ZSTD_CONTENTSIZE_UNKNOWN) {
         ret = zstd_uncompress_unknown_size(in_data, in_len, out_data, out_len);
         return ret;
+    }
+
+    if (size > FLB_ZSTD_DECOMPRESS_MAX) {
+        flb_error("[zstd] maximum decompression size is %d bytes",
+                  FLB_ZSTD_DECOMPRESS_MAX);
+        return -1;
     }
 
     buf = flb_malloc(size);


### PR DESCRIPTION
Backporting of https://github.com/fluent/fluent-bit/pull/11854.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
