### PR TITLE
tests: runtime: isolate Loki mock server configuration

### DIFF
--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -48,8 +48,11 @@ static int tenant_policy_fail_tenant_a = FLB_FALSE;
 struct tenant_policy_server {
     struct flb_http_server server;
     struct flb_net_setup net_setup;
+    struct flb_config *config;
     struct mk_event_loop *event_loop;
     pthread_t thread;
+    int server_initialized;
+    int server_started;
     int thread_started;
     int stop;
 };
@@ -243,9 +246,40 @@ static void *tenant_policy_server_loop(void *data)
     return NULL;
 }
 
+static void stop_tenant_policy_server(struct tenant_policy_server *mock)
+{
+    if (mock->thread_started == FLB_TRUE) {
+        pthread_mutex_lock(&result_mutex);
+        mock->stop = FLB_TRUE;
+        pthread_mutex_unlock(&result_mutex);
+
+        pthread_join(mock->thread, NULL);
+        mock->thread_started = FLB_FALSE;
+    }
+
+    if (mock->server_started == FLB_TRUE) {
+        flb_http_server_stop(&mock->server);
+        mock->server_started = FLB_FALSE;
+    }
+
+    if (mock->server_initialized == FLB_TRUE) {
+        flb_http_server_destroy(&mock->server);
+        mock->server_initialized = FLB_FALSE;
+    }
+
+    if (mock->event_loop != NULL) {
+        mk_event_loop_destroy(mock->event_loop);
+        mock->event_loop = NULL;
+    }
+
+    if (mock->config != NULL) {
+        flb_config_exit(mock->config);
+        mock->config = NULL;
+    }
+}
+
 static int start_tenant_policy_server(struct tenant_policy_server *mock,
-                                      const char *port,
-                                      struct flb_config *config)
+                                      const char *port)
 {
     int ret;
     struct flb_http_server_options options;
@@ -255,8 +289,14 @@ static int start_tenant_policy_server(struct tenant_policy_server *mock,
     flb_http_server_options_init(&options);
     flb_net_setup_init(&mock->net_setup);
 
+    mock->config = flb_config_init();
+    if (mock->config == NULL) {
+        return -1;
+    }
+
     mock->event_loop = mk_event_loop_create(256);
     if (mock->event_loop == NULL) {
+        stop_tenant_policy_server(mock);
         return -1;
     }
 
@@ -267,32 +307,27 @@ static int start_tenant_policy_server(struct tenant_policy_server *mock,
     options.networking_flags = 0;
     options.networking_setup = &mock->net_setup;
     options.event_loop = mock->event_loop;
-    options.system_context = config;
+    options.system_context = mock->config;
     options.use_caller_event_loop = FLB_TRUE;
 
     ret = flb_http_server_init_with_options(&mock->server, &options);
     if (ret != 0) {
-        mk_event_loop_destroy(mock->event_loop);
-        mock->event_loop = NULL;
+        stop_tenant_policy_server(mock);
         return -1;
     }
+    mock->server_initialized = FLB_TRUE;
 
     ret = flb_http_server_start(&mock->server);
     if (ret != 0) {
-        flb_http_server_destroy(&mock->server);
-        mk_event_loop_destroy(mock->event_loop);
-        mock->event_loop = NULL;
+        stop_tenant_policy_server(mock);
         return -1;
     }
+    mock->server_started = FLB_TRUE;
 
     mock->stop = FLB_FALSE;
-    mock->thread_started = FLB_FALSE;
     ret = pthread_create(&mock->thread, NULL, tenant_policy_server_loop, mock);
     if (ret != 0) {
-        flb_http_server_stop(&mock->server);
-        flb_http_server_destroy(&mock->server);
-        mk_event_loop_destroy(mock->event_loop);
-        mock->event_loop = NULL;
+        stop_tenant_policy_server(mock);
         return -1;
     }
     mock->thread_started = FLB_TRUE;
@@ -300,25 +335,6 @@ static int start_tenant_policy_server(struct tenant_policy_server *mock,
     flb_time_msleep(500);
 
     return 0;
-}
-
-static void stop_tenant_policy_server(struct tenant_policy_server *mock)
-{
-    if (mock->event_loop == NULL) {
-        return;
-    }
-
-    pthread_mutex_lock(&result_mutex);
-    mock->stop = FLB_TRUE;
-    pthread_mutex_unlock(&result_mutex);
-
-    if (mock->thread_started == FLB_TRUE) {
-        pthread_join(mock->thread, NULL);
-    }
-    flb_http_server_stop(&mock->server);
-    flb_http_server_destroy(&mock->server);
-    mk_event_loop_destroy(mock->event_loop);
-    mock->event_loop = NULL;
 }
 
 #define JSON_BASIC "[12345678, {\"key\":\"value\"}]"
@@ -1035,8 +1051,7 @@ void flb_test_tenant_id_key_splits_requests()
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);
 
-    ret = start_tenant_policy_server(&mock_server, LOKI_TENANT_SPLIT_PORT,
-                                     ctx->config);
+    ret = start_tenant_policy_server(&mock_server, LOKI_TENANT_SPLIT_PORT);
     TEST_CHECK(ret == 0);
 
     ret = flb_lib_push(ctx, in_ffd, tenant_a, strlen(tenant_a));
@@ -1109,7 +1124,7 @@ static void run_tenant_id_key_partial_handling(char *mode,
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);
 
-    ret = start_tenant_policy_server(&mock_server, port, ctx->config);
+    ret = start_tenant_policy_server(&mock_server, port);
     TEST_CHECK(ret == 0);
 
     ret = flb_lib_push(ctx, in_ffd, tenant_a, strlen(tenant_a));


### PR DESCRIPTION
## Summary

- give the Loki tenant-policy mock HTTP server its own `flb_config`
- keep the mock downstream and connection queues out of the running Fluent Bit engine configuration
- make partial initialization and teardown safe for both the split-request and partial-handling fixtures

## Root cause

The runtime test started Fluent Bit and then registered the mock HTTP server downstream in `ctx->config`. The mock server event-loop thread modified downstream connection and destruction queues while the engine thread iterated and processed the same structures. Helgrind therefore reported races in downstream setup, timeout processing, connection release, and pending destruction.

This is a test-fixture ownership issue, not a Loki plugin or allocator bug.

## Lifecycle

The mock fixture now:

1. initializes an independent configuration before the HTTP server
2. stops and joins its server thread
3. stops and destroys the HTTP server
4. destroys the event loop
5. calls `flb_config_exit()` only after mock activity has ended

Initialization state is tracked so every failure path releases only initialized resources.

## Validation

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`
- `ctest --test-dir build -R '^flb-rt-out_loki$' --output-on-failure` — passed
- `build/bin/flb-rt-out_loki tenant_id_key_splits_requests tenant_id_key_partial_success tenant_id_key_partial_error` — passed
- `tenant_id_key_splits_requests` repeated 30 times — 30/30 passed
- Memcheck focused run — zero errors and zero leaks
- Helgrind focused run — mock-server downstream races removed; remaining reports are unrelated engine lifecycle and third-party `libp11-kit` reports
- GCC 13.3.0 with `FLB_JEMALLOC=On` — built and `flb-rt-out_loki` passed
- HEAD and full PR-range commit-prefix checks — passed

No production code or bundled library code is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test mock server startup and shutdown reliability.
  * Added deterministic cleanup for server, event loop, configuration, and thread resources.
  * Enhanced failure handling during test server initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->