### PR TITLE
tests: runtime: Try to eliminate flakyness on CI load [Backport to 4.2]

### DIFF
--- a/tests/runtime/out_lib.c
+++ b/tests/runtime/out_lib.c
@@ -441,6 +441,9 @@ static void test_max_records(void)
     int num;
     char *input_json = "[1,{\"hoge\":\"moge\", \"bool\":true, \"int\":100, \"float\":-2.0}]";
     int size = strlen(input_json);
+    char *input_buffer;
+    int input_records = 100;
+    int input_size;
     int i;
     int unused;
     int expected = 5 /* max_records */;
@@ -469,9 +472,18 @@ static void test_max_records(void)
     ret = flb_start(ctx->flb);
     TEST_CHECK(ret == 0);
 
-    for (i=0; i<100; i++) {
-        ret = flb_lib_push(ctx->flb, ctx->i_ffd, input_json,size);
+    input_size = size * input_records;
+    input_buffer = flb_malloc(input_size);
+    TEST_CHECK(input_buffer != NULL);
+
+    if (input_buffer != NULL) {
+        for (i = 0; i < input_records; i++) {
+            memcpy(input_buffer + (i * size), input_json, size);
+        }
+
+        ret = flb_lib_push(ctx->flb, ctx->i_ffd, input_buffer, input_size);
         TEST_CHECK(ret >= 0);
+        flb_free(input_buffer);
     }
 
     /* waiting to flush */


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/11984.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
