### PR TITLE
in_ebpf: Generate mostly monotonic event id for increasing traceability

### DIFF
--- a/plugins/in_ebpf/traces/bind/bpf.c
+++ b/plugins/in_ebpf/traces/bind/bpf.c
@@ -20,6 +20,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #define MAX_ENTRIES 10240
 
@@ -75,6 +76,7 @@ static int handle_bind_exit(struct pt_regs *ctx, short ver) {
     event->common.gid = (u32)(uid_gid >> 32);
     event->common.mntns_id = mntns_id;
     event->type = EVENT_TYPE_BIND;
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     bpf_get_current_comm(&event->common.comm, sizeof(event->common.comm));
 

--- a/plugins/in_ebpf/traces/dns/bpf.c
+++ b/plugins/in_ebpf/traces/dns/bpf.c
@@ -14,6 +14,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #ifndef AF_INET
 #define AF_INET 2
@@ -96,6 +97,7 @@ static __always_inline void fill_common(struct event *event, __u64 mntns_id)
     pid_tgid = bpf_get_current_pid_tgid();
     uid_gid = bpf_get_current_uid_gid();
 
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = (__u32) (pid_tgid >> 32);
     event->common.tid = (__u32) pid_tgid;

--- a/plugins/in_ebpf/traces/exec/bpf.c
+++ b/plugins/in_ebpf/traces/exec/bpf.c
@@ -14,6 +14,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #define MAX_ENTRIES 10240
 #define ARGV_MAX_SCAN 20
@@ -71,6 +72,7 @@ static __always_inline int submit_exec_event(void *ctx,
     pid_tgid = bpf_get_current_pid_tgid();
     uid_gid = bpf_get_current_uid_gid();
 
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = (__u32) (pid_tgid >> 32);
     event->common.tid = (__u32) pid_tgid;

--- a/plugins/in_ebpf/traces/includes/common/encoder.h
+++ b/plugins/in_ebpf/traces/includes/common/encoder.h
@@ -66,6 +66,16 @@ static inline int encode_common_fields(struct flb_log_event_encoder *log_encoder
         return -1;
     }
 
+    /* Encode event ID */
+    ret = flb_log_event_encoder_append_body_cstring(log_encoder, "event_id");
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+    ret = flb_log_event_encoder_append_body_uint64(log_encoder, e->common.event_id);
+    if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+        return -1;
+    }
+
     /* Encode process ID */
     ret = flb_log_event_encoder_append_body_cstring(log_encoder, "pid");
     if (ret != FLB_EVENT_ENCODER_SUCCESS) {

--- a/plugins/in_ebpf/traces/includes/common/event_id.bpf.h
+++ b/plugins/in_ebpf/traces/includes/common/event_id.bpf.h
@@ -1,0 +1,27 @@
+#ifndef EBPF_EVENT_ID_H
+#define EBPF_EVENT_ID_H
+
+#include <bpf/bpf_helpers.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, __u32);
+    __type(value, __u64);
+    __uint(max_entries, 1);
+} seq_counter SEC(".maps");
+
+static __always_inline void generate_event_id(__u64 *event_id)
+{
+    __u32 key = 0;
+    __u64 *counter = bpf_map_lookup_elem(&seq_counter, &key);
+    if (counter) {
+        /* ID is CPU shifted left by 48 bits, OR'd with per-CPU counter */
+        *event_id = ((__u64)bpf_get_smp_processor_id() << 48) | (*counter);
+        (*counter)++;
+    }
+    else {
+        *event_id = 0;
+    }
+}
+
+#endif /* EBPF_EVENT_ID_H */

--- a/plugins/in_ebpf/traces/includes/common/events.h
+++ b/plugins/in_ebpf/traces/includes/common/events.h
@@ -49,6 +49,7 @@ enum memop {
 };
 
 struct event_common {
+    __u64 event_id;
     __u64 timestamp_raw;
     __u32 pid;
     __u32 tid;

--- a/plugins/in_ebpf/traces/malloc/bpf.c.in
+++ b/plugins/in_ebpf/traces/malloc/bpf.c.in
@@ -15,6 +15,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #define MAX_ENTRIES 10240
 
@@ -72,6 +73,7 @@ static int gen_alloc_exit(struct pt_regs *ctx, enum memop op, u64 addr) {
 
     u64 uid_gid = bpf_get_current_uid_gid();
 
+    generate_event_id(&eventp->common.event_id);
     eventp->common.timestamp_raw = bpf_ktime_get_ns();
     eventp->common.pid = tid >> 32;
     eventp->common.tid = tid;
@@ -102,6 +104,7 @@ static int gen_free_enter(struct pt_regs *ctx, enum memop op, u64 addr) {
 
     u32 tid = (u32)bpf_get_current_pid_tgid();
 
+    generate_event_id(&eventp->common.event_id);
     eventp->common.timestamp_raw = bpf_ktime_get_ns();
     eventp->common.pid = tid >> 32;
     eventp->common.tid = tid;

--- a/plugins/in_ebpf/traces/openssl/bpf.c.in
+++ b/plugins/in_ebpf/traces/openssl/bpf.c.in
@@ -18,6 +18,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #define MAX_ENTRIES 10240
 
@@ -50,6 +51,7 @@ static __always_inline void fill_common(struct event *event)
     pid_tgid = bpf_get_current_pid_tgid();
     uid_gid = bpf_get_current_uid_gid();
 
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = (__u32) (pid_tgid >> 32);
     event->common.tid = (__u32) pid_tgid;

--- a/plugins/in_ebpf/traces/sched/bpf.c
+++ b/plugins/in_ebpf/traces/sched/bpf.c
@@ -14,6 +14,7 @@
 #include <gadget/mntns_filter.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 struct wakeup_info {
     __u64 wakeup_ns;
@@ -102,6 +103,7 @@ int BPF_PROG(trace_sched_switch, bool preempt, struct task_struct *prev,
     }
 
     event->type = EVENT_TYPE_SCHED;
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = next_pid;
     event->common.tid = next_tid;

--- a/plugins/in_ebpf/traces/signal/bpf.c
+++ b/plugins/in_ebpf/traces/signal/bpf.c
@@ -16,6 +16,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h" 
+#include "common/event_id.bpf.h"
 
 
 struct value {
@@ -81,6 +82,7 @@ static int handle_signal_exit(void *ctx, int ret) {
         return 0;
 
     /* Populate the event with data */
+    generate_event_id(&eventp->common.event_id);
     eventp->common.timestamp_raw = bpf_ktime_get_boot_ns();
     eventp->common.pid = pid_tgid >> 32;
     eventp->common.tid = tid;
@@ -167,6 +169,7 @@ int ig_sig_generate(struct trace_event_raw_signal_generate *ctx) {
         return 0;
 
     /* Populate the event with data */
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = pid;
     event->common.tid = (__u32)pid_tgid;

--- a/plugins/in_ebpf/traces/tcp/bpf.c
+++ b/plugins/in_ebpf/traces/tcp/bpf.c
@@ -15,6 +15,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #ifndef AF_UNSPEC
 #define AF_UNSPEC 0
@@ -81,6 +82,7 @@ static __always_inline void fill_common(struct event *event, __u64 mntns_id)
     pid_tgid = bpf_get_current_pid_tgid();
     uid_gid = bpf_get_current_uid_gid();
 
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = (__u32) (pid_tgid >> 32);
     event->common.tid = (__u32) pid_tgid;

--- a/plugins/in_ebpf/traces/vfs/bpf.c
+++ b/plugins/in_ebpf/traces/vfs/bpf.c
@@ -14,6 +14,7 @@
 #include <gadget/types.h>
 
 #include "common/events.h"
+#include "common/event_id.bpf.h"
 
 #define MAX_ENTRIES 10240
 
@@ -87,6 +88,7 @@ int trace_vfs_openat_exit(struct syscall_trace_exit *ctx)
 
     uid_gid = bpf_get_current_uid_gid();
 
+    generate_event_id(&event->common.event_id);
     event->common.timestamp_raw = bpf_ktime_get_boot_ns();
     event->common.pid = pid_tgid >> 32;
     event->common.tid = tid;


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is because without IDs per CPU, it's really hard to trace the event sequence.
After adding event_id per CPU, it's easier to trace the sequence of events.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
Fluent Bit v5.0.8
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/06/25 14:35:23.136] [ info] Configuration:
[2026/06/25 14:35:23.158] [ info]  flush time     | 1.000000 seconds
[2026/06/25 14:35:23.163] [ info]  grace          | 5 seconds
[2026/06/25 14:35:23.164] [ info]  daemon         | 0
[2026/06/25 14:35:23.164] [ info] ___________
[2026/06/25 14:35:23.164] [ info]  inputs:
[2026/06/25 14:35:23.164] [ info]      ebpf
[2026/06/25 14:35:23.165] [ info] ___________
[2026/06/25 14:35:23.165] [ info]  filters:
[2026/06/25 14:35:23.165] [ info] ___________
[2026/06/25 14:35:23.165] [ info]  outputs:
[2026/06/25 14:35:23.166] [ info]      stdout.0
[2026/06/25 14:35:23.166] [ info] ___________
[2026/06/25 14:35:23.166] [ info]  collectors:
[2026/06/25 14:35:23.233] [ info] [fluent bit] version=5.0.8, commit=dc22be7406, pid=275420
[2026/06/25 14:35:23.241] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/06/25 14:35:23.247] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/06/25 14:35:23.247] [ info] [simd    ] SSE2
[2026/06/25 14:35:23.248] [ info] [cmetrics] version=2.1.5
[2026/06/25 14:35:23.248] [ info] [ctraces ] version=0.7.1
[2026/06/25 14:35:23.263] [ info] [input:ebpf:ebpf.0] initializing
[2026/06/25 14:35:23.264] [ info] [input:ebpf:ebpf.0] storage_strategy='memory' (memory only)
[2026/06/25 14:35:23.266] [debug] [ebpf:ebpf.0] created event channels: read=21 write=22
[2026/06/25 14:35:23.266] [debug] [input:ebpf:ebpf.0] initializing eBPF input plugin
[2026/06/25 14:35:23.271] [debug] [input:ebpf:ebpf.0] processing trace: trace_openssl
[2026/06/25 14:35:23.271] [debug] [input:ebpf:ebpf.0] setting up trace configuration for: trace_openssl
[2026/06/25 14:35:28.323] [debug] [input:ebpf:ebpf.0] attaching BPF program for trace: trace_openssl
[2026/06/25 14:35:28.363] [debug] [input:ebpf:ebpf.0] registering trace handler for: trace_openssl
[2026/06/25 14:35:28.366] [ info] [input:ebpf:ebpf.0] registered trace handler for: trace_openssl
[2026/06/25 14:35:28.367] [ info] [input:ebpf:ebpf.0] trace configuration completed for: trace_openssl
[2026/06/25 14:35:28.367] [debug] [input:ebpf:ebpf.0] setting up collector with poll interval: 1000 ms
[2026/06/25 14:35:28.369] [ info] [input:ebpf:ebpf.0] eBPF input plugin initialized successfully
[2026/06/25 14:35:28.373] [debug] [stdout:stdout.0] created event channels: read=68 write=69
[2026/06/25 14:35:28.409] [ info] [sp] stream processor started
[2026/06/25 14:35:28.412] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/06/25 14:35:28.421] [ info] [output:stdout:stdout.0] worker #0 started
[2026/06/25 14:35:28.490] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:28.490] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:28.491] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 14:35:29.471] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:29.472] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:29.472] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 14:35:30.472] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:30.472] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:30.472] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 14:35:31.472] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:31.472] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:31.521] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[0] ebpf.0: [[1782365731.482789467, {}], {"event_type"=>"tls_handshake", "event_id"=>562949953421312, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>94797606761120, "latency_ns"=>20596999, "ret"=>-1}]
[1] ebpf.0: [[1782365731.516787242, {}], {"event_type"=>"tls_handshake", "event_id"=>562949953421313, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>94797606761120, "latency_ns"=>822858, "ret"=>1}]
[2] ebpf.0: [[1782365731.517948490, {}], {"event_type"=>"tls_read", "event_id"=>562949953421314, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>4463, "ret"=>-1}]
[3] ebpf.0: [[1782365731.518970179, {}], {"event_type"=>"tls_write", "event_id"=>562949953421315, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>94797606761120, "latency_ns"=>15520, "ret"=>64}]
[4] ebpf.0: [[1782365731.519215011, {}], {"event_type"=>"tls_write", "event_id"=>562949953421316, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>94797606761120, "latency_ns"=>2461, "ret"=>36}]
[5] ebpf.0: [[1782365731.519376038, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817216, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>104899, "ret"=>40}]
[6] ebpf.0: [[1782365731.519528389, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817217, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>3437, "ret"=>-1}]
[7] ebpf.0: [[1782365731.519692847, {}], {"event_type"=>"tls_write", "event_id"=>3096224743817218, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>94797606761120, "latency_ns"=>45009, "ret"=>9}]
[8] ebpf.0: [[1782365731.519823016, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817219, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>9579, "ret"=>9}]
[9] ebpf.0: [[1782365731.519950765, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817220, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>2705, "ret"=>-1}]
[10] ebpf.0: [[1782365731.520095216, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817221, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>104819, "ret"=>406}]
[11] ebpf.0: [[1782365731.520475561, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817222, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>25431, "ret"=>239}]
[12] ebpf.0: [[1782365731.520785952, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817223, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>18871, "ret"=>9}]
[13] ebpf.0: [[1782365731.520937557, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817224, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>19203, "ret"=>17}]
[14] ebpf.0: [[1782365731.521070460, {}], {"event_type"=>"tls_write", "event_id"=>3096224743817225, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>94797606761120, "latency_ns"=>127108, "ret"=>17}]
[15] ebpf.0: [[1782365731.521218835, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817226, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>18456, "ret"=>-1}]
[2026/06/25 14:35:32.490] [debug] [task] created task=0x8436270 id=0 OK
[16] ebpf.0: [[1782365731.521395834, {}], {"event_type"=>"tls_shutdown", "event_id"=>3096224743817227, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_shutdown", "ssl_ptr"=>94797606761120, "latency_ns"=>33546, "ret"=>0}]
[2026/06/25 14:35:32.492] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[17] ebpf.0: [[1782365731.521621631, {}], {"event_type"=>"tls_read", "event_id"=>3096224743817228, "pid"=>275438, "tid"=>275438, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>94797606761120, "latency_ns"=>24986, "ret"=>-1}]
[2026/06/25 14:35:32.493] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:32.493] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:32.493] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 14:35:32.511] [debug] [out flush] cb_destroy coro_id=0
[2026/06/25 14:35:32.519] [debug] [task] destroy task=0x8436270 (task_id=0)
[2026/06/25 14:35:33.471] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:33.472] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:33.477] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[0] ebpf.0: [[1782365733.472626529, {}], {"event_type"=>"tls_handshake", "event_id"=>562949953421317, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>98811799495600, "latency_ns"=>18017408, "ret"=>-1}]
[1] ebpf.0: [[1782365733.473756712, {}], {"event_type"=>"tls_handshake", "event_id"=>562949953421318, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_handshake", "ssl_ptr"=>98811799495600, "latency_ns"=>1369447, "ret"=>1}]
[2] ebpf.0: [[1782365733.474394499, {}], {"event_type"=>"tls_read", "event_id"=>562949953421319, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>5959, "ret"=>-1}]
[3] ebpf.0: [[1782365733.474979536, {}], {"event_type"=>"tls_write", "event_id"=>562949953421320, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>98811799495600, "latency_ns"=>10399, "ret"=>64}]
[4] ebpf.0: [[1782365733.475540011, {}], {"event_type"=>"tls_write", "event_id"=>562949953421321, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>98811799495600, "latency_ns"=>2646, "ret"=>40}]
[5] ebpf.0: [[1782365733.476068383, {}], {"event_type"=>"tls_read", "event_id"=>562949953421322, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>74936, "ret"=>49}]
[6] ebpf.0: [[1782365733.476549650, {}], {"event_type"=>"tls_read", "event_id"=>562949953421323, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>1990, "ret"=>-1}]
[7] ebpf.0: [[1782365733.476977758, {}], {"event_type"=>"tls_write", "event_id"=>562949953421324, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_write", "ssl_ptr"=>98811799495600, "latency_ns"=>24220, "ret"=>9}]
[2026/06/25 14:35:34.471] [debug] [task] created task=0x84e4b10 id=0 OK
[2026/06/25 14:35:34.472] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/25 14:35:34.476] [debug] [out flush] cb_destroy coro_id=1
[2026/06/25 14:35:34.477] [debug] [input:ebpf:ebpf.0] collecting events from ring buffers
[2026/06/25 14:35:34.477] [debug] [input:ebpf:ebpf.0] consuming events from ring buffer trace_openssl
[2026/06/25 14:35:34.491] [debug] [input:ebpf:ebpf.0] successfully consumed events from ring buffer trace_openssl
[2026/06/25 14:35:34.491] [debug] [task] destroy task=0x84e4b10 (task_id=0)
^C[2026/06/25 14:35:35] [engine] caught signal (SIGINT)
[2026/06/25 14:35:35.317] [debug] [task] created task=0x8671ec0 id=0 OK
[2026/06/25 14:35:35.317] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] ebpf.0: [[1782365734.477942546, {}], {"event_type"=>"tls_read", "event_id"=>1970324836974592, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>102064, "ret"=>712}]
[1] ebpf.0: [[1782365734.479691113, {}], {"event_type"=>"tls_read", "event_id"=>0, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>102303, "ret"=>1369}]
[2] ebpf.0: [[1782365734.480538128, {}], {"event_type"=>"tls_read", "event_id"=>1, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>13056, "ret"=>1369}]
[3] ebpf.0: [[1782365734.480756998, {}], {"event_type"=>"tls_read", "event_id"=>2, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12192, "ret"=>1369}]
[4] ebpf.0: [[1782365734.480963838, {}], {"event_type"=>"tls_read", "event_id"=>3, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12275, "ret"=>1369}]
[5] ebpf.0: [[1782365734.481221763, {}], {"event_type"=>"tls_read", "event_id"=>4, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12434, "ret"=>1369}]
[6] ebpf.0: [[1782365734.481440899, {}], {"event_type"=>"tls_read", "event_id"=>5, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12392, "ret"=>1369}]
[7] ebpf.0: [[1782365734.481649497, {}], {"event_type"=>"tls_read", "event_id"=>6, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11816, "ret"=>1369}]
[8] ebpf.0: [[1782365734.481844817, {}], {"event_type"=>"tls_read", "event_id"=>7, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11983, "ret"=>1369}]
[9] ebpf.0: [[1782365734.482032464, {}], {"event_type"=>"tls_read", "event_id"=>8, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11894, "ret"=>1369}]
[10] ebpf.0: [[1782365734.482275088, {}], {"event_type"=>"tls_read", "event_id"=>9, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12006, "ret"=>1369}]
[11] ebpf.0: [[1782365734.482498432, {}], {"event_type"=>"tls_read", "event_id"=>10, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12354, "ret"=>1369}]
[12] ebpf.0: [[1782365734.482723928, {}], {"event_type"=>"tls_read", "event_id"=>11, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12647, "ret"=>1369}]
[13] ebpf.0: [[1782365734.482955318, {}], {"event_type"=>"tls_read", "event_id"=>12, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12177, "ret"=>1369}]
[14] ebpf.0: [[1782365734.483201924, {}], {"event_type"=>"tls_read", "event_id"=>13, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12448, "ret"=>1369}]
[15] ebpf.0: [[1782365734.483482424, {}], {"event_type"=>"tls_read", "event_id"=>14, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>12339, "ret"=>1369}]
[16] ebpf.0: [[1782365734.483724219, {}], {"event_type"=>"tls_read", "event_id"=>15, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>19928, "ret"=>-1}]
[17] ebpf.0: [[1782365734.483964639, {}], {"event_type"=>"tls_read", "event_id"=>16, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>22374, "ret"=>-1}]
[18] ebpf.0: [[1782365734.484233945, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553280, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>69903, "ret"=>1369}]
[19] ebpf.0: [[1782365734.484464146, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553281, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>15662, "ret"=>1369}]
[20] ebpf.0: [[1782365734.484716160, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553282, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11330, "ret"=>1369}]
[21] ebpf.0: [[1782365734.484926283, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553283, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>10847, "ret"=>1369}]
[22] ebpf.0: [[1782365734.485135011, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553284, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11021, "ret"=>1369}]
[23] ebpf.0: [[1782365734.485369291, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553285, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11287, "ret"=>1369}]
[24] ebpf.0: [[1782365734.485580372, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553286, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>11626, "ret"=>-1}]
[25] ebpf.0: [[1782365734.485805449, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553287, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>53401, "ret"=>1369}]
[26] ebpf.0: [[1782365734.486002174, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553288, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>39177, "ret"=>-1}]
[27] ebpf.0: [[1782365734.486839578, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553289, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>6203, "ret"=>-1}]
[28] ebpf.0: [[1782365734.487054110, {}], {"event_type"=>"tls_read", "event_id"=>562949953421325, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>41550, "ret"=>1369}]
[29] ebpf.0: [[1782365734.487254716, {}], {"event_type"=>"tls_read", "event_id"=>562949953421326, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>9768, "ret"=>1369}]
[30] ebpf.0: [[1782365734.487489519, {}], {"event_type"=>"tls_read", "event_id"=>562949953421327, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>7239, "ret"=>1369}]
[31] ebpf.0: [[1782365734.487774716, {}], {"event_type"=>"tls_read", "event_id"=>562949953421328, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>7344, "ret"=>1369}]
[32] ebpf.0: [[1782365734.487992045, {}], {"event_type"=>"tls_read", "event_id"=>562949953421329, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>9558, "ret"=>-1}]
[33] ebpf.0: [[1782365734.488233285, {}], {"event_type"=>"tls_read", "event_id"=>562949953421330, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>3760, "ret"=>-1}]
[34] ebpf.0: [[1782365734.488649408, {}], {"event_type"=>"tls_read", "event_id"=>562949953421331, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>30460, "ret"=>1369}]
[35] ebpf.0: [[1782365734.488879253, {}], {"event_type"=>"tls_read", "event_id"=>562949953421332, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>10063, "ret"=>1369}]
[36] ebpf.0: [[1782365734.489095888, {}], {"event_type"=>"tls_read", "event_id"=>562949953421333, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>8392, "ret"=>1369}]
[37] ebpf.0: [[1782365734.489283707, {}], {"event_type"=>"tls_read", "event_id"=>562949953421334, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>8195, "ret"=>1369}]
[38] ebpf.0: [[1782365734.489465033, {}], {"event_type"=>"tls_read", "event_id"=>562949953421335, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>9041, "ret"=>1369}]
[39] ebpf.0: [[1782365734.489625034, {}], {"event_type"=>"tls_read", "event_id"=>562949953421336, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>8027, "ret"=>1369}]
[40] ebpf.0: [[1782365734.489787200, {}], {"event_type"=>"tls_read", "event_id"=>562949953421337, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>7975, "ret"=>1369}]
[41] ebpf.0: [[1782365734.489975962, {}], {"event_type"=>"tls_read", "event_id"=>562949953421338, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>7806, "ret"=>1369}]
[42] ebpf.0: [[1782365734.490146159, {}], {"event_type"=>"tls_read", "event_id"=>562949953421339, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>7839, "ret"=>1369}]
[43] ebpf.0: [[1782365734.490351961, {}], {"event_type"=>"tls_read", "event_id"=>562949953421340, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>7717, "ret"=>1369}]
[44] ebpf.0: [[1782365734.490535322, {}], {"event_type"=>"tls_read", "event_id"=>562949953421341, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>8009, "ret"=>1369}]
[45] ebpf.0: [[1782365734.490716568, {}], {"event_type"=>"tls_read", "event_id"=>562949953421342, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>8040, "ret"=>1369}]
[46] ebpf.0: [[1782365734.490920419, {}], {"event_type"=>"tls_read", "event_id"=>562949953421343, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>9330, "ret"=>-1}]
[47] ebpf.0: [[1782365734.491095188, {}], {"event_type"=>"tls_read", "event_id"=>1407374883553290, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>20274, "ret"=>-1}]
[48] ebpf.0: [[1782365734.491269282, {}], {"event_type"=>"tls_read", "event_id"=>562949953421344, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>63624, "ret"=>1369}]
[49] ebpf.0: [[1782365734.491454490, {}], {"event_type"=>"tls_read", "event_id"=>562949953421345, "pid"=>275499, "tid"=>275499, "comm"=>"curl", "trace"=>"openssl_tls_read", "ssl_ptr"=>98811799495600, "latency_ns"=>15188, "ret"=>4229}]
[2026/06/25 14:35:35.318] [ warn] [engine] service will shutdown in max 5 seconds
[2026/06/25 14:35:35.325] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/06/25 14:35:35.326] [ info] [engine] pausing all inputs..
[2026/06/25 14:35:35.327] [ info] [input] pausing ebpf.0
[2026/06/25 14:35:35.329] [debug] [input:ebpf:ebpf.0] collector paused
[2026/06/25 14:35:35.325] [debug] [out flush] cb_destroy coro_id=2
[2026/06/25 14:35:35.331] [debug] [task] destroy task=0x8671ec0 (task_id=0)
[2026/06/25 14:35:35.473] [ info] [engine] service has stopped (0 pending tasks)
[2026/06/25 14:35:35.473] [ info] [input] pausing ebpf.0
[2026/06/25 14:35:35.474] [debug] [input:ebpf:ebpf.0] collector paused
[2026/06/25 14:35:35.476] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/06/25 14:35:35.484] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/06/25 14:35:36.119] [ info] [input:ebpf:ebpf.0] eBPF input plugin exited
```
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```
==275420== 
==275420== HEAP SUMMARY:
==275420==     in use at exit: 0 bytes in 0 blocks
==275420==   total heap usage: 4,802 allocs, 4,802 frees, 21,056,824 bytes allocated
==275420== 
==275420== All heap blocks were freed -- no leaks are possible
==275420== 
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event IDs to trace events across bind, DNS, exec, malloc/free, OpenSSL, scheduling, signal, TCP, and VFS paths.
  * Event payloads now include the new identifier in the common event data returned to consumers.

* **Bug Fixes**
  * Improved trace event consistency by ensuring identifiers are generated before event submission in multiple capture flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->