### PR TITLE
proxy: input plugins can now emit metrics and traces event types

### DIFF
--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -33,7 +33,12 @@
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_plugin_proxy.h>
 #include <fluent-bit/flb_input_log.h>
+#include <fluent-bit/flb_input_metric.h>
+#include <fluent-bit/flb_input_trace.h>
+#include <fluent-bit/flb_input_event.h>
 #include <fluent-bit/flb_custom.h>
+#include <cmetrics/cmt_decode_msgpack.h>
+#include <ctraces/ctr_decode_msgpack.h>
 
 /* Proxies */
 #include "proxy/go/go.h"
@@ -75,8 +80,12 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
                                       struct flb_config *config, void *in_context)
 {
     int ret = FLB_OK;
+    int event_type;
     size_t len = 0;
+    size_t offset = 0;
     void *data = NULL;
+    struct cmt *cmt = NULL;
+    struct ctrace *ctr = NULL;
     struct flb_plugin_input_proxy_context *ctx = (struct flb_plugin_input_proxy_context *) in_context;
 
 #ifdef FLB_HAVE_PROXY_GO
@@ -85,7 +94,7 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
         ret = proxy_go_input_collect(ctx, &data, &len);
 
         if (len == 0) {
-            flb_trace("[GO] No logs are ingested");
+            flb_trace("[GO] No data ingested");
             return -1;
         }
 
@@ -94,17 +103,58 @@ static int flb_proxy_input_cb_collect(struct flb_input_instance *ins,
             return -1;
         }
 
-        flb_input_log_append(ins, NULL, 0, data, len);
+        event_type = ctx->proxy->def->event_type;
 
-        ret = proxy_go_input_cleanup(ctx, data);
-        if (ret == -1) {
+        if (event_type == FLB_INPUT_METRICS) {
+            ret = cmt_decode_msgpack_create(&cmt, (char *) data, len, &offset);
+            if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
+                flb_error("[proxy] failed to decode metrics msgpack (error %d)", ret);
+                proxy_go_input_cleanup(ctx, data);
+                return -1;
+            }
+            ret = flb_input_metrics_append(ins, NULL, 0, cmt);
+            if (ret != 0) {
+                flb_error("[proxy] could not append metrics, ret=%d", ret);
+                cmt_decode_msgpack_destroy(cmt);
+                proxy_go_input_cleanup(ctx, data);
+                return -1;
+            }
+            cmt_decode_msgpack_destroy(cmt);
+        }
+        else if (event_type == FLB_INPUT_TRACES) {
+            ret = ctr_decode_msgpack_create(&ctr, (char *) data, len, &offset);
+            if (ret != CTR_DECODE_MSGPACK_SUCCESS) {
+                flb_error("[proxy] failed to decode traces msgpack (error %d)", ret);
+                proxy_go_input_cleanup(ctx, data);
+                return -1;
+            }
+            ret = flb_input_trace_append(ins, NULL, 0, ctr);
+            if (ret != 0) {
+                flb_error("[proxy] could not append traces, ret=%d", ret);
+                ctr_decode_msgpack_destroy(ctr);
+                proxy_go_input_cleanup(ctx, data);
+                return -1;
+            }
+            /* flb_input_trace_append takes ownership of ctr and destroys it on success */
+        }
+        else if (event_type == FLB_INPUT_LOGS) {
+            ret = flb_input_log_append(ins, NULL, 0, data, len);
+        }
+        else {
+            flb_error("[proxy] unsupported event_type %d for input plugin '%s'",
+                      event_type, ins->name);
+            proxy_go_input_cleanup(ctx, data);
+            return -1;
+        }
+
+        if (proxy_go_input_cleanup(ctx, data) == -1) {
             flb_errno();
             return -1;
         }
     }
 #endif
 
-    return 0;
+    return ret;
 }
 
 static int flb_proxy_input_cb_init(struct flb_input_instance *ins,


### PR DESCRIPTION
Allow proxy input plugins (e.g. Go plugins via fluent-bit-go) to emit metrics and traces event types, not just logs.

The proxy input collect callback previously hardcoded `flb_input_log_append`, making it impossible for proxy-based input plugins to feed the metrics or traces pipeline. This change reads `event_type` from the proxy plugin definition and dispatches to the appropriate append function:

- `FLB_INPUT_METRICS` → decode msgpack with `cmt_decode_msgpack_create`, append via `flb_input_metrics_append`
- `FLB_INPUT_TRACES` → decode msgpack with `ctr_decode_msgpack_create`, append via `flb_input_trace_append`
- default (0 / logs) → original `flb_input_log_append` behavior, fully backwards compatible

The output proxy side already supports `event_type` with the same pattern; this brings input plugins to parity. Error handling mirrors `fw_prot.c:append_log`.

The `event_type` field already exists on `flb_plugin_proxy_def` (unused for inputs until now), so Go plugins can set it during `FLBPluginRegister` without any SDK-side C changes — though the fluent-bit-go SDK will need to expose the field to users.

Fixes #11914

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

**Backporting**
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy input now ingests metrics and traces in addition to logs when using the Go proxy path
  * Automatic selection of the appropriate payload decoder based on incoming event type

* **Bug Fixes**
  * Improved error handling and resource cleanup during metric and trace ingestion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->