### PR TITLE
tests: runtime: out_tcp: Make more rigid accumutated assertions

### DIFF
--- a/tests/runtime/out_tcp.c
+++ b/tests/runtime/out_tcp.c
@@ -70,12 +70,30 @@ static void clear_output_num()
     set_output_num(0);
 }
 
+static int wait_for_output_num(int expected, uint32_t timeout_ms)
+{
+    uint32_t elapsed = 0;
+
+    while (elapsed < timeout_ms) {
+        if (get_output_num() >= expected) {
+            return 0;
+        }
+
+        flb_time_msleep(10);
+        elapsed += 10;
+    }
+
+    return -1;
+}
+
 struct str_list {
     size_t size;
     char **lists;
     int *matches;
     int require_json_array;
     char *joined;
+    char *expected_payload;
+    flb_sds_t accumulated_payload;
 };
 
 static int validate_json_array_payload(flb_sds_t out_line, struct str_list *l)
@@ -92,6 +110,29 @@ static int validate_json_array_payload(flb_sds_t out_line, struct str_list *l)
         strstr(out_line, l->lists[1]) != NULL &&
         !TEST_CHECK(strstr(out_line, l->joined) != NULL)) {
         TEST_MSG("expected JSON array separator, got: %s", out_line);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int accumulate_payload(flb_sds_t out_line, struct str_list *l)
+{
+    int ret;
+
+    if (l->accumulated_payload == NULL) {
+        l->accumulated_payload = flb_sds_create_size(flb_sds_len(out_line));
+        if (!TEST_CHECK(l->accumulated_payload != NULL)) {
+            TEST_MSG("could not allocate accumulated payload");
+            return -1;
+        }
+    }
+
+    ret = flb_sds_cat_safe(&l->accumulated_payload,
+                           out_line,
+                           flb_sds_len(out_line));
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("could not append accumulated payload");
         return -1;
     }
 
@@ -127,17 +168,22 @@ static void cb_check_str_list(void *ctx, int ffd, int res_ret,
         validate_json_array_payload(out_line, l);
     }
 
-    for (i=0; i<l->size; i++) {
-        p = strstr(out_line, l->lists[i]);
-        if (l->matches != NULL) {
-            if (p != NULL) {
-                l->matches[i]++;
+    if (l->expected_payload != NULL) {
+        accumulate_payload(out_line, l);
+    }
+    else {
+        for (i=0; i<l->size; i++) {
+            p = strstr(out_line, l->lists[i]);
+            if (l->matches != NULL) {
+                if (p != NULL) {
+                    l->matches[i]++;
+                }
+                continue;
             }
-            continue;
-        }
 
-        if (!TEST_CHECK(p != NULL)) {
-            TEST_MSG("  Got   :%s\n  expect:%s", out_line, l->lists[i]);
+            if (!TEST_CHECK(p != NULL)) {
+                TEST_MSG("  Got   :%s\n  expect:%s", out_line, l->lists[i]);
+            }
         }
     }
     set_output_num(num+1);
@@ -156,6 +202,34 @@ static int check_str_list_matches(struct str_list *l)
             ret = -1;
         }
     }
+
+    return ret;
+}
+
+static int check_accumulated_payload(struct str_list *l)
+{
+    int ret = 0;
+    size_t expected_size;
+    size_t actual_size;
+
+    if (!TEST_CHECK(l->accumulated_payload != NULL)) {
+        TEST_MSG("no payload was accumulated");
+        return -1;
+    }
+
+    expected_size = strlen(l->expected_payload);
+    actual_size = flb_sds_len(l->accumulated_payload);
+    if (!TEST_CHECK(actual_size == expected_size &&
+                    memcmp(l->accumulated_payload,
+                           l->expected_payload,
+                           expected_size) == 0)) {
+        TEST_MSG("  Got   :%s\n  expect:%s",
+                 l->accumulated_payload, l->expected_payload);
+        ret = -1;
+    }
+
+    flb_sds_destroy(l->accumulated_payload);
+    l->accumulated_payload = NULL;
 
     return ret;
 }
@@ -562,10 +636,10 @@ void flb_test_format_json_stream()
     char *buf2 = "[2, {\"msg\":\"hello world\"}]";
     size_t size2 = strlen(buf2);
 
-    char *expected_strs[] = {"{\"date\":1.0,\"msg\":\"hello world\"}{\"date\":2.0,\"msg\":\"hello world\"}"};
     struct str_list expected = {
-                                .size = sizeof(expected_strs)/sizeof(char*),
-                                .lists = &expected_strs[0],
+                                .expected_payload =
+                                    "{\"date\":1.0,\"msg\":\"hello world\"}"
+                                    "{\"date\":2.0,\"msg\":\"hello world\"}",
     };
 
     clear_output_num();
@@ -604,6 +678,7 @@ void flb_test_format_json_stream()
     if (!TEST_CHECK(num > 0))  {
         TEST_MSG("no outputs");
     }
+    check_accumulated_payload(&expected);
 
     test_ctx_destroy(ctx);
 }
@@ -619,10 +694,10 @@ void flb_test_format_json_lines()
     char *buf2 = "[2, {\"msg\":\"hello world\"}]";
     size_t size2 = strlen(buf2);
 
-    char *expected_strs[] = {"{\"date\":1.0,\"msg\":\"hello world\"}\n{\"date\":2.0,\"msg\":\"hello world\"}"};
     struct str_list expected = {
-                                .size = sizeof(expected_strs)/sizeof(char*),
-                                .lists = &expected_strs[0],
+                                .expected_payload =
+                                    "{\"date\":1.0,\"msg\":\"hello world\"}\n"
+                                    "{\"date\":2.0,\"msg\":\"hello world\"}\n",
     };
 
     clear_output_num();
@@ -651,6 +726,13 @@ void flb_test_format_json_lines()
     /* Ingest data sample */
     ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf1, size1);
     TEST_CHECK(ret >= 0);
+
+    /* Make the second record use a separate input chunk. */
+    ret = wait_for_output_num(1, 2000);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("first json_lines record was not formatted before timeout");
+    }
+
     ret = flb_lib_push(ctx->flb, ctx->i_ffd, (char *) buf2, size2);
     TEST_CHECK(ret >= 0);
 
@@ -661,6 +743,7 @@ void flb_test_format_json_lines()
     if (!TEST_CHECK(num > 0))  {
         TEST_MSG("no outputs");
     }
+    check_accumulated_payload(&expected);
 
     test_ctx_destroy(ctx);
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation for streamed and line-delimited JSON output.
  * Added checks to confirm complete formatted payloads, preserving output order and content.
  * Added timing control to ensure the first record is produced before subsequent input is sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->