### PR TITLE
in_tail: Another attempt to plug segv on in tail

### DIFF
--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -387,6 +387,10 @@ static int in_tail_progress_check_callback(struct flb_input_instance *ins,
 
     pending_data_detected = FLB_FALSE;
 
+    if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
+        return 0;
+    }
+
     mk_list_foreach_safe(head, tmp, &ctx->files_event) {
         file = mk_list_entry(head, struct flb_tail_file, _head);
         ret = reconcile_file_state(ctx, file, "in_tail_progress_check", &pending);

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -2289,6 +2289,28 @@ void flb_test_inotify_watcher_false()
 }
 
 #ifdef FLB_HAVE_INOTIFY
+static int wait_tail_collectors_state(struct flb_tail_config *tail_ctx,
+                                      struct flb_input_instance *ins,
+                                      int expected)
+{
+    int i;
+    int fs_running;
+    int progress_running;
+
+    for (i = 0; i < 50; i++) {
+        fs_running = flb_input_collector_running(tail_ctx->coll_fd_fs1, ins);
+        progress_running = flb_input_collector_running(tail_ctx->coll_fd_progress_check,
+                                                       ins);
+        if (fs_running == expected && progress_running == expected) {
+            return 0;
+        }
+
+        flb_time_msleep(100);
+    }
+
+    return -1;
+}
+
 void flb_test_inotify_pause_collectors()
 {
     int ret;
@@ -2335,6 +2357,54 @@ void flb_test_inotify_pause_collectors()
     TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_fs1, ins) == FLB_TRUE);
     TEST_CHECK(flb_input_collector_running(tail_ctx->coll_fd_progress_check,
                                            ins) == FLB_TRUE);
+
+    test_tail_ctx_destroy(ctx);
+}
+
+void flb_test_inotify_threaded_pause_collectors()
+{
+    int ret;
+    struct mk_list *head;
+    struct flb_input_instance *ins;
+    struct flb_tail_config *tail_ctx;
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    char *file[] = {"inotify_threaded_pause_collectors.log"};
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = NULL;
+
+    ctx = test_tail_ctx_create(&cb_data, &file[0], 1, FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file[0],
+                        "threaded", "true",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    head = ctx->flb->config->inputs.next;
+    ins = mk_list_entry(head, struct flb_input_instance, _head);
+    tail_ctx = ins->context;
+
+    ret = wait_tail_collectors_state(tail_ctx, ins, FLB_TRUE);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_pause(ins);
+    TEST_CHECK(ret == 0);
+    ret = wait_tail_collectors_state(tail_ctx, ins, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_input_resume(ins);
+    TEST_CHECK(ret == 0);
+    ret = wait_tail_collectors_state(tail_ctx, ins, FLB_TRUE);
+    TEST_CHECK(ret == 0);
 
     test_tail_ctx_destroy(ctx);
 }
@@ -2942,6 +3012,7 @@ TEST_LIST = {
 #ifdef FLB_HAVE_INOTIFY
     {"inotify_watcher_false", flb_test_inotify_watcher_false},
     {"inotify_pause_collectors", flb_test_inotify_pause_collectors},
+    {"inotify_threaded_pause_collectors", flb_test_inotify_threaded_pause_collectors},
 #endif /* FLB_HAVE_INOTIFY */
 
 #ifdef FLB_HAVE_REGEX


### PR DESCRIPTION
<!-- Provide summary of changes -->
In threaded mode, we need to pause ingesting evens chunks.
This is because with threaded mode, we must confirm the buffers on plugins whether are paused or not.
This PR adds this type of checks on ingestion.

Closes https://github.com/fluent/fluent-bit/issues/12009.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tail input processing now immediately stops extra file-event reconciliation and related progress signaling when the input is paused, reducing unnecessary work during pause.
  * Threaded inotify tail collectors now pause and resume more reliably in sync with the input state.
* **Tests**
  * Added a new threaded inotify pause/resume runtime test to verify fs1 and progress-check collectors correctly transition between running and non-running states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->