### PR TITLE
node_exporter_metrics: Add file path to error messages [Backport to 4.2]

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_cpu_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpu_linux.c
@@ -112,7 +112,7 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
         entry = mk_list_entry(head, struct flb_slist_entry, _head);
 
         /* Core ID */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "topology", "core_id",
                                         &core_id);
@@ -121,7 +121,7 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
         }
 
         /* Physical ID */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "topology", "physical_package_id",
                                         &physical_package_id);
@@ -130,7 +130,7 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
         }
 
         /* Package Metric: node_cpu_core_throttles_total */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "thermal_throttle", "core_throttle_count",
                                         &core_throttle_count);
@@ -150,7 +150,7 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
         }
 
         /* Package Metric: node_cpu_package_throttles_total */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "thermal_throttle", "package_throttle_count",
                                         &package_throttle_count);
@@ -307,7 +307,7 @@ static int cpu_stat_update(struct flb_ne *ctx, uint64_t ts)
     struct flb_slist_entry *line;
     struct cpu_stat_info st = {0};
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/stat", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/stat", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_cpufreq_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpufreq_linux.c
@@ -118,7 +118,7 @@ static int cpufreq_update(struct flb_ne *ctx)
         cpu_id++;
 
         /* node_cpu_frequency_hertz */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str, "cpufreq", "cpuinfo_cur_freq",
                                         &val);
         if (ret == 0) {
@@ -128,7 +128,7 @@ static int cpufreq_update(struct flb_ne *ctx)
         }
 
         /* node_cpu_frequency_max_hertz */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str, "cpufreq", "cpuinfo_max_freq",
                                         &val);
         if (ret == 0) {
@@ -138,7 +138,7 @@ static int cpufreq_update(struct flb_ne *ctx)
         }
 
         /* node_cpu_frequency_min_hertz */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str, "cpufreq", "cpuinfo_min_freq",
                                         &val);
         if (ret == 0) {
@@ -149,7 +149,7 @@ static int cpufreq_update(struct flb_ne *ctx)
 
 
         /* node_cpu_scaling_frequency_hertz */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str, "cpufreq", "scaling_cur_freq",
                                         &val);
         if (ret == 0) {
@@ -159,7 +159,7 @@ static int cpufreq_update(struct flb_ne *ctx)
         }
 
         /* node_cpu_scaling_frequency_max_hertz */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str, "cpufreq", "scaling_max_freq",
                                         &val);
         if (ret == 0) {
@@ -169,7 +169,7 @@ static int cpufreq_update(struct flb_ne *ctx)
         }
 
         /* node_cpu_frequency_min_hertz */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str, "cpufreq", "scaling_min_freq",
                                         &val);
         if (ret == 0) {

--- a/plugins/in_node_exporter_metrics/ne_diskstats_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_diskstats_linux.c
@@ -404,7 +404,7 @@ static int diskstats_update(struct flb_ne *ctx)
     mk_list_init(&list);
     mk_list_init(&split_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/diskstats", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/diskstats", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_filefd_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_filefd_linux.c
@@ -58,7 +58,7 @@ static int filefd_update(struct flb_ne *ctx)
     struct flb_slist_entry *max;
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/sys/fs/file-nr", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/sys/fs/file-nr", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_hwmon_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_hwmon_linux.c
@@ -185,14 +185,14 @@ static void hwmon_process_sensor(struct flb_ne *ctx, const char *chip_path,
     }
 
     /* read input value */
-    ret = ne_utils_file_read_uint64(ctx->path_sysfs, sensor_path,
+    ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs, sensor_path,
                                     NULL, NULL, &val);
     if (ret != 0) {
         return;
     }
 
     snprintf(label_name, sizeof(label_name) - 1, "%s_label", sensor_name);
-    if (ne_utils_file_read_sds(ctx->path_sysfs, chip_path,
+    if (ne_utils_file_read_sds(ctx, ctx->path_sysfs, chip_path,
                                label_name, NULL, &label) == 0) {
         sensor_label = label;
     }
@@ -206,7 +206,7 @@ static void hwmon_process_sensor(struct flb_ne *ctx, const char *chip_path,
                       2, (char *[]) {(char *) chip_name, (char *) sensor_label});
 
         snprintf(file_tmp, sizeof(file_tmp) - 1, "%s_max", sensor_name);
-        if (ne_utils_file_read_uint64(ctx->path_sysfs, chip_path,
+        if (ne_utils_file_read_uint64(ctx, ctx->path_sysfs, chip_path,
                                        file_tmp, NULL, &val) == 0) {
             cmt_gauge_set(ctx->hwmon_temp_max_celsius, tstamp,
                           ((double) val) / 1000.0,
@@ -214,7 +214,7 @@ static void hwmon_process_sensor(struct flb_ne *ctx, const char *chip_path,
         }
 
         snprintf(file_tmp, sizeof(file_tmp) - 1, "%s_crit", sensor_name);
-        if (ne_utils_file_read_uint64(ctx->path_sysfs, chip_path,
+        if (ne_utils_file_read_uint64(ctx, ctx->path_sysfs, chip_path,
                                        file_tmp, NULL, &val) == 0) {
             cmt_gauge_set(ctx->hwmon_temp_crit_celsius, tstamp,
                           ((double) val) / 1000.0,
@@ -269,7 +269,7 @@ static int ne_hwmon_update(struct flb_input_instance *ins,
     mk_list_foreach(head, &hwmons) {
         entry = mk_list_entry(head, struct flb_slist_entry, _head);
 
-        if (ne_utils_file_read_sds(ctx->path_sysfs, entry->str,
+        if (ne_utils_file_read_sds(ctx, ctx->path_sysfs, entry->str,
                                    "name", NULL, &chip) != 0) {
             continue;
         }

--- a/plugins/in_node_exporter_metrics/ne_loadavg_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_loadavg_linux.c
@@ -67,7 +67,7 @@ static int loadavg_update(struct flb_ne *ctx)
     mk_list_init(&list);
     mk_list_init(&split_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/loadavg", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/loadavg", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_meminfo_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_meminfo_linux.c
@@ -53,7 +53,7 @@ static int meminfo_configure(struct flb_ne *ctx)
     mk_list_init(&list);
     mk_list_init(&split_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/meminfo", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/meminfo", &list);
     if (ret == -1) {
         return -1;
     }
@@ -202,7 +202,7 @@ static int meminfo_update(struct flb_ne *ctx)
     struct flb_slist_entry *entry;
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/meminfo", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/meminfo", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_netdev_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_netdev_linux.c
@@ -98,7 +98,7 @@ static int netdev_configure(struct flb_ne *ctx)
     mk_list_init(&rx_list);
     mk_list_init(&tx_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/dev", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/dev", &list);
     if (ret == -1) {
         return -1;
     }
@@ -236,7 +236,7 @@ static int netdev_update(struct flb_ne *ctx)
     mk_list_init(&rx_list);
     mk_list_init(&tx_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/dev", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/dev", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_netstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_netstat_linux.c
@@ -215,7 +215,7 @@ static int netstat_update(struct flb_ne *ctx)
     int prev_proto;
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/snmp", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/snmp", &list);
     if (ret == -1) {
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_nvme_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_nvme_linux.c
@@ -105,7 +105,7 @@ static int nvme_get_entry_value(struct flb_ne *ctx,
     if (check_path_for_sysfs(ctx, nvme_info->str, entry_path) != 0) {
         return -1;
     }
-    ret = ne_utils_file_read_lines(nvme_info->str, nvme_sysentry, out_info_list);
+    ret = ne_utils_file_read_lines(ctx, nvme_info->str, nvme_sysentry, out_info_list);
     if (ret == -1) {
         return ret;
     }

--- a/plugins/in_node_exporter_metrics/ne_processes_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_processes_linux.c
@@ -195,7 +195,7 @@ static int processes_thread_update(struct flb_ne *ctx, flb_sds_t pid_str, flb_sd
         }
 
         mk_list_init(&stat_list);
-        ret = ne_utils_file_read_lines(thread->str, "/stat", &stat_list);
+        ret = ne_utils_file_read_lines(ctx,thread->str, "/stat", &stat_list);
         if (ret == -1) {
             continue;
         }
@@ -271,7 +271,7 @@ static int processes_update(struct flb_ne *ctx)
 
     ts = cfl_time_now();
 
-    ret = ne_utils_file_read_uint64(ctx->path_procfs, "/sys", "kernel", "threads-max", &val);
+    ret = ne_utils_file_read_uint64(ctx, ctx->path_procfs, "/sys", "kernel", "threads-max", &val);
     if (ret == -1) {
         return -1;
     }
@@ -282,7 +282,7 @@ static int processes_update(struct flb_ne *ctx)
                       (double)val, 0, NULL);
     }
 
-    ret = ne_utils_file_read_uint64(ctx->path_procfs, "/sys", "kernel", "pid_max", &val);
+    ret = ne_utils_file_read_uint64(ctx, ctx->path_procfs, "/sys", "kernel", "pid_max", &val);
     if (ret == -1) {
         return -1;
     }
@@ -313,7 +313,7 @@ static int processes_update(struct flb_ne *ctx)
         }
 
         mk_list_init(&stat_list);
-        ret = ne_utils_file_read_lines(process->str, "/stat", &stat_list);
+        ret = ne_utils_file_read_lines(ctx,process->str, "/stat", &stat_list);
         if (ret == -1) {
             continue;
         }

--- a/plugins/in_node_exporter_metrics/ne_sockstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_sockstat_linux.c
@@ -170,7 +170,7 @@ static int sockstat_update(struct flb_ne *ctx)
     struct flb_slist_entry *val;
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/sockstat", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/sockstat", &list);
     if (ret == -1) {
         return -1;
     }
@@ -298,7 +298,7 @@ static int sockstat_update(struct flb_ne *ctx)
 
     /* Parse IPv6 statistics */
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/sockstat6", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/sockstat6", &list);
     if (ret != -1) {
         mk_list_foreach(head, &list) {
             line = mk_list_entry(head, struct flb_slist_entry, _head);

--- a/plugins/in_node_exporter_metrics/ne_stat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_stat_linux.c
@@ -83,7 +83,7 @@ static int stat_update(struct flb_ne *ctx)
     struct flb_slist_entry *s_val;
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/stat", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/stat", &list);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "failed to read %s/stat", ctx->path_procfs);
         return -1;

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_linux.c
@@ -122,7 +122,7 @@ static int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
         entry = mk_list_entry(head, struct flb_slist_entry, _head);
 
         /* Core ID */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "temp", NULL,
                                         &temp);
@@ -130,7 +130,7 @@ static int ne_thermalzone_update_thermal_zones(struct flb_ne *ctx)
             continue;
         }
 
-        ret = ne_utils_file_read_sds(ctx->path_sysfs, entry->str, "type", NULL, &type);
+        ret = ne_utils_file_read_sds(ctx, ctx->path_sysfs, entry->str, "type", NULL, &type);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "unable to get type for zone: %s", entry->str);
             continue;
@@ -206,7 +206,7 @@ static int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
         entry = mk_list_entry(head, struct flb_slist_entry, _head);
 
         /* Core ID */
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "cur_state", NULL,
                                         &cur_state);
@@ -214,7 +214,7 @@ static int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
             continue;
         }
 
-        ret = ne_utils_file_read_uint64(ctx->path_sysfs,
+        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
                                         entry->str,
                                         "max_state", NULL,
                                         &max_state);
@@ -222,7 +222,7 @@ static int ne_thermalzone_update_cooling_devices(struct flb_ne *ctx)
             continue;
         }
 
-        ret = ne_utils_file_read_sds(ctx->path_sysfs, entry->str, "type", NULL, &type);
+        ret = ne_utils_file_read_sds(ctx, ctx->path_sysfs, entry->str, "type", NULL, &type);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "unable to get type for zone: %s", entry->str);
             continue;

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -65,7 +65,8 @@ int ne_utils_str_to_uint64(char *str, uint64_t *out_val)
     return 0;
 }
 
-int ne_utils_file_read_uint64(const char *mount,
+int ne_utils_file_read_uint64(struct flb_ne *ctx,
+                              const char *mount,
                               const char *path,
                               const char *join_a, const char *join_b,
                               uint64_t *out_val)
@@ -122,6 +123,12 @@ int ne_utils_file_read_uint64(const char *mount,
 
     fd = open(p, O_RDONLY);
     if (fd == -1) {
+        if (ctx) {
+            flb_plg_error(ctx->ins, "could not open '%s'", p);
+        }
+        else {
+            flb_errno();
+        }
         flb_sds_destroy(p);
         return -1;
     }
@@ -129,7 +136,12 @@ int ne_utils_file_read_uint64(const char *mount,
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
-        flb_errno();
+        if (ctx) {
+            flb_plg_error(ctx->ins, "could not read from '%s'", p);
+        }
+        else {
+            flb_errno();
+        }
         close(fd);
         return -1;
     }
@@ -148,7 +160,7 @@ int ne_utils_file_read_uint64(const char *mount,
  * Read a file and every non-empty line is stored as a flb_slist_entry in the
  * given list.
  */
-int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list)
+int ne_utils_file_read_lines(struct flb_ne *ctx, const char *mount, const char *path, struct mk_list *list)
 {
     int len;
     int ret;
@@ -167,7 +179,12 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
     snprintf(real_path, sizeof(real_path) - 1, "%s%s", mount, path);
     f = fopen(real_path, "r");
     if (f == NULL) {
-        flb_errno();
+        if (ctx) {
+            flb_plg_error(ctx->ins, "could not open '%s'", real_path);
+        }
+        else {
+            flb_errno();
+        }
         return -1;
     }
 
@@ -196,7 +213,8 @@ int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list
 /*
  * Read a file and store the first line as a string.
  */
-int ne_utils_file_read_sds(const char *mount,
+int ne_utils_file_read_sds(struct flb_ne *ctx,
+                           const char *mount,
                            const char *path,
                            const char *join_a,
                            const char *join_b,
@@ -250,6 +268,12 @@ int ne_utils_file_read_sds(const char *mount,
 
     fd = open(p, O_RDONLY);
     if (fd == -1) {
+        if (ctx) {
+            flb_plg_error(ctx->ins, "could not open '%s'", p);
+        }
+        else {
+            flb_errno();
+        }
         flb_sds_destroy(p);
         return -1;
     }
@@ -257,7 +281,12 @@ int ne_utils_file_read_sds(const char *mount,
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
-        flb_errno();
+        if (ctx) {
+            flb_plg_error(ctx->ins, "could not read from '%s'", p);
+        }
+        else {
+            flb_errno();
+        }
         close(fd);
         return -1;
     }

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -132,7 +132,6 @@ int ne_utils_file_read_uint64(struct flb_ne *ctx,
         flb_sds_destroy(p);
         return -1;
     }
-    flb_sds_destroy(p);
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
@@ -143,9 +142,11 @@ int ne_utils_file_read_uint64(struct flb_ne *ctx,
             flb_errno();
         }
         close(fd);
+        flb_sds_destroy(p);
         return -1;
     }
     close(fd);
+    flb_sds_destroy(p);
 
     ret = ne_utils_str_to_uint64(tmp, &val);
     if (ret == -1) {
@@ -277,7 +278,6 @@ int ne_utils_file_read_sds(struct flb_ne *ctx,
         flb_sds_destroy(p);
         return -1;
     }
-    flb_sds_destroy(p);
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
@@ -288,9 +288,11 @@ int ne_utils_file_read_sds(struct flb_ne *ctx,
             flb_errno();
         }
         close(fd);
+        flb_sds_destroy(p);
         return -1;
     }
     close(fd);
+    flb_sds_destroy(p);
 
     for (i = bytes-1; i > 0; i--) {
         if (tmp[i] != '\n' && tmp[i] != '\r') {

--- a/plugins/in_node_exporter_metrics/ne_utils.h
+++ b/plugins/in_node_exporter_metrics/ne_utils.h
@@ -41,7 +41,10 @@ int ne_utils_file_read_sds(struct flb_ne *ctx,
                            const char *join_b,
                            flb_sds_t *str);
 
-int ne_utils_file_read_lines(struct flb_ne *ctx, const char *mount, const char *path, struct mk_list *list);
+int ne_utils_file_read_lines(struct flb_ne *ctx,
+                             const char *mount,
+                             const char *path,
+                             struct mk_list *list);
 int ne_utils_path_scan(struct flb_ne *ctx, const char *mount, const char *path,
                        int expected, struct mk_list *list);
 #endif

--- a/plugins/in_node_exporter_metrics/ne_utils.h
+++ b/plugins/in_node_exporter_metrics/ne_utils.h
@@ -28,18 +28,20 @@
 int ne_utils_str_to_double(char *str, double *out_val);
 int ne_utils_str_to_uint64(char *str, uint64_t *out_val);
 
-int ne_utils_file_read_uint64(const char *mount,
+int ne_utils_file_read_uint64(struct flb_ne *ctx,
+                              const char *mount,
                               const char *path,
                               const char *join_a, const char *join_b,
                               uint64_t *out_val);
 
-int ne_utils_file_read_sds(const char *mount,
+int ne_utils_file_read_sds(struct flb_ne *ctx,
+                           const char *mount,
                            const char *path,
                            const char *join_a,
                            const char *join_b,
                            flb_sds_t *str);
 
-int ne_utils_file_read_lines(const char *mount, const char *path, struct mk_list *list);
+int ne_utils_file_read_lines(struct flb_ne *ctx, const char *mount, const char *path, struct mk_list *list);
 int ne_utils_path_scan(struct flb_ne *ctx, const char *mount, const char *path,
                        int expected, struct mk_list *list);
 #endif

--- a/plugins/in_node_exporter_metrics/ne_vmstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_vmstat_linux.c
@@ -64,7 +64,7 @@ static int vmstat_configure(struct flb_ne *ctx)
     mk_list_init(&list);
     mk_list_init(&split_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/vmstat", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/vmstat", &list);
     if (ret == -1) {
         return -1;
     }
@@ -139,7 +139,7 @@ static int vmstat_update(struct flb_ne *ctx)
     mk_list_init(&list);
     mk_list_init(&split_list);
 
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/vmstat", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/vmstat", &list);
     if (ret == -1) {
         return -1;
     }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backporting of https://github.com/fluent/fluent-bit/pull/11839.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
