### PR TITLE
out_cloudwatch_logs: Plug SEGV on not found error

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -99,6 +99,34 @@ static struct flb_aws_header put_log_events_header[] = {
     },
 };
 
+static int mock_create_log_stream_calls;
+static int mock_put_log_events_calls;
+static int mock_create_log_stream_after_put_calls;
+
+void cloudwatch_mock_call_count_reset(void)
+{
+    mock_create_log_stream_calls = 0;
+    mock_put_log_events_calls = 0;
+    mock_create_log_stream_after_put_calls = 0;
+}
+
+int cloudwatch_mock_call_count_get(const char *api)
+{
+    if (strcmp(api, "CreateLogStream") == 0) {
+        return mock_create_log_stream_calls;
+    }
+    else if (strcmp(api, "PutLogEvents") == 0) {
+        return mock_put_log_events_calls;
+    }
+
+    return 0;
+}
+
+int cloudwatch_mock_create_after_put_count_get(void)
+{
+    return mock_create_log_stream_after_put_calls;
+}
+
 int plugin_under_test()
 {
     if (getenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST") != NULL) {
@@ -136,6 +164,16 @@ struct flb_http_client *mock_http_call(char *error_env_var, char *api)
     /* create an http client so that we can set the response */
     struct flb_http_client *c = NULL;
     char *error = mock_error_response(error_env_var);
+
+    if (strcmp(api, "CreateLogStream") == 0) {
+        mock_create_log_stream_calls++;
+        if (mock_put_log_events_calls > 0) {
+            mock_create_log_stream_after_put_calls++;
+        }
+    }
+    else if (strcmp(api, "PutLogEvents") == 0) {
+        mock_put_log_events_calls++;
+    }
 
     c = flb_calloc(1, sizeof(struct flb_http_client));
     if (!c) {
@@ -1623,6 +1661,11 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
                                   data, bytes,
                                   config);
     }
+
+    if (buf->non_retriable_error == FLB_TRUE) {
+        return -1;
+    }
+
     /* send any remaining events */
     ret = send_log_events(ctx, buf);
     reset_flush_buf(ctx, buf);
@@ -2118,6 +2161,7 @@ int put_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
 
     struct flb_http_client *c = NULL;
     struct flb_aws_client *cw_client;
+    flb_sds_t error;
     int num_headers = 1;
     int retry = FLB_TRUE;
 
@@ -2172,6 +2216,19 @@ retry_request:
 
         /* Check error */
         if (c->resp.payload_size > 0) {
+            error = flb_aws_error(c->resp.payload, c->resp.payload_size);
+            if (error != NULL) {
+                if (strcmp(error, ERR_CODE_NOT_FOUND) == 0) {
+                    flb_plg_error(ctx->ins, "Log stream %s not found. "
+                                  "Rejecting the chunk without retry.",
+                                  stream->name);
+                    buf->non_retriable_error = FLB_TRUE;
+                    flb_sds_destroy(error);
+                    flb_http_client_destroy(c);
+                    return -1;
+                }
+                flb_sds_destroy(error);
+            }
             flb_aws_print_error(c->resp.payload, c->resp.payload_size,
                                                   "PutLogEvents", ctx->ins);
         }

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -1692,15 +1692,13 @@ struct log_stream *get_or_create_log_stream(struct flb_cloudwatch *ctx,
     now = time(NULL);
     mk_list_foreach_safe(head, tmp, &ctx->streams) {
         stream = mk_list_entry(head, struct log_stream, _head);
-        if (strcmp(stream_name, stream->name) == 0 && strcmp(group_name, stream->group) == 0) {
-            return stream;
+        if (stream->expiration < now) {
+            mk_list_del(&stream->_head);
+            log_stream_destroy(stream);
         }
-        else {
-            /* check if stream is expired, if so, clean it up */
-            if (stream->expiration < now) {
-                mk_list_del(&stream->_head);
-                log_stream_destroy(stream);
-            }
+        else if (strcmp(stream_name, stream->name) == 0 &&
+                 strcmp(group_name, stream->group) == 0) {
+            return stream;
         }
     }
 
@@ -2222,6 +2220,7 @@ retry_request:
                     flb_plg_error(ctx->ins, "Log stream %s not found. "
                                   "Rejecting the chunk without retry.",
                                   stream->name);
+                    stream->expiration = 0;
                     buf->non_retriable_error = FLB_TRUE;
                     flb_sds_destroy(error);
                     flb_http_client_destroy(c);

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -48,7 +48,7 @@
  * https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
  * AWS CloudWatch's documented maximum event size is 1,048,576 bytes (1 MiB),
  * including JSON encoding overhead (structure, escaping, etc.).
- * 
+ *
  * Setting MAX_EVENT_LEN to 1,000,000 bytes (1 MB) provides a ~4.6% safety margin
  * to account for JSON encoding overhead and ensure reliable operation.
  * Testing confirmed messages up to 1,048,546 bytes (encoding to 1,048,586 bytes)
@@ -80,5 +80,8 @@ int put_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
 int create_log_group(struct flb_cloudwatch *ctx, struct log_stream *stream);
 int compare_events(const void *a_arg, const void *b_arg);
 void reset_flush_buf(struct flb_cloudwatch *ctx, struct cw_flush *buf);
+void cloudwatch_mock_call_count_reset(void);
+int cloudwatch_mock_call_count_get(const char *api);
+int cloudwatch_mock_create_after_put_count_get(void);
 
 #endif

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -458,6 +458,10 @@ static void cb_cloudwatch_flush(struct flb_event_chunk *event_chunk,
                                    event_chunk->type, config);
     if (event_count < 0) {
         flb_plg_error(ctx->ins, "Failed to send events");
+        if (buf->non_retriable_error == FLB_TRUE) {
+            cw_flush_destroy(buf);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
         cw_flush_destroy(buf);
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -106,6 +106,9 @@ struct cw_flush {
 
     /* current log stream that we are sending records too */
     struct log_stream *current_stream;
+
+    /* marks a delivery failure that must not be retried */
+    int non_retriable_error;
 };
 
 struct cw_event {

--- a/tests/runtime/out_cloudwatch.c
+++ b/tests/runtime/out_cloudwatch.c
@@ -324,9 +324,15 @@ void flb_test_cloudwatch_error_put_log_events_not_found(void)
     flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
 
     sleep(2);
-    flb_stop(ctx);
     TEST_CHECK(cloudwatch_mock_call_count_get("PutLogEvents") == 1);
     TEST_CHECK(cloudwatch_mock_create_after_put_count_get() == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    TEST_CHECK(cloudwatch_mock_call_count_get("PutLogEvents") == 2);
+    TEST_CHECK(cloudwatch_mock_create_after_put_count_get() == 1);
     flb_destroy(ctx);
     unsetenv("TEST_PUT_LOG_EVENTS_ERROR");
 }

--- a/tests/runtime/out_cloudwatch.c
+++ b/tests/runtime/out_cloudwatch.c
@@ -8,7 +8,12 @@
 /* CloudWatch API constants */
 #include "../../plugins/out_cloudwatch_logs/cloudwatch_api.h"
 
-#define ERROR_ALREADY_EXISTS "{\"__type\":\"ResourceAlreadyExistsException\"}"
+#ifdef FLB_SYSTEM_WINDOWS
+#define setenv(name, value, overwrite) _putenv_s(name, value)
+#define unsetenv(name) _putenv_s(name, "")
+#endif
+
+#define CLOUDWATCH_ERROR_ALREADY_EXISTS "{\"__type\":\"ResourceAlreadyExistsException\"}"
 #define CLOUDWATCH_ERROR_NOT_FOUND "{\"__type\":\"ResourceNotFoundException\"}"
 /* not a real error code, but tests that the code can respond to any error */
 #define ERROR_UNKNOWN "{\"__type\":\"UNKNOWN\"}"
@@ -109,7 +114,7 @@ void flb_test_cloudwatch_already_exists_create_group(void)
 
     /* mocks calls- signals that we are in test mode */
     setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
-    setenv("TEST_CREATE_LOG_GROUP_ERROR", ERROR_ALREADY_EXISTS, 1);
+    setenv("TEST_CREATE_LOG_GROUP_ERROR", CLOUDWATCH_ERROR_ALREADY_EXISTS, 1);
 
     ctx = flb_create();
 
@@ -146,7 +151,7 @@ void flb_test_cloudwatch_already_exists_create_stream(void)
 
     /* mocks calls- signals that we are in test mode */
     setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
-    setenv("TEST_CREATE_LOG_STREAM_ERROR", ERROR_ALREADY_EXISTS, 1);
+    setenv("TEST_CREATE_LOG_STREAM_ERROR", CLOUDWATCH_ERROR_ALREADY_EXISTS, 1);
 
     ctx = flb_create();
 
@@ -292,9 +297,10 @@ void flb_test_cloudwatch_error_put_log_events_not_found(void)
     int in_ffd;
     int out_ffd;
 
-    /* ResourceNotFoundException must follow the normal output retry path. */
+    /* ResourceNotFoundException must reject the chunk without retrying it. */
     setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
     setenv("TEST_PUT_LOG_EVENTS_ERROR", CLOUDWATCH_ERROR_NOT_FOUND, 1);
+    cloudwatch_mock_call_count_reset();
 
     ctx = flb_create();
 
@@ -319,6 +325,8 @@ void flb_test_cloudwatch_error_put_log_events_not_found(void)
 
     sleep(2);
     flb_stop(ctx);
+    TEST_CHECK(cloudwatch_mock_call_count_get("PutLogEvents") == 1);
+    TEST_CHECK(cloudwatch_mock_create_after_put_count_get() == 0);
     flb_destroy(ctx);
     unsetenv("TEST_PUT_LOG_EVENTS_ERROR");
 }
@@ -369,7 +377,7 @@ void flb_test_cloudwatch_already_exists_create_group_put_retention_policy(void)
 
     /* mocks calls- signals that we are in test mode */
     setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
-    setenv("TEST_CREATE_LOG_GROUP_ERROR", ERROR_ALREADY_EXISTS, 1);
+    setenv("TEST_CREATE_LOG_GROUP_ERROR", CLOUDWATCH_ERROR_ALREADY_EXISTS, 1);
 
     /* PutRetentionPolicy is not called if the group already exists */
     setenv("TEST_PUT_RETENTION_POLICY_ERROR", ERROR_UNKNOWN, 1);


### PR DESCRIPTION
<!-- Provide summary of changes -->
In this PR, we'll treat unrecoverable error on not found exception occurred on out_cloudwatch_logs.

Closes https://github.com/fluent/fluent-bit/issues/11959.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CloudWatch log delivery now treats “resource not found” failures as non-retriable, preventing repeated send attempts and improving recovery.
  * Flush now honors non-retriable delivery failures by returning the correct non-retry outcome.

* **Tests**
  * Updated CloudWatch runtime scenarios for “already exists” and “not found” behaviors.
  * Enhanced CloudWatch mock call-count tracking to verify when log streams are created and when `PutLogEvents` is invoked, including “create after put” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->