### PR TITLE
in_node_exporter_metrics: Add a capability to adjust log level w/ error paths [Backport to 5.0]

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_cpu_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_cpu_linux.c
@@ -130,10 +130,12 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
         }
 
         /* Package Metric: node_cpu_core_throttles_total */
-        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
-                                        entry->str,
-                                        "thermal_throttle", "core_throttle_count",
-                                        &core_throttle_count);
+        ret = ne_utils_file_read_uint64_at_level(ctx, ctx->path_sysfs,
+                                                 entry->str,
+                                                 "thermal_throttle",
+                                                 "core_throttle_count",
+                                                 &core_throttle_count,
+                                                 FLB_LOG_DEBUG);
         if (ret != 0) {
             flb_plg_debug(ctx->ins,
                           "CPU is missing core_throttle_count: %s",
@@ -150,10 +152,12 @@ static int cpu_thermal_update(struct flb_ne *ctx, uint64_t ts)
         }
 
         /* Package Metric: node_cpu_package_throttles_total */
-        ret = ne_utils_file_read_uint64(ctx, ctx->path_sysfs,
-                                        entry->str,
-                                        "thermal_throttle", "package_throttle_count",
-                                        &package_throttle_count);
+        ret = ne_utils_file_read_uint64_at_level(ctx, ctx->path_sysfs,
+                                                 entry->str,
+                                                 "thermal_throttle",
+                                                 "package_throttle_count",
+                                                 &package_throttle_count,
+                                                 FLB_LOG_DEBUG);
         if (ret != 0) {
             flb_plg_debug(ctx->ins,
                           "CPU is missing package_throttle_count: %s",

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -20,7 +20,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_sds.h>
-#include "ne.h"
+#include "ne_utils.h"
 
 /* required by stat(2), open(2) */
 #include <sys/types.h>
@@ -29,6 +29,34 @@
 #include <fcntl.h>
 
 #include <glob.h>
+
+static void ne_utils_file_log(struct flb_ne *ctx, int log_level,
+                              const char *operation, const char *path)
+{
+    if (!ctx) {
+        flb_errno();
+        return;
+    }
+
+    switch (log_level) {
+    case FLB_LOG_TRACE:
+        flb_plg_trace(ctx->ins, "could not %s '%s'", operation, path);
+        break;
+    case FLB_LOG_DEBUG:
+        flb_plg_debug(ctx->ins, "could not %s '%s'", operation, path);
+        break;
+    case FLB_LOG_INFO:
+        flb_plg_info(ctx->ins, "could not %s '%s'", operation, path);
+        break;
+    case FLB_LOG_WARN:
+        flb_plg_warn(ctx->ins, "could not %s '%s'", operation, path);
+        break;
+    case FLB_LOG_ERROR:
+    default:
+        flb_plg_error(ctx->ins, "could not %s '%s'", operation, path);
+        break;
+    }
+}
 
 int ne_utils_str_to_double(char *str, double *out_val)
 {
@@ -70,6 +98,18 @@ int ne_utils_file_read_uint64(struct flb_ne *ctx,
                               const char *path,
                               const char *join_a, const char *join_b,
                               uint64_t *out_val)
+{
+    return ne_utils_file_read_uint64_at_level(ctx, mount, path, join_a, join_b,
+                                             out_val, FLB_LOG_ERROR);
+}
+
+int ne_utils_file_read_uint64_at_level(struct flb_ne *ctx,
+                                       const char *mount,
+                                       const char *path,
+                                       const char *join_a,
+                                       const char *join_b,
+                                       uint64_t *out_val,
+                                       int log_level)
 {
     int fd;
     int len;
@@ -123,24 +163,14 @@ int ne_utils_file_read_uint64(struct flb_ne *ctx,
 
     fd = open(p, O_RDONLY);
     if (fd == -1) {
-        if (ctx) {
-            flb_plg_error(ctx->ins, "could not open '%s'", p);
-        }
-        else {
-            flb_errno();
-        }
+        ne_utils_file_log(ctx, log_level, "open", p);
         flb_sds_destroy(p);
         return -1;
     }
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
-        if (ctx) {
-            flb_plg_error(ctx->ins, "could not read from '%s'", p);
-        }
-        else {
-            flb_errno();
-        }
+        ne_utils_file_log(ctx, log_level, "read from", p);
         close(fd);
         flb_sds_destroy(p);
         return -1;
@@ -221,6 +251,18 @@ int ne_utils_file_read_sds(struct flb_ne *ctx,
                            const char *join_b,
                            flb_sds_t *str)
 {
+    return ne_utils_file_read_sds_at_level(ctx, mount, path, join_a, join_b,
+                                          str, FLB_LOG_ERROR);
+}
+
+int ne_utils_file_read_sds_at_level(struct flb_ne *ctx,
+                                    const char *mount,
+                                    const char *path,
+                                    const char *join_a,
+                                    const char *join_b,
+                                    flb_sds_t *str,
+                                    int log_level)
+{
     int fd;
     int len;
     int i;
@@ -269,24 +311,14 @@ int ne_utils_file_read_sds(struct flb_ne *ctx,
 
     fd = open(p, O_RDONLY);
     if (fd == -1) {
-        if (ctx) {
-            flb_plg_error(ctx->ins, "could not open '%s'", p);
-        }
-        else {
-            flb_errno();
-        }
+        ne_utils_file_log(ctx, log_level, "open", p);
         flb_sds_destroy(p);
         return -1;
     }
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
-        if (ctx) {
-            flb_plg_error(ctx->ins, "could not read from '%s'", p);
-        }
-        else {
-            flb_errno();
-        }
+        ne_utils_file_log(ctx, log_level, "read from", p);
         close(fd);
         flb_sds_destroy(p);
         return -1;

--- a/plugins/in_node_exporter_metrics/ne_utils.c
+++ b/plugins/in_node_exporter_metrics/ne_utils.c
@@ -30,12 +30,17 @@
 
 #include <glob.h>
 
-static void ne_utils_file_log(struct flb_ne *ctx, int log_level,
+static void ne_utils_file_log(struct flb_ne *ctx, int log_level, int err_num,
                               const char *operation, const char *path)
 {
     if (!ctx) {
+        errno = err_num;
         flb_errno();
         return;
+    }
+
+    if (err_num != ENOENT) {
+        log_level = FLB_LOG_ERROR;
     }
 
     switch (log_level) {
@@ -163,14 +168,14 @@ int ne_utils_file_read_uint64_at_level(struct flb_ne *ctx,
 
     fd = open(p, O_RDONLY);
     if (fd == -1) {
-        ne_utils_file_log(ctx, log_level, "open", p);
+        ne_utils_file_log(ctx, log_level, errno, "open", p);
         flb_sds_destroy(p);
         return -1;
     }
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
-        ne_utils_file_log(ctx, log_level, "read from", p);
+        ne_utils_file_log(ctx, log_level, errno, "read from", p);
         close(fd);
         flb_sds_destroy(p);
         return -1;
@@ -311,14 +316,14 @@ int ne_utils_file_read_sds_at_level(struct flb_ne *ctx,
 
     fd = open(p, O_RDONLY);
     if (fd == -1) {
-        ne_utils_file_log(ctx, log_level, "open", p);
+        ne_utils_file_log(ctx, log_level, errno, "open", p);
         flb_sds_destroy(p);
         return -1;
     }
 
     bytes = read(fd, &tmp, sizeof(tmp));
     if (bytes == -1) {
-        ne_utils_file_log(ctx, log_level, "read from", p);
+        ne_utils_file_log(ctx, log_level, errno, "read from", p);
         close(fd);
         flb_sds_destroy(p);
         return -1;

--- a/plugins/in_node_exporter_metrics/ne_utils.h
+++ b/plugins/in_node_exporter_metrics/ne_utils.h
@@ -34,12 +34,28 @@ int ne_utils_file_read_uint64(struct flb_ne *ctx,
                               const char *join_a, const char *join_b,
                               uint64_t *out_val);
 
+int ne_utils_file_read_uint64_at_level(struct flb_ne *ctx,
+                                       const char *mount,
+                                       const char *path,
+                                       const char *join_a,
+                                       const char *join_b,
+                                       uint64_t *out_val,
+                                       int log_level);
+
 int ne_utils_file_read_sds(struct flb_ne *ctx,
                            const char *mount,
                            const char *path,
                            const char *join_a,
                            const char *join_b,
                            flb_sds_t *str);
+
+int ne_utils_file_read_sds_at_level(struct flb_ne *ctx,
+                                    const char *mount,
+                                    const char *path,
+                                    const char *join_a,
+                                    const char *join_b,
+                                    flb_sds_t *str,
+                                    int log_level);
 
 int ne_utils_file_read_lines(struct flb_ne *ctx,
                              const char *mount,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/12057.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
