### PR TITLE
out_es, out_opensearch: fix compose_index_header stack overflow

### DIFF
--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -265,7 +265,7 @@ static int compose_index_header(struct flb_elasticsearch *ctx,
     if (es_index_custom_len > 0) {
         p = logstash_index + es_index_custom_len;
     } else {
-        p = logstash_index + flb_sds_len(ctx->logstash_prefix);
+        p = logstash_index + strlen(logstash_index);
     }
     len = p - logstash_index;
     ret = snprintf(p, logstash_index_size - len, "%s",

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -255,7 +255,7 @@ static int compose_index_header(struct flb_opensearch *ctx,
     if (index_custom_len > 0) {
         p = logstash_index + index_custom_len;
     } else {
-        p = logstash_index + flb_sds_len(ctx->logstash_prefix);
+        p = logstash_index + strlen(logstash_index);
     }
     len = p - logstash_index;
     ret = snprintf(p, logstash_index_size - len, "%s",

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -130,6 +130,26 @@ static void cb_check_logstash_prefix_separator(void *ctx, int ffd,
     flb_free(res_data);
 }
 
+static void cb_check_logstash_format_long_prefix(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char expected[256];
+
+    /* logstash_index is a 256-byte buffer; the prefix is truncated to 255
+     * bytes before it reaches the index, so that is what must show up. */
+    memset(expected, 'a', sizeof(expected) - 1);
+    expected[sizeof(expected) - 1] = '\0';
+
+    p = strstr(out_js, expected);
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Got: %s", out_js);
+    }
+    flb_free(res_data);
+}
+
 static void cb_check_logstash_format_nanos(void *ctx, int ffd,
                                            int res_ret, void *res_data, size_t res_size,
                                            void *data)
@@ -487,6 +507,50 @@ void flb_test_logstash_format()
     TEST_CHECK(ret == 0);
 
     /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_logstash_format_long_prefix()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    char long_prefix[300];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* A prefix longer than the 256-byte logstash_index buffer. */
+    memset(long_prefix, 'a', sizeof(long_prefix) - 1);
+    long_prefix[sizeof(long_prefix) - 1] = '\0';
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "logstash_format", "on",
+                   "logstash_prefix", long_prefix,
+                   "logstash_dateformat", "%Y-%m-%d",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_logstash_format_long_prefix,
+                              NULL, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
     flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
 
     sleep(2);
@@ -1068,6 +1132,7 @@ TEST_LIST = {
     {"write_operation_upsert", flb_test_write_operation_upsert },
     {"index_type"            , flb_test_index_type },
     {"logstash_format"       , flb_test_logstash_format },
+    {"logstash_format_long_prefix" , flb_test_logstash_format_long_prefix },
     {"logstash_format_nanos" , flb_test_logstash_format_nanos },
     {"tag_key"               , flb_test_tag_key },
     {"replace_dots"          , flb_test_replace_dots },

--- a/tests/runtime/out_opensearch.c
+++ b/tests/runtime/out_opensearch.c
@@ -185,6 +185,26 @@ static void cb_check_logstash_prefix_separator(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_logstash_format_long_prefix(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    char *p;
+    char *out_js = res_data;
+    char expected[256];
+
+    /* logstash_index is a 256-byte buffer; the prefix is truncated to 255
+     * bytes before it reaches the index, so that is what must show up. */
+    memset(expected, 'a', sizeof(expected) - 1);
+    expected[sizeof(expected) - 1] = '\0';
+
+    p = strstr(out_js, expected);
+    if (!TEST_CHECK(p != NULL)) {
+        TEST_MSG("Got: %s", out_js);
+    }
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_logstash_format_nanos(void *ctx, int ffd,
                                            int res_ret, void *res_data, size_t res_size,
                                            void *data)
@@ -735,6 +755,50 @@ void flb_test_logstash_format()
     flb_destroy(ctx);
 }
 
+void flb_test_logstash_format_long_prefix()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    char long_prefix[300];
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* A prefix longer than the 256-byte logstash_index buffer. */
+    memset(long_prefix, 'a', sizeof(long_prefix) - 1);
+    long_prefix[sizeof(long_prefix) - 1] = '\0';
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "opensearch", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   NULL);
+
+    flb_output_set(ctx, out_ffd,
+                   "logstash_format", "on",
+                   "logstash_prefix", long_prefix,
+                   "logstash_dateformat", "%Y-%m-%d",
+                   NULL);
+
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_logstash_format_long_prefix,
+                              NULL, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_logstash_format_nanos()
 {
     int ret;
@@ -1110,6 +1174,7 @@ TEST_LIST = {
     {"index_record_accessor_id_key", flb_test_index_record_accessor_with_id_key},
     {"index_record_accessor_generate_id", flb_test_index_record_accessor_with_generate_id},
     {"logstash_format"       , flb_test_logstash_format },
+    {"logstash_format_long_prefix" , flb_test_logstash_format_long_prefix },
     {"logstash_format_nanos" , flb_test_logstash_format_nanos },
     {"tag_key"               , flb_test_tag_key },
     {"replace_dots"          , flb_test_replace_dots },


### PR DESCRIPTION
compose_index_header builds the Logstash index inside a 256-byte on-stack buffer (logstash_index). When logstash_prefix_key is unset it takes the write offset from flb_sds_len(ctx->logstash_prefix), the full prefix length, but the prefix was already strncpy-truncated into that 256-byte buffer a few lines earlier. A logstash_prefix of 256 bytes or more pushes the offset past the buffer, logstash_index_size - len underflows to a large size_t, and the snprintf and strftime that follow write out of bounds. The per-record logstash_prefix_key path already caps its copy at 128 bytes, so only the config-prefix branch is affected. out_opensearch carries the same code and the same bug. Capping the offset at what fits in the buffer keeps the write in bounds and leaves the result unchanged for prefixes that fit. The offset still comes from the configured prefix, so the retry with the default separator starts from the same position. The snprintf truncation check is also tightened to >=, so a prefix that fills the buffer returns early instead of calling strftime with a zero size.

----

**Testing**

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached unit test exercising compose_index_header with an oversized logstash_prefix

```
[INPUT]
    name   dummy
    tag    test

[OUTPUT]
    name             es
    match            *
    logstash_format  on
    logstash_prefix  aaaaaaaa...   # 256 or more characters
```

Added `tests/runtime/out_elasticsearch.c:logstash_format_long_prefix` and `tests/runtime/out_opensearch.c:logstash_format_long_prefix`, each configuring `logstash_format` with a 300-byte prefix. Built with `-DSANITIZE_ADDRESS=On`, both abort on the unpatched tree and pass after the change (the index becomes the safely truncated prefix). ASan on the unpatched tree:

```
==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x...
WRITE of size 1 at 0x... thread T1
    #6 compose_index_header es.c:271
SUMMARY: AddressSanitizer: stack-buffer-overflow in __sfvwrite
```

- [N/A] Run local packaging test showing all targets build.
- [N/A] Set `ok-package-test` label to test for all targets.

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Logstash-formatted index generation when the configured prefix exceeds the available index buffer.
  * Ensured date and remaining index components are written at the correct position.
  * Added stricter handling for index values that exactly reach the available buffer capacity.

* **Tests**
  * Added coverage confirming oversized prefixes are safely truncated and correctly included in Elasticsearch and OpenSearch output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
