### PR TITLE
plugin_proxy: add config map to the plugin registration

### DIFF
--- a/include/fluent-bit/flb_plugin_proxy.h
+++ b/include/fluent-bit/flb_plugin_proxy.h
@@ -35,12 +35,13 @@
 
 struct flb_plugin_proxy_def {
     /* Fields populated once remote flb_cb_register() is called */
-    int type;                 /* defined by FLB_PROXY_[INPUT|OUTPUT]_PLUGIN  */
-    int proxy;                /* proxy type                                  */
+    int type;                           /* defined by FLB_PROXY_[INPUT|OUTPUT]_PLUGIN  */
+    int proxy;                          /* proxy type                                  */
     int flags;
-    char *name;               /* plugin short name                           */
-    char *description;        /* plugin description                          */
-    int event_type;           /* event type (logs/metrics/traces)            */
+    char *name;                         /* plugin short name                           */
+    char *description;                  /* plugin description                          */
+    int event_type;                     /* event type (logs/metrics/traces)            */
+    struct flb_config_map *config_map;  /* plugin's configuration                      */
 };
 
 /* Proxy context */

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -361,6 +361,7 @@ static int flb_proxy_register_output(struct flb_plugin_proxy *proxy,
     out->proxy = proxy;
     out->flags = def->flags;
     out->name  = flb_strdup(def->name);
+    out->config_map = def->config_map;
 
     /* If event_type is unset (0) then default to logs (this is the current behavior) */
     if (def->event_type == 0) {
@@ -404,6 +405,7 @@ static int flb_proxy_register_input(struct flb_plugin_proxy *proxy,
     in->flags = def->flags | FLB_INPUT_THREADED;
     in->name  = flb_strdup(def->name);
     in->description = def->description;
+    in->config_map = def->config_map;
 
     mk_list_add(&in->_head, &config->in_plugins);
 
@@ -505,6 +507,7 @@ int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
      * - plugin type (or proxy type, e.g: Golang)
      * - plugin name
      * - plugin description
+     * - plugin's configuration 
      */
 
     /* Do the registration */

--- a/src/flb_plugin_proxy.c
+++ b/src/flb_plugin_proxy.c
@@ -450,6 +450,7 @@ static int flb_proxy_register_custom(struct flb_plugin_proxy *proxy,
     custom->flags = def->flags;
     custom->name  = flb_strdup(def->name);
     custom->description = def->description;
+    custom->config_map = def->config_map;
     mk_list_add(&custom->_head, &config->custom_plugins);
 
     /*
@@ -507,7 +508,7 @@ int flb_plugin_proxy_register(struct flb_plugin_proxy *proxy,
      * - plugin type (or proxy type, e.g: Golang)
      * - plugin name
      * - plugin description
-     * - plugin's configuration 
+     * - plugin configuration 
      */
 
     /* Do the registration */


### PR DESCRIPTION
<!-- Provide summary of changes -->
Extend the proxy plugin registration flow so input and output Go plugins can attach a `flb_config_map` schema, enabling the same property validation native plugins already receive. Custom plugins are excluded because they don't go through the property-check callback path. For more context can check [this discussion](https://github.com/fluent/fluent-bit/pull/11788#issuecomment-4879630598).

Issue #11776

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin registration now correctly propagates plugin configuration settings when creating proxy-based input, output, and custom plugins.
  * This improves consistency for plugins that depend on custom configuration data during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->