### PR TITLE
in_tail: fix out-of-bounds read in unesc_ends_with_nl

### DIFF
--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -190,7 +190,7 @@ static int unesc_ends_with_nl(char *str, size_t len)
         return FLB_FALSE;
     }
     unesc_len = flb_unescape_string(str, len, &unesc);
-    nl = unesc[unesc_len - 1] == '\n';
+    nl = unesc_len > 0 && unesc[unesc_len - 1] == '\n';
     flb_free(unesc);
     return nl;
 }


### PR DESCRIPTION
AddressSanitizer, in_tail with `Docker_Mode On` parsing a container log line whose `log` field is empty (`{"log":"","stream":"stdout",...}`):

    READ of size 1 at 0x... thread T0
        #0 unesc_ends_with_nl plugins/in_tail/tail_dockermode.c:193
    0x... is located 1 bytes before 1-byte region

`modify_json_cond` calls the `unesc_ends_with_nl` predicate with the value of the `log` key. For an empty value `len` is 0, `flb_unescape_string` returns 0, and `unesc[unesc_len - 1]` indexes `unesc[-1]`. Container stdout is attacker-controlled, so a single empty log line triggers the underflow. Guarding the index on `unesc_len` keeps the trailing-newline check correct for non-empty messages.

----

**Testing**

- [x] Example configuration file for the change

```
[INPUT]
    Name          tail
    Path          /var/log/containers/*.log
    Docker_Mode   On

[OUTPUT]
    Name   stdout
    Match  *
```
Feed it a docker json line with an empty message, e.g. `{"log":"","stream":"stdout","time":"2024-01-01T00:00:00Z"}`.

- [x] Debug log output from testing the change

Reduced the predicate to a standalone harness over the unmodified `flb_unescape_string` and `unesc_ends_with_nl`:

before: `AddressSanitizer: heap-buffer-overflow ... READ of size 1 ... 1 bytes before 1-byte region` at the `unesc[unesc_len - 1]` line.
after: runs clean, returns 0.

- [x] Attached Valgrind/ASan output that shows no leaks or memory corruption was found

ASan flags the read on the unpatched tree and is clean after the patch.

- [N/A] Run local packaging test showing all targets build.
- [N/A] Set `ok-package-test` label to test for all targets.

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential issue in Docker mode tail functionality that could occur when processing certain input conditions, ensuring more stable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->