### PR TITLE
config_format: fall back to CWD for relative includes

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -3009,6 +3009,7 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
     yaml_event_t event;
     FILE *fh;
     struct file_state fstate;
+    struct stat fallback_st;
 
     if (parent && cfg_file[0] != '/') {
 
@@ -3030,6 +3031,22 @@ static int read_config(struct flb_cf *conf, struct local_ctx *ctx,
         }
 #undef PATH_CONCAT_TEMPLATE
 
+        /*
+         * If the file does not exist relative to the including file's
+         * directory, fall back to the path as given so it resolves against
+         * the current working directory, matching classic-mode (@include)
+         * resolution.
+         */
+        if (stat(include_dir, &fallback_st) != 0 &&
+            stat(cfg_file, &fallback_st) == 0) {
+            flb_sds_destroy(include_dir);
+            include_dir = flb_sds_create(cfg_file);
+
+            if (include_dir == NULL) {
+                flb_error("unable to create filename");
+                return -1;
+            }
+        }
     }
     else {
 

--- a/tests/internal/config_format_yaml.c
+++ b/tests/internal/config_format_yaml.c
@@ -14,6 +14,14 @@
 #include "flb_tests_internal.h"
 
 #ifdef _WIN32
+#include <direct.h>
+#define chdir _chdir
+#define getcwd _getcwd
+#else
+#include <unistd.h>
+#endif
+
+#ifdef _WIN32
 #define FLB_TESTS_CONF_PATH FLB_TESTS_DATA_PATH "\\data\\config_format\\yaml"
 #else
 #define FLB_TESTS_CONF_PATH FLB_TESTS_DATA_PATH "/data/config_format/yaml"
@@ -845,6 +853,32 @@ static void test_upstream_servers()
     flb_cf_destroy(cf);
 }
 
+/*
+ * A relative include that does not exist next to the including file must
+ * fall back to the current working directory, matching classic-mode
+ * @include resolution.
+ */
+static void test_include_cwd_fallback()
+{
+    struct flb_cf *cf;
+    char oldcwd[4096];
+
+    TEST_ASSERT(getcwd(oldcwd, sizeof(oldcwd)) != NULL);
+    TEST_ASSERT(chdir(FLB_TESTS_CONF_PATH "/cwd_fallback/workdir") == 0);
+
+    cf = flb_cf_yaml_create(NULL,
+                            FLB_TESTS_CONF_PATH "/cwd_fallback/conf/main.yaml",
+                            NULL, 0);
+    TEST_CHECK(cf != NULL);
+    if (cf) {
+        /* one input from main.yaml plus one from the included cwd_file.yaml */
+        TEST_CHECK(mk_list_size(&cf->inputs) == 2);
+        flb_cf_destroy(cf);
+    }
+
+    TEST_ASSERT(chdir(oldcwd) == 0);
+}
+
 static void test_invalid_property()
 {
     char* test_cases[] = {
@@ -886,6 +920,7 @@ TEST_LIST = {
     { "stream_processor", test_stream_processor},
     { "plugins", test_plugins},
     { "upstream_servers", test_upstream_servers},
+    { "include_cwd_fallback", test_include_cwd_fallback},
     { "invalid_input_property", test_invalid_property},
     { 0 }
 };

--- a/tests/internal/data/config_format/yaml/cwd_fallback/conf/main.yaml
+++ b/tests/internal/data/config_format/yaml/cwd_fallback/conf/main.yaml
@@ -1,0 +1,9 @@
+includes:
+  - cwd_file.yaml
+
+pipeline:
+  inputs:
+    - name: dummy
+  outputs:
+    - name: stdout
+      match: '*'

--- a/tests/internal/data/config_format/yaml/cwd_fallback/workdir/cwd_file.yaml
+++ b/tests/internal/data/config_format/yaml/cwd_fallback/workdir/cwd_file.yaml
@@ -1,0 +1,4 @@
+pipeline:
+  inputs:
+    - name: dummy
+      tag: from_cwd


### PR DESCRIPTION
Relative paths in `includes:` only resolve against the including file's directory. Classic mode resolves `@include` against the current working directory first, so YAML behaves differently for setups that load a configuration file from outside the working directory and expect relative includes to resolve against CWD.

This change makes the YAML loader fall back to the path as given (CWD-relative) when the parent-relative candidate does not exist. Parent-relative resolution still wins when the file exists there, so existing configs are unaffected. Includes a unit test covering the fallback.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ ] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML include-file resolution with a fallback: if a referenced relative include isn’t found in the including file’s directory, the system now checks the current working directory to locate the file, reducing broken includes.

* **Tests**
  * Added cross-platform tests and fixtures validating the new include-file fallback behavior, ensuring consistent parsing across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->