### PR TITLE
build fixes: out_stackdriver int64_t line var, gzip endian-safe magic check

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1907,7 +1907,7 @@ static flb_sds_t stackdriver_format(struct flb_stackdriver *ctx,
     struct flb_mp_map_header entries_mh;
     struct tm tm;
     size_t s;
-    long source_location_line;
+    int64_t source_location_line;
 
     /* consolidated cleanup variables */
     int decoder_initialized = FLB_FALSE;

--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -704,12 +704,13 @@ static int flb_gzip_decompressor_process_header(
     context->read_buffer = &context->read_buffer[FLB_GZIP_HEADER_SIZE];
     context->input_buffer_length -= FLB_GZIP_HEADER_SIZE;
 
-    /* Magic bytes */
-    if (inner_context->gzip_header.magic_number != FLB_GZIP_MAGIC_NUMBER) {
+    /* Magic bytes (stored in little endian order in the header) */
+    if (read_le16((unsigned char *) &inner_context->gzip_header.magic_number) !=
+        FLB_GZIP_MAGIC_NUMBER) {
         context->state = FLB_DECOMPRESSOR_STATE_FAILED;
 
         flb_error("[gzip] invalid magic bytes : %04x",
-                  inner_context->gzip_header.magic_number);
+                  read_le16((unsigned char *) &inner_context->gzip_header.magic_number));
 
         return FLB_DECOMPRESSOR_FAILURE;
     }


### PR DESCRIPTION
Two build/CI fixes found while investigating the failed v5.0.9 staging build (https://github.com/fluent/fluent-bit/actions/runs/28693445706/job/85098879153):

**1. out_stackdriver: use int64_t for source_location_line**

On 32-bit targets (arm/v7) `long` is 32-bit while `int64_t` is `long long`, so `stackdriver_format()` failed to compile when passing `&source_location_line` to `extract_source_location()`, which expects `int64_t *`:

```
/src/fluent-bit/plugins/out_stackdriver/stackdriver.c:2450:61: error: passing argument 2 of 'extract_source_location' from incompatible pointer type [-Wincompatible-pointer-types]
note: expected 'int64_t *' {aka 'long long int *'} but argument is of type 'long int *'
```

Declare the variable as `int64_t` to match the function signature on all architectures.

**2. gzip: read magic number endian-safely in streaming decompressor**

Found via the s390x unit-test job on this PR: the gzip header magic was `memcpy`'d into a `uint16_t` and compared against `0x8B1F`, which only holds on little-endian hosts. On big-endian targets a valid stream was rejected with `invalid magic bytes : 1f8b`. Read the field with `read_le16()` so the comparison works regardless of host byte order.

----

Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [x] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Run [local packaging test](https://github.com/fluent/fluent-bit/tree/master/packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [N/A] Backport to latest stable release.

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source line number handling for Stackdriver output to better preserve accuracy with larger values.
  * Fixed gzip header validation to correctly interpret stored magic bytes as little-endian, with clearer error reporting when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->