### PR TITLE
http_server: plug unsupported shared port issue on windows

### DIFF
--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -563,7 +563,7 @@ static int flb_http_server_worker_initialize(struct flb_downstream_worker *worke
     memcpy(&context->net_setup,
            parent->networking_setup,
            sizeof(struct flb_net_setup));
-    context->net_setup.share_port = FLB_TRUE;
+    context->net_setup.share_port = parent->reuse_port;
 
     flb_http_server_options_init(&options);
 
@@ -585,7 +585,7 @@ static int flb_http_server_worker_initialize(struct flb_downstream_worker *worke
     options.connection_counter = parent->connection_counter;
     options.workers = 1;
     options.use_caller_event_loop = FLB_TRUE;
-    options.reuse_port = FLB_TRUE;
+    options.reuse_port = parent->reuse_port;
     options.cb_worker_init = parent->cb_worker_init;
     options.cb_worker_exit = parent->cb_worker_exit;
 

--- a/tests/internal/http_server.c
+++ b/tests/internal/http_server.c
@@ -356,6 +356,79 @@ void test_http_server_worker_exit_runs_on_worker_thread()
     test_http_server_network_cleanup();
 }
 
+void test_http_server_single_managed_worker_start()
+{
+    int port;
+    int ret;
+    struct flb_config *config;
+    struct flb_net_setup net_setup;
+    struct flb_http_server server;
+    struct flb_http_server_options options;
+    struct test_http_server_context context;
+
+    ret = test_http_server_network_init();
+    if (ret != 0) {
+        return;
+    }
+
+    config = flb_config_init();
+    if (!TEST_CHECK(config != NULL)) {
+        test_http_server_network_cleanup();
+        return;
+    }
+
+    test_http_server_context_init(&context);
+    context.expected_idle_timeout = HTTP_SERVER_DEFAULT_IDLE_TIMEOUT;
+
+    port = test_http_server_reserve_port();
+    if (!TEST_CHECK(port > 0)) {
+        test_http_server_context_destroy(&context);
+        flb_config_exit(config);
+        test_http_server_network_cleanup();
+        return;
+    }
+
+    flb_net_setup_init(&net_setup);
+    flb_http_server_options_init(&options);
+
+    options.protocol_version = HTTP_PROTOCOL_VERSION_AUTODETECT;
+    options.request_callback = test_http_server_request_handler;
+    options.user_data = &context;
+    options.address = (char *) TEST_HTTP_SERVER_HOST;
+    options.port = port;
+    options.networking_flags = FLB_IO_TCP;
+    options.networking_setup = &net_setup;
+    options.system_context = config;
+    options.workers = 1;
+    options.use_caller_event_loop = FLB_FALSE;
+    options.cb_worker_init = test_http_server_worker_init;
+    options.cb_worker_exit = test_http_server_worker_exit;
+
+    ret = flb_http_server_init_with_options(&server, &options);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        TEST_CHECK(server.reuse_port == FLB_FALSE);
+
+        ret = flb_http_server_start(&server);
+        TEST_CHECK(ret == 0);
+        if (ret == 0) {
+            TEST_CHECK(context.init_calls == 1);
+            TEST_CHECK(context.idle_timeout_mismatches == 0);
+        }
+
+        flb_http_server_destroy(&server);
+
+        if (ret == 0) {
+            TEST_CHECK(context.exit_calls == 1);
+            TEST_CHECK(context.exit_thread_mismatches == 0);
+        }
+    }
+
+    test_http_server_context_destroy(&context);
+    flb_config_exit(config);
+    test_http_server_network_cleanup();
+}
+
 void test_http_server_workers_reject_distinct_ephemeral_ports()
 {
     int ret;
@@ -616,6 +689,8 @@ TEST_LIST = {
     { "http_server_managed_worker_contract", test_http_server_managed_worker_contract },
     { "http_server_worker_exit_runs_on_worker_thread",
       test_http_server_worker_exit_runs_on_worker_thread },
+    { "http_server_single_managed_worker_start",
+      test_http_server_single_managed_worker_start },
     { "http_server_workers_reject_distinct_ephemeral_ports",
       test_http_server_workers_reject_distinct_ephemeral_ports },
     { "http_server_idle_timeout_applies_to_networking_setup",


### PR DESCRIPTION
<!-- Provide summary of changes -->

In Windows, http_server which is built on top of shared port functionality with single managed worker is not working properly with the default configuration.
We need to inherit the setting of shared port from the parent.
 
Otherwise, the following error is happened and not to be able to bind the specified port:

```
[2026/07/14 23:20:39.012] [debug] [dummy:dummy.0] created event channels: read=984 write=996
[2026/07/14 23:20:39.013] [debug] [stdout:stdout.0] created event channels: read=1008 write=1020
[2026/07/14 23:20:39.020] [ info] [output:stdout:stdout.0] worker #0 started
[2026/07/14 23:20:39.021] [error] shared listener ports are not supported on this platform
[2026/07/14 23:20:39.021] [error] [downstream] could not bind address 0.0.0.0:2021. Aborting
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP server workers now respect the parent server’s port-sharing configuration instead of always enabling port reuse.
  * Improved single-worker server startup behavior and lifecycle handling.

* **Tests**
  * Added coverage for managed HTTP servers configured with a single worker, including startup, initialization, and shutdown callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->