### PR TITLE
in_lib: Adjust consuming mechanism to improve throughput

### DIFF
--- a/plugins/in_lib/in_lib.c
+++ b/plugins/in_lib/in_lib.c
@@ -75,7 +75,7 @@ static int in_lib_collect(struct flb_input_instance *ins,
 
             perror("read");
             flb_pipe_error();
-            if (errno == -EPIPE) {
+            if (errno == EPIPE) {
                 return -1;
             }
             return 0;

--- a/plugins/in_lib/in_lib.c
+++ b/plugins/in_lib/in_lib.c
@@ -42,40 +42,60 @@ static int in_lib_collect(struct flb_input_instance *ins,
     int out_size;
     int capacity;
     int size;
+    int total_bytes = 0;
     char *ptr;
     char *pack;
     struct flb_log_event record;
     struct flb_log_event_decoder decoder;
     struct flb_in_lib_config *ctx = in_context;
 
-    capacity = (ctx->buf_size - ctx->buf_len);
+    while (total_bytes < LIB_MAX_READ_SIZE) {
+        capacity = (ctx->buf_size - ctx->buf_len);
 
-    /* Allocate memory as required (FIXME: this will be limited in later) */
-    if (capacity == 0) {
-        size = ctx->buf_size + LIB_BUF_CHUNK;
-        ptr = flb_realloc(ctx->buf_data, size);
-        if (!ptr) {
-            flb_errno();
-            return -1;
+        /* Allocate memory as required (FIXME: this will be limited in later) */
+        if (capacity == 0) {
+            size = ctx->buf_size + LIB_BUF_CHUNK;
+            ptr = flb_realloc(ctx->buf_data, size);
+            if (!ptr) {
+                flb_errno();
+                return -1;
+            }
+            ctx->buf_data = ptr;
+            ctx->buf_size = size;
+            capacity = LIB_BUF_CHUNK;
         }
-        ctx->buf_data = ptr;
-        ctx->buf_size = size;
-        capacity = LIB_BUF_CHUNK;
+
+        bytes = flb_pipe_r(ctx->fd,
+                           ctx->buf_data + ctx->buf_len,
+                           capacity);
+        if (bytes == -1) {
+            if (FLB_PIPE_WOULDBLOCK()) {
+                break;
+            }
+
+            perror("read");
+            flb_pipe_error();
+            if (errno == -EPIPE) {
+                return -1;
+            }
+            return 0;
+        }
+        else if (bytes == 0) {
+            break;
+        }
+
+        ctx->buf_len += bytes;
+        total_bytes += bytes;
+
+#ifndef FLB_SYSTEM_WINDOWS
+        break;
+#endif
     }
 
-    bytes = flb_pipe_r(ctx->fd,
-                       ctx->buf_data + ctx->buf_len,
-                       capacity);
-    flb_plg_trace(ctx->ins, "in_lib read() = %i", bytes);
-    if (bytes == -1) {
-        perror("read");
-        flb_pipe_error();
-        if (errno == -EPIPE) {
-            return -1;
-        }
+    flb_plg_trace(ctx->ins, "in_lib read() = %i", total_bytes);
+    if (total_bytes == 0) {
         return 0;
     }
-    ctx->buf_len += bytes;
 
     /* initially we should support json input */
     ret = flb_pack_json_state(ctx->buf_data, ctx->buf_len,
@@ -213,8 +233,25 @@ static int in_lib_init(struct flb_input_instance *in,
     }
 
     /* Init communication channel */
-    flb_input_channel_init(in);
+    ret = flb_input_channel_init(in);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not initialize input channel");
+        flb_free(ctx->buf_data);
+        flb_free(ctx);
+        return -1;
+    }
     ctx->fd = in->channel[0];
+
+#ifdef FLB_SYSTEM_WINDOWS
+    ret = flb_pipe_set_nonblocking(ctx->fd);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not set input channel to nonblocking mode");
+        flb_pipe_destroy(in->channel);
+        flb_free(ctx->buf_data);
+        flb_free(ctx);
+        return -1;
+    }
+#endif
 
     /* Set the context */
     flb_input_set_context(in, ctx);

--- a/plugins/in_lib/in_lib.c
+++ b/plugins/in_lib/in_lib.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -86,10 +87,6 @@ static int in_lib_collect(struct flb_input_instance *ins,
 
         ctx->buf_len += bytes;
         total_bytes += bytes;
-
-#ifndef FLB_SYSTEM_WINDOWS
-        break;
-#endif
     }
 
     flb_plg_trace(ctx->ins, "in_lib read() = %i", total_bytes);
@@ -110,7 +107,10 @@ static int in_lib_collect(struct flb_input_instance *ins,
         flb_pack_state_init(&ctx->state);
         return -1;
     }
-    ctx->buf_len = 0;
+    ctx->buf_len -= ctx->state.last_byte;
+    memmove(ctx->buf_data,
+            ctx->buf_data + ctx->state.last_byte,
+            ctx->buf_len);
 
     dec_ret = flb_log_event_decoder_init(&decoder, pack, out_size);
     if (dec_ret != FLB_EVENT_DECODER_SUCCESS) {
@@ -242,7 +242,6 @@ static int in_lib_init(struct flb_input_instance *in,
     }
     ctx->fd = in->channel[0];
 
-#ifdef FLB_SYSTEM_WINDOWS
     ret = flb_pipe_set_nonblocking(ctx->fd);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not set input channel to nonblocking mode");
@@ -251,7 +250,6 @@ static int in_lib_init(struct flb_input_instance *in,
         flb_free(ctx);
         return -1;
     }
-#endif
 
     /* Set the context */
     flb_input_set_context(in, ctx);

--- a/plugins/in_lib/in_lib.h
+++ b/plugins/in_lib/in_lib.h
@@ -26,7 +26,10 @@
 #include <fluent-bit/flb_log_event_encoder.h>
 #include <fluent-bit/flb_pthread.h>
 
-#define LIB_BUF_CHUNK   65536
+#define LIB_BUF_CHUNK       65536
+
+/* Bound each collector dispatch so other engine events keep making progress. */
+#define LIB_MAX_READ_SIZE   (LIB_BUF_CHUNK * 64)
 
 pthread_key_t flb_active_lib_context;
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Otherwise, Fluent Bit tests can fail as below on Windows:

```
126/163 Test  #35: flb-rt-filter_rewrite_tag ........................***Failed   59.15 sec
Test matched...                                 [ OK ]
Test not_matched...                             [ OK ]
Test keep_true...                               [ OK ]
Test heavy_input_pause_emitter...               [ OK ]
Test busy_emitter_keeps_original...             [ FAILED ]
  filter_rewrite_tag.c:435: Check got == heavy_loop... failed
    expect: 100000 got: 44307
Test issue_4518...                              [ OK ]
Test issue_4793...                              [ OK ]
Test sigsegv_issue_5846...                      [ OK ]
FAILED: 1 of 8 unit tests has failed.

```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large input payloads by reading data in a controlled loop, expanding the buffer as needed.
  * Added safer “no data” early exit to avoid unnecessary work.
  * Updated error handling for pipe read failures to better distinguish end-of-stream vs. other cases.
  * Improved buffer compaction after processing to retain remaining bytes correctly.
  * Strengthened initialization by validating nonblocking setup and performing cleanup on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->