### PR TITLE
in_kubernetes_events: log missed payload on level warn instead of debug

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -754,7 +754,7 @@ static int process_http_chunk(struct k8s_events* ctx, struct flb_http_client *c,
         token_size = token_end - token_start;
         ret = flb_pack_json(token_start, token_size, &buf_data, &buf_size, &root_type, &consumed);
         if (ret == -1) {
-            flb_plg_debug(ctx->ins, "could not process payload, incomplete or bad formed JSON: %s",
+            flb_plg_warn(ctx->ins, "could not process payload, incomplete or bad formed JSON: %s",
                           c->resp.payload);
         }
         else {


### PR DESCRIPTION
<!-- Provide summary of changes -->
While https://github.com/fluent/fluent-bit/issues/11252 was closed incorrectly by stale-bot, and https://github.com/fluent/fluent-bit/pull/11268 has had no recent activity, users should at least be warned about missed kubernetes events by logging them at warning level instead of debug level.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing failures for JSON event payloads now surface as warnings instead of debug messages, making malformed or incomplete payload issues easier to notice during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->