### PR TITLE
in_forward: validate PING is a msgpack array in check_ping

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -550,6 +550,13 @@ static int check_ping(struct flb_input_instance *ins,
 
     /* Parse PING message */
     root = result.data;
+    if (root.type != MSGPACK_OBJECT_ARRAY) {
+        flb_plg_error(ins, "Invalid PING message");
+        flb_free(serverside);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
     if (root.via.array.size != 6) {
         flb_plg_error(ins, "Invalid PING message");
         flb_free(serverside);


### PR DESCRIPTION
ASan, with a malformed secure-forward PING where the client sends a 6-byte msgpack str where the array is expected:

    ==ERROR: AddressSanitizer: SEGV on unknown address 0x414141414141
      #0 strncmp
      #1 check_ping fw_prot.c:568

check_ping reads root.via.array.size and root.via.array.ptr[0] before checking root.type == MSGPACK_OBJECT_ARRAY. via is a union, so a non-array PING makes via.array.ptr alias attacker-controlled bytes and the strncmp at line 568 dereferences a pointer the client fully controls. The PING is read straight off the socket during the shared_key handshake, before auth completes. Every other array parser in this file (fw_prot_process, get_options_chunk, get_options_metadata) checks the type first; check_ping was the only one missing it.