### PR TITLE
config_format: fix variant array not resizable in YAML parser

### DIFF
--- a/src/config_format/flb_cf_yaml.c
+++ b/src/config_format/flb_cf_yaml.c
@@ -2816,6 +2816,8 @@ static struct parser_state *state_push_variant(struct local_ctx *ctx,
           return NULL;
       }
 
+      cfl_array_resizable(array, CFL_TRUE);
+
       variant = cfl_variant_create_from_array(array);
 
       if (variant == NULL) {


### PR DESCRIPTION
The variant array in state_push_variant() was created with a fixed size of 10 but not marked as resizable. This causes "unable to add key to list map" errors when parsing YAML configs with more than 10 entries in a list (e.g., rewrite_tag rules or OTel routes).

Add cfl_array_resizable(array, CFL_TRUE) to match the same pattern already used in state_push_witharr() in the same file.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML configuration parsing stability by optimizing internal array handling during variant construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->