### PR TITLE
in_windows_exporter_metrics: Implement user-defined performance counters w/ PDH

### DIFF
--- a/plugins/in_windows_exporter_metrics/CMakeLists.txt
+++ b/plugins/in_windows_exporter_metrics/CMakeLists.txt
@@ -10,6 +10,7 @@ set(src
   we_util.c
   we_metric.c
   we_cache.c
+  we_performancecounter.c
   we_perflib.c
   we_wmi_thermalzone.c
   we_wmi_cpu_info.c
@@ -26,6 +27,7 @@ set(libs
   wbemuuid
   netapi32
   iphlpapi
+  pdh
 )
 
 FLB_PLUGIN(in_windows_exporter_metrics "${src}" "${libs}")

--- a/plugins/in_windows_exporter_metrics/we.c
+++ b/plugins/in_windows_exporter_metrics/we.c
@@ -35,6 +35,7 @@
 #include "we_logical_disk.h"
 #include "we_cs.h"
 #include "we_cache.h"
+#include "we_performancecounter.h"
 
 /* wmi collectors */
 #include "we_wmi_cpu_info.h"
@@ -197,6 +198,17 @@ static int we_timer_wmi_tcp_metrics_cb(struct flb_input_instance *ins,
     return 0;
 }
 
+static int we_timer_performancecounter_metrics_cb(struct flb_input_instance *ins,
+                                                  struct flb_config *config,
+                                                  void *in_context)
+{
+    struct flb_we *ctx = in_context;
+
+    we_performancecounter_update(ctx);
+
+    return 0;
+}
+
 struct flb_we_callback {
     char *name;
     void (*func)(char *, void *, void *);
@@ -354,6 +366,13 @@ static void we_wmi_tcp_update_cb(char *name, void *p1, void *p2)
     we_wmi_tcp_update(ctx);
 }
 
+static void we_performancecounter_update_cb(char *name, void *p1, void *p2)
+{
+    struct flb_we *ctx = p1;
+
+    we_performancecounter_update(ctx);
+}
+
 static int we_update_cb(struct flb_we *ctx, char *name)
 {
     int ret;
@@ -382,6 +401,7 @@ struct flb_we_callback ne_callbacks[] = {
     { "paging_file", we_wmi_paging_file_update_cb },
     { "process", we_wmi_process_update_cb },
     { "tcp", we_wmi_tcp_update_cb },
+    { "performancecounter", we_performancecounter_update_cb },
     { 0 }
 };
 
@@ -421,6 +441,7 @@ static int in_we_init(struct flb_input_instance *in,
     ctx->coll_wmi_paging_file_fd = -1;
     ctx->coll_wmi_process_fd = -1;
     ctx->coll_wmi_tcp_fd = -1;
+    ctx->coll_performancecounter_fd = -1;
 
     ctx->callback = flb_callback_create(in->name);
     if (!ctx->callback) {
@@ -474,6 +495,7 @@ static int in_we_init(struct flb_input_instance *in,
     if (ctx->metrics) {
         mk_list_foreach(head, ctx->metrics) {
             entry = mk_list_entry(head, struct flb_slist_entry, _head);
+            metric_idx = -1;
             ret = flb_callback_exists(ctx->callback, entry->str);
 
             if (ret == FLB_FALSE) {
@@ -851,6 +873,32 @@ static int in_we_init(struct flb_input_instance *in,
                         return -1;
                     }
                 }
+                else if (strncmp(entry->str, "performancecounter", 18) == 0) {
+                    if (ctx->performancecounter_scrape_interval == 0) {
+                        flb_plg_debug(ctx->ins, "enabled metrics %s", entry->str);
+                        metric_idx = 15;
+                    }
+                    else {
+                        /* Create the performancecounter collector */
+                        ret = flb_input_set_collector_time(
+                                  in,
+                                  we_timer_performancecounter_metrics_cb,
+                                  ctx->performancecounter_scrape_interval, 0,
+                                  config);
+                        if (ret == -1) {
+                            flb_plg_error(ctx->ins,
+                                          "could not set performancecounter collector "
+                                          "for Windows Exporter Metrics plugin");
+                            return -1;
+                        }
+                        ctx->coll_performancecounter_fd = ret;
+                    }
+
+                    ret = we_performancecounter_init(ctx);
+                    if (ret) {
+                        return -1;
+                    }
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                     metric_idx = -1;
@@ -939,6 +987,9 @@ static int in_we_exit(void *data, struct flb_config *config)
                 else if (strncmp(entry->str, "tcp", 3) == 0) {
                     we_wmi_tcp_exit(ctx);
                 }
+                else if (strncmp(entry->str, "performancecounter", 18) == 0) {
+                    we_performancecounter_exit(ctx);
+                }
                 else {
                     flb_plg_warn(ctx->ins, "Unknown metrics: %s", entry->str);
                 }
@@ -993,6 +1044,9 @@ static int in_we_exit(void *data, struct flb_config *config)
     }
     if (ctx->coll_wmi_tcp_fd != -1) {
         we_wmi_tcp_exit(ctx);
+    }
+    if (ctx->coll_performancecounter_fd != -1) {
+        we_performancecounter_exit(ctx);
     }
 
     flb_we_config_destroy(ctx);
@@ -1052,6 +1106,9 @@ static void in_we_pause(void *data, struct flb_config *config)
     if (ctx->coll_wmi_tcp_fd != -1) {
         flb_input_collector_pause(ctx->coll_wmi_tcp_fd, ctx->ins);
     }
+    if (ctx->coll_performancecounter_fd != -1) {
+        flb_input_collector_pause(ctx->coll_performancecounter_fd, ctx->ins);
+    }
 }
 
 static void in_we_resume(void *data, struct flb_config *config)
@@ -1108,6 +1165,9 @@ static void in_we_resume(void *data, struct flb_config *config)
     }
     if (ctx->coll_wmi_tcp_fd != -1) {
         flb_input_collector_resume(ctx->coll_wmi_tcp_fd, ctx->ins);
+    }
+    if (ctx->coll_performancecounter_fd != -1) {
+        flb_input_collector_resume(ctx->coll_performancecounter_fd, ctx->ins);
     }
 }
 
@@ -1210,6 +1270,12 @@ static struct flb_config_map config_map[] = {
     },
 
     {
+     FLB_CONFIG_MAP_TIME, "collector.performancecounter.scrape_interval", "0",
+     0, FLB_TRUE, offsetof(struct flb_we, performancecounter_scrape_interval),
+     "scrape interval to collect performancecounter metrics from the node."
+    },
+
+    {
      FLB_CONFIG_MAP_CLIST, "metrics",
      "cpu,cpu_info,os,net,logical_disk,cs,cache,thermalzone,logon,system,service,tcp",
      0, FLB_TRUE, offsetof(struct flb_we, metrics),
@@ -1254,6 +1320,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "we.process.deny_process_regex", NULL,
      0, FLB_TRUE, offsetof(struct flb_we, raw_denying_process),
      "Specify the regex for process metrics to prevent collection of/ignore."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "PerformanceCounter", NULL,
+     FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_we, raw_performance_counters),
+     "Windows Performance Counter in name=counter_path form."
     },
     /* EOF */
     {0}

--- a/plugins/in_windows_exporter_metrics/we.h
+++ b/plugins/in_windows_exporter_metrics/we.h
@@ -31,6 +31,8 @@
 
 #include <windows.h>
 #include <wbemidl.h>
+#include <pdh.h>
+#include <pdhmsg.h>
 
 #include "we_metric.h"
 
@@ -248,6 +250,40 @@ struct we_wmi_tcp_counters {
     struct cmt_gauge            *segments_sent_total;
 };
 
+struct we_performancecounter_definition {
+    char             *name;
+    char             *path;
+    wchar_t          *path_w;
+    struct cmt_gauge *metric;
+    int               has_wildcard;
+    int               warned_expand_failure;
+    int               warned_no_instances;
+    struct mk_list    _head;
+};
+
+struct we_performancecounter_counter {
+    struct we_performancecounter_definition *definition;
+    char             *name;
+    char             *path;
+    wchar_t          *path_w;
+    char             *instance;
+    char             *label_values[1];
+    PDH_HCOUNTER      handle;
+    struct cmt_gauge *metric;
+    int               label_count;
+    int               valid;
+    int               seen_valid;
+    int               stale;
+    struct mk_list    _head;
+};
+
+struct we_performancecounter_counters {
+    PDH_HQUERY    query;
+    int           operational;
+    struct mk_list definitions;
+    struct mk_list counters;
+};
+
 struct we_os_counters {
     struct cmt_gauge *info;
     struct cmt_gauge *users;
@@ -286,6 +322,7 @@ struct flb_we {
     char *raw_service_exclude;
     char *raw_allowing_process;
     char *raw_denying_process;
+    struct mk_list *raw_performance_counters;
     char *service_include_buffer;
     int   service_include_buffer_size;
     char *service_exclude_buffer;
@@ -324,6 +361,7 @@ struct flb_we {
     int wmi_paging_file_scrape_interval;
     int wmi_process_scrape_interval;
     int wmi_tcp_scrape_interval;
+    int performancecounter_scrape_interval;
 
     int coll_cpu_fd;                                    /* collector fd (cpu)    */
     int coll_net_fd;                                    /* collector fd (net)  */
@@ -340,6 +378,7 @@ struct flb_we {
     int coll_wmi_paging_file_fd;                        /* collector fd (wmi_paging_file) */
     int coll_wmi_process_fd;                            /* collector fd (wmi_process) */
     int coll_wmi_tcp_fd;                                /* collector fd (wmi_tcp) */
+    int coll_performancecounter_fd;                      /* collector fd (performancecounter) */
 
     /*
      * Metrics Contexts
@@ -361,6 +400,7 @@ struct flb_we {
     struct we_wmi_paging_file_counters *wmi_paging_file;
     struct we_wmi_process_counters *wmi_process;
     struct we_wmi_tcp_counters *wmi_tcp;
+    struct we_performancecounter_counters *performancecounter;
 };
 
 typedef int (*collector_cb)(struct flb_we *);

--- a/plugins/in_windows_exporter_metrics/we_performancecounter.c
+++ b/plugins/in_windows_exporter_metrics/we_performancecounter.c
@@ -1,0 +1,830 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_sds.h>
+#include <cmetrics/cmt_map.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "we_performancecounter.h"
+#include "we_util.h"
+
+static char *sanitize_metric_name(char *name)
+{
+    size_t i;
+    size_t j;
+    size_t len;
+    char *out;
+    int last_was_separator;
+
+    len = strlen(name);
+    if (len == 0) {
+        return NULL;
+    }
+
+    out = flb_strdup(name);
+    if (out == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    j = 0;
+    last_was_separator = FLB_TRUE;
+
+    for (i = 0; i < len; i++) {
+        if (isalnum((unsigned char) name[i])) {
+            out[j] = tolower((unsigned char) name[i]);
+            j++;
+            last_was_separator = FLB_FALSE;
+            continue;
+        }
+
+        if (!last_was_separator) {
+            out[j] = '_';
+            j++;
+            last_was_separator = FLB_TRUE;
+        }
+    }
+
+    if (j > 0 && out[j - 1] == '_') {
+        j--;
+    }
+
+    out[j] = '\0';
+
+    if (j == 0) {
+        flb_free(out);
+        return NULL;
+    }
+
+    return out;
+}
+
+static int parse_counter_config(struct flb_we *ctx,
+                                char *entry,
+                                char **out_name,
+                                char **out_path,
+                                int *out_has_wildcard)
+{
+    char *separator;
+    char *name;
+    char *path;
+    char *name_end;
+
+    separator = strchr(entry, '=');
+    if (separator == NULL) {
+        name = entry;
+        path = entry;
+    }
+    else {
+        name = entry;
+        path = separator + 1;
+        *separator = '\0';
+    }
+
+    while (isspace((unsigned char) *name)) {
+        name++;
+    }
+
+    if (separator != NULL) {
+        name_end = separator - 1;
+        while (name_end >= name && isspace((unsigned char) *name_end)) {
+            *name_end = '\0';
+            name_end--;
+        }
+    }
+
+    while (isspace((unsigned char) *path)) {
+        path++;
+    }
+
+    if ((separator != NULL && *name == '\0') || *path == '\0') {
+        flb_plg_error(ctx->ins,
+                      "invalid PerformanceCounter '%s', expected name=counter_path",
+                      entry);
+        return -1;
+    }
+
+    *out_name = name;
+    *out_path = path;
+    *out_has_wildcard = FLB_FALSE;
+
+    if (strchr(path, '*') != NULL) {
+        *out_has_wildcard = FLB_TRUE;
+    }
+
+    return 0;
+}
+
+static char *compose_instance_label(char *parent, char *instance, DWORD index)
+{
+    size_t len;
+    char *out;
+    char index_buf[32];
+    int has_parent;
+    int has_index;
+
+    has_parent = FLB_FALSE;
+    has_index = FLB_FALSE;
+    index_buf[0] = '\0';
+
+    if (parent != NULL && parent[0] != '\0') {
+        has_parent = FLB_TRUE;
+    }
+
+    if (index != (DWORD) -1) {
+        snprintf(index_buf, sizeof(index_buf), "#%lu", (unsigned long) index);
+        has_index = FLB_TRUE;
+    }
+
+    len = strlen(instance) + 1;
+    if (has_parent) {
+        len += strlen(parent) + 1;
+    }
+    if (has_index) {
+        len += strlen(index_buf);
+    }
+
+    out = flb_malloc(len);
+    if (out == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    if (has_parent && has_index) {
+        snprintf(out, len, "%s/%s%s", parent, instance, index_buf);
+    }
+    else if (has_parent) {
+        snprintf(out, len, "%s/%s", parent, instance);
+    }
+    else if (has_index) {
+        snprintf(out, len, "%s%s", instance, index_buf);
+    }
+    else {
+        snprintf(out, len, "%s", instance);
+    }
+
+    return out;
+}
+
+static char *get_counter_instance(wchar_t *path_w)
+{
+    PDH_STATUS status;
+    DWORD size;
+    PPDH_COUNTER_PATH_ELEMENTS_W elements;
+    char *instance;
+    char *parent;
+    char *label;
+
+    size = 0;
+    status = PdhParseCounterPathW(path_w, NULL, &size, 0);
+    if (status != PDH_MORE_DATA) {
+        return NULL;
+    }
+
+    elements = flb_calloc(1, size);
+    if (elements == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    status = PdhParseCounterPathW(path_w, elements, &size, 0);
+    if (status != ERROR_SUCCESS) {
+        flb_free(elements);
+        return NULL;
+    }
+
+    if (elements->szInstanceName == NULL) {
+        flb_free(elements);
+        return NULL;
+    }
+
+    instance = we_convert_wstr(elements->szInstanceName, CP_UTF8);
+    if (instance == NULL) {
+        flb_free(elements);
+        return NULL;
+    }
+
+    parent = NULL;
+    if (elements->szParentInstance != NULL) {
+        parent = we_convert_wstr(elements->szParentInstance, CP_UTF8);
+        if (parent == NULL) {
+            flb_free(instance);
+            flb_free(elements);
+            return NULL;
+        }
+    }
+
+    label = compose_instance_label(parent, instance, elements->dwInstanceIndex);
+
+    flb_free(parent);
+    flb_free(instance);
+    flb_free(elements);
+
+    return label;
+}
+
+static void remove_counter(struct we_performancecounter_counter *counter,
+                           int remove_metric)
+{
+    struct cmt_metric *metric;
+
+    if (counter->handle != NULL) {
+        PdhRemoveCounter(counter->handle);
+    }
+
+    if (remove_metric && counter->label_count > 0) {
+        metric = cmt_map_metric_get(&counter->metric->opts,
+                                    counter->metric->map,
+                                    counter->label_count,
+                                    counter->label_values,
+                                    CMT_FALSE);
+        if (metric != NULL) {
+            cmt_map_metric_destroy(metric);
+        }
+    }
+
+    mk_list_del(&counter->_head);
+
+    flb_free(counter->name);
+    flb_free(counter->path);
+    flb_free(counter->path_w);
+    flb_free(counter->instance);
+    flb_free(counter);
+}
+
+static struct we_performancecounter_counter *find_counter_path(
+        struct flb_we *ctx, struct we_performancecounter_definition *definition,
+        char *path)
+{
+    struct mk_list *head;
+    struct we_performancecounter_counter *counter;
+
+    mk_list_foreach(head, &ctx->performancecounter->counters) {
+        counter = mk_list_entry(head, struct we_performancecounter_counter, _head);
+        if (counter->definition == definition && strcmp(counter->path, path) == 0) {
+            return counter;
+        }
+    }
+
+    return NULL;
+}
+
+static int add_counter_path(struct flb_we *ctx,
+                            struct we_performancecounter_definition *definition,
+                            char *path,
+                            int with_instance_label,
+                            int use_english_path)
+{
+    PDH_STATUS status;
+    wchar_t *path_w;
+    struct we_performancecounter_counter *counter;
+
+    path_w = we_convert_str(path);
+    if (path_w == NULL) {
+        return -1;
+    }
+
+    counter = flb_calloc(1, sizeof(struct we_performancecounter_counter));
+    if (counter == NULL) {
+        flb_errno();
+        flb_free(path_w);
+        return -1;
+    }
+
+    counter->definition = definition;
+    counter->name = flb_strdup(definition->name);
+    counter->path = flb_strdup(path);
+    counter->path_w = path_w;
+    counter->metric = definition->metric;
+    counter->label_count = 0;
+    counter->valid = FLB_FALSE;
+    counter->seen_valid = FLB_FALSE;
+    counter->stale = FLB_FALSE;
+
+    if (counter->name == NULL || counter->path == NULL) {
+        flb_errno();
+        flb_free(counter->path_w);
+        flb_free(counter->name);
+        flb_free(counter->path);
+        flb_free(counter);
+        return -1;
+    }
+
+    if (with_instance_label) {
+        counter->instance = get_counter_instance(counter->path_w);
+        if (counter->instance == NULL) {
+            counter->instance = flb_strdup(counter->path);
+        }
+        if (counter->instance == NULL) {
+            flb_errno();
+            flb_free(counter->path_w);
+            flb_free(counter->name);
+            flb_free(counter->path);
+            flb_free(counter);
+            return -1;
+        }
+        counter->label_values[0] = counter->instance;
+        counter->label_count = 1;
+    }
+
+    if (use_english_path) {
+        status = PdhAddEnglishCounterW(ctx->performancecounter->query,
+                                       counter->path_w,
+                                       0,
+                                       &counter->handle);
+    }
+    else {
+        status = PdhAddCounterW(ctx->performancecounter->query,
+                                counter->path_w,
+                                0,
+                                &counter->handle);
+    }
+
+    if (status == ERROR_SUCCESS) {
+        counter->valid = FLB_TRUE;
+    }
+    else {
+        flb_plg_warn(ctx->ins,
+                     "could not add PerformanceCounter '%s' (%s): 0x%08lx",
+                     counter->name, counter->path, (unsigned long) status);
+    }
+
+    mk_list_add(&counter->_head, &ctx->performancecounter->counters);
+
+    return 0;
+}
+
+static void free_definition(struct we_performancecounter_definition *definition)
+{
+    mk_list_del(&definition->_head);
+
+    flb_free(definition->name);
+    flb_free(definition->path);
+    flb_free(definition->path_w);
+    flb_free(definition);
+}
+
+static int get_localized_wildcard_path(struct flb_we *ctx,
+                                       struct we_performancecounter_definition *definition,
+                                       wchar_t **out_path)
+{
+    PDH_STATUS status;
+    PDH_HCOUNTER handle;
+    DWORD size;
+    PPDH_COUNTER_INFO_W info;
+    wchar_t *localized_path;
+
+    handle = NULL;
+    size = 0;
+    info = NULL;
+    localized_path = NULL;
+    *out_path = NULL;
+
+    status = PdhAddEnglishCounterW(ctx->performancecounter->query,
+                                   definition->path_w,
+                                   0,
+                                   &handle);
+    if (status != ERROR_SUCCESS) {
+        return status;
+    }
+
+    status = PdhGetCounterInfoW(handle, TRUE, &size, NULL);
+    if (status != PDH_MORE_DATA) {
+        PdhRemoveCounter(handle);
+        return status;
+    }
+
+    info = flb_calloc(1, size);
+    if (info == NULL) {
+        flb_errno();
+        PdhRemoveCounter(handle);
+        return ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    status = PdhGetCounterInfoW(handle, TRUE, &size, info);
+    if (status != ERROR_SUCCESS) {
+        flb_free(info);
+        PdhRemoveCounter(handle);
+        return status;
+    }
+
+    localized_path = flb_calloc(wcslen(info->szFullPath) + 1, sizeof(wchar_t));
+    if (localized_path == NULL) {
+        flb_errno();
+        flb_free(info);
+        PdhRemoveCounter(handle);
+        return ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    wcscpy(localized_path, info->szFullPath);
+
+    flb_free(info);
+    PdhRemoveCounter(handle);
+
+    *out_path = localized_path;
+
+    return ERROR_SUCCESS;
+}
+
+static int add_expanded_counter_paths(struct flb_we *ctx,
+                                      struct we_performancecounter_definition *definition)
+{
+    PDH_STATUS status;
+    DWORD length;
+    wchar_t *paths;
+    wchar_t *path;
+    wchar_t *localized_path;
+    char *path_utf8;
+    struct we_performancecounter_counter *counter;
+    int added;
+
+    length = 0;
+    localized_path = NULL;
+
+    status = get_localized_wildcard_path(ctx, definition, &localized_path);
+    if (status != ERROR_SUCCESS) {
+        if (!definition->warned_expand_failure) {
+            flb_plg_warn(ctx->ins,
+                         "could not localize PerformanceCounter wildcard '%s': 0x%08lx",
+                         definition->path, (unsigned long) status);
+            definition->warned_expand_failure = FLB_TRUE;
+        }
+        return 1;
+    }
+
+    status = PdhExpandWildCardPathW(NULL, localized_path, NULL, &length, 0);
+    if (status != PDH_MORE_DATA) {
+        if (!definition->warned_expand_failure) {
+            flb_plg_warn(ctx->ins,
+                         "could not expand PerformanceCounter wildcard '%s': 0x%08lx",
+                         definition->path, (unsigned long) status);
+            definition->warned_expand_failure = FLB_TRUE;
+        }
+        flb_free(localized_path);
+        return 1;
+    }
+
+    paths = flb_calloc(length, sizeof(wchar_t));
+    if (paths == NULL) {
+        flb_errno();
+        flb_free(localized_path);
+        return -1;
+    }
+
+    status = PdhExpandWildCardPathW(NULL, localized_path, paths, &length, 0);
+    flb_free(localized_path);
+
+    if (status != ERROR_SUCCESS) {
+        if (!definition->warned_expand_failure) {
+            flb_plg_warn(ctx->ins,
+                         "could not expand PerformanceCounter wildcard '%s': 0x%08lx",
+                         definition->path, (unsigned long) status);
+            definition->warned_expand_failure = FLB_TRUE;
+        }
+        flb_free(paths);
+        return 1;
+    }
+
+    definition->warned_expand_failure = FLB_FALSE;
+
+    added = 0;
+    path = paths;
+
+    while (*path != L'\0') {
+        path_utf8 = we_convert_wstr(path, CP_UTF8);
+        if (path_utf8 == NULL) {
+            flb_free(paths);
+            return -1;
+        }
+
+        counter = find_counter_path(ctx, definition, path_utf8);
+        if (counter != NULL) {
+            counter->stale = FLB_FALSE;
+            flb_free(path_utf8);
+            added++;
+            path += wcslen(path) + 1;
+            continue;
+        }
+
+        if (add_counter_path(ctx, definition, path_utf8, FLB_TRUE, FLB_FALSE) != 0) {
+            flb_free(path_utf8);
+            flb_free(paths);
+            return -1;
+        }
+
+        flb_free(path_utf8);
+        added++;
+        path += wcslen(path) + 1;
+    }
+
+    if (added == 0) {
+        if (!definition->warned_no_instances) {
+            flb_plg_warn(ctx->ins,
+                         "PerformanceCounter wildcard '%s' did not match any instances",
+                         definition->path);
+            definition->warned_no_instances = FLB_TRUE;
+        }
+    }
+    else {
+        definition->warned_no_instances = FLB_FALSE;
+    }
+
+    flb_free(paths);
+
+    return 0;
+}
+
+static int refresh_wildcard_counters(struct flb_we *ctx,
+                                     struct we_performancecounter_definition *definition)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct we_performancecounter_counter *counter;
+    int ret;
+
+    mk_list_foreach(head, &ctx->performancecounter->counters) {
+        counter = mk_list_entry(head, struct we_performancecounter_counter, _head);
+        if (counter->definition == definition) {
+            counter->stale = FLB_TRUE;
+        }
+    }
+
+    ret = add_expanded_counter_paths(ctx, definition);
+    if (ret < 0) {
+        return -1;
+    }
+    else if (ret > 0) {
+        mk_list_foreach(head, &ctx->performancecounter->counters) {
+            counter = mk_list_entry(head, struct we_performancecounter_counter, _head);
+            if (counter->definition == definition) {
+                counter->stale = FLB_FALSE;
+            }
+        }
+        return 0;
+    }
+
+    mk_list_foreach_safe(head, tmp, &ctx->performancecounter->counters) {
+        counter = mk_list_entry(head, struct we_performancecounter_counter, _head);
+        if (counter->definition == definition && counter->stale) {
+            remove_counter(counter, FLB_TRUE);
+        }
+    }
+
+    return 0;
+}
+
+static int add_counter(struct flb_we *ctx, char *entry)
+{
+    char *name;
+    char *path;
+    char *metric_name;
+    struct cmt_gauge *gauge;
+    int has_wildcard;
+    int label_count;
+    char *labels[] = { "instance" };
+    struct we_performancecounter_definition *definition;
+    int ret;
+
+    if (parse_counter_config(ctx, entry, &name, &path, &has_wildcard) != 0) {
+        return -1;
+    }
+
+    metric_name = sanitize_metric_name(name);
+    if (metric_name == NULL) {
+        return -1;
+    }
+
+    label_count = 0;
+    if (has_wildcard) {
+        label_count = 1;
+    }
+
+    gauge = cmt_gauge_create(ctx->cmt, "windows", "performancecounter",
+                             metric_name,
+                             "Windows Performance Counter value",
+                             label_count, labels);
+    if (gauge == NULL) {
+        flb_plg_error(ctx->ins,
+                      "could not create performancecounter metric '%s'",
+                      metric_name);
+        flb_free(metric_name);
+        return -1;
+    }
+
+    definition = flb_calloc(1, sizeof(struct we_performancecounter_definition));
+    if (definition == NULL) {
+        flb_errno();
+        flb_free(metric_name);
+        return -1;
+    }
+
+    definition->name = flb_strdup(metric_name);
+    definition->path = flb_strdup(path);
+    definition->path_w = we_convert_str(path);
+    definition->metric = gauge;
+    definition->has_wildcard = has_wildcard;
+    definition->warned_expand_failure = FLB_FALSE;
+    definition->warned_no_instances = FLB_FALSE;
+
+    if (definition->name == NULL || definition->path == NULL ||
+        definition->path_w == NULL) {
+        flb_errno();
+        flb_free(definition->name);
+        flb_free(definition->path);
+        flb_free(definition->path_w);
+        flb_free(definition);
+        flb_free(metric_name);
+        return -1;
+    }
+
+    mk_list_add(&definition->_head, &ctx->performancecounter->definitions);
+
+    if (!has_wildcard) {
+        ret = add_counter_path(ctx, definition, path, FLB_FALSE, FLB_TRUE);
+        flb_free(metric_name);
+        return ret;
+    }
+
+    ret = add_expanded_counter_paths(ctx, definition);
+    if (ret > 0) {
+        ret = 0;
+    }
+
+    flb_free(metric_name);
+
+    return ret;
+}
+
+int we_performancecounter_init(struct flb_we *ctx)
+{
+    PDH_STATUS status;
+    struct mk_list *head;
+    struct flb_config_map_val *mv;
+
+    ctx->performancecounter = flb_calloc(1, sizeof(struct we_performancecounter_counters));
+    if (ctx->performancecounter == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    ctx->performancecounter->query = NULL;
+    ctx->performancecounter->operational = FLB_FALSE;
+    mk_list_init(&ctx->performancecounter->definitions);
+    mk_list_init(&ctx->performancecounter->counters);
+
+    if (ctx->raw_performance_counters == NULL ||
+        mk_list_size(ctx->raw_performance_counters) == 0) {
+        flb_plg_error(ctx->ins,
+                      "performancecounter metrics require at least one PerformanceCounter entry");
+        we_performancecounter_exit(ctx);
+        return -1;
+    }
+
+    status = PdhOpenQueryW(NULL, 0, &ctx->performancecounter->query);
+    if (status != ERROR_SUCCESS) {
+        flb_plg_warn(ctx->ins,
+                     "could not initialize PerformanceCounter PDH query: 0x%08lx",
+                     (unsigned long) status);
+        we_performancecounter_exit(ctx);
+        return -1;
+    }
+
+    flb_config_map_foreach(head, mv, ctx->raw_performance_counters) {
+        if (add_counter(ctx, mv->val.str) != 0) {
+            we_performancecounter_exit(ctx);
+            return -1;
+        }
+    }
+
+    status = PdhCollectQueryData(ctx->performancecounter->query);
+    if (status != ERROR_SUCCESS) {
+        flb_plg_debug(ctx->ins,
+                      "initial PerformanceCounter collection failed: 0x%08lx",
+                      (unsigned long) status);
+    }
+
+    ctx->performancecounter->operational = FLB_TRUE;
+
+    return 0;
+}
+
+int we_performancecounter_exit(struct flb_we *ctx)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct we_performancecounter_counter *counter;
+    struct we_performancecounter_definition *definition;
+
+    if (ctx->performancecounter == NULL) {
+        return 0;
+    }
+
+    ctx->performancecounter->operational = FLB_FALSE;
+
+    mk_list_foreach_safe(head, tmp, &ctx->performancecounter->counters) {
+        counter = mk_list_entry(head, struct we_performancecounter_counter, _head);
+        remove_counter(counter, FLB_FALSE);
+    }
+
+    mk_list_foreach_safe(head, tmp, &ctx->performancecounter->definitions) {
+        definition = mk_list_entry(head, struct we_performancecounter_definition, _head);
+        free_definition(definition);
+    }
+
+    if (ctx->performancecounter->query != NULL) {
+        PdhCloseQuery(ctx->performancecounter->query);
+    }
+
+    flb_free(ctx->performancecounter);
+    ctx->performancecounter = NULL;
+
+    return 0;
+}
+
+int we_performancecounter_update(struct flb_we *ctx)
+{
+    PDH_STATUS status;
+    PDH_FMT_COUNTERVALUE value;
+    uint64_t timestamp;
+    struct mk_list *head;
+    struct we_performancecounter_counter *counter;
+    struct we_performancecounter_definition *definition;
+
+    if (ctx->performancecounter == NULL ||
+        !ctx->performancecounter->operational) {
+        flb_plg_debug(ctx->ins,
+                      "performancecounter collector not in operational state");
+        return 0;
+    }
+
+    mk_list_foreach(head, &ctx->performancecounter->definitions) {
+        definition = mk_list_entry(head, struct we_performancecounter_definition, _head);
+        if (definition->has_wildcard) {
+            if (refresh_wildcard_counters(ctx, definition) != 0) {
+                flb_plg_debug(ctx->ins,
+                              "PerformanceCounter wildcard refresh failed for '%s'",
+                              definition->path);
+            }
+        }
+    }
+
+    status = PdhCollectQueryData(ctx->performancecounter->query);
+    if (status != ERROR_SUCCESS) {
+        flb_plg_debug(ctx->ins,
+                      "PerformanceCounter collection failed: 0x%08lx",
+                      (unsigned long) status);
+        return 0;
+    }
+
+    timestamp = cfl_time_now();
+
+    mk_list_foreach(head, &ctx->performancecounter->counters) {
+        counter = mk_list_entry(head, struct we_performancecounter_counter, _head);
+        if (!counter->valid) {
+            continue;
+        }
+
+        memset(&value, 0, sizeof(value));
+
+        status = PdhGetFormattedCounterValue(counter->handle,
+                                             PDH_FMT_DOUBLE,
+                                             NULL,
+                                             &value);
+        if (status != ERROR_SUCCESS || value.CStatus != ERROR_SUCCESS) {
+            flb_plg_debug(ctx->ins,
+                          "PerformanceCounter '%s' returned invalid data: "
+                          "status=0x%08lx cstatus=0x%08lx",
+                          counter->name,
+                          (unsigned long) status,
+                          (unsigned long) value.CStatus);
+            continue;
+        }
+
+        counter->seen_valid = FLB_TRUE;
+        cmt_gauge_set(counter->metric, timestamp, value.doubleValue,
+                      counter->label_count, counter->label_values);
+    }
+
+    return 0;
+}

--- a/plugins/in_windows_exporter_metrics/we_performancecounter.h
+++ b/plugins/in_windows_exporter_metrics/we_performancecounter.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_WE_PERFORMANCECOUNTER_H
+#define FLB_WE_PERFORMANCECOUNTER_H
+
+#include "we.h"
+
+int we_performancecounter_init(struct flb_we *ctx);
+int we_performancecounter_exit(struct flb_we *ctx);
+int we_performancecounter_update(struct flb_we *ctx);
+
+#endif


### PR DESCRIPTION
In the current implementation of windows exporter metrics, we do not provide user-defined PerformanceCounter query capability.
So, it'll be useful to define an arbitrary query not to be implemented by default.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
[SERVICE]
    flush_interval 3
    HTTP_Server On
    HTTP_Port 2020
    Log_Level debug

[INPUT]
    Name    windows_exporter_metrics
    Tag     windows
    Scrape_Interval  2
    Metrics cpu,logical_disk,memory,performancecounter

    # Example: custom Performance Counters
    PerformanceCounter process_fluent_bit_thread_count=\Process(fluent-bit)\Thread Count
    PerformanceCounter gpu_3d_utilization=\GPU Engine(*engtype_3D)\Utilization Percentage
    PerformanceCounter gpu_copy_utilization=\GPU Engine(*engtype_Copy)\Utilization Percentage
    PerformanceCounter gpu_video_decode_utilization=\GPU Engine(*engtype_VideoDecode)\Utilization Percentage

[OUTPUT]
    Name stdout
```
- [x] Debug log output from testing the change

```
Fluent Bit v5.0.8
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/06/26 17:03:04.236] [ info] Configuration:
[2026/06/26 17:03:04.236] [ info]  flush time     | 1.000000 seconds
[2026/06/26 17:03:04.236] [ info]  grace          | 5 seconds
[2026/06/26 17:03:04.236] [ info]  daemon         | 0
[2026/06/26 17:03:04.236] [ info] ___________
[2026/06/26 17:03:04.236] [ info]  inputs:
[2026/06/26 17:03:04.236] [ info]      windows_exporter_metrics
[2026/06/26 17:03:04.236] [ info] ___________
[2026/06/26 17:03:04.236] [ info]  filters:
[2026/06/26 17:03:04.236] [ info] ___________
[2026/06/26 17:03:04.236] [ info]  outputs:
[2026/06/26 17:03:04.236] [ info]      stdout.0
[2026/06/26 17:03:04.236] [ info] ___________
[2026/06/26 17:03:04.236] [ info]  collectors:
[2026/06/26 17:03:04.238] [ info] [fluent bit] version=5.0.8, commit=d4e7541139, pid=180644
[2026/06/26 17:03:04.238] [debug] [engine] maxstdio set: 512
[2026/06/26 17:03:04.238] [debug] [engine] coroutine stack size: 98302 bytes (96.0K)
[2026/06/26 17:03:04.238] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/06/26 17:03:04.239] [ info] [simd    ] SSE2
[2026/06/26 17:03:04.239] [ info] [cmetrics] version=2.1.5
[2026/06/26 17:03:04.239] [ info] [ctraces ] version=0.7.1
[2026/06/26 17:03:04.239] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing
[2026/06/26 17:03:04.239] [ info] [input:windows_exporter_metrics:windows_exporter_metrics.0] storage_strategy='memory' (memory only)
[2026/06/26 17:03:04.239] [debug] [windows_exporter_metrics:windows_exporter_metrics.0] created event channels: read=780 write=784
[2026/06/26 17:03:04.314] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics cpu
[2026/06/26 17:03:04.314] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics logical_disk
[2026/06/26 17:03:04.314] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics memory
[2026/06/26 17:03:04.314] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] enabled metrics performancecounter
[2026/06/26 17:03:04.673] [debug] [stdout:stdout.0] created event channels: read=1132 write=1136
[2026/06/26 17:03:04.675] [ info] [output:stdout:stdout.0] worker #0 started
[2026/06/26 17:03:04.675] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2026/06/26 17:03:04.676] [ info] [sp] stream processor started
[2026/06/26 17:03:04.676] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/06/26 17:03:06.683] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2026/06/26 17:03:06.716] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2026/06/26 17:03:07.676] [debug] [task] created task=00000276559C2230 id=0 OK
[2026/06/26 17:03:07.676] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,0",state="c1"} = 9295.8910732000004
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,0",state="c2"} = 208.55313200000001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,0",state="c3"} = 137219.84215790001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,1",state="c1"} = 13442.286695700001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,1",state="c2"} = 272.55754489999998
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,1",state="c3"} = 136962.5192066
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,2",state="c1"} = 18363.891972599999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,2",state="c2"} = 130.2987411
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,2",state="c3"} = 140891.89595420001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,3",state="c1"} = 18394.690231299999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,3",state="c2"} = 146.87673810000001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,3",state="c3"} = 140614.4917019
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,4",state="c1"} = 18393.324182699998
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,4",state="c2"} = 130.91331339999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,4",state="c3"} = 140901.0956615
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,5",state="c1"} = 18356.969965600001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,5",state="c2"} = 113.67996549999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,5",state="c3"} = 141123.31954900001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,6",state="c1"} = 17327.0885958
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,6",state="c2"} = 219.56994119999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,6",state="c3"} = 139757.0300653
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,7",state="c1"} = 17522.962978299998
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,7",state="c2"} = 180.63305130000001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,7",state="c3"} = 140218.1078233
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,8",state="c1"} = 17600.4568697
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,8",state="c2"} = 173.8375892
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,8",state="c3"} = 140489.54279070001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,9",state="c1"} = 17522.5240448
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,9",state="c2"} = 177.59460970000001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,9",state="c3"} = 140558.4336283
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,10",state="c1"} = 7762.4903029999996
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,10",state="c2"} = 193.61915740000001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,10",state="c3"} = 138503.0911967
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,11",state="c1"} = 14252.7444524
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,11",state="c2"} = 962.90285440000002
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,11",state="c3"} = 129627.62236769999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,12",state="c1"} = 7819.5007047999998
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,12",state="c2"} = 212.41929239999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,12",state="c3"} = 138384.3488759
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,13",state="c1"} = 11326.6528275
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,13",state="c2"} = 207.2948868
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,13",state="c3"} = 138482.50026629999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,14",state="c1"} = 17740.0271999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,14",state="c2"} = 207.73055909999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,14",state="c3"} = 140331.86538619999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,15",state="c1"} = 17539.975118999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,15",state="c2"} = 181.21429939999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,15",state="c3"} = 140559.91205079999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,16",state="c1"} = 17623.824232300001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,16",state="c2"} = 176.00649759999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,16",state="c3"} = 140619.0150168
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,17",state="c1"} = 17398.990005399999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,17",state="c2"} = 182.73010669999999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,17",state="c3"} = 140581.14175040001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,18",state="c1"} = 17332.445049900001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,18",state="c2"} = 232.4264986
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,18",state="c3"} = 140056.1589023
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,19",state="c1"} = 17441.164998100001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,19",state="c2"} = 197.2230146
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,19",state="c3"} = 140462.38961380001
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,20",state="c1"} = 17434.880455499999
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,20",state="c2"} = 184.2476417
2026-06-26T08:03:06.674139500Z windows_cpu_cstate_seconds_total{core="0,20",state="c3"} = 140615.51527470001
<snip>
2026-06-26T08:03:06.773174800Z windows_performancecounter_process_fluent_bit_thread_count = 13
<snip>
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_11872_luid_0x00000000_0x00014485_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_12304_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0.038007811308556433
<snip>
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_2660_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 14.387620901817147
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_2660_luid_0x00000000_0x00014453_phys_0_eng_0_engtype_3D#0"} = 0
<snip>
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_2660_luid_0x00000000_0x00014485_phys_0_eng_0_engtype_3D#0"} = 0.36890835688568813
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_27548_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_27548_luid_0x00000000_0x00014485_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_28064_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 2.6018428983539654
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_28692_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_29320_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_30636_luid_0x00000000_0x00014485_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_3080_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 1.1449325076998662
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_31488_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_33040_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_33080_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 14.838853983013891
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_33348_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_35248_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 13.977334308435408
<snip>
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_4_luid_0x00000000_0x0001406D_phys_0_eng_0_engtype_3D#0"} = 0.099330051393413152
2026-06-26T08:03:06.773174800Z windows_performancecounter_gpu_3d_utilization{instance="pid_4_luid_0x00000000_0x00014453_phys_0_eng_0_engtype_3D#0"} = 0
<snip>
[2026/06/26 17:03:07.680] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2026/06/26 17:03:07.680] [debug] [out flush] cb_destroy coro_id=0
[2026/06/26 17:03:07.680] [debug] [task] destroy task=00000276559C2230 (task_id=0)
[2026/06/26 17:03:08] [engine] caught signal (SIGINT)
[2026/06/26 17:03:08.689] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] initializing WMI instance....
[2026/06/26 17:03:08.713] [debug] [input:windows_exporter_metrics:windows_exporter_metrics.0] deinitializing WMI instance....
[2026/06/26 17:03:08.782] [debug] [task] created task=00000276559ACF30 id=0 OK
[2026/06/26 17:03:08.782] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/06/26 17:03:08.782] [ warn] [engine] service will shutdown in max 5 seconds
[2026/06/26 17:03:08.782] [debug] [engine] task 0 already scheduled to run, not re-scheduling it.
[2026/06/26 17:03:08.782] [ info] [engine] pausing all inputs..
[2026/06/26 17:03:08.782] [ info] [input] pausing windows_exporter_metrics.0
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/2610

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows performance counter metric collection support.
  * New configuration options let you set a scrape interval and define performance counter metrics.

* **Bug Fixes**
  * Improved metric lifecycle handling so the new collector pauses, resumes, and shuts down cleanly with the rest of the plugin.
  * Added support for wildcard counter paths and per-instance labels for more detailed metric output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->