### PR TITLE
gzip: read magic number endian-safely in streaming decompressor [Backport to 4.2]

### DIFF
--- a/src/flb_gzip.c
+++ b/src/flb_gzip.c
@@ -704,12 +704,13 @@ static int flb_gzip_decompressor_process_header(
     context->read_buffer = &context->read_buffer[FLB_GZIP_HEADER_SIZE];
     context->input_buffer_length -= FLB_GZIP_HEADER_SIZE;
 
-    /* Magic bytes */
-    if (inner_context->gzip_header.magic_number != FLB_GZIP_MAGIC_NUMBER) {
+    /* Magic bytes (stored in little endian order in the header) */
+    if (read_le16((unsigned char *) &inner_context->gzip_header.magic_number) !=
+        FLB_GZIP_MAGIC_NUMBER) {
         context->state = FLB_DECOMPRESSOR_STATE_FAILED;
 
         flb_error("[gzip] invalid magic bytes : %04x",
-                  inner_context->gzip_header.magic_number);
+                  read_le16((unsigned char *) &inner_context->gzip_header.magic_number));
 
         return FLB_DECOMPRESSOR_FAILURE;
     }


### PR DESCRIPTION
The gzip header magic was memcpy'd into a uint16_t and compared against 0x8B1F, which only holds on little endian hosts. On big endian targets (s390x) a valid stream was rejected with 'invalid magic bytes : 1f8b'. Read the field with read_le16() so the comparison works regardless of host byte order.

This PR is partially backporting of https://github.com/fluent/fluent-bit/pull/12045 due to already fixed incompatible type on source_location_line.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
