### PR TITLE
out_es: add support for dynamic index using record accessor patterns

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -503,7 +503,8 @@ static int elasticsearch_format(struct flb_config *config,
                                         map, NULL);
             if (!ra_index) {
                 flb_plg_warn(ctx->ins,
-                             "invalid index translation from record accessor pattern, default to static index");
+                             "invalid index translation from record accessor pattern, default to default Elasticsearch index");
+                es_index = FLB_ES_DEFAULT_INDEX;
             }
             else {
                 es_index = ra_index;

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -304,6 +304,7 @@ static int elasticsearch_format(struct flb_config *config,
     flb_sds_t out_buf;
     size_t out_buf_len = 0;
     flb_sds_t tmp_buf;
+    flb_sds_t ra_index = NULL;
     flb_sds_t id_key_str = NULL;
     // msgpack_unpacked result;
     // msgpack_object root;
@@ -358,7 +359,9 @@ static int elasticsearch_format(struct flb_config *config,
      * The header stored in 'j_index' will be used for the all records on
      * this payload.
      */
-    if (ctx->logstash_format == FLB_FALSE && ctx->generate_id == FLB_FALSE) {
+    if (ctx->logstash_format == FLB_FALSE &&
+        ctx->generate_id == FLB_FALSE &&
+        ctx->ra_index == NULL) {
         flb_time_get(&tms);
         gmtime_r(&tms.tm.tv_sec, &tm);
         strftime(index_formatted, sizeof(index_formatted) - 1,
@@ -490,6 +493,37 @@ static int elasticsearch_format(struct flb_config *config,
                      ctx->index, &tm);
             es_index = index_formatted;
         }
+        else if (ctx->ra_index) {
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
+
+            ra_index = flb_ra_translate(ctx->ra_index,
+                                        (char *) tag, tag_len,
+                                        map, NULL);
+            if (!ra_index) {
+                flb_plg_warn(ctx->ins,
+                             "invalid index translation from record accessor pattern, default to static index");
+            }
+            else {
+                es_index = ra_index;
+            }
+
+            if (ctx->suppress_type_name) {
+                index_len = flb_sds_snprintf(&j_index,
+                                             flb_sds_alloc(j_index),
+                                             ES_BULK_INDEX_FMT_WITHOUT_TYPE,
+                                             ctx->es_action,
+                                             es_index);
+            }
+            else {
+                index_len = flb_sds_snprintf(&j_index,
+                                             flb_sds_alloc(j_index),
+                                             ES_BULK_INDEX_FMT,
+                                             ctx->es_action,
+                                             es_index, ctx->type);
+            }
+        }
 
         /* Tag Key */
         if (ctx->include_tag_key == FLB_TRUE) {
@@ -511,6 +545,9 @@ static int elasticsearch_format(struct flb_config *config,
             flb_log_event_decoder_destroy(&log_decoder);
             msgpack_sbuffer_destroy(&tmp_sbuf);
             es_bulk_destroy(bulk);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             flb_sds_destroy(j_index);
             return -1;
         }
@@ -565,6 +602,9 @@ static int elasticsearch_format(struct flb_config *config,
         if (!out_buf) {
             flb_log_event_decoder_destroy(&log_decoder);
             es_bulk_destroy(bulk);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             flb_sds_destroy(j_index);
             return -1;
         }
@@ -594,6 +634,9 @@ static int elasticsearch_format(struct flb_config *config,
             flb_log_event_decoder_destroy(&log_decoder);
             *out_size = 0;
             es_bulk_destroy(bulk);
+            if (ra_index != NULL) {
+                flb_sds_destroy(ra_index);
+            }
             flb_sds_destroy(j_index);
             return -1;
         }
@@ -613,6 +656,9 @@ static int elasticsearch_format(struct flb_config *config,
     if (ctx->trace_output) {
         fwrite(*out_data, 1, *out_size, stdout);
         fflush(stdout);
+    }
+    if (ra_index != NULL) {
+        flb_sds_destroy(ra_index);
     }
     flb_sds_destroy(j_index);
     return 0;

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -126,6 +126,7 @@ struct flb_elasticsearch {
 
     /* id_key */
     flb_sds_t id_key;
+    struct flb_record_accessor *ra_index;
     struct flb_record_accessor *ra_id_key;
 
     /* include_tag_key */

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -265,6 +265,20 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     if (f_index) {
         ctx->index = flb_strdup(f_index->value); /* FIXME */
     }
+    else {
+        /* Check if index has been set in the configuration */
+        if (ctx->index) {
+            /* Do we have a record accessor pattern ? */
+            if (strchr(ctx->index, '$')) {
+                ctx->ra_index = flb_ra_create(ctx->index, FLB_TRUE);
+                if (!ctx->ra_index) {
+                    flb_plg_error(ctx->ins, "invalid record accessor pattern set for 'index' property");
+                    flb_es_conf_destroy(ctx);
+                    return NULL;
+                }
+            }
+        }
+    }
 
     if (f_type) {
         ctx->type = flb_strdup(f_type->value); /* FIXME */
@@ -527,6 +541,10 @@ int flb_es_conf_destroy(struct flb_elasticsearch *ctx)
 
     if (ctx->ra_prefix_key) {
         flb_ra_destroy(ctx->ra_prefix_key);
+    }
+
+    if (ctx->ra_index) {
+        flb_ra_destroy(ctx->ra_index);
     }
 
     flb_free(ctx->cloud_passwd);

--- a/plugins/out_es/es_conf.c
+++ b/plugins/out_es/es_conf.c
@@ -265,17 +265,16 @@ struct flb_elasticsearch *flb_es_conf_create(struct flb_output_instance *ins,
     if (f_index) {
         ctx->index = flb_strdup(f_index->value); /* FIXME */
     }
-    else {
-        /* Check if index has been set in the configuration */
-        if (ctx->index) {
-            /* Do we have a record accessor pattern ? */
-            if (strchr(ctx->index, '$')) {
-                ctx->ra_index = flb_ra_create(ctx->index, FLB_TRUE);
-                if (!ctx->ra_index) {
-                    flb_plg_error(ctx->ins, "invalid record accessor pattern set for 'index' property");
-                    flb_es_conf_destroy(ctx);
-                    return NULL;
-                }
+
+    /* Check if index has been set in the configuration */
+    if (ctx->index) {
+        /* Do we have a record accessor pattern ? */
+        if (strchr(ctx->index, '$')) {
+            ctx->ra_index = flb_ra_create(ctx->index, FLB_TRUE);
+            if (!ctx->ra_index) {
+                flb_plg_error(ctx->ins, "invalid record accessor pattern set for 'index' property");
+                flb_es_conf_destroy(ctx);
+                return NULL;
             }
         }
     }

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -100,6 +100,76 @@ static void cb_check_index_type(void *ctx, int ffd,
     flb_free(res_data);
 }
 
+static void cb_check_index_record_accessor(void *ctx, int ffd,
+                                           int res_ret, void *res_data,
+                                           size_t res_size, void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char *index_line = "{\"create\":{\"_index\":\"abc\",\"_type\":\"def\"}";
+
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    flb_free(res_data);
+}
+
+static void cb_check_index_record_accessor_suppress_type(void *ctx, int ffd,
+                                                         int res_ret, void *res_data,
+                                                         size_t res_size, void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char *index_line = "{\"create\":{\"_index\":\"abc\"}";
+
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    flb_free(res_data);
+}
+
+static void cb_check_index_record_accessor_id_key(void *ctx, int ffd,
+                                                   int res_ret, void *res_data,
+                                                   size_t res_size, void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char *index_line = "{\"create\":{\"_index\":\"abc\",\"_type\":\"def\",\"_id\":\"something\"}}";
+
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    flb_free(res_data);
+}
+
+static void cb_check_index_record_accessor_generate_id(void *ctx, int ffd,
+                                                       int res_ret, void *res_data,
+                                                       size_t res_size, void *data)
+{
+    char *p;
+    char *id = NULL;
+    char c;
+    int i;
+    char *out_js = res_data;
+    char *index_line = "{\"create\":{\"_index\":\"code\",\"_type\":\"def\",\"_id\":\"";
+
+    /* Check that index translation is working */
+    p = strstr(out_js, index_line);
+    TEST_CHECK(p != NULL);
+
+    /* Check that we have a UUID */
+    id = p + strlen(index_line);
+    TEST_CHECK(strlen(id) > 36);
+    for (i = 0; i < strlen(id) && i < 36; i++) {
+        c = (*(id + i));
+        TEST_CHECK((c >= 'A' && c <= 'F') ||
+                   (c == '-') ||
+                   (c >= '0' && c <= '9'));
+    }
+
+    flb_free(res_data);
+}
+
 static void cb_check_logstash_format(void *ctx, int ffd,
                                      int res_ret, void *res_data, size_t res_size,
                                      void *data)
@@ -442,6 +512,184 @@ void flb_test_index_type()
 
     /* Ingest data sample */
     flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_index_record_accessor()
+{
+    int ret;
+    int len;
+    int in_ffd;
+    int out_ffd;
+    char *record = "[1448403340, {\"key\": \"something\", \"myindex\": \"abc\"}]";
+    flb_ctx_t *ctx;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "$myindex",
+                   "type", "def",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_record_accessor,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    len = strlen(record);
+    flb_lib_push(ctx, in_ffd, record, len);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_index_record_accessor_suppress_type()
+{
+    int ret;
+    int len;
+    int in_ffd;
+    int out_ffd;
+    char *record = "[1448403340, {\"key\": \"something\", \"myindex\": \"abc\"}]";
+    flb_ctx_t *ctx;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "$myindex",
+                   "suppress_type_name", "true",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_record_accessor_suppress_type,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    len = strlen(record);
+    flb_lib_push(ctx, in_ffd, record, len);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_index_record_accessor_with_id_key()
+{
+    int ret;
+    int len;
+    int in_ffd;
+    int out_ffd;
+    char *record = "[1448403340, {\"key\": \"something\", \"myindex\": \"abc\"}]";
+    flb_ctx_t *ctx;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "$myindex",
+                   "type", "def",
+                   "id_key", "key",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_record_accessor_id_key,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    len = strlen(record);
+    flb_lib_push(ctx, in_ffd, record, len);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_index_record_accessor_with_generate_id()
+{
+    int ret;
+    int len;
+    int in_ffd;
+    int out_ffd;
+    char *record = "[1448403340, {\"key\": \"xul\", \"myindex\": \"code\"}]";
+    flb_ctx_t *ctx;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Elasticsearch output */
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "index", "$myindex",
+                   "type", "def",
+                   "generate_id", "true",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_index_record_accessor_generate_id,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    len = strlen(record);
+    flb_lib_push(ctx, in_ffd, record, len);
 
     sleep(2);
     flb_stop(ctx);
@@ -1067,6 +1315,10 @@ TEST_LIST = {
     {"write_operation_update", flb_test_write_operation_update },
     {"write_operation_upsert", flb_test_write_operation_upsert },
     {"index_type"            , flb_test_index_type },
+    {"index_record_accessor" , flb_test_index_record_accessor},
+    {"index_record_accessor_suppress_type", flb_test_index_record_accessor_suppress_type},
+    {"index_record_accessor_id_key", flb_test_index_record_accessor_with_id_key},
+    {"index_record_accessor_generate_id", flb_test_index_record_accessor_with_generate_id},
     {"logstash_format"       , flb_test_logstash_format },
     {"logstash_format_nanos" , flb_test_logstash_format_nanos },
     {"tag_key"               , flb_test_tag_key },


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR adds dynamic Elasticsearch index resolution in out_es using record accessor patterns on the index field (example: $myindex), enabling per-record index routing without duplicating output sections.

What changed:
- Added index record accessor support in ES output context:
  - Added ra_index field to output context.
  - Parse and initialize record accessor when index contains accessor syntax.
  - Release ra_index during plugin teardown.
- Updated bulk formatter logic:
  - When dynamic index is enabled, resolve target index per record at format time.
  - Preserve existing behavior for logstash_format, generate_id, id_key, suppress_type_name.
  - Fallback behavior: if accessor translation fails for a record, use configured static index and log warning.
- Added runtime test coverage:
  - Dynamic index basic behavior.
  - Dynamic index with suppress_type_name.
  - Dynamic index with id_key.
  - Dynamic index with generate_id.

Definitions:
- Record accessor pattern:
  - A field expression that extracts values from a record at runtime (for example, $myindex).
- Dynamic index:
  - The _index value in Elasticsearch bulk metadata is computed per event rather than fixed per output.
- Static fallback:
  - If accessor translation fails, plugin keeps pipeline alive by using configured default index.

Architectural impact:
- Scope-limited to output plugin out_es.
- No protocol/API contract changes outside ES bulk metadata composition.
- Backward compatibility preserved for existing static index and logstash-based index generation paths.
- Operational benefit: multi-tenant or domain-routed indexing from one output instance.

Example behavior:
- Input record:
  - {"message":"ok","myindex":"tenant-a-logs","key":"abc"}
- Configuration:
  - index $myindex
  - type _doc or suppress_type_name true
- Bulk action metadata generated:
  - {"create":{"_index":"tenant-a-logs","_type":"_doc"}}
  - or without type when suppress_type_name is enabled.

Example configuration file:
```ini
[SERVICE]
    Flush       1
    Log_Level   debug

[INPUT]
    Name        dummy
    Tag         app.test
    Dummy       {"message":"ok","myindex":"tenant-a-logs","key":"abc"}

[OUTPUT]
    Name        es
    Match       app.test
    Host        127.0.0.1
    Port        9200
    Index       $myindex
    Type        _doc
    Generate_ID true
```

Issue:
[N/A]

----
Enter [N/A] in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set ok-package-test label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elasticsearch output can derive index names from record fields using pattern-based references.

* **Bug Fixes**
  * If dynamic index resolution fails, the plugin now warns and reliably falls back to the configured static index.

* **Tests**
  * Added runtime tests covering dynamic index selection, type suppression, custom ID, and auto-generated ID behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->