### PR TITLE
workflows: Windows docker insufficient disk space fix [Backport to 4.2]

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -47,10 +47,7 @@ RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
       \"--channelUri ${msvs_build_tools_channel}\", `
       \"--installChannelUri ${msvs_build_tools_channel}\", `
       '--add Microsoft.VisualStudio.Workload.VCTools', `
-      '--add Microsoft.VisualStudio.Workload.MSBuildTools', `
       '--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64', `
-      '--add Microsoft.VisualStudio.Component.VC.CoreBuildTools', `
-      '--add Microsoft.VisualStudio.Component.VC.MSVC.143', `
       '--add Microsoft.VisualStudio.Component.Windows10SDK.19041' `
       -NoNewWindow -Wait; `
     Remove-Item -Force \"${msvs_build_tools_dist}\"; `

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -85,6 +85,26 @@ RUN if ([System.Version] \"${env:CMAKE_VERSION}\" -ge [System.Version] \"3.20.0\
     Write-Host \"${env:PATH}\"; `
     [Environment]::SetEnvironmentVariable(\"PATH\", \"${env:PATH}\", [EnvironmentVariableTarget]::Machine);
 
+ENV NINJA_HOME="C:\ninja"
+ARG NINJA_VERSION="1.13.2"
+ARG NINJA_URL="https://github.com/ninja-build/ninja/releases/download"
+
+RUN $ninja_dist_name=\"ninja-win.zip\"; `
+    $ninja_dist=\"${env:TMP}\${ninja_dist_name}\"; `
+    $ninja_download_url=\"${env:NINJA_URL}/v${env:NINJA_VERSION}/${ninja_dist_name}\"; `
+    Write-Host \"Downloading Ninja...\"; `
+    Write-Host \"${ninja_download_url} -> ${ninja_dist}\"; `
+    Invoke-WebRequest -OutFile \"${ninja_dist}\" \"${ninja_download_url}\"; `
+    New-Item -Path \"${env:NINJA_HOME}\" -ItemType \"directory\"; `
+    Write-Host \"Extracting Ninja...\"; `
+    Write-Host \"${ninja_dist} -> ${env:NINJA_HOME}\"; `
+    Expand-Archive \"${ninja_dist}\" -Destination \"${env:NINJA_HOME}\"; `
+    Remove-Item -Force \"${ninja_dist}\"; `
+    $env:PATH=\"${env:PATH};${env:NINJA_HOME}\"; `
+    Write-Host \"Setting PATH...\"; `
+    Write-Host \"${env:PATH}\"; `
+    [Environment]::SetEnvironmentVariable(\"PATH\", \"${env:PATH}\", [EnvironmentVariableTarget]::Machine);
+
 ENV WIN_FLEX_BISON_VERSION="2.5.22" `
     WIN_FLEX_BISON_HOME="C:\WinFlexBison" `
     WIN_FLEX_BISON_DOWNLOAD_URL="https://github.com/lexxmark/winflexbison/releases/download"
@@ -172,7 +192,7 @@ COPY . /src/
 ARG BUILD_PARALLEL=1
 SHELL ["cmd", "/S", "/C"]
 RUN call "%MSVS_HOME%\VC\Auxiliary\Build\vcvars64.bat" && `
-    cmake -G "NMake Makefiles" `
+    cmake -G "Ninja" `
       -DOPENSSL_ROOT_DIR='C:\dev\vcpkg\packages\openssl_x64-windows-static' `
       -DFLB_LIBYAML_DIR='C:\dev\vcpkg\packages\libyaml_x64-windows-static' `
       -DFLB_SIMD=On `
@@ -182,7 +202,7 @@ RUN call "%MSVS_HOME%\VC\Auxiliary\Build\vcvars64.bat" && `
       -DFLB_DEBUG=Off `
       -DFLB_RELEASE=On `
       ..\ && `
-    cmake --build . --config Release -j "%BUILD_PARALLEL%"
+    cmake --build . -j "%BUILD_PARALLEL%"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backporting of https://github.com/fluent/fluent-bit/pull/11671

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
