### PR TITLE
packaging: deprecate unzip and wget in Dockerfiles

### DIFF
--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -8,7 +8,7 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
     sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
     yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel flex bison \
+    systemd-devel flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel \
     tar gzip

--- a/packaging/distros/almalinux/Dockerfile
+++ b/packaging/distros/almalinux/Dockerfile
@@ -18,7 +18,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-powertools.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -38,7 +38,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-powertools.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -57,7 +57,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -77,7 +77,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -96,7 +96,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config \
     libzstd-devel && \
@@ -118,7 +118,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/almalinux-crb.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config \
     libzstd-devel && \

--- a/packaging/distros/amazonlinux/Dockerfile
+++ b/packaging/distros/amazonlinux/Dockerfile
@@ -20,7 +20,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates make bash \
     gcc gcc-c++ \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs glibc-devel \
     libyaml-devel zlib-devel libcurl-devel pkgconf-pkg-config \
@@ -45,7 +45,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
     libyaml-devel zlib-devel libcurl-devel pkgconf-pkg-config \
@@ -70,7 +70,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl-minimal ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
     libyaml-devel zlib-devel libcurl-devel pkgconf-pkg-config \
@@ -97,7 +97,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl-minimal ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel \
     postgresql-devel postgresql-libs \
     libyaml-devel zlib-devel libcurl-devel pkgconf-pkg-config \

--- a/packaging/distros/centos/Dockerfile
+++ b/packaging/distros/centos/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
     sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
     yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel \
     tar gzip && \
@@ -60,7 +60,7 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
     sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo && \
     yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     postgresql-libs postgresql-devel postgresql-server postgresql libyaml-devel \
     tar gzip && \
@@ -107,7 +107,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     libyaml-devel zlib-devel \
@@ -150,7 +150,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     libyaml-devel zlib-devel \
@@ -188,7 +188,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033,DL3041
 RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-enabled crb && \
     dnf -y install rpm-build ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     libyaml-devel zlib-devel \
@@ -219,7 +219,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033,DL3041
 RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-enabled crb && \
     dnf -y install rpm-build ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     libyaml-devel zlib-devel \
@@ -257,7 +257,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033,DL3041
 RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-enabled crb && \
     dnf -y install rpm-build ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     libyaml-devel zlib-devel libzstd-devel \
@@ -289,7 +289,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3033,DL3041
 RUN dnf -y install 'dnf-command(config-manager)' && dnf -y config-manager --set-enabled crb && \
     dnf -y install rpm-build ca-certificates gcc gcc-c++ make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libcurl-devel pkgconf-pkg-config \
     libyaml-devel zlib-devel libzstd-devel \

--- a/packaging/distros/debian/Dockerfile
+++ b/packaging/distros/debian/Dockerfile
@@ -25,7 +25,7 @@ RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -56,7 +56,7 @@ RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -80,7 +80,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -106,7 +106,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -130,7 +130,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -156,7 +156,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -180,7 +180,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \
@@ -206,7 +206,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
     apt-get install -y curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config \

--- a/packaging/distros/raspbian/Dockerfile
+++ b/packaging/distros/raspbian/Dockerfile
@@ -15,7 +15,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y cmake=3.13.4-1 cmake-data=3.13.4-1 \
     curl ca-certificates build-essential \
-    make bash sudo wget unzip dh-make \
+    make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
@@ -28,7 +28,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential \
-    cmake make bash sudo wget unzip dh-make \
+    cmake make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \
@@ -41,7 +41,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential \
-    cmake make bash sudo wget unzip dh-make \
+    cmake make bash sudo dh-make \
     libsystemd-dev zlib1g-dev flex bison \
     libssl3 libssl-dev libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev libyaml-dev libcurl4-openssl-dev pkg-config && \

--- a/packaging/distros/rockylinux/Dockerfile
+++ b/packaging/distros/rockylinux/Dockerfile
@@ -18,7 +18,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -38,7 +38,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/Rocky-PowerTools.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -57,7 +57,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -77,7 +77,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config && \
     yum clean all
@@ -96,7 +96,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config  \
     libzstd-devel && \
@@ -118,7 +118,7 @@ RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/rocky-devel.repo
 # hadolint ignore=DL3033
 RUN yum -y update && \
     yum install -y --allowerasing rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
-    wget unzip systemd-devel wget flex bison \
+    systemd-devel wget flex bison \
     postgresql-libs postgresql-devel postgresql-server postgresql \
     cyrus-sasl-lib cyrus-sasl-devel openssl openssl-libs openssl-devel libyaml-devel pkgconf-pkg-config  \
     libzstd-devel && \

--- a/packaging/distros/ubuntu/Dockerfile
+++ b/packaging/distros/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all software-properties-common \
     software-properties-common libyaml-dev apt-transport-https  \
     pkg-config libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.0 \
@@ -54,7 +54,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates gcc-8 g++-8 libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
     software-properties-common libyaml-dev apt-transport-https pkg-config zlib1g-dev \
@@ -88,7 +88,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates gcc-8 g++-8 libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
     software-properties-common libyaml-dev apt-transport-https pkg-config zlib1g-dev \
@@ -118,7 +118,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -144,7 +144,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -168,7 +168,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -194,7 +194,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -218,7 +218,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -244,7 +244,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -268,7 +268,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \
@@ -294,7 +294,7 @@ ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
 # hadolint ignore=DL3008,DL3015
 RUN apt-get update && \
     apt-get install -y curl ca-certificates build-essential libsystemd-dev \
-    make bash wget unzip nano vim valgrind dh-make flex bison \
+    make bash wget nano vim valgrind dh-make flex bison \
     libpq-dev postgresql-server-dev-all libpq5 \
     libsasl2-2 libsasl2-dev openssl libssl-dev libssl3 libcurl4-openssl-dev \
     libyaml-dev pkg-config zlib1g-dev \


### PR DESCRIPTION
Remove unzip and wget from Dockerfile as the latest Fluent Bit codebase no longer depends on these packages. They are legacy artifacts and are no longer required.

For Ubuntu dockerfile, removed unzip but kept wget as it's still invoked

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build container package dependencies across CentOS, AlmaLinux, AmazonLinux, Debian, Ubuntu, Raspbian, and RockyLinux for both amd64 and ARM64 variants.
  * Package install lists were adjusted to remove `unzip` and to de-duplicate `wget` entries where they appeared multiple times, keeping the rest of the tooling dependency sets consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->