### PR TITLE
opentelemetry: fix JSON histogram bounds handling

### DIFF
--- a/src/opentelemetry/flb_opentelemetry_metrics.c
+++ b/src/opentelemetry/flb_opentelemetry_metrics.c
@@ -1808,6 +1808,23 @@ static int parse_histogram_bounds(msgpack_object *explicit_bounds_object,
     return 0;
 }
 
+static int check_histogram_bounds_order(double *bounds, size_t count)
+{
+    size_t index;
+
+    if (bounds == NULL) {
+        return -1;
+    }
+
+    for (index = 1 ; index < count ; index++) {
+        if (bounds[index - 1] >= bounds[index]) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 static int parse_histogram_bucket_counts(msgpack_object *bucket_counts_object,
                                          uint64_t **out_bucket_counts,
                                          size_t *out_count)
@@ -2192,6 +2209,14 @@ static int process_metric_histogram_data_points(struct cmt *context,
             continue;
         }
 
+        if (check_histogram_bounds_order(point_bounds, point_bound_count) != 0) {
+            flb_free(bucket_counts);
+            flb_free(point_bounds);
+            destroy_label_arrays(metric_label_count, metric_label_keys, NULL);
+            flb_free(metric_bounds);
+            return OTEL_METRICS_JSON_DECODER_ERROR;
+        }
+
         if (bucket_counts_count != point_bound_count + 1) {
             flb_free(bucket_counts);
             flb_free(point_bounds);
@@ -2313,24 +2338,12 @@ static int process_metric_histogram_data_points(struct cmt *context,
                 return result;
             }
 
-            buckets = cmt_histogram_buckets_create_size(metric_bounds,
-                                                        metric_bound_count);
-            if (buckets == NULL) {
-                flb_sds_destroy(metric_name);
-                flb_sds_destroy(metric_help);
-                destroy_label_arrays(point_label_count, NULL, point_label_values);
-                destroy_label_arrays(metric_label_count, metric_label_keys, NULL);
-                flb_free(metric_bounds);
-                flb_free(bucket_counts);
-                return CMT_DECODE_OPENTELEMETRY_ALLOCATION_ERROR;
-            }
-
             histogram = cmt_histogram_create(context,
                                              "",
                                              "",
                                              metric_name,
                                              metric_help,
-                                             buckets,
+                                             NULL,
                                              metric_label_count,
                                              (char **) metric_label_keys);
             flb_sds_destroy(metric_name);
@@ -2338,13 +2351,27 @@ static int process_metric_histogram_data_points(struct cmt *context,
             metric_help = NULL;
 
             if (histogram == NULL) {
-                cmt_histogram_buckets_destroy(buckets);
                 destroy_label_arrays(point_label_count, NULL, point_label_values);
                 destroy_label_arrays(metric_label_count, metric_label_keys, NULL);
                 flb_free(metric_bounds);
                 flb_free(bucket_counts);
                 return CMT_DECODE_OPENTELEMETRY_ALLOCATION_ERROR;
             }
+
+            buckets = cmt_histogram_buckets_create_size(metric_bounds,
+                                                        metric_bound_count);
+            if (buckets == NULL) {
+                destroy_label_arrays(point_label_count, NULL, point_label_values);
+                destroy_label_arrays(metric_label_count, metric_label_keys, NULL);
+                flb_free(metric_bounds);
+                flb_free(bucket_counts);
+                cmt_histogram_destroy(histogram);
+                return CMT_DECODE_OPENTELEMETRY_ALLOCATION_ERROR;
+            }
+
+            cmt_histogram_buckets_destroy(histogram->buckets);
+            histogram->buckets = buckets;
+            buckets = NULL;
 
             result = set_metric_unit(histogram->map, metric_map);
             if (result != 0) {

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -414,6 +414,41 @@ def build_scope_schema_logs_json_payload():
     return json.dumps(payload).encode("utf-8")
 
 
+def build_histogram_json_payload(explicit_bounds, name="histogram_bounds"):
+    payload = {
+        "resourceMetrics": [
+            {
+                "resource": {
+                    "attributes": [],
+                },
+                "scopeMetrics": [
+                    {
+                        "metrics": [
+                            {
+                                "name": name,
+                                "histogram": {
+                                    "aggregationTemporality": 2,
+                                    "dataPoints": [
+                                        {
+                                            "count": "3",
+                                            "sum": 3.0,
+                                            "bucketCounts": ["1", "1", "1"],
+                                            "explicitBounds": explicit_bounds,
+                                            "timeUnixNano": "1",
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    return json.dumps(payload).encode("utf-8")
+
+
 class Service:
     def __init__(self, config_file, *, use_auth_server=False):
         # Compose the absolute path for the Fluent Bit configuration file
@@ -777,6 +812,65 @@ def test_in_opentelemetry_rejects_invalid_metrics_payload():
 
     assert response.status_code >= 400
     assert len(data_storage["metrics"]) == 0
+
+
+def test_in_opentelemetry_rejects_json_histogram_with_descending_bounds():
+    service = Service("001-fluent-bit.yaml")
+    service.start()
+
+    try:
+        response = service.send_raw_request(
+            "/v1/metrics",
+            build_histogram_json_payload([2, 1]),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert service.flb.process is not None
+        assert service.flb.process.poll() is None
+        assert len(data_storage["metrics"]) == 0
+
+        response = service.send_raw_request(
+            "/v1/metrics",
+            build_histogram_json_payload([1, 1]),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert service.flb.process is not None
+        assert service.flb.process.poll() is None
+        assert len(data_storage["metrics"]) == 0
+
+        response = service.send_raw_request(
+            "/v1/metrics",
+            build_histogram_json_payload([1, 2], name=""),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert service.flb.process is not None
+        assert service.flb.process.poll() is None
+        assert len(data_storage["metrics"]) == 0
+
+        response = service.send_raw_request(
+            "/v1/metrics",
+            build_histogram_json_payload([1, 2]),
+            content_type="application/json",
+        )
+        assert 200 <= response.status_code < 300
+
+        output = service.read_response("metrics")
+    finally:
+        service.stop()
+
+    metrics = {item["metric"]["name"]: item for item in iter_metric_entries(output)}
+    histogram = metrics["histogram_bounds"]["metric"]["histogram"]
+    histogram_datapoint = histogram["dataPoints"][0]
+
+    assert histogram_datapoint["count"] == "3"
+    assert histogram_datapoint["sum"] == 3.0
+    assert histogram_datapoint["bucketCounts"] == ["1", "1", "1"]
+    assert histogram_datapoint["explicitBounds"] == [1.0, 2.0]
 
 
 def test_in_opentelemetry_rejects_invalid_traces_payload():


### PR DESCRIPTION
## Problem

OTLP/HTTP JSON metrics can carry histogram `explicitBounds` that are not monotonically non-decreasing. The JSON decoder passed those bounds into cmetrics before rejecting them, and then freed the bucket object again when `cmt_histogram_create()` returned `NULL`.

## Changes

- Validate JSON histogram explicit bounds in the OpenTelemetry metrics decoder before creating cmetrics buckets.
- Treat `cmt_histogram_create()` as consuming the buckets object once called, including internal failure paths.
- Add an in-opentelemetry integration regression test that rejects descending bounds and verifies the listener remains healthy by accepting a subsequent valid histogram.

## Validation

- `cmake --build build --target fluent-bit-bin -j 8`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_rejects_json_histogram_with_descending_bounds -q`
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_rejects_json_histogram_with_descending_bounds -q`
- `ctest --test-dir build -R flb-it-opentelemetry --output-on-failure`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OTLP JSON histogram validation to reject `explicitBounds` that are not in non-decreasing order, including degenerate or invalid bound sequences.
  * Refined histogram construction and error handling so failures during bucket setup are handled safely and consistently.

* **Tests**
  * Added an integration test covering rejection of descending/invalid histogram `explicitBounds` and acceptance of valid bounds, verifying stored datapoint values (including normalized `explicitBounds`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->