### PR TITLE
http2: pre-allocate body buffer to eliminate realloc overhead

### DIFF
--- a/src/http_server/flb_http_server_http2.c
+++ b/src/http_server/flb_http_server_http2.c
@@ -743,7 +743,48 @@ static int http2_data_chunk_recv_callback(nghttp2_session *inner_session,
     }
 
     if (stream->request.body == NULL) {
-        stream->request.body = cfl_sds_create_size(len);
+        /*
+         * Pre-allocate body buffer to avoid repeated reallocs as 16KB HTTP/2
+         * frames arrive. Three strategies, in priority order:
+         *   1. Content-Length header — exact size (non-gRPC HTTP/2)
+         *   2. gRPC 5-byte frame header — parse message length for exact size
+         *   3. Fallback to frame size (len) — original behavior
+         */
+        size_t initial_size;
+
+        if (stream->request.content_length > 0) {
+            initial_size = stream->request.content_length;
+        }
+        else if (len >= 5 &&
+                 stream->request.content_type != NULL &&
+                 strncmp(stream->request.content_type, "application/grpc", 16) == 0) {
+            /* gRPC length-prefixed frame: 1 byte flags + 4 bytes message length */
+            uint32_t grpc_msg_len = ((uint32_t) data[1] << 24) |
+                                    ((uint32_t) data[2] << 16) |
+                                    ((uint32_t) data[3] << 8)  |
+                                    ((uint32_t) data[4]);
+            if ((size_t) grpc_msg_len > SIZE_MAX - 5) {
+                stream->status = HTTP_STREAM_STATUS_ERROR;
+                return -1;
+            }
+            initial_size = (size_t) grpc_msg_len + 5;
+        }
+        else {
+            initial_size = len;
+        }
+
+        if (initial_size < len) {
+            stream->status = HTTP_STREAM_STATUS_ERROR;
+            return -1;
+        }
+
+        if (http2_request_body_limit_exceeded(stream, initial_size)) {
+            stream->status = HTTP_STREAM_STATUS_ERROR;
+
+            return -1;
+        }
+
+        stream->request.body = cfl_sds_create_size(initial_size);
 
         if (stream->request.body == NULL) {
             stream->status = HTTP_STREAM_STATUS_ERROR;


### PR DESCRIPTION
Pre-allocate HTTP/2 body buffer on the first DATA frame to avoid repeated reallocs as 16KB frames arrive. Three strategies in priority order:
1. Content-Length header — exact size (non-gRPC HTTP/2)
2. gRPC 5-byte frame header — parse message length for exact size
3. Fallback to frame size (len) — original behavior

cfl_sds_cat calls cfl_sds_increase which grows by exactly len (16KB = nghttp2 frame size), not doubling. For a 4MB gRPC message this means ~250 realloc+memcpy calls. CPU profiling showed _realloc_base consuming 78.8% of fluent-bit CPU at 500 QPS OTLP gRPC ingest.
<img width="800" height="184" alt="image" src="https://github.com/user-attachments/assets/0b489def-4ee2-401b-9d4f-387a16899cbc" />
**_realloc_base** dominates the call stack at 2.08% total CPU (78.8% of fluent-bit)

Also validates the pre-allocated size against buffer_max_size upfront to reject oversized messages before allocating.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance**
  * Improved HTTP/2 request buffer allocation by pre-sizing request bodies using known content length, with special handling for gRPC message framing to better estimate expected size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->