### PR TITLE
out_azure_blob: correctly handle successful Delete Blob responses

### DIFF
--- a/plugins/out_azure_blob/azure_blob.c
+++ b/plugins/out_azure_blob/azure_blob.c
@@ -829,7 +829,7 @@ static int delete_blob(struct flb_azure_blob *ctx,
         goto cleanup_delete;
     }
 
-    if (c->resp.status == 201) {
+    if (c->resp.status == 202) {
         /* delete "&sig=..." in the c->uri for security */
         char *p = strstr(c->uri, "&sig=");
         if (p) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes an incorrect success status check in the Azure Blob output delete path.

Azure Blob Storage Delete Blob returns HTTP 202 Accepted on success, but delete_blob() was checking for HTTP 201 Created. This caused successful delete responses in the stale/aborted buffered-file cleanup path to be treated as failures.

Reference:
https://learn.microsoft.com/en-us/rest/api/storageservices/delete-blob

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
No issue.
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```ini
[SERVICE]
    Flush        1
    Log_Level    debug

[INPUT]
    Name   dummy
    Tag    test.azure
    Dummy  {"message":"test"}
    Rate   1
[OUTPUT]
    Name                azure_blob
    Match               test.azure
    account_name        testaccount
    shared_key          dGVzdGtleWZvcmF6dXJlYmxvYnRlc3Rpbmc=
    container_name      testcontainer
    blob_type           blockblob
    endpoint            http://127.0.0.1:8080
    emulator_mode       on
    buffering_enabled   true
    database_file       /tmp/flb_azure_delete_test.db
    upload_timeout      2s
    upload_parts_timeout 2s
    file_delivery_attempt_limit 1
    part_delivery_attempt_limit 1
    delete_on_max_upload_error on
    upload_file_size    1048576
    part_size           262144
```

- [x] Debug log output from testing the change

Tested locally with a mock Azure Blob endpoint returning HTTP `202` for `DELETE` requests. Since `delete_blob()` is reached through the database-backed stale/aborted cleanup path, I inserted an aborted file row into the local Azure Blob buffering database to trigger that path.

Before this change, Fluent Bit treated the `202` response as a failure:

```text
[error] [output:azure_blob:azure_blob.0] http_status=202 cannot delete append blob
```
After this change, Fluent Bit accepted the `202` response as successful:

```text
[ info] [output:azure_blob:azure_blob.0] blob deleted successfully: /testaccount/testcontainer/test.azure/manual-delete-test
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
This change only updates the expected HTTP success status code for Azure Blob delete responses. It does not add allocations or change memory ownership.

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Azure Blob Storage deletion status handling to properly recognize successful blob removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->