### PR TITLE
mp: avoid unbounded recursion in chunk cobj record iteration

### DIFF
--- a/src/flb_mp.c
+++ b/src/flb_mp.c
@@ -1688,182 +1688,200 @@ int flb_mp_chunk_cobj_record_next(struct flb_mp_chunk_cobj *chunk_cobj,
     struct flb_condition *condition = NULL;
 
     *out_record = NULL;
-    bytes = chunk_cobj->log_decoder->length - chunk_cobj->log_decoder->offset;
 
     /* Check if we have a condition */
     condition = chunk_cobj->condition;
 
     /*
-     * if there are remaining decoder bytes, keep iterating msgpack and populate
-     * the cobj list. Otherwise it means all the content is ready as a chunk_cobj_record.
+     * Iterate until a record that matches the condition (if one is configured)
+     * is found, or until the end of the chunk is reached.
+     *
+     * This was previously implemented with tail recursion: whenever a record
+     * did not match the condition, the function called itself to advance to the
+     * next record. With a large run of non-matching records (for example a
+     * condition that filters out most of a chunk) the recursion depth grew
+     * proportionally to the number of records and could exhaust the stack. An
+     * explicit loop keeps the stack usage constant.
      */
-    if (bytes > 0) {
-        record = flb_mp_chunk_record_create(chunk_cobj);
-        if (!record) {
-            return FLB_MP_CHUNK_RECORD_ERROR;
-        }
+    while (1) {
+        /*
+         * if there are remaining decoder bytes, keep iterating msgpack and
+         * populate the cobj list. Otherwise it means all the content is ready
+         * as a chunk_cobj_record.
+         */
+        bytes = chunk_cobj->log_decoder->length - chunk_cobj->log_decoder->offset;
 
-        ret = flb_log_event_decoder_next(chunk_cobj->log_decoder, &record->event);
-        if (ret != FLB_EVENT_DECODER_SUCCESS) {
-            flb_free(record);
-            return -1;
-        }
-
-        record->cobj_metadata = flb_mp_object_to_cfl(record->event.metadata);
-        if (!record->cobj_metadata) {
-            flb_free(record);
-            return FLB_MP_CHUNK_RECORD_ERROR;
-        }
-
-        record->cobj_record = flb_mp_object_to_cfl(record->event.body);
-        if (!record->cobj_record) {
-            cfl_object_destroy(record->cobj_metadata);
-            flb_free(record);
-            return -1;
-        }
-
-        ret = flb_log_event_decoder_get_record_type(&record->event, &record_type);
-        if (ret != FLB_EVENT_DECODER_SUCCESS) {
-            cfl_object_destroy(record->cobj_record);
-            cfl_object_destroy(record->cobj_metadata);
-            flb_free(record);
-            return FLB_MP_CHUNK_RECORD_ERROR;
-        }
-
-        record->owns_group_metadata = FLB_FALSE;
-        record->owns_group_attributes = FLB_FALSE;
-
-        if (record_type == FLB_LOG_EVENT_GROUP_START) {
-            if (record->cobj_metadata) {
-                record->cobj_group_metadata = record->cobj_metadata;
-                record->owns_group_metadata = FLB_TRUE;
-            }
-            if (record->cobj_record) {
-                record->cobj_group_attributes = record->cobj_record;
-                record->owns_group_attributes = FLB_TRUE;
+        if (bytes > 0) {
+            record = flb_mp_chunk_record_create(chunk_cobj);
+            if (!record) {
+                return FLB_MP_CHUNK_RECORD_ERROR;
             }
 
-            chunk_cobj->active_group_metadata = record->cobj_group_metadata;
-            chunk_cobj->active_group_attributes = record->cobj_group_attributes;
-        }
-        else if (record_type == FLB_LOG_EVENT_GROUP_END) {
-            record->cobj_group_metadata = chunk_cobj->active_group_metadata;
-            record->cobj_group_attributes = chunk_cobj->active_group_attributes;
+            ret = flb_log_event_decoder_next(chunk_cobj->log_decoder, &record->event);
+            if (ret != FLB_EVENT_DECODER_SUCCESS) {
+                flb_free(record);
+                return -1;
+            }
 
-            chunk_cobj->active_group_metadata = NULL;
-            chunk_cobj->active_group_attributes = NULL;
-        }
-        else {
-            record->cobj_group_metadata = chunk_cobj->active_group_metadata;
-            record->cobj_group_attributes = chunk_cobj->active_group_attributes;
-        }
+            record->cobj_metadata = flb_mp_object_to_cfl(record->event.metadata);
+            if (!record->cobj_metadata) {
+                flb_free(record);
+                return FLB_MP_CHUNK_RECORD_ERROR;
+            }
 
-        if (!record->cobj_group_metadata &&
-            record->event.group_metadata &&
-            (record->event.group_metadata->type == MSGPACK_OBJECT_MAP ||
-             record->event.group_metadata->type == MSGPACK_OBJECT_ARRAY)) {
-            record->cobj_group_metadata = flb_mp_object_to_cfl(record->event.group_metadata);
-            if (!record->cobj_group_metadata) {
-                if (record->owns_group_attributes && record->cobj_group_attributes) {
-                    cfl_object_destroy(record->cobj_group_attributes);
-                }
+            record->cobj_record = flb_mp_object_to_cfl(record->event.body);
+            if (!record->cobj_record) {
+                cfl_object_destroy(record->cobj_metadata);
+                flb_free(record);
+                return -1;
+            }
+
+            ret = flb_log_event_decoder_get_record_type(&record->event, &record_type);
+            if (ret != FLB_EVENT_DECODER_SUCCESS) {
                 cfl_object_destroy(record->cobj_record);
                 cfl_object_destroy(record->cobj_metadata);
                 flb_free(record);
                 return FLB_MP_CHUNK_RECORD_ERROR;
             }
-            record->owns_group_metadata = FLB_TRUE;
-            if (!chunk_cobj->active_group_metadata) {
+
+            record->owns_group_metadata = FLB_FALSE;
+            record->owns_group_attributes = FLB_FALSE;
+
+            if (record_type == FLB_LOG_EVENT_GROUP_START) {
+                if (record->cobj_metadata) {
+                    record->cobj_group_metadata = record->cobj_metadata;
+                    record->owns_group_metadata = FLB_TRUE;
+                }
+                if (record->cobj_record) {
+                    record->cobj_group_attributes = record->cobj_record;
+                    record->owns_group_attributes = FLB_TRUE;
+                }
+
                 chunk_cobj->active_group_metadata = record->cobj_group_metadata;
-            }
-        }
-
-        if (!record->cobj_group_attributes &&
-            record->event.group_attributes &&
-            (record->event.group_attributes->type == MSGPACK_OBJECT_MAP ||
-             record->event.group_attributes->type == MSGPACK_OBJECT_ARRAY)) {
-            record->cobj_group_attributes = flb_mp_object_to_cfl(record->event.group_attributes);
-            if (!record->cobj_group_attributes) {
-                if (record->owns_group_metadata && record->cobj_group_metadata) {
-                    cfl_object_destroy(record->cobj_group_metadata);
-                }
-                cfl_object_destroy(record->cobj_record);
-                cfl_object_destroy(record->cobj_metadata);
-                flb_free(record);
-                return FLB_MP_CHUNK_RECORD_ERROR;
-            }
-            record->owns_group_attributes = FLB_TRUE;
-            if (!chunk_cobj->active_group_attributes) {
                 chunk_cobj->active_group_attributes = record->cobj_group_attributes;
             }
-        }
+            else if (record_type == FLB_LOG_EVENT_GROUP_END) {
+                record->cobj_group_metadata = chunk_cobj->active_group_metadata;
+                record->cobj_group_attributes = chunk_cobj->active_group_attributes;
 
-        cfl_list_add(&record->_head, &chunk_cobj->records);
-
-        /* If there's a condition, check if the record matches */
-        if (condition != NULL && record != NULL) {
-            flb_trace("[mp] evaluating condition for record");
-            ret = flb_condition_evaluate(condition, record);
-            flb_trace("[mp] condition evaluation result: %s", ret ? "TRUE" : "FALSE");
-            if (ret == FLB_FALSE) {
-                flb_trace("[mp] record didn't match condition, skipping");
-                /* Record doesn't match the condition, continue to next record */
-                return flb_mp_chunk_cobj_record_next(chunk_cobj, out_record);
+                chunk_cobj->active_group_metadata = NULL;
+                chunk_cobj->active_group_attributes = NULL;
             }
-            flb_trace("[mp] record matched condition, processing");
-        }
-
-        ret = FLB_MP_CHUNK_RECORD_OK;
-    }
-    else if (chunk_cobj->record_pos != NULL) {
-        /* is the actual record the last one ? */
-        if (chunk_cobj->record_pos == cfl_list_entry_last(&chunk_cobj->records, struct flb_mp_chunk_record, _head)) {
-            chunk_cobj->record_pos = NULL;
-            return FLB_MP_CHUNK_RECORD_EOF;
-        }
-
-        record = cfl_list_entry_next(&chunk_cobj->record_pos->_head, struct flb_mp_chunk_record,
-                                    _head, &chunk_cobj->records);
-
-        /* If there's a condition, check if the record matches */
-        if (condition != NULL && record != NULL) {
-            flb_trace("[mp] evaluating condition for next record");
-            ret = flb_condition_evaluate(condition, record);
-            flb_trace("[mp] next record condition evaluation result: %s", ret ? "TRUE" : "FALSE");
-            if (ret == FLB_FALSE) {
-                flb_trace("[mp] next record didn't match condition, skipping");
-                /* Record doesn't match the condition, set as current and try again */
-                chunk_cobj->record_pos = record;
-                return flb_mp_chunk_cobj_record_next(chunk_cobj, out_record);
+            else {
+                record->cobj_group_metadata = chunk_cobj->active_group_metadata;
+                record->cobj_group_attributes = chunk_cobj->active_group_attributes;
             }
-            flb_trace("[mp] next record matched condition, processing");
-        }
 
-        ret = FLB_MP_CHUNK_RECORD_OK;
-    }
-    else {
-        if (cfl_list_size(&chunk_cobj->records) == 0) {
-            return FLB_MP_CHUNK_RECORD_EOF;
-        }
-
-        /* check if we are the last in the list */
-        record = cfl_list_entry_first(&chunk_cobj->records, struct flb_mp_chunk_record, _head);
-
-        /* If there's a condition, check if the record matches */
-        if (condition != NULL && record != NULL) {
-            flb_trace("[mp] evaluating condition for first record");
-            ret = flb_condition_evaluate(condition, record);
-            flb_trace("[mp] first record condition evaluation result: %s", ret ? "TRUE" : "FALSE");
-            if (ret == FLB_FALSE) {
-                flb_trace("[mp] first record didn't match condition, skipping");
-                /* Record doesn't match the condition, set as current and try again */
-                chunk_cobj->record_pos = record;
-                return flb_mp_chunk_cobj_record_next(chunk_cobj, out_record);
+            if (!record->cobj_group_metadata &&
+                record->event.group_metadata &&
+                (record->event.group_metadata->type == MSGPACK_OBJECT_MAP ||
+                 record->event.group_metadata->type == MSGPACK_OBJECT_ARRAY)) {
+                record->cobj_group_metadata = flb_mp_object_to_cfl(record->event.group_metadata);
+                if (!record->cobj_group_metadata) {
+                    if (record->owns_group_attributes && record->cobj_group_attributes) {
+                        cfl_object_destroy(record->cobj_group_attributes);
+                    }
+                    cfl_object_destroy(record->cobj_record);
+                    cfl_object_destroy(record->cobj_metadata);
+                    flb_free(record);
+                    return FLB_MP_CHUNK_RECORD_ERROR;
+                }
+                record->owns_group_metadata = FLB_TRUE;
+                if (!chunk_cobj->active_group_metadata) {
+                    chunk_cobj->active_group_metadata = record->cobj_group_metadata;
+                }
             }
-            flb_trace("[mp] first record matched condition, processing");
+
+            if (!record->cobj_group_attributes &&
+                record->event.group_attributes &&
+                (record->event.group_attributes->type == MSGPACK_OBJECT_MAP ||
+                 record->event.group_attributes->type == MSGPACK_OBJECT_ARRAY)) {
+                record->cobj_group_attributes = flb_mp_object_to_cfl(record->event.group_attributes);
+                if (!record->cobj_group_attributes) {
+                    if (record->owns_group_metadata && record->cobj_group_metadata) {
+                        cfl_object_destroy(record->cobj_group_metadata);
+                    }
+                    cfl_object_destroy(record->cobj_record);
+                    cfl_object_destroy(record->cobj_metadata);
+                    flb_free(record);
+                    return FLB_MP_CHUNK_RECORD_ERROR;
+                }
+                record->owns_group_attributes = FLB_TRUE;
+                if (!chunk_cobj->active_group_attributes) {
+                    chunk_cobj->active_group_attributes = record->cobj_group_attributes;
+                }
+            }
+
+            cfl_list_add(&record->_head, &chunk_cobj->records);
+
+            /* If there's a condition, check if the record matches */
+            if (condition != NULL && record != NULL) {
+                flb_trace("[mp] evaluating condition for record");
+                ret = flb_condition_evaluate(condition, record);
+                flb_trace("[mp] condition evaluation result: %s", ret ? "TRUE" : "FALSE");
+                if (ret == FLB_FALSE) {
+                    flb_trace("[mp] record didn't match condition, skipping");
+                    /* Record doesn't match the condition, continue to next record */
+                    continue;
+                }
+                flb_trace("[mp] record matched condition, processing");
+            }
+
+            ret = FLB_MP_CHUNK_RECORD_OK;
+        }
+        else if (chunk_cobj->record_pos != NULL) {
+            /* is the actual record the last one ? */
+            if (chunk_cobj->record_pos == cfl_list_entry_last(&chunk_cobj->records, struct flb_mp_chunk_record, _head)) {
+                chunk_cobj->record_pos = NULL;
+                return FLB_MP_CHUNK_RECORD_EOF;
+            }
+
+            record = cfl_list_entry_next(&chunk_cobj->record_pos->_head, struct flb_mp_chunk_record,
+                                        _head, &chunk_cobj->records);
+
+            /* If there's a condition, check if the record matches */
+            if (condition != NULL && record != NULL) {
+                flb_trace("[mp] evaluating condition for next record");
+                ret = flb_condition_evaluate(condition, record);
+                flb_trace("[mp] next record condition evaluation result: %s", ret ? "TRUE" : "FALSE");
+                if (ret == FLB_FALSE) {
+                    flb_trace("[mp] next record didn't match condition, skipping");
+                    /* Record doesn't match the condition, set as current and try again */
+                    chunk_cobj->record_pos = record;
+                    continue;
+                }
+                flb_trace("[mp] next record matched condition, processing");
+            }
+
+            ret = FLB_MP_CHUNK_RECORD_OK;
+        }
+        else {
+            if (cfl_list_size(&chunk_cobj->records) == 0) {
+                return FLB_MP_CHUNK_RECORD_EOF;
+            }
+
+            /* check if we are the last in the list */
+            record = cfl_list_entry_first(&chunk_cobj->records, struct flb_mp_chunk_record, _head);
+
+            /* If there's a condition, check if the record matches */
+            if (condition != NULL && record != NULL) {
+                flb_trace("[mp] evaluating condition for first record");
+                ret = flb_condition_evaluate(condition, record);
+                flb_trace("[mp] first record condition evaluation result: %s", ret ? "TRUE" : "FALSE");
+                if (ret == FLB_FALSE) {
+                    flb_trace("[mp] first record didn't match condition, skipping");
+                    /* Record doesn't match the condition, set as current and try again */
+                    chunk_cobj->record_pos = record;
+                    continue;
+                }
+                flb_trace("[mp] first record matched condition, processing");
+            }
+
+            ret = FLB_MP_CHUNK_RECORD_OK;
         }
 
-        ret = FLB_MP_CHUNK_RECORD_OK;
+        /* A matching record (or the next record) was found; stop iterating. */
+        break;
     }
 
     chunk_cobj->record_pos = record;

--- a/tests/internal/mp_chunk_cobj.c
+++ b/tests/internal/mp_chunk_cobj.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_log_event_encoder.h>
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_mp_chunk.h>
+#include <fluent-bit/flb_conditionals.h>
 
 #include <cfl/cfl_kvlist.h>
 
@@ -412,8 +413,149 @@ cleanup:
 }
 
 
+/*
+ * Regression test for the condition-filtering path of
+ * flb_mp_chunk_cobj_record_next().
+ *
+ * When a processor condition is attached to a chunk, records that do not match
+ * the condition are skipped. This used to be implemented with tail recursion:
+ * every non-matching record made the function call itself to advance to the
+ * next one, so the recursion depth grew proportionally to the number of
+ * records. A large run of non-matching records (a common case for a condition
+ * that filters out most of a chunk) could therefore exhaust the stack.
+ *
+ * This test builds a chunk with many records where only a few match the
+ * condition, including a long trailing run of non-matching records, and
+ * verifies that exactly the matching records are returned and the iteration
+ * terminates cleanly.
+ */
+void record_next_condition_filter()
+{
+    struct flb_log_event_encoder *builder = NULL;
+    struct flb_log_event_encoder *chunk_encoder = NULL;
+    struct flb_log_event_decoder decoder;
+    struct flb_mp_chunk_cobj *chunk = NULL;
+    struct flb_mp_chunk_record *record = NULL;
+    struct flb_condition *cond = NULL;
+    struct flb_time ts;
+    int decoder_ready = FLB_FALSE;
+    int ret;
+    int i;
+    int matched = 0;
+    int expected = 0;
+    const int total = 20000;
+    const int stride = 5000;
+
+    builder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!TEST_CHECK(builder != NULL)) {
+        return;
+    }
+
+    flb_time_set(&ts, 1700000000, 0);
+
+    /*
+     * Records where (i % stride == 0) carry match="yes", the rest match="no".
+     * With total=20000 and stride=5000 this yields matches at i = 0, 5000,
+     * 10000, 15000, each separated by a long run of non-matching records and
+     * followed by a long trailing run that does not match.
+     */
+    for (i = 0; i < total; i++) {
+        const char *value = (i % stride == 0) ? "yes" : "no";
+
+        if (i % stride == 0) {
+            expected++;
+        }
+
+        ret = flb_log_event_encoder_begin_record(builder);
+        if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+            goto cleanup;
+        }
+
+        ret = flb_log_event_encoder_set_timestamp(builder, &ts);
+        if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+            goto cleanup;
+        }
+
+        ret = flb_log_event_encoder_append_body_values(
+                builder,
+                FLB_LOG_EVENT_CSTRING_VALUE("match"),
+                FLB_LOG_EVENT_CSTRING_VALUE(value));
+        if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+            goto cleanup;
+        }
+
+        ret = flb_log_event_encoder_commit_record(builder);
+        if (!TEST_CHECK(ret == FLB_EVENT_ENCODER_SUCCESS)) {
+            goto cleanup;
+        }
+    }
+
+    ret = flb_log_event_decoder_init(&decoder,
+                                     builder->output_buffer,
+                                     builder->output_length);
+    if (!TEST_CHECK(ret == FLB_EVENT_DECODER_SUCCESS)) {
+        goto cleanup;
+    }
+    decoder_ready = FLB_TRUE;
+
+    chunk_encoder = flb_log_event_encoder_create(FLB_LOG_EVENT_FORMAT_DEFAULT);
+    if (!TEST_CHECK(chunk_encoder != NULL)) {
+        goto cleanup;
+    }
+
+    chunk = flb_mp_chunk_cobj_create(chunk_encoder, &decoder);
+    if (!TEST_CHECK(chunk != NULL)) {
+        goto cleanup;
+    }
+
+    /* Only records whose body has match == "yes" should be returned */
+    cond = flb_condition_create(FLB_COND_OP_AND);
+    if (!TEST_CHECK(cond != NULL)) {
+        goto cleanup;
+    }
+
+    if (!TEST_CHECK(flb_condition_add_rule(cond, "$match", FLB_RULE_OP_EQ,
+                                           "yes", 0,
+                                           RECORD_CONTEXT_BODY) == FLB_TRUE)) {
+        goto cleanup;
+    }
+
+    /* The chunk borrows the condition; it does not take ownership of it */
+    chunk->condition = cond;
+
+    while ((ret = flb_mp_chunk_cobj_record_next(chunk, &record)) ==
+           FLB_MP_CHUNK_RECORD_OK) {
+        matched++;
+    }
+
+    TEST_CHECK(ret == FLB_MP_CHUNK_RECORD_EOF);
+    TEST_MSG("expected FLB_MP_CHUNK_RECORD_EOF, got ret=%d", ret);
+
+    TEST_CHECK(matched == expected);
+    TEST_MSG("expected %d matching records, got %d", expected, matched);
+
+cleanup:
+    if (chunk) {
+        flb_mp_chunk_cobj_destroy(chunk);
+    }
+    if (cond) {
+        flb_condition_destroy(cond);
+    }
+    if (chunk_encoder) {
+        flb_log_event_encoder_destroy(chunk_encoder);
+    }
+    if (decoder_ready == FLB_TRUE) {
+        flb_log_event_decoder_destroy(&decoder);
+    }
+    if (builder) {
+        flb_log_event_encoder_destroy(builder);
+    }
+}
+
+
 TEST_LIST = {
     { "decoder_groups_cobj", decoder_groups_cobj },
+    { "record_next_condition_filter", record_next_condition_filter },
     { 0 }
 };
 


### PR DESCRIPTION
Fixes #12125

**Description**

`flb_mp_chunk_cobj_record_next()` skipped records that do not match a processor `condition` by calling itself recursively to advance to the next record:

```c
if (ret == FLB_FALSE) {
    /* Record doesn't match the condition, continue to next record */
    return flb_mp_chunk_cobj_record_next(chunk_cobj, out_record);
}
```

A new stack frame is pushed for every non-matching record, so the recursion depth grows proportionally to the number of consecutive non-matching records in a chunk. A condition that filters out a large run of records can drive the depth to tens of thousands of frames and exhaust the stack. Tail-call optimization is not guaranteed (particularly in debug/unoptimized builds), so this is a real crash risk.

This PR converts the tail recursion into an explicit loop. The record decoding, group tracking and condition evaluation logic are unchanged — each former self-call becomes a loop continuation — so behavior is preserved while stack usage stays constant regardless of how many records are skipped.

A regression test is added in `tests/internal/mp_chunk_cobj.c`: it builds a chunk with 20k records where only a few match an attached condition (with long non-matching runs, including a trailing run) and verifies exactly the matching records are returned and iteration ends with `FLB_MP_CHUNK_RECORD_EOF`. Previously no test drove the condition-filtering path of `flb_mp_chunk_cobj_record_next()`.

**Testing**

Coverage is provided by the new `record_next_condition_filter` case in the `flb-it-mp_chunk_cobj` internal test.

Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/) output that shows no leaks or memory corruption still exists

Note: this is an internal correctness fix with no configuration surface, so an example config and runtime debug log are not applicable. I have not attached local Valgrind output because I could not build in my environment; the change is covered by the added internal unit test run in CI. I'm happy to provide Valgrind output for the `mp_chunk_cobj` test if a maintainer would like it.

---

**Documentation**

- [ ] Documentation required for this feature

Not applicable — internal correctness fix, no user-facing configuration change.

**Backporting**

- [ ] Backport to latest stable release.

---

_Fluent Bit is licensed under Apache 2.0, and this contribution is submitted under that license._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record filtering to reliably skip non-matching records and continue iteration until a matching record or end of data is reached.
  * Ensured filtered record iteration works correctly with large datasets.

* **Tests**
  * Added regression coverage for condition-based filtering across 20,000 records.
  * Verified that only matching records are returned and iteration ends correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->