### PR TITLE
dockerfiles: windows: fixed VS Build Tools installation [Backport to 4.2]

### DIFF
--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -49,7 +49,13 @@ RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
       '--add Microsoft.VisualStudio.Workload.VCTools', `
       '--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64', `
       '--add Microsoft.VisualStudio.Component.Windows10SDK.19041' `
-      -NoNewWindow -Wait; `
+      -NoNewWindow -Wait -PassThru; `
+    if (${p}.ExitCode -ne 0 -and ${p}.ExitCode -ne 3010) { `
+      throw \"Visual Studio Build Tools installer failed with exit code $(${p}.ExitCode)\" `
+    }; `
+    if (-not (Test-Path \"${env:MSVS_HOME}\VC\Auxiliary\Build\vcvars64.bat\")) { `
+      throw \"Visual Studio Build Tools installation is incomplete: ${env:MSVS_HOME}\VC\Auxiliary\Build\vcvars64.bat not found\" `
+    }; `
     Remove-Item -Force \"${msvs_build_tools_dist}\"; `
     Remove-Item -Path \"${msvs_build_tools_channel}\" -Force;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11643.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
