### PR TITLE
http_client_http2: bracket IPv6 authority hosts

### DIFF
--- a/src/flb_http_client_http2.c
+++ b/src/flb_http_client_http2.c
@@ -21,7 +21,13 @@
 #include <string.h>
 #include <stdio.h>
 
+#ifdef FLB_SYSTEM_WINDOWS
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
 #include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_compat.h>
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>
@@ -83,6 +89,87 @@ static inline size_t http2_lower_value(size_t left_value, size_t right_value)
     }
 
     return right_value;
+}
+
+static int http2_is_ipv6_literal(const char *host,
+                                 char *address_buffer,
+                                 size_t address_buffer_size,
+                                 const char **host_for_authority)
+{
+    struct in6_addr address;
+    const char     *zone_id;
+    size_t          host_length;
+
+    *host_for_authority = host;
+
+    if (host == NULL || host[0] == '[') {
+        return FLB_FALSE;
+    }
+
+    zone_id = strchr(host, '%');
+
+    if (zone_id != NULL) {
+        host_length = zone_id - host;
+
+        if (host_length == 0 || host_length >= address_buffer_size) {
+            return FLB_FALSE;
+        }
+
+        memcpy(address_buffer, host, host_length);
+        address_buffer[host_length] = '\0';
+
+        if (inet_pton(AF_INET6, address_buffer, &address) == 1) {
+            return FLB_TRUE;
+        }
+
+        return FLB_FALSE;
+    }
+
+    if (inet_pton(AF_INET6, host, &address) == 1) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+static int http2_request_set_authority(struct flb_http_request *request)
+{
+    cfl_sds_t  sds_result;
+    const char *host_for_authority;
+    char        address_buffer[INET6_ADDRSTRLEN];
+    int         is_ipv6;
+
+    request->authority = cfl_sds_create_size(strlen(request->host) + 32);
+
+    if (request->authority == NULL) {
+        return -1;
+    }
+
+    is_ipv6 = http2_is_ipv6_literal(request->host,
+                                    address_buffer,
+                                    sizeof(address_buffer),
+                                    &host_for_authority);
+
+    if (is_ipv6) {
+        sds_result = cfl_sds_printf(&request->authority,
+                                    "[%s]:%u",
+                                    host_for_authority,
+                                    request->port);
+    }
+    else {
+        sds_result = cfl_sds_printf(&request->authority,
+                                    "%s:%u",
+                                    request->host,
+                                    request->port);
+    }
+
+    if (sds_result == NULL) {
+        return -1;
+    }
+
+    request->authority = sds_result;
+
+    return 0;
 }
 
 /* PRIVATE */
@@ -486,7 +573,6 @@ int flb_http2_request_begin(struct flb_http_request *request)
 int flb_http2_request_commit(struct flb_http_request *request)
 {
     struct flb_http_client_session  *parent_session;
-    cfl_sds_t                        sds_result;
     struct flb_http2_client_session *session;
     struct flb_http_stream          *stream;
     int                              result;
@@ -562,17 +648,8 @@ int flb_http2_request_commit(struct flb_http_request *request)
     }
 
     if (request->authority == NULL) {
-        request->authority = cfl_sds_create(request->host);
-
-        if (request->authority == NULL) {
-            return -1;
-        }
-
-        sds_result = cfl_sds_printf(&request->authority,
-                                    ":%u",
-                                    request->port);
-
-        if (sds_result == NULL) {
+        result = http2_request_set_authority(request);
+        if (result != 0) {
             return -1;
         }
     }

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -9,6 +9,7 @@ Flask==3.0.3
 google==3.0.0
 googleapis-common-protos==1.63.2
 grpcio==1.64.1
+h2==4.1.0
 idna==3.7
 importlib_metadata==7.1.0
 iniconfig==2.0.0

--- a/tests/integration/scenarios/out_opentelemetry/config/out_otel_http2_ipv6_logs.yaml
+++ b/tests/integration/scenarios/out_opentelemetry/config/out_otel_http2_ipv6_logs.yaml
@@ -1,0 +1,23 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: ipv6_http2
+      samples: 1
+      dummy: |
+        {
+          "message": "hello over ipv6 http2"
+        }
+
+  outputs:
+    - name: opentelemetry
+      match: ipv6_http2
+      host: "::1"
+      port: ${TEST_SUITE_HTTP_PORT}
+      http2: on
+      retry_limit: 1

--- a/tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
+++ b/tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
@@ -3,10 +3,14 @@ import json
 import logging
 import os
 import socket
+import threading
 
 import requests
 import pytest
 from google.protobuf import json_format
+from h2.config import H2Configuration
+from h2.connection import H2Connection
+from h2.events import DataReceived, RequestReceived, StreamEnded
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
@@ -256,6 +260,152 @@ class Service:
             "traces": ExportTraceServiceRequest(),
         }
         return json_format.Parse(json.dumps(payload_dict), messages[signal_type])
+
+
+class IPv6Http2OtlpReceiver:
+    def __init__(self, port):
+        self.port = port
+        self.server_socket = None
+        self.thread = None
+        self.requests = []
+        self.stop_event = threading.Event()
+
+    def start(self):
+        self.server_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind(("::1", self.port))
+        self.server_socket.listen(5)
+        self.server_socket.settimeout(0.5)
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+
+        if self.server_socket is not None:
+            self.server_socket.close()
+            self.server_socket = None
+
+        if self.thread is not None:
+            self.thread.join(timeout=5)
+            self.thread = None
+
+    def _serve(self):
+        while not self.stop_event.is_set():
+            try:
+                client_socket, _ = self.server_socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            with client_socket:
+                self._handle_connection(client_socket)
+
+    def _handle_connection(self, client_socket):
+        connection = H2Connection(
+            config=H2Configuration(client_side=False, header_encoding="utf-8")
+        )
+        request = {
+            "headers": {},
+            "path": None,
+            "body": b"",
+        }
+
+        client_socket.settimeout(2)
+        connection.initiate_connection()
+        client_socket.sendall(connection.data_to_send())
+
+        while not self.stop_event.is_set():
+            try:
+                data = client_socket.recv(65535)
+            except socket.timeout:
+                continue
+
+            if not data:
+                break
+
+            for event in connection.receive_data(data):
+                if isinstance(event, RequestReceived):
+                    request["headers"] = dict(event.headers)
+                    request["path"] = request["headers"].get(":path")
+                elif isinstance(event, DataReceived):
+                    request["body"] += event.data
+                    connection.acknowledge_received_data(
+                        event.flow_controlled_length,
+                        event.stream_id,
+                    )
+                elif isinstance(event, StreamEnded):
+                    self.requests.append(request)
+                    self._send_response(connection, event.stream_id)
+                    client_socket.sendall(connection.data_to_send())
+                    return
+
+            pending = connection.data_to_send()
+            if pending:
+                client_socket.sendall(pending)
+
+    def _send_response(self, connection, stream_id):
+        body = b"{}"
+
+        connection.send_headers(
+            stream_id,
+            [
+                (":status", "200"),
+                ("content-type", "application/json"),
+                ("content-length", str(len(body))),
+            ],
+        )
+        connection.send_data(stream_id, body, end_stream=True)
+
+
+class Http2IPv6Service:
+    def __init__(self):
+        self.config_file = _repo_relative("../config", "out_otel_http2_ipv6_logs.yaml")
+        self.receiver = None
+        self.test_suite_http_port = None
+        self.service = FluentBitTestService(
+            self.config_file,
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        self.test_suite_http_port = service.test_suite_http_port
+        self.receiver = IPv6Http2OtlpReceiver(service.test_suite_http_port)
+        self.receiver.start()
+
+    def _stop_receiver(self, service):
+        if self.receiver is not None:
+            self.receiver.stop()
+            self.receiver = None
+
+    def start(self):
+        self.service.start()
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_requests(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: self.receiver.requests
+            if len(self.receiver.requests) >= minimum_count
+            else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} IPv6 HTTP/2 OTLP requests",
+        )
+
+
+def ipv6_loopback_available():
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        sock.bind(("::1", 0))
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
 
 
 def _build_resource_collision_payload(user_id, body):
@@ -619,6 +769,23 @@ def test_out_opentelemetry_grpc_custom_logs_uri():
     assert request_seen["path"] == "/custom.logs.v1.Logs/Push"
     assert request_seen["headers"]["x-grpc"] == "otlp-test"
     assert record["body"]["stringValue"] == "hello via grpc"
+
+
+def test_out_opentelemetry_http2_ipv6_authority_header():
+    if not ipv6_loopback_available():
+        pytest.skip("IPv6 loopback is not available")
+
+    service = Http2IPv6Service()
+    try:
+        service.start()
+        requests_seen = service.wait_for_requests(1, timeout=30)
+    finally:
+        service.stop()
+
+    request_seen = requests_seen[0]
+
+    assert request_seen["path"] == "/v1/logs"
+    assert request_seen["headers"][":authority"] == f"[::1]:{service.test_suite_http_port}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fixes #11895

 Fix HTTP/2 `:authority` generation for IPv6 literal hosts by formatting
  unbracketed IPv6 addresses as `[host]:port`.

  ## Root Cause

  The HTTP/2 client built `request->authority` by appending `:<port>` directly to
  `request->host`. For IPv6 literals this produced invalid authority values such
  as `::1:4317`, which strict HTTP/2 servers reject. The older HTTP/1 Host header
  path already handled IPv6 bracketing, but the newer HTTP/2 request path did not.

  ## Changes

  - Add IPv6 literal detection in `src/flb_http_client_http2.c`.
  - Format HTTP/2 authority as `[ipv6]:port` for unbracketed IPv6 literals.
  - Add an out_opentelemetry integration scenario using IPv6 loopback and HTTP/2.
  - Add a focused raw HTTP/2 test receiver that asserts the emitted `:authority`.
  
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better IPv6 address handling and authority header formatting for HTTP/2 requests
  * Improved Windows socket compatibility for the HTTP/2 client

* **Tests**
  * Added IPv6 HTTP/2 integration tests for OpenTelemetry logging (validates :authority and path)
  * Added test dependency: h2 (pinned to 4.1.0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->