### PR TITLE
tests: link test binaries against shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1531,9 +1531,9 @@ else()
 endif()
 
 # Instruct CMake to build the Fluent Bit Core
-if(MSVC)
-  # Some tests access plugin-private state that is not exported from fluent-bit.dll.
-  # Keep one copy of that state by linking the test and plugin code statically.
+if(MSVC OR FLB_JEMALLOC)
+  # MSVC tests need plugin-private symbols that are not exported from fluent-bit.dll.
+  # Jemalloc must not be embedded in both the test executable and shared library.
   set(FLB_TEST_LINK_LIBRARY fluent-bit-static)
 else()
   set(FLB_TEST_LINK_LIBRARY fluent-bit-shared)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1531,6 +1531,14 @@ else()
 endif()
 
 # Instruct CMake to build the Fluent Bit Core
+if(MSVC)
+  # Some tests access plugin-private state that is not exported from fluent-bit.dll.
+  # Keep one copy of that state by linking the test and plugin code statically.
+  set(FLB_TEST_LINK_LIBRARY fluent-bit-static)
+else()
+  set(FLB_TEST_LINK_LIBRARY fluent-bit-shared)
+endif()
+
 add_subdirectory(include)
 add_subdirectory(plugins)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -525,7 +525,7 @@ endif()
 
 # Shared Library
 if(FLB_SHARED_LIB OR
-   (NOT MSVC AND
+   (NOT MSVC AND NOT FLB_JEMALLOC AND
     (FLB_TESTS_RUNTIME OR FLB_TESTS_INTERNAL OR FLB_TESTS_INTERNAL_FUZZ)))
   add_library(fluent-bit-shared SHARED ${src})
   add_sanitizers(fluent-bit-shared)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -524,8 +524,9 @@ set(flb_rc_files
 endif()
 
 # Shared Library
-if(FLB_SHARED_LIB OR FLB_TESTS_RUNTIME OR FLB_TESTS_INTERNAL OR
-   FLB_TESTS_INTERNAL_FUZZ)
+if(FLB_SHARED_LIB OR
+   (NOT MSVC AND
+    (FLB_TESTS_RUNTIME OR FLB_TESTS_INTERNAL OR FLB_TESTS_INTERNAL_FUZZ)))
   add_library(fluent-bit-shared SHARED ${src})
   add_sanitizers(fluent-bit-shared)
   set_target_properties(fluent-bit-shared

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -524,7 +524,8 @@ set(flb_rc_files
 endif()
 
 # Shared Library
-if(FLB_SHARED_LIB)
+if(FLB_SHARED_LIB OR FLB_TESTS_RUNTIME OR FLB_TESTS_INTERNAL OR
+   FLB_TESTS_INTERNAL_FUZZ)
   add_library(fluent-bit-shared SHARED ${src})
   add_sanitizers(fluent-bit-shared)
   set_target_properties(fluent-bit-shared
@@ -542,11 +543,13 @@ if(FLB_SHARED_LIB)
       PROPERTIES PDB_NAME fluent-bit.dll)
   endif()
 
-  # Library install routines
-  install(TARGETS fluent-bit-shared
-    LIBRARY DESTINATION ${FLB_INSTALL_LIBDIR}
-    COMPONENT library
-    RUNTIME DESTINATION ${FLB_INSTALL_BINDIR})
+  if(FLB_SHARED_LIB)
+    # Library install routines
+    install(TARGETS fluent-bit-shared
+      LIBRARY DESTINATION ${FLB_INSTALL_LIBDIR}
+      COMPONENT library
+      RUNTIME DESTINATION ${FLB_INSTALL_BINDIR})
+  endif()
 endif()
 
 # Static Library

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -246,7 +246,9 @@ function(prepare_unit_tests TEST_PREFIX SOURCEFILES)
         target_link_libraries(${source_file_we} flb-aws)
       endif()
 
-      if(FLB_OUT_AZURE_BLOB AND "${source_file_we}" STREQUAL "flb-it-azure_blob_path")
+      if(FLB_OUT_AZURE_BLOB AND
+         "${source_file_we}" STREQUAL "flb-it-azure_blob_path" AND
+         "${FLB_TEST_LINK_LIBRARY}" STREQUAL "fluent-bit-static")
         target_link_libraries(${source_file_we} flb-plugin-out_azure_blob)
       endif()
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -254,7 +254,7 @@ function(prepare_unit_tests TEST_PREFIX SOURCEFILES)
         target_link_libraries(${source_file_we} flb-sp)
       endif()
 
-      target_link_libraries(${source_file_we} fluent-bit-static cfl-static)
+      target_link_libraries(${source_file_we} fluent-bit-shared cfl-static)
 
       if(FLB_AVRO_ENCODER)
         target_link_libraries(${source_file_we} avro-static jansson)

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -254,7 +254,7 @@ function(prepare_unit_tests TEST_PREFIX SOURCEFILES)
         target_link_libraries(${source_file_we} flb-sp)
       endif()
 
-      target_link_libraries(${source_file_we} fluent-bit-shared cfl-static)
+      target_link_libraries(${source_file_we} ${FLB_TEST_LINK_LIBRARY} cfl-static)
 
       if(FLB_AVRO_ENCODER)
         target_link_libraries(${source_file_we} avro-static jansson)

--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach(source_file ${UNIT_TESTS_FILES})
     target_link_libraries(${source_file_we} flb-sp)
   endif()
 
-  target_link_libraries(${source_file_we} fluent-bit-shared)
+  target_link_libraries(${source_file_we} ${FLB_TEST_LINK_LIBRARY})
 
   if (FLB_TESTS_OSSFUZZ)
    add_executable(${source_file_we}_OSSFUZZ ${source_file})

--- a/tests/internal/fuzzers/CMakeLists.txt
+++ b/tests/internal/fuzzers/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach(source_file ${UNIT_TESTS_FILES})
     target_link_libraries(${source_file_we} flb-sp)
   endif()
 
-  target_link_libraries(${source_file_we} fluent-bit-static)
+  target_link_libraries(${source_file_we} fluent-bit-shared)
 
   if (FLB_TESTS_OSSFUZZ)
    add_executable(${source_file_we}_OSSFUZZ ${source_file})

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -91,11 +91,14 @@ if (FLB_CUSTOM_CALYPTIA)
         get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
         set(TEST_TARGET "flb-rt-${TEST_NAME}")
-        add_executable(${TEST_TARGET}
-            ${TEST_SOURCE}
-            "../../plugins/custom_calyptia/calyptia.c"
-            "../../plugins/in_calyptia_fleet/in_calyptia_fleet.c"
-        )
+        add_executable(${TEST_TARGET} ${TEST_SOURCE})
+
+        if("${FLB_TEST_LINK_LIBRARY}" STREQUAL "fluent-bit-static")
+            target_sources(${TEST_TARGET} PRIVATE
+                "../../plugins/custom_calyptia/calyptia.c"
+                "../../plugins/in_calyptia_fleet/in_calyptia_fleet.c"
+            )
+        endif()
 
         target_link_libraries(${TEST_TARGET}
             ${CALYPTIA_TEST_LINK_LIBS}

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 if (FLB_CUSTOM_CALYPTIA)
     set(CALYPTIA_TEST_LINK_LIBS
-        fluent-bit-shared
+        ${FLB_TEST_LINK_LIBRARY}
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
@@ -106,7 +106,7 @@ if (FLB_CUSTOM_CALYPTIA)
                  WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
 
         set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
-        add_dependencies(${TEST_TARGET} fluent-bit-shared)
+        add_dependencies(${TEST_TARGET} ${FLB_TEST_LINK_LIBRARY})
     endforeach()
 endif()
 
@@ -117,7 +117,7 @@ if(FLB_IN_EBPF)
     )
 
     set(EBPF_TEST_LINK_LIBS
-        fluent-bit-shared
+        ${FLB_TEST_LINK_LIBRARY}
         ${CMAKE_THREAD_LIBS_INIT}
         ${SYSTEMD_LIB}
         -lbpf
@@ -195,13 +195,13 @@ if(FLB_IN_EBPF)
         "../../plugins/in_ebpf/traces/sched/handler.c"
     )
 
-    add_dependencies(flb-rt-in_ebpf_bind_handler fluent-bit-shared)
-    add_dependencies(flb-rt-in_ebpf_signal_handler fluent-bit-shared)
-    add_dependencies(flb-rt-in_ebpf_malloc_handler fluent-bit-shared)
-    add_dependencies(flb-rt-in_ebpf_tcp_handler fluent-bit-shared)
-    add_dependencies(flb-rt-in_ebpf_exec_handler fluent-bit-shared)
-    add_dependencies(flb-rt-in_ebpf_openssl_handler fluent-bit-shared)
-    add_dependencies(flb-rt-in_ebpf_sched_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_bind_handler ${FLB_TEST_LINK_LIBRARY})
+    add_dependencies(flb-rt-in_ebpf_signal_handler ${FLB_TEST_LINK_LIBRARY})
+    add_dependencies(flb-rt-in_ebpf_malloc_handler ${FLB_TEST_LINK_LIBRARY})
+    add_dependencies(flb-rt-in_ebpf_tcp_handler ${FLB_TEST_LINK_LIBRARY})
+    add_dependencies(flb-rt-in_ebpf_exec_handler ${FLB_TEST_LINK_LIBRARY})
+    add_dependencies(flb-rt-in_ebpf_openssl_handler ${FLB_TEST_LINK_LIBRARY})
+    add_dependencies(flb-rt-in_ebpf_sched_handler ${FLB_TEST_LINK_LIBRARY})
 
 endif()
 
@@ -367,7 +367,7 @@ foreach(source_file ${CHECK_PROGRAMS})
       target_compile_options(${source_file_we} PRIVATE /Zc:preprocessor)
     endif()
     target_link_libraries(${source_file_we}
-      fluent-bit-shared
+      ${FLB_TEST_LINK_LIBRARY}
       ${CMAKE_THREAD_LIBS_INIT}
       ${SYSTEMD_LIB}
       )

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 if (FLB_CUSTOM_CALYPTIA)
     set(CALYPTIA_TEST_LINK_LIBS
-        fluent-bit-static
+        fluent-bit-shared
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
@@ -106,7 +106,7 @@ if (FLB_CUSTOM_CALYPTIA)
                  WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build)
 
         set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "runtime")
-        add_dependencies(${TEST_TARGET} fluent-bit-static)
+        add_dependencies(${TEST_TARGET} fluent-bit-shared)
     endforeach()
 endif()
 
@@ -117,7 +117,7 @@ if(FLB_IN_EBPF)
     )
 
     set(EBPF_TEST_LINK_LIBS
-        fluent-bit-static
+        fluent-bit-shared
         ${CMAKE_THREAD_LIBS_INIT}
         ${SYSTEMD_LIB}
         -lbpf
@@ -195,13 +195,13 @@ if(FLB_IN_EBPF)
         "../../plugins/in_ebpf/traces/sched/handler.c"
     )
 
-    add_dependencies(flb-rt-in_ebpf_bind_handler fluent-bit-static)
-    add_dependencies(flb-rt-in_ebpf_signal_handler fluent-bit-static)
-    add_dependencies(flb-rt-in_ebpf_malloc_handler fluent-bit-static)
-    add_dependencies(flb-rt-in_ebpf_tcp_handler fluent-bit-static)
-    add_dependencies(flb-rt-in_ebpf_exec_handler fluent-bit-static)
-    add_dependencies(flb-rt-in_ebpf_openssl_handler fluent-bit-static)
-    add_dependencies(flb-rt-in_ebpf_sched_handler fluent-bit-static)
+    add_dependencies(flb-rt-in_ebpf_bind_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_signal_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_malloc_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_tcp_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_exec_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_openssl_handler fluent-bit-shared)
+    add_dependencies(flb-rt-in_ebpf_sched_handler fluent-bit-shared)
 
 endif()
 
@@ -367,7 +367,7 @@ foreach(source_file ${CHECK_PROGRAMS})
       target_compile_options(${source_file_we} PRIVATE /Zc:preprocessor)
     endif()
     target_link_libraries(${source_file_we}
-      fluent-bit-static
+      fluent-bit-shared
       ${CMAKE_THREAD_LIBS_INIT}
       ${SYSTEMD_LIB}
       )


### PR DESCRIPTION
## Summary

- link runtime, internal, and local fuzz test binaries against `fluent-bit-shared`
- build the shared library as an internal test dependency even when `FLB_SHARED_LIB=Off`
- preserve `FLB_SHARED_LIB=Off` installation behavior and keep OSS-Fuzz targets static

## Motivation

Each test binary previously linked the complete static Fluent Bit engine and enabled plugin set. In a debug build this produced roughly 200 binaries near 65 MB each and made `build/bin` consume about 13 GB.

With shared test linkage, representative test executables are around 112-244 KB and the fully built `build/bin` directory is about 102 MB.

## Validation

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`
- `ctest --test-dir build -R "^(flb-rt-out_null|flb-rt-in_dummy|flb-it-sds|flb-it-config_map|flb-it-opentelemetry)$" --output-on-failure`
- repeated configuration with `-DFLB_SHARED_LIB=Off`
- `cmake --build build -j8 --target flb-rt-out_null flb-it-sds`
- `ctest --test-dir build -R "^(flb-rt-out_null|flb-it-sds)$" --output-on-failure`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master python .github/scripts/commit_prefix_check.py`

All selected tests and commit-prefix validation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Testing**
  * Made internal unit, fuzzing, and runtime test executables use a configurable core library choice (static on MSVC; shared otherwise).
  * Generalized test linking and adjusted build dependencies so tests track the selected library.
  * Broadened when the shared library is produced for fuzz/testing runtime modes (with exclusions).
  * Tightened installation so the shared-library install only happens when shared builds are explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->