### PR TITLE
in_winlog: bound pack_message args loop to PARAM_MAXNUM

### DIFF
--- a/plugins/in_winlog/pack.c
+++ b/plugins/in_winlog/pack.c
@@ -280,7 +280,7 @@ static int pack_message(msgpack_packer *mp_pck, PEVENTLOGRECORD evt,
         }
 
         tmp = (wchar_t *) ((char *) evt + evt->StringOffset);
-        for (i = 0; i < evt->NumStrings; i++) {
+        for (i = 0; i < evt->NumStrings && i < PARAM_MAXNUM; i++) {
             args[i] = (DWORD_PTR) tmp;
             tmp += wcslen(tmp) + 1;
         }


### PR DESCRIPTION
`args` is `flb_calloc(PARAM_MAXNUM, sizeof(DWORD_PTR))` (127 slots, 1016 bytes on 64-bit), but the loop that fills it is bounded by `evt->NumStrings`:

```c
tmp = (wchar_t *) ((char *) evt + evt->StringOffset);
for (i = 0; i < evt->NumStrings; i++) {
    args[i] = (DWORD_PTR) tmp;   /* i >= 127 writes past the allocation */
    tmp += wcslen(tmp) + 1;
}
```

`evt` is an `EVENTLOGRECORD` read by `ReadEventLogW()` in `winlog_read()`, and `NumStrings` is a `WORD` (0-65535) carried in that record. `pack_message()` runs for every event, so a record whose `NumStrings` is above 127 overruns the heap `args` allocation with insertion-string pointers. The file already documents 127 as the cap (`/* 127 is the max number of function params */`); the loop just never enforced it. Bounding `i` by `PARAM_MAXNUM` keeps the writes inside `args` and still passes every argument `FormatMessageW` can consume. Valid records (up to the documented 127 strings) behave exactly as before.

Issue: N/A

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented potential memory corruption when processing Windows event messages containing more string parameters than supported.
  - Improved stability by safely limiting message formatting to the supported parameter count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->