### PR TITLE
scheduler: Plug FD leaks on destroy [Backport to 4.2]

### DIFF
--- a/src/flb_scheduler.c
+++ b/src/flb_scheduler.c
@@ -751,6 +751,9 @@ struct flb_sched *flb_sched_create(struct flb_config *config,
 
     sched->config = config;
     sched->evl = evl;
+    sched->ch_events[0] = -1;
+    sched->ch_events[1] = -1;
+    MK_EVENT_ZERO(&sched->event);
 
     /* Initialize lists */
     mk_list_init(&sched->requests);
@@ -791,7 +794,7 @@ struct flb_sched *flb_sched_create(struct flb_config *config,
     ret = mk_event_channel_create(sched->evl,
                                   &sched->ch_events[0],
                                   &sched->ch_events[1],
-                                  sched);
+                                  &sched->event);
     if (ret == -1) {
         flb_sched_destroy(sched);
         return NULL;
@@ -847,6 +850,15 @@ int flb_sched_destroy(struct flb_sched *sched)
         timer = mk_list_entry(head, struct flb_sched_timer, _head);
         flb_sched_timer_destroy(timer);
         c++;
+    }
+
+    if (sched->ch_events[0] != -1) {
+        mk_event_channel_destroy(sched->evl,
+                                 sched->ch_events[0],
+                                 sched->ch_events[1],
+                                 &sched->event);
+        sched->ch_events[0] = -1;
+        sched->ch_events[1] = -1;
     }
 
     flb_free(sched);

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -37,6 +37,7 @@ set(UNIT_TESTS_FILES
   flb_event_loop.c
   ring_buffer.c
   regex.c
+  scheduler.c
   parser_json.c
   parser_ltsv.c
   parser_regex.c

--- a/tests/internal/scheduler.c
+++ b/tests/internal/scheduler.c
@@ -1,0 +1,110 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_pipe.h>
+#include <fluent-bit/flb_scheduler.h>
+
+#include "flb_tests_internal.h"
+
+static void test_scheduler_event_channel_cleanup(void)
+{
+    int ret;
+    char data = '\0';
+    flb_pipefd_t read_fd[2];
+    flb_pipefd_t write_fd[2];
+    struct flb_sched *sched[2];
+    struct flb_config *config;
+    struct mk_event_loop *evl;
+#ifdef FLB_SYSTEM_WINDOWS
+    WSADATA wsa_data;
+
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (!TEST_CHECK(ret == 0)) {
+        return;
+    }
+#endif
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        goto socket_cleanup;
+    }
+
+    config->evl = mk_event_loop_create(8);
+    if (!TEST_CHECK(config->evl != NULL)) {
+        flb_config_exit(config);
+        goto socket_cleanup;
+    }
+
+    sched[0] = flb_sched_create(config, config->evl);
+    if (!TEST_CHECK(sched[0] != NULL)) {
+        flb_config_exit(config);
+        goto socket_cleanup;
+    }
+    config->sched = sched[0];
+
+    evl = mk_event_loop_create(8);
+    if (!TEST_CHECK(evl != NULL)) {
+        flb_config_exit(config);
+        goto socket_cleanup;
+    }
+
+    sched[1] = flb_sched_create(config, evl);
+    if (!TEST_CHECK(sched[1] != NULL)) {
+        mk_event_loop_destroy(evl);
+        flb_config_exit(config);
+        goto socket_cleanup;
+    }
+
+    read_fd[0] = sched[0]->ch_events[0];
+    write_fd[0] = sched[0]->ch_events[1];
+    read_fd[1] = sched[1]->ch_events[0];
+    write_fd[1] = sched[1]->ch_events[1];
+
+    flb_sched_destroy(sched[1]);
+    mk_event_loop_destroy(evl);
+
+    flb_sched_destroy(sched[0]);
+    config->sched = NULL;
+
+    ret = flb_pipe_w(write_fd[0], &data, sizeof(data));
+    TEST_CHECK(ret == -1);
+
+    ret = flb_pipe_r(read_fd[0], &data, sizeof(data));
+    TEST_CHECK(ret == -1);
+
+    ret = flb_pipe_w(write_fd[1], &data, sizeof(data));
+    TEST_CHECK(ret == -1);
+
+    ret = flb_pipe_r(read_fd[1], &data, sizeof(data));
+    TEST_CHECK(ret == -1);
+
+    flb_config_exit(config);
+
+socket_cleanup:
+    (void) ret;
+#ifdef FLB_SYSTEM_WINDOWS
+    WSACleanup();
+#endif
+}
+
+TEST_LIST = {
+    {"event_channel_cleanup", test_scheduler_event_channel_cleanup},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

Backporting of https://github.com/fluent/fluent-bit/pull/11977.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
