### PR TITLE
out_forward: align secure forward handshake and chunk ack with protocol spec

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -947,6 +947,20 @@ static int config_set_properties(struct flb_upstream_node *node,
         fc->password = "";
     }
 
+    /*
+     * username/password authorization is part of the secure forward
+     * handshake, which is only performed when a shared_key is set. Reject
+     * credentials that would otherwise be silently ignored.
+     */
+    if (fc->shared_key == NULL &&
+        (strlen(fc->username) > 0 || strlen(fc->password) > 0)) {
+        flb_plg_error(ctx->ins,
+                      "'username'/'password' is set but no 'shared_key' or "
+                      "'empty_shared_key' is configured: username/password "
+                      "authentication requires the secure forward handshake");
+        return -1;
+    }
+
     /* Self Hostname */
     tmp = config_get_property("self_hostname", node, ctx);
     if (tmp) {
@@ -1111,7 +1125,11 @@ static int forward_config_ha(const char *upstream_file,
         }
 
         /* Read properties into 'fc' context */
-        config_set_properties(node, fc, ctx);
+        ret = config_set_properties(node, fc, ctx);
+        if (ret == -1) {
+            forward_config_destroy(fc);
+            return -1;
+        }
 
         /* Initialize and validate forward_config context */
         ret = forward_config_init(fc, ctx);
@@ -1218,7 +1236,11 @@ static int forward_config_simple(struct flb_forward *ctx,
         flb_output_upstream_set(ctx->u, ins);
     }
     /* Read properties into 'fc' context */
-    config_set_properties(NULL, fc, ctx);
+    ret = config_set_properties(NULL, fc, ctx);
+    if (ret == -1) {
+        forward_config_destroy(fc);
+        return -1;
+    }
 
     /* Initialize and validate forward_config context */
     ret = forward_config_init(fc, ctx);

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1734,6 +1734,12 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
                               event_chunk->tag, flb_sds_len(event_chunk->tag),
                               event_chunk->data, event_chunk->size,
                               &out_buf, &out_size);
+    if (mode == -1) {
+        flb_plg_error(ctx->ins, "failed to format outgoing payload");
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        flb_free(flush_ctx);
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
 
     /* Get a TCP connection instance */
     if (fc->unix_path == NULL) {

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -378,8 +378,15 @@ static void secure_forward_set_ping(struct flb_forward_ping *ping,
     }
 }
 
-static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
-                                          struct flb_forward_ping *ping,
+/*
+ * Compute sha512_hex(shared_key_salt + hostname + nonce + shared_key) as
+ * defined by the Forward protocol handshake (PING and PONG digests).
+ */
+static int secure_forward_hash_key_digest(struct flb_forward_config *fc,
+                                          const char *hostname,
+                                          size_t hostname_len,
+                                          const char *nonce,
+                                          size_t nonce_len,
                                           char *buf, int buflen)
 {
     size_t             length_entries[4];
@@ -394,11 +401,11 @@ static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
     data_entries[0]   = (unsigned char *) fc->shared_key_salt;
     length_entries[0] = 16;
 
-    data_entries[1]   = (unsigned char *) fc->self_hostname;
-    length_entries[1] = strlen(fc->self_hostname);
+    data_entries[1]   = (unsigned char *) hostname;
+    length_entries[1] = hostname_len;
 
-    data_entries[2]   = (unsigned char *) ping->nonce;
-    length_entries[2] = ping->nonce_len;
+    data_entries[2]   = (unsigned char *) nonce;
+    length_entries[2] = nonce_len;
 
     data_entries[3]   = (unsigned char *) fc->shared_key;
     length_entries[3] = strlen(fc->shared_key);
@@ -417,6 +424,17 @@ static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
     flb_forward_format_bin_to_hex(hash, 64, buf);
 
     return 0;
+}
+
+static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
+                                          struct flb_forward_ping *ping,
+                                          char *buf, int buflen)
+{
+    return secure_forward_hash_key_digest(fc,
+                                          fc->self_hostname,
+                                          strlen(fc->self_hostname),
+                                          ping->nonce, ping->nonce_len,
+                                          buf, buflen);
 }
 
 static int secure_forward_hash_password(struct flb_forward_config *fc,
@@ -458,7 +476,7 @@ static int secure_forward_hash_password(struct flb_forward_config *fc,
 }
 
 static int secure_forward_ping(struct flb_connection *u_conn,
-                               msgpack_object map,
+                               struct flb_forward_ping *ping,
                                struct flb_forward_config *fc,
                                struct flb_forward *ctx)
 {
@@ -468,22 +486,14 @@ static int secure_forward_ping(struct flb_connection *u_conn,
     char password_hexdigest[128];
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
-    struct flb_forward_ping ping;
 
-    secure_forward_set_ping(&ping, &map);
-
-    if (ping.nonce == NULL) {
-        flb_plg_error(ctx->ins, "nonce not found");
-        return -1;
-    }
-
-    if (secure_forward_hash_shared_key(fc, &ping, shared_key_hexdigest, 128)) {
+    if (secure_forward_hash_shared_key(fc, ping, shared_key_hexdigest, 128)) {
         flb_plg_error(ctx->ins, "failed to hash shared_key");
         return -1;
     }
 
-    if (ping.auth != NULL) {
-        if (secure_forward_hash_password(fc, &ping, password_hexdigest, 128)) {
+    if (ping->auth != NULL) {
+        if (secure_forward_hash_password(fc, ping, password_hexdigest, 128)) {
             flb_plg_error(ctx->ins, "failed to hash password");
             return -1;
         }
@@ -512,7 +522,7 @@ static int secure_forward_ping(struct flb_connection *u_conn,
     msgpack_pack_str_body(&mp_pck, shared_key_hexdigest, 128);
 
     /* [4] Username and password (optional) */
-    if (ping.auth != NULL) {
+    if (ping->auth != NULL) {
         msgpack_pack_str(&mp_pck, strlen(fc->username));
         msgpack_pack_str_body(&mp_pck, fc->username, strlen(fc->username));
         msgpack_pack_str(&mp_pck, 128);
@@ -537,18 +547,25 @@ static int secure_forward_ping(struct flb_connection *u_conn,
     return -1;
 }
 
-static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
+static int secure_forward_pong(struct flb_forward *ctx,
+                               struct flb_forward_config *fc,
+                               const char *nonce, size_t nonce_len,
+                               char *buf, int buf_size)
 {
     int ret;
     char msg[32] = {0};
+    char server_hexdigest[128];
     size_t off = 0;
     msgpack_unpacked result;
     msgpack_object root;
     msgpack_object o;
+    msgpack_object hostname;
+    msgpack_object digest;
 
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, buf_size, &off);
     if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
         return -1;
     }
 
@@ -557,7 +574,14 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
         goto error;
     }
 
-    if (root.via.array.size < 4) {
+    /*
+     * PONG is defined as:
+     *
+     *   [type, auth_result, reason, server_hostname, shared_key_hexdigest]
+     */
+    if (root.via.array.size != 5) {
+        flb_plg_error(ctx->ins, "invalid PONG message: expected 5 fields, "
+                      "got %i", root.via.array.size);
         goto error;
     }
 
@@ -575,11 +599,7 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
         goto error;
     }
 
-    if (o.via.boolean) {
-        msgpack_unpacked_destroy(&result);
-        return 0;
-    }
-    else {
+    if (!o.via.boolean) {
         o = root.via.array.ptr[2];
         if (o.type != MSGPACK_OBJECT_STR) {
             goto error;
@@ -593,7 +613,47 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
             msg[o.via.str.size] = '\0';
         }
         flb_plg_error(ctx->ins, "failed authorization: %s", msg);
+        goto error;
     }
+
+    /*
+     * Mutual authentication: the server must prove it holds the same
+     * shared_key by returning
+     *
+     *   sha512_hex(shared_key_salt + server_hostname + nonce + shared_key)
+     */
+    hostname = root.via.array.ptr[3];
+    if (hostname.type != MSGPACK_OBJECT_STR) {
+        flb_plg_error(ctx->ins, "invalid PONG server_hostname type");
+        goto error;
+    }
+
+    digest = root.via.array.ptr[4];
+    if (digest.type != MSGPACK_OBJECT_STR || digest.via.str.size != 128) {
+        flb_plg_error(ctx->ins, "invalid PONG shared_key_hexdigest");
+        goto error;
+    }
+
+    ret = secure_forward_hash_key_digest(fc,
+                                         hostname.via.str.ptr,
+                                         hostname.via.str.size,
+                                         nonce, nonce_len,
+                                         server_hexdigest,
+                                         sizeof(server_hexdigest));
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to hash PONG shared_key");
+        goto error;
+    }
+
+    if (memcmp(server_hexdigest, digest.via.str.ptr, 128) != 0) {
+        flb_plg_error(ctx->ins,
+                      "PONG shared_key digest mismatch: "
+                      "server does not hold the same shared_key");
+        goto error;
+    }
+
+    msgpack_unpacked_destroy(&result);
+    return 0;
 
  error:
     msgpack_unpacked_destroy(&result);
@@ -606,11 +666,14 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
 {
     int ret;
     char buf[1024];
+    char nonce[1024];
+    size_t nonce_len;
     size_t out_len;
     size_t off;
     msgpack_unpacked result;
     msgpack_object root;
     msgpack_object o;
+    struct flb_forward_ping ping;
 
     /* Wait for server HELO */
     ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
@@ -665,7 +728,28 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
         return -1;
     }
 
-    ret = secure_forward_ping(u_conn, o, fc, ctx);
+    secure_forward_set_ping(&ping, &o);
+    if (ping.nonce == NULL) {
+        flb_plg_error(ctx->ins, "nonce not found");
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    /*
+     * Keep a copy of the HELO nonce: 'ping.nonce' points into 'buf' and
+     * the same buffer is reused below to read the PONG message. The nonce
+     * is required to validate the PONG shared_key digest.
+     */
+    if (ping.nonce_len < 0 || (size_t) ping.nonce_len > sizeof(nonce)) {
+        flb_plg_error(ctx->ins, "HELO nonce is too large (%i bytes)",
+                      ping.nonce_len);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+    nonce_len = ping.nonce_len;
+    memcpy(nonce, ping.nonce, nonce_len);
+
+    ret = secure_forward_ping(u_conn, &ping, fc, ctx);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "Failed PING");
         msgpack_unpacked_destroy(&result);
@@ -675,13 +759,13 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
     /* Expect a PONG */
     ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
     if (ret == -1) {
-        flb_plg_error(ctx->ins, "handshake error expecting HELO");
+        flb_plg_error(ctx->ins, "handshake error expecting PONG");
         msgpack_unpacked_destroy(&result);
         return -1;
     }
 
     /* Process PONG */
-    ret = secure_forward_pong(ctx, buf, out_len);
+    ret = secure_forward_pong(ctx, fc, nonce, nonce_len, buf, out_len);
     if (ret == -1) {
         msgpack_unpacked_destroy(&result);
         return -1;

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -134,10 +134,16 @@ struct flb_forward_ping {
     int keepalive;
 };
 
+/*
+ * Maximum storage required for a 'chunk' ack token: Base64 representation
+ * of a 128 bits unique id (24 bytes) plus NUL terminator.
+ */
+#define FLB_FORWARD_CHUNK_TOKEN_SIZE   25
+
 /* Flush callback context */
 struct flb_forward_flush {
     struct flb_forward_config *fc;
-    char checksum_hex[33];
+    char chunk_token[FLB_FORWARD_CHUNK_TOKEN_SIZE];
 };
 
 struct flb_forward_config *flb_forward_target(struct flb_forward *ctx,

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_crypto.h>
+#include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 #include <fluent-bit/flb_log_event_decoder.h>
@@ -99,6 +100,7 @@ static int append_options(struct flb_forward *ctx,
                           char *out_chunk)
 {
     char *chunk = NULL;
+    size_t chunk_len = 0;
     uint8_t checksum[64];
     int     result;
     struct mk_list *head;
@@ -112,8 +114,9 @@ static int append_options(struct flb_forward *ctx,
 
     if (fc->require_ack_response == FLB_TRUE) {
         /*
-         * for ack we calculate  sha512 of context, take 16 bytes,
-         * make 32 byte hex string of it
+         * The 'chunk' ack token is a Base64 representation of a 128 bits
+         * unique id: we take the first 16 bytes of the SHA512 checksum of
+         * the payload content.
          */
         result = flb_hash_simple(FLB_HASH_SHA512,
                                  data, bytes,
@@ -123,9 +126,13 @@ static int append_options(struct flb_forward *ctx,
             return -1;
         }
 
-        flb_forward_format_bin_to_hex(checksum, 16, out_chunk);
+        result = flb_base64_encode((unsigned char *) out_chunk,
+                                   FLB_FORWARD_CHUNK_TOKEN_SIZE, &chunk_len,
+                                   checksum, 16);
+        if (result != 0) {
+            return -1;
+        }
 
-        out_chunk[32] = '\0';
         chunk = (char *) out_chunk;
     }
 
@@ -134,8 +141,8 @@ static int append_options(struct flb_forward *ctx,
         flb_mp_map_header_append(&mh);
         msgpack_pack_str(mp_pck, 5);
         msgpack_pack_str_body(mp_pck, "chunk", 5);
-        msgpack_pack_str(mp_pck, 32);
-        msgpack_pack_str_body(mp_pck, out_chunk, 32);
+        msgpack_pack_str(mp_pck, chunk_len);
+        msgpack_pack_str_body(mp_pck, chunk, chunk_len);
     }
 
     /* "size": entries */
@@ -229,7 +236,7 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
     int entries = 0;
     size_t record_size;
     char *chunk;
-    char chunk_buf[33];
+    char chunk_buf[FLB_FORWARD_CHUNK_TOKEN_SIZE] = {0};
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
     struct flb_time tm;
@@ -292,7 +299,7 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
         record_size = log_decoder.record_length;
 
         if (ff) {
-            chunk = ff->checksum_hex;
+            chunk = ff->chunk_token;
         }
         else {
             chunk = chunk_buf;
@@ -411,17 +418,17 @@ static int flb_forward_format_forward_mode(struct flb_forward *ctx,
     int result;
     int entries = 0;
     char *chunk;
-    char chunk_buf[33];
+    char chunk_buf[FLB_FORWARD_CHUNK_TOKEN_SIZE] = {0};
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
-    char *transcoded_buffer;
-    size_t transcoded_length;
+    char *transcoded_buffer = NULL;
+    size_t transcoded_length = 0;
 
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     if (ff) {
-        chunk = ff->checksum_hex;
+        chunk = ff->chunk_token;
     }
     else {
         chunk = chunk_buf;
@@ -479,7 +486,7 @@ static int flb_forward_format_forward_compat_mode(struct flb_forward *ctx,
 {
     int entries = 0;
     char *chunk;
-    char chunk_buf[33];
+    char chunk_buf[FLB_FORWARD_CHUNK_TOKEN_SIZE] = {0};
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
     struct flb_log_event_decoder log_decoder;
@@ -499,7 +506,7 @@ static int flb_forward_format_forward_compat_mode(struct flb_forward *ctx,
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     if (ff) {
-        chunk = ff->checksum_hex;
+        chunk = ff->chunk_token;
     }
     else {
         chunk = chunk_buf;

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -207,7 +207,7 @@ static int append_options(struct flb_forward *ctx,
 
     flb_plg_debug(ctx->ins,
                   "send options records=%d chunk='%s'",
-                  entries, out_chunk ? out_chunk : "NULL");
+                  entries, chunk ? chunk : "NULL");
     return 0;
 }
 
@@ -449,15 +449,18 @@ static int flb_forward_format_forward_mode(struct flb_forward *ctx,
                                                   &transcoded_buffer,
                                                   &transcoded_length);
 
-            if (result == 0) {
-                entries = flb_mp_count(transcoded_buffer, transcoded_length);
-                append_options(ctx, fc, event_type, &mp_pck, entries,
-                               transcoded_buffer,
-                               transcoded_length,
-                               NULL, chunk);
-
-                free(transcoded_buffer);
+            if (result != 0) {
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
             }
+
+            entries = flb_mp_count(transcoded_buffer, transcoded_length);
+            append_options(ctx, fc, event_type, &mp_pck, entries,
+                           transcoded_buffer,
+                           transcoded_length,
+                           NULL, chunk);
+
+            free(transcoded_buffer);
         }
         else {
             append_options(ctx, fc, event_type, &mp_pck, entries, (char *) data, bytes, NULL, chunk);

--- a/tests/integration/scenarios/out_forward/config/out_forward_secure_sender.yaml
+++ b/tests/integration/scenarios/out_forward/config/out_forward_secure_sender.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FORWARD_SECURE_SENDER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_SECURE_RECEIVER_PORT}
+      shared_key: integration-secret
+      self_hostname: sender-node
+      send_options: true
+      require_ack_response: true

--- a/tests/integration/scenarios/out_forward/tests/test_out_forward_secure_001.py
+++ b/tests/integration/scenarios/out_forward/tests/test_out_forward_secure_001.py
@@ -1,0 +1,193 @@
+import base64
+import os
+import socket
+import time
+
+import pytest
+
+from server.forward_server import (
+    data_storage as forward_data_storage,
+    forward_server_run,
+    forward_server_stop,
+)
+from utils.data_utils import read_file
+from utils.fluent_bit_manager import FluentBitManager
+from utils.network import find_available_port, wait_for_port_to_be_free
+
+
+TEST_TAG = "test"
+TEST_TS = 1234567890
+SECURE_SHARED_KEY = "integration-secret"
+
+
+def _pack_uint(value):
+    if value < 0x80:
+        return bytes([value])
+    if value <= 0xFF:
+        return b"\xCC" + bytes([value])
+    if value <= 0xFFFF:
+        return b"\xCD" + value.to_bytes(2, "big")
+    if value <= 0xFFFFFFFF:
+        return b"\xCE" + value.to_bytes(4, "big")
+    return b"\xCF" + value.to_bytes(8, "big")
+
+
+def _pack_str(value):
+    data = value.encode()
+    length = len(data)
+    if length <= 31:
+        return bytes([0xA0 | length]) + data
+    if length <= 0xFF:
+        return b"\xD9" + bytes([length]) + data
+    return b"\xDA" + length.to_bytes(2, "big") + data
+
+
+def _pack_obj(value):
+    if isinstance(value, int):
+        return _pack_uint(value)
+    if isinstance(value, str):
+        return _pack_str(value)
+    if isinstance(value, list):
+        return bytes([0x90 | len(value)]) + b"".join(_pack_obj(item) for item in value)
+    if isinstance(value, dict):
+        encoded = []
+        for key, item in value.items():
+            encoded.append(_pack_obj(key))
+            encoded.append(_pack_obj(item))
+        return bytes([0x80 | len(value)]) + b"".join(encoded)
+    raise TypeError(f"Unsupported value type {type(value)!r}")
+
+
+def _send_message(port, message):
+    payload = _pack_obj([TEST_TAG, TEST_TS, {"message": message}])
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(payload)
+
+
+class SecureForwardChain:
+    """
+    Fluent Bit sender (out_forward + shared_key) -> python secure forward
+    receiver.
+    """
+
+    def __init__(self, *, corrupt_pong_digest=False):
+        config_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config"))
+        self.sender_config_file = os.path.join(config_dir, "out_forward_secure_sender.yaml")
+        self.corrupt_pong_digest = corrupt_pong_digest
+        self.sender = None
+        self.previous_env = {}
+
+    def _set_env(self, key, value):
+        self.previous_env.setdefault(key, os.environ.get(key))
+        os.environ[key] = str(value)
+
+    def _restore_env(self):
+        for key, value in self.previous_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        self.previous_env.clear()
+
+    def start(self):
+        self.sender_port = find_available_port()
+        self.receiver_port = find_available_port()
+
+        self._set_env("FORWARD_SECURE_SENDER_PORT", self.sender_port)
+        self._set_env("FORWARD_SECURE_RECEIVER_PORT", self.receiver_port)
+
+        forward_server_run(
+            self.receiver_port,
+            shared_key=SECURE_SHARED_KEY,
+            corrupt_pong_digest=self.corrupt_pong_digest,
+        )
+
+        self.sender = FluentBitManager(self.sender_config_file)
+        self.sender.start()
+
+    def stop(self):
+        try:
+            if self.sender:
+                self.sender.stop()
+        finally:
+            forward_server_stop()
+            wait_for_port_to_be_free(
+                self.receiver_port,
+                timeout=10 if os.environ.get("VALGRIND") else 5,
+            )
+            self._restore_env()
+
+    def wait_for_forward_messages(self, minimum_count, timeout=10):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            messages = forward_data_storage["messages"]
+            if len(messages) >= minimum_count:
+                return messages
+            time.sleep(0.2)
+        raise TimeoutError(f"Timed out waiting for {minimum_count} captured forward messages")
+
+    def wait_for_handshakes(self, minimum_count, timeout=10):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            handshakes = forward_data_storage["handshakes"]
+            if len(handshakes) >= minimum_count:
+                return handshakes
+            time.sleep(0.2)
+        raise TimeoutError(f"Timed out waiting for {minimum_count} secure forward handshakes")
+
+    def wait_for_sender_log(self, text, timeout=10):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            log_text = read_file(self.sender.log_file)
+            if text in log_text:
+                return log_text
+            time.sleep(0.2)
+        raise TimeoutError(f"Timed out waiting for sender log text {text!r}")
+
+
+def test_out_forward_secure_handshake_delivers_records():
+    chain = SecureForwardChain()
+    chain.start()
+
+    try:
+        _send_message(chain.sender_port, "secure-forward-e2e")
+        messages = chain.wait_for_forward_messages(
+            1, timeout=20 if os.environ.get("VALGRIND") else 10
+        )
+        handshakes = chain.wait_for_handshakes(1)
+    finally:
+        chain.stop()
+
+    # The client proved the shared_key in PING:
+    # sha512_hex(shared_key_salt + client_hostname + nonce + shared_key)
+    assert handshakes[0]["client_hostname"] == "sender-node"
+    assert handshakes[0]["client_digest_valid"] is True
+
+    message = messages[0]
+    assert message["tag"] == TEST_TAG
+    assert message["options"]["fluent_signal"] == 0
+    assert message["records"][0]["body"]["message"] == "secure-forward-e2e"
+
+    # 'chunk' must be a Base64 representation of a 128 bits unique id
+    chunk = message["options"]["chunk"]
+    assert len(chunk) == 24
+    decoded = base64.b64decode(chunk, validate=True)
+    assert len(decoded) == 16
+
+
+def test_out_forward_secure_handshake_rejects_wrong_server_digest():
+    chain = SecureForwardChain(corrupt_pong_digest=True)
+    chain.start()
+
+    try:
+        _send_message(chain.sender_port, "secure-forward-reject")
+
+        # The client must attempt the handshake and reject the PONG
+        chain.wait_for_handshakes(1)
+        chain.wait_for_sender_log("digest mismatch", timeout=15)
+
+        # No event data may be accepted by the (impostor) server
+        with pytest.raises(TimeoutError):
+            chain.wait_for_forward_messages(1, timeout=3)
+    finally:
+        chain.stop()

--- a/tests/integration/src/server/forward_server.py
+++ b/tests/integration/src/server/forward_server.py
@@ -15,7 +15,9 @@
 #  limitations under the License.
 
 import gzip
+import hashlib
 import logging
+import os
 import socket
 import struct
 import subprocess
@@ -28,11 +30,20 @@ logger = logging.getLogger(__name__)
 data_storage = {
     "messages": [],
     "connections": [],
+    "handshakes": [],
 }
 
 server_thread = None
 server_port = None
 server_stop_event = threading.Event()
+
+# Secure forward (shared_key handshake) behavior; configured by
+# forward_server_run().
+server_options = {
+    "shared_key": None,
+    "self_hostname": "python-forward-server",
+    "corrupt_pong_digest": False,
+}
 
 
 class IncompleteBuffer(Exception):
@@ -42,6 +53,7 @@ class IncompleteBuffer(Exception):
 def reset_forward_server_state():
     data_storage["messages"] = []
     data_storage["connections"] = []
+    data_storage["handshakes"] = []
     server_stop_event.clear()
 
 
@@ -226,6 +238,10 @@ def _pack_map(mapping):
 
 
 def _pack_obj(value):
+    if value is None:
+        return b"\xC0"
+    if isinstance(value, bool):
+        return b"\xC3" if value else b"\xC2"
     if isinstance(value, str):
         return _pack_str(value)
     if isinstance(value, bytes):
@@ -233,6 +249,10 @@ def _pack_obj(value):
         if length <= 0xFF:
             return b"\xC4" + bytes([length]) + value
         return b"\xC5" + length.to_bytes(2, "big") + value
+    if isinstance(value, list):
+        if len(value) > 15:
+            raise TypeError("only fixarray packing is supported")
+        return bytes([0x90 | len(value)]) + b"".join(_pack_obj(item) for item in value)
     if isinstance(value, dict):
         return _pack_map(value)
     raise TypeError(f"Unsupported pack type {type(value)!r}")
@@ -240,6 +260,72 @@ def _pack_obj(value):
 
 def _send_ack(sock, chunk):
     sock.sendall(_pack_obj({"ack": chunk}))
+
+
+def _sha512_hex(*parts):
+    hasher = hashlib.sha512()
+    for part in parts:
+        if isinstance(part, str):
+            part = part.encode()
+        hasher.update(part)
+    return hasher.hexdigest()
+
+
+def _recv_msgpack(conn, buffer=b""):
+    while True:
+        if buffer:
+            try:
+                value, offset = _unpack_obj(buffer, 0)
+                return value, buffer[offset:]
+            except IncompleteBuffer:
+                pass
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise ConnectionError("connection closed during secure handshake")
+        buffer += chunk
+
+
+def _perform_secure_handshake(conn):
+    """
+    Secure forward handshake (Forward protocol v1/v1.5):
+
+      server -> HELO ["HELO", {"nonce", "auth", "keepalive"}]
+      client -> PING ["PING", client_hostname, shared_key_salt,
+                      shared_key_hexdigest, username, password]
+      server -> PONG ["PONG", auth_result, reason, server_hostname,
+                      shared_key_hexdigest]
+
+    Returns any bytes received beyond the PING message.
+    """
+    shared_key = server_options["shared_key"]
+    self_hostname = server_options["self_hostname"]
+    nonce = os.urandom(16)
+
+    conn.sendall(_pack_obj(["HELO", {"nonce": nonce, "auth": b"", "keepalive": True}]))
+
+    ping, leftover = _recv_msgpack(conn)
+    if not isinstance(ping, list) or len(ping) != 6 or ping[0] != "PING":
+        raise ValueError(f"invalid PING message: {ping!r}")
+
+    client_hostname = ping[1]
+    shared_key_salt = ping[2]
+    client_digest = ping[3]
+
+    expected_client_digest = _sha512_hex(shared_key_salt, client_hostname,
+                                         nonce, shared_key)
+    data_storage["handshakes"].append({
+        "client_hostname": client_hostname,
+        "client_digest_valid": client_digest == expected_client_digest,
+    })
+
+    server_digest = _sha512_hex(shared_key_salt, self_hostname, nonce, shared_key)
+    if server_options["corrupt_pong_digest"]:
+        first = "1" if server_digest[0] == "0" else "0"
+        server_digest = first + server_digest[1:]
+
+    conn.sendall(_pack_obj(["PONG", True, "", self_hostname, server_digest]))
+
+    return leftover
 
 
 def _decode_packed_entries(entry, options):
@@ -316,6 +402,15 @@ def _classify_message(root):
 def _handle_client(conn, address):
     data_storage["connections"].append({"peer": address})
     buffer = b""
+
+    if server_options["shared_key"] is not None:
+        conn.settimeout(5)
+        try:
+            buffer = _perform_secure_handshake(conn)
+        except (ConnectionError, OSError, ValueError) as error:
+            logger.info("secure forward handshake aborted: %s", error)
+            return
+
     conn.settimeout(0.5)
 
     while not server_stop_event.is_set():
@@ -370,10 +465,15 @@ def run_forward_server(port):
                 _handle_client(conn, address)
 
 
-def forward_server_run(port):
+def forward_server_run(port, shared_key=None,
+                       self_hostname="python-forward-server",
+                       corrupt_pong_digest=False):
     global server_thread, server_port
 
     reset_forward_server_state()
+    server_options["shared_key"] = shared_key
+    server_options["self_hostname"] = self_hostname
+    server_options["corrupt_pong_digest"] = corrupt_pong_digest
     server_port = port
     server_thread = threading.Thread(target=run_forward_server, args=(port,), daemon=True)
     server_thread.start()

--- a/tests/runtime/out_forward.c
+++ b/tests/runtime/out_forward.c
@@ -23,6 +23,8 @@
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_chunk.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_crypto.h>
 
 #ifndef FLB_SYSTEM_WINDOWS
 #include <errno.h>
@@ -40,10 +42,24 @@
 #include "../../plugins/out_forward/forward.h"
 
 #ifndef FLB_SYSTEM_WINDOWS
+
+/* PONG behaviors used by the mock secure forward server */
+#define PONG_MODE_OVERSIZED_REASON  0
+#define PONG_MODE_VALID             1
+#define PONG_MODE_WRONG_DIGEST      2
+#define PONG_MODE_MISSING_DIGEST    3
+#define PONG_MODE_WRONG_DIGEST_TYPE 4
+
+#define SECURE_SERVER_HOSTNAME "server-host"
+#define SECURE_SERVER_NONCE    "0123456789abcdef"
+#define SECURE_SHARED_KEY      "secret"
+
 struct secure_forward_server {
     int listen_fd;
     int port;
     int got_ping;
+    int got_event;
+    int pong_mode;
     pthread_t thread;
 };
 
@@ -163,7 +179,8 @@ static int forward_pack_oversized_pong(msgpack_sbuffer *mp_sbuf)
     return 0;
 }
 
-static int forward_read_msgpack(int fd, char *buf, size_t size)
+static int forward_read_msgpack(int fd, char *buf, size_t size,
+                                size_t *out_len)
 {
     int ret;
     ssize_t bytes;
@@ -186,6 +203,9 @@ static int forward_read_msgpack(int fd, char *buf, size_t size)
         ret = msgpack_unpack_next(&result, buf, buf_off, &off);
         if (ret == MSGPACK_UNPACK_SUCCESS) {
             msgpack_unpacked_destroy(&result);
+            if (out_len) {
+                *out_len = buf_off;
+            }
             return 0;
         }
 
@@ -197,6 +217,193 @@ static int forward_read_msgpack(int fd, char *buf, size_t size)
 
     msgpack_unpacked_destroy(&result);
     return -1;
+}
+
+static void forward_test_bin_to_hex(uint8_t *buf, size_t len, char *out)
+{
+    size_t i;
+    static char map[] = "0123456789abcdef";
+
+    for (i = 0; i < len; i++) {
+        out[i * 2]     = map[buf[i] >> 4];
+        out[i * 2 + 1] = map[buf[i] & 0x0f];
+    }
+}
+
+/*
+ * Compose a PONG reply from a captured PING request:
+ *
+ *   PING: [type, client_hostname, shared_key_salt, shared_key_hexdigest,
+ *          username, password]
+ *   PONG: [type, auth_result, reason, server_hostname,
+ *          shared_key_hexdigest]
+ *
+ * The server digest is sha512_hex(shared_key_salt + server_hostname +
+ * nonce + shared_key).
+ */
+static int forward_pack_pong_from_ping(msgpack_sbuffer *mp_sbuf,
+                                       int pong_mode,
+                                       const char *ping_buf,
+                                       size_t ping_size)
+{
+    int ret;
+    size_t off = 0;
+    char digest_hex[128];
+    uint8_t hash[64];
+    size_t length_entries[4];
+    unsigned char *data_entries[4];
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object salt;
+    msgpack_packer mp_pck;
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, ping_buf, ping_size, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    root = result.data;
+    if (root.type != MSGPACK_OBJECT_ARRAY || root.via.array.size < 4) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    salt = root.via.array.ptr[2];
+    if (salt.type != MSGPACK_OBJECT_STR && salt.type != MSGPACK_OBJECT_BIN) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    data_entries[0]   = (unsigned char *) salt.via.bin.ptr;
+    length_entries[0] = salt.via.bin.size;
+
+    data_entries[1]   = (unsigned char *) SECURE_SERVER_HOSTNAME;
+    length_entries[1] = strlen(SECURE_SERVER_HOSTNAME);
+
+    data_entries[2]   = (unsigned char *) SECURE_SERVER_NONCE;
+    length_entries[2] = strlen(SECURE_SERVER_NONCE);
+
+    data_entries[3]   = (unsigned char *) SECURE_SHARED_KEY;
+    length_entries[3] = strlen(SECURE_SHARED_KEY);
+
+    ret = flb_hash_simple_batch(FLB_HASH_SHA512, 4,
+                                data_entries, length_entries,
+                                hash, sizeof(hash));
+    msgpack_unpacked_destroy(&result);
+
+    if (ret != FLB_CRYPTO_SUCCESS) {
+        return -1;
+    }
+
+    forward_test_bin_to_hex(hash, 64, digest_hex);
+
+    if (pong_mode == PONG_MODE_WRONG_DIGEST) {
+        /* corrupt the digest */
+        digest_hex[0] = (digest_hex[0] == '0') ? '1' : '0';
+    }
+
+    msgpack_sbuffer_init(mp_sbuf);
+    msgpack_packer_init(&mp_pck, mp_sbuf, msgpack_sbuffer_write);
+
+    if (pong_mode == PONG_MODE_MISSING_DIGEST) {
+        msgpack_pack_array(&mp_pck, 4);
+    }
+    else {
+        msgpack_pack_array(&mp_pck, 5);
+    }
+
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "PONG", 4);
+    msgpack_pack_true(&mp_pck);
+    msgpack_pack_str(&mp_pck, 0);
+    msgpack_pack_str_body(&mp_pck, "", 0);
+    msgpack_pack_str(&mp_pck, strlen(SECURE_SERVER_HOSTNAME));
+    msgpack_pack_str_body(&mp_pck, SECURE_SERVER_HOSTNAME,
+                          strlen(SECURE_SERVER_HOSTNAME));
+
+    if (pong_mode == PONG_MODE_WRONG_DIGEST_TYPE) {
+        msgpack_pack_int64(&mp_pck, 42);
+    }
+    else if (pong_mode != PONG_MODE_MISSING_DIGEST) {
+        msgpack_pack_str(&mp_pck, 128);
+        msgpack_pack_str_body(&mp_pck, digest_hex, 128);
+    }
+
+    return 0;
+}
+
+static void *secure_forward_handshake_server_thread(void *data)
+{
+    int ret;
+    int conn_fd;
+    fd_set read_fds;
+    struct timeval timeout;
+    char buf[2048];
+    size_t ping_size;
+    msgpack_sbuffer helo;
+    msgpack_sbuffer pong;
+    struct secure_forward_server *server;
+
+    server = data;
+
+    FD_ZERO(&read_fds);
+    FD_SET(server->listen_fd, &read_fds);
+    timeout.tv_sec = 5;
+    timeout.tv_usec = 0;
+
+    ret = select(server->listen_fd + 1, &read_fds, NULL, NULL, &timeout);
+    if (ret <= 0) {
+        return NULL;
+    }
+
+    conn_fd = accept(server->listen_fd, NULL, NULL);
+    if (conn_fd == -1) {
+        return NULL;
+    }
+
+    if (forward_pack_secure_helo(&helo) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+
+    if (forward_socket_write_all(conn_fd, helo.data, helo.size) != 0) {
+        msgpack_sbuffer_destroy(&helo);
+        close(conn_fd);
+        return NULL;
+    }
+    msgpack_sbuffer_destroy(&helo);
+
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf), &ping_size) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+    server->got_ping = FLB_TRUE;
+
+    if (forward_pack_pong_from_ping(&pong, server->pong_mode,
+                                    buf, ping_size) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+
+    if (forward_socket_write_all(conn_fd, pong.data, pong.size) != 0) {
+        msgpack_sbuffer_destroy(&pong);
+        close(conn_fd);
+        return NULL;
+    }
+    msgpack_sbuffer_destroy(&pong);
+
+    /*
+     * If the client accepted the PONG, an event payload follows; if it
+     * rejected it, the connection is closed and no data arrives.
+     */
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf), NULL) == 0) {
+        server->got_event = FLB_TRUE;
+    }
+
+    close(conn_fd);
+    return NULL;
 }
 
 static void *secure_forward_oversized_pong_server_thread(void *data)
@@ -240,7 +447,7 @@ static void *secure_forward_oversized_pong_server_thread(void *data)
     }
     msgpack_sbuffer_destroy(&helo);
 
-    if (forward_read_msgpack(conn_fd, buf, sizeof(buf)) != 0) {
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf), NULL) != 0) {
         close(conn_fd);
         return NULL;
     }
@@ -605,7 +812,11 @@ static void cb_check_forward_mode_ack_options(void *ctx, int ffd,
             strncmp(key.via.str.ptr, "chunk", 5) == 0) {
             TEST_CHECK(val.type == MSGPACK_OBJECT_STR);
             if (val.type == MSGPACK_OBJECT_STR) {
-                TEST_CHECK(val.via.str.size == 32);
+                /* Base64 representation of a 128 bits unique id */
+                TEST_CHECK(val.via.str.size == 24);
+                TEST_CHECK(val.via.str.size >= 2 &&
+                           strncmp(val.via.str.ptr + val.via.str.size - 2,
+                                   "==", 2) == 0);
             }
             have_chunk = FLB_TRUE;
         }
@@ -1270,7 +1481,136 @@ void flb_test_secure_forward_oversized_pong_reason()
 
     TEST_CHECK(server.got_ping == FLB_TRUE);
 }
+
+/*
+ * Run a secure forward handshake against the mock server using the given
+ * PONG behavior; 'expect_event' tells whether the client is expected to
+ * accept the PONG and deliver data on the same connection.
+ */
+static void run_secure_forward_handshake_case(int pong_mode, int expect_event)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char port[16];
+    flb_ctx_t *ctx;
+    struct secure_forward_server server;
+
+    memset(&server, 0, sizeof(server));
+    server.listen_fd = -1;
+    server.pong_mode = pong_mode;
+
+    server.listen_fd = forward_create_listen_socket(&server.port);
+    TEST_CHECK(server.listen_fd != -1);
+    if (server.listen_fd == -1) {
+        return;
+    }
+
+    ret = pthread_create(&server.thread, NULL,
+                         secure_forward_handshake_server_thread,
+                         &server);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        close(server.listen_fd);
+        return;
+    }
+
+    snprintf(port, sizeof(port), "%i", server.port);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd,
+                  "tag", "test",
+                  "samples", "1",
+                  "dummy", "{\"key\":\"value\"}",
+                  NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "host", "127.0.0.1",
+                   "port", port,
+                   "shared_key", SECURE_SHARED_KEY,
+                   "workers", "1",
+                   "retry_limit", "no_retries",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2500);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    close(server.listen_fd);
+    pthread_join(server.thread, NULL);
+
+    TEST_CHECK(server.got_ping == FLB_TRUE);
+    TEST_CHECK(server.got_event == expect_event);
+}
+
+void flb_test_secure_forward_valid_pong()
+{
+    run_secure_forward_handshake_case(PONG_MODE_VALID, FLB_TRUE);
+}
+
+void flb_test_secure_forward_wrong_server_digest()
+{
+    run_secure_forward_handshake_case(PONG_MODE_WRONG_DIGEST, FLB_FALSE);
+}
+
+void flb_test_secure_forward_missing_server_digest()
+{
+    run_secure_forward_handshake_case(PONG_MODE_MISSING_DIGEST, FLB_FALSE);
+}
+
+void flb_test_secure_forward_wrong_digest_type()
+{
+    run_secure_forward_handshake_case(PONG_MODE_WRONG_DIGEST_TYPE, FLB_FALSE);
+}
 #endif
+
+/*
+ * username/password without shared_key or empty_shared_key must be
+ * rejected at configuration time (fail-close): the credentials would
+ * otherwise be silently unused.
+ */
+void flb_test_forward_username_without_shared_key()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    flb_ctx_t *ctx;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "host", "127.0.0.1",
+                   "port", "24224",
+                   "username", "alice",
+                   "password", "s3cr3t",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+    if (ret == 0) {
+        TEST_MSG("username/password without shared_key unexpectedly started");
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+}
 
 /* Test list */
 TEST_LIST = {
@@ -1290,6 +1630,15 @@ TEST_LIST = {
 #ifndef FLB_SYSTEM_WINDOWS
     {"secure_forward_oversized_pong_reason",
      flb_test_secure_forward_oversized_pong_reason },
+    {"secure_forward_valid_pong", flb_test_secure_forward_valid_pong },
+    {"secure_forward_wrong_server_digest",
+     flb_test_secure_forward_wrong_server_digest },
+    {"secure_forward_missing_server_digest",
+     flb_test_secure_forward_missing_server_digest },
+    {"secure_forward_wrong_digest_type",
+     flb_test_secure_forward_wrong_digest_type },
 #endif
+    {"forward_username_without_shared_key",
+     flb_test_forward_username_without_shared_key },
     {NULL, NULL}
 };


### PR DESCRIPTION
This PR aligns out_forward with the Fluentd Forward protocol specification (v1 / v1.5), based on a review of the local Forward implementation against the spec documents.

A few details of the out_forward implementation diverged from what the spec describes: the client did not check the server_hostname and shared_key_hexdigest fields that servers return in the PONG message, username/password settings were silently unused when no shared_key was configured, the chunk ack token was sent as a hex string although the spec defines it as a Base64 representation of a 128-bit unique id, and the formatter had two small robustness bugs (a failed metadata transcode still returned success, and a debug log could print an uninitialized buffer). 
  
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure forward handshake support for authenticated sender/receiver communication.
  * Forward acknowledgments now use a compact Base64 chunk token.

* **Bug Fixes**
  * Improved handshake validation to reject invalid, missing, or malformed server responses.
  * Added stricter configuration checks and clearer handling for payload formatting failures.
  * Fixed transcode failure handling so failed sends retry correctly.

* **Tests**
  * Added integration and runtime coverage for successful and failing secure-forward handshake flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->