### PR TITLE
Add 'ignore_unavailable' config option to in_tail plugin

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -577,8 +577,8 @@ static struct flb_config_map config_map[] = {
      "files matching a certain criteria, e.g: 'exclude_path *.gz,*.zip'"
     },
     {
-     FLB_CONFIG_MAP_BOOL, "ignore_missing_paths", "false",
-     0, FLB_TRUE, offsetof(struct flb_tail_config, ignore_missing_paths),
+     FLB_CONFIG_MAP_BOOL, "ignore_unavailable", "false",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, ignore_unavailable),
      "Do not search directories that do not exist for files."
     },
     {

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -577,6 +577,11 @@ static struct flb_config_map config_map[] = {
      "files matching a certain criteria, e.g: 'exclude_path *.gz,*.zip'"
     },
     {
+     FLB_CONFIG_MAP_BOOL, "ignore_missing_paths", "false",
+     0, FLB_TRUE, offsetof(struct flb_tail_config, ignore_missing_paths),
+     "Do not search directories that do not exist for files."
+    },
+    {
      FLB_CONFIG_MAP_STR, "key", "log",
      0, FLB_TRUE, offsetof(struct flb_tail_config, key),
      "when a message is unstructured (no parser applied), it's appended "

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -88,7 +88,7 @@ struct flb_tail_config {
     long refresh_interval_nsec;/* nanoseconds to re-scan       */
     int read_newly_discovered_files_from_head; /* read new files from head after startup */
     int read_from_head;        /* read new files from head     */
-    int ignore_unavailable;  /* Ignore directory paths that do not exist */
+    int ignore_unavailable;    /* gnore unavailable paths during scanning */
     int rotate_wait;           /* sec to wait on rotated files */
     int watcher_interval;      /* watcher interval             */
     int ignore_older;          /* ignore fields older than X seconds */

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -88,7 +88,7 @@ struct flb_tail_config {
     long refresh_interval_nsec;/* nanoseconds to re-scan       */
     int read_newly_discovered_files_from_head; /* read new files from head after startup */
     int read_from_head;        /* read new files from head     */
-    int ignore_missing_paths;  /* Ignore directory paths that do not exist */
+    int ignore_unavailable;  /* Ignore directory paths that do not exist */
     int rotate_wait;           /* sec to wait on rotated files */
     int watcher_interval;      /* watcher interval             */
     int ignore_older;          /* ignore fields older than X seconds */

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -88,7 +88,7 @@ struct flb_tail_config {
     long refresh_interval_nsec;/* nanoseconds to re-scan       */
     int read_newly_discovered_files_from_head; /* read new files from head after startup */
     int read_from_head;        /* read new files from head     */
-    int ignore_unavailable;    /* gnore unavailable paths during scanning */
+    int ignore_unavailable;    /* ignore unavailable paths during scanning */
     int rotate_wait;           /* sec to wait on rotated files */
     int watcher_interval;      /* watcher interval             */
     int ignore_older;          /* ignore fields older than X seconds */

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -88,6 +88,7 @@ struct flb_tail_config {
     long refresh_interval_nsec;/* nanoseconds to re-scan       */
     int read_newly_discovered_files_from_head; /* read new files from head after startup */
     int read_from_head;        /* read new files from head     */
+    int ignore_missing_paths;  /* Ignore directory paths that do not exist */
     int rotate_wait;           /* sec to wait on rotated files */
     int watcher_interval;      /* watcher interval             */
     int ignore_older;          /* ignore fields older than X seconds */

--- a/plugins/in_tail/tail_scan.c
+++ b/plugins/in_tail/tail_scan.c
@@ -110,12 +110,12 @@ int flb_tail_scan(struct mk_list *path_list, struct flb_tail_config *ctx)
     mk_list_foreach(head, path_list) {
         pattern = mk_list_entry(head, struct flb_slist_entry, _head);
         ret = tail_scan_path(pattern->str, ctx);
-        if (ret == -1) {
-            flb_plg_warn(ctx->ins, "error scanning path: %s", pattern->str);
-        }
-        else {
+        if (ret != -1) {
             flb_plg_debug(ctx->ins, "%i new files found on path '%s'",
                           ret, pattern->str);
+        }
+        else if (!ctx->ignore_missing_paths) {
+            flb_plg_warn(ctx->ins, "error scanning path: %s", pattern->str);
         }
     }
 

--- a/plugins/in_tail/tail_scan.c
+++ b/plugins/in_tail/tail_scan.c
@@ -114,7 +114,7 @@ int flb_tail_scan(struct mk_list *path_list, struct flb_tail_config *ctx)
             flb_plg_debug(ctx->ins, "%i new files found on path '%s'",
                           ret, pattern->str);
         }
-        else if (!ctx->ignore_missing_paths) {
+        else if (!ctx->ignore_unavailable) {
             flb_plg_warn(ctx->ins, "error scanning path: %s", pattern->str);
         }
     }

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -212,12 +212,16 @@ static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
             flb_plg_error(ctx->ins, "no memory space available");
             return -1;
         case GLOB_ABORTED:
-            flb_plg_error(ctx->ins, "read error, check permissions: %s", path);
+            if (!ctx->ignore_missing_paths) {
+                flb_plg_error(ctx->ins, "read error, check permissions: %s", path);
+            }
             return -1;
         case GLOB_NOMATCH:
             ret = stat(path, &st);
             if (ret == -1) {
-                flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
+                if (!ctx->ignore_missing_paths) {
+                    flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
+                }
             }
             else {
                 ret = access(path, R_OK);

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -212,25 +212,26 @@ static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
             return -1;
         case GLOB_ABORTED:
             if (errno == EACCES) {
-                flb_plg_error(ctx->ins, "NO read access for path: %s", path);
-            } else if (!ctx->ignore_unavailable) {
-                switch (errno) {
-                    case ENOENT:
-                        flb_plg_warn(ctx->ins, "No such file at path: %s", path);
-                        break;
-                    case ENOTDIR:
-                        flb_plg_error(ctx->ins, "Not directory at path: %s", path);
-                        break;
-                    default:
-                        flb_plg_error(ctx->ins, "Unable to read path: %s", path);
-                        break;
+                flb_plg_error(ctx->ins, "No read access for path: %s", path);
+            } else if (errno == ENOENT || errno == ENOTDIR) {
+                if (!ctx->ignore_unavailable) {
+                    flb_plg_error(ctx->ins, "%s at path: %s", 
+                                    (errno == ENOENT) ? "No such file" : "Not a directory",
+                                    path);
                 }
+            } else {
+                flb_plg_error(ctx->ins, "Unable to scan path (system error: %s): %s",
+                            strerror(errno), path);
             }
             return -1;
         case GLOB_NOMATCH:
             ret = stat(path, &st);
             if (ret == -1) {
-                flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
+                if (errno == ENOTDIR && !ctx->ignore_unavailable) {
+                    flb_plg_error(ctx->ins, "Not a directory at path: %s", path);
+                } else {
+                    flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
+                }
             }
             else {
                 ret = access(path, R_OK);

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -217,10 +217,13 @@ static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
                 switch (errno) {
                     case ENOENT:
                         flb_plg_warn(ctx->ins, "No such file at path: %s", path);
+                        break;
                     case ENOTDIR:
                         flb_plg_error(ctx->ins, "Not directory at path: %s", path);
+                        break;
                     default:
                         flb_plg_error(ctx->ins, "Unable to read path: %s", path);
+                        break;
                 }
             }
             return -1;

--- a/plugins/in_tail/tail_scan_glob.c
+++ b/plugins/in_tail/tail_scan_glob.c
@@ -183,7 +183,6 @@ static inline int do_glob(const char *pattern, int flags,
     return ret;
 }
 
-
 /* Scan a path, register the entries and return how many */
 static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
 {
@@ -212,16 +211,23 @@ static int tail_scan_path(const char *path, struct flb_tail_config *ctx)
             flb_plg_error(ctx->ins, "no memory space available");
             return -1;
         case GLOB_ABORTED:
-            if (!ctx->ignore_missing_paths) {
-                flb_plg_error(ctx->ins, "read error, check permissions: %s", path);
+            if (errno == EACCES) {
+                flb_plg_error(ctx->ins, "NO read access for path: %s", path);
+            } else if (!ctx->ignore_unavailable) {
+                switch (errno) {
+                    case ENOENT:
+                        flb_plg_warn(ctx->ins, "No such file at path: %s", path);
+                    case ENOTDIR:
+                        flb_plg_error(ctx->ins, "Not directory at path: %s", path);
+                    default:
+                        flb_plg_error(ctx->ins, "Unable to read path: %s", path);
+                }
             }
             return -1;
         case GLOB_NOMATCH:
             ret = stat(path, &st);
             if (ret == -1) {
-                if (!ctx->ignore_missing_paths) {
-                    flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
-                }
+                flb_plg_debug(ctx->ins, "cannot read info from: %s", path);
             }
             else {
                 ret = access(path, R_OK);


### PR DESCRIPTION
Omit output regarding scanning of directories that do not exist.

<!-- Provide summary of changes -->

Fixes #11964 

This PR adds a boolean config option to the in_tail plugin called "ignore_unavailable". This option will make Fluent-bit omit log output regarding failure to scan paths that do not exist.

The use case for this PR is if you would like to use the same config across different systems/environments where certain log files may or may not exist. In this case, this option will reduce unnecessary error messages generated by missing log files/paths.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
*Config file for change:*
```
[SERVICE]
    Flush        1
    Daemon       Off
    Log_Level    info

[INPUT]
    Name           tail
    Tag            test.log
    Path           /path/to/nowhere/*,/var/log/app/*
    Read_from_Head true
    Refresh_Interval 1
    Ignore_Unavailable true

[OUTPUT]
    Name   stdout
    Match  *
```

*Output with Ignore_Unavailable set to false:*
```bash
[2026/07/13 21:18:01.876] [ info] [fluent bit] version=5.0.9, commit=03fca836ef, pid=70889
[2026/07/13 21:18:01.876] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/07/13 21:18:01.876] [ info] [simd    ] SSE2
[2026/07/13 21:18:01.876] [ info] [cmetrics] version=2.1.5
[2026/07/13 21:18:01.876] [ info] [ctraces ] version=0.7.1
[2026/07/13 21:18:01.876] [ info] [input:tail:tail.0] initializing
[2026/07/13 21:18:01.876] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2026/07/13 21:18:01.877] [ warn] [input:tail:tail.0] No such file at path: /path/to/nowhere/*
[2026/07/13 21:18:01.877] [error] [input:tail:tail.0] Not directory at path: /path/to/nowhere/*
[2026/07/13 21:18:01.877] [error] [input:tail:tail.0] Unable to read path: /path/to/nowhere/*
[2026/07/13 21:18:01.877] [ warn] [input:tail:tail.0] error scanning path: /path/to/nowhere/*
[2026/07/13 21:18:01.877] [ warn] [input:tail:tail.0] No such file at path: /var/log/app/*
[2026/07/13 21:18:01.877] [error] [input:tail:tail.0] Not directory at path: /var/log/app/*
[2026/07/13 21:18:01.877] [error] [input:tail:tail.0] Unable to read path: /var/log/app/*
[2026/07/13 21:18:01.877] [ warn] [input:tail:tail.0] error scanning path: /var/log/app/*
```

*Output with Ignore_Unavailable set to true:*
```bash
[2026/07/13 21:19:05.141] [ info] [fluent bit] version=5.0.9, commit=03fca836ef, pid=70934
[2026/07/13 21:19:05.141] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/07/13 21:19:05.141] [ info] [simd    ] SSE2
[2026/07/13 21:19:05.141] [ info] [cmetrics] version=2.1.5
[2026/07/13 21:19:05.141] [ info] [ctraces ] version=0.7.1
[2026/07/13 21:19:05.141] [ info] [input:tail:tail.0] initializing
[2026/07/13 21:19:05.141] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2026/07/13 21:19:05.142] [ info] [sp] stream processor started
[2026/07/13 21:19:05.142] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/07/13 21:19:05.142] [ info] [output:stdout:stdout.0] worker #0 started
```

*Valgrind output:*
```bash
==70643== HEAP SUMMARY:
==70643==     in use at exit: 0 bytes in 0 blocks
==70643==   total heap usage: 2,522 allocs, 2,522 frees, 532,923 bytes allocated
==70643== 
==70643== All heap blocks were freed -- no leaks are possible
==70643== 
==70643== For lists of detected and suppressed errors, rerun with: -s
==70643== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [Yes ] Documentation required for this feature
- I will create a PR for this 

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
- [ If desired] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `ignore_unavailable` option to the Tail input (boolean, default: `false`) to skip non-existent/unavailable directories when matching files.
* **Bug Fixes**
  * Improved Tail scan error reporting with clearer messages for permission issues and missing paths.
  * Updated behavior so unavailable paths only produce “error scanning path” warnings when `ignore_unavailable` is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->