### PR TITLE
parser: Add IANA time_zone support for native timestamps [Backport to 4.2]

### DIFF
--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -140,7 +140,6 @@ jobs:
             -D FLB_WITHOUT_flb-rt-out_forward=On `
             -D FLB_WITHOUT_flb-rt-in_disk=On `
             -D FLB_WITHOUT_flb-rt-in_proc=On `
-            -D FLB_WITHOUT_flb-it-parser=On `
             -D FLB_WITHOUT_flb-it-unit_sizes=On `
             -D FLB_WITHOUT_flb-it-network=On `
             -D FLB_WITHOUT_flb-it-pack=On `

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -49,6 +49,7 @@ struct flb_parser {
     char *time_key;       /* field name that contains the time */
     int time_offset;      /* fixed UTC offset */
     int time_system_timezone; /* use the system timezone as a fallback */
+    char *time_zone;      /* IANA timezone for naive timestamps */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
     int logfmt_no_bare_keys; /* in logfmt parsers, require all keys to have values */
@@ -91,6 +92,8 @@ static inline time_t flb_parser_tm2time(const struct flb_tm *src,
     return res;
 }
 
+time_t flb_parser_tm2time_parser(const struct flb_tm *src,
+                                 struct flb_parser *parser);
 
 struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      const char *p_regex,
@@ -100,6 +103,22 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
                                      int time_keep,
                                      int time_strict,
                                      int time_system_timezone,
+                                     int logfmt_no_bare_keys,
+                                     struct flb_parser_types *types,
+                                     int types_len,
+                                     struct mk_list *decoders,
+                                     struct flb_config *config);
+struct flb_parser *flb_parser_create_with_time_zone(const char *name,
+                                     const char *format,
+                                     const char *p_regex,
+                                     int skip_empty,
+                                     const char *time_fmt,
+                                     const char *time_key,
+                                     const char *time_offset,
+                                     int time_keep,
+                                     int time_strict,
+                                     int time_system_timezone,
+                                     const char *time_zone,
                                      int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,

--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -50,6 +50,7 @@ struct flb_parser {
     int time_offset;      /* fixed UTC offset */
     int time_system_timezone; /* use the system timezone as a fallback */
     char *time_zone;      /* IANA timezone for naive timestamps */
+    void *time_zone_data; /* parsed native timezone data */
     int time_keep;        /* keep time field */
     int time_strict;      /* parse time field strictly */
     int logfmt_no_bare_keys; /* in logfmt parsers, require all keys to have values */

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -43,6 +43,7 @@
 #include <sys/stat.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <fluent-bit/flb_pthread.h>
@@ -163,6 +164,38 @@ static time_t windows_tm2time_zone(const struct flb_tm *src, const char *iana_zo
 }
 #endif
 
+#ifndef FLB_SYSTEM_WINDOWS
+static int zoneinfo_file_exists(const char *iana_zone)
+{
+    int ret;
+    size_t len;
+    char path[PATH_MAX];
+    const char *tzdir;
+    struct stat st;
+
+    tzdir = getenv("TZDIR");
+    if (tzdir == NULL || tzdir[0] == '\0') {
+        tzdir = "/usr/share/zoneinfo";
+    }
+
+    ret = snprintf(path, sizeof(path), "%s/%s", tzdir, iana_zone);
+    if (ret < 0) {
+        return FLB_FALSE;
+    }
+
+    len = (size_t) ret;
+    if (len >= sizeof(path)) {
+        return FLB_FALSE;
+    }
+
+    if (stat(path, &st) != 0) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+}
+#endif
+
 static int validate_time_zone(const char *iana_zone)
 {
 #ifdef FLB_SYSTEM_WINDOWS
@@ -186,6 +219,10 @@ static int validate_time_zone(const char *iana_zone)
 #ifdef FLB_SYSTEM_WINDOWS
     /* Ensure the mapped native timezone is available on this Windows host. */
     if (windows_time_zone_lookup(windows_zone, &dtzi) != 0) {
+        return -1;
+    }
+#else
+    if (zoneinfo_file_exists(iana_zone) == FLB_FALSE) {
         return -1;
     }
 #endif
@@ -546,7 +583,8 @@ struct flb_parser *flb_parser_create_with_time_zone(const char *name,
                 return NULL;
             }
             if (validate_time_zone(time_zone) != 0) {
-                flb_error("[parser:%s] invalid time_zone '%s'", name, time_zone);
+                flb_error("[parser:%s] invalid or unavailable time_zone '%s'",
+                          name, time_zone);
                 flb_interim_parser_destroy(p);
                 return NULL;
             }

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -42,7 +42,206 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include <fluent-bit/flb_pthread.h>
+
+static pthread_mutex_t flb_time_zone_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+#ifdef FLB_SYSTEM_WINDOWS
+static int utf8_to_wide(const char *str, wchar_t *buf, int buf_size)
+{
+    int ret;
+
+    ret = MultiByteToWideChar(CP_UTF8, 0, str, -1, buf, buf_size);
+    if (ret == 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int windows_time_zone_lookup(const char *windows_zone,
+                                    DYNAMIC_TIME_ZONE_INFORMATION *dtzi)
+{
+    DWORD index;
+    DWORD ret;
+    wchar_t wide_zone[128];
+
+    if (windows_zone == NULL || dtzi == NULL) {
+        return -1;
+    }
+
+    if (utf8_to_wide(windows_zone, wide_zone,
+                     sizeof(wide_zone) / sizeof(wide_zone[0])) != 0) {
+        return -1;
+    }
+
+    for (index = 0; ; index++) {
+        memset(dtzi, 0, sizeof(DYNAMIC_TIME_ZONE_INFORMATION));
+        ret = EnumDynamicTimeZoneInformation(index, dtzi);
+        if (ret == ERROR_NO_MORE_ITEMS) {
+            break;
+        }
+        if (ret != ERROR_SUCCESS) {
+            continue;
+        }
+        if (wcscmp(dtzi->TimeZoneKeyName, wide_zone) == 0) {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int windows_systemtime_from_tm(const struct tm *tm, SYSTEMTIME *st)
+{
+    int year;
+
+    year = tm->tm_year + 1900;
+    if (year < 1601 || year > 30827) {
+        return -1;
+    }
+
+    memset(st, 0, sizeof(SYSTEMTIME));
+    st->wYear = (WORD) year;
+    st->wMonth = (WORD) (tm->tm_mon + 1);
+    st->wDay = (WORD) tm->tm_mday;
+    st->wHour = (WORD) tm->tm_hour;
+    st->wMinute = (WORD) tm->tm_min;
+    st->wSecond = (WORD) tm->tm_sec;
+
+    return 0;
+}
+
+static time_t windows_tm2time_zone(const struct flb_tm *src, const char *iana_zone)
+{
+    int ret;
+    const char *windows_zone;
+    struct tm utc_tm;
+    SYSTEMTIME local_st;
+    SYSTEMTIME utc_st;
+    TIME_ZONE_INFORMATION tzi;
+    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
+
+    windows_zone = flb_time_iana_zone_to_windows(iana_zone);
+    if (windows_zone == NULL) {
+        return (time_t) -1;
+    }
+
+    ret = windows_time_zone_lookup(windows_zone, &dtzi);
+    if (ret != 0) {
+        return (time_t) -1;
+    }
+
+    ret = GetTimeZoneInformationForYear(src->tm.tm_year + 1900, &dtzi, &tzi);
+    if (ret == 0) {
+        return (time_t) -1;
+    }
+
+    ret = windows_systemtime_from_tm(&src->tm, &local_st);
+    if (ret != 0) {
+        return (time_t) -1;
+    }
+
+    ret = TzSpecificLocalTimeToSystemTime(&tzi, &local_st, &utc_st);
+    if (ret == 0) {
+        return (time_t) -1;
+    }
+
+    memset(&utc_tm, 0, sizeof(struct tm));
+    utc_tm.tm_year = utc_st.wYear - 1900;
+    utc_tm.tm_mon = utc_st.wMonth - 1;
+    utc_tm.tm_mday = utc_st.wDay;
+    utc_tm.tm_hour = utc_st.wHour;
+    utc_tm.tm_min = utc_st.wMinute;
+    utc_tm.tm_sec = utc_st.wSecond;
+    utc_tm.tm_isdst = 0;
+
+    return timegm(&utc_tm);
+}
+#endif
+
+static int validate_time_zone(const char *iana_zone)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
+#endif
+    const char *windows_zone;
+
+    if (iana_zone == NULL || iana_zone[0] == '\0') {
+        return 0;
+    }
+
+    /*
+     * Validate against Fluent Bit's built-in IANA timezone index first. On
+     * Windows the same entry also gives us the native timezone key.
+     */
+    windows_zone = flb_time_iana_zone_to_windows(iana_zone);
+    if (windows_zone == NULL) {
+        return -1;
+    }
+
+#ifdef FLB_SYSTEM_WINDOWS
+    /* Ensure the mapped native timezone is available on this Windows host. */
+    if (windows_time_zone_lookup(windows_zone, &dtzi) != 0) {
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+time_t flb_parser_tm2time_parser(const struct flb_tm *src, struct flb_parser *parser)
+{
+    if (parser->time_zone && parser->time_with_tz == FLB_FALSE) {
+#ifdef FLB_SYSTEM_WINDOWS
+        return windows_tm2time_zone(src, parser->time_zone);
+#else
+        char *old_tz = NULL;
+        const char *prev;
+        struct tm tmp;
+        time_t res;
+
+        pthread_mutex_lock(&flb_time_zone_mutex);
+
+        prev = getenv("TZ");
+        if (prev) {
+            old_tz = flb_strdup(prev);
+            if (!old_tz) {
+                pthread_mutex_unlock(&flb_time_zone_mutex);
+                return (time_t) -1;
+            }
+        }
+
+        if (setenv("TZ", parser->time_zone, 1) != 0) {
+            flb_free(old_tz);
+            pthread_mutex_unlock(&flb_time_zone_mutex);
+            return (time_t) -1;
+        }
+
+        tzset();
+        tmp = src->tm;
+        tmp.tm_isdst = -1;
+        res = mktime(&tmp);
+
+        if (old_tz) {
+            setenv("TZ", old_tz, 1);
+            flb_free(old_tz);
+        }
+        else {
+            unsetenv("TZ");
+        }
+        tzset();
+
+        pthread_mutex_unlock(&flb_time_zone_mutex);
+        return res;
+#endif
+    }
+
+    return flb_parser_tm2time(src, parser->time_system_timezone);
+}
 
 static inline uint32_t digits10(uint64_t v) {
     if (v < 10) return 1;
@@ -140,19 +339,25 @@ static void flb_interim_parser_destroy(struct flb_parser *parser)
     if (parser->time_key) {
         flb_free(parser->time_key);
     }
+    if (parser->time_zone) {
+        flb_free(parser->time_zone);
+    }
 
     mk_list_del(&parser->_head);
     flb_free(parser);
 }
 
-struct flb_parser *flb_parser_create(const char *name, const char *format,
+struct flb_parser *flb_parser_create_with_time_zone(const char *name,
+                                     const char *format,
                                      const char *p_regex,
                                      int skip_empty,
-                                     const char *time_fmt, const char *time_key,
+                                     const char *time_fmt,
+                                     const char *time_key,
                                      const char *time_offset,
                                      int time_keep,
                                      int time_strict,
                                      int time_system_timezone,
+                                     const char *time_zone,
                                      int logfmt_no_bare_keys,
                                      struct flb_parser_types *types,
                                      int types_len,
@@ -230,6 +435,12 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     }
 
     p->name = flb_strdup(name);
+
+    if (time_zone && time_zone[0] && !time_fmt) {
+        flb_error("[parser:%s] time_zone requires time_format", name);
+        flb_interim_parser_destroy(p);
+        return NULL;
+    }
 
     if (time_fmt) {
         p->time_fmt_full = flb_strdup(time_fmt);
@@ -319,11 +530,38 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
          */
         p->time_system_timezone = time_system_timezone;
 
+        if (time_zone && time_zone[0]) {
+            if (time_system_timezone) {
+                flb_error("[parser:%s] time_zone cannot be combined with "
+                          "time_system_timezone",
+                          name);
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+            if (time_offset && time_offset[0]) {
+                flb_error("[parser:%s] time_zone cannot be combined with "
+                          "time_offset",
+                          name);
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+            if (validate_time_zone(time_zone) != 0) {
+                flb_error("[parser:%s] invalid time_zone '%s'", name, time_zone);
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+            p->time_zone = flb_strdup(time_zone);
+            if (!p->time_zone) {
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
+        }
+
         /*
          * Optional fixed timezone offset, only applied if
-         * not falling back to system timezone.
+         * not falling back to system timezone or an IANA time_zone.
          */
-        if (!p->time_system_timezone && time_offset) {
+        if (!p->time_system_timezone && !p->time_zone && time_offset) {
             diff = 0;
             len = strlen(time_offset);
             ret = flb_parser_tzone_offset(time_offset, len, &diff);
@@ -347,6 +585,28 @@ struct flb_parser *flb_parser_create(const char *name, const char *format,
     return p;
 }
 
+struct flb_parser *flb_parser_create(const char *name, const char *format,
+                                     const char *p_regex,
+                                     int skip_empty,
+                                     const char *time_fmt, const char *time_key,
+                                     const char *time_offset,
+                                     int time_keep,
+                                     int time_strict,
+                                     int time_system_timezone,
+                                     int logfmt_no_bare_keys,
+                                     struct flb_parser_types *types,
+                                     int types_len,
+                                     struct mk_list *decoders,
+                                     struct flb_config *config)
+{
+    return flb_parser_create_with_time_zone(name, format, p_regex, skip_empty,
+                                            time_fmt, time_key, time_offset,
+                                            time_keep, time_strict,
+                                            time_system_timezone, NULL,
+                                            logfmt_no_bare_keys, types,
+                                            types_len, decoders, config);
+}
+
 void flb_parser_destroy(struct flb_parser *parser)
 {
     int i = 0;
@@ -366,6 +626,9 @@ void flb_parser_destroy(struct flb_parser *parser)
     }
     if (parser->time_key) {
         flb_free(parser->time_key);
+    }
+    if (parser->time_zone) {
+        flb_free(parser->time_zone);
     }
     if (parser->types_len != 0) {
         for (i=0; i<parser->types_len; i++){
@@ -492,6 +755,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     flb_sds_t time_fmt;
     flb_sds_t time_key;
     flb_sds_t time_offset;
+    flb_sds_t time_zone;
     flb_sds_t types_str;
     flb_sds_t tmp_str;
     int skip_empty;
@@ -513,6 +777,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         time_fmt = NULL;
         time_key = NULL;
         time_offset = NULL;
+        time_zone = NULL;
         types_str = NULL;
         tmp_str = NULL;
 
@@ -582,6 +847,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         /* time_offset (UTC offset) */
         time_offset = get_parser_key(config, cf, s, "time_offset");
 
+        /* time_zone (IANA name for naive timestamps) */
+        time_zone = get_parser_key(config, cf, s, "time_zone");
+
         /* logfmt_no_bare_keys */
         logfmt_no_bare_keys = FLB_FALSE;
         tmp_str = get_parser_key(config, cf, s, "logfmt_no_bare_keys");
@@ -603,10 +871,10 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         decoders = flb_parser_decoder_list_create(s);
 
         /* Create the parser context */
-        if (!flb_parser_create(name, format, regex, skip_empty,
+        if (!flb_parser_create_with_time_zone(name, format, regex, skip_empty,
                                time_fmt, time_key, time_offset, time_keep, time_strict,
-                               time_system_timezone, logfmt_no_bare_keys, types, types_len,
-                               decoders, config)) {
+                               time_system_timezone, time_zone, logfmt_no_bare_keys,
+                               types, types_len, decoders, config)) {
             goto fconf_error;
         }
 
@@ -626,6 +894,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         }
         if (time_offset) {
             flb_sds_destroy(time_offset);
+        }
+        if (time_zone) {
+            flb_sds_destroy(time_zone);
         }
         if (types_str) {
             flb_sds_destroy(types_str);
@@ -662,6 +933,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     }
     if (time_offset) {
         flb_sds_destroy(time_offset);
+    }
+    if (time_zone) {
+        flb_sds_destroy(time_zone);
     }
     if (types_str) {
         flb_sds_destroy(types_str);
@@ -1275,7 +1549,7 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
         }
     }
 
-    if (parser->time_with_tz == FLB_FALSE) {
+    if (parser->time_with_tz == FLB_FALSE && !parser->time_zone) {
         flb_tm_gmtoff(tm) = parser->time_offset;
     }
 

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -48,6 +48,10 @@
 #include <string.h>
 
 #ifdef FLB_SYSTEM_WINDOWS
+struct windows_time_zone {
+    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
+};
+
 static int utf8_to_wide(const char *str, wchar_t *buf, int buf_size)
 {
     int ret;
@@ -113,27 +117,37 @@ static int windows_systemtime_from_tm(const struct tm *tm, SYSTEMTIME *st)
     return 0;
 }
 
-static time_t windows_tm2time_zone(const struct flb_tm *src, const char *iana_zone)
+static int windows_time_zone_load(const char *iana_zone, struct windows_time_zone *tz)
 {
     int ret;
     const char *windows_zone;
+
+    windows_zone = flb_time_iana_zone_to_windows(iana_zone);
+    if (windows_zone == NULL) {
+        return -1;
+    }
+
+    ret = windows_time_zone_lookup(windows_zone, &tz->dtzi);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static time_t windows_tm2time_zone(const struct flb_tm *src, struct windows_time_zone *tz)
+{
+    int ret;
     struct tm utc_tm;
     SYSTEMTIME local_st;
     SYSTEMTIME utc_st;
     TIME_ZONE_INFORMATION tzi;
-    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
 
-    windows_zone = flb_time_iana_zone_to_windows(iana_zone);
-    if (windows_zone == NULL) {
+    if (tz == NULL) {
         return (time_t) -1;
     }
 
-    ret = windows_time_zone_lookup(windows_zone, &dtzi);
-    if (ret != 0) {
-        return (time_t) -1;
-    }
-
-    ret = GetTimeZoneInformationForYear(src->tm.tm_year + 1900, &dtzi, &tzi);
+    ret = GetTimeZoneInformationForYear(src->tm.tm_year + 1900, &tz->dtzi, &tzi);
     if (ret == 0) {
         return (time_t) -1;
     }
@@ -160,30 +174,22 @@ static time_t windows_tm2time_zone(const struct flb_tm *src, const char *iana_zo
     return timegm(&utc_tm);
 }
 
-static int windows_time2tm_zone(time_t time, const char *iana_zone,
+static int windows_time2tm_zone(time_t time, struct windows_time_zone *tz,
                                 struct tm *out_tm)
 {
     int ret;
-    const char *windows_zone;
     struct tm utc_tm;
     SYSTEMTIME utc_st;
     SYSTEMTIME local_st;
     TIME_ZONE_INFORMATION tzi;
-    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
 
-    windows_zone = flb_time_iana_zone_to_windows(iana_zone);
-    if (windows_zone == NULL) {
-        return -1;
-    }
-
-    ret = windows_time_zone_lookup(windows_zone, &dtzi);
-    if (ret != 0) {
+    if (tz == NULL) {
         return -1;
     }
 
     gmtime_r(&time, &utc_tm);
 
-    ret = GetTimeZoneInformationForYear(utc_tm.tm_year + 1900, &dtzi, &tzi);
+    ret = GetTimeZoneInformationForYear(utc_tm.tm_year + 1900, &tz->dtzi, &tzi);
     if (ret == 0) {
         return -1;
     }
@@ -631,22 +637,58 @@ static int validate_time_zone(const char *iana_zone)
     return 0;
 }
 
+static void *time_zone_data_create(const char *iana_zone)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    struct windows_time_zone *tz;
+
+    tz = flb_calloc(1, sizeof(struct windows_time_zone));
+    if (tz == NULL) {
+        return NULL;
+    }
+
+    if (windows_time_zone_load(iana_zone, tz) != 0) {
+        flb_free(tz);
+        return NULL;
+    }
+
+    return tz;
+#else
+    struct tzif *tz;
+
+    tz = flb_calloc(1, sizeof(struct tzif));
+    if (tz == NULL) {
+        return NULL;
+    }
+
+    if (tzif_load(iana_zone, tz) != 0) {
+        flb_free(tz);
+        return NULL;
+    }
+
+    return tz;
+#endif
+}
+
+static void time_zone_data_destroy(void *data)
+{
+    if (data == NULL) {
+        return;
+    }
+
+#ifndef FLB_SYSTEM_WINDOWS
+    tzif_destroy((struct tzif *) data);
+#endif
+    flb_free(data);
+}
+
 time_t flb_parser_tm2time_parser(const struct flb_tm *src, struct flb_parser *parser)
 {
     if (parser->time_zone && parser->time_with_tz == FLB_FALSE) {
 #ifdef FLB_SYSTEM_WINDOWS
-        return windows_tm2time_zone(src, parser->time_zone);
+        return windows_tm2time_zone(src, parser->time_zone_data);
 #else
-        struct tzif tz;
-        time_t res;
-
-        if (tzif_load(parser->time_zone, &tz) != 0) {
-            return (time_t) -1;
-        }
-
-        res = tzif_tm2time(&tz, src);
-        tzif_destroy(&tz);
-        return res;
+        return tzif_tm2time(parser->time_zone_data, src);
 #endif
     }
 
@@ -751,6 +793,9 @@ static void flb_interim_parser_destroy(struct flb_parser *parser)
     }
     if (parser->time_zone) {
         flb_free(parser->time_zone);
+    }
+    if (parser->time_zone_data) {
+        time_zone_data_destroy(parser->time_zone_data);
     }
 
     mk_list_del(&parser->_head);
@@ -966,6 +1011,13 @@ struct flb_parser *flb_parser_create_with_time_zone(const char *name,
                 flb_interim_parser_destroy(p);
                 return NULL;
             }
+            p->time_zone_data = time_zone_data_create(time_zone);
+            if (p->time_zone_data == NULL) {
+                flb_error("[parser:%s] could not load time_zone '%s'",
+                          name, time_zone);
+                flb_interim_parser_destroy(p);
+                return NULL;
+            }
         }
 
         /*
@@ -1040,6 +1092,9 @@ void flb_parser_destroy(struct flb_parser *parser)
     }
     if (parser->time_zone) {
         flb_free(parser->time_zone);
+    }
+    if (parser->time_zone_data) {
+        time_zone_data_destroy(parser->time_zone_data);
     }
     if (parser->types_len != 0) {
         for (i=0; i<parser->types_len; i++){
@@ -1854,9 +1909,6 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
     const char *time_ptr = time_str;
     char tmp[64];
     struct tm tmy;
-#ifndef FLB_SYSTEM_WINDOWS
-    struct tzif tz;
-#endif
 
     *ns = 0;
 
@@ -1889,17 +1941,12 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
 
         if (parser->time_zone && parser->time_with_tz == FLB_FALSE) {
 #ifdef FLB_SYSTEM_WINDOWS
-            ret = windows_time2tm_zone(time_now, parser->time_zone, &tmy);
+            ret = windows_time2tm_zone(time_now, parser->time_zone_data, &tmy);
             if (ret != 0) {
                 return -1;
             }
 #else
-            ret = tzif_load(parser->time_zone, &tz);
-            if (ret != 0) {
-                return -1;
-            }
-            ret = tzif_time2tm(&tz, time_now, &tmy);
-            tzif_destroy(&tz);
+            ret = tzif_time2tm(parser->time_zone_data, time_now, &tmy);
             if (ret != 0) {
                 return -1;
             }

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -44,11 +44,8 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
-
-#include <fluent-bit/flb_pthread.h>
-
-static pthread_mutex_t flb_time_zone_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #ifdef FLB_SYSTEM_WINDOWS
 static int utf8_to_wide(const char *str, wchar_t *buf, int buf_size)
@@ -162,9 +159,71 @@ static time_t windows_tm2time_zone(const struct flb_tm *src, const char *iana_zo
 
     return timegm(&utc_tm);
 }
+
+static int windows_time2tm_zone(time_t time, const char *iana_zone,
+                                struct tm *out_tm)
+{
+    int ret;
+    const char *windows_zone;
+    struct tm utc_tm;
+    SYSTEMTIME utc_st;
+    SYSTEMTIME local_st;
+    TIME_ZONE_INFORMATION tzi;
+    DYNAMIC_TIME_ZONE_INFORMATION dtzi;
+
+    windows_zone = flb_time_iana_zone_to_windows(iana_zone);
+    if (windows_zone == NULL) {
+        return -1;
+    }
+
+    ret = windows_time_zone_lookup(windows_zone, &dtzi);
+    if (ret != 0) {
+        return -1;
+    }
+
+    gmtime_r(&time, &utc_tm);
+
+    ret = GetTimeZoneInformationForYear(utc_tm.tm_year + 1900, &dtzi, &tzi);
+    if (ret == 0) {
+        return -1;
+    }
+
+    if (windows_systemtime_from_tm(&utc_tm, &utc_st) != 0) {
+        return -1;
+    }
+
+    ret = SystemTimeToTzSpecificLocalTime(&tzi, &utc_st, &local_st);
+    if (ret == 0) {
+        return -1;
+    }
+
+    memset(out_tm, 0, sizeof(struct tm));
+    out_tm->tm_year = local_st.wYear - 1900;
+    out_tm->tm_mon = local_st.wMonth - 1;
+    out_tm->tm_mday = local_st.wDay;
+    out_tm->tm_hour = local_st.wHour;
+    out_tm->tm_min = local_st.wMinute;
+    out_tm->tm_sec = local_st.wSecond;
+
+    return 0;
+}
 #endif
 
 #ifndef FLB_SYSTEM_WINDOWS
+struct tzif_type {
+    int32_t gmtoff;
+    unsigned char isdst;
+};
+
+struct tzif {
+    int timecnt;
+    int typecnt;
+    int default_type;
+    int64_t *transitions;
+    unsigned char *transition_types;
+    struct tzif_type *types;
+};
+
 static int zoneinfo_file_exists(const char *iana_zone)
 {
     int ret;
@@ -193,6 +252,348 @@ static int zoneinfo_file_exists(const char *iana_zone)
     }
 
     return FLB_TRUE;
+}
+
+static int zoneinfo_path(const char *iana_zone, char *path, size_t path_size)
+{
+    int ret;
+    size_t len;
+    const char *tzdir;
+
+    tzdir = getenv("TZDIR");
+    if (tzdir == NULL || tzdir[0] == '\0') {
+        tzdir = "/usr/share/zoneinfo";
+    }
+
+    ret = snprintf(path, path_size, "%s/%s", tzdir, iana_zone);
+    if (ret < 0) {
+        return -1;
+    }
+
+    len = (size_t) ret;
+    if (len >= path_size) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static uint32_t read_be32(const unsigned char *buf)
+{
+    return ((uint32_t) buf[0] << 24) |
+           ((uint32_t) buf[1] << 16) |
+           ((uint32_t) buf[2] << 8) |
+           (uint32_t) buf[3];
+}
+
+static int32_t read_be32s(const unsigned char *buf)
+{
+    return (int32_t) read_be32(buf);
+}
+
+static int64_t read_be64s(const unsigned char *buf)
+{
+    uint64_t value;
+
+    value = ((uint64_t) buf[0] << 56) |
+            ((uint64_t) buf[1] << 48) |
+            ((uint64_t) buf[2] << 40) |
+            ((uint64_t) buf[3] << 32) |
+            ((uint64_t) buf[4] << 24) |
+            ((uint64_t) buf[5] << 16) |
+            ((uint64_t) buf[6] << 8) |
+            (uint64_t) buf[7];
+
+    return (int64_t) value;
+}
+
+static void tzif_destroy(struct tzif *tz)
+{
+    if (tz == NULL) {
+        return;
+    }
+
+    flb_free(tz->transitions);
+    flb_free(tz->transition_types);
+    flb_free(tz->types);
+}
+
+static int tzif_data_size(const unsigned char *header, int time_size,
+                          size_t *out_size)
+{
+    uint32_t isutcnt;
+    uint32_t isstdcnt;
+    uint32_t leapcnt;
+    uint32_t timecnt;
+    uint32_t typecnt;
+    uint32_t charcnt;
+    size_t size;
+
+    isutcnt = read_be32(header + 20);
+    isstdcnt = read_be32(header + 24);
+    leapcnt = read_be32(header + 28);
+    timecnt = read_be32(header + 32);
+    typecnt = read_be32(header + 36);
+    charcnt = read_be32(header + 40);
+
+    size = ((size_t) timecnt * (size_t) time_size) +
+           (size_t) timecnt +
+           ((size_t) typecnt * 6) +
+           (size_t) charcnt +
+           ((size_t) leapcnt * ((size_t) time_size + 4)) +
+           (size_t) isstdcnt +
+           (size_t) isutcnt;
+
+    *out_size = size;
+    return 0;
+}
+
+static int tzif_parse_data(const unsigned char *buf, size_t size,
+                           int time_size, struct tzif *tz)
+{
+    int i;
+    int type;
+    size_t off;
+    uint32_t timecnt;
+    uint32_t typecnt;
+
+    if (size < 44) {
+        return -1;
+    }
+
+    timecnt = read_be32(buf + 32);
+    typecnt = read_be32(buf + 36);
+    if (typecnt == 0 || timecnt > INT_MAX || typecnt > INT_MAX) {
+        return -1;
+    }
+
+    off = 44;
+    if (off + ((size_t) timecnt * (size_t) time_size) > size) {
+        return -1;
+    }
+
+    memset(tz, 0, sizeof(struct tzif));
+    tz->timecnt = (int) timecnt;
+    tz->typecnt = (int) typecnt;
+    tz->default_type = 0;
+
+    if (timecnt > 0) {
+        tz->transitions = flb_calloc(timecnt, sizeof(int64_t));
+        if (tz->transitions == NULL) {
+            return -1;
+        }
+    }
+
+    for (i = 0; i < (int) timecnt; i++) {
+        if (time_size == 8) {
+            tz->transitions[i] = read_be64s(buf + off);
+        }
+        else {
+            tz->transitions[i] = read_be32s(buf + off);
+        }
+        off += time_size;
+    }
+
+    if (off + timecnt > size) {
+        tzif_destroy(tz);
+        return -1;
+    }
+
+    if (timecnt > 0) {
+        tz->transition_types = flb_malloc(timecnt);
+        if (tz->transition_types == NULL) {
+            tzif_destroy(tz);
+            return -1;
+        }
+        memcpy(tz->transition_types, buf + off, timecnt);
+    }
+    off += timecnt;
+
+    if (off + ((size_t) typecnt * 6) > size) {
+        tzif_destroy(tz);
+        return -1;
+    }
+
+    tz->types = flb_calloc(typecnt, sizeof(struct tzif_type));
+    if (tz->types == NULL) {
+        tzif_destroy(tz);
+        return -1;
+    }
+
+    for (i = 0; i < (int) typecnt; i++) {
+        tz->types[i].gmtoff = read_be32s(buf + off);
+        tz->types[i].isdst = buf[off + 4];
+        off += 6;
+    }
+
+    for (i = 0; i < (int) timecnt; i++) {
+        type = tz->transition_types[i];
+        if (type < 0 || type >= (int) typecnt) {
+            tzif_destroy(tz);
+            return -1;
+        }
+    }
+
+    for (i = 0; i < (int) typecnt; i++) {
+        if (tz->types[i].isdst == 0) {
+            tz->default_type = i;
+            break;
+        }
+    }
+
+    return 0;
+}
+
+static int tzif_load(const char *iana_zone, struct tzif *tz)
+{
+    int ret;
+    char path[PATH_MAX];
+    FILE *fp;
+    long file_size;
+    size_t read_size;
+    size_t block_size;
+    unsigned char *buf;
+    const unsigned char *header;
+    const unsigned char *parse_header;
+    unsigned char version;
+
+    if (zoneinfo_path(iana_zone, path, sizeof(path)) != 0) {
+        return -1;
+    }
+
+    fp = fopen(path, "rb");
+    if (fp == NULL) {
+        return -1;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return -1;
+    }
+
+    file_size = ftell(fp);
+    if (file_size <= 0) {
+        fclose(fp);
+        return -1;
+    }
+
+    rewind(fp);
+
+    buf = flb_malloc((size_t) file_size);
+    if (buf == NULL) {
+        fclose(fp);
+        return -1;
+    }
+
+    read_size = fread(buf, 1, (size_t) file_size, fp);
+    fclose(fp);
+    if (read_size != (size_t) file_size) {
+        flb_free(buf);
+        return -1;
+    }
+
+    if ((size_t) file_size < 44 || memcmp(buf, "TZif", 4) != 0) {
+        flb_free(buf);
+        return -1;
+    }
+
+    header = buf;
+    version = header[4];
+    parse_header = header;
+
+    if (version == '2' || version == '3' || version == '4') {
+        ret = tzif_data_size(header, 4, &block_size);
+        if (ret != 0 || 44 + block_size + 44 > (size_t) file_size) {
+            flb_free(buf);
+            return -1;
+        }
+
+        parse_header = buf + 44 + block_size;
+        if (memcmp(parse_header, "TZif", 4) != 0) {
+            flb_free(buf);
+            return -1;
+        }
+
+        ret = tzif_parse_data(parse_header,
+                              (size_t) file_size - (size_t) (parse_header - buf),
+                              8, tz);
+    }
+    else {
+        ret = tzif_parse_data(parse_header, (size_t) file_size, 4, tz);
+    }
+
+    flb_free(buf);
+    return ret;
+}
+
+static int tzif_type_at_utc(struct tzif *tz, int64_t utc)
+{
+    int lo;
+    int hi;
+    int mid;
+
+    if (tz->timecnt == 0 || utc < tz->transitions[0]) {
+        return tz->default_type;
+    }
+
+    lo = 0;
+    hi = tz->timecnt - 1;
+    while (lo <= hi) {
+        mid = lo + ((hi - lo) / 2);
+        if (tz->transitions[mid] <= utc) {
+            lo = mid + 1;
+        }
+        else {
+            hi = mid - 1;
+        }
+    }
+
+    return tz->transition_types[hi];
+}
+
+static time_t tzif_tm2time(struct tzif *tz, const struct flb_tm *src)
+{
+    int i;
+    int type;
+    int64_t local_epoch;
+    int64_t candidate;
+    struct tm tmp;
+
+    tmp = src->tm;
+    tmp.tm_isdst = 0;
+    local_epoch = (int64_t) timegm(&tmp);
+
+    for (i = 0; i < tz->typecnt; i++) {
+        candidate = local_epoch - (int64_t) tz->types[i].gmtoff;
+        type = tzif_type_at_utc(tz, candidate);
+        if (type >= 0 && type < tz->typecnt &&
+            tz->types[type].gmtoff == tz->types[i].gmtoff) {
+            return (time_t) candidate;
+        }
+    }
+
+    type = tzif_type_at_utc(tz, local_epoch);
+    if (type < 0 || type >= tz->typecnt) {
+        return (time_t) -1;
+    }
+
+    return (time_t) (local_epoch - (int64_t) tz->types[type].gmtoff);
+}
+
+static int tzif_time2tm(struct tzif *tz, time_t time, struct tm *out_tm)
+{
+    int type;
+    time_t local_time;
+
+    type = tzif_type_at_utc(tz, (int64_t) time);
+    if (type < 0 || type >= tz->typecnt) {
+        return -1;
+    }
+
+    local_time = time + tz->types[type].gmtoff;
+    gmtime_r(&local_time, out_tm);
+
+    return 0;
 }
 #endif
 
@@ -236,43 +637,15 @@ time_t flb_parser_tm2time_parser(const struct flb_tm *src, struct flb_parser *pa
 #ifdef FLB_SYSTEM_WINDOWS
         return windows_tm2time_zone(src, parser->time_zone);
 #else
-        char *old_tz = NULL;
-        const char *prev;
-        struct tm tmp;
+        struct tzif tz;
         time_t res;
 
-        pthread_mutex_lock(&flb_time_zone_mutex);
-
-        prev = getenv("TZ");
-        if (prev) {
-            old_tz = flb_strdup(prev);
-            if (!old_tz) {
-                pthread_mutex_unlock(&flb_time_zone_mutex);
-                return (time_t) -1;
-            }
-        }
-
-        if (setenv("TZ", parser->time_zone, 1) != 0) {
-            flb_free(old_tz);
-            pthread_mutex_unlock(&flb_time_zone_mutex);
+        if (tzif_load(parser->time_zone, &tz) != 0) {
             return (time_t) -1;
         }
 
-        tzset();
-        tmp = src->tm;
-        tmp.tm_isdst = -1;
-        res = mktime(&tmp);
-
-        if (old_tz) {
-            setenv("TZ", old_tz, 1);
-            flb_free(old_tz);
-        }
-        else {
-            unsetenv("TZ");
-        }
-        tzset();
-
-        pthread_mutex_unlock(&flb_time_zone_mutex);
+        res = tzif_tm2time(&tz, src);
+        tzif_destroy(&tz);
         return res;
 #endif
     }
@@ -1481,6 +1854,9 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
     const char *time_ptr = time_str;
     char tmp[64];
     struct tm tmy;
+#ifndef FLB_SYSTEM_WINDOWS
+    struct tzif tz;
+#endif
 
     *ns = 0;
 
@@ -1511,7 +1887,25 @@ int flb_parser_time_lookup(const char *time_str, size_t tsize,
             time_now = now;
         }
 
-        if (parser->time_system_timezone == FLB_TRUE) {
+        if (parser->time_zone && parser->time_with_tz == FLB_FALSE) {
+#ifdef FLB_SYSTEM_WINDOWS
+            ret = windows_time2tm_zone(time_now, parser->time_zone, &tmy);
+            if (ret != 0) {
+                return -1;
+            }
+#else
+            ret = tzif_load(parser->time_zone, &tz);
+            if (ret != 0) {
+                return -1;
+            }
+            ret = tzif_time2tm(&tz, time_now, &tmy);
+            tzif_destroy(&tz);
+            if (ret != 0) {
+                return -1;
+            }
+#endif
+        }
+        else if (parser->time_system_timezone == FLB_TRUE) {
             localtime_r(&time_now, &tmy);
         }
         else {

--- a/src/flb_parser_json.c
+++ b/src/flb_parser_json.c
@@ -211,7 +211,7 @@ int flb_parser_json_do(struct flb_parser *parser,
         skip = map_size;
     }
     else {
-        time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+        time_lookup = flb_parser_tm2time_parser(&tm, parser);
     }
 
     /* Compose a new map without the time_key field */

--- a/src/flb_parser_logfmt.c
+++ b/src/flb_parser_logfmt.c
@@ -166,7 +166,7 @@ static int logfmt_parser(struct flb_parser *parser,
                                   parser->name, parser->time_fmt_full);
                         return -1;
                     }
-                    *time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+                    *time_lookup = flb_parser_tm2time_parser(&tm, parser);
                 }
                 time_found = FLB_TRUE;
             }

--- a/src/flb_parser_ltsv.c
+++ b/src/flb_parser_ltsv.c
@@ -139,7 +139,7 @@ static int ltsv_parser(struct flb_parser *parser,
                                  parser->name, parser->time_fmt_full);
                        return -1;
                     }
-                    *time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+                    *time_lookup = flb_parser_tm2time_parser(&tm, parser);
                 }
                 time_found = FLB_TRUE;
             }

--- a/src/flb_parser_regex.c
+++ b/src/flb_parser_regex.c
@@ -87,7 +87,7 @@ static void cb_results(const char *name, const char *value,
             }
 
             pcb->time_frac = frac;
-            pcb->time_lookup = flb_parser_tm2time(&tm, parser->time_system_timezone);
+            pcb->time_lookup = flb_parser_tm2time_parser(&tm, parser);
 
             if (parser->time_keep == FLB_FALSE) {
                 pcb->num_skipped++;

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -9,6 +9,9 @@
 
 #include <time.h>
 #include <string.h>
+#ifdef FLB_SYSTEM_WINDOWS
+#include <stdlib.h>
+#endif
 #include "flb_tests_internal.h"
 
 /* Parsers configuration */
@@ -21,6 +24,28 @@
 
 #define isleap(y) ((y) % 4 == 0 && ((y) % 400 == 0 || (y) % 100 != 0))
 #define year2sec(y) (isleap(y) ? 31622400 : 31536000)
+
+#ifdef FLB_SYSTEM_WINDOWS
+#define flb_test_tzset() _tzset()
+
+static int flb_test_setenv(const char *name, const char *value, int overwrite)
+{
+    if (overwrite == 0 && getenv(name) != NULL) {
+        return 0;
+    }
+
+    return _putenv_s(name, value);
+}
+
+static int flb_test_unsetenv(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#else
+#define flb_test_tzset() tzset()
+#define flb_test_setenv(name, value, overwrite) setenv(name, value, overwrite)
+#define flb_test_unsetenv(name) unsetenv(name)
+#endif
 
 /* Timezone */
 struct tz_check {
@@ -529,14 +554,20 @@ void test_parser_time_system_timezone_midnight()
     char *orig_tz;
     struct flb_parser *parser;
     struct flb_config *config;
+#ifdef FLB_SYSTEM_WINDOWS
+    char *test_tz = "CET-1CEST,M3.5.0/2,M10.5.0/3";
+#else
+    char *test_tz = "Europe/Stockholm";
+#endif
 
     orig_tz = getenv("TZ");
     if (orig_tz != NULL) {
         orig_tz = flb_strdup(orig_tz);
     }
 
-    setenv("TZ", "Europe/Stockholm", 1);
-    tzset();
+    ret = flb_test_setenv("TZ", test_tz, 1);
+    TEST_CHECK(ret == 0);
+    flb_test_tzset();
 
     memset(&now_tm, 0, sizeof(struct tm));
     now_tm.tm_year = 2025 - 1900;
@@ -575,13 +606,13 @@ void test_parser_time_system_timezone_midnight()
     TEST_CHECK(epoch == flb_parser_tm2time(&tm, FLB_TRUE));
 
     if (orig_tz != NULL) {
-        setenv("TZ", orig_tz, 1);
+        flb_test_setenv("TZ", orig_tz, 1);
         flb_free(orig_tz);
     }
     else {
-        unsetenv("TZ");
+        flb_test_unsetenv("TZ");
     }
-    tzset();
+    flb_test_tzset();
 
     flb_parser_destroy(parser);
     flb_parser_exit(config);

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -9,8 +9,11 @@
 
 #include <time.h>
 #include <string.h>
-#ifdef FLB_SYSTEM_WINDOWS
 #include <stdlib.h>
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/stat.h>
+#include <limits.h>
+#include <stdio.h>
 #endif
 #include "flb_tests_internal.h"
 
@@ -46,6 +49,40 @@ static int flb_test_unsetenv(const char *name)
 #define flb_test_setenv(name, value, overwrite) setenv(name, value, overwrite)
 #define flb_test_unsetenv(name) unsetenv(name)
 #endif
+
+static int flb_test_timezone_available(const char *iana_zone)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    return FLB_TRUE;
+#else
+    int ret;
+    size_t len;
+    char path[PATH_MAX];
+    const char *tzdir;
+    struct stat st;
+
+    tzdir = getenv("TZDIR");
+    if (tzdir == NULL || tzdir[0] == '\0') {
+        tzdir = "/usr/share/zoneinfo";
+    }
+
+    ret = snprintf(path, sizeof(path), "%s/%s", tzdir, iana_zone);
+    if (ret < 0) {
+        return FLB_FALSE;
+    }
+
+    len = (size_t) ret;
+    if (len >= sizeof(path)) {
+        return FLB_FALSE;
+    }
+
+    if (stat(path, &st) != 0) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+#endif
+}
 
 /* Timezone */
 struct tz_check {
@@ -634,6 +671,12 @@ void test_parser_time_zone_iana(void)
         return;
     }
 
+    if (flb_test_timezone_available("America/New_York") == FLB_FALSE) {
+        TEST_MSG("skipped: America/New_York zoneinfo is not available");
+        flb_config_exit(config);
+        return;
+    }
+
     parser = flb_parser_create_with_time_zone("iana_ny", "regex",
                                               "^(?<time>.*)$",
                                               FLB_FALSE,
@@ -680,6 +723,12 @@ void test_parser_time_zone_iana_australia(void)
     config = flb_config_init();
     TEST_CHECK(config != NULL);
     if (!config) {
+        return;
+    }
+
+    if (flb_test_timezone_available("Australia/Sydney") == FLB_FALSE) {
+        TEST_MSG("skipped: Australia/Sydney zoneinfo is not available");
+        flb_config_exit(config);
         return;
     }
 

--- a/tests/internal/parser.c
+++ b/tests/internal/parser.c
@@ -588,6 +588,174 @@ void test_parser_time_system_timezone_midnight()
     flb_config_exit(config);
 }
 
+void test_parser_time_zone_iana(void)
+{
+    int ret;
+    struct flb_config *config;
+    struct flb_parser *parser;
+    struct flb_tm tm;
+    double ns;
+    time_t epoch;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        return;
+    }
+
+    parser = flb_parser_create_with_time_zone("iana_ny", "regex",
+                                              "^(?<time>.*)$",
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "America/New_York",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+    if (!parser) {
+        flb_config_exit(config);
+        return;
+    }
+
+    ret = flb_parser_time_lookup("07/17/2017 16:17:03", 19, 0,
+                                 parser, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time_parser(&tm, parser);
+    TEST_CHECK(epoch == (time_t) 1500322623);
+
+    ret = flb_parser_time_lookup("01/15/2017 15:00:00", 19, 0,
+                                 parser, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time_parser(&tm, parser);
+    TEST_CHECK(epoch == (time_t) 1484510400);
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_parser_time_zone_iana_australia(void)
+{
+    int ret;
+    struct flb_config *config;
+    struct flb_parser *parser;
+    struct flb_tm tm;
+    double ns;
+    time_t epoch;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        return;
+    }
+
+    parser = flb_parser_create_with_time_zone("iana_sydney", "regex",
+                                              "^(?<time>.*)$",
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "Australia/Sydney",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+    if (!parser) {
+        flb_config_exit(config);
+        return;
+    }
+
+    ret = flb_parser_time_lookup("01/15/2017 15:00:00", 19, 0,
+                                 parser, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time_parser(&tm, parser);
+    TEST_CHECK(epoch == (time_t) 1484452800);
+
+    ret = flb_parser_time_lookup("07/17/2017 16:17:03", 19, 0,
+                                 parser, &tm, &ns);
+    TEST_CHECK(ret == 0);
+    epoch = flb_parser_tm2time_parser(&tm, parser);
+    TEST_CHECK(epoch == (time_t) 1500272223);
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_parser_time_zone_conflicts(void)
+{
+    struct flb_config *config;
+    struct flb_parser *parser;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (!config) {
+        return;
+    }
+
+    parser = flb_parser_create_with_time_zone("iana_without_format", "regex",
+                                              "^(?<time>.*)$",
+                                              FLB_FALSE,
+                                              NULL,
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "America/New_York",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    TEST_CHECK(parser == NULL);
+
+    parser = flb_parser_create_with_time_zone("iana_with_system_tz", "regex",
+                                              "^(?<time>.*)$",
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_TRUE,
+                                              "America/New_York",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    TEST_CHECK(parser == NULL);
+
+    parser = flb_parser_create_with_time_zone("iana_with_offset", "regex",
+                                              "^(?<time>.*)$",
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              "+0000",
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "America/New_York",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    TEST_CHECK(parser == NULL);
+
+    parser = flb_parser_create_with_time_zone("iana_invalid", "regex",
+                                              "^(?<time>.*)$",
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "America/Not_A_City",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    TEST_CHECK(parser == NULL);
+
+    flb_config_exit(config);
+}
+
 
 TEST_LIST = {
     { "tzone_offset", test_parser_tzone_offset},
@@ -595,6 +763,9 @@ TEST_LIST = {
     { "json_time_lookup", test_json_parser_time_lookup},
     { "regex_time_lookup", test_regex_parser_time_lookup},
     { "time_system_timezone_midnight", test_parser_time_system_timezone_midnight},
+    { "time_zone_iana", test_parser_time_zone_iana },
+    { "time_zone_iana_australia", test_parser_time_zone_iana_australia },
+    { "time_zone_conflicts", test_parser_time_zone_conflicts },
     { "mysql_unquoted" , test_mysql_unquoted },
     { 0 }
 };

--- a/tests/internal/parser_regex.c
+++ b/tests/internal/parser_regex.c
@@ -480,6 +480,134 @@ void test_decode_field_json()
     flb_config_exit(config);
 }
 
+void test_time_zone()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret = 0;
+    char *regex = "^(?<time>\\d{2}/\\d{2}/\\d{4} \\d{2}:\\d{2}:\\d{2}) (?<message>.+)$";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = {"message", "summer"};
+    struct str_list expected = {
+                                .size = sizeof(expected_strs)/sizeof(char*),
+                                .lists = &expected_strs[0],
+    };
+
+    config = flb_config_init();
+    if(!TEST_CHECK(config != NULL)) {
+        TEST_MSG("flb_config_init failed");
+        exit(1);
+    }
+
+    parser = flb_parser_create_with_time_zone("regex_iana_ny", "regex", regex,
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "America/New_York",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create_with_time_zone failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, "07/17/2017 16:17:03 summer",
+                        strlen("07/17/2017 16:17:03 summer"),
+                        &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = compare_msgpack(out_buf, out_size, &expected);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("compare failed");
+    }
+
+    TEST_CHECK(out_time.tm.tv_sec == 1500322623);
+    TEST_CHECK(out_time.tm.tv_nsec == 0);
+
+    flb_free(out_buf);
+    out_buf = NULL;
+    out_size = 0;
+
+    ret = flb_parser_do(parser, "01/15/2017 15:00:00 winter",
+                        strlen("01/15/2017 15:00:00 winter"),
+                        &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    TEST_CHECK(out_time.tm.tv_sec == 1484510400);
+    TEST_CHECK(out_time.tm.tv_nsec == 0);
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+
+    parser = flb_parser_create_with_time_zone("regex_iana_sydney", "regex", regex,
+                                              FLB_FALSE,
+                                              "%m/%d/%Y %H:%M:%S",
+                                              "time",
+                                              NULL,
+                                              FLB_FALSE,
+                                              FLB_TRUE,
+                                              FLB_FALSE,
+                                              "Australia/Sydney",
+                                              FLB_FALSE,
+                                              NULL, 0, NULL, config);
+    if (!TEST_CHECK(parser != NULL)) {
+        TEST_MSG("flb_parser_create_with_time_zone failed");
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    ret = flb_parser_do(parser, "01/15/2017 15:00:00 summer",
+                        strlen("01/15/2017 15:00:00 summer"),
+                        &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    TEST_CHECK(out_time.tm.tv_sec == 1484452800);
+    TEST_CHECK(out_time.tm.tv_nsec == 0);
+
+    flb_free(out_buf);
+    out_buf = NULL;
+    out_size = 0;
+
+    ret = flb_parser_do(parser, "07/17/2017 16:17:03 winter",
+                        strlen("07/17/2017 16:17:03 winter"),
+                        &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+        flb_parser_destroy(parser);
+        flb_config_exit(config);
+        exit(1);
+    }
+
+    TEST_CHECK(out_time.tm.tv_sec == 1500272223);
+    TEST_CHECK(out_time.tm.tv_nsec == 0);
+
+    flb_free(out_buf);
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
 
 TEST_LIST = {
     { "basic", test_basic},
@@ -487,5 +615,6 @@ TEST_LIST = {
     { "time_keep", test_time_keep},
     { "types", test_types},
     { "decode_field_json", test_decode_field_json},
+    { "time_zone", test_time_zone},
     { 0 }
 };

--- a/tests/internal/parser_regex.c
+++ b/tests/internal/parser_regex.c
@@ -25,7 +25,47 @@
 #include <msgpack.h>
 #include <float.h>
 #include <math.h>
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/stat.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#endif
 #include "flb_tests_internal.h"
+
+static int timezone_available(const char *iana_zone)
+{
+#ifdef FLB_SYSTEM_WINDOWS
+    return FLB_TRUE;
+#else
+    int ret;
+    size_t len;
+    char path[PATH_MAX];
+    const char *tzdir;
+    struct stat st;
+
+    tzdir = getenv("TZDIR");
+    if (tzdir == NULL || tzdir[0] == '\0') {
+        tzdir = "/usr/share/zoneinfo";
+    }
+
+    ret = snprintf(path, sizeof(path), "%s/%s", tzdir, iana_zone);
+    if (ret < 0) {
+        return FLB_FALSE;
+    }
+
+    len = (size_t) ret;
+    if (len >= sizeof(path)) {
+        return FLB_FALSE;
+    }
+
+    if (stat(path, &st) != 0) {
+        return FLB_FALSE;
+    }
+
+    return FLB_TRUE;
+#endif
+}
 
 static int msgpack_strncmp(char* str, size_t str_len, msgpack_object obj)
 {
@@ -499,6 +539,18 @@ void test_time_zone()
     if(!TEST_CHECK(config != NULL)) {
         TEST_MSG("flb_config_init failed");
         exit(1);
+    }
+
+    if (timezone_available("America/New_York") == FLB_FALSE) {
+        TEST_MSG("skipped: America/New_York zoneinfo is not available");
+        flb_config_exit(config);
+        return;
+    }
+
+    if (timezone_available("Australia/Sydney") == FLB_FALSE) {
+        TEST_MSG("skipped: Australia/Sydney zoneinfo is not available");
+        flb_config_exit(config);
+        return;
     }
 
     parser = flb_parser_create_with_time_zone("regex_iana_ny", "regex", regex,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11913 except for integration tests.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
