### PR TITLE
in_tcp/in_udp: Added unparsed log message in tcp_conn.c and udp_conn.c

### DIFF
--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -306,6 +306,7 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
                 else {
                     flb_plg_debug(ctx->ins, "parser '%s' failed on incoming data",
                                   ctx->parser_name);
+                    flb_plg_debug(ctx->ins, "unparsed log message: %.*s", len, buf);
                     ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
                     if (ret == FLB_EVENT_ENCODER_SUCCESS) {

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -306,7 +306,7 @@ static ssize_t parse_payload_none(struct tcp_conn *conn)
                 else {
                     flb_plg_debug(ctx->ins, "parser '%s' failed on incoming data",
                                   ctx->parser_name);
-                    flb_plg_debug(ctx->ins, "unparsed log message: %.*s", len, buf);
+                    flb_plg_debug(ctx->ins, "unparsed log message: %.*s", (int) len, buf);
                     ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
                     if (ret == FLB_EVENT_ENCODER_SUCCESS) {

--- a/plugins/in_udp/udp_conn.c
+++ b/plugins/in_udp/udp_conn.c
@@ -365,6 +365,7 @@ static ssize_t parse_payload_none(struct udp_conn *conn)
 
                     flb_plg_debug(ctx->ins, "parser '%s' failed on incoming data",
                                   ctx->parser_name);
+                    flb_plg_debug(ctx->ins, "unparsed log message: %.*s", (int) len, buf);
                     ret = flb_log_event_encoder_begin_record(ctx->log_encoder);
 
                     if (ret == FLB_EVENT_ENCODER_SUCCESS) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Added unparsed message print to log file for in_tcp plugin.

Unfortunately, I don't know C.
I have gave a shot add this feature by myself.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added more detailed debug logging when incoming payload parsing fails, including the unparsed message content (bounded by the received length) to help diagnose issues more easily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->