### PR TITLE
opentelemetry: render unset AnyValue in OTLP JSON

### DIFF
--- a/src/opentelemetry/flb_opentelemetry_otlp_json.c
+++ b/src/opentelemetry/flb_opentelemetry_otlp_json.c
@@ -524,6 +524,11 @@ static struct flb_json_mut_val *create_binary_value(struct flb_json_mut_doc *doc
 static struct flb_json_mut_val *msgpack_object_to_otlp_any_value(struct flb_json_mut_doc *doc,
                                                         msgpack_object *object);
 
+static struct flb_json_mut_val *empty_otlp_any_value(struct flb_json_mut_doc *doc)
+{
+    return flb_json_mut_obj(doc);
+}
+
 static struct flb_json_mut_val *msgpack_array_to_otlp_any_value(struct flb_json_mut_doc *doc,
                                                        msgpack_object_array *array)
 {
@@ -544,7 +549,12 @@ static struct flb_json_mut_val *msgpack_array_to_otlp_any_value(struct flb_json_
     }
 
     for (index = 0; index < array->size; index++) {
-        entry = msgpack_object_to_otlp_any_value(doc, &array->ptr[index]);
+        if (array->ptr[index].type == MSGPACK_OBJECT_NIL) {
+            entry = empty_otlp_any_value(doc);
+        }
+        else {
+            entry = msgpack_object_to_otlp_any_value(doc, &array->ptr[index]);
+        }
         if (entry == NULL || !flb_json_mut_arr_add_val(values, entry)) {
             return NULL;
         }
@@ -573,7 +583,12 @@ static struct flb_json_mut_val *msgpack_map_to_otlp_kv_array(struct flb_json_mut
         }
 
         entry = flb_json_mut_obj(doc);
-        value = msgpack_object_to_otlp_any_value(doc, &map->ptr[index].val);
+        if (map->ptr[index].val.type == MSGPACK_OBJECT_NIL) {
+            value = empty_otlp_any_value(doc);
+        }
+        else {
+            value = msgpack_object_to_otlp_any_value(doc, &map->ptr[index].val);
+        }
         if (entry == NULL || value == NULL) {
             return NULL;
         }
@@ -625,7 +640,12 @@ static struct flb_json_mut_val *msgpack_map_to_otlp_kv_array_filtered(
         }
 
         entry = flb_json_mut_obj(doc);
-        value = msgpack_object_to_otlp_any_value(doc, &map->ptr[index].val);
+        if (map->ptr[index].val.type == MSGPACK_OBJECT_NIL) {
+            value = empty_otlp_any_value(doc);
+        }
+        else {
+            value = msgpack_object_to_otlp_any_value(doc, &map->ptr[index].val);
+        }
         if (entry == NULL || value == NULL) {
             return NULL;
         }
@@ -846,6 +866,8 @@ static struct flb_json_mut_val *cfl_variant_to_otlp_any_value(struct flb_json_mu
         value = cfl_kvlist_to_otlp_any_value(doc, variant->data.as_kvlist);
         return (value != NULL &&
                 flb_json_mut_obj_add_val(doc, root, "kvlistValue", value)) ? root : NULL;
+    case CFL_VARIANT_NULL:
+        return root;
     default:
         return NULL;
     }

--- a/tests/integration/scenarios/out_kafka/config/out_kafka_otlp_json_partition_by_resource_small_message_max.yaml
+++ b/tests/integration/scenarios/out_kafka/config/out_kafka_otlp_json_partition_by_resource_small_message_max.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: kafka
+      match: "*"
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: otlp-topic
+      format: otlp_json
+      otlp_logs_partition_by_resource: true
+      queue_full_retries: 1
+      rdkafka.message.max.bytes: 100000
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -1,6 +1,7 @@
 import json
 import os
 import struct
+import time
 from copy import deepcopy
 
 import requests
@@ -255,6 +256,157 @@ def _build_resource_collision_payload(user_id, body, schema_url=None):
     return payload
 
 
+def _build_monolithic_logs_payload(record_count):
+    body_padding = "x" * 256
+    current_time_ns = 1640995200000000000
+
+    resource_log = {
+        "resource": {
+            "attributes": [
+                {
+                    "key": "service.name",
+                    "value": {
+                        "string_value": "monolithic-payment-backend",
+                    },
+                },
+                {
+                    "key": "deployment.environment",
+                    "value": {
+                        "string_value": "production",
+                    },
+                },
+                {
+                    "key": "k8s.namespace.name",
+                    "value": {
+                        "string_value": "transactions",
+                    },
+                },
+                {
+                    "key": "cloud.region",
+                    "value": {
+                        "string_value": "eastus2",
+                    },
+                },
+            ],
+        },
+        "scope_logs": [
+            {
+                "scope": {
+                    "name": "io.opentelemetry.contrib.mongodb",
+                    "version": "1.0.0",
+                },
+                "log_records": [],
+            }
+        ],
+    }
+
+    for index in range(record_count):
+        resource_log["scope_logs"][0]["log_records"].append(
+            {
+                "time_unix_nano": str(current_time_ns - (index * 100000)),
+                "observed_time_unix_nano": str(current_time_ns),
+                "severity_number": 13,
+                "severity_text": "WARN",
+                "body": {
+                    "string_value": (
+                        "Database transaction query execution took longer than "
+                        f"expected threshold. Execution time: {120 + index}ms. "
+                        f"{body_padding}"
+                    ),
+                },
+                "attributes": [
+                    {
+                        "key": "component",
+                        "value": {
+                            "string_value": "database-proxy",
+                        },
+                    },
+                    {
+                        "key": "db.system",
+                        "value": {
+                            "string_value": "mongodb",
+                        },
+                    },
+                    {
+                        "key": "db.operation",
+                        "value": {
+                            "string_value": "findAndModify",
+                        },
+                    },
+                    {
+                        "key": "exception.type",
+                        "value": {
+                            "string_value": "com.mongodb.MongoTimeoutException",
+                        },
+                    },
+                ],
+                "dropped_attributes_count": 0,
+            }
+        )
+
+    return {
+        "resource_logs": [
+            resource_log,
+        ],
+    }
+
+
+def _build_logs_payload_with_unset_attribute_values():
+    return {
+        "resource_logs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "service.name",
+                            "value": {
+                                "string_value": "unset-any-value-service",
+                            },
+                        },
+                        {
+                            "key": "resource.unset",
+                            "value": {},
+                        },
+                    ],
+                },
+                "scope_logs": [
+                    {
+                        "scope": {
+                            "name": "unset-any-value-scope",
+                            "attributes": [
+                                {
+                                    "key": "scope.unset",
+                                    "value": {},
+                                },
+                            ],
+                        },
+                        "log_records": [
+                            {
+                                "time_unix_nano": "1640995200000000000",
+                                "body": {
+                                    "string_value": "log with unset attribute values",
+                                },
+                                "attributes": [
+                                    {
+                                        "key": "record.unset",
+                                        "value": {},
+                                    },
+                                    {
+                                        "key": "record.ok",
+                                        "value": {
+                                            "string_value": "ok",
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+
 def _decode_kafka_payload(message, format_name, signal_type):
     if format_name == "otlp_json":
         return json.loads(message["value"].decode("utf-8"))
@@ -270,6 +422,24 @@ def _collect_resources(messages, format_name, signal_type):
         resources.extend(payload[resource_key])
 
     return resources
+
+
+def _wait_for_log_text(log_file, pattern, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        try:
+            with open(log_file, "r", encoding="utf-8") as log:
+                text = log.read()
+        except FileNotFoundError:
+            text = ""
+
+        if pattern in text:
+            return text
+
+        time.sleep(0.25)
+
+    raise TimeoutError(f"Timed out waiting for log pattern {pattern!r}")
 
 
 def test_out_kafka_sends_json_payload():
@@ -369,6 +539,39 @@ def test_out_kafka_otlp_json_logs():
     assert payload["resourceLogs"]
     assert record["body"]["stringValue"] == "This is an example log message."
     assert payload["resourceLogs"][0]["resource"]["attributes"][0]["key"] == "service.name"
+
+
+def test_out_kafka_otlp_json_logs_preserves_unset_attribute_values():
+    service = Service("out_kafka_otlp_json.yaml")
+    service.start()
+    service.send_payload_dict(_build_logs_payload_with_unset_attribute_values(), "logs")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    payload = json.loads(messages[0]["value"].decode("utf-8"))
+    resource_log = payload["resourceLogs"][0]
+    scope_log = resource_log["scopeLogs"][0]
+    record = scope_log["logRecords"][0]
+
+    resource_attrs = {
+        attr["key"]: attr["value"]
+        for attr in resource_log["resource"]["attributes"]
+    }
+    scope_attrs = {
+        attr["key"]: attr["value"]
+        for attr in scope_log["scope"]["attributes"]
+    }
+    record_attrs = {
+        attr["key"]: attr["value"]
+        for attr in record["attributes"]
+    }
+
+    assert resource_attrs["resource.unset"] == {}
+    assert scope_attrs["scope.unset"] == {}
+    assert record_attrs["record.unset"] == {}
+    assert record_attrs["record.ok"]["stringValue"] == "ok"
+    assert record["body"]["stringValue"] == "log with unset attribute values"
 
 
 def test_out_kafka_otlp_json_metrics():
@@ -699,3 +902,41 @@ def test_out_kafka_otlp_logs_partition_by_resource(format_name, config_file):
         "event-a": "user-a",
         "event-b": "user-b",
     }
+
+
+def test_out_kafka_otlp_json_partition_by_resource_keeps_monolithic_resource_valid():
+    record_count = 512
+    service = Service("out_kafka_otlp_json_partition_by_resource.yaml")
+    service.start()
+    service.send_payload_dict(_build_monolithic_logs_payload(record_count), "logs")
+
+    messages = service.wait_for_messages(1, timeout=10)
+    service.stop()
+
+    assert len(messages) == 1
+    message = messages[0]
+    payload = json.loads(message["value"].decode("utf-8"))
+    resource_logs = payload["resourceLogs"]
+
+    assert message["topic"] == "otlp-topic"
+    assert len(resource_logs) == 1
+    assert len(resource_logs[0]["scopeLogs"]) == 1
+    assert len(resource_logs[0]["scopeLogs"][0]["logRecords"]) == record_count
+    assert len(message["value"]) > 100000
+
+
+def test_out_kafka_otlp_json_partition_by_resource_rejects_oversized_message():
+    service = Service("out_kafka_otlp_json_partition_by_resource_small_message_max.yaml")
+    service.start()
+    service.send_payload_dict(_build_monolithic_logs_payload(512), "logs")
+
+    timeout = 30 if os.environ.get("VALGRIND") else 10
+    log_text = _wait_for_log_text(
+        service.flb.log_file,
+        "Broker: Message size too large",
+        timeout=timeout,
+    )
+    service.stop()
+
+    assert data_storage["messages"] == []
+    assert "could not convert partitioned OTLP logs" not in log_text

--- a/tests/integration/src/server/kafka_server.py
+++ b/tests/integration/src/server/kafka_server.py
@@ -54,7 +54,10 @@ def _recv_exact(sock, size):
     remaining = size
 
     while remaining > 0:
-        chunk = sock.recv(remaining)
+        try:
+            chunk = sock.recv(remaining)
+        except ConnectionResetError:
+            return None
         if not chunk:
             return None
         chunks.append(chunk)


### PR DESCRIPTION
This fixes an OTLP JSON rendering failure in the Kafka output path when a valid OTLP logs payload contains an unset `AnyValue` in resource, scope, or record attributes.

Kafka `format: otlp_json` reuses the shared OTLP logs JSON renderer. The protobuf OTLP input accepts unset `AnyValue` fields and stores them internally as msgpack nil, but the renderer treated nil attribute values as conversion failures while building OTLP key/value arrays. That made the Kafka output drop the chunk with:

```text
[error] [output:kafka:kafka.0] could not convert event chunk to OTLP JSON: -2
```

The renderer now emits unset attribute values as an empty OTLP AnyValue object (`{}`), while still omitting an absent/nil log body when the whole body candidate is nil.

This also adds Kafka integration coverage for:

- protobuf OTLP logs with unset resource, scope, and record attribute values;
- monolithic single-resource OTLP JSON payloads with `otlp_logs_partition_by_resource: true`;
- oversized Kafka messages proving the failure is reported as broker message-size rejection, not OTLP JSON conversion failure.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

`tests/integration/scenarios/out_kafka/config/out_kafka_otlp_json_partition_by_resource_small_message_max.yaml`

- [x] Debug log output from testing the change

Before the fix, the new integration test reproduced the failure:

```text
tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_logs_preserves_unset_attribute_values -q
```

Result: failed waiting for Kafka output. Fluent Bit log contained:

```text
[error] [output:kafka:kafka.0] could not convert event chunk to OTLP JSON: -2
```

After the fix:

```text
tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_logs_preserves_unset_attribute_values tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_partition_by_resource_keeps_monolithic_resource_valid tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_partition_by_resource_rejects_oversized_message -q
```

Result: `3 passed`.

- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```text
VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_logs_preserves_unset_attribute_values tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_partition_by_resource_keeps_monolithic_resource_valid tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_otlp_json_partition_by_resource_rejects_oversized_message -q
```

Result: `3 passed`. Each focused valgrind log reported `ERROR SUMMARY: 0 errors`.

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature

**Backporting**

- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTLP JSON conversion now properly handles null-like input values by converting them to empty objects instead of producing conversion failures.

* **Tests**
  * Added integration tests for OTLP-to-Kafka pipeline scenarios, including validation of unset attribute handling, resource partitioning behavior, and oversized message rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->