### PR TITLE
in_opentelemetry: reduce protobuf decode allocation churn

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_logs.c
+++ b/plugins/in_opentelemetry/opentelemetry_logs.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_log_event_encoder.h>
@@ -25,9 +26,74 @@
 #include <fluent-bit/flb_opentelemetry.h>
 #include <fluent-otel-proto/fluent-otel.h>
 
+#include <cfl/cfl_arena.h>
 
 #include "opentelemetry.h"
 #include "opentelemetry_utils.h"
+
+#define OTEL_PROTOBUF_ARENA_MIN_PAYLOAD_SIZE 65536
+#define OTEL_PROTOBUF_ARENA_INITIAL_CHUNK_SIZE 4096
+#define OTEL_PROTOBUF_ARENA_MAX_CHUNK_SIZE 65536
+
+static void *protobuf_arena_chunk_malloc(void *context, size_t size)
+{
+    (void) context;
+
+    return flb_malloc(size);
+}
+
+static void protobuf_arena_chunk_free(void *context, void *pointer)
+{
+    (void) context;
+
+    flb_free(pointer);
+}
+
+static void *protobuf_arena_alloc(void *allocator_data, size_t size)
+{
+    struct cfl_arena *arena;
+
+    arena = allocator_data;
+    if (size == 0) {
+        size = 1;
+    }
+
+    return cfl_arena_malloc(arena, size);
+}
+
+static void protobuf_arena_free(void *allocator_data, void *pointer)
+{
+    (void) allocator_data;
+    (void) pointer;
+}
+
+static struct cfl_arena *protobuf_arena_create(void)
+{
+    struct cfl_arena_options options;
+
+    cfl_arena_options_init(&options);
+    options.chunk_size = OTEL_PROTOBUF_ARENA_INITIAL_CHUNK_SIZE;
+    options.maximum_chunk_size = OTEL_PROTOBUF_ARENA_MAX_CHUNK_SIZE;
+    options.malloc_fn = protobuf_arena_chunk_malloc;
+    options.free_fn = protobuf_arena_chunk_free;
+
+    return cfl_arena_create_with_options(&options);
+}
+
+static Opentelemetry__Proto__Collector__Logs__V1__ExportLogsServiceRequest *
+protobuf_logs_unpack(ProtobufCAllocator *allocator, size_t size, const uint8_t *data)
+{
+    return opentelemetry__proto__collector__logs__v1__export_logs_service_request__unpack(
+        allocator, size, data);
+}
+
+static void protobuf_logs_free(
+    Opentelemetry__Proto__Collector__Logs__V1__ExportLogsServiceRequest *logs,
+    ProtobufCAllocator *allocator)
+{
+    opentelemetry__proto__collector__logs__v1__export_logs_service_request__free_unpacked(
+        logs, allocator);
+}
 
 /*
  * OTLP encoding functions to pack the log records as msgpack
@@ -327,9 +393,12 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
     int log_record_index;
     char *logs_body_key;
     int scope_has_schema_url;
+    struct cfl_arena *protobuf_arena;
     struct flb_mp_map_header mh;
     struct flb_mp_map_header mh_tmp;
     struct flb_time tm;
+    ProtobufCAllocator arena_allocator;
+    ProtobufCAllocator *protobuf_allocator;
 
     msgpack_packer *mp_pck;
     msgpack_packer *mp_pck_meta;
@@ -347,9 +416,22 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
 
     mp_pck = &encoder->body.packer;
     mp_pck_meta = &encoder->metadata.packer;
+    input_logs = NULL;
+    protobuf_arena = NULL;
+    protobuf_allocator = NULL;
+
+    if (in_size >= OTEL_PROTOBUF_ARENA_MIN_PAYLOAD_SIZE) {
+        protobuf_arena = protobuf_arena_create();
+        if (protobuf_arena != NULL) {
+            arena_allocator.alloc = protobuf_arena_alloc;
+            arena_allocator.free = protobuf_arena_free;
+            arena_allocator.allocator_data = protobuf_arena;
+            protobuf_allocator = &arena_allocator;
+        }
+    }
 
     /* unpack logs from protobuf payload */
-    input_logs = opentelemetry__proto__collector__logs__v1__export_logs_service_request__unpack(NULL, in_size, in_buf);
+    input_logs = protobuf_logs_unpack(protobuf_allocator, in_size, in_buf);
     if (input_logs == NULL) {
         flb_plg_warn(ctx->ins, "failed to unpack input logs from OpenTelemetry payload");
         ret = -1;
@@ -673,9 +755,9 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
 
  binary_payload_to_msgpack_end:
     if (input_logs) {
-        opentelemetry__proto__collector__logs__v1__export_logs_service_request__free_unpacked(
-                                            input_logs, NULL);
+        protobuf_logs_free(input_logs, protobuf_allocator);
     }
+    cfl_arena_destroy(protobuf_arena);
 
     if (ret != 0) {
         return -1;

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -678,6 +678,49 @@ def test_opentelemetry_to_opentelemetry_basic_log():
         assert item["record_attributes"]["example_key"] == "example_value"
 
 
+def test_in_opentelemetry_large_protobuf_logs():
+    service = Service("001-fluent-bit.yaml")
+    source = ExportLogsServiceRequest()
+    source.ParseFromString(service.build_otel_payload("test_logs_001.in.json", "logs"))
+
+    payload = ExportLogsServiceRequest()
+    payload.CopyFrom(source)
+    source_records = list(source.resource_logs[0].scope_logs[0].log_records)
+
+    while payload.ByteSize() < 128 * 1024:
+        payload.resource_logs[0].scope_logs[0].log_records.extend(source_records)
+
+    expected_record_count = sum(
+        len(scope_logs.log_records)
+        for resource_logs in payload.resource_logs
+        for scope_logs in resource_logs.scope_logs
+    )
+
+    service.start()
+    try:
+        logs_before = len(data_storage["logs"])
+        response = service.send_raw_request("/v1/logs", payload.SerializeToString())
+
+        assert response.status_code == 201
+        received_record_count = service.service.wait_for_condition(
+            lambda: count if (
+                count := sum(
+                    len(scope_logs.log_records)
+                    for received in data_storage["logs"][logs_before:]
+                    for resource_logs in received.resource_logs
+                    for scope_logs in resource_logs.scope_logs
+                )
+            ) >= expected_record_count else None,
+            timeout=20,
+            interval=0.25,
+            description="all large protobuf log records",
+        )
+    finally:
+        service.stop()
+
+    assert received_record_count == expected_record_count
+
+
 # Start a Fluent Bit Pipeline with Dummy message and then it gets handle by OpenTelemetry output, the config
 # aims to populate traceId and spanId fields with the values from the Dummy message.
 #
@@ -797,10 +840,14 @@ def test_opentelemetry_to_opentelemetry_parent_child_traces():
 def test_in_opentelemetry_rejects_invalid_logs_payload():
     service = Service("001-fluent-bit.yaml")
     service.start()
-    response = service.send_raw_request("/v1/logs", b"not-a-valid-otlp-payload")
-    service.stop()
+    try:
+        small_response = service.send_raw_request("/v1/logs", b"not-a-valid-otlp-payload")
+        large_response = service.send_raw_request("/v1/logs", b"\x80" * (64 * 1024))
+    finally:
+        service.stop()
 
-    assert response.status_code >= 400
+    assert small_response.status_code >= 400
+    assert large_response.status_code >= 400
     assert len(data_storage["logs"]) == 0
 
 


### PR DESCRIPTION
## Problem

Decoding a large OTLP protobuf logs request asks protobuf-c to allocate every
message, repeated field, string, and byte field independently. These objects
share the request lifetime, so individual heap allocations and frees add CPU
and allocator churn without providing useful lifetime granularity.

## Change

- Decode protobuf log payloads of at least 64 KiB with a request-local CFL
  arena.
- Keep protobuf-c's default allocator for smaller requests, avoiding arena
  setup on the latency-sensitive small-payload path.
- Fall back to the default allocator if arena creation fails.
- Destroy the arena after conversion, including malformed and partially
  decoded requests.
- Add integration coverage for a valid 128 KiB request and malformed input at
  the 64 KiB boundary.

This is most beneficial for high-volume OTLP log ingestion with large batched
protobuf requests containing many records and nested attributes. JSON, metrics,
traces, and small protobuf log requests are unchanged.

## Performance

Release build with GCC 13.3, pinned to CPU 2. The same 2,978,046-byte,
2,048-record request was decoded 50 times. Each `perf stat` value is the mean
of five runs.

| Counter | Before | After | Change |
| --- | ---: | ---: | ---: |
| task-clock | 985.86 ms | 821.58 ms | **-16.66%** |
| cycles | 4.947B | 4.161B | **-15.88%** |
| instructions | 15.491B | 12.558B | **-18.94%** |

Massif measured the same 49,758,368-byte process peak before and after. Its
cumulative allocation-time proxy fell 0.59%. This optimization reduces CPU and
allocation-call churn; this workload does not demonstrate lower peak memory.

## Verification

```text
ctest --test-dir /tmp/flb-proto-input-test \
  -R '^(flb-rt-in_opentelemetry|flb-rt-in_opentelemetry_routing|flb-it-opentelemetry|flb-it-http_server)$' \
  --output-on-failure
```

Passed 4/4.

The following focused cases passed 3/3 normally and 3/3 under strict Valgrind:

```text
FLUENT_BIT_BINARY=/tmp/flb-proto-input-test/bin/fluent-bit \
tests/integration/.venv/bin/python -m pytest -q \
tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_opentelemetry_to_opentelemetry_basic_log \
tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_large_protobuf_logs \
tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_rejects_invalid_logs_payload

VALGRIND=1 VALGRIND_STRICT=1 \
FLUENT_BIT_BINARY=/tmp/flb-proto-input-test/bin/fluent-bit \
tests/integration/.venv/bin/python -m pytest -q \
tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_opentelemetry_to_opentelemetry_basic_log \
tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_large_protobuf_logs \
tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_rejects_invalid_logs_payload
```

Commit-prefix validation passed for the full `master..HEAD` range.

## Compatibility

There are no configuration or wire-format changes. The arena is local to one
decode operation and is not shared between requests or threads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large OpenTelemetry Logs protobuf payloads to support reliable processing and cleanup.
  * Continued rejecting invalid or oversized log payloads with appropriate error responses.

* **Tests**
  * Added coverage for large log batches.
  * Expanded invalid-payload testing to include oversized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->