### PR TITLE
tests: runtime: Handle byte order mark for non-ASCII environment of Windows correctly

### DIFF
--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+﻿/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*  Fluent Bit
  *  ==========

--- a/tests/runtime/out_syslog.c
+++ b/tests/runtime/out_syslog.c
@@ -28,6 +28,8 @@
 #include <fcntl.h>
 #include "flb_tests_runtime.h"
 
+#define UTF8_BOM "\xEF\xBB\xBF"
+
 struct test_ctx {
     flb_ctx_t *flb;    /* Fluent Bit library context */
     int i_ffd;         /* Input fd  */
@@ -213,7 +215,7 @@ void flb_test_severity_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<13>" /* 1(user-level messages) * 8 + 5(severity) */,
-                             "<13>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+                             "<13>1 1970-01-01T00:00:01.000000Z - - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -270,7 +272,7 @@ void flb_test_severity_preset_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<13>" /* 1(user-level messages) * 8 + 5(severity) */,
-                             "<13>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+                             "<13>1 1970-01-01T00:00:01.000000Z - - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -438,7 +440,7 @@ void flb_test_facility_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<110>" /* 13(log audit) * 8 + 6(default severity) */,
-                             "<110>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+                             "<110>1 1970-01-01T00:00:01.000000Z - - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -494,7 +496,7 @@ void flb_test_facility_preset_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<110>" /* 13(log audit) * 8 + 6(default severity) */,
-                             "<110>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+                             "<110>1 1970-01-01T00:00:01.000000Z - - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -662,7 +664,7 @@ void flb_test_severity_facility_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "<109>" /* 13(log audit) * 8 + 5(severity) */,
-                             "<109>1 1970-01-01T00:00:01.000000Z - - - - - ﻿hello world"};
+                             "<109>1 1970-01-01T00:00:01.000000Z - - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -776,7 +778,7 @@ void flb_test_hostname_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "localhost",
-                             "<14>1 1970-01-01T00:00:01.000000Z localhost - - - - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z localhost - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -832,7 +834,7 @@ void flb_test_hostname_preset_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "localhost",
-                             "<14>1 1970-01-01T00:00:01.000000Z localhost - - - - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z localhost - - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1000,7 +1002,7 @@ void flb_test_appname_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "fluent-bit",
-                             "<14>1 1970-01-01T00:00:01.000000Z - fluent-bit - - - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - fluent-bit - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1056,7 +1058,7 @@ void flb_test_appname_preset_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "fluent-bit",
-                             "<14>1 1970-01-01T00:00:01.000000Z - fluent-bit - - - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - fluent-bit - - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1224,7 +1226,7 @@ void flb_test_procid_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "1234",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - 1234 - - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - 1234 - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1280,7 +1282,7 @@ void flb_test_procid_preset_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "1234",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - 1234 - - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - 1234 - - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1336,7 +1338,7 @@ void flb_test_msgid_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "TCPIN",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - - TCPIN - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - - TCPIN - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1392,7 +1394,7 @@ void flb_test_msgid_preset_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z", "TCPIN",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - - TCPIN - ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - - TCPIN - " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1448,7 +1450,7 @@ void flb_test_sd_key_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - - - [sd_key logtype=\"access\" clustername=\"mycluster\" namespace=\"mynamespace\"] ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - - - [sd_key logtype=\"access\" clustername=\"mycluster\" namespace=\"mynamespace\"] " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1504,7 +1506,7 @@ void flb_test_allow_longer_sd_id_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - - - [sd_key_that_is_longer_than_32_characters logtype_that_is_longer_than_32_characters=\"access\" clustername=\"mycluster\" namespace=\"mynamespace\"] ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - - - [sd_key_that_is_longer_than_32_characters logtype_that_is_longer_than_32_characters=\"access\" clustername=\"mycluster\" namespace=\"mynamespace\"] " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],
@@ -1561,7 +1563,7 @@ void flb_test_malformed_longer_sd_id_rfc5424()
     size_t size = strlen(buf);
 
     char *expected_strs[] = {"hello world", "1970-01-01T00:00:01.000000Z",
-                             "<14>1 1970-01-01T00:00:01.000000Z - - - - [sd_key_that_is_longer_than_32_ch logtype_that_is_longer_than_32_c=\"access\" clustername=\"mycluster\" namespace=\"mynamespace\"] ﻿hello world"};
+                             "<14>1 1970-01-01T00:00:01.000000Z - - - - [sd_key_that_is_longer_than_32_ch logtype_that_is_longer_than_32_c=\"access\" clustername=\"mycluster\" namespace=\"mynamespace\"] " UTF8_BOM "hello world"};
     struct str_list expected = {
                                 .size = sizeof(expected_strs)/sizeof(char*),
                                 .lists = &expected_strs[0],


### PR DESCRIPTION
Especially, cp932 Windows causes compilation failure without appropriate BOM handlings on in_tail and out_syslog runtime tests.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of files that begin with a UTF-8 byte order mark (BOM), ensuring the initial mode comment is recognized correctly.

* **Tests**
  * Updated RFC5424 syslog formatter expectations to avoid embedding an invisible UTF-8 BOM directly in string literals, improving test reliability across severity, facility, hostname, appname, procid, msgid, and structured data cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->