### PR TITLE
build: plugins: Generate plugin defs on separated build directories

### DIFF
--- a/cmake/headers.cmake
+++ b/cmake/headers.cmake
@@ -7,6 +7,7 @@ if(NOT DEFINED FLB_PATH_ROOT_BINARY_DIR)
 endif()
 
 include_directories(
+  ${FLB_PATH_ROOT_BINARY_DIR}/generated/include
   ${FLB_PATH_ROOT_SOURCE}/include/
   ${FLB_PATH_ROOT_SOURCE}/lib/
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -492,10 +492,11 @@ if(EXT_FILTER_PLUGINS)
   endforeach()
 endif()
 
-# Generate the header from the template
+# Keep the generated plugin registry local to each build configuration.
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/generated/include/fluent-bit")
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_plugins.h.in"
-  "${PROJECT_SOURCE_DIR}/include/fluent-bit/flb_plugins.h"
+  "${PROJECT_BINARY_DIR}/generated/include/fluent-bit/flb_plugins.h"
   )
 
 set(FLB_PLUGINS "${flb_plugins}" PARENT_SCOPE)


### PR DESCRIPTION
<!-- Provide summary of changes -->
When building in the several build directories, the generated flb_plugins.h would be collided.
So, we need to manage in the different directory for the generated header.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to generate plugin headers in the build directory rather than modifying the source tree.
  * Improved build configuration to locate generated headers automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->