### PR TITLE
pack: harden flb_msgpack_to_json buffer handling

### DIFF
--- a/src/flb_pack.c
+++ b/src/flb_pack.c
@@ -1163,9 +1163,21 @@ int flb_msgpack_to_json(char *json_str, size_t json_size,
         return -1;
     }
 
+    /* a zero-capacity buffer would wrap 'json_size - 1' to SIZE_MAX below */
+    if (json_size == 0) {
+        return -1;
+    }
+
     ret = msgpack2json(json_str, &off, json_size - 1, obj, escape_unicode);
     json_str[off] = '\0';
-    return ret ? off: ret;
+
+    /*
+     * msgpack2json() returns FLB_FALSE (0) when the output did not fit in the
+     * buffer. Report that as a negative value so fixed-buffer callers can
+     * distinguish truncation from a successful zero-length write, matching the
+     * documented contract above.
+     */
+    return ret ? off : -1;
 }
 
 flb_sds_t flb_msgpack_raw_to_json_sds(const void *in_buf, size_t in_size, int escape_unicode)

--- a/tests/internal/pack.c
+++ b/tests/internal/pack.c
@@ -928,6 +928,47 @@ void test_json_pack_nan()
     flb_pack_init(&config);
 }
 
+/*
+ * flb_msgpack_to_json() must report a buffer overflow as a negative value
+ * (not 0), so fixed-buffer callers can tell truncation apart from a
+ * successful zero-length write.
+ */
+void test_json_pack_truncation()
+{
+    int ret;
+    char small[4];
+    msgpack_sbuffer mp_sbuf;
+    msgpack_packer mp_pck;
+    msgpack_object obj;
+    msgpack_zone mempool;
+    msgpack_unpack_return unpack_ret;
+
+    /* a value whose JSON form does not fit in the destination buffer */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_double(&mp_pck, 123456789.0);
+    msgpack_zone_init(&mempool, 2048);
+    unpack_ret = msgpack_unpack(mp_sbuf.data, mp_sbuf.size, NULL, &mempool, &obj);
+    if (!TEST_CHECK(unpack_ret == MSGPACK_UNPACK_SUCCESS)) {
+        TEST_MSG("msgpack_unpack failed: %d", unpack_ret);
+        msgpack_zone_destroy(&mempool);
+        msgpack_sbuffer_destroy(&mp_sbuf);
+        return;
+    }
+
+    ret = flb_msgpack_to_json(small, sizeof(small), &obj, FLB_TRUE);
+    if (!TEST_CHECK(ret < 0)) {
+        TEST_MSG("truncation must return a negative value, got %d", ret);
+    }
+
+    /* a zero-capacity buffer must be rejected, not wrapped to SIZE_MAX */
+    ret = flb_msgpack_to_json(small, 0, &obj, FLB_TRUE);
+    TEST_CHECK(ret < 0);
+
+    msgpack_zone_destroy(&mempool);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+}
+
 static int check_msgpack_val(msgpack_object obj, int expected_type, char *expected_val)
 {
     int len;
@@ -1303,6 +1344,7 @@ TEST_LIST = {
     { "json_pack_bug342"   , test_json_pack_bug342},
     { "json_pack_bug1278"  , test_json_pack_bug1278},
     { "json_pack_nan"      , test_json_pack_nan},
+    { "json_pack_truncation", test_json_pack_truncation},
     { "json_pack_bug5336"  , test_json_pack_bug5336},
     { "json_pack_empty_array", test_json_pack_empty_array},
     { "json_date_iso8601" , test_json_date_iso8601},


### PR DESCRIPTION
Scope: this is a small, self-contained **API contract / buffer-safety** fix for `flb_msgpack_to_json()`. It does **not** attempt to fix any caller's overflow recovery — see the note at the bottom.

## Two boundary issues in `flb_msgpack_to_json()`

**1. Overflow reported as `0` instead of a negative value.**
The function is documented to return "a number of characters on success, or a negative value", but on a buffer overflow it returns `0` (the `FLB_FALSE` from `msgpack2json()`), which is indistinguishable from a successful zero-length write:
```c
ret = msgpack2json(json_str, &off, json_size - 1, obj, escape_unicode);
json_str[off] = '\0';
return ret ? off: ret;   /* ret == 0 on overflow */
```
Return `-1` on overflow to match the contract. I audited every caller: the `_str`/`_sds` wrappers and the AWS/CloudWatch/Kinesis paths already test `ret <= 0`, so they are unaffected; only `out_s3`/`out_chronicle` test `ret < 0` (see note).

**2. Zero-capacity buffer wraps the size computation.**
`json_size - 1` underflows to `SIZE_MAX` when a non-NULL buffer is passed with `json_size == 0`, allowing `msgpack2json()` to write out of bounds. Reject `json_size == 0` up front.

## Testing
- [x] `tests/internal/pack.c::json_pack_truncation` asserts overflow returns a negative value and that a zero-capacity buffer is rejected. `flb-it-pack` passes.

## Note on callers (out_s3 / out_chronicle)
These two `log_key` extraction paths test `ret < 0` and simply `break` — they do **not** grow/retry, so an oversized `log_key` value is still dropped (previously it was emitted empty). That is a pre-existing data-loss bug and the real fix belongs in those plugins (grow-and-retry, like `flb_msgpack_to_json_str` already does). It will be sent as a separate `out_s3`/`out_chronicle` PR; this PR is intentionally scoped to the core contract/safety only.

Surfaced during review of #12129.

---

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved msgpack-to-JSON conversion by safely rejecting zero-capacity destination buffers.
  * Adjusted return-value behavior so truncated or non-fit JSON outputs are consistently reported as errors (negative results), while only successful conversions are treated as positive.

* **Tests**
  * Added a new unit test covering both too-small destination truncation and zero-capacity buffer rejection for msgpack-to-JSON conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->