### PR TITLE
in_mqtt: fix off-by-one in publish topic length validation

### DIFF
--- a/plugins/in_mqtt/mqtt_prot.c
+++ b/plugins/in_mqtt/mqtt_prot.c
@@ -286,6 +286,10 @@ static int mqtt_handle_publish(struct mqtt_conn *conn)
     conn->buf_pos++;
     hlen |= BUFC();
 
+    /* Move past the 2-byte topic length field before measuring how much
+     * of the frame is left for the topic itself. */
+    conn->buf_pos++;
+
     /* Validate topic length against current buffer capacity (overflow) */
     frame_avail = conn->buf_frame_end - conn->buf_pos + 1;
     if (hlen > frame_avail) {
@@ -293,7 +297,6 @@ static int mqtt_handle_publish(struct mqtt_conn *conn)
         return -1;
     }
 
-    conn->buf_pos++;
     topic     = conn->buf_pos;
     topic_len = hlen;
     conn->buf_pos += hlen;


### PR DESCRIPTION
AddressSanitizer, malformed PUBLISH that fills the connection buffer:

    ==ERROR: AddressSanitizer: heap-buffer-overflow READ of size 1
        #0 mqtt_handle_publish plugins/in_mqtt/mqtt_prot.c
    address is 0 bytes after the 2048-byte connection buffer

mqtt_handle_publish() compares the 2-byte topic length (hlen) against frame_avail while conn->buf_pos still points at the length field's low byte, so frame_avail counts that byte as space for the topic. The buf_pos++ right after moves onto the topic, so a PUBLISH whose declared topic length equals frame_avail reads one byte past buf_frame_end; when the packet fills the buffer to buffer_size that byte is buf[buffer_size]. Moving the increment above the check makes frame_avail measure the actual topic space. Existing in_mqtt runtime tests still pass.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**

- [N/A] Documentation required for this feature

**Backporting**

- [ ] Backport to latest stable release.

----
Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incoming MQTT PUBLISH messages by validating the topic length against the correct remaining buffer range.
  * This helps prevent malformed packets from being accepted and improves reliability when processing message topics and payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->