### PR TITLE
in_splunk: return Splunk HEC auth status codes [Backport to 4.2]

### DIFF
--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -656,7 +656,7 @@ static int validate_auth_header(struct flb_splunk *ctx, struct mk_http_request *
         mk_list_foreach(head, &ctx->auth_tokens) {
             splunk_token = mk_list_entry(head, struct flb_splunk_tokens, _head);
             if (flb_sds_len(authorization) != splunk_token->length) {
-                ret = SPLUNK_AUTH_UNAUTHORIZED;
+                ret = SPLUNK_AUTH_INVALID_AUTHORIZATION;
                 continue;
             }
 
@@ -669,7 +669,7 @@ static int validate_auth_header(struct flb_splunk *ctx, struct mk_http_request *
             }
         }
 
-        ret = SPLUNK_AUTH_UNAUTHORIZED;
+        ret = SPLUNK_AUTH_INVALID_AUTHORIZATION;
         flb_sds_destroy(authorization);
         return ret;
     }
@@ -989,7 +989,7 @@ int splunk_prot_handle(struct flb_splunk *ctx, struct splunk_conn *conn,
         if (ret == SPLUNK_AUTH_MISSING_CRED) {
             flb_plg_warn(ctx->ins, "missing credentials in request headers");
         }
-        else if (ret == SPLUNK_AUTH_UNAUTHORIZED) {
+        else if (ret == SPLUNK_AUTH_INVALID_AUTHORIZATION) {
             flb_plg_warn(ctx->ins, "wrong credentials in request headers");
         }
 

--- a/plugins/in_splunk/splunk_prot.c
+++ b/plugins/in_splunk/splunk_prot.c
@@ -1203,6 +1203,12 @@ static int send_json_message_response_ng(struct flb_http_response *response,
     else if (http_status == 400) {
         flb_http_response_set_message(response, "Bad Request");
     }
+    else if (http_status == 401) {
+        flb_http_response_set_message(response, "Unauthorized");
+    }
+    else if (http_status == 403) {
+        flb_http_response_set_message(response, "Forbidden");
+    }
 
     flb_http_response_set_header(response,
                                 "content-type", 0,
@@ -1250,7 +1256,12 @@ static int validate_auth_header_ng(struct flb_splunk *ctx, struct flb_http_reque
             }
         }
 
-        return SPLUNK_AUTH_UNAUTHORIZED;
+        if (strncasecmp(auth_header, "Splunk ", 7) == 0 &&
+            strlen(auth_header) > 7) {
+            return SPLUNK_AUTH_INVALID_TOKEN;
+        }
+
+        return SPLUNK_AUTH_INVALID_AUTHORIZATION;
     }
     else {
         return SPLUNK_AUTH_MISSING_CRED;
@@ -1388,12 +1399,19 @@ int splunk_prot_handle_ng(struct flb_http_request *request,
     ret = validate_auth_header_ng(context, request);
 
     if (ret < 0) {
-        send_response_ng(response, 401, "error: unauthorized\n");
-
         if (ret == SPLUNK_AUTH_MISSING_CRED) {
+            send_json_message_response_ng(response, 401,
+                                          "{\"text\":\"Token is required\",\"code\":2}");
             flb_plg_warn(context->ins, "missing credentials in request headers");
         }
-        else if (ret == SPLUNK_AUTH_UNAUTHORIZED) {
+        else if (ret == SPLUNK_AUTH_INVALID_AUTHORIZATION) {
+            send_json_message_response_ng(response, 401,
+                                          "{\"text\":\"Invalid authorization\",\"code\":3}");
+            flb_plg_warn(context->ins, "invalid authorization in request headers");
+        }
+        else if (ret == SPLUNK_AUTH_INVALID_TOKEN) {
+            send_json_message_response_ng(response, 403,
+                                          "{\"text\":\"Invalid token\",\"code\":4}");
             flb_plg_warn(context->ins, "wrong credentials in request headers");
         }
 

--- a/plugins/in_splunk/splunk_prot.h
+++ b/plugins/in_splunk/splunk_prot.h
@@ -20,10 +20,11 @@
 #ifndef FLB_IN_SPLUNK_PROT
 #define FLB_IN_SPLUNK_PROT
 
-#define SPLUNK_AUTH_UNAUTH        1
-#define SPLUNK_AUTH_SUCCESS       0
-#define SPLUNK_AUTH_MISSING_CRED -1
-#define SPLUNK_AUTH_UNAUTHORIZED -2
+#define SPLUNK_AUTH_UNAUTH                 1
+#define SPLUNK_AUTH_SUCCESS                0
+#define SPLUNK_AUTH_MISSING_CRED          -1
+#define SPLUNK_AUTH_INVALID_AUTHORIZATION -2
+#define SPLUNK_AUTH_INVALID_TOKEN         -3
 
 #define SPLUNK_XFF_HEADER "x-forwarded-for"
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Partially backporting of https://github.com/fluent/fluent-bit/pull/12043 due to lack of integration testing mechanism on 4.2 branch.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
