### PR TITLE
out_logdna: stop duplicating promoted keys in line field

### DIFF
--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -31,6 +31,8 @@
 #define LOGDNA_SEVERITY_KEY "severity"
 #define LOGDNA_FILE_KEY "file"
 #define LOGDNA_APP_KEY "app"
+#define LOGDNA_MESSAGE_KEY "message"
+#define LOGDNA_LOG_KEY "log"
 
 static inline int primary_key_check(msgpack_object k, char *name, int len)
 {
@@ -47,6 +49,44 @@ static inline int primary_key_check(msgpack_object k, char *name, int len)
     }
 
     return FLB_FALSE;
+}
+
+/*
+ * Prefer a dedicated text field for the ingest "line" value.
+ * Look up "message" first, then "log". Only string values are accepted.
+ */
+static msgpack_object *record_find_line_text(msgpack_object *map)
+{
+    int i;
+    msgpack_object k;
+    msgpack_object *message = NULL;
+    msgpack_object *log_val = NULL;
+
+    if (map->type != MSGPACK_OBJECT_MAP) {
+        return NULL;
+    }
+
+    for (i = 0; i < map->via.map.size; i++) {
+        k = map->via.map.ptr[i].key;
+        if (primary_key_check(k, LOGDNA_MESSAGE_KEY,
+                              sizeof(LOGDNA_MESSAGE_KEY) - 1) == FLB_TRUE) {
+            if (map->via.map.ptr[i].val.type == MSGPACK_OBJECT_STR) {
+                message = &map->via.map.ptr[i].val;
+            }
+        }
+        else if (primary_key_check(k, LOGDNA_LOG_KEY,
+                                   sizeof(LOGDNA_LOG_KEY) - 1) == FLB_TRUE) {
+            if (map->via.map.ptr[i].val.type == MSGPACK_OBJECT_STR) {
+                log_val = &map->via.map.ptr[i].val;
+            }
+        }
+    }
+
+    if (message) {
+        return message;
+    }
+
+    return log_val;
 }
 
 /*
@@ -182,10 +222,13 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
     int len;
     int total_lines;
     int array_size = 0;
+    int use_line_text;
+    int build_line_map;
     off_t map_off;
     size_t off;
     char *line_json;
     flb_sds_t json;
+    msgpack_object *line_text;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_line_pck;
@@ -226,13 +269,16 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
         msgpack_pack_map(&mp_pck, array_size);
 
         /*
-         * Append primary keys found, the return value is the number of appended
-         * keys to the record, we use that to adjust the map header size.
-         *
-         * When exclude_promoted_keys is enabled, non-primary keys are packed
-         * into mp_line_sbuf for use as the "line" body.
+         * Prefer a dedicated message/log string as the "line" text.
+         * Otherwise, when exclude_promoted_keys is enabled, serialize only
+         * non-primary keys so promoted fields are not duplicated inside line.
          */
-        if (ctx->exclude_promoted_keys) {
+        line_text = record_find_line_text(log_event.body);
+        use_line_text = (line_text != NULL) ? FLB_TRUE : FLB_FALSE;
+        build_line_map = (use_line_text == FLB_FALSE &&
+                          ctx->exclude_promoted_keys) ? FLB_TRUE : FLB_FALSE;
+
+        if (build_line_map) {
             msgpack_sbuffer_init(&mp_line_sbuf);
             msgpack_packer_init(&mp_line_pck, &mp_line_sbuf,
                                 msgpack_sbuffer_write);
@@ -255,7 +301,14 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
         msgpack_pack_str(&mp_pck, 4);
         msgpack_pack_str_body(&mp_pck, "line", 4);
 
-        if (ctx->exclude_promoted_keys) {
+        if (use_line_text) {
+            /* Plain text of the log line (Mezmo ingest "line" field) */
+            msgpack_pack_str(&mp_pck, line_text->via.str.size);
+            msgpack_pack_str_body(&mp_pck,
+                                  line_text->via.str.ptr,
+                                  line_text->via.str.size);
+        }
+        else if (build_line_map) {
             msgpack_unpacked_init(&mp_line_result);
             off = 0;
             msgpack_unpack_next(&mp_line_result,
@@ -266,16 +319,21 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
 
             msgpack_unpacked_destroy(&mp_line_result);
             msgpack_sbuffer_destroy(&mp_line_sbuf);
+
+            len = strlen(line_json);
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, line_json, len);
+            flb_free(line_json);
         }
         else {
+            /* Legacy: serialize the full record into line */
             line_json = flb_msgpack_to_json_str(1024, log_event.body,
                                                 config->json_escape_unicode);
+            len = strlen(line_json);
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, line_json, len);
+            flb_free(line_json);
         }
-
-        len = strlen(line_json);
-        msgpack_pack_str(&mp_pck, len);
-        msgpack_pack_str_body(&mp_pck, line_json, len);
-        flb_free(line_json);
 
         /* Adjust map header size */
         flb_mp_set_map_header_size(mp_sbuf.data + map_off, array_size);
@@ -663,9 +721,11 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "exclude_promoted_keys", "false",
+     FLB_CONFIG_MAP_BOOL, "exclude_promoted_keys", "true",
      0, FLB_TRUE, offsetof(struct flb_logdna, exclude_promoted_keys),
-     "Exclude promoted keys (meta, level, severity (promoted as level), app, file) from the line body"
+     "Exclude promoted keys (meta, level, severity (promoted as level), app, file) "
+     "from the line body when no message/log text field is used. "
+     "When a string message or log key is present, that value is used as line."
     },
 
     /* EOF */

--- a/plugins/out_logdna/logdna.c
+++ b/plugins/out_logdna/logdna.c
@@ -32,6 +32,8 @@
 #define LOGDNA_FILE_KEY "file"
 #define LOGDNA_APP_KEY "app"
 #define LOGDNA_HOSTNAME_KEY "hostname"
+#define LOGDNA_MESSAGE_KEY "message"
+#define LOGDNA_LOG_KEY "log"
 
 static inline int primary_key_check(msgpack_object k, char *name, int len)
 {
@@ -48,6 +50,44 @@ static inline int primary_key_check(msgpack_object k, char *name, int len)
     }
 
     return FLB_FALSE;
+}
+
+/*
+ * Prefer a dedicated text field for the ingest "line" value.
+ * Look up "message" first, then "log". Only string values are accepted.
+ */
+static msgpack_object *record_find_line_text(msgpack_object *map)
+{
+    int i;
+    msgpack_object k;
+    msgpack_object *message = NULL;
+    msgpack_object *log_val = NULL;
+
+    if (map->type != MSGPACK_OBJECT_MAP) {
+        return NULL;
+    }
+
+    for (i = 0; i < map->via.map.size; i++) {
+        k = map->via.map.ptr[i].key;
+        if (primary_key_check(k, LOGDNA_MESSAGE_KEY,
+                              sizeof(LOGDNA_MESSAGE_KEY) - 1) == FLB_TRUE) {
+            if (map->via.map.ptr[i].val.type == MSGPACK_OBJECT_STR) {
+                message = &map->via.map.ptr[i].val;
+            }
+        }
+        else if (primary_key_check(k, LOGDNA_LOG_KEY,
+                                   sizeof(LOGDNA_LOG_KEY) - 1) == FLB_TRUE) {
+            if (map->via.map.ptr[i].val.type == MSGPACK_OBJECT_STR) {
+                log_val = &map->via.map.ptr[i].val;
+            }
+        }
+    }
+
+    if (message) {
+        return message;
+    }
+
+    return log_val;
 }
 
 /*
@@ -207,10 +247,13 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
     int len;
     int total_lines;
     int array_size = 0;
+    int use_line_text;
+    int build_line_map;
     off_t map_off;
     size_t off;
     char *line_json;
     flb_sds_t json;
+    msgpack_object *line_text;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
     msgpack_packer mp_line_pck;
@@ -251,13 +294,16 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
         msgpack_pack_map(&mp_pck, array_size);
 
         /*
-         * Append primary keys found, the return value is the number of appended
-         * keys to the record, we use that to adjust the map header size.
-         *
-         * When exclude_promoted_keys is enabled, non-primary keys are packed
-         * into mp_line_sbuf for use as the "line" body.
+         * Prefer a dedicated message/log string as the "line" text.
+         * Otherwise, when exclude_promoted_keys is enabled, serialize only
+         * non-primary keys so promoted fields are not duplicated inside line.
          */
-        if (ctx->exclude_promoted_keys) {
+        line_text = record_find_line_text(log_event.body);
+        use_line_text = (line_text != NULL) ? FLB_TRUE : FLB_FALSE;
+        build_line_map = (use_line_text == FLB_FALSE &&
+                          ctx->exclude_promoted_keys) ? FLB_TRUE : FLB_FALSE;
+
+        if (build_line_map) {
             msgpack_sbuffer_init(&mp_line_sbuf);
             msgpack_packer_init(&mp_line_pck, &mp_line_sbuf,
                                 msgpack_sbuffer_write);
@@ -280,7 +326,14 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
         msgpack_pack_str(&mp_pck, 4);
         msgpack_pack_str_body(&mp_pck, "line", 4);
 
-        if (ctx->exclude_promoted_keys) {
+        if (use_line_text) {
+            /* Plain text of the log line (Mezmo ingest "line" field) */
+            msgpack_pack_str(&mp_pck, line_text->via.str.size);
+            msgpack_pack_str_body(&mp_pck,
+                                  line_text->via.str.ptr,
+                                  line_text->via.str.size);
+        }
+        else if (build_line_map) {
             msgpack_unpacked_init(&mp_line_result);
             off = 0;
             msgpack_unpack_next(&mp_line_result,
@@ -291,16 +344,21 @@ static flb_sds_t logdna_compose_payload(struct flb_logdna *ctx,
 
             msgpack_unpacked_destroy(&mp_line_result);
             msgpack_sbuffer_destroy(&mp_line_sbuf);
+
+            len = strlen(line_json);
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, line_json, len);
+            flb_free(line_json);
         }
         else {
+            /* Legacy: serialize the full record into line */
             line_json = flb_msgpack_to_json_str(1024, log_event.body,
                                                 config->json_escape_unicode);
+            len = strlen(line_json);
+            msgpack_pack_str(&mp_pck, len);
+            msgpack_pack_str_body(&mp_pck, line_json, len);
+            flb_free(line_json);
         }
-
-        len = strlen(line_json);
-        msgpack_pack_str(&mp_pck, len);
-        msgpack_pack_str_body(&mp_pck, line_json, len);
-        flb_free(line_json);
 
         /* Adjust map header size */
         flb_mp_set_map_header_size(mp_sbuf.data + map_off, array_size);
@@ -688,9 +746,11 @@ static struct flb_config_map config_map[] = {
     },
 
     {
-     FLB_CONFIG_MAP_BOOL, "exclude_promoted_keys", "false",
+     FLB_CONFIG_MAP_BOOL, "exclude_promoted_keys", "true",
      0, FLB_TRUE, offsetof(struct flb_logdna, exclude_promoted_keys),
-     "Exclude promoted keys (meta, level, severity (promoted as level), app, file) from the line body"
+     "Exclude promoted keys (meta, level, severity (promoted as level), app, file) "
+     "from the line body when no message/log text field is used. "
+     "When a string message or log key is present, that value is used as line."
     },
 
     /* EOF */

--- a/tests/runtime/out_logdna.c
+++ b/tests/runtime/out_logdna.c
@@ -50,7 +50,8 @@ static void clear_output_num()
 
 /*
  * Test: primary keys (meta, level, app) are promoted to top-level fields
- * and excluded from the "line" JSON string (no duplication).
+ * and excluded from the "line" value (no duplication). With a string
+ * "message" field present, line is the plain text message.
  */
 #define JSON_WITH_PRIMARY_KEYS \
     "[12345678, {\"message\":\"hello world\"," \
@@ -75,7 +76,7 @@ static void cb_check_non_duplication(void *ctx, int ffd, int res_ret,
         TEST_MSG("missing top-level app: %s", json);
     }
 
-    /* Primary keys must NOT appear inside the line value (escaped) */
+    /* Primary keys must NOT appear inside the line value (escaped JSON) */
     if (!TEST_CHECK(strstr(json, "\\\"meta\\\":") == NULL)) {
         TEST_MSG("meta duplicated in line: %s", json);
     }
@@ -86,9 +87,12 @@ static void cb_check_non_duplication(void *ctx, int ffd, int res_ret,
         TEST_MSG("app duplicated in line: %s", json);
     }
 
-    /* Non-primary key must be in line value (escaped) */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
+    /* message is used as plain-text line, not re-serialized as JSON */
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello world\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") == NULL)) {
+        TEST_MSG("message should not be JSON-escaped in line: %s", json);
     }
 
     set_output_num(get_output_num() + 1);
@@ -116,7 +120,6 @@ void flb_test_non_duplication()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -141,16 +144,15 @@ void flb_test_non_duplication()
 }
 
 /*
- * Test: all non-primary keys are preserved in the "line" body;
- * all primary keys are promoted. No data is lost.
+ * Test: without message/log, non-primary keys are preserved in the "line"
+ * JSON body; all primary keys are promoted. No data is lost.
  */
 #define JSON_ALL_KEYS \
-    "[12345678, {\"message\":\"hello\"," \
+    "[12345678, {\"host\":\"server1\"," \
     "\"meta\":{\"foo\":\"bar\"}," \
     "\"level\":\"info\"," \
     "\"app\":\"myapp\"," \
     "\"file\":\"test.log\"," \
-    "\"host\":\"server1\"," \
     "\"custom\":\"data\"}]"
 
 static void cb_check_data_completeness(void *ctx, int ffd, int res_ret,
@@ -174,9 +176,6 @@ static void cb_check_data_completeness(void *ctx, int ffd, int res_ret,
     }
 
     /* All non-primary keys in line body (escaped) */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
-    }
     if (!TEST_CHECK(strstr(json, "\\\"host\\\":") != NULL)) {
         TEST_MSG("host missing from line: %s", json);
     }
@@ -217,7 +216,6 @@ void flb_test_data_completeness()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -263,6 +261,11 @@ static void cb_check_severity(void *ctx, int ffd, int res_ret,
         TEST_MSG("severity duplicated in line: %s", json);
     }
 
+    /* message used as plain-text line */
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
+    }
+
     set_output_num(get_output_num() + 1);
     flb_sds_destroy(json);
 }
@@ -288,7 +291,6 @@ void flb_test_severity_promoted_as_level()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -341,12 +343,9 @@ static void cb_check_level_and_severity(void *ctx, int ffd, int res_ret,
         TEST_MSG("severity duplicated in line: %s", json);
     }
 
-    /* Non-primary keys preserved in line */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
-    }
-    if (!TEST_CHECK(strstr(json, "\\\"host\\\":") != NULL)) {
-        TEST_MSG("host missing from line: %s", json);
+    /* message preferred as plain-text line */
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
     }
 
     set_output_num(get_output_num() + 1);
@@ -374,7 +373,6 @@ void flb_test_level_and_severity()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -412,6 +410,10 @@ static void cb_check_default_app(void *ctx, int ffd, int res_ret,
 
     if (!TEST_CHECK(strstr(json, "\"app\":\"Fluent Bit\"") != NULL)) {
         TEST_MSG("default app not set: %s", json);
+    }
+
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
     }
 
     set_output_num(get_output_num() + 1);
@@ -463,11 +465,11 @@ void flb_test_default_app()
 }
 
 /*
- * Test: record with no primary keys — all fields go into line,
- * only default app appears at top level.
+ * Test: record with no primary keys — default app at top level;
+ * remaining fields go into line JSON body.
  */
 #define JSON_NO_PRIMARY_KEYS \
-    "[12345678, {\"message\":\"hello\",\"host\":\"server1\"}]"
+    "[12345678, {\"host\":\"server1\",\"custom\":\"data\"}]"
 
 static void cb_check_no_primary_keys(void *ctx, int ffd, int res_ret,
                                       void *res_data, size_t res_size,
@@ -481,11 +483,11 @@ static void cb_check_no_primary_keys(void *ctx, int ffd, int res_ret,
     }
 
     /* All keys in line body */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
-    }
     if (!TEST_CHECK(strstr(json, "\\\"host\\\":") != NULL)) {
         TEST_MSG("host missing from line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"custom\\\":") != NULL)) {
+        TEST_MSG("custom missing from line: %s", json);
     }
 
     /* No meta or level at top level (they aren't in the record) */
@@ -533,6 +535,149 @@ void flb_test_no_primary_keys()
     flb_lib_push(ctx, in_ffd,
                  (char *) JSON_NO_PRIMARY_KEYS,
                  sizeof(JSON_NO_PRIMARY_KEYS) - 1);
+
+    sleep(2);
+
+    if (!TEST_CHECK(get_output_num() > 0)) {
+        TEST_MSG("formatter callback was not invoked");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Test: "log" key is used as line when "message" is absent.
+ */
+#define JSON_LOG_KEY \
+    "[12345678, {\"log\":\"from log field\"," \
+    "\"meta\":{\"env\":\"dev\"}," \
+    "\"level\":\"info\"}]"
+
+static void cb_check_log_key_as_line(void *ctx, int ffd, int res_ret,
+                                     void *res_data, size_t res_size,
+                                     void *data)
+{
+    flb_sds_t json = res_data;
+
+    if (!TEST_CHECK(strstr(json, "\"line\":\"from log field\"") != NULL)) {
+        TEST_MSG("log key not used as line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\"meta\":") != NULL)) {
+        TEST_MSG("missing top-level meta: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"meta\\\":") == NULL)) {
+        TEST_MSG("meta duplicated in line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"log\\\":") == NULL)) {
+        TEST_MSG("log should not be JSON-escaped in line: %s", json);
+    }
+
+    set_output_num(get_output_num() + 1);
+    flb_sds_destroy(json);
+}
+
+void flb_test_log_key_as_line()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+
+    clear_output_num();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "logdna", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "api_key", "test-key",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_log_key_as_line, NULL, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd,
+                 (char *) JSON_LOG_KEY,
+                 sizeof(JSON_LOG_KEY) - 1);
+
+    sleep(2);
+
+    if (!TEST_CHECK(get_output_num() > 0)) {
+        TEST_MSG("formatter callback was not invoked");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Test: when both message and log are present, message wins.
+ */
+#define JSON_MESSAGE_AND_LOG \
+    "[12345678, {\"message\":\"from message\"," \
+    "\"log\":\"from log\"}]"
+
+static void cb_check_message_preferred(void *ctx, int ffd, int res_ret,
+                                       void *res_data, size_t res_size,
+                                       void *data)
+{
+    flb_sds_t json = res_data;
+
+    if (!TEST_CHECK(strstr(json, "\"line\":\"from message\"") != NULL)) {
+        TEST_MSG("message should be preferred over log: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\"line\":\"from log\"") == NULL)) {
+        TEST_MSG("log should not be used when message is present: %s", json);
+    }
+
+    set_output_num(get_output_num() + 1);
+    flb_sds_destroy(json);
+}
+
+void flb_test_message_preferred_over_log()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+
+    clear_output_num();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "logdna", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "api_key", "test-key",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_message_preferred, NULL, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd,
+                 (char *) JSON_MESSAGE_AND_LOG,
+                 sizeof(JSON_MESSAGE_AND_LOG) - 1);
 
     sleep(2);
 
@@ -612,9 +757,15 @@ void flb_test_payload_structure()
 }
 
 /*
- * Test: backward compatibility — when exclude_promoted_keys is not set
- * (default false), promoted keys ARE present in the line body.
+ * Test: legacy mode — when exclude_promoted_keys is false and there is no
+ * message/log text field, promoted keys ARE present in the line body.
  */
+#define JSON_LEGACY_FULL_RECORD \
+    "[12345678, {\"host\":\"server1\"," \
+    "\"meta\":{\"source\":\"test\"}," \
+    "\"level\":\"info\"," \
+    "\"app\":\"myapp\"}]"
+
 static void cb_check_backward_compat(void *ctx, int ffd, int res_ret,
                                       void *res_data, size_t res_size,
                                       void *data)
@@ -668,6 +819,7 @@ void flb_test_backward_compat()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
+                   "exclude_promoted_keys", "false",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -678,8 +830,8 @@ void flb_test_backward_compat()
     TEST_CHECK(ret == 0);
 
     flb_lib_push(ctx, in_ffd,
-                 (char *) JSON_WITH_PRIMARY_KEYS,
-                 sizeof(JSON_WITH_PRIMARY_KEYS) - 1);
+                 (char *) JSON_LEGACY_FULL_RECORD,
+                 sizeof(JSON_LEGACY_FULL_RECORD) - 1);
 
     sleep(2);
 
@@ -749,6 +901,8 @@ TEST_LIST = {
     {"level_and_severity",         flb_test_level_and_severity},
     {"default_app",                flb_test_default_app},
     {"no_primary_keys",            flb_test_no_primary_keys},
+    {"log_key_as_line",            flb_test_log_key_as_line},
+    {"message_preferred_over_log", flb_test_message_preferred_over_log},
     {"payload_structure",          flb_test_payload_structure},
     {"backward_compat",            flb_test_backward_compat},
     {"lifecycle",                  flb_test_lifecycle},

--- a/tests/runtime/out_logdna.c
+++ b/tests/runtime/out_logdna.c
@@ -50,7 +50,8 @@ static void clear_output_num()
 
 /*
  * Test: primary keys (meta, level, app) are promoted to top-level fields
- * and excluded from the "line" JSON string (no duplication).
+ * and excluded from the "line" value (no duplication). With a string
+ * "message" field present, line is the plain text message.
  */
 #define JSON_WITH_PRIMARY_KEYS \
     "[12345678, {\"message\":\"hello world\"," \
@@ -75,7 +76,7 @@ static void cb_check_non_duplication(void *ctx, int ffd, int res_ret,
         TEST_MSG("missing top-level app: %s", json);
     }
 
-    /* Primary keys must NOT appear inside the line value (escaped) */
+    /* Primary keys must NOT appear inside the line value (escaped JSON) */
     if (!TEST_CHECK(strstr(json, "\\\"meta\\\":") == NULL)) {
         TEST_MSG("meta duplicated in line: %s", json);
     }
@@ -86,9 +87,12 @@ static void cb_check_non_duplication(void *ctx, int ffd, int res_ret,
         TEST_MSG("app duplicated in line: %s", json);
     }
 
-    /* Non-primary key must be in line value (escaped) */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
+    /* message is used as plain-text line, not re-serialized as JSON */
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello world\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") == NULL)) {
+        TEST_MSG("message should not be JSON-escaped in line: %s", json);
     }
 
     set_output_num(get_output_num() + 1);
@@ -116,7 +120,6 @@ void flb_test_non_duplication()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -141,16 +144,15 @@ void flb_test_non_duplication()
 }
 
 /*
- * Test: all non-primary keys are preserved in the "line" body;
- * all primary keys are promoted. No data is lost.
+ * Test: without message/log, non-primary keys are preserved in the "line"
+ * JSON body; all primary keys are promoted. No data is lost.
  */
 #define JSON_ALL_KEYS \
-    "[12345678, {\"message\":\"hello\"," \
+    "[12345678, {\"host\":\"server1\"," \
     "\"meta\":{\"foo\":\"bar\"}," \
     "\"level\":\"info\"," \
     "\"app\":\"myapp\"," \
     "\"file\":\"test.log\"," \
-    "\"host\":\"server1\"," \
     "\"custom\":\"data\"}]"
 
 static void cb_check_data_completeness(void *ctx, int ffd, int res_ret,
@@ -174,9 +176,6 @@ static void cb_check_data_completeness(void *ctx, int ffd, int res_ret,
     }
 
     /* All non-primary keys in line body (escaped) */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
-    }
     if (!TEST_CHECK(strstr(json, "\\\"host\\\":") != NULL)) {
         TEST_MSG("host missing from line: %s", json);
     }
@@ -217,7 +216,6 @@ void flb_test_data_completeness()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -263,6 +261,11 @@ static void cb_check_severity(void *ctx, int ffd, int res_ret,
         TEST_MSG("severity duplicated in line: %s", json);
     }
 
+    /* message used as plain-text line */
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
+    }
+
     set_output_num(get_output_num() + 1);
     flb_sds_destroy(json);
 }
@@ -288,7 +291,6 @@ void flb_test_severity_promoted_as_level()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -341,12 +343,9 @@ static void cb_check_level_and_severity(void *ctx, int ffd, int res_ret,
         TEST_MSG("severity duplicated in line: %s", json);
     }
 
-    /* Non-primary keys preserved in line */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
-    }
-    if (!TEST_CHECK(strstr(json, "\\\"host\\\":") != NULL)) {
-        TEST_MSG("host missing from line: %s", json);
+    /* message preferred as plain-text line */
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
     }
 
     set_output_num(get_output_num() + 1);
@@ -374,7 +373,6 @@ void flb_test_level_and_severity()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
-                   "exclude_promoted_keys", "true",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -412,6 +410,10 @@ static void cb_check_default_app(void *ctx, int ffd, int res_ret,
 
     if (!TEST_CHECK(strstr(json, "\"app\":\"Fluent Bit\"") != NULL)) {
         TEST_MSG("default app not set: %s", json);
+    }
+
+    if (!TEST_CHECK(strstr(json, "\"line\":\"hello\"") != NULL)) {
+        TEST_MSG("message not used as line: %s", json);
     }
 
     set_output_num(get_output_num() + 1);
@@ -463,11 +465,11 @@ void flb_test_default_app()
 }
 
 /*
- * Test: record with no primary keys — all fields go into line,
- * only default app appears at top level.
+ * Test: record with no primary keys — default app at top level;
+ * remaining fields go into line JSON body.
  */
 #define JSON_NO_PRIMARY_KEYS \
-    "[12345678, {\"message\":\"hello\",\"host\":\"server1\"}]"
+    "[12345678, {\"host\":\"server1\",\"custom\":\"data\"}]"
 
 static void cb_check_no_primary_keys(void *ctx, int ffd, int res_ret,
                                       void *res_data, size_t res_size,
@@ -481,11 +483,11 @@ static void cb_check_no_primary_keys(void *ctx, int ffd, int res_ret,
     }
 
     /* All keys in line body */
-    if (!TEST_CHECK(strstr(json, "\\\"message\\\":") != NULL)) {
-        TEST_MSG("message missing from line: %s", json);
-    }
     if (!TEST_CHECK(strstr(json, "\\\"host\\\":") != NULL)) {
         TEST_MSG("host missing from line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"custom\\\":") != NULL)) {
+        TEST_MSG("custom missing from line: %s", json);
     }
 
     /* No meta or level at top level (they aren't in the record) */
@@ -533,6 +535,149 @@ void flb_test_no_primary_keys()
     flb_lib_push(ctx, in_ffd,
                  (char *) JSON_NO_PRIMARY_KEYS,
                  sizeof(JSON_NO_PRIMARY_KEYS) - 1);
+
+    sleep(2);
+
+    if (!TEST_CHECK(get_output_num() > 0)) {
+        TEST_MSG("formatter callback was not invoked");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Test: "log" key is used as line when "message" is absent.
+ */
+#define JSON_LOG_KEY \
+    "[12345678, {\"log\":\"from log field\"," \
+    "\"meta\":{\"env\":\"dev\"}," \
+    "\"level\":\"info\"}]"
+
+static void cb_check_log_key_as_line(void *ctx, int ffd, int res_ret,
+                                     void *res_data, size_t res_size,
+                                     void *data)
+{
+    flb_sds_t json = res_data;
+
+    if (!TEST_CHECK(strstr(json, "\"line\":\"from log field\"") != NULL)) {
+        TEST_MSG("log key not used as line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\"meta\":") != NULL)) {
+        TEST_MSG("missing top-level meta: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"meta\\\":") == NULL)) {
+        TEST_MSG("meta duplicated in line: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\\\"log\\\":") == NULL)) {
+        TEST_MSG("log should not be JSON-escaped in line: %s", json);
+    }
+
+    set_output_num(get_output_num() + 1);
+    flb_sds_destroy(json);
+}
+
+void flb_test_log_key_as_line()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+
+    clear_output_num();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "logdna", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "api_key", "test-key",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_log_key_as_line, NULL, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd,
+                 (char *) JSON_LOG_KEY,
+                 sizeof(JSON_LOG_KEY) - 1);
+
+    sleep(2);
+
+    if (!TEST_CHECK(get_output_num() > 0)) {
+        TEST_MSG("formatter callback was not invoked");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Test: when both message and log are present, message wins.
+ */
+#define JSON_MESSAGE_AND_LOG \
+    "[12345678, {\"message\":\"from message\"," \
+    "\"log\":\"from log\"}]"
+
+static void cb_check_message_preferred(void *ctx, int ffd, int res_ret,
+                                       void *res_data, size_t res_size,
+                                       void *data)
+{
+    flb_sds_t json = res_data;
+
+    if (!TEST_CHECK(strstr(json, "\"line\":\"from message\"") != NULL)) {
+        TEST_MSG("message should be preferred over log: %s", json);
+    }
+    if (!TEST_CHECK(strstr(json, "\"line\":\"from log\"") == NULL)) {
+        TEST_MSG("log should not be used when message is present: %s", json);
+    }
+
+    set_output_num(get_output_num() + 1);
+    flb_sds_destroy(json);
+}
+
+void flb_test_message_preferred_over_log()
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd, out_ffd;
+
+    clear_output_num();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "logdna", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "api_key", "test-key",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_message_preferred, NULL, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd,
+                 (char *) JSON_MESSAGE_AND_LOG,
+                 sizeof(JSON_MESSAGE_AND_LOG) - 1);
 
     sleep(2);
 
@@ -612,9 +757,15 @@ void flb_test_payload_structure()
 }
 
 /*
- * Test: backward compatibility — when exclude_promoted_keys is not set
- * (default false), promoted keys ARE present in the line body.
+ * Test: legacy mode — when exclude_promoted_keys is false and there is no
+ * message/log text field, promoted keys ARE present in the line body.
  */
+#define JSON_LEGACY_FULL_RECORD \
+    "[12345678, {\"host\":\"server1\"," \
+    "\"meta\":{\"source\":\"test\"}," \
+    "\"level\":\"info\"," \
+    "\"app\":\"myapp\"}]"
+
 static void cb_check_backward_compat(void *ctx, int ffd, int res_ret,
                                       void *res_data, size_t res_size,
                                       void *data)
@@ -668,6 +819,7 @@ void flb_test_backward_compat()
     flb_output_set(ctx, out_ffd,
                    "match", "test",
                    "api_key", "test-key",
+                   "exclude_promoted_keys", "false",
                    NULL);
 
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
@@ -678,8 +830,8 @@ void flb_test_backward_compat()
     TEST_CHECK(ret == 0);
 
     flb_lib_push(ctx, in_ffd,
-                 (char *) JSON_WITH_PRIMARY_KEYS,
-                 sizeof(JSON_WITH_PRIMARY_KEYS) - 1);
+                 (char *) JSON_LEGACY_FULL_RECORD,
+                 sizeof(JSON_LEGACY_FULL_RECORD) - 1);
 
     sleep(2);
 
@@ -948,6 +1100,8 @@ TEST_LIST = {
     {"level_and_severity",         flb_test_level_and_severity},
     {"default_app",                flb_test_default_app},
     {"no_primary_keys",            flb_test_no_primary_keys},
+    {"log_key_as_line",            flb_test_log_key_as_line},
+    {"message_preferred_over_log", flb_test_message_preferred_over_log},
     {"payload_structure",          flb_test_payload_structure},
     {"backward_compat",            flb_test_backward_compat},
     {"record_hostname_field",      flb_test_record_hostname_field},


### PR DESCRIPTION
## Summary

Fixes #11754.

The `out_logdna` plugin promotes primary keys (`meta`, `level`/`severity`, `app`, `file`) to top-level Mezmo ingest fields, but previously still serialized the full record into `line`. That produced duplicates (e.g. top-level `meta` plus `_meta` from the JSON inside `line`).

This change:

1. **Prefers `message`, then `log`, as the plain-text `line` value** when present as a string (matches Mezmo's "Text of the log line" semantics).
2. **Defaults `exclude_promoted_keys` to `true`**, so when there is no `message`/`log` text field the remaining non-primary keys are serialized into `line` without re-including promoted keys.
3. Keeps legacy full-record-in-`line` behavior available with `exclude_promoted_keys false` (when no string `message`/`log` is used).

### Example payload (with message + meta)

Before (duplication):
```json
{
  "lines": [{
    "meta": {"source": "test"},
    "level": "info",
    "app": "myapp",
    "timestamp": 12345678,
    "line": "{\"message\":\"hello world\",\"meta\":{\"source\":\"test\"},\"level\":\"info\",\"app\":\"myapp\"}"
  }]
}
```

After:
```json
{
  "lines": [{
    "meta": {"source": "test"},
    "level": "info",
    "app": "myapp",
    "timestamp": 12345678,
    "line": "hello world"
  }]
}
```

## Testing

Environment did not have `cmake` available, so full compile/runtime tests were not run here. Runtime coverage is in `tests/runtime/out_logdna.c`.

### Manual verification

```bash
# build with runtime tests
cmake -DFLB_TESTS_RUNTIME=On -DFLB_OUT_LOGDNA=On ..
make -j"$(nproc)" flb-rt-out_logdna
./bin/flb-rt-out_logdna
```

Expected: all tests pass, including:
- `non_duplication` — primary keys not re-serialized into `line`; `message` used as plain text
- `log_key_as_line` / `message_preferred_over_log` — `message` then `log` preference
- `data_completeness` — without message/log, non-primary keys remain in `line` JSON; promoted keys excluded
- `backward_compat` — `exclude_promoted_keys false` still serializes full record when no message/log text field

### Optional end-to-end config

```yaml
service:
  flush: 1
  log_level: info

pipeline:
  inputs:
    - name: dummy
      tag: test
      dummy: '{"message":"hello","meta":{"env":"prod"},"level":"info","app":"myapp"}'

  outputs:
    - name: logdna
      match: test
      api_key: YOUR_API_KEY
      hostname: test-host
      # exclude_promoted_keys defaults to true
```

Capture the HTTP body (or use a local HTTP sink) and confirm `line` is `"hello"` and `meta`/`level`/`app` appear only at the top level of each lines[] entry.

## Documentation

- Existing `exclude_promoted_keys` docs should note the new default (`true`) and that a string `message`/`log` field is preferred for `line`.

Fluent Bit is licensed under Apache 2.0; by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LogDNA output now uses the `message` field as plain-text line content when available.
  * Falls back to the `log` field when `message` is absent.
  * Promoted fields are excluded from line content by default to prevent duplication.
  * Legacy full-record line formatting remains available through configuration.

* **Bug Fixes**
  * Improved output formatting and field handling, including records with both `message` and `log` fields.
  * Records without either field now retain relevant non-promoted fields in the line content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->