### PR TITLE
in_forward: fix stale byte accounting when multiple frames share a buffer

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1756,7 +1756,7 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                 goto cleanup_msgpack;
             }
 
-            ret = msgpack_unpacker_next(unp, &result);
+            ret = msgpack_unpacker_next_with_size(unp, &result, &bytes);
         }
     }
 


### PR DESCRIPTION
## Summary

In `fw_prot_process`, the inner frame loop tracks how many bytes each decoded object consumed in `all_used`, then uses it to trim `conn->buf` once the buffer is drained. The first object is parsed with `msgpack_unpacker_next_with_size(unp, &result, &bytes)`, but the loop tail advanced to the next object with the plain `msgpack_unpacker_next(unp, &result)`, which does **not** refresh `bytes`.

When several frames arrive in a single buffer — common with compressed payloads, which are small — every iteration after the first adds the *previous* object's stale `bytes` to `all_used`. The resulting total is wrong, so `conn->buf` is trimmed by the wrong offset and the remaining frames in the buffer desync.

The fix uses `msgpack_unpacker_next_with_size()` at the loop tail as well, so `bytes` is refreshed for every object, matching the initial parse.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message parsing so incoming data is counted more accurately during processing.
  * Helped ensure multi-packet or multi-object streams are handled reliably without affecting byte tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->