### PR TITLE
out_s3: fix prefix match in log_key extraction

### DIFF
--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -3621,7 +3621,8 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
             }
 
             if (check == FLB_TRUE) {
-                if (strncmp(ctx->log_key, key_str, key_str_size) == 0) {
+                if (strlen(ctx->log_key) == key_str_size && 
+                    strncmp(ctx->log_key, key_str, key_str_size) == 0) {
                     found = FLB_TRUE;
 
                     /*


### PR DESCRIPTION
<!-- Provide summary of changes -->

This fixes `log_key` extraction in the S3 output to require an exact key match.

Previously, `flb_pack_msgpack_extract_log_key()` compared the configured `log_key` against each record key using the record key length, but did not verify that both keys had the same length. This allowed shorter prefix keys to match longer configured keys.


For example, with `log_key log_processed`, a record containing both `log` and `log_processed` could upload the value of `log` if it appeared first in the record.

This change checks that the configured `log_key` length matches the record key length before comparing the key bytes.


For example, with this config:
```
log_key log_processed
```
and this record:
```
{"log":"wrong","log_processed":"correct"}
```

the record key `log` could match the configured key `log_processed` if log appeared first in the record, because only the first 3 characters are compared:

resulting output:
```
wrong
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
[SERVICE]
    Flush        1
    Log_Level    debug

[INPUT]
    Name    dummy
    Tag     test.s3
    Dummy   {"log":"wrong","log_processed":"correct"}
    Samples 1

[OUTPUT]
    Name                         s3
    Match                        test.s3
    bucket                       fluent-bit-test
    region                       us-east-1
    endpoint                     http://127.0.0.1:9000
    total_file_size            1M
    upload_timeout         5s
    store_dir                    /tmp/flb-s3-store
    s3_key_format          /logs/$TAG/%Y/%m/%d/%H/%M/%S-$UUID
    log_key                      log_processed
```

Verified uploaded object content locally with MinIO.
Before this change, the output uploadis:
`wrong`
After this change, with the same config, the uploaded object content is:
`correct`

- [x] Debug log output from testing the change

```
[2026/06/27 07:22:30.686] [debug] [upstream] KA connection #45 to 127.0.0.1:9000 is now available
[2026/06/27 07:22:30.686] [debug] [output:s3:s3.0] PutObject http status=200
[2026/06/27 07:22:30.686] [ info] [output:s3:s3.0] Successfully uploaded object /logs/test.s3/2026/06/27/01/52/23-qEfrOjVi
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
This change only tightens the existing `log_key` comparison logic and does not add new allocations or frees.
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log key matching for structured records so only exact key names are treated as matches.
  * Prevented partial prefix matches from being accepted when a shorter field name appears in the data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->