### PR TITLE
dockerfile: install libzstd-dev for kafka zstd compression (4.2 backport)  

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && \
     pkg-config \
     libsystemd-dev \
     zlib1g-dev \
+    libzstd-dev \
     libpq-dev \
     postgresql-server-dev-all \
     flex \
@@ -262,7 +263,7 @@ RUN apt-get update && \
     openssl \
     htop atop strace iotop sysstat ncdu logrotate hdparm pciutils psmisc tree pv \
     make tar flex bison \
-    libssl-dev libsasl2-dev libsystemd-dev zlib1g-dev libpq-dev libyaml-dev postgresql-server-dev-all \
+    libssl-dev libsasl2-dev libsystemd-dev zlib1g-dev libzstd-dev libpq-dev libyaml-dev postgresql-server-dev-all \
     && apt-get satisfy -y cmake "cmake (<< 4.0)" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -306,3 +306,14 @@ foreach(source_file ${CHECK_PROGRAMS})
     set_property(TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-D${o_source_file_we}")
   endif()
 endforeach()
+
+# The out_kafka runtime test includes librdkafka's public header directly, so it
+# needs the same include path the in_kafka/out_kafka plugins use. Cover both the
+# system librdkafka (pkg-config) and the bundled librdkafka build.
+if(TARGET flb-rt-out_kafka)
+  if(DEFINED KAFKA_INCLUDEDIR)
+    target_include_directories(flb-rt-out_kafka PRIVATE ${KAFKA_INCLUDEDIR}/librdkafka)
+  endif()
+  target_include_directories(flb-rt-out_kafka PRIVATE
+    ${FLB_PATH_ROOT_SOURCE}/${FLB_PATH_LIB_RDKAFKA}/src)
+endif()

--- a/tests/runtime/out_kafka.c
+++ b/tests/runtime/out_kafka.c
@@ -3,8 +3,33 @@
 #include <fluent-bit.h>
 #include "flb_tests_runtime.h"
 
+#include "rdkafka.h"
+
 /* Test data */
 #include "data/td/json_td.h"
+
+/*
+ * Ensure librdkafka was compiled with zstd support so Kafka producers can
+ * negotiate zstd compression. Setting compression.codec to zstd only succeeds
+ * when WITH_ZSTD was enabled at build time, otherwise rd_kafka_conf_set
+ * reports the codec as not built in.
+ */
+void flb_test_zstd_compression_available()
+{
+    rd_kafka_conf_t *conf;
+    rd_kafka_conf_res_t res;
+    char errstr[512] = {0};
+
+    conf = rd_kafka_conf_new();
+    TEST_CHECK(conf != NULL);
+
+    res = rd_kafka_conf_set(conf, "compression.codec", "zstd",
+                            errstr, sizeof(errstr));
+    TEST_CHECK(res == RD_KAFKA_CONF_OK);
+    TEST_MSG("compression.codec=zstd rejected: %s", errstr);
+
+    rd_kafka_conf_destroy(conf);
+}
 
 
 void flb_test_raw_format()
@@ -44,6 +69,7 @@ void flb_test_raw_format()
 }
 
 TEST_LIST = {
+  { "zstd_compression_available", flb_test_zstd_compression_available },
   { "raw_format", flb_test_raw_format },
   { NULL, NULL },
 };


### PR DESCRIPTION
Backport of #12003 to the 4.2 branch.

Container images were built without `libzstd-dev` in the builder stage, so
librdkafka's `find_package(ZSTD)` failed and `WITH_ZSTD` was disabled. Kafka
producers in the shipped images could not use zstd compression.

Changes:
- `dockerfiles/Dockerfile`: add `libzstd-dev` to the builder and debug builder
  stages so librdkafka is compiled with zstd support.
- `tests/runtime/out_kafka.c`: add a runtime test asserting librdkafka accepts
  `compression.codec=zstd` (only true when `WITH_ZSTD` is compiled in).

<!-- Issue number, if available. E.g. "Fixes 31", "Addresses 42, 77" -->
Addresses fluent/fluent-bit#11366 (Packaging: Enable ZSTD compression by default).

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] `local-build-all.sh` builds the native distro packages under `packaging/distros/`. This PR only changes the container images (`dockerfiles/Dockerfile`), which that script does not build. The container image build was verified instead (see test evidence above).
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

<details>
<summary>Test evidence (4.2 branch)</summary>

**Example config** (`rdkafka.compression.codec=zstd`):

```ini
[INPUT]
    Name    dummy
    Tag     test

[OUTPUT]
    Name                       kafka
    Match                      test
    Brokers                    127.0.0.1:9092
    Topics                     test
    rdkafka.compression.codec  zstd
```

**Container build (`dockerfiles/Dockerfile`)** — zstd is now detected so librdkafka
is built with `WITH_ZSTD`:

```
-- Found ZSTD: /usr/lib/aarch64-linux-gnu/libzstd.so
WITH_ZSTD:BOOL=ON
```

**Runtime test** (`tests/runtime/out_kafka.c::zstd_compression_available`):

```
Test zstd_compression_available...              [ OK ]
SUCCESS: All unit tests have passed.
```

(On master the same test was additionally run under Valgrind with no leaks and 0 errors.)

</details>

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] This is the backport to the 4.2 release branch.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
