### PR TITLE
tests: assert histogram/exp_histogram temporality survives in_opentelemetry -> out_opentelemetry round trip

### DIFF
--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -743,6 +743,12 @@ def test_opentelemetry_to_opentelemetry_histogram_and_gauge_metrics():
     assert histogram_datapoint["explicitBounds"] == [100.0]
     assert histogram_datapoint["attributes"][0]["key"] == "http.route"
     assert histogram_datapoint["attributes"][0]["value"]["stringValue"] == "/checkout"
+    # test_metrics_002.in.json declares this histogram with
+    # aggregation_temporality=1 (DELTA). in_opentelemetry decodes it into
+    # cmetrics and out_opentelemetry re-encodes it after a round trip
+    # through Fluent Bit's internal msgpack storage; that temporality must
+    # survive the round trip unchanged.
+    assert histogram["aggregationTemporality"] == "AGGREGATION_TEMPORALITY_DELTA"
 
     assert metrics["cpu.usage"]["scope_version"] == "2.0.0"
     assert gauge_datapoint["asDouble"] == 0.82


### PR DESCRIPTION
## Summary

The actual fix ([fluent/cmetrics#279](https://github.com/fluent/cmetrics/pull/279)) is already included via the `lib: cmetrics: upgrade to v2.2.0` bump merged into master. This PR is now just the missing test coverage.

`tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_opentelemetry_to_opentelemetry_histogram_and_gauge_metrics` already sends a histogram with `aggregation_temporality: 1` (DELTA) through a real `in_opentelemetry → out_opentelemetry` pipeline (`test_metrics_002.in.json`), but never asserted on the output's `aggregationTemporality` field. That gap is exactly how the cmetrics bug — histograms/exp_histograms losing their OTLP temporality across Fluent Bit's internal msgpack buffer — went unnoticed. This adds the missing assertion so a regression here is caught going forward.

## Background

Original bug: `pack_header()` in cmetrics' `cmt_encode_msgpack.c` only wrote the `aggregation_type` meta field for `CMT_COUNTER`. Histograms and exp_histograms decoded from OTLP by `in_opentelemetry`, buffered internally as msgpack, and re-encoded to OTLP by `out_opentelemetry` lost their temporality in that round trip. Downstream OTLP receivers that validate temporality (e.g. Prometheus with `otlp-deltatocumulative` enabled) rejected the metric with `invalid temporality and type combination`. Filed as fluent/fluent-bit#278, fixed in fluent/cmetrics#279.

## Test plan

- [x] Built Fluent Bit with `lib/cmetrics` reverted to pre-v2.2.0 (unpatched): confirmed `test_opentelemetry_to_opentelemetry_histogram_and_gauge_metrics` **fails** — the response's histogram has no `aggregationTemporality` field at all (proto JSON omits `UNSPECIFIED`)
- [x] Built Fluent Bit with `lib/cmetrics` at v2.2.0 (patched): confirmed the same test **passes**, with `aggregationTemporality: AGGREGATION_TEMPORALITY_DELTA` correctly present in the OTLP output
- [x] Ran the full `in_opentelemetry` integration suite (62 tests) — all pass, no regressions
- [x] Ran the full `out_opentelemetry` integration suite (17 tests) — all pass, no regressions
- [x] Also reproduced end-to-end against a real cluster: ran a k6 OTLP load test through `in_opentelemetry → out_opentelemetry → Prometheus` with the unpatched image (k6's histogram metrics rejected by Prometheus) and again with a patched image (same metrics landed correctly, confirmed via direct Prometheus API query)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation that histogram aggregation temporality remains unchanged during the OpenTelemetry round trip.
  * Confirmed delta temporality is correctly decoded and re-encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->