### PR TITLE
filter_write_tag: in_emitter: Mitigate data loss on multiline

### DIFF
--- a/plugins/filter_rewrite_tag/rewrite_tag.c
+++ b/plugins/filter_rewrite_tag/rewrite_tag.c
@@ -414,7 +414,8 @@ static int process_record(const char *tag, int tag_len, msgpack_object map,
     /* Release the tag */
     flb_sds_destroy(out_tag);
 
-    if (ret == -1) {
+    if (ret < 0) {
+        *keep = FLB_TRUE;
         return FLB_FALSE;
     }
 

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -163,14 +163,15 @@ int in_emitter_add_record(const char *tag, int tag_len,
     }
 
 
-    /* Restricted by mem_buf_limit */
-    if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
-        flb_plg_debug(ctx->ins, "emitter memory buffer limit reached. Not accepting record.");
-        return FLB_EMITTER_BUSY;
-    }
-
     /* Use the ring buffer first if it exists */
     if (ctx->msgs) {
+        /* Restricted by mem_buf_limit */
+        if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
+            flb_plg_debug(ctx->ins,
+                          "emitter memory buffer limit reached. Not accepting record.");
+            return FLB_EMITTER_BUSY;
+        }
+
         memset(&temporary_chunk, 0, sizeof(struct em_chunk));
 
         temporary_chunk.tag = flb_sds_create_len(tag, tag_len);
@@ -208,6 +209,16 @@ int in_emitter_add_record(const char *tag, int tag_len,
                       tag);
             return -1;
         }
+    }
+
+    /*
+     * When the emitter is paused, caller-side filters cannot ask the engine to
+     * retry the same record. Keep it in the emitter queue so the collector can
+     * ingest it after resume instead of forcing callers to drop or retag it.
+     */
+    if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
+        flb_plg_debug(ctx->ins,
+                      "emitter memory buffer limit reached. Buffering record.");
     }
 
     /* Append raw msgpack data */
@@ -411,8 +422,7 @@ static int cb_emitter_exit(void *data, struct flb_config *config)
 
     mk_list_foreach_safe(head, tmp, &ctx->chunks) {
         echunk = mk_list_entry(head, struct em_chunk, _head);
-        mk_list_del(&echunk->_head);
-        flb_free(echunk);
+        em_chunk_destroy(echunk);
     }
 
     if (ctx->msgs) {

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -49,6 +49,7 @@ struct input_ref {
 
 struct flb_emitter {
     int coll_fd;                        /* collector id */
+    size_t pending_bytes;               /* bytes waiting in chunks list */
     struct mk_list chunks;              /* list of all pending chunks */
     struct flb_input_instance *ins;     /* input instance */
     struct flb_ring_buffer *msgs;       /* ring buffer for cross-thread messages */
@@ -82,12 +83,33 @@ struct em_chunk *em_chunk_create(const char *tag, int tag_len,
     return ec;
 }
 
-static void em_chunk_destroy(struct em_chunk *ec)
+static void em_chunk_destroy(struct flb_emitter *ctx, struct em_chunk *ec)
 {
+    if (ctx->pending_bytes >= ec->mp_sbuf.size) {
+        ctx->pending_bytes -= ec->mp_sbuf.size;
+    }
+    else {
+        ctx->pending_bytes = 0;
+    }
+
     mk_list_del(&ec->_head);
     flb_sds_destroy(ec->tag);
     msgpack_sbuffer_destroy(&ec->mp_sbuf);
     flb_free(ec);
+}
+
+static int is_queue_overlimit(struct flb_emitter *ctx, size_t append_size)
+{
+    if (ctx->ins->mem_buf_limit == 0) {
+        return FLB_FALSE;
+    }
+
+    if (ctx->ins->mem_chunks_size + ctx->pending_bytes + append_size >
+        ctx->ins->mem_buf_limit) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
 }
 
 int static do_in_emitter_add_record(struct em_chunk *ec,
@@ -110,10 +132,10 @@ int static do_in_emitter_add_record(struct em_chunk *ec,
     if (ret == -1) {
         flb_plg_error(ctx->ins, "error registering chunk with tag: %s", ec->tag);
         /* Release the echunk */
-        em_chunk_destroy(ec);
+        em_chunk_destroy(ctx, ec);
         return -1;
     }
-    em_chunk_destroy(ec);
+    em_chunk_destroy(ctx, ec);
     return 0;
 }
 
@@ -131,6 +153,7 @@ int in_emitter_add_record(const char *tag, int tag_len,
     struct input_ref *i_ref;
     bool ref_found;
     struct mk_list *tmp;
+    int ret;
 
     struct em_chunk *ec;
     struct flb_emitter *ctx;
@@ -191,6 +214,12 @@ int in_emitter_add_record(const char *tag, int tag_len,
                                      sizeof(struct em_chunk));
     }
 
+    if (is_queue_overlimit(ctx, buf_size) == FLB_TRUE) {
+        flb_plg_debug(ctx->ins,
+                      "emitter memory buffer limit reached. Not accepting record.");
+        return FLB_EMITTER_BUSY;
+    }
+
     /* Check if any target chunk already exists */
     mk_list_foreach(head, &ctx->chunks) {
         ec = mk_list_entry(head, struct em_chunk, _head);
@@ -222,7 +251,12 @@ int in_emitter_add_record(const char *tag, int tag_len,
     }
 
     /* Append raw msgpack data */
-    msgpack_sbuffer_write(&ec->mp_sbuf, buf_data, buf_size);
+    ret = msgpack_sbuffer_write(&ec->mp_sbuf, buf_data, buf_size);
+    if (ret != 0) {
+        return -1;
+    }
+
+    ctx->pending_bytes += buf_size;
     return 0;
 }
 
@@ -422,7 +456,7 @@ static int cb_emitter_exit(void *data, struct flb_config *config)
 
     mk_list_foreach_safe(head, tmp, &ctx->chunks) {
         echunk = mk_list_entry(head, struct em_chunk, _head);
-        em_chunk_destroy(echunk);
+        em_chunk_destroy(ctx, echunk);
     }
 
     if (ctx->msgs) {

--- a/tests/runtime/filter_rewrite_tag.c
+++ b/tests/runtime/filter_rewrite_tag.c
@@ -348,10 +348,67 @@ static void flb_test_heavy_input_pause_emitter()
         TEST_MSG("callback is not invoked");
     }
 
-    /* Input should be paused since Mem_Buf_Limit is small size.
-     * So got is less than heavy_loop.
+    /*
+     * Input should be paused since Mem_Buf_Limit is small size. Retagged
+     * records accepted within the emitter budget should drain, but the
+     * emitter must stop accepting before the full unbounded stream is queued.
      */
     if(!TEST_CHECK(heavy_loop > got)) {
+        TEST_MSG("expect: %d got: %d", heavy_loop, got);
+    }
+
+    filter_test_destroy(ctx);
+}
+
+static void flb_test_busy_emitter_keeps_original()
+{
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    int ret;
+    int not_used = 0;
+    int bytes;
+    int heavy_loop = 100000;
+    int got;
+    char p[256];
+    int i;
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+    clear_output_num();
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "Rule", "$key ^(rewrite)$ updated false",
+                         "Emitter_Mem_Buf_Limit", "1kb",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "Match", "*",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_service_set(ctx->flb, "Log_Level", "Off", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    for (i = 0; i < heavy_loop; i++) {
+        memset(p, '\0', sizeof(p));
+        snprintf(p, sizeof(p), "[%d, {\"val\": \"%d\",\"key\": \"rewrite\"}]", i, i);
+        bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, strlen(p));
+        TEST_CHECK(bytes == strlen(p));
+    }
+
+    flb_time_msleep(1500);
+    got = get_output_num();
+
+    if (!TEST_CHECK(got == heavy_loop)) {
         TEST_MSG("expect: %d got: %d", heavy_loop, got);
     }
 
@@ -557,6 +614,7 @@ TEST_LIST = {
     {"not_matched",      flb_test_not_matched},
     {"keep_true",        flb_test_keep_true},
     {"heavy_input_pause_emitter", flb_test_heavy_input_pause_emitter},
+    {"busy_emitter_keeps_original", flb_test_busy_emitter_keeps_original},
     {"issue_4518", flb_test_issue_4518},
     {"issue_4793", flb_test_issue_4793},
     {"sigsegv_issue_5846", flb_test_issue_5846},


### PR DESCRIPTION
<!-- Provide summary of changes -->

With the reproducer, I addressed like as:

```
% bash /private/tmp/rewrite_tag_repro_local.sh
Binary:  bin/fluent-bit
Runs:    1   Cycles/run: 150   Emitter limit: 1M   Flush: 5s

===== run 1/1 =====
  follower : 150/150 delivered (100.00%)
  timeout  : 150/150 delivered (100.00%)
  RESULT: timeout_lost=0 follower_lost=0

========================================================
```

<details>

```shell
#!/usr/bin/env bash
# Self-contained reproducer for the in_emitter FLB_EMITTER_BUSY (-2) silent
# record-loss bug in Fluent Bit's rewrite_tag filter.
#
# Bug: when a rewrite_tag rule re-emits a record into a shared in_emitter
# whose mem-buf-limit is already reached, in_emitter_add_record() returns
# FLB_EMITTER_BUSY (-2) WITHOUT buffering the record. rewrite_tag.c only
# checks `if (ret == -1)`, so the -2 falls through, the filter reports the
# record as emitted, and with keep_record=false (the trailing `false` on the
# Rule) the original is dropped from the stream. Net effect: permanent,
# silent loss of that record.
#
# Why a TIMEOUT-flushed multiline record specifically: #8473's back-pressure
# pauses the SOURCE tail when the emitter is over its limit, which stops
# read-coupled flushes. But a multiline TIMEOUT flush is driven by an idle
# TIMER, not by a read, so it fires while the tail is paused and reaches the
# still-paused emitter -> hits the -2 path. Read-coupled "follower" flushes
# (flushed because the next start line arrived) only happen while reading,
# i.e. while the emitter has room, so they are never lost.
#
# This local variant keeps the original reproducer workload, config, and tally
# logic, but runs a local Fluent Bit binary instead of a stock container image.
# The writer runs as a local POSIX sh process and both processes share a temp
# directory:
#   writer (sh)          -- floods a noise file to keep the shared emitter at
#                           its limit, and single-writes victim burst+idle
#                           pairs so each pair's trailing line is timeout-flushed.
#   fluent-bit (FB_BIN)  -- tails both files; both inputs re-emit through ONE
#                           rewrite_tag/in_emitter; victim -> stdout, noise -> null.
# The host then tallies victim delivery by flush class from the fb stdout.
#
# Usage:
#   bash repro.sh                         # 1 run, defaults
#   RUNS=5 bash repro.sh                  # 5 runs, report repro rate
#   CYCLES=200 bash repro.sh              # more cycles -> more events
#   FB_BIN=build/bin/fluent-bit bash repro.sh
#
# Exit status: 0 if no timeout-flushed loss in any run, 1 if loss occurred.
set -euo pipefail

FB_BIN="${FB_BIN:-bin/fluent-bit}"
RUNS="${RUNS:-1}"
CYCLES="${CYCLES:-150}"          # victim burst+idle pairs per run
IDLE="${IDLE:-1.2}"             # idle after the timeout line (must exceed 1s flush_timeout)
RECV_GAP="${RECV_GAP:-0.007}"   # gap between the follower line and the timeout line
DRAIN="${DRAIN:-8}"             # seconds after last line for the final flushes to land
FLUSH="${FLUSH:-5}"             # engine flush; re-emitted chunks sit this long between drains
EMITTER_LIMIT="${EMITTER_LIMIT:-1M}"  # shared in_emitter mem-buf-limit; lower = easier to pause
NOISE_SIZE="${NOISE_SIZE:-65536}"     # bytes per noise line
NOISE_BURST="${NOISE_BURST:-16}"      # noise lines per burst
NOISE_GAP="${NOISE_GAP:-0.3}"         # seconds between noise bursts

if [[ ! -x "$FB_BIN" ]]; then
    echo "ERROR: FB_BIN is not executable: $FB_BIN" >&2
    exit 2
fi

CFG_DIR="$(mktemp -d)"
if [[ "${KEEP_DIR:-0}" = "1" ]]; then
    trap 'echo "kept repro dir: '"$CFG_DIR"'"' EXIT
else
    trap 'rm -rf "$CFG_DIR"' EXIT
fi

# --- generated config: minimal, generic, no project-specific naming ---------
cat > "$CFG_DIR/parsers.conf" <<'PARSERS'
# Each victim line starts with a "[YYYY-MM-DD HH:MM:SS" preamble, so every
# line is a multiline start_state -> its own one-line record. The previous
# record flushes when the next start line arrives (follower) or, for the last
# line before an idle gap, when flush_timeout (1000ms) fires (timeout).
[MULTILINE_PARSER]
    name           repro
    type           regex
    flush_timeout  1000
    rule  "start_state"  "/^\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}/"  "cont"
    rule  "cont"         "/^(?!\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/"  "cont"
PARSERS

cat > "$CFG_DIR/fluent-bit.conf" <<FLUENTBIT
[SERVICE]
    Flush         ${FLUSH}
    Daemon        Off
    Log_Level     info
    Parsers_File  ${CFG_DIR}/parsers.conf

# Victim: multiline tail. Single-writer burst+idle pairs make each pair's
# trailing line a lone timeout-flushed single-record chunk.
[INPUT]
    Name              tail
    Tag               in.victim
    Path              ${CFG_DIR}/victim.log
    DB                ${CFG_DIR}/victim.db
    Read_from_Head    true
    Buffer_Max_Size   1024k
    Skip_Long_Lines   On
    multiline.parser  repro
    multiline_flush   1

# Aggressor: plain high-volume tail. Its only job is to keep the shared
# in_emitter at its mem-buf-limit while the victim trickles. Buffer_Max_Size
# MUST exceed NOISE_SIZE (default 64KB); the tail default is 32KB, so without
# this the big noise lines hit Skip_Long_Lines and never pressure the emitter.
[INPUT]
    Name              tail
    Tag               in.noise
    Path              ${CFG_DIR}/noise.log
    DB                ${CFG_DIR}/noise.db
    Read_from_Head    true
    Buffer_Max_Size   1024k
    Skip_Long_Lines   On

[FILTER]
    Name    modify
    Alias   tag-victim
    Match   in.victim
    Add     kind  victim

[FILTER]
    Name    modify
    Alias   tag-noise
    Match   in.noise
    Add     kind  noise

# The stage under test: BOTH inputs re-emitted through ONE in_emitter.
# keep_record=false (trailing \`false\`) means the original is dropped once the
# filter believes the re-emit succeeded -- including when it actually got -2.
[FILTER]
    Name                   rewrite_tag
    Alias                  retag-shared-emitter
    Match                  in.*
    Rule                   \$kind ^(.+)\$ out.\$1 false
    Emitter_Name           shared_emitter
    Emitter_Mem_Buf_Limit  ${EMITTER_LIMIT}

# Victim -> stdout (the host tallies seq=/cls= here). Noise -> discard.
[OUTPUT]
    Name              stdout
    Match             out.victim
    Format            json_lines

[OUTPUT]
    Name    null
    Match   out.noise
FLUENTBIT

# Local writer (POSIX sh). It is intentionally close to the original
# in-container writer; DATA_DIR replaces the container's /data mount point.
cat > "$CFG_DIR/writer.sh" <<'WRITER'
#!/bin/sh
set -eu
V="$DATA_DIR/victim.log"
N="$DATA_DIR/noise.log"
L="$DATA_DIR/ledger.tsv"

noise_line=$(head -c "$NOISE_SIZE" /dev/zero | tr '\0' x)
(
  while true; do
    n=0
    while [ "$n" -lt "$NOISE_BURST" ]; do
      printf '%s\n' "$noise_line" >> "$N"
      n=$((n + 1))
    done
    sleep "$NOISE_GAP"
  done
) &
NOISE_PID=$!

i=1
while [ "$i" -le "$CYCLES" ]; do
  seq=$(printf '%06d' "$i")
  ts="[$(date '+%Y-%m-%d %H:%M:%S')]"
  printf '%s seq=%s cls=follower MSG ping received\n' "$ts" "$seq" >> "$V"
  printf '%s\tfollower\n' "$seq" >> "$L"
  sleep "$RECV_GAP"
  ts="[$(date '+%Y-%m-%d %H:%M:%S')]"
  printf '%s seq=%s cls=timeout MSG ping succeeded\n' "$ts" "$seq" >> "$V"
  printf '%s\ttimeout\n' "$seq" >> "$L"
  sleep "$IDLE"
  i=$((i + 1))
done

kill "$NOISE_PID" 2>/dev/null || true
wait "$NOISE_PID" 2>/dev/null || true
sleep "$DRAIN"
WRITER

# Host-side analyzer: tally victim delivery by flush class.
cat > "$CFG_DIR/tally.py" <<'TALLY'
import json, re, sys
ledger_path, stdout_path = sys.argv[1], sys.argv[2]
pat = re.compile(r"seq=(\d{6}) cls=(follower|timeout)")
emitted = {"follower": set(), "timeout": set()}
with open(ledger_path) as f:
    for line in f:
        line = line.strip()
        if not line:
            continue
        seq, cls = line.split("\t")
        emitted[cls].add(seq)
delivered = {"follower": set(), "timeout": set()}
with open(stdout_path) as f:
    for line in f:
        line = line.strip()
        if not line:
            continue
        try:
            rec = json.loads(line)
        except json.JSONDecodeError:
            m = pat.search(line)
            if m:
                delivered[m.group(2)].add(m.group(1))
            continue
        m = pat.search(rec.get("log", ""))
        if m:
            delivered[m.group(2)].add(m.group(1))
lost = {c: sorted(emitted[c] - delivered[c]) for c in emitted}
# Drop the final-cycle line: it can be cut off by process teardown, which is
# a harness artifact, not the emitter bug.
last = "%06d" % max((int(s) for c in emitted for s in emitted[c]), default=0)
for c in lost:
    lost[c] = [s for s in lost[c] if s != last]
for c in ("follower", "timeout"):
    e = len(emitted[c]); l = len(lost[c]); d = e - l
    rate = (d / e * 100) if e else 0.0
    print(f"  {c:9s}: {d}/{e} delivered ({rate:.2f}%)")
    if lost[c]:
        prev = " ".join(lost[c][:20])
        more = "" if len(lost[c]) <= 20 else f" ... (+{len(lost[c]) - 20} more)"
        print(f"             LOST: {prev}{more}")
t_lost = len(lost["timeout"]); f_lost = len(lost["follower"])
print(f"  RESULT: timeout_lost={t_lost} follower_lost={f_lost}")
sys.exit(1 if t_lost else 0)
TALLY

run_once() {
    run_idx="$1"
    fb_pid=""

    # Pre-create files before Fluent Bit starts. On macOS in particular, this
    # avoids a watcher timing difference from the container volume repro.
    : > "$CFG_DIR/victim.log"
    : > "$CFG_DIR/noise.log"
    : > "$CFG_DIR/ledger.tsv"

    # Start local Fluent Bit, tailing the files in the temp directory.
    "$FB_BIN" -c "$CFG_DIR/fluent-bit.conf" > "$CFG_DIR/fb.stdout.${run_idx}" 2>&1 &
    fb_pid=$!
    sleep 3   # let the tail watcher initialize before any write

    # Writer process: floods noise + single-writes victim pairs, then drains.
    DATA_DIR="$CFG_DIR" CYCLES="$CYCLES" IDLE="$IDLE" RECV_GAP="$RECV_GAP" \
        DRAIN="$DRAIN" NOISE_SIZE="$NOISE_SIZE" NOISE_BURST="$NOISE_BURST" \
        NOISE_GAP="$NOISE_GAP" sh "$CFG_DIR/writer.sh"

    # Keep per-run ledger names like the original script.
    mv "$CFG_DIR/ledger.tsv" "$CFG_DIR/ledger.tsv.${run_idx}"

    sleep "$FLUSH"
    kill -TERM "$fb_pid" 2>/dev/null || true
    wait "$fb_pid" 2>/dev/null || true
}

echo "Binary:  $FB_BIN"
echo "Runs:    $RUNS   Cycles/run: $CYCLES   Emitter limit: $EMITTER_LIMIT   Flush: ${FLUSH}s"
echo

runs_with_loss=0
for r in $(seq 1 "$RUNS"); do
    echo "===== run $r/$RUNS ====="
    run_once "$r"
    if python3 "$CFG_DIR/tally.py" "$CFG_DIR/ledger.tsv.${r}" "$CFG_DIR/fb.stdout.${r}"; then
        :
    else
        runs_with_loss=$((runs_with_loss + 1))
    fi
    echo
done

echo "========================================================"
echo "Reproduced timeout-flushed loss in ${runs_with_loss}/${RUNS} run(s)."
[ "$runs_with_loss" -gt 0 ] && exit 1 || exit 0
```

</details>


Closes https://github.com/fluent/fluent-bit/issues/12026.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rewritten records when the emitter is busy or paused, helping ensure original records are preserved on negative failure cases.
  * Refined paused buffering behavior so records are queued more consistently and only limited when the emitter’s buffered payload exceeds the configured limit.
  * Consolidated shutdown cleanup to better release queued chunks and buffered data.
* **Tests**
  * Updated runtime pause/busy expectations and added a new regression test to confirm rewritten records remain correct and all expected output is emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->