### PR TITLE
in_tail: Plug timer lifecycle glitches on progress check

### DIFF
--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -73,11 +73,11 @@ struct flb_tail_config {
     int coll_fd_inactive;
     int coll_fd_dmode_flush;
     int coll_fd_mult_flush;
-    int coll_fd_progress_check;
 
     /* Backend collectors */
     int coll_fd_fs1;           /* used by fs_inotify & fs_stat */
     int coll_fd_fs2;           /* only used by fs_stat         */
+    int coll_fd_progress_check; /* inotify missed-event recovery timer */
 
     /* Configuration */
     int dynamic_tag;           /* dynamic tag ? e.g: abc.*     */

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -433,7 +433,10 @@ int flb_tail_fs_inotify_init(struct flb_input_instance *in,
     }
     ctx->coll_fd_fs1 = ret;
 
-    /* Register callback to check current tail offsets */
+    /*
+     * Keep the collector ID so the recovery timer follows the inotify
+     * collector through input pause and resume transitions.
+     */
     ret = flb_input_set_collector_time(in, in_tail_progress_check_callback,
                                        ctx->progress_check_interval,
                                        ctx->progress_check_interval_nsec,

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -450,11 +450,13 @@ int flb_tail_fs_inotify_init(struct flb_input_instance *in,
 void flb_tail_fs_inotify_pause(struct flb_tail_config *ctx)
 {
     flb_input_collector_pause(ctx->coll_fd_fs1, ctx->ins);
+    flb_input_collector_pause(ctx->coll_fd_progress_check, ctx->ins);
 }
 
 void flb_tail_fs_inotify_resume(struct flb_tail_config *ctx)
 {
     flb_input_collector_resume(ctx->coll_fd_fs1, ctx->ins);
+    flb_input_collector_resume(ctx->coll_fd_progress_check, ctx->ins);
 }
 
 int flb_tail_fs_inotify_add(struct flb_tail_file *file)

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -36,6 +36,10 @@ Approach for this tests is basing on filter_kubernetes tests
 #include <string.h>
 #include "flb_tests_runtime.h"
 
+#ifdef FLB_HAVE_INOTIFY
+#include "../../plugins/in_tail/tail_config.h"
+#endif
+
 #define NEW_LINE "\n"
 #define PATH_SEPARATOR "/"
 
@@ -2096,6 +2100,58 @@ void flb_test_inotify_watcher_false()
     test_tail_ctx_destroy(ctx);
 }
 
+#ifdef FLB_HAVE_INOTIFY
+void flb_test_inotify_pause_collectors()
+{
+    int ret;
+    struct mk_list *head;
+    struct flb_input_instance *ins;
+    struct flb_tail_config *tail_ctx;
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"inotify_pause_collectors.log"};
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = NULL;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], 1, FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    head = ctx->flb->config->inputs.next;
+    ins = mk_list_entry(head, struct flb_input_instance, _head);
+    tail_ctx = ins->context;
+
+    TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_fs1, ins) == FLB_TRUE);
+    TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_progress_check,
+                                           ins) == FLB_TRUE);
+
+    ret = flb_input_pause(ins);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_fs1, ins) == FLB_FALSE);
+    TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_progress_check,
+                                           ins) == FLB_FALSE);
+
+    ret = flb_input_resume(ins);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_fs1, ins) == FLB_TRUE);
+    TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_progress_check,
+                                           ins) == FLB_TRUE);
+
+    test_tail_ctx_destroy(ctx);
+}
+#endif
+
 #ifdef FLB_HAVE_REGEX
 void flb_test_parser()
 {
@@ -2695,6 +2751,7 @@ TEST_LIST = {
     {"ignore_active_older_files", flb_test_in_tail_ignore_active_older_files},
 #ifdef FLB_HAVE_INOTIFY
     {"inotify_watcher_false", flb_test_inotify_watcher_false},
+    {"inotify_pause_collectors", flb_test_inotify_pause_collectors},
 #endif /* FLB_HAVE_INOTIFY */
 
 #ifdef FLB_HAVE_REGEX


### PR DESCRIPTION
<!-- Provide summary of changes -->
The inotify reconciliation changes introduce this glitch of timer lifecycle.
https://github.com/fluent/fluent-bit/pull/11750 introduced this change but it also introduced a side effect by newly introduced reconcile_file_state function.
So, we had to align the lifecycle of a timer of progress check to another timer of inotify.

Follows up https://github.com/fluent/fluent-bit/pull/11750.
Closes https://github.com/fluent/fluent-bit/issues/11954.

Additional contexts: #11750 was relatively huge PR so we didn't backported into 4.2 branch.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input pause/resume behavior for tail file monitoring to properly synchronize both the file event monitoring and recovery timer, ensuring consistent state during pause/resume transitions.

* **Tests**
  * Added test coverage for pause/resume collector synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->