### PR TITLE
out_stackdriver: backport codeowners change

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,7 @@
 /plugins/out_datadog     @nokute78 @edsiper
 /plugins/out_es          @pettitwesley @edsiper
 /plugins/out_pgsql       @sxd
-/plugins/out_stackdriver @braydonk @jefferbrecht @jeffluoo
+/plugins/out_stackdriver @jeffluoo
 
 # AWS Plugins
 /plugins/out_s3               @fluent/aws-fluent-bit-maintainers
@@ -85,8 +85,8 @@
 
 # Google test code
 # --------------
-/tests/runtime/out_stackdriver.c @braydonk @jefferbrecht @jeffluoo
-/tests/runtime/data/stackdriver  @braydonk @jefferbrecht @jeffluoo
+/tests/runtime/out_stackdriver.c @jeffluoo
+/tests/runtime/data/stackdriver  @jeffluoo
 
 # Devcontainer
 /.devcontainer                  @patrick-stephens @niedbalski @edsiper


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR backports the codeowner changes to the 4.2 branch.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
#11917
