### PR TITLE
regex: Plug a regex literal crash [Backport to 4.2]

### DIFF
--- a/src/flb_regex.c
+++ b/src/flb_regex.c
@@ -129,7 +129,7 @@ static int str_to_regex(const char *pattern, OnigRegex *reg)
 
     option = check_option(start, end, &new_end);
 
-    if (pattern[0] == '/' && pattern[len - 1] == '/') {
+    if (len > 1 && pattern[0] == '/' && pattern[len - 1] == '/') {
         start++;
         end--;
     }

--- a/tests/internal/regex.c
+++ b/tests/internal/regex.c
@@ -319,6 +319,95 @@ static void test_option_i_x()
     }
 }
 
+static void test_literal_slash()
+{
+    struct flb_regex *regex = NULL;
+    int ret;
+
+    regex = flb_regex_create("/");
+    if (!TEST_CHECK(regex != NULL)) {
+        TEST_MSG("flb_regex_create failed");
+        exit(1);
+    }
+
+    ret = flb_regex_match(regex, (unsigned char *) "/tmp", 4);
+    if (!TEST_CHECK(ret == 1)) {
+        TEST_MSG("literal slash did not match");
+        flb_regex_destroy(regex);
+        exit(1);
+    }
+
+    ret = flb_regex_match(regex, (unsigned char *) "tmp", 3);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("literal slash matched string without slash");
+        flb_regex_destroy(regex);
+        exit(1);
+    }
+
+    ret = flb_regex_destroy(regex);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_regex_destroy failed");
+        exit(1);
+    }
+}
+
+static void test_slash_delimited_pattern()
+{
+    struct flb_regex *regex = NULL;
+    int ret;
+
+    regex = flb_regex_create("/tmp/");
+    if (!TEST_CHECK(regex != NULL)) {
+        TEST_MSG("flb_regex_create failed");
+        exit(1);
+    }
+
+    ret = flb_regex_match(regex, (unsigned char *) "tmp", 3);
+    if (!TEST_CHECK(ret == 1)) {
+        TEST_MSG("slash-delimited pattern did not match");
+        flb_regex_destroy(regex);
+        exit(1);
+    }
+
+    ret = flb_regex_destroy(regex);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_regex_destroy failed");
+        exit(1);
+    }
+}
+
+static void test_slash_delimited_literal_slashes()
+{
+    struct flb_regex *regex = NULL;
+    int ret;
+
+    regex = flb_regex_create("//tmp//");
+    if (!TEST_CHECK(regex != NULL)) {
+        TEST_MSG("flb_regex_create failed");
+        exit(1);
+    }
+
+    ret = flb_regex_match(regex, (unsigned char *) "/tmp/", 5);
+    if (!TEST_CHECK(ret == 1)) {
+        TEST_MSG("slash-delimited literal slash pattern did not match");
+        flb_regex_destroy(regex);
+        exit(1);
+    }
+
+    ret = flb_regex_match(regex, (unsigned char *) "tmp", 3);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("slash-delimited literal slash pattern matched string without slashes");
+        flb_regex_destroy(regex);
+        exit(1);
+    }
+
+    ret = flb_regex_destroy(regex);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("flb_regex_destroy failed");
+        exit(1);
+    }
+}
+
 TEST_LIST = {
     { "basic" , test_basic},
     { "uri" , test_uri},
@@ -326,5 +415,8 @@ TEST_LIST = {
     { "option_multiline" , test_option_multiline},
     { "option_extend" , test_option_extend},
     { "option_i_x" , test_option_i_x},
+    { "literal_slash" , test_literal_slash},
+    { "slash_delimited_pattern" , test_slash_delimited_pattern},
+    { "slash_delimited_literal_slashes" , test_slash_delimited_literal_slashes},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11938.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
