### PR TITLE
in_prometheus_scrape: call flb_input_upstream_set to apply net.* config

### DIFF
--- a/plugins/in_prometheus_scrape/prom_scrape.c
+++ b/plugins/in_prometheus_scrape/prom_scrape.c
@@ -68,6 +68,13 @@ static struct prom_scrape *prom_scrape_create(struct flb_input_instance *ins,
         flb_free(ctx);
         return NULL;
     }
+
+    if (flb_input_upstream_set(upstream, ins) != 0) {
+        flb_plg_error(ins, "network upstream setup failed");
+        flb_upstream_destroy(upstream);
+        flb_free(ctx);
+        return NULL;
+    }
     ctx->upstream = upstream;
 
     return ctx;


### PR DESCRIPTION
_This PR description was AI-assisted (Claude Code)._

## What does this PR do?

Adds the missing `flb_input_upstream_set()` call in
`in_prometheus_scrape`, following the same pattern already merged for
`in_kubernetes_events` (#11188) and `in_calyptia_fleet` (#10998).

Note: this fix alone is not sufficient to restore connection reuse —
see #12094 and the companion PR against `flb_input_upstream_set()`
itself. Verified via packet capture that this change on its own produces
no observable difference; both PRs are needed together.

## Screenshots

N/A (backend networking change, verified via tcpdump/debug log — see
linked issue)

## Testing

Manually verified against a live instance running v5.0.7 + this patch:
loopback packet capture (`tcpdump -i lo`) and `-vv` debug logging, in
combination with the companion core fix.

Ref #12094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus scraping startup reliability by validating upstream configuration before activation.
  * Added cleanup handling when upstream setup fails, preventing incomplete configurations from continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->