### PR TITLE
opentelemetry: reduce protobuf log allocation churn

### DIFF
--- a/src/opentelemetry/flb_opentelemetry_otlp_proto.c
+++ b/src/opentelemetry/flb_opentelemetry_otlp_proto.c
@@ -43,6 +43,32 @@
 #define FLB_OTEL_LOGS_SCHEMA_KEY "schema"
 #define FLB_OTEL_LOGS_SCHEMA_OTLP "otlp"
 #define FLB_OTEL_LOGS_METADATA_KEY "otlp"
+#define FLB_OTEL_PROTO_ARENA_INITIAL_CHUNK_SIZE 4096
+#define FLB_OTEL_PROTO_ARENA_MAX_CHUNK_SIZE 65536
+
+union otlp_proto_arena_alignment {
+    long double as_long_double;
+    void *as_pointer;
+    uint64_t as_uint64;
+};
+
+struct otlp_proto_arena_chunk {
+    struct otlp_proto_arena_chunk *next;
+    size_t size;
+    size_t used;
+    union otlp_proto_arena_alignment alignment;
+    unsigned char data[];
+};
+
+struct otlp_proto_arena {
+    struct otlp_proto_arena_chunk *chunks;
+    size_t next_chunk_size;
+};
+
+/*
+ * Protobuf objects live until the request has been packed. Pointer arrays that
+ * grow with realloc remain heap-backed and are released separately.
+ */
 
 struct otlp_proto_logs_scope_state {
     int64_t scope_id;
@@ -60,6 +86,119 @@ struct otlp_proto_logs_resource_state {
 
 static msgpack_object *msgpack_map_get_object(msgpack_object_map *map,
                                               const char *key);
+
+static void otlp_proto_arena_init(struct otlp_proto_arena *arena)
+{
+    arena->chunks = NULL;
+    arena->next_chunk_size = FLB_OTEL_PROTO_ARENA_INITIAL_CHUNK_SIZE;
+}
+
+static void otlp_proto_arena_destroy(struct otlp_proto_arena *arena)
+{
+    struct otlp_proto_arena_chunk *chunk;
+    struct otlp_proto_arena_chunk *next;
+
+    chunk = arena->chunks;
+    while (chunk != NULL) {
+        next = chunk->next;
+        flb_free(chunk);
+        chunk = next;
+    }
+
+    arena->chunks = NULL;
+}
+
+static void *otlp_proto_arena_alloc(struct otlp_proto_arena *arena, size_t size)
+{
+    size_t alignment;
+    size_t aligned_size;
+    size_t chunk_size;
+    struct otlp_proto_arena_chunk *chunk;
+
+    alignment = sizeof(union otlp_proto_arena_alignment);
+    if (size == 0) {
+        size = 1;
+    }
+
+    if (size > SIZE_MAX - (alignment - 1)) {
+        return NULL;
+    }
+
+    aligned_size = size + alignment - 1;
+    aligned_size -= aligned_size % alignment;
+
+    chunk = arena->chunks;
+    if (chunk == NULL || aligned_size > chunk->size - chunk->used) {
+        chunk_size = arena->next_chunk_size;
+        if (chunk_size < aligned_size) {
+            chunk_size = aligned_size;
+        }
+
+        if (chunk_size > SIZE_MAX - sizeof(struct otlp_proto_arena_chunk)) {
+            return NULL;
+        }
+
+        chunk = flb_malloc(sizeof(struct otlp_proto_arena_chunk) + chunk_size);
+        if (chunk == NULL) {
+            return NULL;
+        }
+
+        chunk->next = arena->chunks;
+        chunk->size = chunk_size;
+        chunk->used = 0;
+        arena->chunks = chunk;
+
+        if (arena->next_chunk_size < FLB_OTEL_PROTO_ARENA_MAX_CHUNK_SIZE) {
+            arena->next_chunk_size *= 2;
+            if (arena->next_chunk_size > FLB_OTEL_PROTO_ARENA_MAX_CHUNK_SIZE) {
+                arena->next_chunk_size = FLB_OTEL_PROTO_ARENA_MAX_CHUNK_SIZE;
+            }
+        }
+    }
+
+    chunk->used += aligned_size;
+
+    return &chunk->data[chunk->used - aligned_size];
+}
+
+static void *otlp_proto_arena_calloc(struct otlp_proto_arena *arena,
+                                     size_t count,
+                                     size_t size)
+{
+    size_t allocation_size;
+    void *result;
+
+    if (size != 0 && count > SIZE_MAX / size) {
+        return NULL;
+    }
+
+    allocation_size = count * size;
+    result = otlp_proto_arena_alloc(arena, allocation_size);
+    if (result != NULL) {
+        memset(result, 0, allocation_size);
+    }
+
+    return result;
+}
+
+static char *otlp_proto_arena_strndup(struct otlp_proto_arena *arena,
+                                      const char *input,
+                                      size_t length)
+{
+    char *result;
+
+    if (length == SIZE_MAX) {
+        return NULL;
+    }
+
+    result = otlp_proto_arena_alloc(arena, length + 1);
+    if (result != NULL) {
+        memcpy(result, input, length);
+        result[length] = '\0';
+    }
+
+    return result;
+}
 
 static void set_result(int *result, int value)
 {
@@ -249,15 +388,13 @@ static int msgpack_map_get_int64(msgpack_object_map *map,
     return -1;
 }
 
-static void otlp_kvpair_destroy(Opentelemetry__Proto__Common__V1__KeyValue *kvpair);
-static void otlp_any_value_destroy(Opentelemetry__Proto__Common__V1__AnyValue *value);
-static void destroy_log_record(Opentelemetry__Proto__Logs__V1__LogRecord *record);
-
-static Opentelemetry__Proto__Common__V1__ArrayValue *otlp_array_value_initialize(size_t entry_count)
+static Opentelemetry__Proto__Common__V1__ArrayValue *otlp_array_value_initialize(
+    struct otlp_proto_arena *arena, size_t entry_count)
 {
     Opentelemetry__Proto__Common__V1__ArrayValue *value;
 
-    value = flb_calloc(1, sizeof(Opentelemetry__Proto__Common__V1__ArrayValue));
+    value = otlp_proto_arena_calloc(
+                arena, 1, sizeof(Opentelemetry__Proto__Common__V1__ArrayValue));
     if (value == NULL) {
         return NULL;
     }
@@ -265,10 +402,10 @@ static Opentelemetry__Proto__Common__V1__ArrayValue *otlp_array_value_initialize
     opentelemetry__proto__common__v1__array_value__init(value);
 
     if (entry_count > 0) {
-        value->values = flb_calloc(entry_count,
-                                   sizeof(Opentelemetry__Proto__Common__V1__AnyValue *));
+        value->values = otlp_proto_arena_calloc(
+                            arena, entry_count,
+                            sizeof(Opentelemetry__Proto__Common__V1__AnyValue *));
         if (value->values == NULL) {
-            flb_free(value);
             return NULL;
         }
 
@@ -278,11 +415,13 @@ static Opentelemetry__Proto__Common__V1__ArrayValue *otlp_array_value_initialize
     return value;
 }
 
-static Opentelemetry__Proto__Common__V1__KeyValue *otlp_kvpair_value_initialize()
+static Opentelemetry__Proto__Common__V1__KeyValue *otlp_kvpair_value_initialize(
+    struct otlp_proto_arena *arena)
 {
     Opentelemetry__Proto__Common__V1__KeyValue *value;
 
-    value = flb_calloc(1, sizeof(Opentelemetry__Proto__Common__V1__KeyValue));
+    value = otlp_proto_arena_calloc(
+                arena, 1, sizeof(Opentelemetry__Proto__Common__V1__KeyValue));
     if (value != NULL) {
         opentelemetry__proto__common__v1__key_value__init(value);
     }
@@ -290,11 +429,13 @@ static Opentelemetry__Proto__Common__V1__KeyValue *otlp_kvpair_value_initialize(
     return value;
 }
 
-static Opentelemetry__Proto__Common__V1__KeyValueList *otlp_kvlist_value_initialize(size_t entry_count)
+static Opentelemetry__Proto__Common__V1__KeyValueList *otlp_kvlist_value_initialize(
+    struct otlp_proto_arena *arena, size_t entry_count)
 {
     Opentelemetry__Proto__Common__V1__KeyValueList *value;
 
-    value = flb_calloc(1, sizeof(Opentelemetry__Proto__Common__V1__KeyValueList));
+    value = otlp_proto_arena_calloc(
+                arena, 1, sizeof(Opentelemetry__Proto__Common__V1__KeyValueList));
     if (value == NULL) {
         return NULL;
     }
@@ -302,10 +443,10 @@ static Opentelemetry__Proto__Common__V1__KeyValueList *otlp_kvlist_value_initial
     opentelemetry__proto__common__v1__key_value_list__init(value);
 
     if (entry_count > 0) {
-        value->values = flb_calloc(entry_count,
-                                   sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+        value->values = otlp_proto_arena_calloc(
+                            arena, entry_count,
+                            sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
         if (value->values == NULL) {
-            flb_free(value);
             return NULL;
         }
 
@@ -315,12 +456,13 @@ static Opentelemetry__Proto__Common__V1__KeyValueList *otlp_kvlist_value_initial
     return value;
 }
 
-static Opentelemetry__Proto__Common__V1__AnyValue *otlp_any_value_initialize(int data_type,
-                                                                              size_t entry_count)
+static Opentelemetry__Proto__Common__V1__AnyValue *otlp_any_value_initialize(
+    struct otlp_proto_arena *arena, int data_type, size_t entry_count)
 {
     Opentelemetry__Proto__Common__V1__AnyValue *value;
 
-    value = flb_calloc(1, sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
+    value = otlp_proto_arena_calloc(
+                arena, 1, sizeof(Opentelemetry__Proto__Common__V1__AnyValue));
     if (value == NULL) {
         return NULL;
     }
@@ -352,20 +494,18 @@ static Opentelemetry__Proto__Common__V1__AnyValue *otlp_any_value_initialize(int
     else if (data_type == MSGPACK_OBJECT_ARRAY) {
         value->value_case =
             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_ARRAY_VALUE;
-        value->array_value = otlp_array_value_initialize(entry_count);
+        value->array_value = otlp_array_value_initialize(arena, entry_count);
 
         if (value->array_value == NULL) {
-            flb_free(value);
             return NULL;
         }
     }
     else if (data_type == MSGPACK_OBJECT_MAP) {
         value->value_case =
             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_KVLIST_VALUE;
-        value->kvlist_value = otlp_kvlist_value_initialize(entry_count);
+        value->kvlist_value = otlp_kvlist_value_initialize(arena, entry_count);
 
         if (value->kvlist_value == NULL) {
-            flb_free(value);
             return NULL;
         }
     }
@@ -374,120 +514,32 @@ static Opentelemetry__Proto__Common__V1__AnyValue *otlp_any_value_initialize(int
             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_BYTES_VALUE;
     }
     else {
-        flb_free(value);
         return NULL;
     }
 
     return value;
 }
 
-static void otlp_kvarray_destroy(Opentelemetry__Proto__Common__V1__KeyValue **kvarray,
-                                 size_t entry_count)
-{
-    size_t index;
-
-    if (kvarray == NULL) {
-        return;
-    }
-
-    for (index = 0; index < entry_count; index++) {
-        if (kvarray[index] != NULL) {
-            otlp_kvpair_destroy(kvarray[index]);
-        }
-    }
-
-    flb_free(kvarray);
-}
-
-static void otlp_kvlist_destroy(Opentelemetry__Proto__Common__V1__KeyValueList *kvlist)
-{
-    size_t index;
-
-    if (kvlist == NULL) {
-        return;
-    }
-
-    for (index = 0; index < kvlist->n_values; index++) {
-        otlp_kvpair_destroy(kvlist->values[index]);
-    }
-
-    flb_free(kvlist->values);
-    flb_free(kvlist);
-}
-
-static void otlp_array_destroy(Opentelemetry__Proto__Common__V1__ArrayValue *array)
-{
-    size_t index;
-
-    if (array == NULL) {
-        return;
-    }
-
-    for (index = 0; index < array->n_values; index++) {
-        otlp_any_value_destroy(array->values[index]);
-    }
-
-    flb_free(array->values);
-    flb_free(array);
-}
-
-static void otlp_any_value_destroy(Opentelemetry__Proto__Common__V1__AnyValue *value)
-{
-    if (value == NULL) {
-        return;
-    }
-
-    if (value->value_case ==
-        OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_STRING_VALUE) {
-        flb_free(value->string_value);
-    }
-    else if (value->value_case ==
-             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_ARRAY_VALUE) {
-        otlp_array_destroy(value->array_value);
-    }
-    else if (value->value_case ==
-             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_KVLIST_VALUE) {
-        otlp_kvlist_destroy(value->kvlist_value);
-    }
-    else if (value->value_case ==
-             OPENTELEMETRY__PROTO__COMMON__V1__ANY_VALUE__VALUE_BYTES_VALUE) {
-        flb_free(value->bytes_value.data);
-    }
-
-    flb_free(value);
-}
-
-static void otlp_kvpair_destroy(Opentelemetry__Proto__Common__V1__KeyValue *kvpair)
-{
-    if (kvpair == NULL) {
-        return;
-    }
-
-    flb_free(kvpair->key);
-    otlp_any_value_destroy(kvpair->value);
-    flb_free(kvpair);
-}
-
 static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_object_to_otlp_any_value(
-    msgpack_object *object);
+    struct otlp_proto_arena *arena, msgpack_object *object);
 
 static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_array_to_otlp_any_value(
-    msgpack_object *object)
+    struct otlp_proto_arena *arena, msgpack_object *object)
 {
     size_t index;
     Opentelemetry__Proto__Common__V1__AnyValue *entry;
     Opentelemetry__Proto__Common__V1__AnyValue *value;
 
-    value = otlp_any_value_initialize(MSGPACK_OBJECT_ARRAY,
+    value = otlp_any_value_initialize(arena, MSGPACK_OBJECT_ARRAY,
                                       object->via.array.size);
     if (value == NULL) {
         return NULL;
     }
 
     for (index = 0; index < object->via.array.size; index++) {
-        entry = msgpack_object_to_otlp_any_value(&object->via.array.ptr[index]);
+        entry = msgpack_object_to_otlp_any_value(
+                    arena, &object->via.array.ptr[index]);
         if (entry == NULL) {
-            otlp_any_value_destroy(value);
             return NULL;
         }
 
@@ -498,30 +550,27 @@ static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_array_to_otlp_any_val
 }
 
 static Opentelemetry__Proto__Common__V1__KeyValue *msgpack_kv_to_otlp_any_value(
-    struct msgpack_object_kv *input_pair)
+    struct otlp_proto_arena *arena, struct msgpack_object_kv *input_pair)
 {
     Opentelemetry__Proto__Common__V1__KeyValue *kv;
 
-    kv = otlp_kvpair_value_initialize();
+    kv = otlp_kvpair_value_initialize(arena);
     if (kv == NULL) {
         return NULL;
     }
 
     if (input_pair->key.type != MSGPACK_OBJECT_STR) {
-        flb_free(kv);
         return NULL;
     }
 
-    kv->key = flb_strndup(input_pair->key.via.str.ptr, input_pair->key.via.str.size);
+    kv->key = otlp_proto_arena_strndup(
+                  arena, input_pair->key.via.str.ptr, input_pair->key.via.str.size);
     if (kv->key == NULL) {
-        flb_free(kv);
         return NULL;
     }
 
-    kv->value = msgpack_object_to_otlp_any_value(&input_pair->val);
+    kv->value = msgpack_object_to_otlp_any_value(arena, &input_pair->val);
     if (kv->value == NULL) {
-        flb_free(kv->key);
-        flb_free(kv);
         return NULL;
     }
 
@@ -529,7 +578,7 @@ static Opentelemetry__Proto__Common__V1__KeyValue *msgpack_kv_to_otlp_any_value(
 }
 
 static Opentelemetry__Proto__Common__V1__KeyValue **msgpack_map_to_otlp_kvarray(
-    msgpack_object *object, size_t *entry_count)
+    struct otlp_proto_arena *arena, msgpack_object *object, size_t *entry_count)
 {
     size_t index;
     Opentelemetry__Proto__Common__V1__KeyValue **result;
@@ -540,17 +589,18 @@ static Opentelemetry__Proto__Common__V1__KeyValue **msgpack_map_to_otlp_kvarray(
         return NULL;
     }
 
-    result = flb_calloc(*entry_count,
-                        sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+    result = otlp_proto_arena_calloc(
+                 arena, *entry_count,
+                 sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
     if (result == NULL) {
         *entry_count = 0;
         return NULL;
     }
 
     for (index = 0; index < *entry_count; index++) {
-        result[index] = msgpack_kv_to_otlp_any_value(&object->via.map.ptr[index]);
+        result[index] = msgpack_kv_to_otlp_any_value(
+                            arena, &object->via.map.ptr[index]);
         if (result[index] == NULL) {
-            otlp_kvarray_destroy(result, index);
             *entry_count = 0;
             return NULL;
         }
@@ -560,21 +610,21 @@ static Opentelemetry__Proto__Common__V1__KeyValue **msgpack_map_to_otlp_kvarray(
 }
 
 static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_map_to_otlp_any_value(
-    msgpack_object *object)
+    struct otlp_proto_arena *arena, msgpack_object *object)
 {
     size_t index;
     Opentelemetry__Proto__Common__V1__KeyValue *entry;
     Opentelemetry__Proto__Common__V1__AnyValue *value;
 
-    value = otlp_any_value_initialize(MSGPACK_OBJECT_MAP, object->via.map.size);
+    value = otlp_any_value_initialize(arena, MSGPACK_OBJECT_MAP,
+                                      object->via.map.size);
     if (value == NULL) {
         return NULL;
     }
 
     for (index = 0; index < object->via.map.size; index++) {
-        entry = msgpack_kv_to_otlp_any_value(&object->via.map.ptr[index]);
+        entry = msgpack_kv_to_otlp_any_value(arena, &object->via.map.ptr[index]);
         if (entry == NULL) {
-            otlp_any_value_destroy(value);
             return NULL;
         }
 
@@ -585,7 +635,7 @@ static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_map_to_otlp_any_value
 }
 
 static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_object_to_otlp_any_value(
-    msgpack_object *object)
+    struct otlp_proto_arena *arena, msgpack_object *object)
 {
     Opentelemetry__Proto__Common__V1__AnyValue *value;
 
@@ -597,21 +647,20 @@ static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_object_to_otlp_any_va
 
     switch (object->type) {
     case MSGPACK_OBJECT_NIL:
-        value = otlp_any_value_initialize(MSGPACK_OBJECT_NIL, 0);
+        value = otlp_any_value_initialize(arena, MSGPACK_OBJECT_NIL, 0);
         break;
     case MSGPACK_OBJECT_BOOLEAN:
-        value = otlp_any_value_initialize(MSGPACK_OBJECT_BOOLEAN, 0);
+        value = otlp_any_value_initialize(arena, MSGPACK_OBJECT_BOOLEAN, 0);
         if (value != NULL) {
             value->bool_value = object->via.boolean;
         }
         break;
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-        value = otlp_any_value_initialize(object->type, 0);
+        value = otlp_any_value_initialize(arena, object->type, 0);
         if (value != NULL) {
             if (object->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
                 if (object->via.u64 > INT64_MAX) {
-                    otlp_any_value_destroy(value);
                     value = NULL;
                     break;
                 }
@@ -625,29 +674,29 @@ static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_object_to_otlp_any_va
         break;
     case MSGPACK_OBJECT_FLOAT32:
     case MSGPACK_OBJECT_FLOAT64:
-        value = otlp_any_value_initialize(object->type, 0);
+        value = otlp_any_value_initialize(arena, object->type, 0);
         if (value != NULL) {
             value->double_value = object->via.f64;
         }
         break;
     case MSGPACK_OBJECT_STR:
-        value = otlp_any_value_initialize(MSGPACK_OBJECT_STR, 0);
+        value = otlp_any_value_initialize(arena, MSGPACK_OBJECT_STR, 0);
         if (value != NULL) {
-            value->string_value = flb_strndup(object->via.str.ptr,
-                                              object->via.str.size);
+            value->string_value = otlp_proto_arena_strndup(
+                                      arena, object->via.str.ptr,
+                                      object->via.str.size);
             if (value->string_value == NULL) {
-                otlp_any_value_destroy(value);
                 value = NULL;
             }
         }
         break;
     case MSGPACK_OBJECT_BIN:
-        value = otlp_any_value_initialize(MSGPACK_OBJECT_BIN, 0);
+        value = otlp_any_value_initialize(arena, MSGPACK_OBJECT_BIN, 0);
         if (value != NULL) {
             value->bytes_value.len = object->via.bin.size;
-            value->bytes_value.data = flb_malloc(object->via.bin.size);
+            value->bytes_value.data = otlp_proto_arena_alloc(
+                                          arena, object->via.bin.size);
             if (value->bytes_value.data == NULL) {
-                otlp_any_value_destroy(value);
                 value = NULL;
             }
             else {
@@ -658,10 +707,10 @@ static Opentelemetry__Proto__Common__V1__AnyValue *msgpack_object_to_otlp_any_va
         }
         break;
     case MSGPACK_OBJECT_ARRAY:
-        value = msgpack_array_to_otlp_any_value(object);
+        value = msgpack_array_to_otlp_any_value(arena, object);
         break;
     case MSGPACK_OBJECT_MAP:
-        value = msgpack_map_to_otlp_any_value(object);
+        value = msgpack_map_to_otlp_any_value(arena, object);
         break;
     default:
         break;
@@ -759,11 +808,13 @@ static msgpack_object *find_log_body_candidate(msgpack_object *body,
     return body;
 }
 
-static int append_kvarrays(Opentelemetry__Proto__Common__V1__KeyValue ***base,
+static int append_kvarrays(struct otlp_proto_arena *arena,
+                           Opentelemetry__Proto__Common__V1__KeyValue ***base,
                            size_t *base_count,
                            Opentelemetry__Proto__Common__V1__KeyValue **extra,
                            size_t extra_count)
 {
+    size_t total_count;
     Opentelemetry__Proto__Common__V1__KeyValue **tmp;
 
     if (extra == NULL || extra_count == 0) {
@@ -776,23 +827,35 @@ static int append_kvarrays(Opentelemetry__Proto__Common__V1__KeyValue ***base,
         return 0;
     }
 
-    tmp = flb_realloc(*base,
-                      sizeof(Opentelemetry__Proto__Common__V1__KeyValue *) *
-                      (*base_count + extra_count));
+    if (*base_count > SIZE_MAX - extra_count) {
+        return -1;
+    }
+
+    total_count = *base_count + extra_count;
+    if (total_count >
+        SIZE_MAX / sizeof(Opentelemetry__Proto__Common__V1__KeyValue *)) {
+        return -1;
+    }
+
+    tmp = otlp_proto_arena_alloc(
+              arena,
+              sizeof(Opentelemetry__Proto__Common__V1__KeyValue *) * total_count);
     if (tmp == NULL) {
         return -1;
     }
 
-    *base = tmp;
-    memcpy(*base + *base_count, extra,
+    memcpy(tmp, *base,
+           sizeof(Opentelemetry__Proto__Common__V1__KeyValue *) * *base_count);
+    memcpy(tmp + *base_count, extra,
            sizeof(Opentelemetry__Proto__Common__V1__KeyValue *) * extra_count);
+    *base = tmp;
     *base_count += extra_count;
-    flb_free(extra);
 
     return 0;
 }
 
 static int msgpack_map_to_otlp_kvarray_filtered(
+    struct otlp_proto_arena *arena,
     msgpack_object_map *map,
     const char *ignored_key,
     size_t ignored_key_length,
@@ -801,10 +864,8 @@ static int msgpack_map_to_otlp_kvarray_filtered(
 {
     size_t index;
     size_t count;
-    Opentelemetry__Proto__Common__V1__KeyValue **tmp;
     Opentelemetry__Proto__Common__V1__KeyValue **values;
 
-    values = NULL;
     count = 0;
 
     for (index = 0; index < map->size; index++) {
@@ -817,20 +878,37 @@ static int msgpack_map_to_otlp_kvarray_filtered(
             continue;
         }
 
-        tmp = flb_realloc(values,
-                          sizeof(Opentelemetry__Proto__Common__V1__KeyValue *) *
-                          (count + 1));
-        if (tmp == NULL) {
-            otlp_kvarray_destroy(values, count);
-            *out_values = NULL;
-            *out_count = 0;
-            return -1;
-        }
-        values = tmp;
+        count++;
+    }
 
-        values[count] = msgpack_kv_to_otlp_any_value(&map->ptr[index]);
+    if (count == 0) {
+        *out_values = NULL;
+        *out_count = 0;
+        return 0;
+    }
+
+    values = otlp_proto_arena_calloc(
+                 arena, count,
+                 sizeof(Opentelemetry__Proto__Common__V1__KeyValue *));
+    if (values == NULL) {
+        *out_values = NULL;
+        *out_count = 0;
+        return -1;
+    }
+
+    count = 0;
+    for (index = 0; index < map->size; index++) {
+        if (ignored_key != NULL &&
+            map->ptr[index].key.type == MSGPACK_OBJECT_STR &&
+            map->ptr[index].key.via.str.size == ignored_key_length &&
+            strncmp(map->ptr[index].key.via.str.ptr,
+                    ignored_key,
+                    ignored_key_length) == 0) {
+            continue;
+        }
+
+        values[count] = msgpack_kv_to_otlp_any_value(arena, &map->ptr[index]);
         if (values[count] == NULL) {
-            otlp_kvarray_destroy(values, count);
             *out_values = NULL;
             *out_count = 0;
             return -1;
@@ -846,6 +924,7 @@ static int msgpack_map_to_otlp_kvarray_filtered(
 }
 
 static int log_record_set_body_and_attributes(
+    struct otlp_proto_arena *arena,
     Opentelemetry__Proto__Logs__V1__LogRecord *record,
     struct flb_log_event *event,
     const char **logs_body_keys,
@@ -866,7 +945,7 @@ static int log_record_set_body_and_attributes(
                                         &matched_key,
                                         &matched_key_length);
 
-    record->body = msgpack_object_to_otlp_any_value(candidate);
+    record->body = msgpack_object_to_otlp_any_value(arena, candidate);
     if (candidate != NULL && record->body == NULL) {
         return -1;
     }
@@ -875,7 +954,8 @@ static int log_record_set_body_and_attributes(
         matched_key != NULL &&
         event->body != NULL &&
         event->body->type == MSGPACK_OBJECT_MAP) {
-        if (msgpack_map_to_otlp_kvarray_filtered(&event->body->via.map,
+        if (msgpack_map_to_otlp_kvarray_filtered(arena,
+                                                 &event->body->via.map,
                                                  matched_key,
                                                  matched_key_length,
                                                  &attributes,
@@ -883,11 +963,11 @@ static int log_record_set_body_and_attributes(
             return -1;
         }
 
-        if (append_kvarrays(&record->attributes,
+        if (append_kvarrays(arena,
+                            &record->attributes,
                             &record->n_attributes,
                             attributes,
                             attribute_count) != 0) {
-            otlp_kvarray_destroy(attributes, attribute_count);
             return -1;
         }
     }
@@ -896,6 +976,7 @@ static int log_record_set_body_and_attributes(
 }
 
 static int add_msgpack_attributes_to_resource(
+    struct otlp_proto_arena *arena,
     Opentelemetry__Proto__Resource__V1__Resource *resource,
     msgpack_object *resource_object)
 {
@@ -907,7 +988,7 @@ static int add_msgpack_attributes_to_resource(
 
     field = msgpack_map_get_object(&resource_object->via.map, "attributes");
     if (field != NULL && field->type == MSGPACK_OBJECT_MAP) {
-        resource->attributes = msgpack_map_to_otlp_kvarray(field,
+        resource->attributes = msgpack_map_to_otlp_kvarray(arena, field,
                                                            &resource->n_attributes);
         if (field->via.map.size > 0 && resource->attributes == NULL) {
             return -1;
@@ -930,6 +1011,7 @@ static int add_msgpack_attributes_to_resource(
 }
 
 static int add_msgpack_scope_fields(
+    struct otlp_proto_arena *arena,
     Opentelemetry__Proto__Common__V1__InstrumentationScope *scope,
     msgpack_object *scope_object)
 {
@@ -941,7 +1023,8 @@ static int add_msgpack_scope_fields(
 
     field = msgpack_map_get_object(&scope_object->via.map, "name");
     if (field != NULL && field->type == MSGPACK_OBJECT_STR) {
-        scope->name = flb_strndup(field->via.str.ptr, field->via.str.size);
+        scope->name = otlp_proto_arena_strndup(
+                          arena, field->via.str.ptr, field->via.str.size);
         if (scope->name == NULL) {
             return -1;
         }
@@ -949,7 +1032,8 @@ static int add_msgpack_scope_fields(
 
     field = msgpack_map_get_object(&scope_object->via.map, "version");
     if (field != NULL && field->type == MSGPACK_OBJECT_STR) {
-        scope->version = flb_strndup(field->via.str.ptr, field->via.str.size);
+        scope->version = otlp_proto_arena_strndup(
+                             arena, field->via.str.ptr, field->via.str.size);
         if (scope->version == NULL) {
             return -1;
         }
@@ -957,7 +1041,7 @@ static int add_msgpack_scope_fields(
 
     field = msgpack_map_get_object(&scope_object->via.map, "attributes");
     if (field != NULL && field->type == MSGPACK_OBJECT_MAP) {
-        scope->attributes = msgpack_map_to_otlp_kvarray(field,
+        scope->attributes = msgpack_map_to_otlp_kvarray(arena, field,
                                                         &scope->n_attributes);
         if (field->via.map.size > 0 && scope->attributes == NULL) {
             return -1;
@@ -974,6 +1058,7 @@ static int add_msgpack_scope_fields(
 }
 
 static struct otlp_proto_logs_resource_state *append_logs_resource_state(
+    struct otlp_proto_arena *arena,
     Opentelemetry__Proto__Collector__Logs__V1__ExportLogsServiceRequest *export_logs,
     struct otlp_proto_logs_resource_state **states,
     size_t *state_count,
@@ -989,11 +1074,13 @@ static struct otlp_proto_logs_resource_state *append_logs_resource_state(
     Opentelemetry__Proto__Logs__V1__ResourceLogs **tmp;
     msgpack_object *schema_url;
 
-    resource_log = flb_calloc(1, sizeof(Opentelemetry__Proto__Logs__V1__ResourceLogs));
-    resource = flb_calloc(1, sizeof(Opentelemetry__Proto__Resource__V1__Resource));
+    resource_log = otlp_proto_arena_calloc(
+                       arena, 1,
+                       sizeof(Opentelemetry__Proto__Logs__V1__ResourceLogs));
+    resource = otlp_proto_arena_calloc(
+                   arena, 1,
+                   sizeof(Opentelemetry__Proto__Resource__V1__Resource));
     if (resource_log == NULL || resource == NULL) {
-        flb_free(resource_log);
-        flb_free(resource);
         return NULL;
     }
 
@@ -1001,20 +1088,16 @@ static struct otlp_proto_logs_resource_state *append_logs_resource_state(
     opentelemetry__proto__resource__v1__resource__init(resource);
     resource_log->resource = resource;
 
-    if (add_msgpack_attributes_to_resource(resource, resource_object) != 0) {
-        flb_free(resource);
-        flb_free(resource_log);
+    if (add_msgpack_attributes_to_resource(arena, resource, resource_object) != 0) {
         return NULL;
     }
 
     schema_url = resource_schema_url_object(resource_object, resource_body);
     if (schema_url != NULL && schema_url->type == MSGPACK_OBJECT_STR) {
-        resource_log->schema_url = flb_strndup(schema_url->via.str.ptr,
-                                               schema_url->via.str.size);
+        resource_log->schema_url = otlp_proto_arena_strndup(
+                                       arena, schema_url->via.str.ptr,
+                                       schema_url->via.str.size);
         if (resource_log->schema_url == NULL) {
-            otlp_kvarray_destroy(resource->attributes, resource->n_attributes);
-            flb_free(resource);
-            flb_free(resource_log);
             return NULL;
         }
     }
@@ -1023,13 +1106,6 @@ static struct otlp_proto_logs_resource_state *append_logs_resource_state(
                       sizeof(Opentelemetry__Proto__Logs__V1__ResourceLogs *) *
                       (export_logs->n_resource_logs + 1));
     if (tmp == NULL) {
-        otlp_kvarray_destroy(resource->attributes, resource->n_attributes);
-        if (resource_log->schema_url != NULL &&
-            resource_log->schema_url != protobuf_c_empty_string) {
-            flb_free(resource_log->schema_url);
-        }
-        flb_free(resource);
-        flb_free(resource_log);
         return NULL;
     }
 
@@ -1056,6 +1132,7 @@ static struct otlp_proto_logs_resource_state *append_logs_resource_state(
 }
 
 static struct otlp_proto_logs_scope_state *append_logs_scope_state(
+    struct otlp_proto_arena *arena,
     struct otlp_proto_logs_resource_state *resource_state,
     int64_t scope_id,
     uint64_t scope_hash,
@@ -1068,11 +1145,13 @@ static struct otlp_proto_logs_scope_state *append_logs_scope_state(
     Opentelemetry__Proto__Logs__V1__ScopeLogs **tmp;
     msgpack_object *schema_url;
 
-    scope_log = flb_calloc(1, sizeof(Opentelemetry__Proto__Logs__V1__ScopeLogs));
-    scope = flb_calloc(1, sizeof(Opentelemetry__Proto__Common__V1__InstrumentationScope));
+    scope_log = otlp_proto_arena_calloc(
+                    arena, 1,
+                    sizeof(Opentelemetry__Proto__Logs__V1__ScopeLogs));
+    scope = otlp_proto_arena_calloc(
+                arena, 1,
+                sizeof(Opentelemetry__Proto__Common__V1__InstrumentationScope));
     if (scope_log == NULL || scope == NULL) {
-        flb_free(scope_log);
-        flb_free(scope);
         return NULL;
     }
 
@@ -1080,26 +1159,17 @@ static struct otlp_proto_logs_scope_state *append_logs_scope_state(
     opentelemetry__proto__common__v1__instrumentation_scope__init(scope);
     scope_log->scope = scope;
 
-    if (add_msgpack_scope_fields(scope, scope_object) != 0) {
-        flb_free(scope->name);
-        flb_free(scope->version);
-        otlp_kvarray_destroy(scope->attributes, scope->n_attributes);
-        flb_free(scope);
-        flb_free(scope_log);
+    if (add_msgpack_scope_fields(arena, scope, scope_object) != 0) {
         return NULL;
     }
 
     if (scope_object != NULL && scope_object->type == MSGPACK_OBJECT_MAP) {
         schema_url = msgpack_map_get_object(&scope_object->via.map, "schema_url");
         if (schema_url != NULL && schema_url->type == MSGPACK_OBJECT_STR) {
-            scope_log->schema_url = flb_strndup(schema_url->via.str.ptr,
-                                                schema_url->via.str.size);
+            scope_log->schema_url = otlp_proto_arena_strndup(
+                                        arena, schema_url->via.str.ptr,
+                                        schema_url->via.str.size);
             if (scope_log->schema_url == NULL) {
-                flb_free(scope->name);
-                flb_free(scope->version);
-                otlp_kvarray_destroy(scope->attributes, scope->n_attributes);
-                flb_free(scope);
-                flb_free(scope_log);
                 return NULL;
             }
         }
@@ -1109,15 +1179,6 @@ static struct otlp_proto_logs_scope_state *append_logs_scope_state(
                       sizeof(Opentelemetry__Proto__Logs__V1__ScopeLogs *) *
                       (resource_state->resource_log->n_scope_logs + 1));
     if (tmp == NULL) {
-        if (scope_log->schema_url != NULL &&
-            scope_log->schema_url != protobuf_c_empty_string) {
-            flb_free(scope_log->schema_url);
-        }
-        flb_free(scope->name);
-        flb_free(scope->version);
-        otlp_kvarray_destroy(scope->attributes, scope->n_attributes);
-        flb_free(scope);
-        flb_free(scope_log);
         return NULL;
     }
 
@@ -1145,6 +1206,7 @@ static struct otlp_proto_logs_scope_state *append_logs_scope_state(
 }
 
 static int ensure_default_logs_scope_state(
+    struct otlp_proto_arena *arena,
     Opentelemetry__Proto__Collector__Logs__V1__ExportLogsServiceRequest *export_logs,
     struct otlp_proto_logs_resource_state **resource_states,
     size_t *resource_state_count,
@@ -1162,7 +1224,8 @@ static int ensure_default_logs_scope_state(
                                                  0,
                                                  resource_hash);
     if (*current_resource == NULL) {
-        *current_resource = append_logs_resource_state(export_logs,
+        *current_resource = append_logs_resource_state(arena,
+                                                       export_logs,
                                                        resource_states,
                                                        resource_state_count,
                                                        0,
@@ -1176,7 +1239,8 @@ static int ensure_default_logs_scope_state(
 
     *current_scope = find_logs_scope_state(*current_resource, 0, scope_hash);
     if (*current_scope == NULL) {
-        *current_scope = append_logs_scope_state(*current_resource,
+        *current_scope = append_logs_scope_state(arena,
+                                                 *current_resource,
                                                  0,
                                                  scope_hash,
                                                  NULL);
@@ -1188,7 +1252,8 @@ static int ensure_default_logs_scope_state(
     return 0;
 }
 
-static int append_binary_id_field(ProtobufCBinaryData *field,
+static int append_binary_id_field(struct otlp_proto_arena *arena,
+                                  ProtobufCBinaryData *field,
                                   msgpack_object *value,
                                   size_t expected_size)
 {
@@ -1203,7 +1268,7 @@ static int append_binary_id_field(ProtobufCBinaryData *field,
             return 0;
         }
 
-        field->data = flb_malloc(value->via.bin.size);
+        field->data = otlp_proto_arena_alloc(arena, value->via.bin.size);
         if (field->data == NULL) {
             return -1;
         }
@@ -1221,7 +1286,7 @@ static int append_binary_id_field(ProtobufCBinaryData *field,
         return 0;
     }
 
-    field->data = flb_calloc(1, expected_size);
+    field->data = otlp_proto_arena_calloc(arena, 1, expected_size);
     if (field->data == NULL) {
         return -1;
     }
@@ -1232,7 +1297,6 @@ static int append_binary_id_field(ProtobufCBinaryData *field,
         char *str = (char *) value->via.str.ptr;
 
         if (!isxdigit(str[i * 2]) || !isxdigit(str[i * 2 + 1])) {
-            flb_free(field->data);
             field->data = NULL;
             return -1;
         }
@@ -1251,7 +1315,8 @@ static int append_binary_id_field(ProtobufCBinaryData *field,
     return 0;
 }
 
-static int log_record_to_proto(Opentelemetry__Proto__Logs__V1__LogRecord *record,
+static int log_record_to_proto(struct otlp_proto_arena *arena,
+                               Opentelemetry__Proto__Logs__V1__LogRecord *record,
                                struct flb_log_event *event,
                                const char **logs_body_keys,
                                size_t logs_body_key_count,
@@ -1311,8 +1376,9 @@ static int log_record_to_proto(Opentelemetry__Proto__Logs__V1__LogRecord *record
         field = msgpack_map_get_object(&otlp_metadata->via.map,
                                        "severity_text");
         if (field != NULL && field->type == MSGPACK_OBJECT_STR) {
-            record->severity_text = flb_strndup(field->via.str.ptr,
-                                                field->via.str.size);
+            record->severity_text = otlp_proto_arena_strndup(
+                                        arena, field->via.str.ptr,
+                                        field->via.str.size);
             if (record->severity_text == NULL) {
                 return -1;
             }
@@ -1320,28 +1386,30 @@ static int log_record_to_proto(Opentelemetry__Proto__Logs__V1__LogRecord *record
 
         field = msgpack_map_get_object(&otlp_metadata->via.map, "attributes");
         if (field != NULL && field->type == MSGPACK_OBJECT_MAP) {
-            attrs = msgpack_map_to_otlp_kvarray(field, &count);
+            attrs = msgpack_map_to_otlp_kvarray(arena, field, &count);
             if (field->via.map.size > 0 && attrs == NULL) {
                 return -1;
             }
 
-            if (append_kvarrays(&record->attributes,
+            if (append_kvarrays(arena,
+                                &record->attributes,
                                 &record->n_attributes,
                                 attrs,
                                 count) != 0) {
-                otlp_kvarray_destroy(attrs, count);
                 return -1;
             }
         }
 
-        if (append_binary_id_field(&record->trace_id,
+        if (append_binary_id_field(arena,
+                                   &record->trace_id,
                                    msgpack_map_get_object(&otlp_metadata->via.map,
                                                           "trace_id"),
                                    16) != 0) {
             return -1;
         }
 
-        if (append_binary_id_field(&record->span_id,
+        if (append_binary_id_field(arena,
+                                   &record->span_id,
                                    msgpack_map_get_object(&otlp_metadata->via.map,
                                                           "span_id"),
                                    8) != 0) {
@@ -1349,7 +1417,8 @@ static int log_record_to_proto(Opentelemetry__Proto__Logs__V1__LogRecord *record
         }
     }
 
-    if (log_record_set_body_and_attributes(record,
+    if (log_record_set_body_and_attributes(arena,
+                                           record,
                                            event,
                                            logs_body_keys,
                                            logs_body_key_count,
@@ -1360,29 +1429,11 @@ static int log_record_to_proto(Opentelemetry__Proto__Logs__V1__LogRecord *record
     return 0;
 }
 
-static void destroy_log_record(Opentelemetry__Proto__Logs__V1__LogRecord *record)
-{
-    if (record == NULL) {
-        return;
-    }
-
-    otlp_any_value_destroy(record->body);
-    otlp_kvarray_destroy(record->attributes, record->n_attributes);
-    if (record->severity_text != NULL &&
-        record->severity_text != protobuf_c_empty_string) {
-        flb_free(record->severity_text);
-    }
-    flb_free(record->span_id.data);
-    flb_free(record->trace_id.data);
-    flb_free(record);
-}
-
-static void destroy_export_logs(
+static void destroy_export_logs_arrays(
     Opentelemetry__Proto__Collector__Logs__V1__ExportLogsServiceRequest *export_logs)
 {
     size_t index;
     size_t inner;
-    size_t record_index;
     Opentelemetry__Proto__Logs__V1__ResourceLogs *resource_log;
     Opentelemetry__Proto__Logs__V1__ScopeLogs *scope_log;
 
@@ -1402,44 +1453,10 @@ static void destroy_export_logs(
                 continue;
             }
 
-            for (record_index = 0;
-                 record_index < scope_log->n_log_records;
-                 record_index++) {
-                destroy_log_record(scope_log->log_records[record_index]);
-            }
-
             flb_free(scope_log->log_records);
-            if (scope_log->scope != NULL) {
-                if (scope_log->scope->name != NULL &&
-                    scope_log->scope->name != protobuf_c_empty_string) {
-                    flb_free(scope_log->scope->name);
-                }
-                if (scope_log->scope->version != NULL &&
-                    scope_log->scope->version != protobuf_c_empty_string) {
-                    flb_free(scope_log->scope->version);
-                }
-                otlp_kvarray_destroy(scope_log->scope->attributes,
-                                     scope_log->scope->n_attributes);
-                flb_free(scope_log->scope);
-            }
-            if (scope_log->schema_url != NULL &&
-                scope_log->schema_url != protobuf_c_empty_string) {
-                flb_free(scope_log->schema_url);
-            }
-            flb_free(scope_log);
         }
 
         flb_free(resource_log->scope_logs);
-        if (resource_log->resource != NULL) {
-            otlp_kvarray_destroy(resource_log->resource->attributes,
-                                 resource_log->resource->n_attributes);
-            flb_free(resource_log->resource);
-        }
-        if (resource_log->schema_url != NULL &&
-            resource_log->schema_url != protobuf_c_empty_string) {
-            flb_free(resource_log->schema_url);
-        }
-        flb_free(resource_log);
     }
 
     flb_free(export_logs->resource_logs);
@@ -1598,12 +1615,14 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
     flb_sds_t output;
     struct flb_log_event event;
     struct flb_log_event_decoder decoder;
+    struct otlp_proto_arena arena;
     msgpack_object *group_metadata;
     msgpack_object *group_body;
     msgpack_object *resource_object;
     msgpack_object *scope_object;
     uint64_t resource_hash;
     uint64_t scope_hash;
+    Opentelemetry__Proto__Logs__V1__LogRecord **tmp;
     struct otlp_proto_logs_scope_state *current_scope;
     struct otlp_proto_logs_resource_state *current_resource;
     struct otlp_proto_logs_resource_state *resource_states;
@@ -1637,6 +1656,7 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
 
     opentelemetry__proto__collector__logs__v1__export_logs_service_request__init(
         &export_logs);
+    otlp_proto_arena_init(&arena);
 
     current_scope = NULL;
     current_resource = NULL;
@@ -1647,6 +1667,7 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
                                      (char *) event_chunk_data,
                                      event_chunk_size);
     if (ret != FLB_EVENT_DECODER_SUCCESS) {
+        otlp_proto_arena_destroy(&arena);
         set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_INVALID_ARGUMENT, EINVAL);
         return NULL;
     }
@@ -1658,7 +1679,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
         ret = flb_log_event_decoder_get_record_type(&event, &record_type);
         if (ret != 0) {
             flb_log_event_decoder_destroy(&decoder);
-            destroy_export_logs(&export_logs);
+            destroy_export_logs_arrays(&export_logs);
+            otlp_proto_arena_destroy(&arena);
             destroy_logs_resource_states(resource_states, resource_state_count);
             set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_INVALID_LOG_EVENT, EINVAL);
             return NULL;
@@ -1677,7 +1699,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
                 msgpack_map_get_int64(&group_metadata->via.map, "scope_id", &scope_id) != 0) {
                 if (require_otel_metadata == FLB_TRUE) {
                     flb_log_event_decoder_destroy(&decoder);
-                    destroy_export_logs(&export_logs);
+                    destroy_export_logs_arrays(&export_logs);
+                    otlp_proto_arena_destroy(&arena);
                     destroy_logs_resource_states(resource_states, resource_state_count);
                     set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_INVALID_LOG_EVENT, EINVAL);
                     return NULL;
@@ -1704,7 +1727,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
                                                         resource_id,
                                                         resource_hash);
             if (current_resource == NULL) {
-                current_resource = append_logs_resource_state(&export_logs,
+                current_resource = append_logs_resource_state(&arena,
+                                                              &export_logs,
                                                               &resource_states,
                                                               &resource_state_count,
                                                               resource_id,
@@ -1713,7 +1737,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
                                                               group_body);
                 if (current_resource == NULL) {
                     flb_log_event_decoder_destroy(&decoder);
-                    destroy_export_logs(&export_logs);
+                    destroy_export_logs_arrays(&export_logs);
+                    otlp_proto_arena_destroy(&arena);
                     destroy_logs_resource_states(resource_states, resource_state_count);
                     set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
                     return NULL;
@@ -1724,13 +1749,15 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
                                                   scope_id,
                                                   scope_hash);
             if (current_scope == NULL) {
-                current_scope = append_logs_scope_state(current_resource,
+                current_scope = append_logs_scope_state(&arena,
+                                                        current_resource,
                                                         scope_id,
                                                         scope_hash,
                                                         scope_object);
                 if (current_scope == NULL) {
                     flb_log_event_decoder_destroy(&decoder);
-                    destroy_export_logs(&export_logs);
+                    destroy_export_logs_arrays(&export_logs);
+                    otlp_proto_arena_destroy(&arena);
                     destroy_logs_resource_states(resource_states, resource_state_count);
                     set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
                     return NULL;
@@ -1748,33 +1775,35 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
         if (current_scope == NULL) {
             if (require_otel_metadata == FLB_TRUE) {
                 flb_log_event_decoder_destroy(&decoder);
-                destroy_export_logs(&export_logs);
+                destroy_export_logs_arrays(&export_logs);
+                otlp_proto_arena_destroy(&arena);
                 destroy_logs_resource_states(resource_states, resource_state_count);
                 set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_INVALID_LOG_EVENT, EINVAL);
                 return NULL;
             }
 
-            if (ensure_default_logs_scope_state(&export_logs,
+            if (ensure_default_logs_scope_state(&arena,
+                                                &export_logs,
                                                 &resource_states,
                                                 &resource_state_count,
                                                 &current_resource,
                                                 &current_scope) != 0) {
                 flb_log_event_decoder_destroy(&decoder);
-                destroy_export_logs(&export_logs);
+                destroy_export_logs_arrays(&export_logs);
+                otlp_proto_arena_destroy(&arena);
                 destroy_logs_resource_states(resource_states, resource_state_count);
                 set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
                 return NULL;
             }
         }
 
-        Opentelemetry__Proto__Logs__V1__LogRecord **tmp;
-
         tmp = flb_realloc(current_scope->scope_log->log_records,
                           sizeof(Opentelemetry__Proto__Logs__V1__LogRecord *) *
                           (current_scope->scope_log->n_log_records + 1));
         if (tmp == NULL) {
             flb_log_event_decoder_destroy(&decoder);
-            destroy_export_logs(&export_logs);
+            destroy_export_logs_arrays(&export_logs);
+            otlp_proto_arena_destroy(&arena);
             destroy_logs_resource_states(resource_states, resource_state_count);
             set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
             return NULL;
@@ -1782,12 +1811,15 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
 
         current_scope->scope_log->log_records = tmp;
 
-        record = flb_calloc(1, sizeof(Opentelemetry__Proto__Logs__V1__LogRecord));
+        record = otlp_proto_arena_calloc(
+                     &arena, 1,
+                     sizeof(Opentelemetry__Proto__Logs__V1__LogRecord));
         current_scope->scope_log->log_records[
             current_scope->scope_log->n_log_records] = record;
         if (record == NULL) {
             flb_log_event_decoder_destroy(&decoder);
-            destroy_export_logs(&export_logs);
+            destroy_export_logs_arrays(&export_logs);
+            otlp_proto_arena_destroy(&arena);
             destroy_logs_resource_states(resource_states, resource_state_count);
             set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
             return NULL;
@@ -1796,16 +1828,17 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
         opentelemetry__proto__logs__v1__log_record__init(record);
 
         if (log_record_to_proto(
+                &arena,
                 record,
                 &event,
                 logs_body_keys,
                 logs_body_key_count,
                 logs_body_key_attributes) != 0) {
-            destroy_log_record(record);
             current_scope->scope_log->log_records[
                 current_scope->scope_log->n_log_records] = NULL;
             flb_log_event_decoder_destroy(&decoder);
-            destroy_export_logs(&export_logs);
+            destroy_export_logs_arrays(&export_logs);
+            otlp_proto_arena_destroy(&arena);
             destroy_logs_resource_states(resource_states, resource_state_count);
             set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
             return NULL;
@@ -1819,7 +1852,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
 
     if (ret != FLB_EVENT_DECODER_SUCCESS &&
         ret != FLB_EVENT_DECODER_ERROR_INSUFFICIENT_DATA) {
-        destroy_export_logs(&export_logs);
+        destroy_export_logs_arrays(&export_logs);
+        otlp_proto_arena_destroy(&arena);
         set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_INVALID_LOG_EVENT, EINVAL);
         return NULL;
     }
@@ -1828,7 +1862,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
         opentelemetry__proto__collector__logs__v1__export_logs_service_request__get_packed_size(
             &export_logs));
     if (output == NULL) {
-        destroy_export_logs(&export_logs);
+        destroy_export_logs_arrays(&export_logs);
+        otlp_proto_arena_destroy(&arena);
         set_error(result, FLB_OPENTELEMETRY_OTLP_PROTO_NOT_SUPPORTED, ENOMEM);
         return NULL;
     }
@@ -1837,7 +1872,8 @@ flb_sds_t flb_opentelemetry_logs_to_otlp_proto(const void *event_chunk_data,
         opentelemetry__proto__collector__logs__v1__export_logs_service_request__pack(
             &export_logs, (uint8_t *) output));
 
-    destroy_export_logs(&export_logs);
+    destroy_export_logs_arrays(&export_logs);
+    otlp_proto_arena_destroy(&arena);
     set_result(result, FLB_OPENTELEMETRY_OTLP_PROTO_SUCCESS);
 
     return output;


### PR DESCRIPTION
## Summary

Reduce allocator overhead while converting Fluent Bit log events into an OTLP protobuf `ExportLogsServiceRequest`.

The protobuf resource, scope, record, attribute, `AnyValue`, string, and binary-ID objects all have the same lifetime: they remain live until the request is packed. This change allocates those objects from a request-local geometric arena and releases all arena chunks together after packing. Pointer arrays that still require `realloc` remain heap-backed and are released separately.

This is intentionally limited to OTLP protobuf **log output construction**. It does not change protobuf ingestion, OTLP JSON encoding, metrics encoding, or trace encoding.

## Beneficial use cases

This benefits workloads that serialize Fluent Bit log-event chunks to OTLP protobuf, including:

- `out_opentelemetry` exporting logs with protobuf;
- OTLP log forwarding where `in_opentelemetry` events are re-encoded to protobuf;
- batches with many log records or deeply nested attributes, where the previous implementation performed many individual allocations and frees.

The benefit grows with record and attribute count. It is not expected to affect JSON output or non-log signals.

## Performance

Paired measurements used GCC 13.3.0, a Release build, CPU 2 affinity, and `perf stat -r 5`. Baseline and arena binaries used identical benchmark code and fixtures.

| Workload | Counter | Baseline | Arena | Change |
| --- | ---: | ---: | ---: | ---: |
| 5.9 KiB / 27-record batch, 30,000 renders | task-clock | 904.81 ms | 795.72 ms | **-12.06%** |
|  | cycles | 4.573 B | 4.020 B | **-12.11%** |
|  | instructions | 13.262 B | 11.785 B | **-11.13%** |
| 12.3 MiB / 40,960-record batch, 50 renders | task-clock | 1,888.22 ms | 1,610.10 ms | **-14.73%** |
|  | cycles | 9.558 B | 8.150 B | **-14.73%** |
|  | instructions | 28.032 B | 24.042 B | **-14.23%** |

Fixture hashes:

```text
c99642546c3630bbf02dc3efa1189cfe83b037271a3686aee73a74ea9bf8b56d  otlp_logs_sample.json
b9c234aea5b5ccb410177c9d00aa4b763b4679899aae2f6714d28a60f13413f2  otlp_logs_many_records.json
```

Valgrind Massif peak heap was unchanged:

| Workload | Baseline | Arena |
| --- | ---: | ---: |
| Small batch | 63,716 B | 63,716 B |
| Large batch | 49,721,494 B | 49,721,494 B |

The improvement is CPU and allocator-operation reduction, not a peak-memory reduction.

## Verification

```sh
cmake --build build --target fluent-bit-bin flb-it-opentelemetry -j8

ctest --test-dir build \
  -R '^(flb-it-opentelemetry|flb-rt-in_opentelemetry)$' \
  --output-on-failure
```

Passed 2/2.

Focused integration tests passed normally:

```sh
tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_opentelemetry_to_opentelemetry_basic_log \
  tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_dummy_to_opentelemetry_log -q
```

Passed 2/2.

The same focused integration tests passed under strict valgrind:

```sh
VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_opentelemetry_to_opentelemetry_basic_log \
  tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_dummy_to_opentelemetry_log -q
```

Passed 2/2. A direct memcheck of the 40,960-record render also completed with zero errors, zero leaks, and zero bytes in use at exit.

Commit-prefix validation passed both for HEAD and the full PR range against `master`.