### PR TITLE
in_splunk: return Splunk HEC auth status codes

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -582,6 +582,9 @@ static int send_json_message_response_ng(struct flb_http_response *response,
     else if (http_status == 401) {
         flb_http_response_set_message(response, "Unauthorized");
     }
+    else if (http_status == 403) {
+        flb_http_response_set_message(response, "Forbidden");
+    }
 
     flb_http_response_set_header(response,
                                 "content-type", 0,
@@ -629,7 +632,12 @@ static int validate_auth_header_ng(struct flb_splunk *ctx, struct flb_http_reque
             }
         }
 
-        return SPLUNK_AUTH_UNAUTHORIZED;
+        if (strncasecmp(auth_header, "Splunk ", 7) == 0 &&
+            strlen(auth_header) > 7) {
+            return SPLUNK_AUTH_INVALID_TOKEN;
+        }
+
+        return SPLUNK_AUTH_INVALID_AUTHORIZATION;
     }
     else {
         return SPLUNK_AUTH_MISSING_CRED;
@@ -770,12 +778,19 @@ int splunk_prot_handle_ng(struct flb_http_request *request,
     ret = validate_auth_header_ng(context, request);
 
     if (ret < 0) {
-        send_response_ng(response, 401, "error: unauthorized\n");
-
         if (ret == SPLUNK_AUTH_MISSING_CRED) {
+            send_json_message_response_ng(response, 401,
+                                          "{\"text\":\"Token is required\",\"code\":2}");
             flb_plg_warn(context->ins, "missing credentials in request headers");
         }
-        else if (ret == SPLUNK_AUTH_UNAUTHORIZED) {
+        else if (ret == SPLUNK_AUTH_INVALID_AUTHORIZATION) {
+            send_json_message_response_ng(response, 401,
+                                          "{\"text\":\"Invalid authorization\",\"code\":3}");
+            flb_plg_warn(context->ins, "invalid authorization in request headers");
+        }
+        else if (ret == SPLUNK_AUTH_INVALID_TOKEN) {
+            send_json_message_response_ng(response, 403,
+                                          "{\"text\":\"Invalid token\",\"code\":4}");
             flb_plg_warn(context->ins, "wrong credentials in request headers");
         }
 

--- a/plugins/in_splunk/splunk_prot.h
+++ b/plugins/in_splunk/splunk_prot.h
@@ -20,10 +20,11 @@
 #ifndef FLB_IN_SPLUNK_PROT
 #define FLB_IN_SPLUNK_PROT
 
-#define SPLUNK_AUTH_UNAUTH        1
-#define SPLUNK_AUTH_SUCCESS       0
-#define SPLUNK_AUTH_MISSING_CRED -1
-#define SPLUNK_AUTH_UNAUTHORIZED -2
+#define SPLUNK_AUTH_UNAUTH                 1
+#define SPLUNK_AUTH_SUCCESS                0
+#define SPLUNK_AUTH_MISSING_CRED          -1
+#define SPLUNK_AUTH_INVALID_AUTHORIZATION -2
+#define SPLUNK_AUTH_INVALID_TOKEN         -3
 
 #define SPLUNK_XFF_HEADER "x-forwarded-for"
 

--- a/tests/integration/scenarios/in_splunk/config/splunk_http1_token_auth.yaml
+++ b/tests/integration/scenarios/in_splunk/config/splunk_http1_token_auth.yaml
@@ -1,0 +1,17 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: splunk
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      host: 0.0.0.0
+      http2: off
+      net.keepalive: on
+      tls: off
+      splunk_token: 11111111-1111-1111-1111-111111111111
+  outputs:
+    - name: stdout
+      match: '*'

--- a/tests/integration/scenarios/in_splunk/tests/test_in_splunk_001.py
+++ b/tests/integration/scenarios/in_splunk/tests/test_in_splunk_001.py
@@ -198,6 +198,65 @@ def test_in_splunk_accepts_missing_authorization_header_by_default():
     assert result["status_code"] == 200
 
 
+SPLUNK_HEC_TOKEN = "11111111-1111-1111-1111-111111111111"
+SPLUNK_HEC_ENDPOINT = "/services/collector/event"
+
+
+SPLUNK_AUTH_CASES = [
+    {
+        "id": "valid_token",
+        "headers": [
+            f"Authorization: Splunk {SPLUNK_HEC_TOKEN}",
+            "Content-Type: application/json",
+        ],
+        "status_code": 200,
+        "body": SUCCESS_BODY,
+    },
+    {
+        "id": "invalid_token",
+        "headers": [
+            "Authorization: Splunk 99999999-0000-0000-0000-000000000000",
+            "Content-Type: application/json",
+        ],
+        "status_code": 403,
+        "body": '{"text":"Invalid token","code":4}',
+    },
+    {
+        "id": "malformed_authorization",
+        "headers": [
+            f"Authorization: {SPLUNK_HEC_TOKEN}",
+            "Content-Type: application/json",
+        ],
+        "status_code": 401,
+        "body": '{"text":"Invalid authorization","code":3}',
+    },
+    {
+        "id": "missing_authorization",
+        "headers": ["Content-Type: application/json"],
+        "status_code": 401,
+        "body": '{"text":"Token is required","code":2}',
+    },
+]
+
+
+@pytest.mark.parametrize("case", SPLUNK_AUTH_CASES, ids=[case["id"] for case in SPLUNK_AUTH_CASES])
+def test_in_splunk_hec_auth_status_codes(case):
+    service = Service("splunk_http1_token_auth.yaml")
+    service.start()
+
+    result = run_curl_request(
+        f"http://localhost:{service.flb_listener_port}{SPLUNK_HEC_ENDPOINT}",
+        json.dumps({"event": "x"}),
+        headers=case["headers"],
+        http_mode="http1.1",
+    )
+
+    service.stop()
+
+    assert result["status_code"] == case["status_code"]
+    assert result["body"] == case["body"]
+
+
 def test_in_splunk_to_out_splunk_prefers_configured_output_token():
     service = ForwardingService("in_splunk_to_out_splunk.yaml")
     service.start()


### PR DESCRIPTION
Align `in_splunk` HEC authentication failures with Splunk's documented HTTP status codes and JSON error bodies.

Previously, every auth failure returned **401** with plain text `error: unauthorized\n`. That breaks clients (e.g. Adobe Cloud onboarding prechecks) that expect Splunk's documented behavior:

- **401** for missing or malformed `Authorization` headers
- **403** for correctly formatted `Authorization: Splunk <token>` where the token is unknown

This change classifies auth failures in `validate_auth_header_ng()` and returns Splunk-compatible JSON responses from `splunk_prot_handle_ng()`.

| Case | Example | HTTP | Body |
|------|---------|------|------|
| Valid token | `Authorization: Splunk <configured>` | 200 | `{"text":"Success","code":0}` |
| Missing header | no `Authorization` | 401 | `{"text":"Token is required","code":2}` |
| Malformed header | `Authorization: <token>` (no `Splunk ` prefix) | 401 | `{"text":"Invalid authorization","code":3}` |
| Unknown token | `Authorization: Splunk <wrong>` | 403 | `{"text":"Invalid token","code":4}` |

Auth is enforced only when `splunk_token` is configured. Behavior without a configured token is unchanged.

Fixes #12036 

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

<details><summary>config</summary>
<p>

```yaml
service:
  flush: 1
  log_level: debug
pipeline:
  inputs:
    - name: splunk
      listen: 0.0.0.0
      port: 8088
      splunk_token: 11111111-1111-1111-1111-111111111111
  outputs:
    - name: stdout
      match: '*'
```


</p>
</details> 

- [x] Debug log output from testing the change


<details><summary>Debug log</summary>
<p>

```text
Fluent Bit v5.0.9
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/07/03 15:09:17.878] [ info] Configuration:
[2026/07/03 15:09:17.878] [ info]  flush time     | 1.000000 seconds
[2026/07/03 15:09:17.878] [ info]  grace          | 5 seconds
[2026/07/03 15:09:17.878] [ info]  daemon         | 0
[2026/07/03 15:09:17.878] [ info] ___________
[2026/07/03 15:09:17.878] [ info]  inputs:
[2026/07/03 15:09:17.878] [ info]      splunk
[2026/07/03 15:09:17.878] [ info] ___________
[2026/07/03 15:09:17.878] [ info]  filters:
[2026/07/03 15:09:17.878] [ info] ___________
[2026/07/03 15:09:17.878] [ info]  outputs:
[2026/07/03 15:09:17.878] [ info]      stdout.0
[2026/07/03 15:09:17.878] [ info] ___________
[2026/07/03 15:09:17.878] [ info]  collectors:
[2026/07/03 15:09:17.879] [ info] [fluent bit] version=5.0.9, commit=d0612246fe, pid=19652
[2026/07/03 15:09:17.879] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/07/03 15:09:17.879] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/07/03 15:09:17.879] [ info] [simd    ] disabled
[2026/07/03 15:09:17.879] [ info] [cmetrics] version=2.1.5
[2026/07/03 15:09:17.879] [ info] [ctraces ] version=0.7.1
[2026/07/03 15:09:17.879] [ info] [input:splunk:splunk.0] initializing
[2026/07/03 15:09:17.879] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2026/07/03 15:09:17.879] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2026/07/03 15:09:17.879] [debug] [downstream] listening on 0.0.0.0:8088
[2026/07/03 15:09:17.879] [ info] [input:splunk:splunk.0] listening on 0.0.0.0:8088 with 1 worker
[2026/07/03 15:09:17.879] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2026/07/03 15:09:17.879] [ info] [sp] stream processor started
[2026/07/03 15:09:17.879] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/07/03 15:09:17.880] [ info] [output:stdout:stdout.0] worker #0 started
[2026/07/03 15:09:37.301] [debug] [input:splunk:splunk.0] Mark as unknown type for ingested payloads
[2026/07/03 15:09:37.580] [debug] [task] created task=0x7fa08802f0f0 id=0 OK
[2026/07/03 15:09:37.580] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[0] splunk.0: [[1783091377.301386910, {"hec_token"=>"Splunk 11111111-1111-1111-1111-111111111111"}], {"event"=>"x"}]
[2026/07/03 15:09:37.580] [debug] [out flush] cb_destroy coro_id=0
[2026/07/03 15:09:37.580] [debug] [task] destroy task=0x7fa08802f0f0 (task_id=0)
[2026/07/03 15:09:46.390] [ warn] [input:splunk:splunk.0] wrong credentials in request headers
[2026/07/03 15:10:00.342] [ warn] [input:splunk:splunk.0] invalid authorization in request headers
^C[2026/07/03 15:10:10] [engine] caught signal (SIGINT)
[2026/07/03 15:10:10.847] [ warn] [engine] service will shutdown in max 5 seconds
[2026/07/03 15:10:10.847] [ info] [engine] pausing all inputs..
[2026/07/03 15:10:11.580] [ info] [engine] service has stopped (0 pending tasks)
[2026/07/03 15:10:11.580] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/07/03 15:10:11.580] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

</p>
</details> 

- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

<details><summary>valgrind</summary>
<p>

```text

valgrind --leak-check=yes $FBIT_HOME/fluent-bit -c fluent-bit.yml
==94070== Memcheck, a memory error detector
==94070== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==94070== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==94070== Command: /home/lecaros/fluent-bit/build/bin/fluent-bit -c fluent-bit.yml
==94070==
Fluent Bit v5.0.9
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/07/03 17:51:30.144] [ info] Configuration:
[2026/07/03 17:51:30.174] [ info]  flush time     | 1.000000 seconds
[2026/07/03 17:51:30.182] [ info]  grace          | 5 seconds
[2026/07/03 17:51:30.183] [ info]  daemon         | 0
[2026/07/03 17:51:30.183] [ info] ___________
[2026/07/03 17:51:30.184] [ info]  inputs:
[2026/07/03 17:51:30.184] [ info]      splunk
[2026/07/03 17:51:30.185] [ info] ___________
[2026/07/03 17:51:30.185] [ info]  filters:
[2026/07/03 17:51:30.186] [ info] ___________
[2026/07/03 17:51:30.186] [ info]  outputs:
[2026/07/03 17:51:30.187] [ info]      stdout.0
[2026/07/03 17:51:30.187] [ info] ___________
[2026/07/03 17:51:30.188] [ info]  collectors:
[2026/07/03 17:51:30.356] [ info] [fluent bit] version=5.0.9, commit=d0612246fe, pid=94070
[2026/07/03 17:51:30.371] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2026/07/03 17:51:30.397] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/07/03 17:51:30.398] [ info] [simd    ] SSE2
[2026/07/03 17:51:30.399] [ info] [cmetrics] version=2.1.5
[2026/07/03 17:51:30.419] [ info] [ctraces ] version=0.7.1
[2026/07/03 17:51:30.463] [ info] [input:splunk:splunk.0] initializing
[2026/07/03 17:51:30.464] [ info] [input:splunk:splunk.0] storage_strategy='memory' (memory only)
[2026/07/03 17:51:30.467] [debug] [splunk:splunk.0] created event channels: read=21 write=22
[2026/07/03 17:51:30.526] [debug] [downstream] listening on 0.0.0.0:8088
[2026/07/03 17:51:30.529] [ info] [input:splunk:splunk.0] listening on 0.0.0.0:8088 with 1 worker
[2026/07/03 17:51:30.539] [debug] [stdout:stdout.0] created event channels: read=24 write=25
[2026/07/03 17:51:30.711] [ info] [sp] stream processor started
[2026/07/03 17:51:30.717] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/07/03 17:51:30.757] [ info] [output:stdout:stdout.0] worker #0 started
[2026/07/03 17:52:07.830] [debug] [input:splunk:splunk.0] Mark as unknown type for ingested payloads
[2026/07/03 17:52:08.696] [debug] [task] created task=0x58af1b0 id=0 OK
[0] splunk.0: [[1783101127.846571359, {"hec_token"=>"Splunk 11111111-1111-1111-1111-111111111111"}], {"event"=>"x"}]
[2026/07/03 17:52:08.701] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/07/03 17:52:08.728] [debug] [out flush] cb_destroy coro_id=0
[2026/07/03 17:52:08.743] [debug] [task] destroy task=0x58af1b0 (task_id=0)
[2026/07/03 17:52:14.227] [ warn] [input:splunk:splunk.0] wrong credentials in request headers
[2026/07/03 17:52:21.680] [ warn] [input:splunk:splunk.0] invalid authorization in request headers
^C[2026/07/03 17:52:23] [engine] caught signal (SIGINT)
[2026/07/03 17:52:23.962] [ warn] [engine] service will shutdown in max 5 seconds
[2026/07/03 17:52:23.963] [ info] [engine] pausing all inputs..
[2026/07/03 17:52:24.686] [ info] [engine] service has stopped (0 pending tasks)
[2026/07/03 17:52:24.691] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/07/03 17:52:24.701] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==94070==
==94070== HEAP SUMMARY:
==94070==     in use at exit: 0 bytes in 0 blocks
==94070==   total heap usage: 2,875 allocs, 2,875 frees, 3,976,457 bytes allocated
==94070==
==94070== All heap blocks were freed -- no leaks are possible
==94070==
==94070== For lists of detected and suppressed errors, rerun with: -s
==94070== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

</p>
</details> 


**Backporting**
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Splunk HEC authentication responses with HEC-style JSON errors and clearer status codes: missing credentials (401, code 2), invalid authorization (401, code 3), and invalid tokens (403, code 4).
  * Added more accurate HTTP reason phrase mapping for forbidden responses (403 → “Forbidden”).
* **Tests**
  * Added integration scenario coverage for HEC authentication variants (valid token, invalid token, malformed header, missing authorization) and asserts expected HTTP status codes and response bodies, using a new Splunk HEC token auth test configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->