### PR TITLE
in_collectd: validate value part length before reading count

### DIFF
--- a/plugins/in_collectd/netprot.c
+++ b/plugins/in_collectd/netprot.c
@@ -96,6 +96,12 @@ static int netprot_pack_value(char *ptr, int size, struct netprot_header *hdr,
         return -1;
     }
 
+    /* The value part begins with a 2-byte count, read it only if present */
+    if (size < sizeof(uint16_t)) {
+        flb_error("[in_collectd] data truncated (size=%i)", size);
+        return -1;
+    }
+
     /*
      * Since each value uses (1 + 8) bytes, the total buffer size must
      * be 2-byte header plus <count * 9> bytes.


### PR DESCRIPTION
1. netprot_pack_value() reads the 2-byte value count via be16read(ptr) without checking the part actually carries those bytes.
2. a PART_VALUE with a declared length of 4 or 5 (payload size 0 or 1) makes that read run past the part, and past the received datagram when it is the last part, reachable from a single collectd UDP packet.
3. the time/interval parts already gate their 8-byte read with `size < sizeof(uint64_t)` in netprot_to_msgpack(); the value part had no equivalent.

Added the matching length check before reading the count.

----

**Testing**

- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [x] Attached AddressSanitizer output that shows the out-of-bounds read before the fix and a clean run after

Config used to reach the parser:

```
[INPUT]
    name    collectd
    listen  0.0.0.0
    port    25826
```

Trigger: a collectd UDP datagram ending with a PART_VALUE part of declared length 4 (`00 06 00 04`), preceded by any PART_TYPE part. Exercising netprot_to_msgpack() on a buffer sized to the datagram under AddressSanitizer:

Before:
```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 2 ... 0 bytes after 10-byte region
  #0 netprot_pack_value  (count = be16read(ptr))
```
After: the short value part is rejected with `data truncated` and the read stays in bounds.

- [N/A] Run local packaging test
- [N/A] Set `ok-package-test` label

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of network protocol data to properly detect and handle truncated payloads, preventing potential system crashes or errors when processing incomplete network data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->