### PR TITLE
thread_storage: Fix incorrectly to detect C TLS existence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1453,8 +1453,8 @@ if(NOT FLB_POSIX_TLS)
   check_c_source_compiles("
    __thread int a;
    int main() {
-       __tls_get_addr(0);
-       return 0;
+       a = 1;
+       return a - 1;
    }" FLB_HAVE_C_TLS)
   if(FLB_HAVE_C_TLS)
     FLB_DEFINITION(FLB_HAVE_C_TLS)

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -246,6 +246,9 @@ struct flb_config *flb_config_init()
         return NULL;
     }
 
+    /* Prepare worker TLS before any config-time logging checks. */
+    flb_worker_init(config);
+
     MK_EVENT_ZERO(&config->ch_event);
     MK_EVENT_ZERO(&config->event_flush);
     MK_EVENT_ZERO(&config->event_shutdown);
@@ -477,9 +480,6 @@ struct flb_config *flb_config_init()
     /* Ignore SIGPIPE */
     signal(SIGPIPE, SIG_IGN);
 #endif
-
-    /* Prepare worker interface */
-    flb_worker_init(config);
 
 #ifdef FLB_HAVE_REGEX
     /* Regex support */

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -22,6 +22,7 @@ set(UNIT_TESTS_FILES
   gzip.c
   zstd.c
   random.c
+  thread_storage.c
   config_map.c
   mp.c
   mp_chunk_cobj.c

--- a/tests/internal/thread_storage.c
+++ b/tests/internal/thread_storage.c
@@ -1,0 +1,35 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_thread_storage.h>
+
+#include "flb_tests_internal.h"
+
+struct thread_storage_test {
+    int value;
+};
+
+FLB_TLS_DEFINE(struct thread_storage_test, thread_storage_ctx);
+
+void test_thread_storage_get_before_init(void)
+{
+    struct thread_storage_test context;
+
+    context.value = 42;
+
+    TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == NULL);
+
+    FLB_TLS_SET(thread_storage_ctx, &context);
+    TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == &context);
+    TEST_CHECK(((struct thread_storage_test *) FLB_TLS_GET(thread_storage_ctx))->value == 42);
+
+    FLB_TLS_INIT(thread_storage_ctx);
+    TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == &context);
+
+    FLB_TLS_SET(thread_storage_ctx, NULL);
+    TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == NULL);
+}
+
+TEST_LIST = {
+    {"get_before_init", test_thread_storage_get_before_init},
+    { 0 }
+};

--- a/tests/internal/thread_storage.c
+++ b/tests/internal/thread_storage.c
@@ -8,28 +8,137 @@ struct thread_storage_test {
     int value;
 };
 
+#define THREAD_STORAGE_THREADS 8
+
+struct thread_storage_thread {
+    int index;
+    int result;
+    int *ready;
+    int *start;
+    pthread_mutex_t *lock;
+    pthread_cond_t *cond;
+    struct thread_storage_test context;
+};
+
 FLB_TLS_DEFINE(struct thread_storage_test, thread_storage_ctx);
 
-void test_thread_storage_get_before_init(void)
+static void *thread_storage_concurrent_worker(void *data)
+{
+    struct thread_storage_thread *thread;
+    struct thread_storage_test *context;
+
+    thread = data;
+    context = &thread->context;
+    context->value = thread->index;
+
+    pthread_mutex_lock(thread->lock);
+    (*thread->ready)++;
+    pthread_cond_broadcast(thread->cond);
+
+    while (*thread->start == FLB_FALSE) {
+        pthread_cond_wait(thread->cond, thread->lock);
+    }
+    pthread_mutex_unlock(thread->lock);
+
+    if (FLB_TLS_GET(thread_storage_ctx) != NULL) {
+        thread->result = -1;
+        return NULL;
+    }
+
+    FLB_TLS_SET(thread_storage_ctx, context);
+
+    if (FLB_TLS_GET(thread_storage_ctx) != context) {
+        thread->result = -2;
+        return NULL;
+    }
+
+    if (((struct thread_storage_test *) FLB_TLS_GET(thread_storage_ctx))->value != thread->index) {
+        thread->result = -3;
+        return NULL;
+    }
+
+    thread->result = 0;
+    return NULL;
+}
+
+void test_thread_storage_concurrent_access(void)
+{
+    int i;
+    int ret;
+    int ready;
+    int start;
+    int created;
+    pthread_t threads[THREAD_STORAGE_THREADS];
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    struct thread_storage_thread contexts[THREAD_STORAGE_THREADS];
+
+    ready = 0;
+    start = FLB_FALSE;
+    created = 0;
+
+    pthread_mutex_init(&lock, NULL);
+    pthread_cond_init(&cond, NULL);
+
+    FLB_TLS_INIT(thread_storage_ctx);
+
+    for (i = 0; i < THREAD_STORAGE_THREADS; i++) {
+        contexts[i].index = i;
+        contexts[i].result = -4;
+        contexts[i].ready = &ready;
+        contexts[i].start = &start;
+        contexts[i].lock = &lock;
+        contexts[i].cond = &cond;
+
+        ret = pthread_create(&threads[i], NULL, thread_storage_concurrent_worker, &contexts[i]);
+        TEST_CHECK(ret == 0);
+        if (ret != 0) {
+            break;
+        }
+        created++;
+    }
+
+    pthread_mutex_lock(&lock);
+    while (ready < created) {
+        pthread_cond_wait(&cond, &lock);
+    }
+    start = FLB_TRUE;
+    pthread_cond_broadcast(&cond);
+    pthread_mutex_unlock(&lock);
+
+    TEST_CHECK(created == THREAD_STORAGE_THREADS);
+
+    for (i = 0; i < created; i++) {
+        ret = pthread_join(threads[i], NULL);
+        TEST_CHECK(ret == 0);
+        TEST_CHECK(contexts[i].result == 0);
+    }
+
+    TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == NULL);
+
+    pthread_cond_destroy(&cond);
+    pthread_mutex_destroy(&lock);
+}
+
+void test_thread_storage_get_after_init(void)
 {
     struct thread_storage_test context;
 
     context.value = 42;
 
+    FLB_TLS_INIT(thread_storage_ctx);
     TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == NULL);
 
     FLB_TLS_SET(thread_storage_ctx, &context);
     TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == &context);
     TEST_CHECK(((struct thread_storage_test *) FLB_TLS_GET(thread_storage_ctx))->value == 42);
 
-    FLB_TLS_INIT(thread_storage_ctx);
-    TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == &context);
-
     FLB_TLS_SET(thread_storage_ctx, NULL);
     TEST_CHECK(FLB_TLS_GET(thread_storage_ctx) == NULL);
 }
 
 TEST_LIST = {
-    {"get_before_init", test_thread_storage_get_before_init},
+    {"concurrent_access", test_thread_storage_concurrent_access},
+    {"get_after_init", test_thread_storage_get_after_init},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
We incorrectly used __tls_get_addr in thread storage detection.
Instead, we just use __thread attribute in that detector and ensuring pthread thread storage to be initialized once on each of the threads.
Also, I added a test cases for confirming define/get/set of thread storage.

Closes https://github.com/fluent/fluent-bit/issues/12065.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-time detection for thread-local storage support to ensure correct TLS behavior on more toolchains.
  * Updated worker initialization ordering to improve reliability of thread-local storage across worker threads.
* **Tests**
  * Added internal pthread-based unit tests covering concurrent TLS access and verifying TLS state after initialization and clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->