### PR TITLE
out_forward: process type and length of pong strictly [Backport to 4.2]

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -339,22 +339,39 @@ static void secure_forward_set_ping(struct flb_forward_ping *ping,
     memset(ping, 0, sizeof(struct flb_forward_ping));
     ping->keepalive = 1; /* default, as per spec */
 
+    if (map->type != MSGPACK_OBJECT_MAP) {
+        return;
+    }
+
     for (i = 0; i < map->via.map.size; i++) {
         key = map->via.map.ptr[i].key;
         val = map->via.map.ptr[i].val;
+
+        if (key.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
 
         ptr = key.via.str.ptr;
         len = key.via.str.size;
 
         if (len == 5 && memcmp(ptr, "nonce", len) == 0) {
+            if (val.type != MSGPACK_OBJECT_STR && val.type != MSGPACK_OBJECT_BIN) {
+                continue;
+            }
             ping->nonce = val.via.bin.ptr;
             ping->nonce_len = val.via.bin.size;
         }
         else if (len == 4 && memcmp(ptr, "auth", len) == 0) {
+            if (val.type != MSGPACK_OBJECT_STR && val.type != MSGPACK_OBJECT_BIN) {
+                continue;
+            }
             ping->auth = val.via.bin.ptr;
             ping->auth_len = val.via.bin.size;
         }
         else if (len == 9 && memcmp(ptr, "keepalive", len) == 0) {
+            if (val.type != MSGPACK_OBJECT_BOOLEAN) {
+                continue;
+            }
             ping->keepalive = val.via.boolean;
         }
     }
@@ -548,7 +565,7 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
         goto error;
     }
 
-    if (strncmp(o.via.str.ptr, "PONG", 4) != 0 || o.via.str.size != 4) {
+    if (o.via.str.size != 4 || strncmp(o.via.str.ptr, "PONG", 4) != 0) {
         goto error;
     }
 
@@ -563,7 +580,17 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
     }
     else {
         o = root.via.array.ptr[2];
-        memcpy(msg, o.via.str.ptr, o.via.str.size);
+        if (o.type != MSGPACK_OBJECT_STR) {
+            goto error;
+        }
+        if (o.via.str.size >= sizeof(msg)) {
+            memcpy(msg, o.via.str.ptr, sizeof(msg) - 1);
+            msg[sizeof(msg) - 1] = '\0';
+        }
+        else {
+            memcpy(msg, o.via.str.ptr, o.via.str.size);
+            msg[o.via.str.size] = '\0';
+        }
         flb_plg_error(ctx->ins, "failed authorization: %s", msg);
     }
 
@@ -602,6 +629,12 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
 
     /* Parse HELO message */
     root = result.data;
+    if (root.type != MSGPACK_OBJECT_ARRAY) {
+        flb_plg_error(ctx->ins, "Invalid HELO type message");
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
     if (root.via.array.size < 2) {
         flb_plg_error(ctx->ins, "Invalid HELO message");
         msgpack_unpacked_destroy(&result);
@@ -615,7 +648,7 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
         return -1;
     }
 
-    if (strncmp(o.via.str.ptr, "HELO", 4) != 0 || o.via.str.size != 4) {
+    if (o.via.str.size != 4 || strncmp(o.via.str.ptr, "HELO", 4) != 0) {
         flb_plg_error(ctx->ins, "Invalid HELO content message");
         msgpack_unpacked_destroy(&result);
         return -1;
@@ -625,6 +658,12 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
 
     /* Compose and send PING message */
     o = root.via.array.ptr[1];
+    if (o.type != MSGPACK_OBJECT_MAP) {
+        flb_plg_error(ctx->ins, "Invalid HELO options message");
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
     ret = secure_forward_ping(u_conn, o, fc, ctx);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "Failed PING");
@@ -699,8 +738,16 @@ static int forward_read_ack(struct flb_forward *ctx,
     /* Lookup ack field */
     for (i = 0; i < map.size; i++) {
         key = map.ptr[i].key;
+        if (key.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
         if (key.via.str.size == 3 && strncmp(key.via.str.ptr, "ack", 3) == 0) {
             val     = map.ptr[i].val;
+            if (val.type != MSGPACK_OBJECT_STR) {
+                goto error;
+            }
+
             ack_len = val.via.str.size;
             ack     = val.via.str.ptr;
             break;
@@ -714,15 +761,15 @@ static int forward_read_ack(struct flb_forward *ctx,
 
     if (ack_len != chunk_len) {
         flb_plg_error(ctx->ins,
-                      "ack: ack len does not match ack(%ld)(%.*s) chunk(%d)(%.*s)",
+                      "ack: ack len does not match ack(%zu)(%.*s) chunk(%d)(%.*s)",
                       ack_len, (int) ack_len, ack,
                       chunk_len, (int) chunk_len, chunk);
         goto error;
     }
 
     if (strncmp(ack, chunk, ack_len) != 0) {
-        flb_plg_error(ctx->ins, "ACK: mismatch received=%s, expected=(%.*s)",
-                      ack, chunk_len, chunk);
+        flb_plg_error(ctx->ins, "ACK: mismatch received=%.*s, expected=(%.*s)",
+                      (int) ack_len, ack, chunk_len, chunk);
         goto error;
     }
 

--- a/tests/runtime/out_forward.c
+++ b/tests/runtime/out_forward.c
@@ -21,10 +21,240 @@
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_record_accessor.h>
 
+#ifndef FLB_SYSTEM_WINDOWS
+#include <errno.h>
+#include <pthread.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#endif
+
 #include "flb_tests_runtime.h"
 
 /* Include plugin header to get the flush_ctx structure definition */
 #include "../../plugins/out_forward/forward.h"
+
+#ifndef FLB_SYSTEM_WINDOWS
+struct secure_forward_server {
+    int listen_fd;
+    int port;
+    int got_ping;
+    pthread_t thread;
+};
+
+static int forward_socket_write_all(int fd, const char *buffer, size_t length)
+{
+    ssize_t bytes;
+    size_t offset;
+
+    offset = 0;
+
+    while (offset < length) {
+        bytes = write(fd, buffer + offset, length - offset);
+        if (bytes == -1) {
+            if (errno == EINTR) {
+                continue;
+            }
+
+            return -1;
+        }
+
+        if (bytes == 0) {
+            return -1;
+        }
+
+        offset += bytes;
+    }
+
+    return 0;
+}
+
+static int forward_create_listen_socket(int *out_port)
+{
+    int fd;
+    int ret;
+    int enable;
+    socklen_t length;
+    struct sockaddr_in address;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd == -1) {
+        return -1;
+    }
+
+    enable = 1;
+    ret = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+    if (ret == -1) {
+        close(fd);
+        return -1;
+    }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = htons(0);
+
+    if (bind(fd, (struct sockaddr *) &address, sizeof(address)) == -1) {
+        close(fd);
+        return -1;
+    }
+
+    if (listen(fd, 4) == -1) {
+        close(fd);
+        return -1;
+    }
+
+    length = sizeof(address);
+    if (getsockname(fd, (struct sockaddr *) &address, &length) == -1) {
+        close(fd);
+        return -1;
+    }
+
+    *out_port = ntohs(address.sin_port);
+
+    return fd;
+}
+
+static int forward_pack_secure_helo(msgpack_sbuffer *mp_sbuf)
+{
+    msgpack_packer mp_pck;
+
+    msgpack_sbuffer_init(mp_sbuf);
+    msgpack_packer_init(&mp_pck, mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "HELO", 4);
+    msgpack_pack_map(&mp_pck, 1);
+    msgpack_pack_str(&mp_pck, 5);
+    msgpack_pack_str_body(&mp_pck, "nonce", 5);
+    msgpack_pack_str(&mp_pck, 16);
+    msgpack_pack_str_body(&mp_pck, "0123456789abcdef", 16);
+
+    return 0;
+}
+
+static int forward_pack_oversized_pong(msgpack_sbuffer *mp_sbuf)
+{
+    char reason[900];
+    msgpack_packer mp_pck;
+
+    memset(reason, 'A', sizeof(reason));
+
+    msgpack_sbuffer_init(mp_sbuf);
+    msgpack_packer_init(&mp_pck, mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 5);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "PONG", 4);
+    msgpack_pack_false(&mp_pck);
+    msgpack_pack_str(&mp_pck, sizeof(reason));
+    msgpack_pack_str_body(&mp_pck, reason, sizeof(reason));
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "host", 4);
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "desc", 4);
+
+    return 0;
+}
+
+static int forward_read_msgpack(int fd, char *buf, size_t size)
+{
+    int ret;
+    ssize_t bytes;
+    size_t off;
+    size_t buf_off;
+    msgpack_unpacked result;
+
+    buf_off = 0;
+    msgpack_unpacked_init(&result);
+
+    while (buf_off < size) {
+        bytes = read(fd, buf + buf_off, size - buf_off);
+        if (bytes <= 0) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+
+        buf_off += bytes;
+        off = 0;
+        ret = msgpack_unpack_next(&result, buf, buf_off, &off);
+        if (ret == MSGPACK_UNPACK_SUCCESS) {
+            msgpack_unpacked_destroy(&result);
+            return 0;
+        }
+
+        if (ret != MSGPACK_UNPACK_CONTINUE) {
+            msgpack_unpacked_destroy(&result);
+            return -1;
+        }
+    }
+
+    msgpack_unpacked_destroy(&result);
+    return -1;
+}
+
+static void *secure_forward_oversized_pong_server_thread(void *data)
+{
+    int ret;
+    int conn_fd;
+    fd_set read_fds;
+    struct timeval timeout;
+    char buf[1024];
+    msgpack_sbuffer helo;
+    msgpack_sbuffer pong;
+    struct secure_forward_server *server;
+
+    server = data;
+    conn_fd = -1;
+
+    FD_ZERO(&read_fds);
+    FD_SET(server->listen_fd, &read_fds);
+    timeout.tv_sec = 5;
+    timeout.tv_usec = 0;
+
+    ret = select(server->listen_fd + 1, &read_fds, NULL, NULL, &timeout);
+    if (ret <= 0) {
+        return NULL;
+    }
+
+    conn_fd = accept(server->listen_fd, NULL, NULL);
+    if (conn_fd == -1) {
+        return NULL;
+    }
+
+    if (forward_pack_secure_helo(&helo) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+
+    if (forward_socket_write_all(conn_fd, helo.data, helo.size) != 0) {
+        msgpack_sbuffer_destroy(&helo);
+        close(conn_fd);
+        return NULL;
+    }
+    msgpack_sbuffer_destroy(&helo);
+
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf)) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+    server->got_ping = FLB_TRUE;
+
+    if (forward_pack_oversized_pong(&pong) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+
+    forward_socket_write_all(conn_fd, pong.data, pong.size);
+    msgpack_sbuffer_destroy(&pong);
+    close(conn_fd);
+
+    return NULL;
+}
+#endif
 
 static void cb_check_message_mode(void *ctx, int ffd,
                                   int res_ret, void *res_data, size_t res_size,
@@ -352,6 +582,70 @@ void flb_test_forward_compat_mode()
     flb_destroy(ctx);
 }
 
+#ifndef FLB_SYSTEM_WINDOWS
+void flb_test_secure_forward_oversized_pong_reason()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char port[16];
+    flb_ctx_t *ctx;
+    struct secure_forward_server server;
+
+    memset(&server, 0, sizeof(server));
+    server.listen_fd = -1;
+
+    server.listen_fd = forward_create_listen_socket(&server.port);
+    TEST_CHECK(server.listen_fd != -1);
+    if (server.listen_fd == -1) {
+        return;
+    }
+
+    ret = pthread_create(&server.thread, NULL,
+                         secure_forward_oversized_pong_server_thread,
+                         &server);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        close(server.listen_fd);
+        return;
+    }
+
+    snprintf(port, sizeof(port), "%i", server.port);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd,
+                  "tag", "test",
+                  "samples", "1",
+                  "dummy", "{\"key\":\"value\"}",
+                  NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "host", "127.0.0.1",
+                   "port", port,
+                   "shared_key", "secret",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    close(server.listen_fd);
+    pthread_join(server.thread, NULL);
+
+    TEST_CHECK(server.got_ping == FLB_TRUE);
+}
+#endif
+
 /* Test list */
 TEST_LIST = {
 #ifdef FLB_HAVE_RECORD_ACCESSOR
@@ -360,5 +654,9 @@ TEST_LIST = {
 #endif
     {"forward_mode"       , flb_test_forward_mode },
     {"forward_compat_mode", flb_test_forward_compat_mode },
+#ifndef FLB_SYSTEM_WINDOWS
+    {"secure_forward_oversized_pong_reason",
+     flb_test_secure_forward_oversized_pong_reason },
+#endif
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

backporting of https://github.com/fluent/fluent-bit/pull/11945.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
