### PR TITLE
config_format: yaml: Handle list format of parsers_file on service section

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -120,6 +120,7 @@ enum state {
     STATE_SECTION,         /* top level */
     STATE_SECTION_KEY,
     STATE_SECTION_VAL,
+    STATE_SECTION_VAL_LIST,
 
     STATE_SERVICE,         /* 'service' section */
     STATE_INCLUDE,         /* 'includes' section */
@@ -268,6 +269,8 @@ static char *state_str(enum state val)
         return "section-key";
     case STATE_SECTION_VAL:
         return "section-value";
+    case STATE_SECTION_VAL_LIST:
+        return "section-value-list";
     case STATE_SERVICE:
         return "service";
     case STATE_INCLUDE:
@@ -885,6 +888,7 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
     char *value;
     struct flb_cf_env_var *keyval;
     char *last_included;
+    flb_sds_t normalized_key;
 
     last_included = state_get_last(ctx);
 
@@ -1952,6 +1956,75 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
                     flb_error("unable to add property");
                     return YAML_FAILURE;
                 }
+            }
+
+            state = state_pop(ctx);
+
+            if (state == NULL) {
+                flb_error("no state left");
+                return YAML_FAILURE;
+            }
+
+            if (state->state != STATE_SECTION_KEY) {
+                yaml_error_event(ctx, state, event);
+                return YAML_FAILURE;
+            }
+            break;
+        case YAML_SEQUENCE_START_EVENT:
+            normalized_key = flb_cf_key_translate(conf, state->key, flb_sds_len(state->key));
+            if (normalized_key == NULL) {
+                flb_error("unable to normalize key");
+                return YAML_FAILURE;
+            }
+
+            ret = strcasecmp(normalized_key, "parsers_file");
+            flb_sds_destroy(normalized_key);
+
+            if (state->section != SECTION_SERVICE || ret != 0) {
+                yaml_error_event(ctx, state, event);
+                return YAML_FAILURE;
+            }
+
+            state = state_push_key(ctx, STATE_SECTION_VAL_LIST, state->key);
+            if (state == NULL) {
+                flb_error("unable to allocate state");
+                return YAML_FAILURE;
+            }
+            break;
+        default:
+            yaml_error_event(ctx, state, event);
+            return YAML_FAILURE;
+        }
+        break;
+
+    case STATE_SECTION_VAL_LIST:
+        switch(event->type) {
+        case YAML_SCALAR_EVENT:
+            value = (char *) event->data.scalar.value;
+
+            if (state->cf_section == NULL) {
+                flb_error("no section to register key value to");
+                return YAML_FAILURE;
+            }
+
+            if (flb_cf_section_property_add(conf, state->cf_section->properties,
+                                            state->key, flb_sds_len(state->key),
+                                            value, strlen(value)) < 0) {
+                flb_error("unable to add property");
+                return YAML_FAILURE;
+            }
+            break;
+        case YAML_SEQUENCE_END_EVENT:
+            state = state_pop(ctx);
+
+            if (state == NULL) {
+                flb_error("no state left");
+                return YAML_FAILURE;
+            }
+
+            if (state->state != STATE_SECTION_VAL) {
+                yaml_error_event(ctx, state, event);
+                return YAML_FAILURE;
             }
 
             state = state_pop(ctx);

--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2009,7 +2009,7 @@ static int consume_event(struct flb_cf *conf, struct local_ctx *ctx,
 
             if (flb_cf_section_property_add(conf, state->cf_section->properties,
                                             state->key, flb_sds_len(state->key),
-                                            value, strlen(value)) < 0) {
+                                            value, strlen(value)) == NULL) {
                 flb_error("unable to add property");
                 return YAML_FAILURE;
             }

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -32,6 +32,8 @@
 #define FLB_004 FLB_TESTS_CONF_PATH "/stream_processor.yaml"
 #define FLB_005 FLB_TESTS_CONF_PATH "/plugins.yaml"
 #define FLB_006 FLB_TESTS_CONF_PATH "/upstream.yaml"
+#define FLB_PARSERS_LIST FLB_TESTS_CONF_PATH "/parsers/parsers-list.yaml"
+#define FLB_PARSERS_LIST_CAMEL_CASE FLB_TESTS_CONF_PATH "/parsers/parsers-list-camel-case.yaml"
 
 #define FLB_000_WIN FLB_TESTS_CONF_PATH "\\fluent-bit-windows.yaml"
 #define FLB_BROKEN_PLUGIN_VARIANT FLB_TESTS_CONF_PATH "/broken_plugin_variant.yaml"
@@ -320,6 +322,52 @@ static void test_parser_conf()
     flb_cf_dump(cf);
     flb_cf_destroy(cf);
     flb_config_exit(config);
+}
+
+static void test_parser_conf_list_file(char *path)
+{
+    struct flb_cf *cf;
+    struct flb_config *config;
+    int ret;
+    int cnt;
+
+    cf = flb_cf_yaml_create(NULL, path, NULL, 0);
+    TEST_CHECK(cf != NULL);
+    if (!cf) {
+        exit(EXIT_FAILURE);
+    }
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    config->conf_path = flb_strdup(FLB_TESTS_CONF_PATH "/parsers/");
+
+    /* Count the parsers registered automatically by fluent-bit */
+    cnt = mk_list_size(&config->parsers);
+
+    ret = flb_config_load_config_format(config, cf);
+    if (ret != 0) {
+        exit(EXIT_FAILURE);
+    }
+
+    if (!TEST_CHECK(mk_list_size(&config->parsers) == cnt + 2)) {
+        TEST_MSG("Section number error. Got=%d expect=%d",
+                 mk_list_size(&config->parsers),
+                 cnt + 2);
+    }
+
+    flb_cf_dump(cf);
+    flb_cf_destroy(cf);
+    flb_config_exit(config);
+}
+
+static void test_parser_conf_list(void)
+{
+    test_parser_conf_list_file(FLB_PARSERS_LIST);
+}
+
+static void test_parser_conf_list_camel_case(void)
+{
+    test_parser_conf_list_file(FLB_PARSERS_LIST_CAMEL_CASE);
 }
 
 static inline int check_camel_to_snake(char *input, char *output)
@@ -880,6 +928,8 @@ TEST_LIST = {
     { "slist odd", test_slist_odd},
     { "slist even", test_slist_even},
     { "parsers file conf", test_parser_conf},
+    { "parsers file conf list", test_parser_conf_list},
+    { "parsers file conf list camel case", test_parser_conf_list_camel_case},
     { "camel_case_key", test_camel_case_key},
     { "processors", test_processors},
     { "parsers_and_multiline_parsers", test_parsers_and_multiline_parsers},

--- a/tests/internal/data/config_format/yaml/parsers/parsers-extra.conf
+++ b/tests/internal/data/config_format/yaml/parsers/parsers-extra.conf
@@ -1,0 +1,4 @@
+[PARSER]
+    Name        extra
+    Format      regex
+    Regex       ^(?<message>.*)$

--- a/tests/internal/data/config_format/yaml/parsers/parsers-list-camel-case.yaml
+++ b/tests/internal/data/config_format/yaml/parsers/parsers-list-camel-case.yaml
@@ -1,0 +1,4 @@
+service:
+  parsersFile:
+    - parsers.conf
+    - parsers-extra.conf

--- a/tests/internal/data/config_format/yaml/parsers/parsers-list.yaml
+++ b/tests/internal/data/config_format/yaml/parsers/parsers-list.yaml
@@ -1,0 +1,4 @@
+service:
+  parsers_file:
+    - parsers.conf
+    - parsers-extra.conf


### PR DESCRIPTION
<!-- Provide summary of changes -->
In this PR, we support a list format of parsers_file.

Closes https://github.com/fluent/fluent-bit/issues/11910.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YAML config now accepts a list of parser files in the service section and recognizes camelCase variants of the key, allowing multiple parser files to be specified.

* **Tests**
  * Added fixtures and tests verifying multiple parser files are loaded from YAML lists (snake_case and camelCase) and included an extra test parser to exercise this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->