### PR TITLE
build: do not embed the build directory in the binary

### DIFF
--- a/lib/cfl/CMakeLists.txt
+++ b/lib/cfl/CMakeLists.txt
@@ -41,11 +41,7 @@ if(NOT MSVC)
 endif()
 
 # Define __FILENAME__ consistently across Operating Systems
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
-else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
-endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 
 
 

--- a/lib/cmetrics/CMakeLists.txt
+++ b/lib/cmetrics/CMakeLists.txt
@@ -61,11 +61,7 @@ if(NOT MSVC)
 endif()
 
 # Define __CMT_FILENAME__ consistently across Operating Systems
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
-else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__=__FILE__")
-endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__=__FILE__")
 
 # Configuration options
 option(CMT_DEV                       "Enable development mode"                    No)

--- a/lib/ctraces/CMakeLists.txt
+++ b/lib/ctraces/CMakeLists.txt
@@ -31,11 +31,7 @@ set(CTR_VERSION_PATCH  1)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
-else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
-endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 
 # Configuration options
 option(CTR_DEV             "Enable development mode"                   No)

--- a/lib/monkey/CMakeLists.txt
+++ b/lib/monkey/CMakeLists.txt
@@ -15,10 +15,10 @@ include(GNUInstallDirs)
 # Set default compiler options
 if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath \$$<))\"'")
-else()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 endif()
+
+# Define __FILENAME__ consistently across Operating Systems
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 
 # Monkey Version
 set(MK_VERSION_MAJOR  1)


### PR DESCRIPTION
monkey, cfl, ctraces and cmetrics define __FILENAME__/__CMT_FILENAME__ via a GNU Make expression that only the Make generator expands; under Ninja the literal string, including the absolute ${CMAKE_SOURCE_DIR}, is baked into every object file. Use plain __FILE__ as the Windows branch already does, and drop the then-identical conditional.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified how file name information is passed during builds across multiple components.
  * Standardized file name macros to use a consistent value on all platforms.
  * Removed platform-specific filename normalization logic, reducing build complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->