### PR TITLE
in_forward: fix 100% CPU hang and connection teardown use-after-free

### DIFF
--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -28,6 +28,8 @@
 #include "fw_prot.h"
 #include "fw_conn.h"
 
+static void fw_conn_drop(struct flb_connection *connection);
+
 static int fw_conn_event_internal(struct flb_connection *connection)
 {
     int ret;
@@ -41,6 +43,15 @@ static int fw_conn_event_internal(struct flb_connection *connection)
     struct flb_in_fw_config *ctx;
 
     conn = connection->user_data;
+
+    /*
+     * The wrapper may have already been released by the engine drop
+     * notification (e.g. a queued/injected event that fires after an IO
+     * timeout closed the connection). Nothing to do in that case.
+     */
+    if (conn == NULL) {
+        return 0;
+    }
 
     ctx = conn->ctx;
 
@@ -137,6 +148,14 @@ int fw_conn_event(void *data)
     connection = (struct flb_connection *) data;
 
     conn = connection->user_data;
+
+    /*
+     * The wrapper may have already been released by the engine drop
+     * notification (e.g. an injected event firing after an IO timeout).
+     */
+    if (conn == NULL) {
+        return 0;
+    }
 
     ctx = conn->ctx;
 
@@ -249,16 +268,26 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     }
 
     mk_list_add(&conn->_head, &ctx->connections);
+
+    /*
+     * Install the drop notification callback only after all fallible setup
+     * has succeeded. If an earlier allocation or mk_event_add() fails, conn
+     * is freed and the caller releases the connection; installing the
+     * callback before that point would make prepare_destroy_conn() invoke
+     * fw_conn_drop() on the freed wrapper (use-after-free/double-free).
+     */
+    connection->drop_notification_callback = fw_conn_drop;
+
     return conn;
 }
 
-int fw_conn_del(struct fw_conn *conn)
+/*
+ * Free the plugin-side connection wrapper. This does NOT release the
+ * underlying downstream connection; the caller decides whether the engine
+ * (drop notification) or the plugin (fw_conn_del) owns that release.
+ */
+static void fw_conn_release(struct fw_conn *conn)
 {
-    /* The downstream unregisters the file descriptor from the event-loop
-     * so there's nothing to be done by the plugin
-     */
-    flb_downstream_conn_release(conn->connection);
-
     /* Release resources */
     mk_list_del(&conn->_head);
 
@@ -278,6 +307,55 @@ int fw_conn_del(struct fw_conn *conn)
     }
     flb_free(conn->buf);
     flb_free(conn);
+}
+
+/*
+ * Invoked by the engine (via prepare_destroy_conn) when the underlying
+ * connection is being destroyed out from under the plugin, e.g. on an IO
+ * timeout. Detach and free the wrapper here so it is never left in
+ * ctx->connections pointing at a freed connection, which would otherwise
+ * cause a use-after-free on the next fw_conn_del_all (shutdown/pause).
+ */
+static void fw_conn_drop(struct flb_connection *connection)
+{
+    struct fw_conn *conn;
+
+    if (connection == NULL) {
+        return;
+    }
+
+    conn = connection->user_data;
+
+    /* The engine owns the connection release from this point on */
+    connection->drop_notification_callback = NULL;
+    connection->user_data = NULL;
+
+    if (conn != NULL) {
+        conn->connection = NULL;
+        fw_conn_release(conn);
+    }
+}
+
+int fw_conn_del(struct fw_conn *conn)
+{
+    struct flb_connection *connection = conn->connection;
+
+    /*
+     * Detach the wrapper from the connection first so the drop
+     * notification callback becomes a no-op during the release below and
+     * cannot double-free the wrapper.
+     */
+    if (connection != NULL) {
+        connection->drop_notification_callback = NULL;
+        connection->user_data = NULL;
+
+        /* The downstream unregisters the file descriptor from the
+         * event-loop so there's nothing else to be done by the plugin.
+         */
+        flb_downstream_conn_release(connection);
+    }
+
+    fw_conn_release(conn);
 
     return 0;
 }

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -272,8 +272,19 @@ static inline int prepare_destroy_conn_safe(struct flb_connection *connection)
 
 static int destroy_conn(struct flb_connection *connection)
 {
-    /* Delay the destruction of busy connections */
-    if (connection->busy_flag) {
+    /*
+     * Delay the destruction if the connection is still marked busy or if
+     * there are pending events referencing it (e.g. an event still linked
+     * in the priority bucket queue after mk_event_inject). Freeing the
+     * connection while its event is queued would leave a dangling
+     * _priority_head in the bucket queue, causing a use-after-free and a
+     * stuck event that spins the input thread at 100% CPU.
+     *
+     * The connection stays in the destroy_queue and is retried on the next
+     * pending-destroy sweep, by which point the event has been drained.
+     */
+    if (connection->busy_flag ||
+        !mk_list_entry_is_orphan(&connection->event._priority_head)) {
         return 0;
     }
 
@@ -413,6 +424,18 @@ void flb_downstream_destroy(struct flb_downstream *stream)
 
         mk_list_foreach_safe(head, tmp, &stream->destroy_queue) {
             connection = mk_list_entry(head, struct flb_connection, _head);
+
+            /*
+             * This is the terminal cleanup: there is no later
+             * pending-destroy sweep. destroy_conn() defers connections
+             * whose event is still linked in the priority bucket queue, so
+             * unlink any lingering event here (the bucket queue is still
+             * alive at this point) to make sure the connection is freed
+             * instead of leaked.
+             */
+            if (!mk_list_entry_is_orphan(&connection->event._priority_head)) {
+                mk_list_del(&connection->event._priority_head);
+            }
 
             destroy_conn(connection);
         }

--- a/tests/integration/scenarios/in_forward/config/in_forward_conn_churn.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_conn_churn.yaml
@@ -1,0 +1,26 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      threaded: true
+      net.keepalive: on
+      net.io_timeout: 2
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -1027,6 +1027,58 @@ def test_in_forward_tls_message_mode():
     assert records[0]["message"] == "tls-message"
 
 
+def test_in_forward_tls_idle_connection_timeout_churn(monkeypatch):
+    """
+    Regression test for issue #12025.
+
+    Open many idle TLS connections so net.io_timeout expires for all of them
+    in the same downstream timeout sweep. Previously the engine could free a
+    connection while its injected teardown event was still linked in the
+    priority bucket queue (100% CPU spin / use-after-free), and the forward
+    plugin left orphaned connection wrappers that crashed on the next
+    pause/shutdown. The listener must survive and keep ingesting.
+    """
+    service = Service("in_forward_conn_churn.yaml")
+    service.start()
+
+    port = service.flb_listener_port
+    cafile = service.tls_crt_file
+
+    try:
+        for _ in range(3):
+            idle = []
+            for _ in range(30):
+                context = ssl.create_default_context(cafile=cafile)
+                context.check_hostname = False
+                context.verify_mode = ssl.CERT_NONE
+                raw = socket.create_connection(("127.0.0.1", port), timeout=5)
+                tls = context.wrap_socket(raw, server_hostname="localhost")
+                idle.append(tls)
+
+            # net.io_timeout is 2s: let the whole batch time out in one sweep
+            time.sleep(4)
+
+            for tls in idle:
+                try:
+                    tls.close()
+                except OSError:
+                    pass
+
+        # The listener must still accept a fresh connection and ingest data
+        context = ssl.create_default_context(cafile=cafile)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        raw = socket.create_connection(("127.0.0.1", port), timeout=5)
+        with context.wrap_socket(raw, server_hostname="localhost") as tls:
+            tls.sendall(_message_mode_payload(TEST_TAG, {"message": "after-churn"}))
+
+        records = service.wait_for_record_count(1, timeout=15)
+    finally:
+        service.stop()
+
+    assert any(record.get("message") == "after-churn" for record in records)
+
+
 def test_in_forward_secure_forward_auth_success():
     service = Service("in_forward_secure.yaml")
     service.start()


### PR DESCRIPTION
#### Summary

Fixes #12025. The `in_forward` input thread could spin at 100% CPU with connections stuck in `CLOSE_WAIT` and their event handlers never dispatched. Root cause is in the shared downstream connection teardown path; while reproducing it I also found and fixed a related use-after-free on the pause/shutdown path.

#### Root cause

When a batch of connections times out in a single sweep, each gets `prepare_destroy_conn()` + `mk_event_inject()`. The event loop only processes `FLB_ENGINE_LOOP_MAX_ITER` (10) events per round, but `flb_downstream_conn_pending_destroy_list()` freed **all** queued connections at the end of the round — including those whose injected event was still linked in the priority bucket queue via `_priority_head`.

That produced two failures:

1. **100% CPU hang (the reported issue).** The freed connection left a stale, non-NULL `_priority_head` in the bucket queue. `flb_event_load_bucket_queue_event()` skips it (`prev == NULL` check fails), so the readable `CLOSE_WAIT` fd keeps waking epoll while its handler is never dispatched → the input thread spins. There is also a use-after-free when the freed node is popped on the next iteration.

2. **Pause/shutdown crash.** `in_forward` never registered a drop-notification callback, so when the engine reclaimed a timed-out connection the plugin's `fw_conn` wrapper was left pointing at freed memory. The next `fw_conn_del_all()` (backpressure pause or shutdown) dereferenced it.

The upstream connection path already guards against (1) — see e7caf86dc — but the downstream path was missing the equivalent protection.

#### Fix

- **`flb_downstream.c` (primary):** defer destroying a connection while its event is still linked in the priority bucket queue; it stays in the destroy queue and is freed on a later sweep once the event has drained. Mirrors the existing upstream guard.
- **`in_forward` (`fw_conn.c`):** register a `drop_notification_callback` so the plugin wrapper is released in sync with the connection, matching the pattern `flb_http_server` already uses. Splits wrapper cleanup from the downstream release to avoid double-release, and guards `fw_conn_event` against an injected event firing after teardown.

#### Reproduction

Opening many idle TLS connections so `net.io_timeout` expires for the whole batch in one sweep reproduces all three reported symptoms on the pre-fix build: forward thread at ~100% CPU with no clients connected, sockets in `CLOSE_WAIT`, and (via gdb) events with stale non-NULL `_priority_head`. Valgrind shows the use-after-free with the exact stack from the issue (freed in `destroy_conn`, read in `flb_bucket_queue_pop_min` from `input_thread`).

#### Testing

- New integration regression test (`test_in_forward_tls_idle_connection_timeout_churn`) drives the idle-connection-timeout churn and asserts the listener survives and keeps ingesting.
- Full lifecycle including shutdown is clean under Valgrind (0 errors), down from 26 invalid reads/writes + SIGABRT before the fix.
- `scenarios/in_forward` integration suite passes.

Note: the primary change is in shared core code (`flb_downstream.c`) and affects all network inputs, not just forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forward-secure connection lifetime management to avoid stale event handling and dangling references during connection churn.
  * Hardened downstream connection teardown so connections aren’t freed while still referenced by internal event queues, preventing leaks and reducing risk of instability.
* **Tests**
  * Added a new integration scenario covering forward connection churn over TLS.
  * Added a regression test that repeatedly churns idle TLS sockets and confirms messages continue to forward successfully afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->