### PR TITLE
CODEOWNERS: remove @braydonk and @jefferbrecht

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,7 @@
 /plugins/out_datadog     @nokute78 @edsiper
 /plugins/out_es          @pettitwesley @edsiper
 /plugins/out_pgsql       @sxd
-/plugins/out_stackdriver @braydonk @jefferbrecht @jeffluoo
+/plugins/out_stackdriver @jeffluoo
 
 # AWS Plugins
 /plugins/out_s3               @fluent/aws-fluent-bit-maintainers
@@ -85,8 +85,8 @@
 
 # Google test code
 # --------------
-/tests/runtime/out_stackdriver.c @braydonk @jefferbrecht @jeffluoo
-/tests/runtime/data/stackdriver  @braydonk @jefferbrecht @jeffluoo
+/tests/runtime/out_stackdriver.c @jeffluoo
+/tests/runtime/data/stackdriver  @jeffluoo
 
 # Devcontainer
 /.devcontainer                  @patrick-stephens @niedbalski @edsiper


### PR DESCRIPTION
Going forward, @jeffluoo will be the primary owner for the `out_stackdriver` plugin. I am removing myself and @jefferbrecht from any code owner status. Jeff Luo is now fully in charge of the plugin, along with anyone he may want to add as code owners in the future.

I do still have maintainer privileges on this repo, which was simply so I could merge PRs that only touched the `out_stackdriver` plugin/test code without needing to bother maintainers. I can't do it myself, but I would suggest this permission and general interaction be passed on to @jeffluoo as well.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for the Stackdriver output plugin and its runtime test data to reflect current maintainers. This clarifies maintenance and review responsibilities. No functional, public API, or exported-entity changes were made. Low review effort; minor metadata-only edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->