### PR TITLE
out_kafka: Implement resolving registry of avro schema

### DIFF
--- a/plugins/out_kafka/CMakeLists.txt
+++ b/plugins/out_kafka/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Fluent Bit Kafka Output plugin
 set(src
   kafka_config.c
+  kafka_schema_registry.c
   kafka_topic.c
   kafka.c)
 

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -345,6 +345,12 @@ int produce_message(struct flb_time *tm, msgpack_object *map,
 #ifdef FLB_HAVE_AVRO_ENCODER
     else if (ctx->format == FLB_KAFKA_FMT_AVRO) {
 
+        ret = flb_kafka_schema_registry_resolve(ctx);
+        if (ret != FLB_OK) {
+            msgpack_sbuffer_destroy(&mp_sbuf);
+            return ret;
+        }
+
         flb_plg_debug(ctx->ins, "avro schema ID:%d:\n", ctx->avro_fields.schema_id);
         flb_plg_debug(ctx->ins, "avro schema string:%s:\n", ctx->avro_fields.schema_str);
 
@@ -1497,6 +1503,76 @@ static struct flb_config_map config_map[] = {
     0, FLB_TRUE, offsetof(struct flb_out_kafka, avro_fields) + offsetof(struct flb_avro_fields, schema_id),
     "Set AVRO schema ID."
    },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_url", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_url),
+    "Set the Confluent Schema Registry base URL for AVRO schemas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema.registry.url", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_url),
+    "Set the Confluent Schema Registry base URL for AVRO schemas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_subject", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_subject),
+    "Set the Confluent Schema Registry subject for AVRO schemas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema.registry.subject", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_subject),
+    "Set the Confluent Schema Registry subject for AVRO schemas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_version", "latest",
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_version),
+    "Set the Confluent Schema Registry subject version for AVRO schemas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema.registry.version", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_version),
+    "Set the Confluent Schema Registry subject version for AVRO schemas."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_http_user", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_http_user),
+    "Set the Confluent Schema Registry HTTP basic authentication user."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema.registry.http.user", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_http_user),
+    "Set the Confluent Schema Registry HTTP basic authentication user."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_http_passwd", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_http_passwd),
+    "Set the Confluent Schema Registry HTTP basic authentication password."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema.registry.http.password", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_http_passwd),
+    "Set the Confluent Schema Registry HTTP basic authentication password."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_bearer_token", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_bearer_token),
+    "Set the Confluent Schema Registry bearer token."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema.registry.bearer.token", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_bearer_token),
+    "Set the Confluent Schema Registry bearer token."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "schema_registry_framing", "cp1",
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_framing),
+    "Set the Schema Registry serializer framing. Only cp1 is supported."
+   },
+   {
+    FLB_CONFIG_MAP_STR, "serializer.framing", (char *)NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, schema_registry_framing),
+    "Set the Schema Registry serializer framing. Only cp1 is supported."
+   },
 #endif
    {
     FLB_CONFIG_MAP_STR, "topics", (char *)NULL,
@@ -1556,6 +1632,6 @@ struct flb_output_plugin out_kafka_plugin = {
     .cb_flush     = cb_kafka_flush,
     .cb_exit      = cb_kafka_exit,
     .config_map   = config_map,
-    .flags        = 0,
+    .flags        = FLB_IO_OPT_TLS,
     .event_type   = FLB_OUTPUT_LOGS
 };

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -50,6 +50,9 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     ctx->ins = ins;
     ctx->blocked = FLB_FALSE;
     mk_list_init(&ctx->topics);
+#ifdef FLB_HAVE_AVRO_ENCODER
+    mk_list_init(&ctx->schema_registry_endpoints);
+#endif
 
     ret = flb_output_config_map_set(ins, (void*) ctx);
     if (ret == -1) {
@@ -266,6 +269,12 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
     if (tmp) {
         ctx->avro_fields.schema_str = flb_sds_create(tmp);
     }
+
+    ret = flb_kafka_schema_registry_configure(ctx, config);
+    if (ret == -1) {
+        flb_out_kafka_destroy(ctx);
+        return NULL;
+    }
 #endif
 
     /* Config: Topic */
@@ -341,6 +350,7 @@ int flb_out_kafka_destroy(struct flb_out_kafka *ctx)
 #ifdef FLB_HAVE_AVRO_ENCODER
     // avro
     flb_sds_destroy(ctx->avro_fields.schema_str);
+    flb_kafka_schema_registry_destroy(ctx);
 #endif
 
     flb_free(ctx);

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -27,6 +27,7 @@
 #endif
 
 #include <fluent-bit/flb_kafka.h>
+#include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/aws/flb_aws_msk_iam.h>
 
 #define FLB_KAFKA_FMT_JSON            0
@@ -55,6 +56,16 @@
 #define FLB_JSON_DATE_ISO8601     1
 #define FLB_JSON_DATE_ISO8601_NS  2
 #define FLB_JSON_DATE_ISO8601_FMT "%Y-%m-%dT%H:%M:%S"
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+struct flb_kafka_schema_registry_endpoint {
+    flb_sds_t host;
+    flb_sds_t uri;
+    int port;
+    struct flb_upstream *upstream;
+    struct mk_list _head;
+};
+#endif
 
 struct flb_kafka_topic {
     int name_len;
@@ -127,6 +138,18 @@ struct flb_out_kafka {
     // flb_sds_t avro_schema_str;
     // flb_sds_t avro_schema_id;
     struct flb_avro_fields avro_fields;
+
+    /* Optional Confluent Schema Registry resolver for Avro schemas */
+    flb_sds_t schema_registry_url;
+    flb_sds_t schema_registry_subject;
+    flb_sds_t schema_registry_version;
+    flb_sds_t schema_registry_http_user;
+    flb_sds_t schema_registry_http_passwd;
+    flb_sds_t schema_registry_bearer_token;
+    flb_sds_t schema_registry_framing;
+    int schema_registry_endpoint_count;
+    int schema_registry_endpoint_index;
+    struct mk_list schema_registry_endpoints;
 #endif
 
 #ifdef FLB_HAVE_AWS_MSK_IAM
@@ -146,5 +169,15 @@ struct flb_out_kafka {
 struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
                                            struct flb_config *config);
 int flb_out_kafka_destroy(struct flb_out_kafka *ctx);
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+int flb_kafka_schema_registry_configure(struct flb_out_kafka *ctx,
+                                        struct flb_config *config);
+int flb_kafka_schema_registry_resolve(struct flb_out_kafka *ctx);
+int flb_kafka_schema_registry_parse_response(struct flb_out_kafka *ctx,
+                                             const char *payload,
+                                             size_t payload_size);
+void flb_kafka_schema_registry_destroy(struct flb_out_kafka *ctx);
+#endif
 
 #endif

--- a/plugins/out_kafka/kafka_schema_registry.c
+++ b/plugins/out_kafka/kafka_schema_registry.c
@@ -1,0 +1,548 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_uri.h>
+#include <fluent-bit/flb_utils.h>
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+#include <jansson.h>
+#endif
+
+#include "kafka_config.h"
+
+#ifdef FLB_HAVE_AVRO_ENCODER
+
+#define FLB_KAFKA_SR_ACCEPT "application/vnd.schemaregistry.v1+json, application/json"
+
+static int schema_registry_set_base_uri(struct flb_kafka_schema_registry_endpoint *endpoint,
+                                        char *uri)
+{
+    size_t len;
+
+    if (uri == NULL || uri[0] == '\0' || strcmp(uri, "/") == 0) {
+        endpoint->uri = flb_sds_create("");
+        return endpoint->uri == NULL ? -1 : 0;
+    }
+
+    endpoint->uri = flb_sds_create(uri);
+    if (endpoint->uri == NULL) {
+        return -1;
+    }
+
+    len = flb_sds_len(endpoint->uri);
+    if (len > 1 && endpoint->uri[len - 1] == '/') {
+        flb_sds_len_set(endpoint->uri, len - 1);
+        endpoint->uri[len - 1] = '\0';
+    }
+
+    return 0;
+}
+
+static void schema_registry_endpoint_destroy(struct flb_kafka_schema_registry_endpoint *endpoint)
+{
+    if (endpoint == NULL) {
+        return;
+    }
+
+    flb_sds_destroy(endpoint->host);
+    flb_sds_destroy(endpoint->uri);
+
+    if (endpoint->upstream != NULL) {
+        flb_upstream_destroy(endpoint->upstream);
+    }
+
+    flb_free(endpoint);
+}
+
+static int schema_registry_endpoint_create(struct flb_out_kafka *ctx,
+                                           struct flb_config *config,
+                                           char *url)
+{
+    int ret;
+    int port;
+    int io_flags;
+    char *protocol;
+    char *host;
+    char *port_str;
+    char *uri;
+    struct flb_kafka_schema_registry_endpoint *endpoint;
+
+    protocol = NULL;
+    host = NULL;
+    port_str = NULL;
+    uri = NULL;
+
+    endpoint = flb_calloc(1, sizeof(struct flb_kafka_schema_registry_endpoint));
+    if (endpoint == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    ret = flb_utils_url_split(url, &protocol, &host, &port_str, &uri);
+    if (ret == -1 || protocol == NULL || host == NULL) {
+        flb_plg_error(ctx->ins, "invalid schema_registry_url '%s'", url);
+        ret = -1;
+        goto cleanup;
+    }
+
+    if (strcasecmp(protocol, "http") == 0) {
+        port = port_str != NULL ? atoi(port_str) : 80;
+        io_flags = FLB_IO_TCP;
+    }
+    else if (strcasecmp(protocol, "https") == 0) {
+#ifdef FLB_HAVE_TLS
+        port = port_str != NULL ? atoi(port_str) : 443;
+        io_flags = FLB_IO_TLS;
+#else
+        flb_plg_error(ctx->ins, "schema_registry_url requires TLS support");
+        ret = -1;
+        goto cleanup;
+#endif
+    }
+    else {
+        flb_plg_error(ctx->ins, "unsupported schema_registry_url protocol '%s'",
+                      protocol);
+        ret = -1;
+        goto cleanup;
+    }
+
+    if (port <= 0) {
+        flb_plg_error(ctx->ins, "invalid schema_registry_url port");
+        ret = -1;
+        goto cleanup;
+    }
+
+    endpoint->host = flb_sds_create(host);
+    if (endpoint->host == NULL) {
+        flb_errno();
+        ret = -1;
+        goto cleanup;
+    }
+
+    ret = schema_registry_set_base_uri(endpoint, uri);
+    if (ret == -1) {
+        flb_errno();
+        goto cleanup;
+    }
+
+    endpoint->port = port;
+    endpoint->upstream = flb_upstream_create(config,
+                                             endpoint->host,
+                                             port,
+                                             io_flags,
+                                             ctx->ins->tls);
+    if (endpoint->upstream == NULL) {
+        flb_plg_error(ctx->ins, "cannot create Schema Registry upstream");
+        ret = -1;
+        goto cleanup;
+    }
+
+    flb_output_upstream_set(endpoint->upstream, ctx->ins);
+    mk_list_add(&endpoint->_head, &ctx->schema_registry_endpoints);
+    ctx->schema_registry_endpoint_count++;
+    endpoint = NULL;
+    ret = 0;
+
+cleanup:
+    schema_registry_endpoint_destroy(endpoint);
+    flb_free(protocol);
+    flb_free(host);
+    flb_free(port_str);
+    flb_free(uri);
+
+    return ret;
+}
+
+int flb_kafka_schema_registry_configure(struct flb_out_kafka *ctx,
+                                        struct flb_config *config)
+{
+    int ret;
+    size_t url_len;
+    char *url;
+    char *comma;
+    flb_sds_t url_copy;
+
+    url_copy = NULL;
+
+    if (ctx->schema_registry_framing != NULL &&
+        strcasecmp(ctx->schema_registry_framing, "cp1") != 0) {
+        flb_plg_error(ctx->ins,
+                      "unsupported Schema Registry serializer framing '%s': "
+                      "only cp1 is supported",
+                      ctx->schema_registry_framing);
+        return -1;
+    }
+
+    if (ctx->schema_registry_url == NULL) {
+        return 0;
+    }
+
+    url = ctx->schema_registry_url;
+    while (*url != '\0') {
+        while (*url == ' ') {
+            url++;
+        }
+
+        comma = strchr(url, ',');
+        if (comma != NULL) {
+            url_len = comma - url;
+        }
+        else {
+            url_len = strlen(url);
+        }
+
+        while (url_len > 0 && url[url_len - 1] == ' ') {
+            url_len--;
+        }
+
+        if (url_len > 0) {
+            url_copy = flb_sds_create_len(url, url_len);
+            if (url_copy == NULL) {
+                flb_errno();
+                return -1;
+            }
+
+            ret = schema_registry_endpoint_create(ctx, config, url_copy);
+            flb_sds_destroy(url_copy);
+            url_copy = NULL;
+            if (ret == -1) {
+                return -1;
+            }
+        }
+
+        if (comma == NULL) {
+            break;
+        }
+        url = comma + 1;
+    }
+
+    if (ctx->schema_registry_endpoint_count == 0) {
+        flb_plg_error(ctx->ins, "schema_registry_url does not contain a valid URL");
+        return -1;
+    }
+
+    if (ctx->schema_registry_version == NULL) {
+        ctx->schema_registry_version = flb_sds_create("latest");
+        if (ctx->schema_registry_version == NULL) {
+            flb_errno();
+            return -1;
+        }
+    }
+
+    if (ctx->avro_fields.schema_str == NULL &&
+        ctx->avro_fields.schema_id <= 0 &&
+        ctx->schema_registry_subject == NULL) {
+        flb_plg_error(ctx->ins,
+                      "schema_registry_url requires schema_id or schema_registry_subject");
+        return -1;
+    }
+
+    return 0;
+}
+
+static struct flb_kafka_schema_registry_endpoint *schema_registry_endpoint_get(
+        struct flb_out_kafka *ctx, int index)
+{
+    int i;
+    struct mk_list *head;
+    struct flb_kafka_schema_registry_endpoint *endpoint;
+
+    i = 0;
+    mk_list_foreach(head, &ctx->schema_registry_endpoints) {
+        endpoint = mk_list_entry(head,
+                                 struct flb_kafka_schema_registry_endpoint,
+                                 _head);
+        if (i == index) {
+            return endpoint;
+        }
+        i++;
+    }
+
+    return NULL;
+}
+
+static flb_sds_t schema_registry_uri_by_id(
+        struct flb_kafka_schema_registry_endpoint *endpoint,
+        struct flb_out_kafka *ctx)
+{
+    flb_sds_t uri;
+
+    uri = flb_sds_create_size(flb_sds_len(endpoint->uri) + 32);
+    if (uri == NULL) {
+        return NULL;
+    }
+
+    uri = flb_sds_cat(uri, endpoint->uri, flb_sds_len(endpoint->uri));
+    uri = flb_sds_printf(&uri, "/schemas/ids/%d", ctx->avro_fields.schema_id);
+
+    return uri;
+}
+
+static flb_sds_t schema_registry_uri_by_subject(
+        struct flb_kafka_schema_registry_endpoint *endpoint,
+        struct flb_out_kafka *ctx)
+{
+    flb_sds_t uri;
+    flb_sds_t subject;
+
+    subject = flb_uri_encode(ctx->schema_registry_subject,
+                             flb_sds_len(ctx->schema_registry_subject));
+    if (subject == NULL) {
+        return NULL;
+    }
+
+    uri = flb_sds_create_size(flb_sds_len(endpoint->uri) +
+                              flb_sds_len(subject) +
+                              flb_sds_len(ctx->schema_registry_version) + 32);
+    if (uri == NULL) {
+        flb_sds_destroy(subject);
+        return NULL;
+    }
+
+    uri = flb_sds_cat(uri, endpoint->uri, flb_sds_len(endpoint->uri));
+    uri = flb_sds_cat(uri, "/subjects/", 10);
+    uri = flb_sds_cat(uri, subject, flb_sds_len(subject));
+    uri = flb_sds_cat(uri, "/versions/", 10);
+    uri = flb_sds_cat(uri, ctx->schema_registry_version,
+                      flb_sds_len(ctx->schema_registry_version));
+
+    flb_sds_destroy(subject);
+
+    return uri;
+}
+
+int flb_kafka_schema_registry_parse_response(struct flb_out_kafka *ctx,
+                                             const char *payload,
+                                             size_t payload_size)
+{
+    int schema_id;
+    const char *schema;
+    const char *schema_type;
+    json_t *root;
+    json_t *id_value;
+    json_t *schema_value;
+    json_t *schema_type_value;
+    json_error_t error;
+    flb_sds_t schema_copy;
+
+    root = json_loadb(payload, payload_size, 0, &error);
+    if (root == NULL) {
+        flb_plg_error(ctx->ins, "cannot parse Schema Registry response: %s",
+                      error.text);
+        return -1;
+    }
+
+    schema_type_value = json_object_get(root, "schemaType");
+    if (schema_type_value != NULL && json_is_string(schema_type_value)) {
+        schema_type = json_string_value(schema_type_value);
+        if (strcasecmp(schema_type, "AVRO") != 0) {
+            flb_plg_error(ctx->ins,
+                          "unsupported Schema Registry schemaType '%s'",
+                          schema_type);
+            json_decref(root);
+            return -1;
+        }
+    }
+
+    schema_value = json_object_get(root, "schema");
+    if (schema_value == NULL || !json_is_string(schema_value)) {
+        flb_plg_error(ctx->ins,
+                      "Schema Registry response does not contain a schema string");
+        json_decref(root);
+        return -1;
+    }
+
+    schema_id = ctx->avro_fields.schema_id;
+    id_value = json_object_get(root, "id");
+    if (id_value != NULL && json_is_integer(id_value)) {
+        schema_id = (int) json_integer_value(id_value);
+    }
+
+    if (schema_id <= 0) {
+        flb_plg_error(ctx->ins,
+                      "Schema Registry response does not contain a valid schema id");
+        json_decref(root);
+        return -1;
+    }
+
+    schema = json_string_value(schema_value);
+    schema_copy = flb_sds_create(schema);
+    if (schema_copy == NULL) {
+        flb_errno();
+        json_decref(root);
+        return -1;
+    }
+
+    flb_sds_destroy(ctx->avro_fields.schema_str);
+    ctx->avro_fields.schema_str = schema_copy;
+    ctx->avro_fields.schema_id = schema_id;
+
+    json_decref(root);
+
+    return 0;
+}
+
+int flb_kafka_schema_registry_resolve(struct flb_out_kafka *ctx)
+{
+    int i;
+    int ret;
+    int index;
+    size_t bytes;
+    flb_sds_t uri;
+    struct flb_kafka_schema_registry_endpoint *endpoint;
+    struct flb_connection *conn;
+    struct flb_http_client *client;
+
+    if (ctx->avro_fields.schema_str != NULL &&
+        ctx->avro_fields.schema_id > 0) {
+        return FLB_OK;
+    }
+
+    if (ctx->schema_registry_endpoint_count == 0) {
+        flb_plg_error(ctx->ins,
+                      "format avro requires schema_str and schema_id or schema_registry_url");
+        return FLB_ERROR;
+    }
+
+    ret = FLB_RETRY;
+    index = ctx->schema_registry_endpoint_index;
+    for (i = 0; i < ctx->schema_registry_endpoint_count; i++) {
+        endpoint = schema_registry_endpoint_get(ctx, index);
+        if (endpoint == NULL) {
+            index = 0;
+            endpoint = schema_registry_endpoint_get(ctx, index);
+            if (endpoint == NULL) {
+                return FLB_ERROR;
+            }
+        }
+
+        if (ctx->schema_registry_subject != NULL) {
+            uri = schema_registry_uri_by_subject(endpoint, ctx);
+        }
+        else {
+            uri = schema_registry_uri_by_id(endpoint, ctx);
+        }
+
+        if (uri == NULL) {
+            flb_errno();
+            return FLB_ERROR;
+        }
+
+        conn = flb_upstream_conn_get(endpoint->upstream);
+        if (conn == NULL) {
+            flb_sds_destroy(uri);
+            ret = FLB_RETRY;
+            goto next_endpoint;
+        }
+
+        client = flb_http_client(conn, FLB_HTTP_GET, uri, NULL, 0,
+                                 endpoint->host, endpoint->port, NULL, 0);
+        if (client == NULL) {
+            flb_upstream_conn_release(conn);
+            flb_sds_destroy(uri);
+            ret = FLB_RETRY;
+            goto next_endpoint;
+        }
+
+        flb_http_add_header(client, "Accept", 6,
+                            FLB_KAFKA_SR_ACCEPT,
+                            sizeof(FLB_KAFKA_SR_ACCEPT) - 1);
+        flb_http_add_header(client, "User-Agent", 10, "Fluent-Bit", 10);
+
+        if (ctx->schema_registry_http_user != NULL) {
+            flb_http_basic_auth(client,
+                                ctx->schema_registry_http_user,
+                                ctx->schema_registry_http_passwd != NULL ?
+                                ctx->schema_registry_http_passwd : "");
+        }
+        else if (ctx->schema_registry_bearer_token != NULL) {
+            flb_http_bearer_auth(client, ctx->schema_registry_bearer_token);
+        }
+
+        ret = flb_http_do(client, &bytes);
+        if (ret != 0) {
+            flb_plg_warn(ctx->ins,
+                         "Schema Registry request to '%s' failed: %i",
+                         endpoint->host, ret);
+            ret = FLB_RETRY;
+            flb_http_client_destroy(client);
+            flb_upstream_conn_release(conn);
+            flb_sds_destroy(uri);
+            goto next_endpoint;
+        }
+
+        if (client->resp.status < 200 || client->resp.status > 299) {
+            flb_plg_warn(ctx->ins,
+                         "Schema Registry request to '%s' returned HTTP status %i",
+                         endpoint->host, client->resp.status);
+            ret = FLB_RETRY;
+            flb_http_client_destroy(client);
+            flb_upstream_conn_release(conn);
+            flb_sds_destroy(uri);
+            goto next_endpoint;
+        }
+
+        ret = flb_kafka_schema_registry_parse_response(ctx,
+                                                       client->resp.payload,
+                                                       client->resp.payload_size);
+        flb_http_client_destroy(client);
+        flb_upstream_conn_release(conn);
+        flb_sds_destroy(uri);
+
+        if (ret != 0) {
+            return FLB_ERROR;
+        }
+
+        ctx->schema_registry_endpoint_index =
+            (index + 1) % ctx->schema_registry_endpoint_count;
+        flb_plg_info(ctx->ins,
+                     "loaded Avro schema id %d from Schema Registry '%s'",
+                     ctx->avro_fields.schema_id, endpoint->host);
+
+        return FLB_OK;
+
+    next_endpoint:
+        index = (index + 1) % ctx->schema_registry_endpoint_count;
+    }
+
+    ctx->schema_registry_endpoint_index = index;
+
+    return ret;
+}
+
+void flb_kafka_schema_registry_destroy(struct flb_out_kafka *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct flb_kafka_schema_registry_endpoint *endpoint;
+
+    mk_list_foreach_safe(head, tmp, &ctx->schema_registry_endpoints) {
+        endpoint = mk_list_entry(head,
+                                 struct flb_kafka_schema_registry_endpoint,
+                                 _head);
+        mk_list_del(&endpoint->_head);
+        schema_registry_endpoint_destroy(endpoint);
+    }
+}
+
+#endif

--- a/tests/integration/scenarios/out_kafka/config/out_kafka_avro_schema_registry.yaml
+++ b/tests/integration/scenarios/out_kafka/config/out_kafka_avro_schema_registry.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"message":"hello avro","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: avro
+      schema_registry_url: http://127.0.0.1:${TEST_SUITE_SCHEMA_REGISTRY_PORT}
+      schema_registry_subject: out-kafka-avro-value
+      schema_registry_version: latest
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -12,14 +12,22 @@ from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportM
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
 from server.kafka_server import data_storage, kafka_server_run, kafka_server_stop
+from server.schema_registry_server import (
+    SCHEMA_ID,
+    SCHEMA_SUBJECT,
+    data_storage as schema_registry_data_storage,
+    schema_registry_server_run,
+    schema_registry_server_stop,
+)
 from utils.data_utils import read_json_file
 from utils.memory_check import memory_check_enabled
 from utils.test_service import FluentBitTestService
 
 
 class Service:
-    def __init__(self, config_file):
+    def __init__(self, config_file, *, use_schema_registry=False):
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        self.use_schema_registry = use_schema_registry
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
@@ -31,8 +39,13 @@ class Service:
     def _start_receiver(self, service):
         self.kafka_port = service.allocate_port_env("TEST_SUITE_KAFKA_PORT")
         kafka_server_run(self.kafka_port)
+        if self.use_schema_registry:
+            self.schema_registry_port = service.allocate_port_env("TEST_SUITE_SCHEMA_REGISTRY_PORT")
+            schema_registry_server_run(self.schema_registry_port)
 
     def _stop_receiver(self, service):
+        if self.use_schema_registry:
+            schema_registry_server_stop()
         kafka_server_stop()
 
     def start(self):
@@ -521,6 +534,28 @@ def test_out_kafka_msgpack_format_sends_msgpack_payload():
     assert payload["message"] == "hello msgpack"
     assert payload["count"] == 7
     assert payload["source"] == "dummy"
+
+
+def test_out_kafka_avro_resolves_schema_registry_subject():
+    service = Service("out_kafka_avro_schema_registry.yaml", use_schema_registry=True)
+    service.start()
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    value = message["value"]
+
+    assert message["topic"] == "test"
+    assert value[0] == 0
+    assert int.from_bytes(value[1:5], "big") == SCHEMA_ID
+    assert len(value) > 5
+
+    requests_seen = schema_registry_data_storage["requests"]
+    assert len(requests_seen) == 1
+    assert requests_seen[0]["method"] == "GET"
+    assert requests_seen[0]["path"] == f"/subjects/{SCHEMA_SUBJECT}/versions/latest"
+    assert "application/vnd.schemaregistry.v1+json" in requests_seen[0]["headers"]["Accept"]
 
 
 def test_out_kafka_otlp_json_logs():

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -21,6 +21,7 @@ from server.schema_registry_server import (
 )
 from utils.data_utils import read_json_file
 from utils.memory_check import memory_check_enabled
+from utils.fluent_bit_manager import FluentBitStartupError
 from utils.test_service import FluentBitTestService
 
 
@@ -456,6 +457,44 @@ def _wait_for_log_text(log_file, pattern, timeout=10):
     raise TimeoutError(f"Timed out waiting for log pattern {pattern!r}")
 
 
+def _read_fluent_bit_log(service):
+    if not service.service.flb or not service.service.flb.log_file:
+        return ""
+
+    try:
+        with open(service.service.flb.log_file, "r", encoding="utf-8", errors="replace") as log:
+            return log.read()
+    except FileNotFoundError:
+        return ""
+
+
+def _start_or_skip_without_avro_encoder(service):
+    try:
+        service.start()
+    except FluentBitStartupError as error:
+        log_contents = _read_fluent_bit_log(service)
+        error_message = str(error)
+        unsupported_markers = [
+            "unknown configuration property 'schema_registry_url'",
+            "unknown configuration property 'schema_registry_subject'",
+            "unknown configuration property 'schema_registry_version'",
+        ]
+
+        if any(marker in log_contents or marker in error_message
+               for marker in unsupported_markers):
+            try:
+                service.stop()
+            except Exception:
+                pass
+            pytest.skip("Kafka Avro Schema Registry requires FLB_AVRO_ENCODER=On")
+
+        try:
+            service.stop()
+        except Exception:
+            pass
+        raise
+
+
 def test_out_kafka_sends_json_payload():
     service = Service("out_kafka_basic.yaml")
     service.start()
@@ -538,7 +577,7 @@ def test_out_kafka_msgpack_format_sends_msgpack_payload():
 
 def test_out_kafka_avro_resolves_schema_registry_subject():
     service = Service("out_kafka_avro_schema_registry.yaml", use_schema_registry=True)
-    service.start()
+    _start_or_skip_without_avro_encoder(service)
 
     messages = service.wait_for_messages(1)
     service.stop()

--- a/tests/integration/src/server/schema_registry_server.py
+++ b/tests/integration/src/server/schema_registry_server.py
@@ -1,0 +1,108 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+SCHEMA_ID = 42
+SCHEMA_SUBJECT = "out-kafka-avro-value"
+SCHEMA_VERSION = 3
+SCHEMA = {
+    "type": "record",
+    "name": "out_kafka_avro_record",
+    "fields": [
+        {"name": "message", "type": "string"},
+        {"name": "source", "type": "string"},
+    ],
+}
+
+data_storage = {"requests": []}
+logger = logging.getLogger(__name__)
+server_instance = None
+server_thread = None
+
+
+def reset_schema_registry_server_state():
+    data_storage["requests"] = []
+
+
+class SchemaRegistryHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        logger.debug("schema_registry_server: " + fmt, *args)
+
+    def do_GET(self):
+        data_storage["requests"].append(
+            {
+                "path": self.path,
+                "headers": dict(self.headers),
+                "method": "GET",
+            }
+        )
+
+        if self.path == f"/subjects/{SCHEMA_SUBJECT}/versions/latest":
+            self._send_json(
+                {
+                    "subject": SCHEMA_SUBJECT,
+                    "id": SCHEMA_ID,
+                    "version": SCHEMA_VERSION,
+                    "schema": json.dumps(SCHEMA, separators=(",", ":")),
+                    "schemaType": "AVRO",
+                }
+            )
+            return
+
+        if self.path == f"/schemas/ids/{SCHEMA_ID}":
+            self._send_json(
+                {
+                    "schema": json.dumps(SCHEMA, separators=(",", ":")),
+                    "schemaType": "AVRO",
+                }
+            )
+            return
+
+        self._send_json({"error_code": 40403, "message": "Schema not found"}, status=404)
+
+    def _send_json(self, body, status=200):
+        payload = json.dumps(body).encode("utf-8")
+
+        self.send_response(status)
+        self.send_header("Content-Type", "application/vnd.schemaregistry.v1+json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def schema_registry_server_run(port, host="127.0.0.1"):
+    global server_instance
+    global server_thread
+
+    reset_schema_registry_server_state()
+    server_instance = ThreadingHTTPServer((host, port), SchemaRegistryHandler)
+    server_thread = threading.Thread(target=server_instance.serve_forever, daemon=True)
+    server_thread.start()
+    return server_thread
+
+
+def schema_registry_server_stop():
+    global server_instance
+
+    if server_instance is not None:
+        server_instance.shutdown()
+        server_instance.server_close()
+        server_instance = None

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -153,6 +153,7 @@ if(FLB_AVRO_ENCODER)
   set(UNIT_TESTS_FILES
     ${UNIT_TESTS_FILES}
     avro.c
+    kafka_schema_registry.c
     )
 endif()
 
@@ -329,6 +330,17 @@ if(FLB_METRICS AND FLB_PROCESSOR_CUMULATIVE_TO_DELTA)
     ${CUMULATIVE_TO_DELTA_CORE_SOURCE})
   target_include_directories(flb-it-cumulative_to_delta PRIVATE
     ${CUMULATIVE_TO_DELTA_PLUGIN_DIR})
+endif()
+
+if(FLB_AVRO_ENCODER)
+  target_sources(flb-it-kafka_schema_registry PRIVATE
+    ${PROJECT_SOURCE_DIR}/plugins/out_kafka/kafka_schema_registry.c)
+  target_include_directories(flb-it-kafka_schema_registry PRIVATE
+    ${PROJECT_SOURCE_DIR}/plugins/out_kafka)
+  if(DEFINED KAFKA_INCLUDEDIR)
+    target_include_directories(flb-it-kafka_schema_registry PRIVATE
+      ${KAFKA_INCLUDEDIR}/librdkafka)
+  endif()
 endif()
 
 if(FLB_TESTS_INTERNAL_FUZZ)

--- a/tests/internal/kafka_schema_registry.c
+++ b/tests/internal/kafka_schema_registry.c
@@ -1,0 +1,82 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+
+#include <fluent-bit/flb_sds.h>
+
+#include "flb_tests_internal.h"
+#include "kafka_config.h"
+
+static const char expected_schema[] =
+    "{\"type\":\"record\",\"name\":\"registry_test\","
+    "\"fields\":[{\"name\":\"message\",\"type\":\"string\"}]}";
+
+static void test_parse_subject_version_response()
+{
+    int ret;
+    struct flb_out_kafka ctx = {0};
+    const char response[] =
+        "{\"subject\":\"topic-value\",\"id\":42,\"version\":3,"
+        "\"schema\":\"{\\\"type\\\":\\\"record\\\","
+        "\\\"name\\\":\\\"registry_test\\\","
+        "\\\"fields\\\":[{\\\"name\\\":\\\"message\\\","
+        "\\\"type\\\":\\\"string\\\"}]}\"}";
+
+    ret = flb_kafka_schema_registry_parse_response(&ctx,
+                                                   response,
+                                                   sizeof(response) - 1);
+
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(ctx.avro_fields.schema_id == 42);
+    TEST_CHECK(ctx.avro_fields.schema_str != NULL);
+    TEST_CHECK(strcmp(ctx.avro_fields.schema_str, expected_schema) == 0);
+
+    flb_sds_destroy(ctx.avro_fields.schema_str);
+}
+
+static void test_parse_schema_id_response()
+{
+    int ret;
+    struct flb_out_kafka ctx = {0};
+    const char response[] =
+        "{\"schema\":\"{\\\"type\\\":\\\"record\\\","
+        "\\\"name\\\":\\\"registry_test\\\","
+        "\\\"fields\\\":[{\\\"name\\\":\\\"message\\\","
+        "\\\"type\\\":\\\"string\\\"}]}\"}";
+
+    ctx.avro_fields.schema_id = 7;
+
+    ret = flb_kafka_schema_registry_parse_response(&ctx,
+                                                   response,
+                                                   sizeof(response) - 1);
+
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(ctx.avro_fields.schema_id == 7);
+    TEST_CHECK(ctx.avro_fields.schema_str != NULL);
+    TEST_CHECK(strcmp(ctx.avro_fields.schema_str, expected_schema) == 0);
+
+    flb_sds_destroy(ctx.avro_fields.schema_str);
+}
+
+TEST_LIST = {
+    {"parse_subject_version_response", test_parse_subject_version_response},
+    {"parse_schema_id_response", test_parse_schema_id_response},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
Without libserdes, we're able to implement a basic functionalities of resolving avro schema from remote registries.
This is because we already have http client, TLS authentication, and using resolved schema.

Closes https://github.com/fluent/fluent-bit/issues/11737.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Confluent Schema Registry support for Avro serialization in the Kafka output plugin, including schema resolution before AVRO encoding.
  * Added configuration for Schema Registry URL(s), subject, version, authentication (basic/bearer token), and framing/HTTP request options (with dot/underscore key aliases).
  * Enabled Schema Registry endpoint lifecycle management for proper setup and teardown, and supports TLS when applicable.
* **Tests**
  * Added integration coverage with a mock Schema Registry service and validation of schema ID/magic byte and request headers.
  * Added unit tests for Schema Registry response parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->