### PR TITLE
out_stackdriver: add trust_payload_local_resource_id option

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -672,6 +672,61 @@ static int parse_monitored_resource(struct flb_stackdriver *ctx, const void *dat
 }
 
 /*
+ * Check if the payload carries a monitored resource map that
+ * parse_monitored_resource() would consume, without packing anything
+ */
+static int payload_has_monitored_resource(const void *data, size_t bytes)
+{
+    int found = FLB_FALSE;
+    int ret;
+    msgpack_object *obj;
+    msgpack_object_kv *kv;
+    msgpack_object_kv *kvend;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    struct flb_log_event_decoder log_decoder;
+    struct flb_log_event log_event;
+
+    ret = flb_log_event_decoder_init(&log_decoder, (char *) data, bytes);
+    if (ret != FLB_EVENT_DECODER_SUCCESS) {
+        return FLB_FALSE;
+    }
+
+    while (found == FLB_FALSE &&
+           flb_log_event_decoder_next(&log_decoder,
+                                      &log_event) == FLB_EVENT_DECODER_SUCCESS) {
+        obj = log_event.body;
+        kv = obj->via.map.ptr;
+        kvend = obj->via.map.ptr + obj->via.map.size;
+        for (; kv < kvend; ++kv) {
+            if (kv->val.type != MSGPACK_OBJECT_MAP ||
+                kv->key.type != MSGPACK_OBJECT_STR ||
+                strncmp(MONITORED_RESOURCE_KEY,
+                        kv->key.via.str.ptr, kv->key.via.str.size) != 0) {
+                continue;
+            }
+
+            p = kv->val.via.map.ptr;
+            pend = kv->val.via.map.ptr + kv->val.via.map.size;
+            for (; p < pend; ++p) {
+                if (p->key.type == MSGPACK_OBJECT_STR &&
+                    p->val.type == MSGPACK_OBJECT_MAP &&
+                    p->val.via.map.size > 0 &&
+                    strncmp("labels", p->key.via.str.ptr,
+                            p->key.via.str.size) == 0) {
+                    found = FLB_TRUE;
+                    break;
+                }
+            }
+        }
+    }
+
+    flb_log_event_decoder_destroy(&log_decoder);
+
+    return found;
+}
+
+/*
  * Given a local_resource_id, split the content using the proper separator generating
  * a linked list to store the spliited string
  */
@@ -748,8 +803,13 @@ static int extract_local_resource_id(const void *data, size_t bytes,
                     &log_decoder,
                     &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
         map = log_event.body->via.map;
-        local_resource_id = get_str_value_from_msgpack_map(map, LOCAL_RESOURCE_ID_KEY,
-                                                           LEN_LOCAL_RESOURCE_ID_KEY);
+        if (ctx->trust_payload_local_resource_id == FLB_TRUE) {
+            local_resource_id = get_str_value_from_msgpack_map(map, LOCAL_RESOURCE_ID_KEY,
+                                                               LEN_LOCAL_RESOURCE_ID_KEY);
+        }
+        else {
+            local_resource_id = NULL;
+        }
 
         if (local_resource_id == NULL) {
             /* if local_resource_id is not found, use the tag of the log */
@@ -1091,13 +1151,21 @@ static int process_local_resource_id(struct stackdriver_format_ctx *fmt_ctx,
     if (is_tag_match_regex(ctx, tag, tag_len) > 0) {
         ret = extract_resource_labels_from_regex(fmt_ctx, tag, tag_len, FLB_TRUE);
     }
-    else {
+    else if (ctx->trust_payload_local_resource_id == FLB_TRUE) {
         if (is_local_resource_id_match_regex(fmt_ctx) > 0) {
             ret = extract_resource_labels_from_regex(fmt_ctx, tag, tag_len, FLB_FALSE);
         }
         else {
             ret = set_monitored_resource_labels(fmt_ctx, type);
         }
+    }
+    else {
+        /*
+         * The payload cannot be trusted and the tag carries no resource
+         * labels; stackdriver_format() already fell back to the cluster
+         * scoped resource before reaching this path.
+         */
+        ret = -1;
     }
 
     return ret;
@@ -1881,6 +1949,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     char *new_trace;
     char *newtag;
     char *new_log_name;
+    const char *resource_type;
     char *operation_id;
     char *operation_producer;
     char *source_location_file;
@@ -1952,12 +2021,31 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     /* type & labels */
     msgpack_pack_map(&mp_pck, 2);
 
+    /*
+     * When the payload local_resource_id is untrusted and no trusted source
+     * of resource labels is available (tag regex, configured resource labels
+     * or a payload monitored resource), attribute the entries to the cluster
+     * scoped resource instead of forgeable namespace/pod/container labels.
+     */
+    resource_type = ctx->resource;
+    if (ctx->trust_payload_local_resource_id == FLB_FALSE &&
+        ctx->resource_type == RESOURCE_TYPE_K8S &&
+        strcmp(ctx->resource, K8S_CLUSTER) != 0 &&
+        (ctx->should_skip_resource_labels_api == FLB_TRUE ||
+         mk_list_size(&ctx->resource_labels_kvs) == 0) &&
+        payload_has_monitored_resource(data, bytes) == FLB_FALSE &&
+        is_tag_match_regex(ctx, tag, tag_len) <= 0) {
+        resource_type = K8S_CLUSTER;
+        flb_plg_debug(ctx->ins, "untrusted payload local_resource_id and tag "
+                      "without resource labels; falling back to k8s_cluster "
+                      "resource for tag %s", tag);
+    }
+
     /* type */
     msgpack_pack_str(&mp_pck, 4);
     msgpack_pack_str_body(&mp_pck, "type", 4);
-    msgpack_pack_str(&mp_pck, flb_sds_len(ctx->resource));
-    msgpack_pack_str_body(&mp_pck, ctx->resource,
-                          flb_sds_len(ctx->resource));
+    msgpack_pack_str(&mp_pck, strlen(resource_type));
+    msgpack_pack_str_body(&mp_pck, resource_type, strlen(resource_type));
 
     msgpack_pack_str(&mp_pck, 6);
     msgpack_pack_str_body(&mp_pck, "labels", 6);
@@ -2077,7 +2165,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
                 }
                 flb_mp_map_header_end(&mh);
             }
-            else if (strcmp(ctx->resource, K8S_CONTAINER) == 0) {
+            else if (strcmp(resource_type, K8S_CONTAINER) == 0) {
                 /* k8s_container resource has fields project_id, location, cluster_name,
                 *                                   namespace_name, pod_name, container_name
                 *
@@ -2154,7 +2242,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
 
                 flb_mp_map_header_end(&mh);
             }
-            else if (strcmp(ctx->resource, K8S_NODE) == 0) {
+            else if (strcmp(resource_type, K8S_NODE) == 0) {
                 /* k8s_node resource has fields project_id, location, cluster_name, node_name
                 *
                 * The local_resource_id for k8s_node is in format:
@@ -2210,7 +2298,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
 
                 flb_mp_map_header_end(&mh);
             }
-            else if (strcmp(ctx->resource, K8S_POD) == 0) {
+            else if (strcmp(resource_type, K8S_POD) == 0) {
                 /* k8s_pod resource has fields project_id, location, cluster_name,
                 *                             namespace_name, pod_name.
                 *
@@ -2277,7 +2365,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
 
                 flb_mp_map_header_end(&mh);
             }
-            else if (strcmp(ctx->resource, K8S_CLUSTER) == 0) {
+            else if (strcmp(resource_type, K8S_CLUSTER) == 0) {
                 /* k8s_cluster resource has fields project_id, location, cluster_name
                 *
                 * There is no local_resource_id for k8s_cluster as we get all info
@@ -3386,7 +3474,13 @@ static struct flb_config_map config_map[] = {
       0, FLB_TRUE, offsetof(struct flb_stackdriver, cloud_logging_base_url),
       "The base Cloud Logging API URL to use for the /v2/entries:write API request. Default: https://logging.googleapis.com"
     },
-
+    {
+      FLB_CONFIG_MAP_BOOL, "trust_payload_local_resource_id", "true",
+      0, FLB_TRUE, offsetof(struct flb_stackdriver, trust_payload_local_resource_id),
+      "Trust the logging.googleapis.com/local_resource_id field supplied in the "
+      "log payload. When disabled and the tag carries no resource labels, "
+      "entries are attributed to the k8s_cluster resource instead"
+    },
 
     /* EOF */
     {0}

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -217,6 +217,9 @@ struct flb_stackdriver {
     flb_sds_t cloud_logging_base_url;
     flb_sds_t cloud_logging_write_url;
 
+    /* trust the local_resource_id supplied in the log payload */
+    int trust_payload_local_resource_id;
+
 #ifdef FLB_HAVE_METRICS
     /* metrics */
     struct cmt_counter *cmt_successful_requests;

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -621,7 +621,52 @@ static void cb_check_k8s_container_resource(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_k8s_container_untrusted(void *ctx, int ffd,
+                                             int res_ret, void *res_data, size_t res_size,
+                                             void *data)
+{
+    int ret;
 
+    /* payload local_resource_id is untrusted and the tag does not match the
+     * regex, so entries fall back to the cluster scoped resource */
+    ret = mp_kv_cmp(res_data, res_size, "$resource['type']", "k8s_cluster");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* project id */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['project_id']", "fluent-bit");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* location */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['location']", "test_cluster_location");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* cluster name */
+    ret = mp_kv_cmp(res_data, res_size,
+                    "$resource['labels']['cluster_name']", "test_cluster_name");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* no workload scoped labels may be derived from the untrusted payload */
+    ret = mp_kv_exists(res_data, res_size,
+                       "$resource['labels']['namespace_name']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_exists(res_data, res_size,
+                       "$resource['labels']['pod_name']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_exists(res_data, res_size,
+                       "$resource['labels']['container_name']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* check `local_resource_id` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size,
+                       "$entries[0]['jsonPayload']['logging.googleapis.com/local_resource_id']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
 
 static void cb_check_k8s_container_resource_diff_tag(void *ctx, int ffd,
                                                      int res_ret, void *res_data, size_t res_size,
@@ -3632,7 +3677,96 @@ void flb_test_resource_k8s_container_common()
     flb_destroy(ctx);
 }
 
+void flb_test_resource_k8s_container_untrusted()
+{
+    int ret;
+    int size = sizeof(K8S_CONTAINER_COMMON) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
 
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   "trust_payload_local_resource_id", "false",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_container_untrusted,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample carrying a forged local_resource_id */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_COMMON, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_resource_k8s_container_untrusted_tag_wins()
+{
+    int ret;
+    int size = sizeof(K8S_CONTAINER_COMMON_DIFF_TAGS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag",
+                  "kube.var.log.containers.apache-logs-annotated_default_apache-aeeccc7a9f00f6e4e066aeff0434cf80621215071f1b20a51e8340aa7c35eac6.log", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "kube.var.log.containers.*",
+                   "resource", "k8s_container",
+                   "google_service_credentials", SERVICE_CREDENTIALS,
+                   "k8s_cluster_name", "test_cluster_name",
+                   "k8s_cluster_location", "test_cluster_location",
+                   "tag_prefix", "kube.var.log.containers.",
+                   "trust_payload_local_resource_id", "false",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_k8s_container_resource_default_regex,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample with a different local_resource_id in the payload;
+     * the trusted tag must win over the untrusted payload value */
+    flb_lib_push(ctx, in_ffd, (char *) K8S_CONTAINER_COMMON_DIFF_TAGS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
 
 void flb_test_resource_k8s_container_multi_tag_value()
 {
@@ -6720,7 +6854,8 @@ TEST_LIST = {
 
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
-
+    {"resource_k8s_container_untrusted", flb_test_resource_k8s_container_untrusted },
+    {"resource_k8s_container_untrusted_tag_wins", flb_test_resource_k8s_container_untrusted_tag_wins },
     {"resource_k8s_container_no_local_resource_id", flb_test_resource_k8s_container_no_local_resource_id },
     {"resource_k8s_container_multi_tag_value", flb_test_resource_k8s_container_multi_tag_value } ,
     {"resource_k8s_container_concurrency", flb_test_resource_k8s_container_concurrency },


### PR DESCRIPTION
## Summary

Adds a `trust_payload_local_resource_id` option (default: `true`, existing behavior unchanged) to the Stackdriver output.

The plugin reads `logging.googleapis.com/local_resource_id` from the **log payload** to derive the `k8s_container` / `k8s_pod` / `k8s_node` monitored-resource labels. In multi-tenant pipelines the payload is workload-controlled: a compromised or malicious workload can forge this field and attribute its log entries to another namespace/pod/container across trust boundaries (log-injection/forgery). The Go-based logging agent addressed the same issue in GoogleCloudPlatform/k8s-stackdriver#1186.

With `trust_payload_local_resource_id false`:

- the payload `local_resource_id` is ignored; resource labels are derived only from trusted sources — the tag (`tag_prefix` + regex), configured `resource_labels`, or a payload monitored-resource map;
- when none of those sources is available, entries fall back to the cluster-scoped `k8s_cluster` resource (project/location/cluster labels from plugin config) rather than packing workload-scoped labels forged from the payload.

This is defense-in-depth for pipelines that currently trust the payload value; pipelines where the tag regex always resolves (e.g. standard `tail` + kubernetes setups) see no behavioral difference other than the forged value being ignored.

> **Note:** #12023 (the multi-worker data-race fix this change was based on) has merged. This PR is now rebased onto current master and contains only the two `trust_payload_local_resource_id` commits.

## Testing

- [x] New runtime tests:
  - `resource_k8s_container_untrusted`: payload-supplied `local_resource_id` with a non-matching tag falls back to `k8s_cluster` with no workload labels.
  - `resource_k8s_container_untrusted_tag_wins`: a tag matching the default regex still resolves the full `k8s_container` resource; the untrusted payload value is ignored.
- [x] `ctest -R flb-rt-out_stackdriver` passes (full suite, including the multi-worker concurrency test).
- [x] Valgrind memcheck on the new tests: 0 errors, no leaks.

## Documentation

- [ ] Docs PR for the new config option to follow in fluent/fluent-bit-docs once the option name/semantics are settled in review.

## Backporting

- [N/A] New optional feature, no backport needed.

---
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether resource identifiers in log payloads are trusted.
  * Untrusted identifiers now fall back to cluster-level resource attribution when trusted resource details are unavailable.
  * Trusted tag-based resource information takes precedence over untrusted payload data.

* **Bug Fixes**
  * Prevented forged payload metadata from generating misleading namespace, pod, or container labels.

* **Tests**
  * Added coverage for untrusted payload identifiers and trusted tag overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->