### PR TITLE
github: workflows: Enable runtime tests only for x64 Windows architecure

### DIFF
--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -37,18 +37,21 @@ jobs:
           - name: "Windows 32bit"
             arch: x86
             cmake_additional_opt: ""
+            runtime_tests: "Off"
             vcpkg_triplet: x86-windows-static
             cmake_version: "3.31.6"
             os: windows-latest
           - name: "Windows 64bit"
             arch: x64
             cmake_additional_opt: ""
+            runtime_tests: "On"
             vcpkg_triplet: x64-windows-static
             cmake_version: "3.31.6"
             os: windows-latest
           - name: "Windows 64bit (Arm64)"
             arch: amd64_arm64
             cmake_additional_opt: "-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_SYSTEM_PROCESSOR=ARM64"
+            runtime_tests: "Off"
             vcpkg_triplet: arm64-windows-static
             cmake_version: "3.31.6"
             os: windows-11-arm
@@ -207,6 +210,7 @@ jobs:
         run: |
           cmake -G "NMake Makefiles" `
             -D FLB_TESTS_INTERNAL=On `
+            -D FLB_TESTS_RUNTIME=${{ matrix.config.runtime_tests }} `
             -D FLB_NIGHTLY_BUILD='${{ inputs.unstable }}' `
             -D OPENSSL_ROOT_DIR='C:\vcpkg\installed\${{ matrix.config.vcpkg_triplet }}' `
             ${{ matrix.config.cmake_additional_opt }} `

--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -251,6 +251,12 @@ jobs:
 
       - name: Run unit tests for Fluent Bit packages (x86, x64, and ARM64)
         run: |
-            ctest --build-run-dir "$PWD" --output-on-failure
+            $nparallel = 1
+            if ('${{ matrix.config.runtime_tests }}' -eq 'On') {
+              $nparallel = [Math]::Min([Environment]::ProcessorCount, 8)
+            }
+
+            Write-Host "Running CTest with parallel level $nparallel"
+            ctest --parallel $nparallel --build-run-dir "$PWD" --output-on-failure
         shell: pwsh
         working-directory: build

--- a/.github/workflows/call-windows-unit-tests.yaml
+++ b/.github/workflows/call-windows-unit-tests.yaml
@@ -218,6 +218,7 @@ jobs:
             -D FLB_WITHOUT_flb-rt-out_elasticsearch=On `
             -D FLB_WITHOUT_flb-rt-out_td=On `
             -D FLB_WITHOUT_flb-rt-out_forward=On `
+            -D FLB_WITHOUT_flb-rt-filter_rewrite_tag=On `
             -D FLB_WITHOUT_flb-rt-in_disk=On `
             -D FLB_WITHOUT_flb-rt-in_proc=On `
             -D FLB_WITHOUT_flb-it-unit_sizes=On `

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,16 @@
 ## Preferred Commands
 - Configure: `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
 - Configure on Windows:
-  `cmake -S . -B build -DFLB_TESTS_RUNTIME=Off -DFLB_TESTS_INTERNAL=On`
+  `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
 - Build: `cmake --build build -j8`
 - Test: `ctest --test-dir build --output-on-failure`
 - Prefer targeted tests with `ctest --test-dir build -R <name> --output-on-failure`
   when the affected area is known, because the full enabled suite can be slow.
-- On Windows, do not run runtime test cases yet. Runtime tests are not supported
-  there, so skip them and report the skip instead of treating missing runtime
-  verification as a failure. Configure with `-DFLB_TESTS_RUNTIME=Off` and
-  prefer filtered non-runtime CTest runs over the full suite.
+- Windows supports building and running runtime tests. Prefer focused
+  `flb-rt-*` targets or CTest matches because the full runtime suite can be
+  slow. The GitHub Actions unit-test workflow enables runtime execution only
+  for x64 to control CI running time. Do not apply that CI-only restriction to
+  local agents or AI cloud builds.
 - Run a focused integration test with
   `ctest --test-dir build -R flb-it-opentelemetry --output-on-failure`
 - Run the in-tree Python integration suite with:
@@ -49,9 +50,8 @@ Keep changes scoped: plugin logic in its plugin directory, shared behavior in `s
   asks for that structure.
 
 ## Build, Test, and Development Commands
-- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`: configure with runtime + internal tests.
-- `cmake -S . -B build -DFLB_TESTS_RUNTIME=Off -DFLB_TESTS_INTERNAL=On`:
-  configure on Windows, where runtime tests are unsupported.
+- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`:
+  configure runtime and internal tests, including on Windows.
 - `cmake --build build -j8`: compile Fluent Bit and tests.
 - `ctest --test-dir build --output-on-failure`: run enabled tests.
 - `ctest --test-dir build -R flb-it-opentelemetry --output-on-failure`: run a focused integration test.
@@ -84,12 +84,12 @@ Keep changes scoped: plugin logic in its plugin directory, shared behavior in `s
 - Add or update tests for behavior changes, especially protocol parsing and encoder/decoder paths.
 - Prefer targeted tests close to the changed module (`tests/internal`, plugin runtime tests).
 - Prefer focused `ctest -R ...` runs or specific test binaries when the touched area is known.
-- Windows exception: runtime test cases are not supported on Windows yet. When
-  working on Windows, do not run `tests/runtime`, `flb-rt-*` targets, or runtime
-  CTest matches as verification. Configure with `-DFLB_TESTS_RUNTIME=Off` so
-  unsupported runtime targets are not built. Run applicable non-runtime tests
-  instead and state clearly that runtime verification was skipped because the
-  platform does not support it.
+- Windows supports `tests/runtime`, `flb-rt-*` targets, and runtime CTest
+  matches. Configure with `-DFLB_TESTS_RUNTIME=On` and run applicable focused
+  runtime coverage. In `.github/workflows/call-windows-unit-tests.yaml`, keep
+  runtime execution disabled for x86 and ARM64 unless the workflow scope
+  explicitly changes; that exclusion controls GitHub Actions running time only.
+  It does not apply to local agents or AI cloud builds.
 - Use `tests/integration` when validating end-to-end plugin behavior, network
   protocols, downstream request generation, or local fake-server interactions
   that are awkward to cover in `ctest` binaries alone.
@@ -108,9 +108,9 @@ Keep changes scoped: plugin logic in its plugin directory, shared behavior in `s
   `cmake --build build -j8`
   `tests/integration/.venv/bin/python -m pytest <focused-scenario> -q`
   `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest <focused-scenario> -q`
-- On Windows, replace the configure command above with:
-  `cmake -S . -B build -DFLB_TESTS_RUNTIME=Off -DFLB_TESTS_INTERNAL=On`
-  and skip runtime test cases because they are not supported there.
+- On Windows, use the same `-DFLB_TESTS_RUNTIME=On` configuration and run
+  relevant focused runtime cases. Valgrind is normally unavailable on Windows;
+  report that exact blocker instead of conflating it with runtime-test support.
 - Run broader test coverage when changing shared lifecycle, routing, storage, or accounting code.
 - Validate both success and failure paths (invalid payloads, boundary sizes, null/missing fields).
 - You can also run specific binaries from `build/bin` (e.g., `./bin/flb-it-opentelemetry`).
@@ -126,8 +126,6 @@ Keep changes scoped: plugin logic in its plugin directory, shared behavior in `s
   - the exact focused integration command(s) run;
   - whether valgrind was used;
   - pass/fail status;
-  - on Windows, any runtime test cases intentionally skipped because runtime
-    tests are not supported there;
   - any concrete blocker if a required run could not be completed.
 - Keep generated integration artifacts out of git. Do not commit
   `.venv/`, `.pytest_cache/`, `results/`, or `__pycache__/` under
@@ -289,8 +287,8 @@ Keep changes scoped: plugin logic in its plugin directory, shared behavior in `s
 
 ### Testing strategy
 - Use `tests/internal` for core lifecycle/accounting logic.
-- Use `tests/runtime` for plugin-level behavior and end-to-end semantics, except
-  on Windows where runtime test cases are not supported and must be skipped.
+- Use `tests/runtime` for plugin-level behavior and end-to-end semantics,
+  including Windows runtime targets supported by the active toolchain and host.
 - Add regression tests for:
   - mixed signals
   - processor drop/modify paths

--- a/skills/fluent-bit/SKILL.md
+++ b/skills/fluent-bit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: fluent-bit
+description: Work in the Fluent Bit C/C++ repository using its scoped patch, testing, runtime, integration, lifecycle, and review conventions. Use for Fluent Bit source, plugin, pipeline, Windows runtime-test, CI, configuration, protocol, or regression tasks.
+---
+
 # Fluent Bit Repository Skill
 
 Use this skill when working in the Fluent Bit repository or in a similar
@@ -56,15 +61,20 @@ ctest --test-dir build -R <name> --output-on-failure
 ./build/bin/fluent-bit -c conf/fluent-bit.conf
 ```
 
-On Windows, skip runtime test cases. Runtime tests are not supported there yet,
-so configure with runtime tests disabled, use applicable non-runtime
-verification, and report the runtime-test skip:
+Windows supports runtime-test builds and execution on the latest master
+revision. Initialize the appropriate MSVC environment, configure runtime tests,
+and prefer focused targets or CTest matches:
 
 ```sh
-cmake -S . -B build -DFLB_TESTS_RUNTIME=Off -DFLB_TESTS_INTERNAL=On
-cmake --build build -j8
-ctest --test-dir build -R <non-runtime-name> --output-on-failure
+cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On
+cmake --build build --target <flb-rt-target>
+ctest --test-dir build -R '^<flb-rt-target>$' --output-on-failure
 ```
+
+The GitHub Actions Windows unit-test matrix executes runtime tests only for x64
+to control CI running time. Keep that workflow policy scoped to GitHub Actions;
+local agents and AI cloud builds should enable and run applicable runtime tests
+without inheriting the x86/ARM64 CI restriction.
 
 For Python integration scenarios:
 
@@ -82,8 +92,6 @@ Final responses for implementation tasks should include:
 - The exact verification commands run.
 - Pass/fail status.
 - Whether valgrind was used when integration coverage applies.
-- Any runtime tests skipped on Windows because runtime test cases are
-  unsupported there.
 - Any bundled library patch touched, including the upstream project/path and
   confirmation that the user approved editing it.
 - Any concrete blocker for required tests that could not run.

--- a/skills/fluent-bit/testing.md
+++ b/skills/fluent-bit/testing.md
@@ -18,26 +18,45 @@ ctest --test-dir build -R <name> --output-on-failure
 - Run broader tests when changing shared lifecycle, routing, storage, task,
   scheduler, or accounting behavior.
 
-## Windows Runtime Test Exception
+## Windows Runtime Test Support
 
-Runtime test cases are not supported on Windows yet. On Windows, do not run
-`tests/runtime`, `flb-rt-*` targets, or CTest filters that select runtime test
-cases as verification. Run applicable non-runtime tests instead, such as focused
-internal tests or build-only checks, and report the skip explicitly. Configure
-with runtime tests disabled so unsupported runtime targets are not built:
+The latest master revision supports building and running runtime tests on
+Windows. Initialize the appropriate MSVC environment, enable runtime tests, and
+run the focused target or CTest match for the affected component:
+
+- use `VsDevCmd.bat -arch=x64` for x64;
+- use `VsDevCmd.bat -arch=x86` for x86;
+- use an ARM64-capable native or cross-build Developer Command Prompt for
+  ARM64. For a cross-build, add `-DCMAKE_SYSTEM_NAME=Windows`,
+  `-DCMAKE_SYSTEM_VERSION=10.0`, and `-DCMAKE_SYSTEM_PROCESSOR=ARM64`.
 
 ```sh
-cmake -S . -B build -DFLB_TESTS_RUNTIME=Off -DFLB_TESTS_INTERNAL=On
-cmake --build build -j8
-ctest --test-dir build -R <non-runtime-name> --output-on-failure
+cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On
+cmake --build build --target <flb-rt-target>
+ctest --test-dir build -R '^<flb-rt-target>$' --output-on-failure
 ```
+
+The Windows unit-test CI workflow in
+`.github/workflows/call-windows-unit-tests.yaml` enables runtime tests only for
+x64. Its x86 and ARM64 jobs deliberately use `FLB_TESTS_RUNTIME=Off` to control
+GitHub Actions running time. This restriction applies only to that CI workflow.
+Do not use it to skip runtime-test builds or execution by local agents or AI
+cloud builders.
+
+When a cross-built target cannot execute on the current host, report that
+concrete host/toolchain limitation. Do not substitute the GitHub Actions
+running-time policy as the reason for skipping it.
+
+Use `ctest --test-dir build -N` only to inspect registration. It does not prove
+that a runtime executable was built or passed; confirm the target build and run
+the focused test before claiming runtime verification.
 
 ## Integration Test Expectations
 
 If a touched component has a focused `tests/integration` scenario, run it before
 closing the task. Run it once normally and once with valgrind when possible.
 
-Default verification shape for non-Windows platforms:
+Default verification shape for supported platforms, including Windows:
 
 ```sh
 ./tests/integration/setup-venv.sh
@@ -48,8 +67,9 @@ VALGRIND=1 VALGRIND_STRICT=1 \
   tests/integration/.venv/bin/python -m pytest <focused-scenario> -q
 ```
 
-On Windows, replace the configure command with the
-`-DFLB_TESTS_RUNTIME=Off` variant above and do not run runtime test cases.
+On Windows, keep `FLB_TESTS_RUNTIME=On` and run relevant focused runtime cases.
+Valgrind is normally unavailable on Windows, so report that blocker
+explicitly when the required memory-safety run cannot be performed.
 
 Equivalent run-test wrapper shape:
 
@@ -70,7 +90,6 @@ blocker, such as:
 - unavailable scenario;
 - missing `valgrind`;
 - network restriction during dependency setup;
-- Windows runtime test skip because runtime tests are not supported there;
 - infrastructure failure unrelated to the patch.
 
 ## Useful Validation Habits
@@ -93,6 +112,5 @@ Include exact commands and outcomes:
 Verification:
 - PASS: cmake --build build -j8 --target <target>
 - PASS: ctest --test-dir build -R '<regex>' --output-on-failure
-- SKIPPED: runtime tests on Windows because runtime test cases are unsupported
 - BLOCKED: VALGRIND=1 ... failed because valgrind is not installed
 ```

--- a/tests/runtime/filter_rewrite_tag.c
+++ b/tests/runtime/filter_rewrite_tag.c
@@ -77,6 +77,31 @@ static int get_output_num()
     return ret;
 }
 
+static void wait_for_output_num(uint32_t timeout_ms, int expected_num, int *output_num)
+{
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_ms = 0;
+
+    flb_time_get(&start_time);
+
+    while (elapsed_time_ms < timeout_ms) {
+        *output_num = get_output_num();
+
+        if (*output_num >= expected_num) {
+            return;
+        }
+
+        flb_time_msleep(100);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_time_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+    }
+
+    *output_num = get_output_num();
+}
+
 static struct filter_test *filter_test_create(struct flb_lib_out_cb *data)
 {
     int i_ffd;
@@ -405,8 +430,7 @@ static void flb_test_busy_emitter_keeps_original()
         TEST_CHECK(bytes == strlen(p));
     }
 
-    flb_time_msleep(1500);
-    got = get_output_num();
+    wait_for_output_num(30000, heavy_loop, &got);
 
     if (!TEST_CHECK(got == heavy_loop)) {
         TEST_MSG("expect: %d got: %d", heavy_loop, got);


### PR DESCRIPTION


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Windows unit-test execution by architecture: runtime tests are enabled for x64 and disabled for x86 and ARM64 in CI for reliability.
  * Updated runtime-test build and execution to use a runtime-test toggle, with adaptive CTest parallelism when enabled.
  * Improved runtime test synchronization by polling output until the expected count is reached (with timeout) instead of using fixed delays.

* **Documentation**
  * Refreshed Windows build/testing guidance to support runtime tests where available and updated related expectations (including memory-safety tooling notes).
  * Updated Fluent Bit skill and testing instructions to remove outdated “runtime tests unsupported on Windows” guidance and align reporting/close-out steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->