### PR TITLE
input: set FLB_IO_TCP_KA flag in flb_input_upstream_set

### DIFF
--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -2543,6 +2543,17 @@ int flb_input_upstream_set(struct flb_upstream *u, struct flb_input_instance *in
         mk_list_add(&u->base._head, &ins->upstreams);
     }
 
+    /*
+     * Mirror flb_output_upstream_set(): the 'net.keepalive' setting only
+     * takes effect on new connections if the FLB_IO_TCP_KA stream flag is
+     * also set, since flb_upstream_conn_get() derives a connection's
+     * initial recycle state from flb_stream_is_keepalive() (the flag),
+     * not from net.keepalive (the config value) directly.
+     */
+    if (ins->net_setup.keepalive == FLB_TRUE) {
+        flb_stream_enable_flags(&u->base, FLB_IO_TCP_KA);
+    }
+
     /* Set networking options 'net.*' received through instance properties */
     memcpy(&u->base.net, &ins->net_setup, sizeof(struct flb_net_setup));
 


### PR DESCRIPTION
_This PR description was AI-assisted (Claude Code)._

## What does this PR do?

`flb_input_upstream_set()` copies `net.*` config into the upstream's
`net_setup` struct, but never sets the `FLB_IO_TCP_KA` stream flag that
`flb_upstream_conn_get()` actually checks when deciding a new
connection's initial recycle state. This mirrors the equivalent, already
correct logic in `flb_output_upstream_set()`.

Companion PR (#12095) adds the missing `flb_input_upstream_set()` call
to `in_prometheus_scrape`; neither PR alone restores connection reuse —
verified empirically, see #12094.

## Impact

Affects every input plugin calling `flb_input_upstream_set()`:
currently `in_prometheus_scrape` (companion PR), `in_kubernetes_events`,
and `in_calyptia_fleet`. The latter two were not independently
re-tested against this fix — flagging for maintainer visibility since
their existing "fix" may not have been fully effective either.

## Testing

Verified via `-vv` debug logging and tcpdump packet capture on a live
v5.0.7 instance: without this fix, `in_prometheus_scrape` connections
are torn down and recreated every scrape cycle even with `net.keepalive`
on and the companion PR's `upstream_set()` call in place. With this fix,
connections are created once and recycled on subsequent scrapes.

Ref #12094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP connection reliability by consistently applying keepalive settings when initializing upstream connections.
  * Ensures configured keepalive behavior is honored for input connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->