### PR TITLE
out_forward: align secure forward handshake and chunk ack with protocol spec [Backport to 4.2]

### DIFF
--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -946,6 +946,20 @@ static int config_set_properties(struct flb_upstream_node *node,
         fc->password = "";
     }
 
+    /*
+     * username/password authorization is part of the secure forward
+     * handshake, which is only performed when a shared_key is set. Reject
+     * credentials that would otherwise be silently ignored.
+     */
+    if (fc->shared_key == NULL &&
+        (strlen(fc->username) > 0 || strlen(fc->password) > 0)) {
+        flb_plg_error(ctx->ins,
+                      "'username'/'password' is set but no 'shared_key' or "
+                      "'empty_shared_key' is configured: username/password "
+                      "authentication requires the secure forward handshake");
+        return -1;
+    }
+
     /* Self Hostname */
     tmp = config_get_property("self_hostname", node, ctx);
     if (tmp) {
@@ -1105,7 +1119,11 @@ static int forward_config_ha(const char *upstream_file,
         }
 
         /* Read properties into 'fc' context */
-        config_set_properties(node, fc, ctx);
+        ret = config_set_properties(node, fc, ctx);
+        if (ret == -1) {
+            forward_config_destroy(fc);
+            return -1;
+        }
 
         /* Initialize and validate forward_config context */
         ret = forward_config_init(fc, ctx);
@@ -1212,7 +1230,11 @@ static int forward_config_simple(struct flb_forward *ctx,
         flb_output_upstream_set(ctx->u, ins);
     }
     /* Read properties into 'fc' context */
-    config_set_properties(NULL, fc, ctx);
+    ret = config_set_properties(NULL, fc, ctx);
+    if (ret == -1) {
+        forward_config_destroy(fc);
+        return -1;
+    }
 
     /* Initialize and validate forward_config context */
     ret = forward_config_init(fc, ctx);

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -1714,6 +1714,12 @@ static void cb_forward_flush(struct flb_event_chunk *event_chunk,
                               event_chunk->tag, flb_sds_len(event_chunk->tag),
                               event_chunk->data, event_chunk->size,
                               &out_buf, &out_size);
+    if (mode == -1) {
+        flb_plg_error(ctx->ins, "failed to format outgoing payload");
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        flb_free(flush_ctx);
+        FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
 
     /* Get a TCP connection instance */
     if (fc->unix_path == NULL) {

--- a/plugins/out_forward/forward.c
+++ b/plugins/out_forward/forward.c
@@ -377,8 +377,15 @@ static void secure_forward_set_ping(struct flb_forward_ping *ping,
     }
 }
 
-static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
-                                          struct flb_forward_ping *ping,
+/*
+ * Compute sha512_hex(shared_key_salt + hostname + nonce + shared_key) as
+ * defined by the Forward protocol handshake (PING and PONG digests).
+ */
+static int secure_forward_hash_key_digest(struct flb_forward_config *fc,
+                                          const char *hostname,
+                                          size_t hostname_len,
+                                          const char *nonce,
+                                          size_t nonce_len,
                                           char *buf, int buflen)
 {
     size_t             length_entries[4];
@@ -393,11 +400,11 @@ static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
     data_entries[0]   = (unsigned char *) fc->shared_key_salt;
     length_entries[0] = 16;
 
-    data_entries[1]   = (unsigned char *) fc->self_hostname;
-    length_entries[1] = strlen(fc->self_hostname);
+    data_entries[1]   = (unsigned char *) hostname;
+    length_entries[1] = hostname_len;
 
-    data_entries[2]   = (unsigned char *) ping->nonce;
-    length_entries[2] = ping->nonce_len;
+    data_entries[2]   = (unsigned char *) nonce;
+    length_entries[2] = nonce_len;
 
     data_entries[3]   = (unsigned char *) fc->shared_key;
     length_entries[3] = strlen(fc->shared_key);
@@ -416,6 +423,17 @@ static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
     flb_forward_format_bin_to_hex(hash, 64, buf);
 
     return 0;
+}
+
+static int secure_forward_hash_shared_key(struct flb_forward_config *fc,
+                                          struct flb_forward_ping *ping,
+                                          char *buf, int buflen)
+{
+    return secure_forward_hash_key_digest(fc,
+                                          fc->self_hostname,
+                                          strlen(fc->self_hostname),
+                                          ping->nonce, ping->nonce_len,
+                                          buf, buflen);
 }
 
 static int secure_forward_hash_password(struct flb_forward_config *fc,
@@ -457,7 +475,7 @@ static int secure_forward_hash_password(struct flb_forward_config *fc,
 }
 
 static int secure_forward_ping(struct flb_connection *u_conn,
-                               msgpack_object map,
+                               struct flb_forward_ping *ping,
                                struct flb_forward_config *fc,
                                struct flb_forward *ctx)
 {
@@ -467,22 +485,14 @@ static int secure_forward_ping(struct flb_connection *u_conn,
     char password_hexdigest[128];
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_pck;
-    struct flb_forward_ping ping;
 
-    secure_forward_set_ping(&ping, &map);
-
-    if (ping.nonce == NULL) {
-        flb_plg_error(ctx->ins, "nonce not found");
-        return -1;
-    }
-
-    if (secure_forward_hash_shared_key(fc, &ping, shared_key_hexdigest, 128)) {
+    if (secure_forward_hash_shared_key(fc, ping, shared_key_hexdigest, 128)) {
         flb_plg_error(ctx->ins, "failed to hash shared_key");
         return -1;
     }
 
-    if (ping.auth != NULL) {
-        if (secure_forward_hash_password(fc, &ping, password_hexdigest, 128)) {
+    if (ping->auth != NULL) {
+        if (secure_forward_hash_password(fc, ping, password_hexdigest, 128)) {
             flb_plg_error(ctx->ins, "failed to hash password");
             return -1;
         }
@@ -511,7 +521,7 @@ static int secure_forward_ping(struct flb_connection *u_conn,
     msgpack_pack_str_body(&mp_pck, shared_key_hexdigest, 128);
 
     /* [4] Username and password (optional) */
-    if (ping.auth != NULL) {
+    if (ping->auth != NULL) {
         msgpack_pack_str(&mp_pck, strlen(fc->username));
         msgpack_pack_str_body(&mp_pck, fc->username, strlen(fc->username));
         msgpack_pack_str(&mp_pck, 128);
@@ -536,18 +546,25 @@ static int secure_forward_ping(struct flb_connection *u_conn,
     return -1;
 }
 
-static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
+static int secure_forward_pong(struct flb_forward *ctx,
+                               struct flb_forward_config *fc,
+                               const char *nonce, size_t nonce_len,
+                               char *buf, int buf_size)
 {
     int ret;
     char msg[32] = {0};
+    char server_hexdigest[128];
     size_t off = 0;
     msgpack_unpacked result;
     msgpack_object root;
     msgpack_object o;
+    msgpack_object hostname;
+    msgpack_object digest;
 
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, buf_size, &off);
     if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
         return -1;
     }
 
@@ -556,7 +573,14 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
         goto error;
     }
 
-    if (root.via.array.size < 4) {
+    /*
+     * PONG is defined as:
+     *
+     *   [type, auth_result, reason, server_hostname, shared_key_hexdigest]
+     */
+    if (root.via.array.size != 5) {
+        flb_plg_error(ctx->ins, "invalid PONG message: expected 5 fields, "
+                      "got %i", root.via.array.size);
         goto error;
     }
 
@@ -574,11 +598,7 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
         goto error;
     }
 
-    if (o.via.boolean) {
-        msgpack_unpacked_destroy(&result);
-        return 0;
-    }
-    else {
+    if (!o.via.boolean) {
         o = root.via.array.ptr[2];
         if (o.type != MSGPACK_OBJECT_STR) {
             goto error;
@@ -592,7 +612,47 @@ static int secure_forward_pong(struct flb_forward *ctx, char *buf, int buf_size)
             msg[o.via.str.size] = '\0';
         }
         flb_plg_error(ctx->ins, "failed authorization: %s", msg);
+        goto error;
     }
+
+    /*
+     * Mutual authentication: the server must prove it holds the same
+     * shared_key by returning
+     *
+     *   sha512_hex(shared_key_salt + server_hostname + nonce + shared_key)
+     */
+    hostname = root.via.array.ptr[3];
+    if (hostname.type != MSGPACK_OBJECT_STR) {
+        flb_plg_error(ctx->ins, "invalid PONG server_hostname type");
+        goto error;
+    }
+
+    digest = root.via.array.ptr[4];
+    if (digest.type != MSGPACK_OBJECT_STR || digest.via.str.size != 128) {
+        flb_plg_error(ctx->ins, "invalid PONG shared_key_hexdigest");
+        goto error;
+    }
+
+    ret = secure_forward_hash_key_digest(fc,
+                                         hostname.via.str.ptr,
+                                         hostname.via.str.size,
+                                         nonce, nonce_len,
+                                         server_hexdigest,
+                                         sizeof(server_hexdigest));
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to hash PONG shared_key");
+        goto error;
+    }
+
+    if (memcmp(server_hexdigest, digest.via.str.ptr, 128) != 0) {
+        flb_plg_error(ctx->ins,
+                      "PONG shared_key digest mismatch: "
+                      "server does not hold the same shared_key");
+        goto error;
+    }
+
+    msgpack_unpacked_destroy(&result);
+    return 0;
 
  error:
     msgpack_unpacked_destroy(&result);
@@ -605,11 +665,14 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
 {
     int ret;
     char buf[1024];
+    char nonce[1024];
+    size_t nonce_len;
     size_t out_len;
     size_t off;
     msgpack_unpacked result;
     msgpack_object root;
     msgpack_object o;
+    struct flb_forward_ping ping;
 
     /* Wait for server HELO */
     ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
@@ -664,7 +727,28 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
         return -1;
     }
 
-    ret = secure_forward_ping(u_conn, o, fc, ctx);
+    secure_forward_set_ping(&ping, &o);
+    if (ping.nonce == NULL) {
+        flb_plg_error(ctx->ins, "nonce not found");
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    /*
+     * Keep a copy of the HELO nonce: 'ping.nonce' points into 'buf' and
+     * the same buffer is reused below to read the PONG message. The nonce
+     * is required to validate the PONG shared_key digest.
+     */
+    if (ping.nonce_len < 0 || (size_t) ping.nonce_len > sizeof(nonce)) {
+        flb_plg_error(ctx->ins, "HELO nonce is too large (%i bytes)",
+                      ping.nonce_len);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+    nonce_len = ping.nonce_len;
+    memcpy(nonce, ping.nonce, nonce_len);
+
+    ret = secure_forward_ping(u_conn, &ping, fc, ctx);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "Failed PING");
         msgpack_unpacked_destroy(&result);
@@ -674,13 +758,13 @@ static int secure_forward_handshake(struct flb_connection *u_conn,
     /* Expect a PONG */
     ret = secure_forward_read(ctx, u_conn, fc, buf, sizeof(buf) - 1, &out_len);
     if (ret == -1) {
-        flb_plg_error(ctx->ins, "handshake error expecting HELO");
+        flb_plg_error(ctx->ins, "handshake error expecting PONG");
         msgpack_unpacked_destroy(&result);
         return -1;
     }
 
     /* Process PONG */
-    ret = secure_forward_pong(ctx, buf, out_len);
+    ret = secure_forward_pong(ctx, fc, nonce, nonce_len, buf, out_len);
     if (ret == -1) {
         msgpack_unpacked_destroy(&result);
         return -1;

--- a/plugins/out_forward/forward.h
+++ b/plugins/out_forward/forward.h
@@ -134,10 +134,16 @@ struct flb_forward_ping {
     int keepalive;
 };
 
+/*
+ * Maximum storage required for a 'chunk' ack token: Base64 representation
+ * of a 128 bits unique id (24 bytes) plus NUL terminator.
+ */
+#define FLB_FORWARD_CHUNK_TOKEN_SIZE   25
+
 /* Flush callback context */
 struct flb_forward_flush {
     struct flb_forward_config *fc;
-    char checksum_hex[33];
+    char chunk_token[FLB_FORWARD_CHUNK_TOKEN_SIZE];
 };
 
 struct flb_forward_config *flb_forward_target(struct flb_forward *ctx,

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -49,7 +49,7 @@ int flb_forward_format_append_tag(struct flb_forward *ctx,
 #ifdef FLB_HAVE_RECORD_ACCESSOR
     flb_sds_t tmp;
     msgpack_object m;
-    
+
     memset(&m, 0, sizeof(m));
 
     if (!fc->ra_tag) {
@@ -200,7 +200,7 @@ static int append_options(struct flb_forward *ctx,
 
     flb_plg_debug(ctx->ins,
                   "send options records=%d chunk='%s'",
-                  entries, out_chunk ? out_chunk : "NULL");
+                  entries, chunk ? chunk : "NULL");
     return 0;
 }
 
@@ -445,14 +445,18 @@ static int flb_forward_format_forward_mode(struct flb_forward *ctx,
                                                   &transcoded_buffer,
                                                   &transcoded_length);
 
-            if (result == 0) {
-                append_options(ctx, fc, event_type, &mp_pck, entries,
-                               transcoded_buffer,
-                               transcoded_length,
-                               NULL, chunk);
-
-                free(transcoded_buffer);
+            if (result != 0) {
+                msgpack_sbuffer_destroy(&mp_sbuf);
+                return -1;
             }
+
+            entries = flb_mp_count(transcoded_buffer, transcoded_length);
+            append_options(ctx, fc, event_type, &mp_pck, entries,
+                           transcoded_buffer,
+                           transcoded_length,
+                           NULL, chunk);
+
+            free(transcoded_buffer);
         }
         else {
             append_options(ctx, fc, event_type, &mp_pck, entries, (char *) data, bytes, NULL, chunk);

--- a/plugins/out_forward/forward_format.c
+++ b/plugins/out_forward/forward_format.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_crypto.h>
+#include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 #include <fluent-bit/flb_log_event_decoder.h>
@@ -91,6 +92,7 @@ static int append_options(struct flb_forward *ctx,
                           char *out_chunk)
 {
     char *chunk = NULL;
+    size_t chunk_len = 0;
     uint8_t checksum[64];
     int     result;
     struct mk_list *head;
@@ -104,8 +106,9 @@ static int append_options(struct flb_forward *ctx,
 
     if (fc->require_ack_response == FLB_TRUE) {
         /*
-         * for ack we calculate  sha512 of context, take 16 bytes,
-         * make 32 byte hex string of it
+         * The 'chunk' ack token is a Base64 representation of a 128 bits
+         * unique id: we take the first 16 bytes of the SHA512 checksum of
+         * the payload content.
          */
         result = flb_hash_simple(FLB_HASH_SHA512,
                                  data, bytes,
@@ -115,9 +118,13 @@ static int append_options(struct flb_forward *ctx,
             return -1;
         }
 
-        flb_forward_format_bin_to_hex(checksum, 16, out_chunk);
+        result = flb_base64_encode((unsigned char *) out_chunk,
+                                   FLB_FORWARD_CHUNK_TOKEN_SIZE, &chunk_len,
+                                   checksum, 16);
+        if (result != 0) {
+            return -1;
+        }
 
-        out_chunk[32] = '\0';
         chunk = (char *) out_chunk;
     }
 
@@ -126,8 +133,8 @@ static int append_options(struct flb_forward *ctx,
         flb_mp_map_header_append(&mh);
         msgpack_pack_str(mp_pck, 5);
         msgpack_pack_str_body(mp_pck, "chunk", 5);
-        msgpack_pack_str(mp_pck, 32);
-        msgpack_pack_str_body(mp_pck, out_chunk, 32);
+        msgpack_pack_str(mp_pck, chunk_len);
+        msgpack_pack_str_body(mp_pck, chunk, chunk_len);
     }
 
     /* "size": entries */
@@ -224,7 +231,7 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
     size_t off = 0;
     size_t record_size;
     char *chunk;
-    char chunk_buf[33];
+    char chunk_buf[FLB_FORWARD_CHUNK_TOKEN_SIZE] = {0};
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
     struct flb_time tm;
@@ -287,7 +294,7 @@ static int flb_forward_format_message_mode(struct flb_forward *ctx,
         record_size = off - pre;
 
         if (ff) {
-            chunk = ff->checksum_hex;
+            chunk = ff->chunk_token;
         }
         else {
             chunk = chunk_buf;
@@ -407,17 +414,17 @@ static int flb_forward_format_forward_mode(struct flb_forward *ctx,
     int result;
     int entries = 0;
     char *chunk;
-    char chunk_buf[33];
+    char chunk_buf[FLB_FORWARD_CHUNK_TOKEN_SIZE] = {0};
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
-    char *transcoded_buffer;
-    size_t transcoded_length;
+    char *transcoded_buffer = NULL;
+    size_t transcoded_length = 0;
 
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     if (ff) {
-        chunk = ff->checksum_hex;
+        chunk = ff->chunk_token;
     }
     else {
         chunk = chunk_buf;
@@ -474,7 +481,7 @@ static int flb_forward_format_forward_compat_mode(struct flb_forward *ctx,
 {
     int entries = 0;
     char *chunk;
-    char chunk_buf[33];
+    char chunk_buf[FLB_FORWARD_CHUNK_TOKEN_SIZE] = {0};
     msgpack_packer   mp_pck;
     msgpack_sbuffer  mp_sbuf;
     struct flb_log_event_decoder log_decoder;
@@ -494,7 +501,7 @@ static int flb_forward_format_forward_compat_mode(struct flb_forward *ctx,
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
 
     if (ff) {
-        chunk = ff->checksum_hex;
+        chunk = ff->chunk_token;
     }
     else {
         chunk = chunk_buf;

--- a/tests/runtime/out_forward.c
+++ b/tests/runtime/out_forward.c
@@ -20,6 +20,11 @@
 #include <fluent-bit.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_record_accessor.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_chunk.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_crypto.h>
 
 #ifndef FLB_SYSTEM_WINDOWS
 #include <errno.h>
@@ -37,10 +42,24 @@
 #include "../../plugins/out_forward/forward.h"
 
 #ifndef FLB_SYSTEM_WINDOWS
+
+/* PONG behaviors used by the mock secure forward server */
+#define PONG_MODE_OVERSIZED_REASON  0
+#define PONG_MODE_VALID             1
+#define PONG_MODE_WRONG_DIGEST      2
+#define PONG_MODE_MISSING_DIGEST    3
+#define PONG_MODE_WRONG_DIGEST_TYPE 4
+
+#define SECURE_SERVER_HOSTNAME "server-host"
+#define SECURE_SERVER_NONCE    "0123456789abcdef"
+#define SECURE_SHARED_KEY      "secret"
+
 struct secure_forward_server {
     int listen_fd;
     int port;
     int got_ping;
+    int got_event;
+    int pong_mode;
     pthread_t thread;
 };
 
@@ -160,7 +179,8 @@ static int forward_pack_oversized_pong(msgpack_sbuffer *mp_sbuf)
     return 0;
 }
 
-static int forward_read_msgpack(int fd, char *buf, size_t size)
+static int forward_read_msgpack(int fd, char *buf, size_t size,
+                                size_t *out_len)
 {
     int ret;
     ssize_t bytes;
@@ -183,6 +203,9 @@ static int forward_read_msgpack(int fd, char *buf, size_t size)
         ret = msgpack_unpack_next(&result, buf, buf_off, &off);
         if (ret == MSGPACK_UNPACK_SUCCESS) {
             msgpack_unpacked_destroy(&result);
+            if (out_len) {
+                *out_len = buf_off;
+            }
             return 0;
         }
 
@@ -194,6 +217,193 @@ static int forward_read_msgpack(int fd, char *buf, size_t size)
 
     msgpack_unpacked_destroy(&result);
     return -1;
+}
+
+static void forward_test_bin_to_hex(uint8_t *buf, size_t len, char *out)
+{
+    size_t i;
+    static char map[] = "0123456789abcdef";
+
+    for (i = 0; i < len; i++) {
+        out[i * 2]     = map[buf[i] >> 4];
+        out[i * 2 + 1] = map[buf[i] & 0x0f];
+    }
+}
+
+/*
+ * Compose a PONG reply from a captured PING request:
+ *
+ *   PING: [type, client_hostname, shared_key_salt, shared_key_hexdigest,
+ *          username, password]
+ *   PONG: [type, auth_result, reason, server_hostname,
+ *          shared_key_hexdigest]
+ *
+ * The server digest is sha512_hex(shared_key_salt + server_hostname +
+ * nonce + shared_key).
+ */
+static int forward_pack_pong_from_ping(msgpack_sbuffer *mp_sbuf,
+                                       int pong_mode,
+                                       const char *ping_buf,
+                                       size_t ping_size)
+{
+    int ret;
+    size_t off = 0;
+    char digest_hex[128];
+    uint8_t hash[64];
+    size_t length_entries[4];
+    unsigned char *data_entries[4];
+    msgpack_unpacked result;
+    msgpack_object root;
+    msgpack_object salt;
+    msgpack_packer mp_pck;
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, ping_buf, ping_size, &off);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    root = result.data;
+    if (root.type != MSGPACK_OBJECT_ARRAY || root.via.array.size < 4) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    salt = root.via.array.ptr[2];
+    if (salt.type != MSGPACK_OBJECT_STR && salt.type != MSGPACK_OBJECT_BIN) {
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    data_entries[0]   = (unsigned char *) salt.via.bin.ptr;
+    length_entries[0] = salt.via.bin.size;
+
+    data_entries[1]   = (unsigned char *) SECURE_SERVER_HOSTNAME;
+    length_entries[1] = strlen(SECURE_SERVER_HOSTNAME);
+
+    data_entries[2]   = (unsigned char *) SECURE_SERVER_NONCE;
+    length_entries[2] = strlen(SECURE_SERVER_NONCE);
+
+    data_entries[3]   = (unsigned char *) SECURE_SHARED_KEY;
+    length_entries[3] = strlen(SECURE_SHARED_KEY);
+
+    ret = flb_hash_simple_batch(FLB_HASH_SHA512, 4,
+                                data_entries, length_entries,
+                                hash, sizeof(hash));
+    msgpack_unpacked_destroy(&result);
+
+    if (ret != FLB_CRYPTO_SUCCESS) {
+        return -1;
+    }
+
+    forward_test_bin_to_hex(hash, 64, digest_hex);
+
+    if (pong_mode == PONG_MODE_WRONG_DIGEST) {
+        /* corrupt the digest */
+        digest_hex[0] = (digest_hex[0] == '0') ? '1' : '0';
+    }
+
+    msgpack_sbuffer_init(mp_sbuf);
+    msgpack_packer_init(&mp_pck, mp_sbuf, msgpack_sbuffer_write);
+
+    if (pong_mode == PONG_MODE_MISSING_DIGEST) {
+        msgpack_pack_array(&mp_pck, 4);
+    }
+    else {
+        msgpack_pack_array(&mp_pck, 5);
+    }
+
+    msgpack_pack_str(&mp_pck, 4);
+    msgpack_pack_str_body(&mp_pck, "PONG", 4);
+    msgpack_pack_true(&mp_pck);
+    msgpack_pack_str(&mp_pck, 0);
+    msgpack_pack_str_body(&mp_pck, "", 0);
+    msgpack_pack_str(&mp_pck, strlen(SECURE_SERVER_HOSTNAME));
+    msgpack_pack_str_body(&mp_pck, SECURE_SERVER_HOSTNAME,
+                          strlen(SECURE_SERVER_HOSTNAME));
+
+    if (pong_mode == PONG_MODE_WRONG_DIGEST_TYPE) {
+        msgpack_pack_int64(&mp_pck, 42);
+    }
+    else if (pong_mode != PONG_MODE_MISSING_DIGEST) {
+        msgpack_pack_str(&mp_pck, 128);
+        msgpack_pack_str_body(&mp_pck, digest_hex, 128);
+    }
+
+    return 0;
+}
+
+static void *secure_forward_handshake_server_thread(void *data)
+{
+    int ret;
+    int conn_fd;
+    fd_set read_fds;
+    struct timeval timeout;
+    char buf[2048];
+    size_t ping_size;
+    msgpack_sbuffer helo;
+    msgpack_sbuffer pong;
+    struct secure_forward_server *server;
+
+    server = data;
+
+    FD_ZERO(&read_fds);
+    FD_SET(server->listen_fd, &read_fds);
+    timeout.tv_sec = 5;
+    timeout.tv_usec = 0;
+
+    ret = select(server->listen_fd + 1, &read_fds, NULL, NULL, &timeout);
+    if (ret <= 0) {
+        return NULL;
+    }
+
+    conn_fd = accept(server->listen_fd, NULL, NULL);
+    if (conn_fd == -1) {
+        return NULL;
+    }
+
+    if (forward_pack_secure_helo(&helo) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+
+    if (forward_socket_write_all(conn_fd, helo.data, helo.size) != 0) {
+        msgpack_sbuffer_destroy(&helo);
+        close(conn_fd);
+        return NULL;
+    }
+    msgpack_sbuffer_destroy(&helo);
+
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf), &ping_size) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+    server->got_ping = FLB_TRUE;
+
+    if (forward_pack_pong_from_ping(&pong, server->pong_mode,
+                                    buf, ping_size) != 0) {
+        close(conn_fd);
+        return NULL;
+    }
+
+    if (forward_socket_write_all(conn_fd, pong.data, pong.size) != 0) {
+        msgpack_sbuffer_destroy(&pong);
+        close(conn_fd);
+        return NULL;
+    }
+    msgpack_sbuffer_destroy(&pong);
+
+    /*
+     * If the client accepted the PONG, an event payload follows; if it
+     * rejected it, the connection is closed and no data arrives.
+     */
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf), NULL) == 0) {
+        server->got_event = FLB_TRUE;
+    }
+
+    close(conn_fd);
+    return NULL;
 }
 
 static void *secure_forward_oversized_pong_server_thread(void *data)
@@ -237,7 +447,7 @@ static void *secure_forward_oversized_pong_server_thread(void *data)
     }
     msgpack_sbuffer_destroy(&helo);
 
-    if (forward_read_msgpack(conn_fd, buf, sizeof(buf)) != 0) {
+    if (forward_read_msgpack(conn_fd, buf, sizeof(buf), NULL) != 0) {
         close(conn_fd);
         return NULL;
     }
@@ -380,6 +590,230 @@ static void cb_check_forward_mode(void *ctx, int ffd,
     TEST_CHECK(ret == 0);
     TEST_CHECK(val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
     TEST_CHECK(val.via.u64 == 0);
+
+    msgpack_unpacked_destroy(&result);
+    flb_free(res_data);
+}
+
+static void cb_check_forward_mode_ack_options(void *ctx, int ffd,
+                                              int res_ret, void *res_data, size_t res_size,
+                                              void *data)
+{
+    int i;
+    int ret;
+    int have_chunk;
+    int have_size;
+    int have_signal;
+    size_t off;
+    msgpack_object key;
+    msgpack_object val;
+    msgpack_object root;
+    msgpack_unpacked result;
+
+    (void) ctx;
+    (void) ffd;
+    (void) data;
+
+    TEST_CHECK(res_ret == MODE_FORWARD);
+
+    have_chunk = FLB_FALSE;
+    have_size = FLB_FALSE;
+    have_signal = FLB_FALSE;
+    off = 0;
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, res_data, res_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
+        flb_free(res_data);
+        return;
+    }
+
+    root = result.data;
+    TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
+
+    for (i = 0; i < root.via.map.size; i++) {
+        key = root.via.map.ptr[i].key;
+        val = root.via.map.ptr[i].val;
+
+        if (key.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        if (key.via.str.size == 5 &&
+            strncmp(key.via.str.ptr, "chunk", 5) == 0) {
+            TEST_CHECK(val.type == MSGPACK_OBJECT_STR);
+            if (val.type == MSGPACK_OBJECT_STR) {
+                /* Base64 representation of a 128 bits unique id */
+                TEST_CHECK(val.via.str.size == 24);
+                TEST_CHECK(val.via.str.size >= 2 &&
+                           strncmp(val.via.str.ptr + val.via.str.size - 2,
+                                   "==", 2) == 0);
+            }
+            have_chunk = FLB_TRUE;
+        }
+        else if (key.via.str.size == 4 &&
+                 strncmp(key.via.str.ptr, "size", 4) == 0) {
+            TEST_CHECK(val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+            if (val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+                TEST_CHECK(val.via.u64 == 1);
+            }
+            have_size = FLB_TRUE;
+        }
+        else if (key.via.str.size == 13 &&
+                 strncmp(key.via.str.ptr, "fluent_signal", 13) == 0) {
+            TEST_CHECK(val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+            if (val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+                TEST_CHECK(val.via.u64 == 0);
+            }
+            have_signal = FLB_TRUE;
+        }
+    }
+
+    TEST_CHECK(have_chunk == FLB_TRUE);
+    TEST_CHECK(have_size == FLB_TRUE);
+    TEST_CHECK(have_signal == FLB_TRUE);
+
+    msgpack_unpacked_destroy(&result);
+    flb_free(res_data);
+}
+
+#ifdef FLB_HAVE_METRICS
+static void cb_check_forward_mode_metrics_options(void *ctx, int ffd,
+                                                  int res_ret, void *res_data, size_t res_size,
+                                                  void *data)
+{
+    int i;
+    int ret;
+    int have_signal;
+    size_t off;
+    msgpack_object key;
+    msgpack_object val;
+    msgpack_object root;
+    msgpack_unpacked result;
+
+    (void) ctx;
+    (void) ffd;
+    (void) data;
+
+    TEST_CHECK(res_ret == MODE_FORWARD);
+
+    have_signal = FLB_FALSE;
+    off = 0;
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, res_data, res_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
+        flb_free(res_data);
+        return;
+    }
+
+    root = result.data;
+    TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
+
+    for (i = 0; i < root.via.map.size; i++) {
+        key = root.via.map.ptr[i].key;
+        val = root.via.map.ptr[i].val;
+
+        if (key.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        if (key.via.str.size == 4 &&
+            strncmp(key.via.str.ptr, "size", 4) == 0) {
+            TEST_CHECK(val.type == MSGPACK_OBJECT_POSITIVE_INTEGER);
+            if (val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+                TEST_CHECK(val.via.u64 >= 0);
+            }
+        }
+        else if (key.via.str.size == 13 &&
+                 strncmp(key.via.str.ptr, "fluent_signal", 13) == 0) {
+            TEST_CHECK(val.type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
+                       val.type == MSGPACK_OBJECT_NEGATIVE_INTEGER);
+            if (val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+                TEST_CHECK(val.via.u64 == FLB_EVENT_TYPE_METRICS);
+            }
+            else if (val.type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+                TEST_CHECK(val.via.i64 == FLB_EVENT_TYPE_METRICS);
+            }
+            have_signal = FLB_TRUE;
+        }
+    }
+
+    TEST_CHECK(have_signal == FLB_TRUE);
+
+    msgpack_unpacked_destroy(&result);
+    flb_free(res_data);
+}
+#endif
+
+static void cb_check_forward_mode_traces_options(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    int i;
+    int ret;
+    int have_size;
+    int have_signal;
+    size_t off;
+    msgpack_object key;
+    msgpack_object val;
+    msgpack_object root;
+    msgpack_unpacked result;
+
+    (void) ctx;
+    (void) ffd;
+    (void) data;
+
+    TEST_CHECK(res_ret == MODE_FORWARD);
+
+    have_size = FLB_FALSE;
+    have_signal = FLB_FALSE;
+    off = 0;
+
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, res_data, res_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    if (ret != MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacked_destroy(&result);
+        flb_free(res_data);
+        return;
+    }
+
+    root = result.data;
+    TEST_CHECK(root.type == MSGPACK_OBJECT_MAP);
+
+    for (i = 0; i < root.via.map.size; i++) {
+        key = root.via.map.ptr[i].key;
+        val = root.via.map.ptr[i].val;
+
+        if (key.type != MSGPACK_OBJECT_STR) {
+            continue;
+        }
+
+        if (key.via.str.size == 4 &&
+            strncmp(key.via.str.ptr, "size", 4) == 0) {
+            have_size = FLB_TRUE;
+        }
+        else if (key.via.str.size == 13 &&
+                 strncmp(key.via.str.ptr, "fluent_signal", 13) == 0) {
+            TEST_CHECK(val.type == MSGPACK_OBJECT_POSITIVE_INTEGER ||
+                       val.type == MSGPACK_OBJECT_NEGATIVE_INTEGER);
+            if (val.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+                TEST_CHECK(val.via.u64 == FLB_EVENT_TYPE_TRACES);
+            }
+            else if (val.type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
+                TEST_CHECK(val.via.i64 == FLB_EVENT_TYPE_TRACES);
+            }
+            have_signal = FLB_TRUE;
+        }
+    }
+
+    TEST_CHECK(have_size == FLB_FALSE);
+    TEST_CHECK(have_signal == FLB_TRUE);
 
     msgpack_unpacked_destroy(&result);
     flb_free(res_data);
@@ -644,7 +1078,136 @@ void flb_test_secure_forward_oversized_pong_reason()
 
     TEST_CHECK(server.got_ping == FLB_TRUE);
 }
+
+/*
+ * Run a secure forward handshake against the mock server using the given
+ * PONG behavior; 'expect_event' tells whether the client is expected to
+ * accept the PONG and deliver data on the same connection.
+ */
+static void run_secure_forward_handshake_case(int pong_mode, int expect_event)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char port[16];
+    flb_ctx_t *ctx;
+    struct secure_forward_server server;
+
+    memset(&server, 0, sizeof(server));
+    server.listen_fd = -1;
+    server.pong_mode = pong_mode;
+
+    server.listen_fd = forward_create_listen_socket(&server.port);
+    TEST_CHECK(server.listen_fd != -1);
+    if (server.listen_fd == -1) {
+        return;
+    }
+
+    ret = pthread_create(&server.thread, NULL,
+                         secure_forward_handshake_server_thread,
+                         &server);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        close(server.listen_fd);
+        return;
+    }
+
+    snprintf(port, sizeof(port), "%i", server.port);
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "0.2", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd,
+                  "tag", "test",
+                  "samples", "1",
+                  "dummy", "{\"key\":\"value\"}",
+                  NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "host", "127.0.0.1",
+                   "port", port,
+                   "shared_key", SECURE_SHARED_KEY,
+                   "workers", "1",
+                   "retry_limit", "no_retries",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2500);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    close(server.listen_fd);
+    pthread_join(server.thread, NULL);
+
+    TEST_CHECK(server.got_ping == FLB_TRUE);
+    TEST_CHECK(server.got_event == expect_event);
+}
+
+void flb_test_secure_forward_valid_pong()
+{
+    run_secure_forward_handshake_case(PONG_MODE_VALID, FLB_TRUE);
+}
+
+void flb_test_secure_forward_wrong_server_digest()
+{
+    run_secure_forward_handshake_case(PONG_MODE_WRONG_DIGEST, FLB_FALSE);
+}
+
+void flb_test_secure_forward_missing_server_digest()
+{
+    run_secure_forward_handshake_case(PONG_MODE_MISSING_DIGEST, FLB_FALSE);
+}
+
+void flb_test_secure_forward_wrong_digest_type()
+{
+    run_secure_forward_handshake_case(PONG_MODE_WRONG_DIGEST_TYPE, FLB_FALSE);
+}
 #endif
+
+/*
+ * username/password without shared_key or empty_shared_key must be
+ * rejected at configuration time (fail-close): the credentials would
+ * otherwise be silently unused.
+ */
+void flb_test_forward_username_without_shared_key()
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    flb_ctx_t *ctx;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "dummy", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "forward", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "host", "127.0.0.1",
+                   "port", "24224",
+                   "username", "alice",
+                   "password", "s3cr3t",
+                   NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+    if (ret == 0) {
+        TEST_MSG("username/password without shared_key unexpectedly started");
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+}
 
 /* Test list */
 TEST_LIST = {
@@ -657,6 +1220,15 @@ TEST_LIST = {
 #ifndef FLB_SYSTEM_WINDOWS
     {"secure_forward_oversized_pong_reason",
      flb_test_secure_forward_oversized_pong_reason },
+    {"secure_forward_valid_pong", flb_test_secure_forward_valid_pong },
+    {"secure_forward_wrong_server_digest",
+     flb_test_secure_forward_wrong_server_digest },
+    {"secure_forward_missing_server_digest",
+     flb_test_secure_forward_missing_server_digest },
+    {"secure_forward_wrong_digest_type",
+     flb_test_secure_forward_wrong_digest_type },
 #endif
+    {"forward_username_without_shared_key",
+     flb_test_forward_username_without_shared_key },
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Partially backporting of https://github.com/fluent/fluent-bit/pull/12037 due to lack of integration testing mechanism on 4.2 branch.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
