### PR TITLE
in_windows_exporter_metrics: Plug bitwise glitches on 32bit oses

### DIFF
--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -301,6 +301,7 @@ struct flb_we {
     /* WMI locator and service contexts */
     IWbemLocator *locator;
     IWbemServices *service;
+    IWbemContext *wmi_context;
 
     float windows_version;
 

--- a/plugins/in_windows_exporter_metrics/we_util.c
+++ b/plugins/in_windows_exporter_metrics/we_util.c
@@ -152,7 +152,7 @@ wchar_t* we_convert_str(char *str)
         return NULL;
     }
 
-    buf = flb_calloc(1, sizeof(PWSTR) * size);
+    buf = flb_calloc(1, sizeof(wchar_t) * size);
     if (buf == NULL) {
         flb_errno();
         return NULL;

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -35,6 +35,7 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
     HRESULT hr;
     wchar_t *wnamespace;
     BSTR bstrNamespace;
+    SYSTEM_INFO sysInfo;
     VARIANT vArch;
     VARIANT vReq;
 
@@ -74,9 +75,19 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
 
     hr = CoCreateInstance(&CLSID_WbemContext, 0, CLSCTX_INPROC_SERVER, &IID_IWbemContext, (LPVOID *) &ctx->wmi_context);
     if (SUCCEEDED(hr) && ctx->wmi_context != NULL) {
+        GetNativeSystemInfo(&sysInfo);
+
         VariantInit(&vArch);
         vArch.vt = VT_I4;
-        vArch.lVal = 64;
+
+        if (sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 ||
+            sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64) {
+            vArch.lVal = 64;
+        }
+        else {
+            vArch.lVal = 32;
+        }
+
         ctx->wmi_context->lpVtbl->SetValue(ctx->wmi_context, L"__ProviderArchitecture", 0, &vArch);
         VariantClear(&vArch);
 

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -35,6 +35,8 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
     HRESULT hr;
     wchar_t *wnamespace;
     BSTR bstrNamespace;
+    VARIANT vArch;
+    VARIANT vReq;
 
     flb_plg_debug(ctx->ins, "initializing WMI instance....");
 
@@ -70,6 +72,21 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
     }
     ctx->locator = locator;
 
+    hr = CoCreateInstance(&CLSID_WbemContext, 0, CLSCTX_INPROC_SERVER, &IID_IWbemContext, (LPVOID *) &ctx->wmi_context);
+    if (SUCCEEDED(hr) && ctx->wmi_context != NULL) {
+        VariantInit(&vArch);
+        vArch.vt = VT_I4;
+        vArch.lVal = 64;
+        ctx->wmi_context->lpVtbl->SetValue(ctx->wmi_context, L"__ProviderArchitecture", 0, &vArch);
+        VariantClear(&vArch);
+
+        VariantInit(&vReq);
+        vReq.vt = VT_BOOL;
+        vReq.boolVal = VARIANT_TRUE;
+        ctx->wmi_context->lpVtbl->SetValue(ctx->wmi_context, L"__RequiredArchitecture", 0, &vReq);
+        VariantClear(&vReq);
+    }
+
     if (wmi_namespace == NULL) {
         wnamespace = we_convert_str("ROOT\\CIMV2");
     }
@@ -87,7 +104,7 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
                                         0,
                                         0,
                                         0,
-                                        NULL,
+                                        ctx->wmi_context,
                                         &service);
 
     SysFreeString(bstrNamespace);
@@ -96,6 +113,11 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
     if (FAILED(hr)) {
         flb_plg_error(ctx->ins, "Could not connect. Error code = %x", hr);
         locator->lpVtbl->Release(locator);
+        ctx->locator = NULL;
+        if (ctx->wmi_context != NULL) {
+            ctx->wmi_context->lpVtbl->Release(ctx->wmi_context);
+            ctx->wmi_context = NULL;
+        }
         CoUninitialize();
         return hr;
     }
@@ -115,6 +137,12 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
         flb_plg_error(ctx->ins, "Could not set proxy blanket. Error code = %x", hr);
         service->lpVtbl->Release(service);
         locator->lpVtbl->Release(locator);
+        ctx->service = NULL;
+        ctx->locator = NULL;
+        if (ctx->wmi_context != NULL) {
+            ctx->wmi_context->lpVtbl->Release(ctx->wmi_context);
+            ctx->wmi_context = NULL;
+        }
         CoUninitialize();
         return hr;
     }
@@ -335,7 +363,7 @@ static inline int wmi_execute_query(struct flb_we *ctx, struct wmi_query_spec *s
             bstrLanguage,
             bstrQuery,
             WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
-            NULL,
+            ctx->wmi_context,
             &enumerator);
 
     SysFreeString(bstrLanguage);
@@ -377,6 +405,12 @@ static int wmi_exec_query_fixed_val(struct flb_we *ctx, struct wmi_query_spec *s
             &class_obj, &ret);
 
         if(0 == ret) {
+            if (FAILED(hr)) {
+                flb_plg_error(ctx->ins, "WMI Next() failed for fixed val. Error code = %x", hr);
+            }
+            else {
+                flb_plg_debug(ctx->ins, "WMI Next() returned 0 items for %s", spec->wmi_counter);
+            }
             break;
         }
 
@@ -411,6 +445,12 @@ static int wmi_exec_query(struct flb_we *ctx, struct wmi_query_spec *spec)
             &class_obj, &ret);
 
         if(0 == ret) {
+            if (FAILED(hr)) {
+                flb_plg_error(ctx->ins, "WMI Next() failed for query. Error code = %x", hr);
+            }
+            else {
+                flb_plg_debug(ctx->ins, "WMI Next() returned 0 items for %s", spec->wmi_counter);
+            }
             break;
         }
 
@@ -438,6 +478,10 @@ static int wmi_cleanup(struct flb_we *ctx)
     if (ctx->locator != NULL) {
         ctx->locator->lpVtbl->Release(ctx->locator);
         ctx->locator = NULL;
+    }
+    if (ctx->wmi_context != NULL) {
+        ctx->wmi_context->lpVtbl->Release(ctx->wmi_context);
+        ctx->wmi_context = NULL;
     }
     CoUninitialize();
 
@@ -490,6 +534,7 @@ int we_wmi_init(struct flb_we *ctx)
 {
     ctx->locator = NULL;
     ctx->service = NULL;
+    ctx->wmi_context = NULL;
 
     return 0;
 }

--- a/plugins/in_windows_exporter_metrics/we_wmi.c
+++ b/plugins/in_windows_exporter_metrics/we_wmi.c
@@ -34,6 +34,7 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
     IWbemServices *service = 0;
     HRESULT hr;
     wchar_t *wnamespace;
+    BSTR bstrNamespace;
 
     flb_plg_debug(ctx->ins, "initializing WMI instance....");
 
@@ -75,9 +76,12 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
     else {
         wnamespace = we_convert_str(wmi_namespace);
     }
+
+    bstrNamespace = SysAllocString(wnamespace);
+
     /* Connect WMI server */
     hr = locator->lpVtbl->ConnectServer(locator,
-                                        wnamespace,
+                                        bstrNamespace,
                                         NULL,
                                         NULL,
                                         0,
@@ -85,6 +89,8 @@ static int wmi_coinitialize(struct flb_we *ctx, char* wmi_namespace)
                                         0,
                                         NULL,
                                         &service);
+
+    SysFreeString(bstrNamespace);
     flb_free(wnamespace);
 
     if (FAILED(hr)) {
@@ -299,6 +305,8 @@ static inline int wmi_execute_query(struct flb_we *ctx, struct wmi_query_spec *s
     char *query = NULL;
     IEnumWbemClassObject* enumerator = NULL;
     size_t size;
+    BSTR bstrLanguage;
+    BSTR bstrQuery;
 
     size = 14 + strlen(spec->wmi_counter);
     if (spec->where_clause != NULL) {
@@ -319,13 +327,19 @@ static inline int wmi_execute_query(struct flb_we *ctx, struct wmi_query_spec *s
     wquery = we_convert_str(query);
     flb_free(query);
 
+    bstrLanguage = SysAllocString(L"WQL");
+    bstrQuery = SysAllocString(wquery);
+
     hr = ctx->service->lpVtbl->ExecQuery(
             ctx->service,
-            L"WQL",
-            wquery,
+            bstrLanguage,
+            bstrQuery,
             WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
             NULL,
             &enumerator);
+
+    SysFreeString(bstrLanguage);
+    SysFreeString(bstrQuery);
 
     flb_free(wquery);
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
After long running investigations, we found that some of the bit width glitches on 32bit executable of Fluent Bit.
With this PR, we can retrieve prometheus compatible payloads from 32bit version of fluent-bit.exe.

Closes https://github.com/fluent/fluent-bit/issues/10130.

I confirmed that it can retrieve from prometheus_exporter with curl(WebRequest-Invoke Cmdlet) on x86_64 Windows and 32bit/64bit exe pairs, and ARM64 Windows platforms.
32bit/64bit/arm64 executables of fluent-bit.exe are working as expected.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory allocation bug in text conversion to prevent incorrect buffer sizing and potential corruption.
  * Improved Windows metrics initialization to use per-context resources, with stronger cleanup on failures to avoid leaks.
  * Added more robust error detection and logging for query execution and iteration, improving troubleshooting and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->