### PR TITLE
in_podman_metrics: add exclude_name_regex option

### DIFF
--- a/plugins/in_podman_metrics/podman_metrics.c
+++ b/plugins/in_podman_metrics/podman_metrics.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_metrics_exporter.h>
 #include <fluent-bit/flb_jsmn.h>
+#include <fluent-bit/flb_regex.h>
 
 #include <monkey/mk_core/mk_list.h>
 
@@ -119,13 +120,26 @@ static int collect_container_data(struct flb_in_metrics *ctx)
                     image_name[metadata_token_size] = '\0';
 
                     flb_plg_trace(ctx->ins, "Found image name %s", image_name);
-                    add_container_to_list(ctx, id, name, image_name);
                 }
                 else {
                     flb_plg_warn(ctx->ins, "Image name was not found for %s", id);
-                    add_container_to_list(ctx, id, name, "unknown");
+                    strncpy(image_name, "unknown", IMAGE_NAME_SIZE - 1);
+                    image_name[sizeof("unknown") - 1] = '\0';
                 }
-                collected_containers++;
+
+                /* Optionally skip containers whose name matches the
+                 * user-provided exclude regex (e.g. pod infra/service
+                 * containers that carry no useful application metrics). */
+                if (ctx->exclude_name_regex &&
+                    flb_regex_match(ctx->exclude_name_regex,
+                                    (unsigned char *) name, strlen(name)) > 0) {
+                    flb_plg_debug(ctx->ins,
+                                  "Skipping excluded container %s", name);
+                }
+                else {
+                    add_container_to_list(ctx, id, name, image_name);
+                    collected_containers++;
+                }
             }
         }
     }
@@ -427,16 +441,32 @@ static int in_metrics_init(struct flb_input_instance *in, struct flb_config *con
     ctx->rx_errors = NULL;
     ctx->tx_bytes = NULL;
     ctx->tx_errors = NULL;
+    ctx->exclude_name_regex = NULL;
 
     if (flb_input_config_map_set(in, (void *) ctx) == -1) {
         flb_free(ctx);
         return -1;
     }
 
+    if (ctx->exclude_name_regex_text) {
+        ctx->exclude_name_regex =
+            flb_regex_create(ctx->exclude_name_regex_text);
+        if (!ctx->exclude_name_regex) {
+            flb_plg_error(ctx->ins,
+                          "could not compile exclude_name_regex '%s'",
+                          ctx->exclude_name_regex_text);
+            flb_free(ctx);
+            return -1;
+        }
+    }
+
     flb_input_set_context(in, ctx);
     coll_fd_runtime = flb_input_set_collector_time(in, cb_metrics_collect_runtime, ctx->scrape_interval, 0, config);
     if (coll_fd_runtime == -1) {
         flb_plg_error(ctx->ins, "Could not set collector for podman metrics plugin");
+        if (ctx->exclude_name_regex) {
+            flb_regex_destroy(ctx->exclude_name_regex);
+        }
         return -1;
     }
     ctx->coll_fd_runtime = coll_fd_runtime;
@@ -468,6 +498,9 @@ static int in_metrics_init(struct flb_input_instance *in, struct flb_config *con
             flb_plg_error(ctx->ins, "Could not start collector for podman metrics plugin");
             flb_sds_destroy(ctx->config);
             destroy_container_list(ctx);
+            if (ctx->exclude_name_regex) {
+                flb_regex_destroy(ctx->exclude_name_regex);
+            }
             flb_free(ctx);
             return -1;
         }
@@ -491,6 +524,9 @@ static int in_metrics_exit(void *data, struct flb_config *config)
 
     flb_sds_destroy(ctx->config);
     destroy_container_list(ctx);
+    if (ctx->exclude_name_regex) {
+        flb_regex_destroy(ctx->exclude_name_regex);
+    }
     flb_free(ctx);
     return 0;
 }

--- a/plugins/in_podman_metrics/podman_metrics.h
+++ b/plugins/in_podman_metrics/podman_metrics.h
@@ -69,6 +69,12 @@ static struct flb_config_map config_map[] = {
      "Path to podman config file"
     },
     {
+     FLB_CONFIG_MAP_STR, "exclude_name_regex", NULL,
+     0, FLB_TRUE, offsetof(struct flb_in_metrics, exclude_name_regex_text),
+     "Exclude containers whose name matches this regular expression, e.g. "
+     "'-(infra|service)$' to skip pod infra and service containers"
+    },
+    {
      FLB_CONFIG_MAP_STR, "path.sysfs", SYSFS_PATH,
      0, FLB_TRUE, offsetof(struct flb_in_metrics, sysfs_path),
      "Path to sysfs subsystem directory"

--- a/plugins/in_podman_metrics/podman_metrics_config.h
+++ b/plugins/in_podman_metrics/podman_metrics_config.h
@@ -174,6 +174,8 @@ struct flb_in_metrics {
     int scrape_on_start;
     int scrape_interval;
     flb_sds_t podman_config_path;
+    flb_sds_t exclude_name_regex_text;
+    struct flb_regex *exclude_name_regex;
 
     /* container list */
     struct mk_list items;


### PR DESCRIPTION
## Summary

Add an optional `exclude_name_regex` configuration option to `in_podman_metrics`
that skips containers whose name matches a user-supplied regular expression,
before their metrics are collected and emitted.

This mirrors the regex-filtering model already used elsewhere in Fluent Bit,
e.g. `netdev.ignore_device_regex` in `in_node_exporter_metrics`. A typical use
is dropping Podman pod infrastructure containers, for example
`exclude_name_regex '-(infra|service)$'` to skip the pause and catatonit
containers that carry no useful application metrics.

The option defaults to unset, so existing behaviour (collect every container)
is unchanged and the feature is fully opt-in.

## Example configuration

```yaml
pipeline:
  inputs:
    - name: podman_metrics
      scrape_interval: 60
      exclude_name_regex: '-(infra|service)$'
```

## Implementation

- New `FLB_CONFIG_MAP_STR` option `exclude_name_regex` (default `NULL`).
- The regex is compiled once in `in_metrics_init` via `flb_regex_create`.
- Init-failure handling: the regex is compiled and a bad pattern fails init
  cleanly *before* `flb_input_set_context` / `flb_input_set_collector_time`, so
  no collector is ever armed against an uninitialised context. The compiled
  regex is also released on the later init error paths (collector setup and
  initial scrape failures) so it never leaks on a failed startup.
- During `collect_container_data`, a container is skipped when its name matches
  the compiled regex; otherwise it is added and counted as before.
- The compiled regex is released in `in_metrics_exit`.

## Testing

- Built and run against Podman pods on an aarch64 Linux device.
- With `exclude_name_regex '-(infra|service)$'`: only application containers
  emit metrics; pod `-infra`/`-service` (pause/catatonit) containers are
  excluded at the source. Verified via the prometheus exporter output.
- With the option unset: output identical to current behaviour (every
  container emitted).
- Invalid regex: init fails with `could not compile exclude_name_regex '<value>'`,
  no crash and no armed collector.

## Documentation

- A companion documentation PR for `fluent-bit-docs` documents the new
  `exclude_name_regex` option.

---

Signed-off-by: Stefano Tondo <stondo@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional regex-based filtering capability to exclude containers by name from metrics collection via the `exclude_name_regex` configuration option.
  * Container image names now default to "unknown" when metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->