### PR TITLE
out_forward: close connection on failed flush to avoid frame desync

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1789,6 +1789,7 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
         flb_plg_debug(ctx->ins, "handshake status = %i", ret);
         if (ret == -1) {
             if (u_conn) {
+                flb_upstream_conn_recycle(u_conn, FLB_FALSE);
                 flb_upstream_conn_release(u_conn);
             }
 
@@ -1833,6 +1834,17 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
     }
 
     if (u_conn) {
+        if (ret != FLB_OK) {
+            /*
+             * A forward frame is written as multiple non-atomic writes
+             * (header, body, options). On failure part of it may already be
+             * on the socket, so don't return the connection to the keepalive
+             * pool: the next frame would be read as the truncated frame's
+             * missing piece and desync the receiver's msgpack stream. Force
+             * it closed so the next flush starts on a fresh connection.
+             */
+            flb_upstream_conn_recycle(u_conn, FLB_FALSE);
+        }
         flb_upstream_conn_release(u_conn);
     }
 


### PR DESCRIPTION
out_forward reuses upstream connections via the keepalive pool. This PR fixes two cases where a connection left in a desynced protocol state is returned to that pool and reused, corrupting the next exchange.

**1. Failed frame flush (`cb_forward_flush`)**

  A Forward-mode frame is written as multiple non-atomic writes (header, body, options). If one of those writes fails, part of the frame is already committed to the socket. The current code still returns the connection to the keepalive pool, so the next flush reuses it and the receiver reads the following frame's bytes as the missing element of the truncated frame — desyncing its msgpack stream (observed with compressed payloads / large frames as `invalid options field`). We now force the connection closed on any non-`FLB_OK` flush result.

**2. Failed secure-forward handshake**

  The `shared_key` handshake sends a PING before reading the PONG. If the handshake fails after that — e.g. a rejected/mismatched PONG or a read timeout — the connection is left mid-protocol. It was still returned to the keepalive pool and, because `ka_count` then becomes > 0, the next reuse **skips the handshake entirely** (`u_conn->ka_count == 0` guard) and sends data frames on a socket that never completed authentication. We now force it closed on handshake failure too.

  Both fixes call `flb_upstream_conn_recycle(u_conn, FLB_FALSE)` before `flb_upstream_conn_release()`. This matters because`flb_upstream_conn_release()` only skips recycling when `net_error` is set, but several partial-write / protocol-failure paths in `flb_io.c` return `-1` without setting `net_error` (WOULDBLOCK timeout, async socket/event-loop errors, protocol-level rejects), so those connections were previously recycled unsafely.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when forwarding fails by ensuring upstream connections are not kept for reuse after errors.
  * When the secure forwarding handshake fails, the upstream connection is now force-closed rather than returned to the keepalive pool.
  * If only part of a forward frame is written and the flush result is not successful, the upstream connection is recycled to prevent subsequent requests from using an unhealthy connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->