### PR TITLE
io: wait for writable sockets before retrying sync writes

### DIFF
--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -47,6 +47,13 @@
 #include <limits.h>
 #include <assert.h>
 
+#ifdef FLB_SYSTEM_WINDOWS
+#define poll WSAPoll
+#include <winsock2.h>
+#else
+#include <sys/poll.h>
+#endif
+
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
@@ -248,6 +255,7 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
 {
     int ret;
     int tries = 0;
+    struct pollfd poll_fd;
     size_t total = 0;
 
     while (total < len) {
@@ -262,14 +270,20 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
 
         if (ret == -1) {
             if (FLB_WOULDBLOCK()) {
-                /*
-                 * FIXME: for now we are handling this in a very lazy way,
-                 * just sleep for a second and retry (for a max of 30 tries).
-                 */
-                sleep(1);
+                poll_fd.fd = fd;
+                poll_fd.events = POLLOUT;
+                poll_fd.revents = 0;
+                ret = poll(&poll_fd, 1, 1000);
+
+#ifndef FLB_SYSTEM_WINDOWS
+                if (ret < 0 && errno == EINTR) {
+                    continue;
+                }
+#endif
+
                 tries++;
 
-                if (tries == 30) {
+                if (ret < 0 || tries == 30) {
                     /* Since we're aborting after 30 failures we want the
                      * caller to know how much data we were able to send
                      */

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -46,6 +46,13 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#ifdef FLB_SYSTEM_WINDOWS
+#define poll WSAPoll
+#include <winsock2.h>
+#else
+#include <sys/poll.h>
+#endif
+
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
@@ -318,6 +325,7 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
 {
     int ret;
     int tries = 0;
+    struct pollfd poll_fd;
     size_t total = 0;
 
     while (total < len) {
@@ -332,14 +340,20 @@ static int fd_io_write(int fd, struct sockaddr_storage *address,
 
         if (ret == -1) {
             if (FLB_WOULDBLOCK()) {
-                /*
-                 * FIXME: for now we are handling this in a very lazy way,
-                 * just sleep for a second and retry (for a max of 30 tries).
-                 */
-                sleep(1);
+                poll_fd.fd = fd;
+                poll_fd.events = POLLOUT;
+                poll_fd.revents = 0;
+                ret = poll(&poll_fd, 1, 1000);
+
+#ifndef FLB_SYSTEM_WINDOWS
+                if (ret < 0 && errno == EINTR) {
+                    continue;
+                }
+#endif
+
                 tries++;
 
-                if (tries == 30) {
+                if (ret < 0 || tries == 30) {
                     /* Since we're aborting after 30 failures we want the
                      * caller to know how much data we were able to send
                      */

--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -4,11 +4,20 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_io.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/flb_time.h>
 
 #include <time.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
 #include "flb_tests_internal.h"
 
 #define TEST_HOSTv4           "127.0.0.1"
@@ -181,9 +190,238 @@ void test_ipv6_bracketed_listen()
     }
 }
 
+#ifndef FLB_SYSTEM_WINDOWS
+
+#define TEST_WRITE_SIZE (16 * 1024)
+#define TEST_WRITE_MAX_ELAPSED_MILLISECONDS 900
+
+struct socket_reader_context {
+    int fd;
+    int close_peer;
+    size_t bytes_read;
+};
+
+static void *socket_reader(void *data)
+{
+    char buffer[4096];
+    ssize_t bytes_read;
+    struct socket_reader_context *context;
+
+    context = data;
+
+    /*
+     * Give the writer time to fill the small send buffer and enter the
+     * writability wait before draining the peer.
+     */
+    flb_time_msleep(20);
+
+    if (context->close_peer == FLB_TRUE) {
+        flb_socket_close(context->fd);
+        return NULL;
+    }
+
+    while (context->bytes_read < TEST_WRITE_SIZE) {
+        bytes_read = recv(context->fd, buffer, sizeof(buffer), 0);
+
+        if (bytes_read > 0) {
+            context->bytes_read += bytes_read;
+        }
+        else if (bytes_read < 0 && errno == EINTR) {
+            continue;
+        }
+        else {
+            break;
+        }
+    }
+
+    return NULL;
+}
+
+static long elapsed_milliseconds(struct timespec *start, struct timespec *end)
+{
+    return (end->tv_sec - start->tv_sec) * 1000 +
+           (end->tv_nsec - start->tv_nsec) / 1000000;
+}
+
+void test_nonblocking_socket_write_waits_for_writability()
+{
+    char *buffer;
+    int result;
+    int send_buffer_size;
+    int sockets[2];
+    long elapsed;
+    size_t bytes_written;
+    pthread_t reader_thread;
+    struct timespec start;
+    struct timespec end;
+    struct socket_reader_context reader_context;
+
+    result = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+    if (!TEST_CHECK(result == 0)) {
+        return;
+    }
+
+    send_buffer_size = 4096;
+    result = setsockopt(sockets[0],
+                        SOL_SOCKET,
+                        SO_SNDBUF,
+                        &send_buffer_size,
+                        sizeof(send_buffer_size));
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    result = flb_net_socket_nonblocking(sockets[0]);
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    buffer = flb_malloc(TEST_WRITE_SIZE);
+    if (!TEST_CHECK(buffer != NULL)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+    memset(buffer, 'x', TEST_WRITE_SIZE);
+
+    reader_context.fd = sockets[1];
+    reader_context.close_peer = FLB_FALSE;
+    reader_context.bytes_read = 0;
+
+    result = pthread_create(&reader_thread, NULL, socket_reader, &reader_context);
+    if (!TEST_CHECK(result == 0)) {
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    result = flb_io_fd_write(sockets[0],
+                             buffer,
+                             TEST_WRITE_SIZE,
+                             &bytes_written);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    shutdown(sockets[0], SHUT_WR);
+    pthread_join(reader_thread, NULL);
+
+    elapsed = elapsed_milliseconds(&start, &end);
+
+    TEST_CHECK(result == TEST_WRITE_SIZE);
+    TEST_CHECK(bytes_written == TEST_WRITE_SIZE);
+    TEST_CHECK(reader_context.bytes_read == TEST_WRITE_SIZE);
+    TEST_CHECK(elapsed < TEST_WRITE_MAX_ELAPSED_MILLISECONDS);
+
+    flb_free(buffer);
+    flb_socket_close(sockets[0]);
+    flb_socket_close(sockets[1]);
+}
+
+void test_nonblocking_socket_write_propagates_peer_close()
+{
+    char *buffer;
+    int result;
+    int send_buffer_size;
+    int socket_error;
+    int sockets[2];
+    int write_result;
+    size_t bytes_written;
+    pthread_t reader_thread;
+    struct sigaction ignore_action;
+    struct sigaction previous_action;
+    struct socket_reader_context reader_context;
+
+    result = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+    if (!TEST_CHECK(result == 0)) {
+        return;
+    }
+
+    send_buffer_size = 4096;
+    result = setsockopt(sockets[0],
+                        SOL_SOCKET,
+                        SO_SNDBUF,
+                        &send_buffer_size,
+                        sizeof(send_buffer_size));
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    result = flb_net_socket_nonblocking(sockets[0]);
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    buffer = flb_malloc(TEST_WRITE_SIZE);
+    if (!TEST_CHECK(buffer != NULL)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+    memset(buffer, 'x', TEST_WRITE_SIZE);
+
+    reader_context.fd = sockets[1];
+    reader_context.close_peer = FLB_TRUE;
+    reader_context.bytes_read = 0;
+
+    result = pthread_create(&reader_thread, NULL, socket_reader, &reader_context);
+    if (!TEST_CHECK(result == 0)) {
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    memset(&ignore_action, 0, sizeof(ignore_action));
+    ignore_action.sa_handler = SIG_IGN;
+    sigemptyset(&ignore_action.sa_mask);
+    result = sigaction(SIGPIPE, &ignore_action, &previous_action);
+    if (!TEST_CHECK(result == 0)) {
+        pthread_join(reader_thread, NULL);
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        return;
+    }
+
+    errno = 0;
+    write_result = flb_io_fd_write(sockets[0],
+                                   buffer,
+                                   TEST_WRITE_SIZE,
+                                   &bytes_written);
+    socket_error = errno;
+
+    result = sigaction(SIGPIPE, &previous_action, NULL);
+    pthread_join(reader_thread, NULL);
+
+    TEST_CHECK(result == 0);
+    TEST_CHECK(write_result == -1);
+    TEST_CHECK(socket_error == EPIPE ||
+               socket_error == ECONNRESET ||
+               socket_error == ENOTCONN);
+
+    flb_free(buffer);
+    flb_socket_close(sockets[0]);
+}
+
+#endif
+
 TEST_LIST = {
     { "ipv4_client_server", test_ipv4_client_server},
     { "ipv6_client_server", test_ipv6_client_server},
     { "ipv6_bracketed_listen", test_ipv6_bracketed_listen},
+#ifndef FLB_SYSTEM_WINDOWS
+    { "nonblocking_socket_write_waits_for_writability",
+      test_nonblocking_socket_write_waits_for_writability},
+    { "nonblocking_socket_write_propagates_peer_close",
+      test_nonblocking_socket_write_propagates_peer_close},
+#endif
     { 0 }
 };

--- a/tests/internal/network.c
+++ b/tests/internal/network.c
@@ -4,6 +4,7 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_parser.h>
 #include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_io.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/flb_time.h>
@@ -11,6 +12,14 @@
 #include <fluent-bit/flb_downstream.h>
 
 #include <time.h>
+
+#ifndef FLB_SYSTEM_WINDOWS
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
 #include "flb_tests_internal.h"
 
 #define TEST_HOSTv4           "127.0.0.1"
@@ -284,6 +293,285 @@ void test_downstream_event_callback_runs_on_parent_stack()
     flb_coro_destroy(coro);
 }
 
+#ifndef FLB_SYSTEM_WINDOWS
+
+#define TEST_WRITE_SIZE (16 * 1024)
+#define TEST_WRITE_MAX_ELAPSED_MILLISECONDS 900
+#define TEST_PREFILL_LIMIT (8 * 1024 * 1024)
+
+struct socket_reader_context {
+    int fd;
+    int close_peer;
+    size_t drain_target;
+    size_t bytes_read;
+};
+
+/*
+ * SO_SNDBUF is only a hint, so a 16 KiB write can complete without ever
+ * hitting EAGAIN on platforms that round the buffer up. Fill the socket until
+ * the kernel reports backpressure so the write under test is guaranteed to
+ * exercise the writability wait. Returns the number of bytes queued, or 0 if
+ * backpressure could not be produced.
+ */
+static size_t prefill_socket(int fd)
+{
+    char chunk[4096];
+    ssize_t bytes_sent;
+    size_t total;
+
+    memset(chunk, 'p', sizeof(chunk));
+    total = 0;
+
+    while (total < TEST_PREFILL_LIMIT) {
+        bytes_sent = send(fd, chunk, sizeof(chunk), 0);
+
+        if (bytes_sent > 0) {
+            total += bytes_sent;
+        }
+        else if (bytes_sent < 0 && errno == EINTR) {
+            continue;
+        }
+        else {
+            return total;
+        }
+    }
+
+    /* ponytail: never observed in practice, treat as "no backpressure" */
+    return 0;
+}
+
+static void *socket_reader(void *data)
+{
+    char buffer[4096];
+    ssize_t bytes_read;
+    struct socket_reader_context *context;
+
+    context = data;
+
+    /*
+     * Give the writer time to fill the small send buffer and enter the
+     * writability wait before draining the peer.
+     */
+    flb_time_msleep(20);
+
+    if (context->close_peer == FLB_TRUE) {
+        flb_socket_close(context->fd);
+        return NULL;
+    }
+
+    while (context->bytes_read < context->drain_target) {
+        bytes_read = recv(context->fd, buffer, sizeof(buffer), 0);
+
+        if (bytes_read > 0) {
+            context->bytes_read += bytes_read;
+        }
+        else if (bytes_read < 0 && errno == EINTR) {
+            continue;
+        }
+        else {
+            break;
+        }
+    }
+
+    return NULL;
+}
+
+static long elapsed_milliseconds(struct timespec *start, struct timespec *end)
+{
+    return (end->tv_sec - start->tv_sec) * 1000 +
+           (end->tv_nsec - start->tv_nsec) / 1000000;
+}
+
+void test_nonblocking_socket_write_waits_for_writability()
+{
+    char *buffer;
+    int result;
+    int send_buffer_size;
+    int sockets[2];
+    long elapsed;
+    size_t bytes_written;
+    size_t prefilled;
+    pthread_t reader_thread;
+    struct timespec start;
+    struct timespec end;
+    struct socket_reader_context reader_context;
+
+    result = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+    if (!TEST_CHECK(result == 0)) {
+        return;
+    }
+
+    send_buffer_size = 4096;
+    result = setsockopt(sockets[0],
+                        SOL_SOCKET,
+                        SO_SNDBUF,
+                        &send_buffer_size,
+                        sizeof(send_buffer_size));
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    result = flb_net_socket_nonblocking(sockets[0]);
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    buffer = flb_malloc(TEST_WRITE_SIZE);
+    if (!TEST_CHECK(buffer != NULL)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+    memset(buffer, 'x', TEST_WRITE_SIZE);
+
+    prefilled = prefill_socket(sockets[0]);
+    if (!TEST_CHECK(prefilled > 0)) {
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    reader_context.fd = sockets[1];
+    reader_context.close_peer = FLB_FALSE;
+    reader_context.drain_target = prefilled + TEST_WRITE_SIZE;
+    reader_context.bytes_read = 0;
+
+    result = pthread_create(&reader_thread, NULL, socket_reader, &reader_context);
+    if (!TEST_CHECK(result == 0)) {
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    result = flb_io_fd_write(sockets[0],
+                             buffer,
+                             TEST_WRITE_SIZE,
+                             &bytes_written);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    shutdown(sockets[0], SHUT_WR);
+    pthread_join(reader_thread, NULL);
+
+    elapsed = elapsed_milliseconds(&start, &end);
+
+    TEST_CHECK(result == TEST_WRITE_SIZE);
+    TEST_CHECK(bytes_written == TEST_WRITE_SIZE);
+    TEST_CHECK(reader_context.bytes_read == prefilled + TEST_WRITE_SIZE);
+    TEST_CHECK(elapsed < TEST_WRITE_MAX_ELAPSED_MILLISECONDS);
+
+    flb_free(buffer);
+    flb_socket_close(sockets[0]);
+    flb_socket_close(sockets[1]);
+}
+
+void test_nonblocking_socket_write_propagates_peer_close()
+{
+    char *buffer;
+    int result;
+    int send_buffer_size;
+    int socket_error;
+    int sockets[2];
+    int write_result;
+    size_t bytes_written;
+    size_t prefilled;
+    pthread_t reader_thread;
+    struct sigaction ignore_action;
+    struct sigaction previous_action;
+    struct socket_reader_context reader_context;
+
+    result = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+    if (!TEST_CHECK(result == 0)) {
+        return;
+    }
+
+    send_buffer_size = 4096;
+    result = setsockopt(sockets[0],
+                        SOL_SOCKET,
+                        SO_SNDBUF,
+                        &send_buffer_size,
+                        sizeof(send_buffer_size));
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    result = flb_net_socket_nonblocking(sockets[0]);
+    if (!TEST_CHECK(result == 0)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    buffer = flb_malloc(TEST_WRITE_SIZE);
+    if (!TEST_CHECK(buffer != NULL)) {
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+    memset(buffer, 'x', TEST_WRITE_SIZE);
+
+    prefilled = prefill_socket(sockets[0]);
+    if (!TEST_CHECK(prefilled > 0)) {
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    reader_context.fd = sockets[1];
+    reader_context.close_peer = FLB_TRUE;
+    reader_context.drain_target = 0;
+    reader_context.bytes_read = 0;
+
+    result = pthread_create(&reader_thread, NULL, socket_reader, &reader_context);
+    if (!TEST_CHECK(result == 0)) {
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        flb_socket_close(sockets[1]);
+        return;
+    }
+
+    memset(&ignore_action, 0, sizeof(ignore_action));
+    ignore_action.sa_handler = SIG_IGN;
+    sigemptyset(&ignore_action.sa_mask);
+    result = sigaction(SIGPIPE, &ignore_action, &previous_action);
+    if (!TEST_CHECK(result == 0)) {
+        pthread_join(reader_thread, NULL);
+        flb_free(buffer);
+        flb_socket_close(sockets[0]);
+        return;
+    }
+
+    errno = 0;
+    write_result = flb_io_fd_write(sockets[0],
+                                   buffer,
+                                   TEST_WRITE_SIZE,
+                                   &bytes_written);
+    socket_error = errno;
+
+    result = sigaction(SIGPIPE, &previous_action, NULL);
+    pthread_join(reader_thread, NULL);
+
+    TEST_CHECK(result == 0);
+    TEST_CHECK(write_result == -1);
+    TEST_CHECK(socket_error == EPIPE ||
+               socket_error == ECONNRESET ||
+               socket_error == ENOTCONN);
+
+    flb_free(buffer);
+    flb_socket_close(sockets[0]);
+}
+
+#endif
+
 TEST_LIST = {
     { "ipv4_client_server", test_ipv4_client_server},
     { "ipv6_client_server", test_ipv6_client_server},
@@ -291,5 +579,11 @@ TEST_LIST = {
     { "accept_empty_nonblocking_listener", test_accept_empty_nonblocking_listener},
     { "downstream_event_callback_runs_on_parent_stack",
       test_downstream_event_callback_runs_on_parent_stack },
+#ifndef FLB_SYSTEM_WINDOWS
+    { "nonblocking_socket_write_waits_for_writability",
+      test_nonblocking_socket_write_waits_for_writability},
+    { "nonblocking_socket_write_propagates_peer_close",
+      test_nonblocking_socket_write_propagates_peer_close},
+#endif
     { 0 }
 };


### PR DESCRIPTION
## Summary

Replace the one-second sleep used by synchronous nonblocking socket writes
after `EAGAIN`/`EWOULDBLOCK` with a bounded `POLLOUT` wait.

Fixes #12115

## Root cause

`fd_io_write()` currently sleeps for one full second whenever `send()` or
`sendto()` temporarily fills a nonblocking socket buffer. A large response can
hit that path repeatedly, adding one second per backpressure event even when
the socket becomes writable much sooner.

## Changes

- wait for `POLLOUT` for at most one second before retrying;
- use `WSAPoll` on Windows, matching the existing network implementation;
- do not count an interrupted POSIX wait as one of the bounded retries;
- preserve the existing 30-attempt limit and partial-write reporting;
- add deterministic internal tests for prompt wakeup and peer-close error
  propagation using small nonblocking socket pairs.

## Compatibility

There is no configuration or API change. The one-second upper bound and
30-attempt limit remain unchanged. The writer now resumes promptly when the
socket becomes writable instead of always waiting the full second.

The regression tests are POSIX-only because they use `socketpair()` and
pthreads. The Windows source path uses the same `WSAPoll` pattern present in
`src/flb_network.c`.

## Testing

Commands:

```sh
cmake -S . -B build-sync-final \
  -DFLB_TESTS_RUNTIME=On \
  -DFLB_TESTS_INTERNAL=On \
  -DFLB_EXAMPLES=Off \
  -DCMAKE_CXX_FLAGS=-mavx2
cmake --build build-sync-final -j8
ctest --test-dir build-sync-final --output-on-failure \
  -R '^flb-(rt-in_tcp|rt-out_tcp|it-network|it-http_client|it-http_server)$'
ctest --test-dir build-sync-final --output-on-failure \
  --repeat until-fail:10 \
  -R '^flb-it-network$'
```

The tests ran in the documented Debian 12 rootless Podman environment. The
explicit AVX2 flag is a GCC 12 compatibility workaround for bundled `simdutf`,
not part of this change.

Results:

- full runtime/internal build: passed;
- five focused network, HTTP, and TCP tests: passed;
- `flb-it-network`: passed 10 consecutive iterations;
- negative control with the test and old writer: failed in 2.02 seconds at the
  elapsed-time assertion, as expected;
- patched test: completes in approximately 20-30 ms;
- peer-close test: preserves `EPIPE`, `ECONNRESET`, or `ENOTCONN` instead of
  returning with stale `EAGAIN`;
- focused regression under Valgrind: 0 bytes live at exit and 0 errors;
- full-range commit-prefix validation: passed;
- `git diff --check`: passed;
- DCO: signed.

Live syscall evidence from the original reproduction:

```text
before: 16 EAGAIN results, 16 one-second sleeps, 16-17 s response
after:  23 EAGAIN results, 23 POLLOUT waits, 0 sleeps, 0.252 s response
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

- [N/A] No configuration surface is changed
- [x] Runtime and syscall output are included above
- [x] Focused Valgrind run shows no leaks or memory errors

**Packaging**

- [N/A] No packaging or container-output change

**Documentation**

- [N/A] No user-facing configuration or API change

**Backporting**

- [x] Candidate for a separate 5.0 backport after the master change is accepted

Fluent Bit is licensed under Apache 2.0. By submitting this pull request I
understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of non-blocking socket writes by waiting for socket writability instead of using fixed delays.
  * Enhanced handling of interrupted waits, retry limits, write timeouts, and peer disconnects.
  * Added Windows-compatible readiness waiting for socket operations.
  * Improved error reporting when socket writes cannot be completed.

* **Tests**
  * Added coverage for write completion, writability waits, and peer-close error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->