### PR TITLE
out_s3: preserve $INDEX sequence state across restarts

### DIFF
--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -353,6 +353,24 @@ int s3_store_exit(struct flb_s3 *ctx)
         return 0;
     }
 
+    /*
+     * Detach the metadata ("sequence") stream before tearing down the store.
+     *
+     * The $INDEX value is persisted as a plain file inside the metadata stream
+     * directory (sequence/index_metadata/seq_index_<id>); it is not a Chunk I/O
+     * chunk, so the stream has zero registered fstore files. Because
+     * flb_fstore_destroy() recursively deletes any stream that has no files, the
+     * metadata stream (and the persisted $INDEX) would be removed on every
+     * graceful shutdown. Detaching the reference here (without deleting the
+     * directory) preserves the index on disk so it can be restored on the next
+     * start, which is the documented behavior of $INDEX with a persistent
+     * store_dir.
+     */
+    if (ctx->stream_metadata != NULL) {
+        flb_fstore_stream_destroy(ctx->stream_metadata, FLB_FALSE);
+        ctx->stream_metadata = NULL;
+    }
+
     /* release local context on non-multi upload files */
     mk_list_foreach(head, &ctx->fs->streams) {
         fs_stream = mk_list_entry(head, struct flb_fstore_stream, _head);


### PR DESCRIPTION
## Summary

Fixes #11987.

The S3 output persists the `$INDEX` sequence counter as a plain file under the metadata stream directory (`<store_dir>/<bucket>/sequence/index_metadata/seq_index_<id>`). Because this file is not a Chunk I/O chunk, the `sequence` fstore stream has zero registered files, and `flb_fstore_destroy()` deletes any stream with zero files on shutdown — recursively removing the directory and the persisted `$INDEX`. After a graceful restart the index resets to `0` and uploads overwrite previously-written objects, contradicting the documented behavior that `$INDEX` continues from its last value when `store_dir` is on a persistent disk.

This detaches the metadata stream reference in `s3_store_exit()` (without deleting the directory) before the store is destroyed, so the index file survives on disk and `init_seq_index()` recovers it on the next start.

## Root cause

- `$INDEX` is written as a raw file via `init_seq_index()` / `write_seq_index()` in `plugins/out_s3/s3.c`, inside the `sequence` fstore stream, under a nested `index_metadata/` subdirectory.
- `cio_scan_stream_files()` (`lib/chunkio/src/cio_scan.c`) only registers `DT_REG` entries directly under a stream dir, so the nested `index_metadata/` is ignored and the `sequence` stream has 0 files.
- `flb_fstore_destroy()` (`src/flb_fstore.c`) deletes any stream with `files == 0` (`flb_fstore_stream_destroy(stream, FLB_TRUE)` → `cio_stream_delete()` → recursive directory delete).
- `s3_store_exit()` (`plugins/out_s3/s3_store.c`) calls `flb_fstore_destroy()` on shutdown, so the metadata stream and the persisted `$INDEX` are removed on every graceful exit.

## Fix

```c
/* in s3_store_exit(), right after the `if (!ctx->fs) return 0;` guard */
if (ctx->stream_metadata != NULL) {
    flb_fstore_stream_destroy(ctx->stream_metadata, FLB_FALSE);
    ctx->stream_metadata = NULL;
}
```

`flb_fstore_stream_destroy(stream, FLB_FALSE)` removes the fstore reference from `fs->streams` without deleting the on-disk directory; the underlying `cio_stream` is still freed by the subsequent `cio_destroy()`. Only the `sequence` (metadata) stream is affected — `multipart_upload_metadata` uses real Chunk I/O chunks, so it is unaffected by the empty-stream cleanup.

## Testing

- Reproduced the deletion on graceful shutdown: with `store_dir` on a persistent volume, a marker file placed inside `sequence/` and the `seq_index_<id>` file are both gone after a SIGTERM restart (the `sequence/` dir returns with a fresh inode), while a marker placed one level above on the same volume survives — confirming the volume is healthy and Fluent Bit is deleting its own metadata stream. No `Successfully recovered index` log appears, and `$INDEX` resets to 0.
- With this change the metadata directory is retained across restart, so `init_seq_index()` takes the `read_seq_index()` recovery path.
- Verified the referenced symbols/signatures against the source: `ctx->stream_metadata` (`plugins/out_s3/s3.h`), `flb_fstore_stream_destroy(struct flb_fstore_stream *, int delete)` (`include/fluent-bit/flb_fstore.h`).

## Notes

- Present on `4.2.x`, `5.0.x`, and `master` (the `$INDEX` + metadata-stream design is unchanged across these).
- Not multipart-specific — both PutObject and multipart upload paths use the same `init_seq_index()` state file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where metadata could be lost during graceful shutdown in the S3 storage plugin by improving the shutdown sequence to properly protect persisted index data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->