### PR TITLE
in_opentelemetry: return not found for invalid endpoint

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -252,6 +252,9 @@ static int send_response_ng(struct flb_http_response *response,
     else if (http_status == 400) {
         flb_http_response_set_message(response, "Bad Request");
     }
+    else if (http_status == 404) {
+        flb_http_response_set_message(response, "Not Found");
+    }
 
     if (message != NULL) {
         flb_http_response_set_body(response,
@@ -828,7 +831,7 @@ int opentelemetry_prot_handle_ng(struct flb_http_request *request,
         grpc_request = FLB_TRUE;
     }
     else {
-        send_response_ng(response, 400, "error: invalid endpoint\n");
+        send_response_ng(response, 404, "error: invalid endpoint\n");
         return -1;
     }
 

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -1258,6 +1258,27 @@ def test_in_opentelemetry_protocol_matrix(case, signal_type, json_input, endpoin
     assert len(response_payload) > 0
 
 
+def test_in_opentelemetry_http2_invalid_endpoint_returns_404():
+    service = Service(IN_OPENTELEMETRY_PROTOCOL_CONFIGS["http2_cleartext"])
+    service.start()
+
+    result = run_curl_request(
+        f"http://localhost:{service.flb_listener_port}/v1/invalid",
+        b"invalid payload",
+        headers=["Content-Type: application/x-protobuf"],
+        http_mode="http2-prior-knowledge",
+    )
+
+    service.stop()
+
+    assert result["status_code"] == 404
+    assert result["http_version"] == "2"
+    assert result["body"] == "error: invalid endpoint\n"
+    assert len(data_storage["logs"]) == 0
+    assert len(data_storage["metrics"]) == 0
+    assert len(data_storage["traces"]) == 0
+
+
 # This test is branch-specific coverage for the generic HTTP listener worker mode.
 # It does three things:
 # 1. enables http_server.workers on the in_opentelemetry listener,


### PR DESCRIPTION
## Summary

Fixes #12032.

- Return HTTP 404 for unknown OpenTelemetry input endpoints instead of HTTP 400.
- Add the missing `Not Found` response message mapping for the new HTTP server response helper.
- Add focused integration coverage for an invalid OTLP HTTP/2 endpoint.

## Root Cause

The OpenTelemetry input request dispatch treated endpoint mismatches as bad requests before method, payload, or content-type validation. That made an unknown OTLP path return `400 error: invalid endpoint` instead of the expected `404`.

## Validation

- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_http2_invalid_endpoint_returns_404 -q`
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_http2_invalid_endpoint_returns_404 -q`
- `ctest --test-dir build -R flb-it-opentelemetry --output-on-failure`
- `tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid OpenTelemetry HTTP/2 endpoints now return a proper **404 Not Found** response instead of **400 Bad Request**.
  * Response text now matches the 404 status more accurately.

* **Tests**
  * Added integration coverage for invalid HTTP/2 OpenTelemetry requests.
  * Verified that bad endpoint requests do not create logs, metrics, or traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->