### PR TITLE
conditionals: resolve TAG record accessor in processor and filter conditions

### DIFF
--- a/include/fluent-bit/flb_conditionals.h
+++ b/include/fluent-bit/flb_conditionals.h
@@ -97,11 +97,19 @@ int flb_condition_add_rule(struct flb_condition *cond,
 
 void flb_condition_destroy(struct flb_condition *cond);
 
-/* Evaluation function */
+/*
+ * Evaluation functions.
+ *
+ * tag/tag_len reference the tag of the chunk being evaluated so that rules
+ * using the $TAG record accessor can be resolved. Callers that have no tag
+ * available (e.g. the router, which matches by tag natively) may pass NULL/0.
+ */
 int flb_condition_evaluate_ex(struct flb_condition *cond,
                              void *ctx,
-                             flb_condition_get_variant_fn get_variant);
+                             flb_condition_get_variant_fn get_variant,
+                             const char *tag, int tag_len);
 int flb_condition_evaluate(struct flb_condition *cond,
-                          struct flb_mp_chunk_record *record);
+                          struct flb_mp_chunk_record *record,
+                          const char *tag, int tag_len);
 
 #endif /* FLB_CONDITIONS_H */

--- a/include/fluent-bit/flb_mp_chunk.h
+++ b/include/fluent-bit/flb_mp_chunk.h
@@ -56,6 +56,10 @@ struct flb_mp_chunk_cobj {
 
     /* Condition for filtering records during processing */
     struct flb_condition *condition;
+
+    /* Tag of the chunk being processed, so conditions can reference $TAG */
+    const char *tag;
+    int tag_len;
 };
 
 

--- a/src/flb_conditionals.c
+++ b/src/flb_conditionals.c
@@ -278,7 +278,8 @@ void flb_condition_destroy(struct flb_condition *cond)
 }
 
 static int evaluate_rule(struct flb_condition_rule *rule,
-                         struct cfl_variant *record_variant)
+                         struct cfl_variant *record_variant,
+                         const char *tag, int tag_len)
 {
     flb_sds_t str_val;
     int i;
@@ -291,7 +292,8 @@ static int evaluate_rule(struct flb_condition_rule *rule,
     }
 
     flb_trace("[condition] evaluating rule with record accessor");
-    str_val = flb_cfl_ra_translate(rule->ra, NULL, 0, *record_variant, NULL);
+    str_val = flb_cfl_ra_translate(rule->ra, (char *) tag, tag_len,
+                                   *record_variant, NULL);
     if (!str_val) {
         flb_trace("[condition] record accessor translation failed");
         return FLB_FALSE;
@@ -362,7 +364,8 @@ static int evaluate_rule(struct flb_condition_rule *rule,
 
 int flb_condition_evaluate_ex(struct flb_condition *cond,
                               void *ctx,
-                              flb_condition_get_variant_fn get_variant)
+                              flb_condition_get_variant_fn get_variant,
+                              const char *tag, int tag_len)
 {
     struct mk_list *head;
     struct flb_condition_rule *rule;
@@ -406,7 +409,7 @@ int flb_condition_evaluate_ex(struct flb_condition *cond,
         }
 
         flb_trace("[condition] evaluating rule against record");
-        result = evaluate_rule(rule, record_variant);
+        result = evaluate_rule(rule, record_variant, tag, tag_len);
         flb_trace("[condition] rule evaluation result: %d", result);
 
         if (cond->op == FLB_COND_OP_AND && result == FLB_FALSE) {
@@ -438,7 +441,8 @@ int flb_condition_evaluate_ex(struct flb_condition *cond,
 }
 
 int flb_condition_evaluate(struct flb_condition *cond,
-                           struct flb_mp_chunk_record *record)
+                           struct flb_mp_chunk_record *record,
+                           const char *tag, int tag_len)
 {
     if (!cond) {
         return FLB_TRUE;
@@ -448,5 +452,6 @@ int flb_condition_evaluate(struct flb_condition *cond,
         return FLB_FALSE;
     }
 
-    return flb_condition_evaluate_ex(cond, record, default_get_record_variant);
+    return flb_condition_evaluate_ex(cond, record, default_get_record_variant,
+                                     tag, tag_len);
 }

--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -1803,7 +1803,8 @@ int flb_mp_chunk_cobj_record_next(struct flb_mp_chunk_cobj *chunk_cobj,
         /* If there's a condition, check if the record matches */
         if (condition != NULL && record != NULL) {
             flb_trace("[mp] evaluating condition for record");
-            ret = flb_condition_evaluate(condition, record);
+            ret = flb_condition_evaluate(condition, record,
+                                         chunk_cobj->tag, chunk_cobj->tag_len);
             flb_trace("[mp] condition evaluation result: %s", ret ? "TRUE" : "FALSE");
             if (ret == FLB_FALSE) {
                 flb_trace("[mp] record didn't match condition, skipping");
@@ -1828,7 +1829,8 @@ int flb_mp_chunk_cobj_record_next(struct flb_mp_chunk_cobj *chunk_cobj,
         /* If there's a condition, check if the record matches */
         if (condition != NULL && record != NULL) {
             flb_trace("[mp] evaluating condition for next record");
-            ret = flb_condition_evaluate(condition, record);
+            ret = flb_condition_evaluate(condition, record,
+                                         chunk_cobj->tag, chunk_cobj->tag_len);
             flb_trace("[mp] next record condition evaluation result: %s", ret ? "TRUE" : "FALSE");
             if (ret == FLB_FALSE) {
                 flb_trace("[mp] next record didn't match condition, skipping");
@@ -1852,7 +1854,8 @@ int flb_mp_chunk_cobj_record_next(struct flb_mp_chunk_cobj *chunk_cobj,
         /* If there's a condition, check if the record matches */
         if (condition != NULL && record != NULL) {
             flb_trace("[mp] evaluating condition for first record");
-            ret = flb_condition_evaluate(condition, record);
+            ret = flb_condition_evaluate(condition, record,
+                                         chunk_cobj->tag, chunk_cobj->tag_len);
             flb_trace("[mp] first record condition evaluation result: %s", ret ? "TRUE" : "FALSE");
             if (ret == FLB_FALSE) {
                 flb_trace("[mp] first record didn't match condition, skipping");

--- a/src/flb_processor.c
+++ b/src/flb_processor.c
@@ -328,7 +328,8 @@ static int append_buffer_records_to_encoder(struct flb_log_event_encoder *encode
 }
 
 static int evaluate_condition_for_log_event(struct flb_condition *condition,
-                                            struct flb_log_event *log_event)
+                                            struct flb_log_event *log_event,
+                                            const char *tag, int tag_len)
 {
     int ret;
     struct flb_mp_chunk_record record = {0};
@@ -344,7 +345,7 @@ static int evaluate_condition_for_log_event(struct flb_condition *condition,
         return FLB_FALSE;
     }
 
-    ret = flb_condition_evaluate(condition, &record);
+    ret = flb_condition_evaluate(condition, &record, tag, tag_len);
 
     cfl_object_destroy(record.cobj_record);
     cfl_object_destroy(record.cobj_metadata);
@@ -393,7 +394,8 @@ static int run_filter_with_condition(struct flb_filter_instance *f_ins,
 
     while ((ret = flb_log_event_decoder_next(&decoder, &log_event)) ==
            FLB_EVENT_DECODER_SUCCESS) {
-        condition_match = evaluate_condition_for_log_event(condition, &log_event);
+        condition_match = evaluate_condition_for_log_event(condition, &log_event,
+                                                           tag, tag_len);
 
         if (condition_match == FLB_FALSE) {
             ret = append_raw_record_to_encoder(&final_encoder,
@@ -1531,6 +1533,10 @@ int flb_processor_run(struct flb_processor *proc,
                         flb_debug("[processor] no condition set for processor unit (pu=%s)", pu->name);
                     }
 
+                    /* Expose the chunk tag so conditions can reference $TAG */
+                    chunk_cobj->tag = tag;
+                    chunk_cobj->tag_len = tag_len;
+
                     /* Invoke processor plugin callback */
                     ret = p_ins->p->cb_process_logs(p_ins, chunk_cobj, tag, tag_len);
                     if (ret != FLB_PROCESSOR_SUCCESS) {
@@ -1541,6 +1547,8 @@ int flb_processor_run(struct flb_processor *proc,
 
                     /* Clear the condition after processing */
                     chunk_cobj->condition = NULL;
+                    chunk_cobj->tag = NULL;
+                    chunk_cobj->tag_len = 0;
                     finalize = FLB_FALSE;
 
                     /* is this processing_unit the last one from the list ? */

--- a/src/flb_router_condition.c
+++ b/src/flb_router_condition.c
@@ -304,7 +304,7 @@ int flb_condition_eval_logs(struct flb_event_chunk *chunk,
     cfl_list_foreach(head, &context->chunk_cobj->records) {
         record = cfl_list_entry(head, struct flb_mp_chunk_record, _head);
 
-        if (flb_condition_evaluate_ex(compiled, record, route_logs_get_variant) == FLB_TRUE) {
+        if (flb_condition_evaluate_ex(compiled, record, route_logs_get_variant, NULL, 0) == FLB_TRUE) {
             result = FLB_TRUE;
             break;
         }
@@ -432,7 +432,7 @@ int flb_router_condition_evaluate_record(struct flb_route *route,
         return FLB_FALSE;
     }
 
-    return flb_condition_evaluate_ex(compiled, record, route_logs_get_variant);
+    return flb_condition_evaluate_ex(compiled, record, route_logs_get_variant, NULL, 0);
 }
 
 static int parse_rule_operator(const flb_sds_t op_str,

--- a/tests/internal/conditionals.c
+++ b/tests/internal/conditionals.c
@@ -367,7 +367,7 @@ void test_condition_equals()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -383,7 +383,7 @@ void test_condition_equals()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -408,7 +408,7 @@ void test_condition_numeric()
     TEST_CHECK(flb_condition_add_rule(cond, "$count", FLB_RULE_OP_GT,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -425,7 +425,7 @@ void test_condition_numeric()
     TEST_CHECK(flb_condition_add_rule(cond, "$count", FLB_RULE_OP_LT,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -448,7 +448,7 @@ void test_condition_not_equals()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NEQ,
                                     "error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -464,7 +464,7 @@ void test_condition_not_equals()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NEQ,
                                     "error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -488,7 +488,7 @@ void test_condition_in()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -504,7 +504,7 @@ void test_condition_in()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -528,7 +528,7 @@ void test_condition_not_in()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NOT_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -544,7 +544,7 @@ void test_condition_not_in()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NOT_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -569,7 +569,7 @@ void test_condition_and()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NEQ,
                                     "info", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -587,7 +587,7 @@ void test_condition_and()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NEQ,
                                     "info", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -612,7 +612,7 @@ void test_condition_or()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "warn", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -630,7 +630,7 @@ void test_condition_or()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "warn", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -650,7 +650,7 @@ void test_condition_empty()
     cond = flb_condition_create(FLB_COND_OP_AND);
     TEST_CHECK(cond != NULL);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -659,7 +659,7 @@ void test_condition_empty()
     cond = flb_condition_create(FLB_COND_OP_OR);
     TEST_CHECK(cond != NULL);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -682,7 +682,7 @@ void test_condition_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_REGEX,
                                     "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -698,7 +698,7 @@ void test_condition_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_REGEX,
                                     "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -714,7 +714,7 @@ void test_condition_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_REGEX,
                                     "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -731,7 +731,7 @@ void test_condition_invalid_expressions()
     TEST_CHECK(record_data != NULL);
 
     /* Test NULL condition */
-    result = flb_condition_evaluate(NULL, &record_data->chunk);
+    result = flb_condition_evaluate(NULL, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     /* Test NULL record with AND condition */
@@ -741,7 +741,7 @@ void test_condition_invalid_expressions()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, NULL);
+    result = flb_condition_evaluate(cond, NULL, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* NULL record should fail condition */
 
     flb_condition_destroy(cond);
@@ -755,7 +755,7 @@ void test_condition_invalid_expressions()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "warn", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, NULL);
+    result = flb_condition_evaluate(cond, NULL, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* NULL record should fail condition */
 
     flb_condition_destroy(cond);
@@ -764,7 +764,7 @@ void test_condition_invalid_expressions()
     cond = flb_condition_create(FLB_COND_OP_AND);
     TEST_CHECK(cond != NULL);
 
-    result = flb_condition_evaluate(cond, NULL);
+    result = flb_condition_evaluate(cond, NULL, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* NULL record should fail even with empty condition */
 
     flb_condition_destroy(cond);
@@ -782,7 +782,7 @@ void test_condition_invalid_expressions()
     cond = flb_condition_create(999);  /* Invalid operator */
     TEST_CHECK(cond != NULL);  /* Should still create but with default op */
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Default AND behavior */
 
     flb_condition_destroy(cond);
@@ -833,7 +833,7 @@ void test_condition_metadata()
     TEST_CHECK(flb_condition_add_rule(cond, "$streamName", FLB_RULE_OP_EQ,
                                     "production", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -850,7 +850,7 @@ void test_condition_metadata()
     TEST_CHECK(flb_condition_add_rule(cond, "$streamName", FLB_RULE_OP_EQ,
                                     "production", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -869,7 +869,7 @@ void test_condition_metadata()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_EQ,
                                     "error", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -893,7 +893,7 @@ void test_condition_missing_values()
     TEST_CHECK(flb_condition_add_rule(cond, "$non_existent", FLB_RULE_OP_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Missing field should return false */
 
     flb_condition_destroy(cond);
@@ -909,7 +909,7 @@ void test_condition_missing_values()
     TEST_CHECK(flb_condition_add_rule(cond, "$stream", FLB_RULE_OP_EQ,
                                     "production", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Missing metadata should return false */
 
     flb_condition_destroy(cond);
@@ -925,7 +925,7 @@ void test_condition_missing_values()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NOT_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Present value not in array should return true */
 
     flb_condition_destroy(cond);
@@ -941,7 +941,7 @@ void test_condition_missing_values()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_NOT_IN,
                                     (void *)values, 3, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Present value in array should return false */
 
     flb_condition_destroy(cond);
@@ -967,7 +967,7 @@ void test_condition_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$count", FLB_RULE_OP_GT,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Non-numeric string should fail comparison */
 
     flb_condition_destroy(cond);
@@ -983,7 +983,7 @@ void test_condition_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$level", FLB_RULE_OP_IN,
                                     (void *)values, 4, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Empty string should match empty string in array */
 
     flb_condition_destroy(cond);
@@ -999,7 +999,7 @@ void test_condition_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_REGEX,
                                     "^/api/v1/users\\[[0-9]+\\]$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1018,7 +1018,7 @@ void test_condition_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$non_existent", FLB_RULE_OP_EQ,
                                     "non-empty", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Should fail because both conditions are false */
 
     flb_condition_destroy(cond);
@@ -1048,7 +1048,7 @@ void test_condition_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$non_existent", FLB_RULE_OP_EQ,
                                     "production", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Should fail because metadata field is missing */
 
     flb_condition_destroy(cond);
@@ -1074,7 +1074,7 @@ void test_condition_numeric_edge_cases()
                                   &val, 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -1092,7 +1092,7 @@ void test_condition_numeric_edge_cases()
                                  &val, 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1110,7 +1110,7 @@ void test_condition_numeric_edge_cases()
                                  &val, 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1128,7 +1128,7 @@ void test_condition_numeric_edge_cases()
                                  &val, 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -1146,7 +1146,7 @@ void test_condition_numeric_edge_cases()
                                  &val, 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1164,7 +1164,7 @@ void test_condition_numeric_edge_cases()
                                  &val, 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1181,7 +1181,7 @@ void test_condition_numeric_edge_cases()
                                  "0", 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1198,7 +1198,7 @@ void test_condition_numeric_edge_cases()
                                  "-0", 0, RECORD_CONTEXT_BODY);
     TEST_CHECK(result == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1221,7 +1221,7 @@ void test_condition_not_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1237,7 +1237,7 @@ void test_condition_not_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -1253,7 +1253,7 @@ void test_condition_not_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^/api/.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1269,7 +1269,7 @@ void test_condition_not_regex()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^/api/v[0-9]+/.*\\.(json|xml)$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1305,7 +1305,7 @@ void test_condition_not_regex_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$user_agent", FLB_RULE_OP_NOT_REGEX,
                                     ".*[Bb]ot.*", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Both conditions should be true */
 
     flb_condition_destroy(cond);
@@ -1328,7 +1328,7 @@ void test_condition_not_regex_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$method", FLB_RULE_OP_EQ,
                                     "GET", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* First condition is true */
 
     flb_condition_destroy(cond);
@@ -1354,7 +1354,7 @@ void test_condition_not_regex_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$url", FLB_RULE_OP_NOT_REGEX,
                                     "\\.(jpg|png|gif|css|js)$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* All conditions should be true */
 
     flb_condition_destroy(cond);
@@ -1377,7 +1377,7 @@ void test_condition_not_regex_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$log_level", FLB_RULE_OP_NOT_REGEX,
                                     "^(DEBUG|INFO)$", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1406,7 +1406,7 @@ void test_condition_not_regex_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$response_time", FLB_RULE_OP_LT,
                                     &threshold, 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1429,7 +1429,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^/api/[a-z]+/[a-z]+$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Should be true since Unicode chars don't match [a-z] */
 
     flb_condition_destroy(cond);
@@ -1450,7 +1450,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^a{1024}$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Should be true since string is 1023 'a's, not 1024 */
 
     flb_condition_destroy(cond);
@@ -1467,7 +1467,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^\\s+$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Should be false since pattern matches whitespace */
 
     flb_condition_destroy(cond);
@@ -1483,7 +1483,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^before$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Should be true since "beforeafter" doesn't match "^before$" */
 
     flb_condition_destroy(cond);
@@ -1499,7 +1499,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^[A-Z]:\\\\.*$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Should be false since pattern matches Windows path */
 
     flb_condition_destroy(cond);
@@ -1515,7 +1515,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "a{4}b", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Should be true since pattern doesn't match */
 
     flb_condition_destroy(cond);
@@ -1540,7 +1540,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* Should be false since empty string matches ^$ */
 
     flb_condition_destroy(cond);
@@ -1556,7 +1556,7 @@ void test_condition_not_regex_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$path", FLB_RULE_OP_NOT_REGEX,
                                     "^[a-zA-Z]+$", 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* Should be true since non-ASCII doesn't match [a-zA-Z] */
 
     flb_condition_destroy(cond);
@@ -1581,7 +1581,7 @@ void test_condition_gte_lte()
     TEST_CHECK(flb_condition_add_rule(cond, "$cpu_usage", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1598,7 +1598,7 @@ void test_condition_gte_lte()
     TEST_CHECK(flb_condition_add_rule(cond, "$cpu_usage", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1615,7 +1615,7 @@ void test_condition_gte_lte()
     TEST_CHECK(flb_condition_add_rule(cond, "$cpu_usage", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -1632,7 +1632,7 @@ void test_condition_gte_lte()
     TEST_CHECK(flb_condition_add_rule(cond, "$memory_usage", FLB_RULE_OP_LTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1649,7 +1649,7 @@ void test_condition_gte_lte()
     TEST_CHECK(flb_condition_add_rule(cond, "$memory_usage", FLB_RULE_OP_LTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1666,7 +1666,7 @@ void test_condition_gte_lte()
     TEST_CHECK(flb_condition_add_rule(cond, "$memory_usage", FLB_RULE_OP_LTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -1694,7 +1694,7 @@ void test_condition_gte_lte_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$ready_replicas", FLB_RULE_OP_LTE,
                                     &val2, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);  /* 3 replicas is within [2, 5] */
 
     flb_condition_destroy(cond);
@@ -1714,7 +1714,7 @@ void test_condition_gte_lte_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$requested_cpu", FLB_RULE_OP_LTE,
                                     &val2, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);  /* 1.5 CPU is neither >= 2.0 nor <= 1.0 */
 
     flb_condition_destroy(cond);
@@ -1734,7 +1734,7 @@ void test_condition_gte_lte_multiple()
     TEST_CHECK(flb_condition_add_rule(cond, "$namespace", FLB_RULE_OP_EQ,
                                     "production", 0, RECORD_CONTEXT_METADATA) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1759,7 +1759,7 @@ void test_condition_gte_lte_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$pod_status", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_FALSE);
 
     flb_condition_destroy(cond);
@@ -1776,7 +1776,7 @@ void test_condition_gte_lte_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$cpu_limit", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1793,7 +1793,7 @@ void test_condition_gte_lte_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$memory_request", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1810,7 +1810,7 @@ void test_condition_gte_lte_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$current_replicas", FLB_RULE_OP_GTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
 
     flb_condition_destroy(cond);
@@ -1827,8 +1827,91 @@ void test_condition_gte_lte_border_cases()
     TEST_CHECK(flb_condition_add_rule(cond, "$desired_replicas", FLB_RULE_OP_LTE,
                                     &val, 0, RECORD_CONTEXT_BODY) == FLB_TRUE);
 
-    result = flb_condition_evaluate(cond, &record_data->chunk);
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
     TEST_CHECK(result == FLB_TRUE);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+}
+
+/*
+ * Verify that condition rules can reference the chunk tag through the $TAG
+ * record accessor. The tag is supplied to flb_condition_evaluate() and must
+ * be threaded down to the record accessor translation.
+ */
+void test_condition_tag_accessor()
+{
+    struct test_record *record_data;
+    struct flb_condition *cond;
+    const char *tag = "kube.apps.frontend";
+    int result;
+
+    /* Exact match on $TAG */
+    record_data = create_test_record("level", "info");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+    TEST_CHECK(flb_condition_add_rule(cond, "$TAG", FLB_RULE_OP_EQ,
+                                    "kube.apps.frontend", 0,
+                                    RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk, tag, strlen(tag));
+    TEST_CHECK(result == FLB_TRUE);
+    TEST_MSG("$TAG equality against '%s' should match", tag);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Regex match on $TAG */
+    record_data = create_test_record("level", "info");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+    TEST_CHECK(flb_condition_add_rule(cond, "$TAG", FLB_RULE_OP_REGEX,
+                                    "^kube\\.apps\\..*$", 0,
+                                    RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk, tag, strlen(tag));
+    TEST_CHECK(result == FLB_TRUE);
+    TEST_MSG("$TAG regex should match '%s'", tag);
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* Non-matching tag must fail */
+    record_data = create_test_record("level", "info");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+    TEST_CHECK(flb_condition_add_rule(cond, "$TAG", FLB_RULE_OP_EQ,
+                                    "kube.apps.frontend", 0,
+                                    RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk,
+                                    "kube.system.kubelet",
+                                    strlen("kube.system.kubelet"));
+    TEST_CHECK(result == FLB_FALSE);
+    TEST_MSG("$TAG equality should not match a different tag");
+
+    flb_condition_destroy(cond);
+    destroy_test_record(record_data);
+
+    /* A $TAG rule with no tag available (NULL) must not match */
+    record_data = create_test_record("level", "info");
+    TEST_CHECK(record_data != NULL);
+
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    TEST_CHECK(cond != NULL);
+    TEST_CHECK(flb_condition_add_rule(cond, "$TAG", FLB_RULE_OP_EQ,
+                                    "kube.apps.frontend", 0,
+                                    RECORD_CONTEXT_BODY) == FLB_TRUE);
+
+    result = flb_condition_evaluate(cond, &record_data->chunk, NULL, 0);
+    TEST_CHECK(result == FLB_FALSE);
+    TEST_MSG("$TAG rule should not match when no tag is supplied");
 
     flb_condition_destroy(cond);
     destroy_test_record(record_data);
@@ -1855,5 +1938,6 @@ TEST_LIST = {
     {"gte_lte", test_condition_gte_lte},
     {"gte_lte_multiple", test_condition_gte_lte_multiple},
     {"gte_lte_border_cases", test_condition_gte_lte_border_cases},
+    {"tag_accessor", test_condition_tag_accessor},
     {NULL, NULL}
 };


### PR DESCRIPTION
## Summary

Condition rules used by processors and filters could not match on the record
tag. The record accessor already parses `$TAG` / `$TAG[n]`, but the condition
evaluator called `flb_cfl_ra_translate()` with a `NULL` tag, so any rule
referencing `$TAG` silently never resolved.

This PR threads the chunk tag through the condition-evaluation path:

- `flb_condition_evaluate()` / `flb_condition_evaluate_ex()` and `evaluate_rule()`
  gain `tag`/`tag_len` arguments and forward them to `flb_cfl_ra_translate()`.
- `struct flb_mp_chunk_cobj` carries the chunk `tag`/`tag_len`; `flb_processor`
  sets them around the processor callback and clears them afterwards.
- The record-next path (`flb_mp`) and the filter path pass the chunk tag; the
  router passes `NULL` since it already routes by tag natively.

This enables conditions such as:

```yaml
    processors:
      logs:
        - name: content_modifier
          action: insert
          key: matched_tag
          value: "true"
          condition:
            op: and
            rules:
              - field: "$TAG"
                op: regex
                value: "^app\.frontend\..*$"
```

so a processor or filter can select records by tag.

The change is split into per-subsystem commits (`conditionals:`, `mp:`,
`processor:`, `router_condition:`, `tests:`) to satisfy the commit-prefix
convention; the tree builds as a whole.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change (see above)
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Unit coverage is added in `tests/internal/conditionals.c` (`tag_accessor`):
exact-match, regex, non-matching tag, and the no-tag case. I'll follow up with
runtime debug/Valgrind logs.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ ] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
