### PR TITLE
oauth2: add support client secret file in basic/post authentication methods

### DIFF
--- a/include/fluent-bit/flb_oauth2.h
+++ b/include/fluent-bit/flb_oauth2.h
@@ -76,7 +76,6 @@ struct flb_oauth2 {
     int payload_manual;
     flb_lock_t lock;
     time_t expires_at;
-    time_t client_secret_file_mtime; /* last-loaded mtime of client_secret_file */
     int refresh_skew;
 
     /* Token info after successful auth */

--- a/include/fluent-bit/flb_oauth2.h
+++ b/include/fluent-bit/flb_oauth2.h
@@ -42,6 +42,7 @@ struct flb_oauth2_config {
     flb_sds_t token_url;
     flb_sds_t client_id;
     flb_sds_t client_secret;
+    flb_sds_t client_secret_file;
     flb_sds_t user_agent;
     flb_sds_t scope;
     flb_sds_t audience;
@@ -75,6 +76,7 @@ struct flb_oauth2 {
     int payload_manual;
     flb_lock_t lock;
     time_t expires_at;
+    time_t client_secret_file_mtime; /* last-loaded mtime of client_secret_file */
     int refresh_skew;
 
     /* Token info after successful auth */

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -746,7 +746,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "oauth2.client_secret_file", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_http, oauth2_config.client_secret_file),
-     "Path to a file containing the OAuth2 client_secret (re-read when it changes)"
+     "Optional OAuth2 client_secret file path"
     },
     {
      FLB_CONFIG_MAP_STR, "oauth2.user_agent", NULL,

--- a/plugins/out_http/http.c
+++ b/plugins/out_http/http.c
@@ -744,6 +744,11 @@ static struct flb_config_map config_map[] = {
      "OAuth2 client_secret"
     },
     {
+     FLB_CONFIG_MAP_STR, "oauth2.client_secret_file", NULL,
+     0, FLB_TRUE, offsetof(struct flb_out_http, oauth2_config.client_secret_file),
+     "Path to a file containing the OAuth2 client_secret (re-read when it changes)"
+    },
+    {
      FLB_CONFIG_MAP_STR, "oauth2.user_agent", NULL,
      0, FLB_TRUE, offsetof(struct flb_out_http, oauth2_config.user_agent),
      "Optional User-Agent header for OAuth2 token requests"

--- a/plugins/out_http/http_conf.c
+++ b/plugins/out_http/http_conf.c
@@ -367,8 +367,10 @@ struct flb_out_http *flb_http_conf_create(struct flb_output_instance *ins,
                 return NULL;
             }
         }
-        else if (!ctx->oauth2_config.client_secret) {
-            flb_plg_error(ctx->ins, "oauth2 basic/post require client_secret");
+        else if (!ctx->oauth2_config.client_secret &&
+                 !ctx->oauth2_config.client_secret_file) {
+            flb_plg_error(ctx->ins, "oauth2 basic/post require client_secret "
+                          "or client_secret_file");
             flb_http_conf_destroy(ctx);
             return NULL;
         }

--- a/plugins/out_opentelemetry/opentelemetry_conf.c
+++ b/plugins/out_opentelemetry/opentelemetry_conf.c
@@ -449,8 +449,10 @@ struct opentelemetry_context *flb_opentelemetry_context_create(struct flb_output
                 return NULL;
             }
         }
-        else if (!ctx->oauth2_config.client_secret) {
-            flb_plg_error(ctx->ins, "oauth2 basic/post require client_secret");
+        else if (!ctx->oauth2_config.client_secret &&
+                 !ctx->oauth2_config.client_secret_file) {
+            flb_plg_error(ctx->ins, "oauth2 basic/post require client_secret "
+                          "or client_secret_file");
             flb_opentelemetry_context_destroy(ctx);
             return NULL;
         }

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -1247,6 +1247,11 @@ static int oauth2_refresh_client_secret_from_file(struct flb_oauth2 *ctx)
     struct stat st;
     flb_sds_t secret = NULL;
 
+    if (ctx->cfg.auth_method != FLB_OAUTH2_AUTH_METHOD_BASIC &&
+        ctx->cfg.auth_method != FLB_OAUTH2_AUTH_METHOD_POST) {
+        return 0;
+    }
+
     if (!ctx->cfg.client_secret_file) {
         return 0;
     }

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -29,7 +29,6 @@
 #include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_crypto.h>
-#include <fluent-bit/flb_compat.h>
 
 #include <time.h>
 #include <errno.h>
@@ -37,8 +36,6 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <limits.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 
 #include <openssl/bio.h>
 #include <openssl/x509.h>
@@ -1237,14 +1234,14 @@ static int oauth2_read_secret_file(const char *path, flb_sds_t *out)
 }
 
 /*
- * Reload client_secret from client_secret_file when the file's mtime changed
- * (or on first load, since the tracked mtime starts at 0). On success the new
- * value replaces ctx->cfg.client_secret. No-op when client_secret_file is unset.
+ * Load client_secret from client_secret_file, replacing the current value. The
+ * file is re-read on every refresh so a rotated secret is always picked up,
+ * independent of filesystem mtime resolution. No-op for auth methods that do
+ * not use client_secret, or when client_secret_file is unset.
  */
 static int oauth2_refresh_client_secret_from_file(struct flb_oauth2 *ctx)
 {
     int ret;
-    struct stat st;
     flb_sds_t secret = NULL;
 
     if (ctx->cfg.auth_method != FLB_OAUTH2_AUTH_METHOD_BASIC &&
@@ -1253,19 +1250,6 @@ static int oauth2_refresh_client_secret_from_file(struct flb_oauth2 *ctx)
     }
 
     if (!ctx->cfg.client_secret_file) {
-        return 0;
-    }
-
-    ret = stat(ctx->cfg.client_secret_file, &st);
-    if (ret != 0) {
-        flb_errno();
-        flb_error("[oauth2] cannot stat client_secret_file '%s'",
-                  ctx->cfg.client_secret_file);
-        return -1;
-    }
-
-    /* only reload when the file changed since the last load */
-    if (st.st_mtime == ctx->client_secret_file_mtime) {
         return 0;
     }
 
@@ -1278,7 +1262,6 @@ static int oauth2_refresh_client_secret_from_file(struct flb_oauth2 *ctx)
         flb_sds_destroy(ctx->cfg.client_secret);
     }
     ctx->cfg.client_secret = secret;
-    ctx->client_secret_file_mtime = st.st_mtime;
 
     return 0;
 }

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -73,7 +73,7 @@ struct flb_config_map oauth2_config_map[] = {
     {
      FLB_CONFIG_MAP_STR, "oauth2.client_secret_file", NULL,
      0, FLB_TRUE, offsetof(struct flb_oauth2_config, client_secret_file),
-     "Path to a file containing the OAuth2 client_secret (re-read when it changes)"
+     "Optional OAuth2 client_secret file path"
     },
     {
      FLB_CONFIG_MAP_STR, "oauth2.user_agent", NULL,

--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -29,6 +29,7 @@
 #include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_crypto.h>
+#include <fluent-bit/flb_compat.h>
 
 #include <time.h>
 #include <errno.h>
@@ -36,6 +37,8 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include <openssl/bio.h>
 #include <openssl/x509.h>
@@ -66,6 +69,11 @@ struct flb_config_map oauth2_config_map[] = {
      FLB_CONFIG_MAP_STR, "oauth2.client_secret", NULL,
      0, FLB_TRUE, offsetof(struct flb_oauth2_config, client_secret),
      "OAuth2 client_secret"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "oauth2.client_secret_file", NULL,
+     0, FLB_TRUE, offsetof(struct flb_oauth2_config, client_secret_file),
+     "Path to a file containing the OAuth2 client_secret (re-read when it changes)"
     },
     {
      FLB_CONFIG_MAP_STR, "oauth2.user_agent", NULL,
@@ -190,6 +198,7 @@ static void oauth2_apply_defaults(struct flb_oauth2_config *cfg)
     cfg->token_url = NULL;
     cfg->client_id = NULL;
     cfg->client_secret = NULL;
+    cfg->client_secret_file = NULL;
     cfg->user_agent = NULL;
     cfg->scope = NULL;
     cfg->audience = NULL;
@@ -243,6 +252,15 @@ static int oauth2_clone_config(struct flb_oauth2_config *dst,
     if (src->client_secret) {
         dst->client_secret = flb_sds_create(src->client_secret);
         if (!dst->client_secret) {
+            flb_errno();
+            flb_oauth2_config_destroy(dst);
+            return -1;
+        }
+    }
+
+    if (src->client_secret_file) {
+        dst->client_secret_file = flb_sds_create(src->client_secret_file);
+        if (!dst->client_secret_file) {
             flb_errno();
             flb_oauth2_config_destroy(dst);
             return -1;
@@ -339,6 +357,8 @@ void flb_oauth2_config_destroy(struct flb_oauth2_config *cfg)
     cfg->client_id = NULL;
     flb_sds_destroy(cfg->client_secret);
     cfg->client_secret = NULL;
+    flb_sds_destroy(cfg->client_secret_file);
+    cfg->client_secret_file = NULL;
     flb_sds_destroy(cfg->user_agent);
     cfg->user_agent = NULL;
     flb_sds_destroy(cfg->scope);
@@ -1175,10 +1195,103 @@ static int oauth2_http_request(struct flb_oauth2 *ctx, flb_sds_t body)
     return -1;
 }
 
+/*
+ * Read the client_secret from a file, trimming trailing CR/LF characters.
+ * Returns 0 and a newly-allocated flb_sds_t in *out on success, -1 otherwise.
+ */
+static int oauth2_read_secret_file(const char *path, flb_sds_t *out)
+{
+    int ret;
+    size_t len;
+    size_t size = 0;
+    char *buf = NULL;
+
+    ret = flb_utils_read_file((char *) path, &buf, &size);
+    if (ret != 0 || !buf) {
+        flb_error("[oauth2] cannot read client_secret_file '%s'", path);
+        return -1;
+    }
+
+    /* trim trailing new lines */
+    for (len = size; len > 0; len--) {
+        if (buf[len - 1] != '\n' && buf[len - 1] != '\r') {
+            break;
+        }
+    }
+
+    if (len == 0) {
+        flb_free(buf);
+        flb_error("[oauth2] client_secret_file '%s' is empty", path);
+        return -1;
+    }
+
+    *out = flb_sds_create_len(buf, len);
+    flb_free(buf);
+
+    if (!*out) {
+        flb_errno();
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * Reload client_secret from client_secret_file when the file's mtime changed
+ * (or on first load, since the tracked mtime starts at 0). On success the new
+ * value replaces ctx->cfg.client_secret. No-op when client_secret_file is unset.
+ */
+static int oauth2_refresh_client_secret_from_file(struct flb_oauth2 *ctx)
+{
+    int ret;
+    struct stat st;
+    flb_sds_t secret = NULL;
+
+    if (!ctx->cfg.client_secret_file) {
+        return 0;
+    }
+
+    ret = stat(ctx->cfg.client_secret_file, &st);
+    if (ret != 0) {
+        flb_errno();
+        flb_error("[oauth2] cannot stat client_secret_file '%s'",
+                  ctx->cfg.client_secret_file);
+        return -1;
+    }
+
+    /* only reload when the file changed since the last load */
+    if (st.st_mtime == ctx->client_secret_file_mtime) {
+        return 0;
+    }
+
+    ret = oauth2_read_secret_file(ctx->cfg.client_secret_file, &secret);
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (ctx->cfg.client_secret) {
+        flb_sds_destroy(ctx->cfg.client_secret);
+    }
+    ctx->cfg.client_secret = secret;
+    ctx->client_secret_file_mtime = st.st_mtime;
+
+    return 0;
+}
+
 static int oauth2_refresh_locked(struct flb_oauth2 *ctx)
 {
     int ret;
     flb_sds_t body;
+
+    /*
+     * Pick up a rotated secret file before building the request so both the
+     * POST body and the BASIC auth header use the current value.
+     */
+    ret = oauth2_refresh_client_secret_from_file(ctx);
+    if (ret != 0) {
+        flb_error("[oauth2] could not refresh client_secret from file");
+        return -1;
+    }
 
     body = oauth2_build_body(ctx);
     if (!body) {
@@ -1274,6 +1387,27 @@ struct flb_oauth2 *flb_oauth2_create_from_config(struct flb_config *config,
             return NULL;
         }
     }
+
+    /*
+     * When a client_secret_file is configured, load it now so failures are
+     * surfaced at context creation. If both client_secret and
+     * client_secret_file are set, the file takes precedence.
+     */
+    if (ctx->cfg.client_secret_file) {
+        if (ctx->cfg.client_secret) {
+            flb_debug("[oauth2] both client_secret and client_secret_file are "
+                      "set; client_secret_file takes precedence");
+        }
+
+        ret = oauth2_refresh_client_secret_from_file(ctx);
+        if (ret != 0) {
+            flb_error("[oauth2] failed to load client_secret_file '%s'",
+                      ctx->cfg.client_secret_file);
+            flb_oauth2_destroy(ctx);
+            return NULL;
+        }
+    }
+
     ctx->auth_url = flb_sds_create(ctx->cfg.token_url);
     if (!ctx->auth_url) {
         flb_errno();

--- a/tests/internal/oauth2.c
+++ b/tests/internal/oauth2.c
@@ -1385,12 +1385,6 @@ void test_client_secret_file_change_detection(void)
     TEST_CHECK(ret == 0);
     TEST_CHECK(strcmp(value, "secret-v1") == 0);
 
-    /*
-     * Ensure the filesystem mtime advances (>= 1s resolution) before the
-     * rewrite so the change is detected on the next refresh.
-     */
-    sleep(2);
-
     ret = write_text_file(secret_path, "secret-v2\n");
     TEST_CHECK(ret == 0);
 

--- a/tests/internal/oauth2.c
+++ b/tests/internal/oauth2.c
@@ -30,6 +30,7 @@
 #define MOCK_BODY_SIZE 16384
 #define TEST_CERT_FILENAME "oauth2_private_key_jwt_test_cert.pem"
 #define TEST_KEY_FILENAME  "oauth2_private_key_jwt_test_key.pem"
+#define TEST_SECRET_FILENAME "oauth2_client_secret_file_test.txt"
 
 static const char *TEST_PRIVATE_KEY_PEM =
 "-----BEGIN PRIVATE KEY-----\n"
@@ -547,6 +548,42 @@ static struct flb_oauth2 *create_oauth_ctx(struct flb_config *config,
     return create_oauth_ctx_with_user_agent(config, server, refresh_skew, NULL);
 }
 
+/*
+ * Create an OAuth2 context using the POST auth method so the client_secret is
+ * carried in the token request body (captured by the mock server), which lets
+ * the tests assert the exact secret value that was used. Either or both of
+ * inline_secret and secret_file may be provided.
+ */
+static struct flb_oauth2 *create_oauth_ctx_secret_file(struct flb_config *config,
+                                                       struct oauth2_mock_server *server,
+                                                       const char *secret_file,
+                                                       const char *inline_secret)
+{
+    struct flb_oauth2_config cfg;
+    struct flb_oauth2 *ctx;
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.enabled = FLB_TRUE;
+    cfg.token_url = flb_sds_create_size(64);
+    cfg.auth_method = FLB_OAUTH2_AUTH_METHOD_POST;
+    cfg.refresh_skew = 58;
+    cfg.client_id = flb_sds_create("id");
+    if (inline_secret) {
+        cfg.client_secret = flb_sds_create(inline_secret);
+    }
+    if (secret_file) {
+        cfg.client_secret_file = flb_sds_create(secret_file);
+    }
+
+    flb_sds_printf(&cfg.token_url, "http://127.0.0.1:%d/token", server->port);
+
+    ctx = flb_oauth2_create_from_config(config, &cfg);
+
+    flb_oauth2_config_destroy(&cfg);
+
+    return ctx;
+}
+
 void test_user_agent_header_optional(void)
 {
     int ret;
@@ -634,6 +671,27 @@ static int write_text_file(const char *path, const char *content)
     fclose(fp);
 
     if (written != expected) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int test_secret_file_path(char *path, size_t path_size)
+{
+    char *tmpdir;
+    int ret;
+
+    tmpdir = flb_test_env_tmpdir();
+    TEST_CHECK(tmpdir != NULL);
+    if (!tmpdir) {
+        return -1;
+    }
+
+    ret = snprintf(path, path_size, "%s/%s.%d",
+                   tmpdir, TEST_SECRET_FILENAME, (int) getpid());
+    flb_free(tmpdir);
+    if (ret < 0 || (size_t) ret >= path_size) {
         return -1;
     }
 
@@ -1251,6 +1309,224 @@ void test_private_key_jwt_x5t_header(void)
     flb_config_exit(config);
 }
 
+/* AC2/AC4: secret read from a file is used, with trailing newlines trimmed. */
+void test_client_secret_from_file(void)
+{
+    int ret;
+    char secret_path[256];
+    char value[128];
+    flb_sds_t token = NULL;
+    struct flb_config *config;
+    struct flb_oauth2 *ctx;
+    struct oauth2_mock_server server;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    ret = test_secret_file_path(secret_path, sizeof(secret_path));
+    TEST_CHECK(ret == 0);
+
+    ret = write_text_file(secret_path, "filesecret\n");
+    TEST_CHECK(ret == 0);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ctx = create_oauth_ctx_secret_file(config, &server, secret_path, NULL);
+    TEST_CHECK(ctx != NULL);
+
+#ifdef FLB_SYSTEM_MACOS
+    ret = oauth2_mock_server_wait_ready(&server);
+    TEST_CHECK(ret == 0);
+#endif
+
+    ret = flb_oauth2_get_access_token(ctx, &token, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(token != NULL);
+
+    ret = extract_form_value(server.latest_token_request, "client_secret",
+                             value, sizeof(value));
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(strcmp(value, "filesecret") == 0);
+
+    flb_oauth2_destroy(ctx);
+    oauth2_mock_server_stop(&server);
+    unlink(secret_path);
+    flb_config_exit(config);
+}
+
+/* AC3: rewriting the file yields the new secret on the next refresh. */
+void test_client_secret_file_change_detection(void)
+{
+    int ret;
+    char secret_path[256];
+    char value[128];
+    flb_sds_t token = NULL;
+    struct flb_config *config;
+    struct flb_oauth2 *ctx;
+    struct oauth2_mock_server server;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    ret = test_secret_file_path(secret_path, sizeof(secret_path));
+    TEST_CHECK(ret == 0);
+
+    ret = write_text_file(secret_path, "secret-v1\n");
+    TEST_CHECK(ret == 0);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ctx = create_oauth_ctx_secret_file(config, &server, secret_path, NULL);
+    TEST_CHECK(ctx != NULL);
+
+#ifdef FLB_SYSTEM_MACOS
+    ret = oauth2_mock_server_wait_ready(&server);
+    TEST_CHECK(ret == 0);
+#endif
+
+    ret = flb_oauth2_get_access_token(ctx, &token, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    ret = extract_form_value(server.latest_token_request, "client_secret",
+                             value, sizeof(value));
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(strcmp(value, "secret-v1") == 0);
+
+    /*
+     * Ensure the filesystem mtime advances (>= 1s resolution) before the
+     * rewrite so the change is detected on the next refresh.
+     */
+    sleep(2);
+
+    ret = write_text_file(secret_path, "secret-v2\n");
+    TEST_CHECK(ret == 0);
+
+    /* Force a refresh; the reload happens inside oauth2_refresh_locked. */
+    flb_oauth2_invalidate_token(ctx);
+
+    ret = flb_oauth2_get_access_token(ctx, &token, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    ret = extract_form_value(server.latest_token_request, "client_secret",
+                             value, sizeof(value));
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(strcmp(value, "secret-v2") == 0);
+
+    flb_oauth2_destroy(ctx);
+    oauth2_mock_server_stop(&server);
+    unlink(secret_path);
+    flb_config_exit(config);
+}
+
+/* AC5: context creation succeeds with only client_secret_file (no inline secret). */
+void test_client_secret_file_only_validation(void)
+{
+    int ret;
+    char secret_path[256];
+    struct flb_config *config;
+    struct flb_oauth2 *ctx;
+    struct oauth2_mock_server server;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    ret = test_secret_file_path(secret_path, sizeof(secret_path));
+    TEST_CHECK(ret == 0);
+
+    ret = write_text_file(secret_path, "only-file-secret\n");
+    TEST_CHECK(ret == 0);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ctx = create_oauth_ctx_secret_file(config, &server, secret_path, NULL);
+    TEST_CHECK(ctx != NULL);
+
+    flb_oauth2_destroy(ctx);
+    oauth2_mock_server_stop(&server);
+    unlink(secret_path);
+    flb_config_exit(config);
+}
+
+/* Confirmed decision: when both are set, client_secret_file wins. */
+void test_client_secret_file_precedence(void)
+{
+    int ret;
+    char secret_path[256];
+    char value[128];
+    flb_sds_t token = NULL;
+    struct flb_config *config;
+    struct flb_oauth2 *ctx;
+    struct oauth2_mock_server server;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    ret = test_secret_file_path(secret_path, sizeof(secret_path));
+    TEST_CHECK(ret == 0);
+
+    ret = write_text_file(secret_path, "file-wins\n");
+    TEST_CHECK(ret == 0);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ctx = create_oauth_ctx_secret_file(config, &server, secret_path,
+                                       "inline-secret");
+    TEST_CHECK(ctx != NULL);
+
+#ifdef FLB_SYSTEM_MACOS
+    ret = oauth2_mock_server_wait_ready(&server);
+    TEST_CHECK(ret == 0);
+#endif
+
+    ret = flb_oauth2_get_access_token(ctx, &token, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    ret = extract_form_value(server.latest_token_request, "client_secret",
+                             value, sizeof(value));
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(strcmp(value, "file-wins") == 0);
+
+    flb_oauth2_destroy(ctx);
+    oauth2_mock_server_stop(&server);
+    unlink(secret_path);
+    flb_config_exit(config);
+}
+
+/* AC6: missing or empty (newline-only) file fails cleanly at creation. */
+void test_client_secret_file_errors(void)
+{
+    int ret;
+    char secret_path[256];
+    struct flb_config *config;
+    struct flb_oauth2 *ctx;
+    struct oauth2_mock_server server;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    ret = oauth2_mock_server_start(&server, 3600, 0);
+    TEST_CHECK(ret == 0);
+
+    ret = test_secret_file_path(secret_path, sizeof(secret_path));
+    TEST_CHECK(ret == 0);
+
+    /* Nonexistent file -> creation fails. */
+    unlink(secret_path);
+    ctx = create_oauth_ctx_secret_file(config, &server, secret_path, NULL);
+    TEST_CHECK(ctx == NULL);
+
+    /* Empty (newline-only) file -> creation fails. */
+    ret = write_text_file(secret_path, "\n\n");
+    TEST_CHECK(ret == 0);
+    ctx = create_oauth_ctx_secret_file(config, &server, secret_path, NULL);
+    TEST_CHECK(ctx == NULL);
+
+    oauth2_mock_server_stop(&server);
+    unlink(secret_path);
+    flb_config_exit(config);
+}
+
 TEST_LIST = {
     {"parse_refreshes_token_transactionally",
      test_parse_refreshes_token_transactionally},
@@ -1264,5 +1540,12 @@ TEST_LIST = {
     {"legacy_create_manual_payload_flow", test_legacy_create_manual_payload_flow},
     {"private_key_jwt_body", test_private_key_jwt_body},
     {"private_key_jwt_x5t_header", test_private_key_jwt_x5t_header},
+    {"client_secret_from_file", test_client_secret_from_file},
+    {"client_secret_file_change_detection",
+     test_client_secret_file_change_detection},
+    {"client_secret_file_only_validation",
+     test_client_secret_file_only_validation},
+    {"client_secret_file_precedence", test_client_secret_file_precedence},
+    {"client_secret_file_errors", test_client_secret_file_errors},
     {0}
 };

--- a/tests/internal/oauth2.c
+++ b/tests/internal/oauth2.c
@@ -548,12 +548,6 @@ static struct flb_oauth2 *create_oauth_ctx(struct flb_config *config,
     return create_oauth_ctx_with_user_agent(config, server, refresh_skew, NULL);
 }
 
-/*
- * Create an OAuth2 context using the POST auth method so the client_secret is
- * carried in the token request body (captured by the mock server), which lets
- * the tests assert the exact secret value that was used. Either or both of
- * inline_secret and secret_file may be provided.
- */
 static struct flb_oauth2 *create_oauth_ctx_secret_file(struct flb_config *config,
                                                        struct oauth2_mock_server *server,
                                                        const char *secret_file,
@@ -1309,7 +1303,6 @@ void test_private_key_jwt_x5t_header(void)
     flb_config_exit(config);
 }
 
-/* AC2/AC4: secret read from a file is used, with trailing newlines trimmed. */
 void test_client_secret_from_file(void)
 {
     int ret;
@@ -1355,7 +1348,6 @@ void test_client_secret_from_file(void)
     flb_config_exit(config);
 }
 
-/* AC3: rewriting the file yields the new secret on the next refresh. */
 void test_client_secret_file_change_detection(void)
 {
     int ret;
@@ -1418,7 +1410,6 @@ void test_client_secret_file_change_detection(void)
     flb_config_exit(config);
 }
 
-/* AC5: context creation succeeds with only client_secret_file (no inline secret). */
 void test_client_secret_file_only_validation(void)
 {
     int ret;
@@ -1448,7 +1439,6 @@ void test_client_secret_file_only_validation(void)
     flb_config_exit(config);
 }
 
-/* Confirmed decision: when both are set, client_secret_file wins. */
 void test_client_secret_file_precedence(void)
 {
     int ret;
@@ -1493,7 +1483,6 @@ void test_client_secret_file_precedence(void)
     flb_config_exit(config);
 }
 
-/* AC6: missing or empty (newline-only) file fails cleanly at creation. */
 void test_client_secret_file_errors(void)
 {
     int ret;


### PR DESCRIPTION
# Summary
<!-- Provide summary of changes -->

- Add new `oauth2.client_secret_file` option to HTTP output (available for `basic`/`post` authentication methods)
- Secret is automatically updated if the content changes when requesting a new oauth2 token.
- Added `oauth2.client_secret_file` option to OpenTelemetry output as a quick-win.

## Motivation

In Kubernetes, mounting secrets as files is considered best practice, with widely used for projected tokens and external secret services such as CSI drivers and External Secrets Operator.

Additionally other systems offer similar functionality, for example [OpenTelemetry OAuth2 client auth extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/oauth2clientauthextension/README.md).

## Validation

- `cmake --build build -j8 --target flb-it-oauth2 && ./build/bin/flb-it-oauth2` - 16 passed
- Tested in a local kubernetes cluster with full authentication integration leveraging a token fetching using a mounted service account token as a `client_secret_file`, and calling a Gloo service that validated the resulting token as well.

## Example Configuration

```
[OUTPUT]
        Name                            http
        Alias                           http.authenticated
        Match                           kube.*
        Host                            gateway-proxy.default.svc.cluster.local
        port                            8080
        tls                             off
        tls.verify                      off
        uri                             /v1/metrics
        oauth2.enable                   true
        oauth2.auth_method              post
        oauth2.token_url                http://token-service.auth-token-system.svc.cluster.local/oauth2/default/v1/token
        oauth2.client_id                a_client
        oauth2.client_secret_file       /var/run/secrets/auth/fluent-auth 
        storage.total_limit_size        1G
        format                          json_stream

```

> [!NOTE]
> The size limitation for the secret in `oauth2.auth_method=basic` has not been modified, so when using large secrets the `post` method must be used.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- `N/A` Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- `N/A` Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [X] Documentation required for this feature
- https://github.com/fluent/fluent-bit-docs/pull/2629

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Added `oauth2.client_secret_file` to load OAuth2 client secrets from a file (including OAuth2-enabled outputs).
* **Bug Fixes**
  * Updated OAuth2 credential validation to accept either `client_secret` or `client_secret_file`.
  * Improved handling when the secret file is missing, empty, or unreadable.
  * Client secret is reloaded during token refresh so file updates are picked up.
* **Tests**
  * Added test coverage for file-based auth, precedence, refresh reload behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->