### PR TITLE
tls: prevent engine hang from spinning TLS read/write retry loop

### DIFF
--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -35,6 +35,13 @@
 #define FLB_TLS_WANT_READ   -0x7e4
 #define FLB_TLS_WANT_WRITE  -0x7e6
 
+/*
+ * Maximum consecutive WANT_READ/WANT_WRITE retries before treating the
+ * connection as stale. Prevents a dead TLS connection from spinning the
+ * engine thread in a tight yield/resume loop (see #9927).
+ */
+#define FLB_TLS_WANT_READ_MAX_RETRIES  800
+
 /* Cert Flags */
 #define FLB_TLS_CA_ROOT          1
 #define FLB_TLS_CERT             2

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -17,6 +17,8 @@
  *  limitations under the License.
  */
 
+#include <errno.h>
+
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_socket.h>
@@ -393,10 +395,27 @@ int flb_tls_net_read_async(struct flb_coro *co,
     struct mk_event event_backup;
     struct flb_tls *tls;
     int             ret;
+    int             want_read_retries;
 
     tls = session->tls;
 
     event_restore_needed = FLB_FALSE;
+
+    /*
+     * Track consecutive SSL_ERROR_WANT_READ iterations with no progress.
+     * When a TLS connection's underlying socket continuously reports
+     * EPOLLIN but SSL_read() returns WANT_READ (no actual TLS data),
+     * the coroutine bounces between yield and resume in a tight loop,
+     * monopolizing the engine thread and starving all other processing
+     * (output flushes, timers, new connections).
+     *
+     * This happens when a dead TCP connection stays ESTABLISHED but
+     * has no TLS records to deliver — the kernel signals "readable"
+     * but OpenSSL needs more data.
+     *
+     * See: https://github.com/fluent/fluent-bit/issues/9927
+     */
+    want_read_retries = 0;
 
     io_tls_backup_event(session->connection, &event_backup);
 
@@ -404,6 +423,22 @@ int flb_tls_net_read_async(struct flb_coro *co,
     ret = tls->api->net_read(session, buf, len);
 
     if (ret == FLB_TLS_WANT_READ) {
+        want_read_retries++;
+
+        if (want_read_retries > FLB_TLS_WANT_READ_MAX_RETRIES) {
+            flb_warn("[tls] connection #%i exceeded maximum read retries (%i), "
+                     "closing stale connection",
+                     session->connection->fd,
+                     FLB_TLS_WANT_READ_MAX_RETRIES);
+
+            session->connection->coroutine = NULL;
+            session->connection->net_error = ETIMEDOUT;
+
+            io_tls_restore_event(session->connection, &event_backup);
+
+            return -1;
+        }
+
         event_restore_needed = FLB_TRUE;
 
         session->connection->coroutine = co;
@@ -414,6 +449,8 @@ int flb_tls_net_read_async(struct flb_coro *co,
         goto retry_read;
     }
     else if (ret == FLB_TLS_WANT_WRITE) {
+        /* Progress on a different axis, reset the read retry counter */
+        want_read_retries = 0;
         event_restore_needed = FLB_TRUE;
 
         session->connection->coroutine = co;
@@ -500,11 +537,13 @@ int flb_tls_net_write_async(struct flb_coro *co,
     size_t          total;
     int             ret;
     struct flb_tls *tls;
+    int             want_retries;
 
     total = 0;
     tls = session->tls;
 
     event_restore_needed = FLB_FALSE;
+    want_retries = 0;
 
     io_tls_backup_event(session->connection, &event_backup);
 
@@ -516,6 +555,23 @@ retry_write:
                               len - total);
 
     if (ret == FLB_TLS_WANT_WRITE) {
+        want_retries++;
+
+        if (want_retries > FLB_TLS_WANT_READ_MAX_RETRIES) {
+            flb_warn("[tls] connection #%i exceeded maximum write retries (%i), "
+                     "closing stale connection",
+                     session->connection->fd,
+                     FLB_TLS_WANT_READ_MAX_RETRIES);
+
+            session->connection->coroutine = NULL;
+            session->connection->net_error = ETIMEDOUT;
+            *out_len = total;
+
+            io_tls_restore_event(session->connection, &event_backup);
+
+            return -1;
+        }
+
         event_restore_needed = FLB_TRUE;
 
         io_tls_event_switch(session, MK_EVENT_WRITE);
@@ -525,6 +581,23 @@ retry_write:
         goto retry_write;
     }
     else if (ret == FLB_TLS_WANT_READ) {
+        want_retries++;
+
+        if (want_retries > FLB_TLS_WANT_READ_MAX_RETRIES) {
+            flb_warn("[tls] connection #%i exceeded maximum write retries (%i), "
+                     "closing stale connection",
+                     session->connection->fd,
+                     FLB_TLS_WANT_READ_MAX_RETRIES);
+
+            session->connection->coroutine = NULL;
+            session->connection->net_error = ETIMEDOUT;
+            *out_len = total;
+
+            io_tls_restore_event(session->connection, &event_backup);
+
+            return -1;
+        }
+
         event_restore_needed = FLB_TRUE;
 
         io_tls_event_switch(session, MK_EVENT_READ);


### PR DESCRIPTION
## Summary

Fixes #9927 — Fluent Bit silently hangs (stops forwarding data) while appearing healthy.

When a TLS forward input connection dies (peer disconnects ungracefully), `flb_tls_net_read_async()` enters a tight spin loop that monopolizes the main engine thread and starves all output processing.

### Root Cause

In `flb_tls_net_read_async()` (`src/tls/flb_tls.c`):

```c
retry_read:
    ret = tls->api->net_read(session, buf, len);  // SSL_read() -> read(fd) -> EAGAIN
    if (ret == FLB_TLS_WANT_READ) {
        io_tls_event_switch(session, MK_EVENT_READ);  // no-op: already registered
        flb_coro_yield(co, FLB_FALSE);                // yields, immediately resumed
        goto retry_read;                               // infinite loop
    }
```

1. A dead TLS connection's socket stays TCP ESTABLISHED with `rx_queue=0`
2. `SSL_read()` -> `read(fd)` -> `EAGAIN` -> OpenSSL returns `SSL_ERROR_WANT_READ`
3. `io_tls_event_switch()` is a **no-op** because the event is already registered for `MK_EVENT_READ`
4. `flb_coro_yield()` yields, but epoll immediately resumes the coroutine (level-triggered, event never consumed)
5. `goto retry_read` -> step 2 -> **tight spin, ~8,500 iterations/second**

This monopolizes the `flb-pipeline` thread. **All other event processing is starved**: output flushes never execute, scheduler timers don't fire, chunks stay permanently busy.

### Fix

Add `FLB_TLS_WANT_READ_MAX_RETRIES` (800) to cap consecutive `WANT_READ`/`WANT_WRITE` iterations with no progress in both `flb_tls_net_read_async()` and `flb_tls_net_write_async()`. When exceeded, return `-1` to close the stale connection and unblock the engine thread.

### Evidence from Production (Fluent Bit v3.2.2, Ubuntu 22.04, OpenSSL 3.0.2)

**Strace on stuck flb-pipeline thread (the main engine thread):**

```
$ strace -p <pipeline-tid> -c (2 seconds)
% time     seconds  usecs/call     calls    errors syscall
100.00    0.088144           5     17029     17029 read
```

17,029 failed read() calls in 2 seconds — 100% EAGAIN, zero useful work.

**The spinning fd is a dead TCP socket:**

```
$ readlink /proc/<pid>/fd/89
socket:[243422702]

$ ss -tnei src :24224 dst <peer> dport = 36120
ESTAB 0 0  local:24224  peer:36120
    lastrcv:314289920   (~3.6 days since last data)

$ grep <inode> /proc/net/tcp
... 01 00000000:00000000 ...    (ESTABLISHED, rx_queue=0, tx_queue=0)
```

**Output counter frozen:**

```
fluentbit_output_proc_records_total{name="stackdriver.0"} 9123353  (does not increment)
fluentbit_output_errors_total{name="stackdriver.0"} 0              (output never gets to run)
```

**Storage API — chunks stuck busy:**

```json
{"tail.0": {"chunks": {"total":4, "busy":3}}}
```

### Live Validation

Killing the dead TCP connections (simulating what this fix does) **immediately recovered** the pipeline without a restart:

| Step | output_proc_records | Engine thread |
|---|---|---|
| Before (stuck 3 days) | 9,123,353 (frozen) | 100% read(), 8,500 EAGAIN/s |
| After killing dead connections | 9,264,379 (+141,026) | Healthy: epoll_wait, read, write, newfstatat |

**Before (stuck):**

```
$ strace -p <pipeline-tid> -c (2 seconds)
% time     seconds  usecs/call     calls    errors syscall
100.00    0.088144           5     17029     17029 read
```

**After killing dead connections:**

```
$ strace -p <pipeline-tid> -c (2 seconds)
% time     seconds  usecs/call     calls    errors syscall
 44.80    0.006476           5      1100         2 newfstatat
 14.51    0.002097           6       318         6 read
 10.91    0.001577           7       223           epoll_wait
  8.27    0.001195          17        70           fadvise64
  5.17    0.000747           6       108           write
  ...
```

Same pattern confirmed on a second independent node with a different dead connection (47 days idle, different peer IP/port). Multiple dead connections can stack — we had to close 4-5 before the engine fully recovered.

### Files Changed

- `include/fluent-bit/tls/flb_tls.h` — add `FLB_TLS_WANT_READ_MAX_RETRIES` constant (800)
- `src/tls/flb_tls.c` — add retry counter to `flb_tls_net_read_async()` and `flb_tls_net_write_async()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added safeguards to prevent stalled TLS read/write operations from looping indefinitely.
  - Connections that repeatedly return “want read” or “want write” now time out after too many retries, improving stability and reducing deadlocks.
  - Retry handling now resets appropriately when progress is made, helping active connections continue normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->