### PR TITLE
network: Plug an unintialized member

### DIFF
--- a/src/flb_network.c
+++ b/src/flb_network.c
@@ -141,6 +141,7 @@ void flb_net_setup_init(struct flb_net_setup *net)
     net->dns_resolver = NULL;
     net->dns_prefer_ipv4 = FLB_FALSE;
     net->dns_prefer_ipv6 = FLB_FALSE;
+    net->share_port = FLB_FALSE;
     net->keepalive = FLB_TRUE;
     net->keepalive_idle_timeout = 30;
     net->keepalive_max_recycle = 0;


### PR DESCRIPTION
<!-- Provide summary of changes -->
There's another Windows regression exposing an uninitialized field.

The sequence is:

1. `tcp_with_tls` declares `downstream_net_setup` on the stack and calls `flb_net_setup_init()` at [out_tcp.c:391](C:/Users/cosmo/Documents/GitHub/fluent-bit/tests/runtime/out_tcp.c:391).
2. `flb_net_setup_init()` does not initialize `net->share_port` at [flb_network.c:138](C:/Users/cosmo/Documents/GitHub/fluent-bit/src/flb_network.c:138), so it contains unpredictable stack data.
3. In this run it was nonzero, making `flb_net_server()` believe port sharing was requested.
4. Windows has no `SO_REUSEPORT`, so [flb_network.c:234](C:/Users/cosmo/Documents/GitHub/fluent-bit/src/flb_network.c:234) logs:
   `shared listener ports are not supported on this platform`
   and returns failure.
5. The server socket is closed before `bind()` is attempted at [flb_network.c:1694](C:/Users/cosmo/Documents/GitHub/fluent-bit/src/flb_network.c:1694). Therefore, the later “could not bind” message is misleading—it did not reach the actual bind operation.
6. `flb_downstream_create()` returns `NULL`, causing the assertion at [out_tcp.c:403](C:/Users/cosmo/Documents/GitHub/fluent-bit/tests/runtime/out_tcp.c:403) to fail.
7. Because no TLS server is listening, the TCP output’s connection attempt then produces the secondary `unexpected EOF` and `no upstream connections available` errors.

The latent bug became visible after commit `a87985ded` (`network: enforce shared listener socket setup`): unsupported port sharing was previously a no-op on Windows, but it now returns an error.

The direct correction is to initialize:

```c
net->share_port = FLB_FALSE;
```

inside `flb_net_setup_init()`. Setting `downstream_net_setup.share_port = FLB_FALSE` only in this test would also stop this failure, but would leave other direct callers exposed to the same uninitialized-state bug.

CTest already serializes `flb-rt-in_tcp` and `flb-rt-out_tcp` using the `runtime-port-5170` resource lock, so parallel test execution is not the primary cause here.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network setup now applies a consistent default for port sharing, improving reliability during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->