### PR TITLE
tls: openssl: Reload and watch certificates mainly on Linux

### DIFF
--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -25,7 +25,9 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_coro.h>
+#include <fluent-bit/flb_pthread.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define FLB_TLS_ALPN_MAX_LENGTH 16
 
@@ -50,6 +52,17 @@
 struct flb_tls;
 struct flb_connection;
 
+struct flb_tls_file_status {
+    int exists;
+    uint64_t size;
+    uint64_t device;
+    uint64_t inode;
+    uint64_t mtime;
+    uint64_t mtime_nsec;
+    uint64_t ctime;
+    uint64_t ctime_nsec;
+};
+
 struct flb_tls_session {
     /* opaque data type for backend session context */
     void                  *ptr;
@@ -70,6 +83,9 @@ struct flb_tls_backend {
                              const char *, const char *,
                              const char *, const char *,
                              const char *, const char *);
+
+    /* reload backend context */
+    int (*context_reload) (struct flb_tls *);
 
     /* destroy backend context */
     void (*context_destroy) (void *);
@@ -108,16 +124,32 @@ struct flb_tls {
     int verify_client;                /* Verify client certificate */
     int debug;                        /* Debug level               */
     char *vhost;                      /* Virtual hostname for SNI  */
+    char *ca_path;                    /* Path to certificates      */
+    char *ca_file;                    /* CA root cert              */
+    char *crt_file;                   /* Certificate               */
+    char *key_file;                   /* Cert Key                  */
+    char *key_passwd;                 /* Cert Key Password         */
+    char *alpn;                       /* ALPN protocol list        */
+    char *min_version;                /* Minimum TLS version       */
+    char *max_version;                /* Maximum TLS version       */
+    char *ciphers;                    /* TLS ciphers               */
+    struct flb_tls_file_status ca_path_status;
+    struct flb_tls_file_status ca_file_status;
+    struct flb_tls_file_status crt_file_status;
+    struct flb_tls_file_status key_file_status;
     int mode;                         /* Client or Server          */
     int verify_hostname;              /* Verify hostname           */
+    int system_certificates_loaded;    /* System certs loaded       */
 #if defined(FLB_SYSTEM_WINDOWS)
     char *certstore_name;             /* Windows CertStore Name    */
     int use_enterprise_store;         /* Use Enterprise store or not */
+    char *client_thumbprints;         /* Allowed client thumbprints */
 #endif
 
     /* Bakend library for TLS */
     void *ctx;                        /* TLS context created */
     struct flb_tls_backend *api;      /* backend API */
+    pthread_mutex_t reload_mutex;     /* protects reload state */
 };
 
 int flb_tls_init();
@@ -131,6 +163,8 @@ struct flb_tls *flb_tls_create(int mode,
                                const char *key_file, const char *key_passwd);
 
 int flb_tls_destroy(struct flb_tls *tls);
+
+int flb_tls_reload_if_needed(struct flb_tls *tls);
 
 int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn);
 int flb_tls_set_verify_client(struct flb_tls *tls, int verify_client);

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -20,6 +20,9 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_mem.h>
+
+#include <sys/stat.h>
 
 #include "openssl.c"
 
@@ -182,7 +185,150 @@ static inline int io_tls_event_switch(struct flb_tls_session *session,
 
 int flb_tls_load_system_certificates(struct flb_tls *tls)
 {
-    return load_system_certificates(tls->ctx);
+    int ret;
+
+    ret = load_system_certificates(tls->ctx);
+    if (ret == 0) {
+        tls->system_certificates_loaded = FLB_TRUE;
+    }
+
+    return ret;
+}
+
+static int tls_file_status_get(const char *path,
+                               struct flb_tls_file_status *status)
+{
+    struct stat st;
+
+    memset(status, 0, sizeof(struct flb_tls_file_status));
+
+    if (path == NULL) {
+        return 0;
+    }
+
+    if (stat(path, &st) != 0) {
+        status->exists = FLB_FALSE;
+        return -1;
+    }
+
+    status->exists = FLB_TRUE;
+    status->size = (uint64_t) st.st_size;
+#ifdef FLB_SYSTEM_LINUX
+    status->device = (uint64_t) st.st_dev;
+    status->inode = (uint64_t) st.st_ino;
+    status->mtime_nsec = (uint64_t) st.st_mtim.tv_nsec;
+    status->ctime_nsec = (uint64_t) st.st_ctim.tv_nsec;
+#else
+    status->device = 0;
+    status->inode = 0;
+    status->mtime_nsec = 0;
+    status->ctime_nsec = 0;
+#endif
+    status->mtime = (uint64_t) st.st_mtime;
+    status->ctime = (uint64_t) st.st_ctime;
+
+    return 0;
+}
+
+static int tls_file_status_changed(struct flb_tls_file_status *current,
+                                   struct flb_tls_file_status *previous)
+{
+    if (current->exists != previous->exists ||
+        current->size != previous->size ||
+        current->device != previous->device ||
+        current->inode != previous->inode ||
+        current->mtime != previous->mtime ||
+        current->mtime_nsec != previous->mtime_nsec ||
+        current->ctime != previous->ctime ||
+        current->ctime_nsec != previous->ctime_nsec) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+static void tls_file_status_refresh(struct flb_tls *tls)
+{
+    tls_file_status_get(tls->ca_path, &tls->ca_path_status);
+    tls_file_status_get(tls->ca_file, &tls->ca_file_status);
+    tls_file_status_get(tls->crt_file, &tls->crt_file_status);
+    tls_file_status_get(tls->key_file, &tls->key_file_status);
+}
+
+static int tls_file_status_has_changed(
+    struct flb_tls *tls,
+    struct flb_tls_file_status *ca_path_status,
+    struct flb_tls_file_status *ca_file_status,
+    struct flb_tls_file_status *crt_file_status,
+    struct flb_tls_file_status *key_file_status)
+{
+    tls_file_status_get(tls->ca_path, ca_path_status);
+    tls_file_status_get(tls->ca_file, ca_file_status);
+    tls_file_status_get(tls->crt_file, crt_file_status);
+    tls_file_status_get(tls->key_file, key_file_status);
+
+    if (tls_file_status_changed(ca_path_status, &tls->ca_path_status) == FLB_TRUE ||
+        tls_file_status_changed(ca_file_status, &tls->ca_file_status) == FLB_TRUE ||
+        tls_file_status_changed(crt_file_status, &tls->crt_file_status) == FLB_TRUE ||
+        tls_file_status_changed(key_file_status, &tls->key_file_status) == FLB_TRUE) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
+static int tls_should_reload_context(
+    struct flb_tls *tls,
+    struct flb_tls_file_status *ca_path_status,
+    struct flb_tls_file_status *ca_file_status,
+    struct flb_tls_file_status *crt_file_status,
+    struct flb_tls_file_status *key_file_status)
+{
+    if (tls_file_status_has_changed(tls,
+                                    ca_path_status,
+                                    ca_file_status,
+                                    crt_file_status,
+                                    key_file_status) == FLB_TRUE) {
+        return FLB_TRUE;
+    }
+
+#if defined(FLB_SYSTEM_WINDOWS) || defined(FLB_SYSTEM_MACOS)
+    /*
+     * macOS Keychain and Windows CertStore do not expose a portable file
+     * metadata handle for us to watch. Refresh store-backed contexts before
+     * each new TLS session so rotations/imports become visible without a
+     * process restart.
+     */
+    if (tls->system_certificates_loaded == FLB_TRUE) {
+        return FLB_TRUE;
+    }
+#endif
+
+    return FLB_FALSE;
+}
+
+static int tls_store_string(char **slot, const char *value)
+{
+    char *tmp;
+
+    if (*slot != NULL) {
+        flb_free(*slot);
+        *slot = NULL;
+    }
+
+    if (value == NULL) {
+        return 0;
+    }
+
+    tmp = flb_strdup(value);
+    if (tmp == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    *slot = tmp;
+
+    return 0;
 }
 
 struct flb_tls *flb_tls_create(int mode,
@@ -217,30 +363,104 @@ struct flb_tls *flb_tls_create(int mode,
         return NULL;
     }
 
+    tls->ctx = backend;
+    tls->api = &tls_openssl;
+    pthread_mutex_init(&tls->reload_mutex, NULL);
+
     tls->verify = verify;
     tls->debug = debug;
     tls->mode = mode;
     tls->verify_hostname = FLB_FALSE;
+    tls->system_certificates_loaded = FLB_FALSE;
+#if defined(FLB_SYSTEM_WINDOWS) || defined(FLB_SYSTEM_MACOS)
+    if (ca_path == NULL && ca_file == NULL && mode == FLB_TLS_CLIENT_MODE) {
+        tls->system_certificates_loaded = FLB_TRUE;
+    }
+#endif
 #if defined(FLB_SYSTEM_WINDOWS)
     tls->certstore_name = NULL;
     tls->use_enterprise_store = FLB_FALSE;
+    tls->client_thumbprints = NULL;
 #endif
 
-    if (vhost != NULL) {
-        tls->vhost = flb_strdup(vhost);
+    if (tls_store_string(&tls->vhost, vhost) != 0 ||
+        tls_store_string(&tls->ca_path, ca_path) != 0 ||
+        tls_store_string(&tls->ca_file, ca_file) != 0 ||
+        tls_store_string(&tls->crt_file, crt_file) != 0 ||
+        tls_store_string(&tls->key_file, key_file) != 0 ||
+        tls_store_string(&tls->key_passwd, key_passwd) != 0) {
+        flb_tls_destroy(tls);
+        return NULL;
     }
-    tls->ctx = backend;
 
-    tls->api = &tls_openssl;
+    tls_file_status_refresh(tls);
 
     return tls;
+}
+
+int flb_tls_reload_if_needed(struct flb_tls *tls)
+{
+    int ret;
+    struct flb_tls_file_status ca_path_status;
+    struct flb_tls_file_status ca_file_status;
+    struct flb_tls_file_status crt_file_status;
+    struct flb_tls_file_status key_file_status;
+
+    if (tls == NULL || tls->ctx == NULL || tls->api == NULL ||
+        tls->api->context_reload == NULL) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&tls->reload_mutex);
+
+    if (tls_should_reload_context(tls,
+                                  &ca_path_status,
+                                  &ca_file_status,
+                                  &crt_file_status,
+                                  &key_file_status) == FLB_FALSE) {
+        pthread_mutex_unlock(&tls->reload_mutex);
+        return 0;
+    }
+
+    ret = tls->api->context_reload(tls);
+    if (ret != 0) {
+        pthread_mutex_unlock(&tls->reload_mutex);
+        flb_error("[tls] detected certificate file changes but reload failed");
+        return -1;
+    }
+
+    /*
+     * Commit the snapshot that triggered this reload. If a file changes while
+     * the backend is loading it, the next session will observe the newer
+     * metadata and reload again instead of treating unseen contents as loaded.
+     */
+    tls->ca_path_status = ca_path_status;
+    tls->ca_file_status = ca_file_status;
+    tls->crt_file_status = crt_file_status;
+    tls->key_file_status = key_file_status;
+    pthread_mutex_unlock(&tls->reload_mutex);
+    flb_info("[tls] reloaded TLS certificate configuration");
+
+    return 1;
 }
 
 int flb_tls_set_minmax_proto(struct flb_tls *tls,
                              const char *min_version, const char *max_version)
 {
+    int ret;
+
     if (tls->ctx) {
-        return tls->api->set_minmax_proto(tls, min_version, max_version);
+        ret = tls->api->set_minmax_proto(tls, min_version, max_version);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (tls_store_string(&tls->min_version, min_version) != 0 ||
+            tls_store_string(&tls->max_version, max_version) != 0) {
+            return -1;
+        }
+
+        return ret;
     }
 
     return 0;
@@ -248,8 +468,19 @@ int flb_tls_set_minmax_proto(struct flb_tls *tls,
 
 int flb_tls_set_ciphers(struct flb_tls *tls, const char *ciphers)
 {
+    int ret;
+
     if (tls->ctx) {
-        return tls->api->set_ciphers(tls, ciphers);
+        ret = tls->api->set_ciphers(tls, ciphers);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (tls_store_string(&tls->ciphers, ciphers) != 0) {
+            return -1;
+        }
+
+        return ret;
     }
 
     return 0;
@@ -269,12 +500,44 @@ int flb_tls_destroy(struct flb_tls *tls)
     if (tls->vhost != NULL) {
         flb_free(tls->vhost);
     }
+    if (tls->ca_path != NULL) {
+        flb_free(tls->ca_path);
+    }
+    if (tls->ca_file != NULL) {
+        flb_free(tls->ca_file);
+    }
+    if (tls->crt_file != NULL) {
+        flb_free(tls->crt_file);
+    }
+    if (tls->key_file != NULL) {
+        flb_free(tls->key_file);
+    }
+    if (tls->key_passwd != NULL) {
+        flb_free(tls->key_passwd);
+    }
+    if (tls->alpn != NULL) {
+        flb_free(tls->alpn);
+    }
+    if (tls->min_version != NULL) {
+        flb_free(tls->min_version);
+    }
+    if (tls->max_version != NULL) {
+        flb_free(tls->max_version);
+    }
+    if (tls->ciphers != NULL) {
+        flb_free(tls->ciphers);
+    }
 
 #if defined(FLB_SYSTEM_WINDOWS)
     if (tls->certstore_name) {
         flb_free(tls->certstore_name);
     }
+    if (tls->client_thumbprints) {
+        flb_free(tls->client_thumbprints);
+    }
 #endif
+
+    pthread_mutex_destroy(&tls->reload_mutex);
 
     flb_free(tls);
 
@@ -283,8 +546,19 @@ int flb_tls_destroy(struct flb_tls *tls)
 
 int flb_tls_set_alpn(struct flb_tls *tls, const char *alpn)
 {
+    int ret;
+
     if (tls->ctx) {
-        return tls->api->context_alpn_set(tls->ctx, alpn);
+        ret = tls->api->context_alpn_set(tls->ctx, alpn);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (tls_store_string(&tls->alpn, alpn) != 0) {
+            return -1;
+        }
+
+        return ret;
     }
 
     return 0;
@@ -297,6 +571,11 @@ int flb_tls_set_verify_client(struct flb_tls *tls, int verify_client)
     }
 
     tls->verify_client = verify_client;
+#if defined(FLB_SYSTEM_WINDOWS) || defined(FLB_SYSTEM_MACOS)
+    if (verify_client == FLB_TRUE && tls->ca_path == NULL && tls->ca_file == NULL) {
+        tls->system_certificates_loaded = FLB_TRUE;
+    }
+#endif
 
     if (tls->ctx && tls->api->context_set_verify_client) {
         return tls->api->context_set_verify_client(tls->ctx, verify_client);
@@ -319,8 +598,19 @@ int flb_tls_set_verify_hostname(struct flb_tls *tls, int verify_hostname)
 #if defined(FLB_SYSTEM_WINDOWS)
 int flb_tls_set_certstore_name(struct flb_tls *tls, const char *certstore_name)
 {
+    int ret;
+
     if (tls) {
-        return tls->api->set_certstore_name(tls, certstore_name);
+        ret = tls->api->set_certstore_name(tls, certstore_name);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (tls_store_string(&tls->certstore_name, certstore_name) != 0) {
+            return -1;
+        }
+
+        return ret;
     }
 
     return 0;
@@ -328,16 +618,36 @@ int flb_tls_set_certstore_name(struct flb_tls *tls, const char *certstore_name)
 
 int flb_tls_set_use_enterprise_store(struct flb_tls *tls, int use_enterprise)
 {
+    int ret;
+
     if (tls) {
-        return tls->api->set_use_enterprise_store(tls, use_enterprise);
+        ret = tls->api->set_use_enterprise_store(tls, use_enterprise);
+        if (ret != 0) {
+            return ret;
+        }
+
+        tls->use_enterprise_store = use_enterprise;
+
+        return ret;
     }
 
     return 0;
 }
 
 int flb_tls_set_client_thumbprints(struct flb_tls *tls, const char *thumbprints) {
+    int ret;
+
     if (tls && tls->api->set_client_thumbprints) {
-        return tls->api->set_client_thumbprints(tls, thumbprints);
+        ret = tls->api->set_client_thumbprints(tls, thumbprints);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (tls_store_string(&tls->client_thumbprints, thumbprints) != 0) {
+            return -1;
+        }
+
+        return ret;
     }
     return -1;
 }
@@ -607,6 +917,8 @@ int flb_tls_session_create(struct flb_tls *tls,
     int                     result;
     char                   *vhost;
     int                     flag;
+
+    flb_tls_reload_if_needed(tls);
 
     session = flb_calloc(1, sizeof(struct flb_tls_session));
 

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -1316,6 +1316,99 @@ static int tls_set_client_thumbprints(struct flb_tls *tls, const char *thumbprin
 
 #endif
 
+static int tls_context_reload(struct flb_tls *tls)
+{
+    SSL_CTX *old_ssl_ctx;
+    struct tls_context *ctx;
+    struct tls_context *new_ctx;
+    struct flb_tls tmp_tls;
+
+    ctx = tls->ctx;
+
+    new_ctx = tls_context_create(tls->verify,
+                                 tls->debug,
+                                 tls->mode,
+                                 tls->vhost,
+                                 tls->ca_path,
+                                 tls->ca_file,
+                                 tls->crt_file,
+                                 tls->key_file,
+                                 tls->key_passwd);
+    if (new_ctx == NULL) {
+        return -1;
+    }
+
+    memset(&tmp_tls, 0, sizeof(struct flb_tls));
+    tmp_tls.ctx = new_ctx;
+
+    if (tls->verify_client == FLB_TRUE &&
+        tls_context_set_verify_client(new_ctx, tls->verify_client) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+    if ((tls->min_version != NULL || tls->max_version != NULL) &&
+        tls_set_minmax_proto(&tmp_tls, tls->min_version, tls->max_version) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+    if (tls->ciphers != NULL &&
+        tls_set_ciphers(&tmp_tls, tls->ciphers) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+    if (tls->alpn != NULL &&
+        tls_context_alpn_set(new_ctx, tls->alpn) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+#if defined(FLB_SYSTEM_WINDOWS)
+    if (tls->certstore_name != NULL &&
+        tls_set_certstore_name(&tmp_tls, tls->certstore_name) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+    if (tls->use_enterprise_store == FLB_TRUE &&
+        tls_set_use_enterprise_store(&tmp_tls, tls->use_enterprise_store) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+    if (tls->client_thumbprints != NULL &&
+        tls_set_client_thumbprints(&tmp_tls, tls->client_thumbprints) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+#endif
+
+    if (tls->system_certificates_loaded == FLB_TRUE &&
+        load_system_certificates(new_ctx) != 0) {
+        tls_context_destroy(new_ctx);
+        return -1;
+    }
+
+    pthread_mutex_lock(&ctx->mutex);
+    old_ssl_ctx = ctx->ctx;
+    ctx->ctx = new_ctx->ctx;
+    new_ctx->ctx = old_ssl_ctx;
+
+    if (tls->alpn != NULL && tls->mode == FLB_TLS_SERVER_MODE) {
+        SSL_CTX_set_alpn_select_cb(ctx->ctx,
+                                   tls_context_server_alpn_select_callback,
+                                   ctx);
+    }
+
+    pthread_mutex_unlock(&ctx->mutex);
+
+    tls_context_destroy(new_ctx);
+
+    return 0;
+}
+
 static void *tls_session_create(struct flb_tls *tls,
                                 int fd)
 {
@@ -1804,6 +1897,7 @@ static int tls_net_handshake(struct flb_tls *tls,
 static struct flb_tls_backend tls_openssl = {
     .name                 = "openssl",
     .context_create       = tls_context_create,
+    .context_reload       = tls_context_reload,
     .context_destroy      = tls_context_destroy,
     .context_alpn_set     = tls_context_alpn_set,
     .context_set_verify_client = tls_context_set_verify_client,

--- a/tests/internal/upstream_tls.c
+++ b/tests/internal/upstream_tls.c
@@ -10,6 +10,10 @@
 
 #include "flb_tests_internal.h"
 
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
 #ifdef FLB_HAVE_TLS
 
 #ifdef FLB_SYSTEM_WINDOWS
@@ -20,6 +24,72 @@ struct test_backend_ctx {
     int invalidate_calls;
     int destroy_calls;
 };
+
+static int copy_file(const char *src, const char *dst)
+{
+    FILE *in;
+    FILE *out;
+    char buf[4096];
+    size_t bytes;
+
+    in = fopen(src, "rb");
+    if (in == NULL) {
+        return -1;
+    }
+
+    out = fopen(dst, "wb");
+    if (out == NULL) {
+        fclose(in);
+        return -1;
+    }
+
+    while ((bytes = fread(buf, 1, sizeof(buf), in)) > 0) {
+        if (fwrite(buf, 1, bytes, out) != bytes) {
+            fclose(out);
+            fclose(in);
+            return -1;
+        }
+    }
+
+    if (ferror(in)) {
+        fclose(out);
+        fclose(in);
+        return -1;
+    }
+
+    fclose(out);
+    fclose(in);
+
+    return 0;
+}
+
+static int append_file(const char *path, const char *data)
+{
+    FILE *out;
+
+    out = fopen(path, "ab");
+    if (out == NULL) {
+        return -1;
+    }
+
+    if (fwrite(data, 1, strlen(data), out) != strlen(data)) {
+        fclose(out);
+        return -1;
+    }
+
+    fclose(out);
+
+    return 0;
+}
+
+static int reload_mutation_count;
+
+static int test_reload_and_mutate_key(struct flb_tls *tls)
+{
+    reload_mutation_count++;
+
+    return append_file(tls->key_file, "\n");
+}
 
 static void test_session_invalidate(void *session)
 {
@@ -161,12 +231,178 @@ void test_tls_session_destroy_no_double_free(void)
 #endif
 }
 
+void test_tls_reload_when_certificate_file_changes(void)
+{
+    int ret;
+    char src_crt[4096];
+    char src_key[4096];
+    char *dst_crt;
+    char *dst_key;
+    struct flb_tls *tls;
+
+    snprintf(src_crt, sizeof(src_crt), "%sdata/tls/certificate.pem",
+             FLB_TESTS_DATA_PATH);
+    snprintf(src_key, sizeof(src_key), "%sdata/tls/private_key.pem",
+             FLB_TESTS_DATA_PATH);
+
+    dst_crt = flb_test_tmpdir_cat("/flb_tls_reload_certificate.pem");
+    dst_key = flb_test_tmpdir_cat("/flb_tls_reload_private_key.pem");
+    TEST_CHECK(dst_crt != NULL);
+    TEST_CHECK(dst_key != NULL);
+
+    TEST_CHECK(copy_file(src_crt, dst_crt) == 0);
+    TEST_CHECK(copy_file(src_key, dst_key) == 0);
+
+    tls = flb_tls_create(FLB_TLS_SERVER_MODE,
+                         FLB_TRUE,
+                         0,
+                         NULL,
+                         NULL,
+                         NULL,
+                         dst_crt,
+                         dst_key,
+                         NULL);
+    TEST_CHECK(tls != NULL);
+
+    TEST_CHECK(flb_tls_reload_if_needed(tls) == 0);
+
+    TEST_CHECK(append_file(dst_key, "\n") == 0);
+    ret = flb_tls_reload_if_needed(tls);
+    TEST_CHECK(ret == 1);
+
+    flb_tls_destroy(tls);
+    remove(dst_crt);
+    remove(dst_key);
+    flb_free(dst_crt);
+    flb_free(dst_key);
+}
+
+#ifdef FLB_SYSTEM_LINUX
+void test_tls_reload_when_certificate_file_is_replaced(void)
+{
+    char src_crt[4096];
+    char src_key[4096];
+    char *dst_crt;
+    char *dst_key;
+    char *replacement_key;
+    struct stat st;
+    struct flb_tls *tls;
+
+    snprintf(src_crt, sizeof(src_crt), "%sdata/tls/certificate.pem",
+             FLB_TESTS_DATA_PATH);
+    snprintf(src_key, sizeof(src_key), "%sdata/tls/private_key.pem",
+             FLB_TESTS_DATA_PATH);
+
+    dst_crt = flb_test_tmpdir_cat("/flb_tls_replace_certificate.pem");
+    dst_key = flb_test_tmpdir_cat("/flb_tls_replace_private_key.pem");
+    replacement_key = flb_test_tmpdir_cat("/flb_tls_replacement_private_key.pem");
+    TEST_CHECK(dst_crt != NULL);
+    TEST_CHECK(dst_key != NULL);
+    TEST_CHECK(replacement_key != NULL);
+
+    TEST_CHECK(copy_file(src_crt, dst_crt) == 0);
+    TEST_CHECK(copy_file(src_key, dst_key) == 0);
+    TEST_CHECK(copy_file(src_key, replacement_key) == 0);
+
+    tls = flb_tls_create(FLB_TLS_SERVER_MODE,
+                         FLB_TRUE,
+                         0,
+                         NULL,
+                         NULL,
+                         NULL,
+                         dst_crt,
+                         dst_key,
+                         NULL);
+    TEST_CHECK(tls != NULL);
+
+    TEST_CHECK(rename(replacement_key, dst_key) == 0);
+    TEST_CHECK(stat(dst_key, &st) == 0);
+
+    /* Make the inode the only observable difference from the cached status. */
+    tls->key_file_status.size = (uint64_t) st.st_size;
+    tls->key_file_status.device = (uint64_t) st.st_dev;
+    tls->key_file_status.mtime = (uint64_t) st.st_mtime;
+    tls->key_file_status.ctime = (uint64_t) st.st_ctime;
+    tls->key_file_status.mtime_nsec = (uint64_t) st.st_mtim.tv_nsec;
+    tls->key_file_status.ctime_nsec = (uint64_t) st.st_ctim.tv_nsec;
+
+    TEST_CHECK(tls->key_file_status.inode != (uint64_t) st.st_ino);
+    TEST_CHECK(flb_tls_reload_if_needed(tls) == 1);
+
+    flb_tls_destroy(tls);
+    remove(dst_crt);
+    remove(dst_key);
+    remove(replacement_key);
+    flb_free(dst_crt);
+    flb_free(dst_key);
+    flb_free(replacement_key);
+}
+#endif
+
+void test_tls_reload_does_not_hide_concurrent_file_change(void)
+{
+    char src_crt[4096];
+    char src_key[4096];
+    char *dst_crt;
+    char *dst_key;
+    struct flb_tls_backend test_backend = {0};
+    struct flb_tls_backend *openssl_backend;
+    struct flb_tls *tls;
+
+    snprintf(src_crt, sizeof(src_crt), "%sdata/tls/certificate.pem",
+             FLB_TESTS_DATA_PATH);
+    snprintf(src_key, sizeof(src_key), "%sdata/tls/private_key.pem",
+             FLB_TESTS_DATA_PATH);
+
+    dst_crt = flb_test_tmpdir_cat("/flb_tls_concurrent_certificate.pem");
+    dst_key = flb_test_tmpdir_cat("/flb_tls_concurrent_private_key.pem");
+    TEST_CHECK(dst_crt != NULL);
+    TEST_CHECK(dst_key != NULL);
+
+    TEST_CHECK(copy_file(src_crt, dst_crt) == 0);
+    TEST_CHECK(copy_file(src_key, dst_key) == 0);
+
+    tls = flb_tls_create(FLB_TLS_SERVER_MODE,
+                         FLB_TRUE,
+                         0,
+                         NULL,
+                         NULL,
+                         NULL,
+                         dst_crt,
+                         dst_key,
+                         NULL);
+    TEST_CHECK(tls != NULL);
+
+    openssl_backend = tls->api;
+    test_backend.context_reload = test_reload_and_mutate_key;
+    tls->api = &test_backend;
+    reload_mutation_count = 0;
+
+    TEST_CHECK(append_file(dst_key, "\n") == 0);
+    TEST_CHECK(flb_tls_reload_if_needed(tls) == 1);
+    TEST_CHECK(flb_tls_reload_if_needed(tls) == 1);
+    TEST_CHECK(reload_mutation_count == 2);
+
+    tls->api = openssl_backend;
+    flb_tls_destroy(tls);
+    remove(dst_crt);
+    remove(dst_key);
+    flb_free(dst_crt);
+    flb_free(dst_key);
+}
+
 #endif
 
 TEST_LIST = {
 #ifdef FLB_HAVE_TLS
     {"prepare_destroy_conn_marks_tls_session_stale", test_prepare_destroy_conn_marks_tls_session_stale},
     {"tls_session_destroy_no_double_free", test_tls_session_destroy_no_double_free},
+    {"tls_reload_when_certificate_file_changes", test_tls_reload_when_certificate_file_changes},
+#ifdef FLB_SYSTEM_LINUX
+    {"tls_reload_when_certificate_file_is_replaced", test_tls_reload_when_certificate_file_is_replaced},
+#endif
+    {"tls_reload_does_not_hide_concurrent_file_change",
+     test_tls_reload_does_not_hide_concurrent_file_change},
 #endif
     {0}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
On the current shorter validness of certificates proposals, we need to handle reloading certificates on Linux.
This is because shorter period of certificates" validness requests us to relaunching Fluent Bit executable before reaching the expire date of the certificates.
However, there is needed to take care of the possibility to care buffered chunks before flushing/terminating Fluent Bit executable.
Instead, if we had a capability to handle reloading certificates on changes, it'll be quite useful for users who need to handle short period of certificates.
But there is a limitation of this patch because we just storing with the same conditions the previous certificates like passphrase.

Closes https://github.com/fluent/fluent-bit/issues/10692.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime TLS context reload support by detecting changes to configured CA/certificate/key files.
  * Introduced thread-safe reload orchestration with tracked per-file metadata and a reload “if needed” public API.
  * Improved reload behavior on Windows/macOS, including system certificate handling and certstore/thumbprint settings.
* **Tests**
  * Added a TLS reload test that verifies no reload initially and confirms reload is triggered after a key file modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->