### PR TITLE
validate msgpack record array length before indexing

### DIFF
--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -104,8 +104,6 @@ int flb_pack_to_json_format_type(const char *str);
 int flb_pack_to_json_date_type(const char *str);
 
 void flb_pack_print(const char *data, size_t bytes);
-int flb_metadata_pop_from_msgpack(msgpack_object **metadata, msgpack_unpacked *upk,
-                                  msgpack_object **map);
 int flb_msgpack_to_json(char *json_str, size_t str_len,
                         const msgpack_object *obj,
                         int escape_unicode);

--- a/include/fluent-bit/flb_pack.h
+++ b/include/fluent-bit/flb_pack.h
@@ -104,6 +104,8 @@ int flb_pack_to_json_format_type(const char *str);
 int flb_pack_to_json_date_type(const char *str);
 
 void flb_pack_print(const char *data, size_t bytes);
+int flb_metadata_pop_from_msgpack(msgpack_object **metadata, msgpack_unpacked *upk,
+                                  msgpack_object **map);
 int flb_msgpack_to_json(char *json_str, size_t str_len,
                         const msgpack_object *obj,
                         int escape_unicode);

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -861,6 +861,7 @@ static int pack_print_fluent_record(size_t cnt, msgpack_unpacked result)
     msgpack_object  *obj;
     struct flb_time  tms;
     msgpack_object   o;
+    int              ret;
 
     root = result.data;
     if (root.type != MSGPACK_OBJECT_ARRAY || root.via.array.size < 2) {
@@ -881,8 +882,15 @@ static int pack_print_fluent_record(size_t cnt, msgpack_unpacked result)
     }
 
     /* This is a Fluent Bit record, just do the proper unpacking/printing */
-    flb_time_pop_from_msgpack(&tms, &result, &obj);
-    flb_metadata_pop_from_msgpack(&metadata, &result, &obj);
+    ret = flb_time_pop_from_msgpack(&tms, &result, &obj);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ret = flb_metadata_pop_from_msgpack(&metadata, &result, &obj);
+    if (ret != 0) {
+        return -1;
+    }
 
     fprintf(stdout, "[%zd] [[%"PRId32".%09lu, ", cnt, (int32_t) tms.tm.tv_sec, tms.tm.tv_nsec);
 

--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -839,6 +839,15 @@ int flb_metadata_pop_from_msgpack(msgpack_object **metadata, msgpack_unpacked *u
         return -1;
     }
 
+    if (upk->data.via.array.size < 2) {
+        return -1;
+    }
+
+    if (upk->data.via.array.ptr[0].type != MSGPACK_OBJECT_ARRAY ||
+        upk->data.via.array.ptr[0].via.array.size < 2) {
+        return -1;
+    }
+
     *metadata = &upk->data.via.array.ptr[0].via.array.ptr[1];
     *map = &upk->data.via.array.ptr[1];
 
@@ -854,12 +863,12 @@ static int pack_print_fluent_record(size_t cnt, msgpack_unpacked result)
     msgpack_object   o;
 
     root = result.data;
-    if (root.type != MSGPACK_OBJECT_ARRAY) {
+    if (root.type != MSGPACK_OBJECT_ARRAY || root.via.array.size < 2) {
         return -1;
     }
 
     o = root.via.array.ptr[0];
-    if (o.type != MSGPACK_OBJECT_ARRAY) {
+    if (o.type != MSGPACK_OBJECT_ARRAY || o.via.array.size != 2) {
         return -1;
     }
 

--- a/src/flb_time.c
+++ b/src/flb_time.c
@@ -405,6 +405,10 @@ int flb_time_pop_from_msgpack(struct flb_time *time, msgpack_unpacked *upk,
         return -1;
     }
 
+    if (upk->data.via.array.size < 2) {
+        return -1;
+    }
+
     obj = upk->data.via.array.ptr[0];
 
     if (obj.type == MSGPACK_OBJECT_ARRAY) {

--- a/tests/internal/flb_time.c
+++ b/tests/internal/flb_time.c
@@ -466,8 +466,59 @@ void test_iana_zone_to_utc_offset()
     }
 }
 
+/* flb_time_pop_from_msgpack must reject record arrays shorter than 2
+ * elements instead of reading via.array.ptr[0]/ptr[1] out of bounds. */
+static void pop_from_array(const char *data, size_t size, int expect)
+{
+    struct flb_time tm;
+    msgpack_object *map;
+    msgpack_unpacked result;
+    int ret;
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, data, size, NULL);
+
+    ret = flb_time_pop_from_msgpack(&tm, &result, &map);
+    if (!TEST_CHECK(ret == expect)) {
+        TEST_MSG("got %d, expect %d", ret, expect);
+    }
+
+    msgpack_unpacked_destroy(&result);
+}
+
+void test_pop_from_msgpack_short_array()
+{
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* empty array: [] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 0);
+    pop_from_array(mp_sbuf.data, mp_sbuf.size, -1);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    /* single element: [ timestamp ] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 1);
+    msgpack_pack_int(&mp_pck, SEC_32BIT);
+    pop_from_array(mp_sbuf.data, mp_sbuf.size, -1);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    /* valid record: [ timestamp, map ] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_int(&mp_pck, SEC_32BIT);
+    msgpack_pack_map(&mp_pck, 0);
+    pop_from_array(mp_sbuf.data, mp_sbuf.size, 0);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
 TEST_LIST = {
     { "flb_time_to_nanosec"           , test_to_nanosec},
+    { "pop_from_msgpack_short_array"  , test_pop_from_msgpack_short_array},
     { "flb_time_append_to_mpack_v1"   , test_append_to_mpack_v1},
     { "msgpack_to_time_int"           , test_msgpack_to_time_int},
     { "msgpack_to_time_double"        , test_msgpack_to_time_double},

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -1287,6 +1287,10 @@ void test_json_pack_token_count_overflow()
     flb_pack_state_reset(&state);
 }
 
+/* defined in src/flb_pack.c, not part of the installed headers */
+int flb_metadata_pop_from_msgpack(msgpack_object **metadata, msgpack_unpacked *upk,
+                                  msgpack_object **map);
+
 /* flb_metadata_pop_from_msgpack must reject record arrays that are shorter
  * than 2 elements or whose first element is a short array, instead of reading
  * via.array.ptr[1] out of bounds. */

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -1287,6 +1287,71 @@ void test_json_pack_token_count_overflow()
     flb_pack_state_reset(&state);
 }
 
+/* flb_metadata_pop_from_msgpack must reject record arrays that are shorter
+ * than 2 elements or whose first element is a short array, instead of reading
+ * via.array.ptr[1] out of bounds. */
+static void metadata_pop_from_array(const char *data, size_t size, int expect)
+{
+    msgpack_object *metadata;
+    msgpack_object *map;
+    msgpack_unpacked result;
+    int ret;
+
+    msgpack_unpacked_init(&result);
+    msgpack_unpack_next(&result, data, size, NULL);
+
+    ret = flb_metadata_pop_from_msgpack(&metadata, &result, &map);
+    if (!TEST_CHECK(ret == expect)) {
+        TEST_MSG("got %d, expect %d", ret, expect);
+    }
+
+    msgpack_unpacked_destroy(&result);
+}
+
+void test_metadata_pop_from_msgpack_short_array()
+{
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* empty array: [] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 0);
+    metadata_pop_from_array(mp_sbuf.data, mp_sbuf.size, -1);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    /* single element: [ [meta, ...] ] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 1);
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_int(&mp_pck, 0);
+    msgpack_pack_map(&mp_pck, 0);
+    metadata_pop_from_array(mp_sbuf.data, mp_sbuf.size, -1);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    /* first element is a short array: [ [ts], map ] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_array(&mp_pck, 1);
+    msgpack_pack_int(&mp_pck, 0);
+    msgpack_pack_map(&mp_pck, 0);
+    metadata_pop_from_array(mp_sbuf.data, mp_sbuf.size, -1);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    /* valid record: [ [ts, meta], map ] */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_int(&mp_pck, 0);
+    msgpack_pack_map(&mp_pck, 0);
+    msgpack_pack_map(&mp_pck, 0);
+    metadata_pop_from_array(mp_sbuf.data, mp_sbuf.size, 0);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
 TEST_LIST = {
     /* JSON maps iteration */
     { "json_pack"          , test_json_pack },
@@ -1318,5 +1383,8 @@ TEST_LIST = {
     { "json_pack_surrogate_pairs", test_json_pack_surrogate_pairs},
     { "json_pack_surrogate_pairs_with_replacement", test_json_pack_surrogate_pairs_with_replacement},
     { "json_pack_token_count_overflow", test_json_pack_token_count_overflow},
+
+    /* msgpack record array bounds */
+    { "metadata_pop_from_msgpack_short_array", test_metadata_pop_from_msgpack_short_array},
     { 0 }
 };


### PR DESCRIPTION
flb_time_pop_from_msgpack() validates that the inner timestamp array has
two elements but never checks the outer record array before dereferencing
it:

    if (upk->data.type != MSGPACK_OBJECT_ARRAY) {
        return -1;
    }
    obj = upk->data.via.array.ptr[0];        /* size unchecked */
    ...
    *map = &upk->data.via.array.ptr[1];

A record array with fewer than two elements ([] or a lone timestamp)
reads ptr[0]/ptr[1] past the array. flb_metadata_pop_from_msgpack() and
the pack_print_fluent_record() helper have the same gap. The count is
validated in these callees because they sit behind the storage_backlog
reload path and the out_lib/library entrypoints.

Added a regression test under tests/internal/flb_time.c; before the fix
it pops a 1-element array and reads a garbage timestamp, after the fix
the short arrays are rejected. The internal suite passes under
-DSANITIZE_ADDRESS=On.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [N/A] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for MessagePack record parsing to reject malformed or too-short arrays.
  * Added safer error handling when decoding timestamps and metadata, preventing invalid records from being processed.
  * Improved robustness against out-of-bounds access during record parsing.

* **Tests**
  * Added regression tests covering empty, short, and valid MessagePack record layouts to verify correct success and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->