### PR TITLE
tests: integration: Adopt to trace for memory issues for macOS and optimize executions

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -575,11 +575,15 @@ Run test files in parallel with pytest-xdist:
 ```
 
 Use file-level distribution because tests in the same module can share helper
-servers and in-memory capture state. For macOS memory checks, begin with two
-workers to limit simultaneous `leaks` processes:
+servers and in-memory capture state.
+
+Do not combine macOS `leaks` checks with multiple xdist workers. Concurrent
+`leaks` processes can fail to acquire Mach task ports. Run functional tests in
+parallel, then run memory verification serially:
 
 ```bash
-./tests/integration/run_tests.py --leaks-strict -n 2 --dist loadfile
+./tests/integration/run_tests.py -n 4 --dist loadfile
+./tests/integration/run_tests.py --leaks-strict
 ```
 
 Run a subset:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -568,6 +568,20 @@ Run tests with a simple checkbox progress view:
 ./tests/fluent-bit-test-suite/run_tests.py
 ```
 
+Run test files in parallel with pytest-xdist:
+
+```bash
+./tests/integration/run_tests.py -n 4 --dist loadfile
+```
+
+Use file-level distribution because tests in the same module can share helper
+servers and in-memory capture state. For macOS memory checks, begin with two
+workers to limit simultaneous `leaks` processes:
+
+```bash
+./tests/integration/run_tests.py --leaks-strict -n 2 --dist loadfile
+```
+
 Run a subset:
 
 ```bash

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -42,7 +42,7 @@ It starts a real Fluent Bit process, drives real network traffic into it, captur
 - downstream request generation
 - exporter endpoint output
 - negative-path handling
-- memory diagnostics through optional Valgrind execution
+- memory diagnostics through optional Valgrind or macOS `leaks` execution
 
 The suite is designed as a reusable tool for testing Fluent Bit plugins and protocol behavior with deterministic local infrastructure.
 
@@ -60,6 +60,7 @@ It provides:
 - bounded waits instead of ad hoc sleeps
 - per-run logs and result directories
 - optional Valgrind wrapping and parsing
+- optional macOS `leaks --atExit` supervision with graceful shutdown
 
 That makes it useful both for plugin development and for runtime regression testing.
 
@@ -85,7 +86,7 @@ That makes it useful both for plugin development and for runtime regression test
                     | start/stop binary
                     | logs/results
                     | readiness
-                    | valgrind integration
+                    | memory diagnostics
                     +----------+-----------+
                                |
                                v
@@ -108,7 +109,7 @@ That makes it useful both for plugin development and for runtime regression test
 - starts Fluent Bit with a scenario config
 - captures logs in a per-run results directory
 - exposes monitoring-based readiness checks
-- supports `VALGRIND=1`
+- supports `VALGRIND=1` and macOS `LEAKS=1`
 
 [`src/utils/test_service.py`](src/utils/test_service.py)
 
@@ -592,3 +593,36 @@ Require Valgrind-clean runs:
 VALGRIND=1 VALGRIND_STRICT=1 \
 ./tests/fluent-bit-test-suite/.venv/bin/pytest -q tests/fluent-bit-test-suite
 ```
+
+Run a focused scenario with macOS `leaks`:
+
+```bash
+./tests/integration/run_tests.py --leaks \
+    scenarios/out_stdout/tests/test_out_stdout_001.py \
+    -k default_format
+```
+
+Fail the test when `leaks` detects unreachable allocations or encounters a
+profiling error:
+
+```bash
+./tests/integration/run_tests.py --leaks-strict \
+    scenarios/out_stdout/tests/test_out_stdout_001.py \
+    -k default_format
+```
+
+The equivalent environment variables are `LEAKS=1` and
+`LEAKS_STRICT=1`. Each Fluent Bit run writes a `leaks.log` report under
+`tests/integration/results/`.
+
+The harness launches `leaks --atExit` as a supervisor and records the PID of
+its Fluent Bit child. During teardown it sends `SIGTERM` to Fluent Bit, waits
+for normal engine shutdown, and then waits for `leaks` to finish its report.
+Do not signal the `leaks` supervisor directly because that can prevent report
+generation.
+
+The macOS runner must allow `/usr/bin/leaks` to acquire the Fluent Bit Mach
+task port. Debug builds may need to be signed with the
+`com.apple.security.get-task-allow` entitlement. The `leaks` tool detects
+unreachable allocations; use AddressSanitizer or malloc diagnostics for
+invalid accesses and heap corruption.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,6 +19,7 @@ import yaml
 import logging
 import pytest
 
+from utils.fluent_bit_manager import fluent_bit_binary_version, parse_fluent_bit_version
 from utils.test_service import stop_active_services
 
 # Configure logging
@@ -47,6 +48,40 @@ GLOBAL_CONFIG = load_global_config()
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
     logger.info("Configuring pytest")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(config, items):
+    selected_version = fluent_bit_binary_version()
+
+    if selected_version is None:
+        return
+
+    for item in items:
+        marker = item.get_closest_marker("requires_fluent_bit")
+        if marker is None:
+            continue
+
+        if len(marker.args) != 1:
+            raise pytest.UsageError(
+                "requires_fluent_bit expects one minimum version argument"
+            )
+
+        required_text = str(marker.args[0])
+        required_version = parse_fluent_bit_version(required_text)
+        if required_version is None:
+            raise pytest.UsageError(
+                f"invalid requires_fluent_bit version: {required_text}"
+            )
+
+        if selected_version < required_version:
+            selected_text = ".".join(str(component) for component in selected_version)
+            item.add_marker(pytest.mark.skip(
+                reason=(
+                    f"requires Fluent Bit {required_text} or newer; "
+                    f"selected binary is {selected_text}"
+                )
+            ))
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ import yaml
 import logging
 import pytest
 
-from utils.fluent_bit_manager import fluent_bit_binary_version, parse_fluent_bit_version
+from utils.fluent_bit_manager import fluent_bit_binary_version
 from utils.test_service import stop_active_services
 
 # Configure logging
@@ -51,41 +51,9 @@ def pytest_configure(config):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(config, items):
-    selected_version = fluent_bit_binary_version()
-
-    if selected_version is None:
-        return
-
-    for item in items:
-        marker = item.get_closest_marker("requires_fluent_bit")
-        if marker is None:
-            continue
-
-        if len(marker.args) != 1:
-            raise pytest.UsageError(
-                "requires_fluent_bit expects one minimum version argument"
-            )
-
-        required_text = str(marker.args[0])
-        required_version = parse_fluent_bit_version(required_text)
-        if required_version is None:
-            raise pytest.UsageError(
-                f"invalid requires_fluent_bit version: {required_text}"
-            )
-
-        if selected_version < required_version:
-            selected_text = ".".join(str(component) for component in selected_version)
-            item.add_marker(pytest.mark.skip(
-                reason=(
-                    f"requires Fluent Bit {required_text} or newer; "
-                    f"selected binary is {selected_text}"
-                )
-            ))
-
-@pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):
     logger.info("Starting pytest session")
+    fluent_bit_binary_version()
     #flb = FluentBitManager(GLOBAL_CONFIG['fluent_bit']['config_path'])
     #flb = FluentBitManager()
 

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -21,4 +21,3 @@ log_cli = 1
 log_cli_level = INFO
 log_cli_format = %(asctime)s - %(levelname)s - %(message)s
 log_cli_date_format = %Y-%m-%d %H:%M:%S
-

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -29,6 +29,7 @@ packaging==24.1
 pluggy==1.5.0
 protobuf==4.25.3
 pytest==8.2.2
+pytest-xdist==3.8.0
 PyYAML==6.0.1
 requests==2.32.3
 soupsieve==2.5

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -21,15 +21,19 @@ def _maybe_reexec_in_venv() -> None:
     if not VENV_PYTHON.is_file():
         return
 
-    current = Path(sys.executable).resolve()
-    target = VENV_PYTHON.resolve()
+    current_prefix = Path(sys.prefix).resolve()
+    target_prefix = VENV_PYTHON.parent.parent.resolve()
 
-    if current == target:
+    if current_prefix == target_prefix:
         return
 
     env = os.environ.copy()
     env[REEXEC_ENV] = "1"
-    os.execve(str(target), [str(target), str(Path(__file__).resolve()), *sys.argv[1:]], env)
+    os.execve(
+        str(VENV_PYTHON),
+        [str(VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]],
+        env,
+    )
 
 
 _maybe_reexec_in_venv()
@@ -256,6 +260,16 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         help="Run with VALGRIND=1 and VALGRIND_STRICT=1.",
     )
     parser.add_argument(
+        "--leaks",
+        action="store_true",
+        help="Run on macOS with LEAKS=1.",
+    )
+    parser.add_argument(
+        "--leaks-strict",
+        action="store_true",
+        help="Run on macOS with LEAKS=1 and LEAKS_STRICT=1.",
+    )
+    parser.add_argument(
         "--quiet",
         action="store_true",
         help="Use quieter pytest output; checkbox progress still renders.",
@@ -265,7 +279,14 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         action="store_true",
         help="Keep pytest live logs enabled instead of the cleaner wrapper view.",
     )
-    return parser.parse_known_args(argv)
+    args, passthrough = parser.parse_known_args(argv)
+
+    valgrind_requested = args.valgrind or args.valgrind_strict
+    leaks_requested = args.leaks or args.leaks_strict
+    if valgrind_requested and leaks_requested:
+        parser.error("Valgrind and macOS leaks cannot be enabled together")
+
+    return args, passthrough
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -279,6 +300,10 @@ def main(argv: list[str] | None = None) -> int:
         os.environ["VALGRIND"] = "1"
     if args.valgrind_strict:
         os.environ["VALGRIND_STRICT"] = "1"
+    if args.leaks or args.leaks_strict:
+        os.environ["LEAKS"] = "1"
+    if args.leaks_strict:
+        os.environ["LEAKS_STRICT"] = "1"
 
     if args.list_only:
         collector = CollectPlugin()

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -247,6 +247,24 @@ def print_collected_tests(nodeids: list[str]) -> None:
             print(f"  [ ] {short_name_from_nodeid(nodeid)}")
 
 
+def _xdist_uses_multiple_workers(passthrough: list[str]) -> bool:
+    for index, argument in enumerate(passthrough):
+        worker_count = None
+
+        if argument in ("-n", "--numprocesses"):
+            if index + 1 < len(passthrough):
+                worker_count = passthrough[index + 1]
+        elif argument.startswith("--numprocesses="):
+            worker_count = argument.split("=", 1)[1]
+        elif argument.startswith("-n") and len(argument) > 2:
+            worker_count = argument[2:]
+
+        if worker_count is not None:
+            return worker_count not in ("0", "1")
+
+    return False
+
+
 def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser(
         description="List and run the Fluent Bit Python test suite with a simple checkbox progress view."
@@ -285,6 +303,11 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     leaks_requested = args.leaks or args.leaks_strict
     if valgrind_requested and leaks_requested:
         parser.error("Valgrind and macOS leaks cannot be enabled together")
+    if leaks_requested and _xdist_uses_multiple_workers(passthrough):
+        parser.error(
+            "macOS leaks checks require one pytest worker because concurrent "
+            "leaks processes can fail to acquire Mach task ports"
+        )
 
     return args, passthrough
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -265,6 +265,10 @@ def _xdist_uses_multiple_workers(passthrough: list[str]) -> bool:
     return False
 
 
+def _memory_check_environment_enabled(variable_name: str) -> bool:
+    return bool(os.environ.get(variable_name))
+
+
 def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser(
         description="List and run the Fluent Bit Python test suite with a simple checkbox progress view."
@@ -299,8 +303,16 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     )
     args, passthrough = parser.parse_known_args(argv)
 
-    valgrind_requested = args.valgrind or args.valgrind_strict
-    leaks_requested = args.leaks or args.leaks_strict
+    valgrind_requested = (
+        args.valgrind
+        or args.valgrind_strict
+        or _memory_check_environment_enabled("VALGRIND")
+    )
+    leaks_requested = (
+        args.leaks
+        or args.leaks_strict
+        or _memory_check_environment_enabled("LEAKS")
+    )
     if valgrind_requested and leaks_requested:
         parser.error("Valgrind and macOS leaks cannot be enabled together")
     if leaks_requested and _xdist_uses_multiple_workers(passthrough):

--- a/tests/integration/scenarios/hot_reload_watch/tests/test_hot_reload_watch_001.py
+++ b/tests/integration/scenarios/hot_reload_watch/tests/test_hot_reload_watch_001.py
@@ -26,8 +26,11 @@ import requests
 from google.protobuf import json_format
 
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
-from src.server.otlp_server import data_storage, otlp_server_run
-from src.utils.fluent_bit_manager import FluentBitManager
+from src.server.otlp_server import data_storage, otlp_server_run, stop_otlp_server
+from src.utils.fluent_bit_manager import (
+    FluentBitManager,
+    fluent_bit_binary_supports_config_property,
+)
 from src.utils.network import find_available_port
 
 logger = logging.getLogger(__name__)
@@ -67,10 +70,12 @@ class Service:
         self.flb.start()
 
     def stop(self):
-        if getattr(self, "flb", None) is not None and self.flb.process is not None:
-            self.flb.stop()
-        requests.post(f"http://127.0.0.1:{self.test_suite_http_port}/shutdown")
-        shutil.rmtree(self.runtime_dir, ignore_errors=True)
+        try:
+            if getattr(self, "flb", None) is not None and self.flb.process is not None:
+                self.flb.stop()
+        finally:
+            stop_otlp_server()
+            shutil.rmtree(self.runtime_dir, ignore_errors=True)
 
     def wait_for_log_count(self, expected_count, timeout=15):
         start_time = time.time()
@@ -100,6 +105,9 @@ def assert_reload_result(service):
 
 
 def test_hot_reload_watch_yaml_config_change():
+    if not fluent_bit_binary_supports_config_property("hot_reload.watch"):
+        pytest.skip("hot_reload.watch is not supported by the selected Fluent Bit binary")
+
     service = Service("fluent-bit-before.yaml", "fluent-bit-after.yaml")
 
     try:

--- a/tests/integration/scenarios/hot_reload_watch/tests/test_hot_reload_watch_001.py
+++ b/tests/integration/scenarios/hot_reload_watch/tests/test_hot_reload_watch_001.py
@@ -74,8 +74,10 @@ class Service:
             if getattr(self, "flb", None) is not None and self.flb.process is not None:
                 self.flb.stop()
         finally:
-            stop_otlp_server()
-            shutil.rmtree(self.runtime_dir, ignore_errors=True)
+            try:
+                stop_otlp_server()
+            finally:
+                shutil.rmtree(self.runtime_dir, ignore_errors=True)
 
     def wait_for_log_count(self, expected_count, timeout=15):
         start_time = time.time()
@@ -102,6 +104,21 @@ class Service:
 def assert_reload_result(service):
     service.wait_for_log_count(2)
     assert service.read_message(1) == "after"
+
+
+def test_cleanup_removes_runtime_dir_when_otlp_stop_fails(monkeypatch):
+    service = Service("fluent-bit-before.yaml", "fluent-bit-after.yaml")
+    runtime_dir = service.runtime_dir
+
+    def fail_to_stop_otlp_server():
+        raise RuntimeError("OTLP server did not stop")
+
+    monkeypatch.setitem(globals(), "stop_otlp_server", fail_to_stop_otlp_server)
+
+    with pytest.raises(RuntimeError, match="OTLP server did not stop"):
+        service.stop()
+
+    assert not os.path.exists(runtime_dir)
 
 
 def test_hot_reload_watch_yaml_config_change():

--- a/tests/integration/scenarios/in_elasticsearch/tests/test_in_elasticsearch_001.py
+++ b/tests/integration/scenarios/in_elasticsearch/tests/test_in_elasticsearch_001.py
@@ -36,6 +36,10 @@ IN_ELASTICSEARCH_SMALL_BUFFER_REGRESSION_CASES = [
     },
 ]
 
+# A deliberately truncated response can surface as an HTTP/2 framing error (16),
+# a send error (55), or a receive error (56), depending on curl and the protocol.
+SMALL_BUFFER_CURL_EXIT_CODES = {0, 16, 55, 56}
+
 
 def parse_single_item_response(response_text):
     payload = json.loads(response_text)
@@ -325,7 +329,7 @@ def test_in_elasticsearch_bulk_small_status_buffer_does_not_crash(case):
     # The regression condition is process termination from a reachable double-free.
     # Response formatting can still vary under constrained buffer settings, but the
     # parser must not take down the process.
-    assert curl_result.returncode in {0, 55, 56}
+    assert curl_result.returncode in SMALL_BUFFER_CURL_EXIT_CODES
     assert health_result["status_code"] == 200
 
 

--- a/tests/integration/scenarios/in_forward/config/in_forward_storage_limit_multi_output.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_storage_limit_multi_output.yaml
@@ -32,4 +32,4 @@ pipeline:
       format: json
       json_date_key: false
       retry_limit: false
-      storage.total_limit_size: 10K
+      storage.total_limit_size: ${FORWARD_STORAGE_TOTAL_LIMIT_SIZE}

--- a/tests/integration/scenarios/in_forward/config/in_forward_storage_limit_shared_success_output.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_storage_limit_shared_success_output.yaml
@@ -31,4 +31,4 @@ pipeline:
       format: json
       json_date_key: false
       retry_limit: false
-      storage.total_limit_size: 10K
+      storage.total_limit_size: ${FORWARD_STORAGE_TOTAL_LIMIT_SIZE}

--- a/tests/integration/scenarios/in_forward/config/in_forward_storage_limit_single_output.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_storage_limit_single_output.yaml
@@ -22,4 +22,4 @@ pipeline:
       format: json
       json_date_key: false
       retry_limit: false
-      storage.total_limit_size: 10K
+      storage.total_limit_size: ${FORWARD_STORAGE_TOTAL_LIMIT_SIZE}

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -19,6 +19,8 @@ import opentelemetry.proto.collector
 import pytest
 import requests
 
+from utils.memory_check import memory_check_enabled
+
 VENDORED_OTEL_PROTO_ROOT = Path(__file__).resolve().parents[3] / "vendor"
 VENDORED_OTEL_PACKAGE_ROOT = VENDORED_OTEL_PROTO_ROOT / "opentelemetry"
 VENDORED_OTEL_PROTO_PACKAGE_ROOT = VENDORED_OTEL_PACKAGE_ROOT / "proto"
@@ -1646,7 +1648,7 @@ def test_in_forward_storage_limit_multi_output_prefers_deletable_solo_chunk():
 
 def test_in_forward_storage_limit_shared_success_route_deletes_old_chunk():
     service = StorageLimitService("in_forward_storage_limit_shared_success_output.yaml")
-    timeout = 30 if os.environ.get("VALGRIND") else 10
+    timeout = 30 if memory_check_enabled() else 10
     service.start()
 
     try:

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -1,6 +1,7 @@
 import gzip
 import hashlib
 import json
+import mmap
 import os
 import shutil
 import socket
@@ -48,6 +49,7 @@ from server.forward_server import (
 )
 from server.http_server import configure_http_response, data_storage, http_server_run
 from utils.data_utils import read_file, read_json_file
+from utils.fluent_bit_manager import fluent_bit_input_supports_config_property
 from utils.test_service import FluentBitTestService
 
 
@@ -61,6 +63,7 @@ SECURE_SELF_HOSTNAME = "server-node"
 
 class Service:
     def __init__(self, config_file, *, use_unix_socket=False):
+        self.config_name = config_file
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
         self.use_unix_socket = use_unix_socket
         self.socket_path = None
@@ -74,7 +77,10 @@ class Service:
         }
 
         if use_unix_socket:
-            self.socket_path = os.path.join(tempfile.gettempdir(), f"fluent_bit_forward_{uuid.uuid4().hex}.sock")
+            socket_dir = "/tmp" if sys.platform == "darwin" else tempfile.gettempdir()
+            self.socket_path = os.path.join(
+                socket_dir, f"flb-fw-{uuid.uuid4().hex[:12]}.sock"
+            )
             extra_env["FORWARD_UNIX_PATH"] = self.socket_path
 
         self.service = FluentBitTestService(
@@ -106,6 +112,10 @@ class Service:
                 pass
 
     def start(self):
+        if ("workers" in self.config_name and
+                not fluent_bit_input_supports_config_property("forward", "workers")):
+            pytest.skip("forward.workers is not supported by the selected Fluent Bit binary")
+
         self.service.start()
         self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
@@ -151,6 +161,9 @@ class StorageLimitService(Service):
         self.file_output_path = tempfile.mkdtemp(prefix="fluent_bit_forward_file_output_")
         self.service.extra_env["FORWARD_STORAGE_PATH"] = self.storage_path
         self.service.extra_env["FORWARD_FILE_OUTPUT_PATH"] = self.file_output_path
+        self.service.extra_env["FORWARD_STORAGE_TOTAL_LIMIT_SIZE"] = str(
+            mmap.PAGESIZE * 2
+        )
 
     def stop(self):
         try:
@@ -650,7 +663,7 @@ def _send_unix_payload(path, payload):
 
 def _send_tls_payload(port, payload, cafile):
     context = ssl.create_default_context(cafile=cafile)
-    with socket.create_connection(("127.0.0.1", port), timeout=5) as raw_sock:
+    with socket.create_connection(("127.0.0.1", port), timeout=20) as raw_sock:
         with context.wrap_socket(raw_sock, server_hostname="localhost") as tls_sock:
             tls_sock.sendall(payload)
 

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -184,7 +184,17 @@ class StorageLimitService(Service):
         if not stream_dir.exists():
             return []
 
-        return [path.read_bytes() for path in stream_dir.rglob("*.flb") if path.is_file()]
+        contents = []
+
+        for path in stream_dir.rglob("*.flb"):
+            try:
+                if path.is_file():
+                    contents.append(path.read_bytes())
+            except FileNotFoundError:
+                # Chunk eviction can remove a file between discovery and open.
+                continue
+
+        return contents
 
     def file_output_contents(self):
         output_dir = Path(self.file_output_path)

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -1349,12 +1349,13 @@ def test_in_opentelemetry_http_workers_mixed_signal_matrix(case):
         ("metrics", "test_metrics_001.in.json", "/v1/metrics"),
         ("traces", "test_traces_001.in.json", "/v1/traces"),
     ]
+    worker_count = 4
     repeats_per_signal = 4
     total_requests = len(request_plan) * repeats_per_signal
 
     service = Service(IN_OPENTELEMETRY_WORKER_PROTOCOL_CONFIGS[case["config_key"]])
     service.start()
-    service.wait_for_log_message("with 4 workers", timeout=10)
+    service.wait_for_log_message(f"with {worker_count} workers", timeout=10)
 
     scheme = "https" if case["use_tls"] else "http"
     request_jobs = []
@@ -1377,7 +1378,7 @@ def test_in_opentelemetry_http_workers_mixed_signal_matrix(case):
             ca_cert_path=service.tls_crt_file if case["use_tls"] else None,
         )
 
-    with ThreadPoolExecutor(max_workers=total_requests) as executor:
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
         results = list(executor.map(send_job, request_jobs))
 
     for result in results:

--- a/tests/integration/scenarios/in_tail/config/tail_ignore_active_older.yaml
+++ b/tests/integration/scenarios/in_tail/config/tail_ignore_active_older.yaml
@@ -14,7 +14,7 @@ pipeline:
       refresh_interval: 1
       watcher_interval: 1
       progress_check_interval: 1
-      rotate_wait: 6
+      rotate_wait: 1
       inotify_watcher: false
       ignore_older: 2s
       ignore_active_older_files: true

--- a/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
+++ b/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
@@ -1047,7 +1047,7 @@ def test_in_tail_ignore_older_skips_stale_files(workspace):
         service.stop()
 
 
-def test_in_tail_ignore_active_older_files_stops_following_aged_file(workspace):
+def test_in_tail_ignore_active_older_files_resumes_updated_file(workspace):
     log_file = workspace / "active-aged.log"
     db_path = workspace / "tail.db"
 
@@ -1063,9 +1063,11 @@ def test_in_tail_ignore_active_older_files_stops_following_aged_file(workspace):
         time.sleep(4)
         service.assert_no_new_records_for(1, quiet_period=4)
         write_and_sync(log_file, "second-line\n")
-        service.assert_no_new_records_for(1, quiet_period=4)
+        records = service.wait_for_records(2, timeout=20)
     finally:
         service.stop()
+
+    assert_log_set(records, ["first-line", "second-line"])
 
 
 def test_in_tail_docker_mode_parses_and_flushes_docker_json_stream(workspace):

--- a/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
+++ b/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
@@ -12,7 +12,16 @@ import pytest
 import requests
 
 from server.http_server import data_storage, http_server_run
+from utils.fluent_bit_manager import fluent_bit_input_supports_config_property
 from utils.test_service import FluentBitTestService
+
+
+POLLING_CONFIGS = {
+    "tail_ignore_active_older.yaml",
+    "tail_ignore_older.yaml",
+    "tail_stat.yaml",
+    "tail_stat_db_compare_filename.yaml",
+}
 
 
 def _timezone_available(iana_zone):
@@ -44,6 +53,7 @@ class PersistentWriter:
 
 class Service:
     def __init__(self, config_file, *, tail_path, db_path):
+        self.config_name = config_file
         self.config_file = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../config", config_file)
         )
@@ -84,6 +94,14 @@ class Service:
             pass
 
     def start(self):
+        if (self.config_name in POLLING_CONFIGS and
+                not fluent_bit_input_supports_config_property(
+                    "tail", "inotify_watcher"
+                )):
+            pytest.skip(
+                "tail.inotify_watcher is not supported by the selected Fluent Bit binary"
+            )
+
         self.service.start()
         self.flb = self.service.flb
 

--- a/tests/integration/scenarios/in_tcp/tests/test_in_tcp_001.py
+++ b/tests/integration/scenarios/in_tcp/tests/test_in_tcp_001.py
@@ -4,14 +4,17 @@ import ssl
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
 import requests
 
 from server.http_server import data_storage, http_server_run
+from utils.fluent_bit_manager import fluent_bit_input_supports_config_property
 from utils.test_service import FluentBitTestService
 
 
 class Service:
     def __init__(self, config_file):
+        self.config_name = config_file
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
         test_path = os.path.dirname(os.path.abspath(__file__))
         self.parsers_file = os.environ.get("FLUENT_BIT_PARSERS_FILE") or os.path.abspath(
@@ -48,6 +51,10 @@ class Service:
             pass
 
     def start(self):
+        if ("workers" in self.config_name and
+                not fluent_bit_input_supports_config_property("tcp", "workers")):
+            pytest.skip("tcp.workers is not supported by the selected Fluent Bit binary")
+
         self.service.start()
         self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
@@ -110,7 +117,7 @@ def _drop_partial_connection(port, payload):
 
 def _send_tls_line(port, line, cafile):
     context = ssl.create_default_context(cafile=cafile)
-    with socket.create_connection(("127.0.0.1", port), timeout=5) as raw_sock:
+    with socket.create_connection(("127.0.0.1", port), timeout=20) as raw_sock:
         with context.wrap_socket(raw_sock, server_hostname="localhost") as tls_sock:
             tls_sock.sendall(line.encode("utf-8"))
             tls_sock.shutdown(socket.SHUT_WR)

--- a/tests/integration/scenarios/in_udp/tests/test_in_udp_001.py
+++ b/tests/integration/scenarios/in_udp/tests/test_in_udp_001.py
@@ -3,14 +3,17 @@ import socket
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
 import requests
 
 from server.http_server import data_storage, http_server_run
+from utils.fluent_bit_manager import fluent_bit_input_supports_config_property
 from utils.test_service import FluentBitTestService
 
 
 class Service:
     def __init__(self, config_file):
+        self.config_name = config_file
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
         test_path = os.path.dirname(os.path.abspath(__file__))
         self.parsers_file = os.environ.get("FLUENT_BIT_PARSERS_FILE") or os.path.abspath(
@@ -42,6 +45,10 @@ class Service:
             pass
 
     def start(self):
+        if ("workers" in self.config_name and
+                not fluent_bit_input_supports_config_property("udp", "workers")):
+            pytest.skip("udp.workers is not supported by the selected Fluent Bit binary")
+
         self.service.start()
         self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port

--- a/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
+++ b/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
@@ -5,6 +5,7 @@ import threading
 
 import pytest
 
+from utils.memory_check import memory_check_enabled
 from utils.test_service import FluentBitTestService
 
 
@@ -83,7 +84,7 @@ class Service:
         self.service.stop()
 
     def wait_for_requests(self, minimum_count, timeout=10):
-        if os.environ.get("VALGRIND"):
+        if memory_check_enabled():
             timeout = max(timeout * 3, 30)
 
         return self.service.wait_for_condition(
@@ -96,7 +97,7 @@ class Service:
         )
 
     def wait_for_action_lines(self, minimum_count, timeout=10):
-        if os.environ.get("VALGRIND"):
+        if memory_check_enabled():
             timeout = max(timeout * 3, 30)
 
         return self.service.wait_for_condition(

--- a/tests/integration/scenarios/out_forward/tests/test_out_forward_metadata_001.py
+++ b/tests/integration/scenarios/out_forward/tests/test_out_forward_metadata_001.py
@@ -10,6 +10,7 @@ from server.forward_server import (
     forward_server_stop,
 )
 from utils.fluent_bit_manager import FluentBitManager
+from utils.memory_check import memory_check_enabled
 from utils.network import find_available_port, wait_for_port_to_be_free
 
 
@@ -66,7 +67,8 @@ class FluentBitForwardChain:
                 self.receiver.stop()
         finally:
             forward_server_stop()
-            wait_for_port_to_be_free(self.capture_port, timeout=10 if os.environ.get("VALGRIND") else 5)
+            timeout = 10 if memory_check_enabled() else 5
+            wait_for_port_to_be_free(self.capture_port, timeout=timeout)
             self._restore_env()
 
     def wait_for_forward_messages(self, minimum_count, timeout=10):
@@ -162,7 +164,8 @@ def _capture_record(sender_config_file, message):
 
     try:
         _send_log_event_with_metadata(service.sender_port, message)
-        messages = service.wait_for_forward_messages(1, timeout=20 if os.environ.get("VALGRIND") else 10)
+        timeout = 20 if memory_check_enabled() else 10
+        messages = service.wait_for_forward_messages(1, timeout=timeout)
     finally:
         service.stop()
 

--- a/tests/integration/scenarios/out_forward/tests/test_out_forward_secure_001.py
+++ b/tests/integration/scenarios/out_forward/tests/test_out_forward_secure_001.py
@@ -12,6 +12,7 @@ from server.forward_server import (
 )
 from utils.data_utils import read_file
 from utils.fluent_bit_manager import FluentBitManager
+from utils.memory_check import memory_check_enabled
 from utils.network import find_available_port, wait_for_port_to_be_free
 
 
@@ -113,7 +114,7 @@ class SecureForwardChain:
             forward_server_stop()
             wait_for_port_to_be_free(
                 self.receiver_port,
-                timeout=10 if os.environ.get("VALGRIND") else 5,
+                timeout=10 if memory_check_enabled() else 5,
             )
             self._restore_env()
 
@@ -152,7 +153,7 @@ def test_out_forward_secure_handshake_delivers_records():
     try:
         _send_message(chain.sender_port, "secure-forward-e2e")
         messages = chain.wait_for_forward_messages(
-            1, timeout=20 if os.environ.get("VALGRIND") else 10
+            1, timeout=20 if memory_check_enabled() else 10
         )
         handshakes = chain.wait_for_handshakes(1)
     finally:

--- a/tests/integration/scenarios/out_http/tests/test_out_http_001.py
+++ b/tests/integration/scenarios/out_http/tests/test_out_http_001.py
@@ -12,12 +12,13 @@ from server.http_server import (
     http_server_run,
     server_instances,
 )
+from utils.memory_check import memory_check_enabled
 from utils.test_service import FluentBitTestService
 
 logger = logging.getLogger(__name__)
 
-def _valgrind_timeout(timeout):
-    if os.environ.get("VALGRIND"):
+def _memory_check_timeout(timeout):
+    if memory_check_enabled():
         return max(timeout * 3, 30)
 
     return timeout
@@ -135,7 +136,7 @@ class Service:
     def wait_for_requests(self, minimum_count, timeout=10):
         return self.service.wait_for_condition(
             lambda: data_storage["requests"] if len(data_storage["requests"]) >= minimum_count else None,
-            timeout=_valgrind_timeout(timeout),
+            timeout=_memory_check_timeout(timeout),
             interval=0.5,
             description=f"{minimum_count} outbound HTTP requests",
         )
@@ -155,7 +156,7 @@ class Service:
 
         return self.service.wait_for_condition(
             _read_log,
-            timeout=_valgrind_timeout(timeout),
+            timeout=_memory_check_timeout(timeout),
             interval=0.25,
             description=f"log message '{pattern}'",
         )

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -13,6 +13,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTrace
 
 from server.kafka_server import data_storage, kafka_server_run, kafka_server_stop
 from utils.data_utils import read_json_file
+from utils.memory_check import memory_check_enabled
 from utils.test_service import FluentBitTestService
 
 
@@ -930,7 +931,7 @@ def test_out_kafka_otlp_json_partition_by_resource_rejects_oversized_message():
     service.start()
     service.send_payload_dict(_build_monolithic_logs_payload(512), "logs")
 
-    timeout = 30 if os.environ.get("VALGRIND") else 10
+    timeout = 30 if memory_check_enabled() else 10
     log_text = _wait_for_log_text(
         service.flb.log_file,
         "Broker: Message size too large",

--- a/tests/integration/src/server/otlp_server.py
+++ b/tests/integration/src/server/otlp_server.py
@@ -280,6 +280,9 @@ def run_grpc_server(port=4317, *, use_tls=False, tls_crt_file=None, tls_key_file
 def stop_otlp_server():
     global grpc_server_instance
     global http_server_instance
+    global server_thread
+
+    stop_event = None
 
     shutdown_flag.set()
 
@@ -288,8 +291,18 @@ def stop_otlp_server():
         http_server_instance = None
 
     if grpc_server_instance is not None:
-        grpc_server_instance.stop(grace=0)
+        stop_event = grpc_server_instance.stop(grace=0)
         grpc_server_instance = None
+
+    if stop_event is not None:
+        stop_event.wait(timeout=5)
+
+    if server_thread is not None and server_thread is not threading.current_thread():
+        server_thread.join(timeout=5)
+        if server_thread.is_alive():
+            raise RuntimeError("OTLP server thread did not stop")
+
+    server_thread = None
 
 
 def otlp_server_run(port, *, use_tls=False, tls_crt_file=None, tls_key_file=None, use_grpc=False):

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -91,6 +91,24 @@ def fluent_bit_binary_supports_config_property(property_name, binary_path=None):
     return property_marker.encode("utf-8") in binary_contents
 
 
+def fluent_bit_input_supports_config_property(plugin_name, property_name, binary_path=None):
+    resolved_path = _resolve_binary_path(binary_path)
+    property_marker = property_name.lower()
+
+    try:
+        result = subprocess.run(
+            [resolved_path, "-i", plugin_name, "-h"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+
+    help_output = f"{result.stdout}\n{result.stderr}".lower()
+    return property_marker in help_output
+
+
 class FluentBitManager:
     def __init__(self, config_path=None, binary_path=None):
         logger.info(f"config path {config_path}")

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -45,6 +45,7 @@ LEAKS_EXEC_SCRIPT = (
 
 logger = logging.getLogger(__name__)
 FLUENT_BIT_VERSION_PATTERN = re.compile(r"(?:Fluent Bit\s+)?v?(\d+)\.(\d+)\.(\d+)")
+_BINARY_VERSION_INFO_CACHE = {}
 
 class FluentBitStartupError(RuntimeError):
     pass
@@ -76,8 +77,11 @@ def parse_fluent_bit_version(version_text):
     return tuple(int(component) for component in match.groups())
 
 
-def fluent_bit_binary_version(binary_path=None):
+def _read_binary_version_info(binary_path=None):
     resolved_path = _resolve_binary_path(binary_path)
+
+    if resolved_path in _BINARY_VERSION_INFO_CACHE:
+        return _BINARY_VERSION_INFO_CACHE[resolved_path]
 
     try:
         result = subprocess.run(
@@ -89,7 +93,23 @@ def fluent_bit_binary_version(binary_path=None):
     except OSError:
         return None
 
-    return parse_fluent_bit_version(f"{result.stdout}\n{result.stderr}")
+    output = result.stdout.strip().splitlines()
+    if not output:
+        return None
+
+    version = output[0].replace("Fluent Bit ", "").strip()
+    commit = output[1].replace("Git commit: ", "").strip() if len(output) > 1 else "unknown"
+    version_info = (version, commit)
+    _BINARY_VERSION_INFO_CACHE[resolved_path] = version_info
+    return version_info
+
+
+def fluent_bit_binary_version(binary_path=None):
+    version_info = _read_binary_version_info(binary_path)
+    if version_info is None:
+        return None
+
+    return parse_fluent_bit_version(version_info[0])
 
 
 def fluent_bit_binary_supports_config_property(property_name, binary_path=None):
@@ -371,20 +391,13 @@ class FluentBitManager:
         self.process.wait(timeout=5)
 
     def get_version_info(self):
-        try:
-            result = subprocess.run(
-                [self.binary_absolute_path, '--version'],
-                capture_output=True,
-                text=True,
-                check=True,
+        version_info = _read_binary_version_info(self.binary_absolute_path)
+        if version_info is None:
+            raise FluentBitStartupError(
+                f"Unable to execute Fluent Bit binary {self.binary_absolute_path}"
             )
-            output = result.stdout.strip().split('\n')
-            version = output[0].replace('Fluent Bit ', '').strip()
-            commit = output[1].strip().replace('Git commit: ', '') if len(output) > 1 else "unknown"
-            return version, commit
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            logger.error("Error running Fluent Bit: %s", e)
-            raise FluentBitStartupError(f"Unable to execute Fluent Bit binary {self.binary_absolute_path}") from e
+
+        return version_info
 
     def create_results_directory(self, base_dir=None):
         if base_dir is None:

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -193,8 +193,11 @@ class FluentBitManager:
 
         pid = self.target_pid or self.process.pid
         return_code = self.process.poll()
-        if self.process.poll() is None:
+        supervisor_running = self.process.poll() is None
+        if supervisor_running or (leaks_enabled() and self.target_pid):
             self.send_signal(signal.SIGTERM)
+
+        if supervisor_running:
             try:
                 timeout = LEAKS_EXIT_TIMEOUT if leaks_enabled() else 10
                 return_code = self.process.wait(timeout=timeout)

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -312,7 +312,7 @@ class FluentBitManager:
 
     def trigger_http_reload(self):
         url = f"http://127.0.0.1:{self.http_monitoring_port}/api/v2/reload"
-        response = requests.post(url)
+        response = requests.post(url, timeout=0.5)
         response.raise_for_status()
         return response.json()
 
@@ -340,9 +340,9 @@ class FluentBitManager:
 
         return [
             leaks_binary,
-            "--quiet",
-            "--fullStacks",
-            "--atExit",
+            "-quiet",
+            "-fullStacks",
+            "-atExit",
             "--",
             "/bin/sh",
             "-c",
@@ -371,6 +371,7 @@ class FluentBitManager:
                 )
             time.sleep(0.05)
 
+        self._force_stop()
         raise FluentBitStartupError(
             f"Timed out waiting for the Fluent Bit PID from leaks. See {self.leaks_log_file}"
         )

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -19,6 +19,7 @@ import logging
 import os
 import platform
 from pathlib import Path
+import re
 import signal
 import shutil
 import subprocess
@@ -43,6 +44,7 @@ LEAKS_EXEC_SCRIPT = (
 )
 
 logger = logging.getLogger(__name__)
+FLUENT_BIT_VERSION_PATTERN = re.compile(r"(?:Fluent Bit\s+)?v?(\d+)\.(\d+)\.(\d+)")
 
 class FluentBitStartupError(RuntimeError):
     pass
@@ -64,6 +66,30 @@ def _default_binary_path():
 def _resolve_binary_path(binary_path=None):
     selected_path = binary_path or os.environ.get(ENV_FLB_BINARY_PATH) or _default_binary_path()
     return shutil.which(selected_path) or os.path.abspath(selected_path)
+
+
+def parse_fluent_bit_version(version_text):
+    match = FLUENT_BIT_VERSION_PATTERN.search(version_text)
+    if not match:
+        return None
+
+    return tuple(int(component) for component in match.groups())
+
+
+def fluent_bit_binary_version(binary_path=None):
+    resolved_path = _resolve_binary_path(binary_path)
+
+    try:
+        result = subprocess.run(
+            [resolved_path, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+
+    return parse_fluent_bit_version(f"{result.stdout}\n{result.stderr}")
 
 
 def fluent_bit_binary_supports_config_property(property_name, binary_path=None):

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -17,17 +17,30 @@
 import datetime
 import logging
 import os
+import platform
 from pathlib import Path
+import signal
 import shutil
 import subprocess
+import tempfile
 import time
 
 import requests
 
 from utils.network import find_available_port, wait_for_port_to_be_free
+from utils.leaks import assert_leaks_clean
+from utils.memory_check import leaks_enabled, memory_check_enabled, valgrind_enabled
 from utils.valgrind import assert_valgrind_clean
 
 ENV_FLB_HTTP_MONITORING_PORT = "FLUENT_BIT_HTTP_MONITORING_PORT"
+ENV_FLB_BINARY_PATH = "FLUENT_BIT_BINARY"
+LEAKS_TARGET_PID_TIMEOUT = 10
+LEAKS_EXIT_TIMEOUT = 120
+
+LEAKS_EXEC_SCRIPT = (
+    'printf "%s\\n" "$$" > "$1"; output_file="$2"; shift 2; '
+    'exec "$@" >> "$output_file" 2>&1'
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,17 +61,50 @@ def _default_binary_path():
     return str(local_binary)
 
 
+def _resolve_binary_path(binary_path=None):
+    selected_path = binary_path or os.environ.get(ENV_FLB_BINARY_PATH) or _default_binary_path()
+    return shutil.which(selected_path) or os.path.abspath(selected_path)
+
+
+def fluent_bit_binary_supports_config_property(property_name, binary_path=None):
+    resolved_path = _resolve_binary_path(binary_path)
+    property_marker = property_name.lower()
+
+    try:
+        result = subprocess.run(
+            [resolved_path, "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        help_output = f"{result.stdout}\n{result.stderr}".lower()
+        if property_marker in help_output:
+            return True
+    except OSError:
+        pass
+
+    try:
+        binary_contents = Path(resolved_path).read_bytes().lower()
+    except OSError:
+        return False
+
+    return property_marker.encode("utf-8") in binary_contents
+
+
 class FluentBitManager:
     def __init__(self, config_path=None, binary_path=None):
         logger.info(f"config path {config_path}")
         self.config_path = config_path
-        self.binary_path = binary_path or os.environ.get("FLUENT_BIT_BINARY") or _default_binary_path()
-        self.binary_absolute_path = os.path.abspath(self.binary_path)
+        self.binary_path = binary_path or os.environ.get(ENV_FLB_BINARY_PATH) or _default_binary_path()
+        self.binary_absolute_path = _resolve_binary_path(self.binary_path)
         self.process = None
         self.http_monitoring_port = None
         self.results_dir = None
         self.log_file = None
         self.valgrind_log_file = None
+        self.leaks_log_file = None
+        self.leaks_target_pid_file = None
+        self.target_pid = None
         self.output_handle = None
 
     def set_http_monitoring_port(self, env_var_name, starting_port=0):
@@ -82,7 +128,12 @@ class FluentBitManager:
         self.results_dir = out_dir
         self.log_file = os.path.join(out_dir, "fluent_bit.log")
         self.valgrind_log_file = os.path.join(out_dir, "valgrind.log")
+        self.leaks_log_file = os.path.join(out_dir, "leaks.log")
+        self.leaks_target_pid_file = os.path.join(out_dir, "leaks_target.pid")
         self.set_http_monitoring_port(ENV_FLB_HTTP_MONITORING_PORT)
+
+        if valgrind_enabled() and leaks_enabled():
+            raise FluentBitStartupError("VALGRIND and LEAKS cannot be enabled together")
 
         version, commit = self.get_version_info()
         logger.info(f'Fluent Bit info')
@@ -92,8 +143,10 @@ class FluentBitManager:
         logger.info(f" logfile    : {self.log_file}")
         logger.info(f" http port  : {self.http_monitoring_port}")
         logger.info(f" commit     : {commit}")
-        if self.valgrind_log_file:
+        if valgrind_enabled():
             logger.info(f" valgrind   : {self.valgrind_log_file}")
+        if leaks_enabled():
+            logger.info(f" leaks      : {self.leaks_log_file}")
 
         command = [
             self.binary_absolute_path,
@@ -101,8 +154,7 @@ class FluentBitManager:
             "-l", self.log_file
         ]
 
-        valgrind = os.environ.get('VALGRIND', False)
-        if valgrind:
+        if valgrind_enabled():
             command = [
                 "valgrind",
                 f"--log-file={self.valgrind_log_file}",
@@ -110,17 +162,27 @@ class FluentBitManager:
                 "--show-leak-kinds=all"
             ] + command
 
+        if leaks_enabled():
+            command = self._build_leaks_command(command)
 
         logger.info(f"Running command {command}")
 
-        self.output_handle = open(self.log_file, "a", encoding="utf-8")
+        output_path = self.leaks_log_file if leaks_enabled() else self.log_file
+        self.output_handle = open(output_path, "a", encoding="utf-8")
         self.process = subprocess.Popen(
             command,
             stdout=self.output_handle,
             stderr=subprocess.STDOUT,
-            text=True,
         )
-        logger.info(f"Fluent Bit started (pid: {self.process.pid})")
+
+        if leaks_enabled():
+            self.target_pid = self._wait_for_leaks_target_pid()
+        else:
+            self.target_pid = self.process.pid
+
+        logger.info(
+            f"Fluent Bit started (pid: {self.target_pid}, supervisor pid: {self.process.pid})"
+        )
 
         # wait for Fluent Bit to start
         self.wait_for_fluent_bit()
@@ -129,27 +191,137 @@ class FluentBitManager:
         if not self.process:
             return
 
-        pid = self.process.pid
+        pid = self.target_pid or self.process.pid
+        return_code = self.process.poll()
         if self.process.poll() is None:
-            self.process.terminate()
+            self.send_signal(signal.SIGTERM)
             try:
-                self.process.wait(timeout=10)
+                timeout = LEAKS_EXIT_TIMEOUT if leaks_enabled() else 10
+                return_code = self.process.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
-                self.process.kill()
-                self.process.wait(timeout=5)
+                self._force_stop()
+                return_code = self.process.returncode
         self.process = None
+        self.target_pid = None
 
         if self.output_handle:
             self.output_handle.close()
             self.output_handle = None
 
         if self.http_monitoring_port:
-            wait_for_port_to_be_free(int(self.http_monitoring_port), timeout=10 if os.environ.get("VALGRIND") else 5)
+            timeout = 10 if memory_check_enabled() else 5
+            wait_for_port_to_be_free(int(self.http_monitoring_port), timeout=timeout)
 
-        if os.environ.get("VALGRIND") and os.environ.get("VALGRIND_STRICT"):
+        if valgrind_enabled() and os.environ.get("VALGRIND_STRICT"):
             assert_valgrind_clean(self.valgrind_log_file)
 
+        if leaks_enabled() and os.environ.get("LEAKS_STRICT"):
+            assert_leaks_clean(return_code, self.leaks_log_file)
+
         logger.info(f"Fluent Bit stopped (pid: {pid})")
+
+    def send_signal(self, signal_number):
+        if not self.process:
+            raise RuntimeError("Fluent Bit is not running")
+
+        if leaks_enabled():
+            if not self.target_pid:
+                raise RuntimeError("Fluent Bit target PID is unavailable")
+            try:
+                os.kill(self.target_pid, signal_number)
+            except ProcessLookupError:
+                pass
+        else:
+            self.process.send_signal(signal_number)
+
+    def send_sighup(self):
+        self.send_signal(signal.SIGHUP)
+
+    def get_reload_status(self):
+        url = f"http://127.0.0.1:{self.http_monitoring_port}/api/v2/reload"
+        response = requests.get(url, timeout=0.5)
+        response.raise_for_status()
+        return response.json()
+
+    def trigger_http_reload(self):
+        url = f"http://127.0.0.1:{self.http_monitoring_port}/api/v2/reload"
+        response = requests.post(url)
+        response.raise_for_status()
+        return response.json()
+
+    def wait_for_hot_reload_count(self, expected_count, timeout=10):
+        deadline = time.time() + timeout
+
+        while time.time() < deadline:
+            try:
+                payload = self.get_reload_status()
+                if payload.get("hot_reload_count", 0) >= expected_count:
+                    return payload
+            except requests.RequestException:
+                pass
+            time.sleep(0.1)
+
+        raise TimeoutError(f"Timed out waiting for hot reload count {expected_count}")
+
+    def _build_leaks_command(self, command):
+        if platform.system() != "Darwin":
+            raise FluentBitStartupError("LEAKS is only supported on macOS")
+
+        leaks_binary = shutil.which("leaks")
+        if not leaks_binary:
+            raise FluentBitStartupError("The macOS leaks command was not found")
+
+        return [
+            leaks_binary,
+            "--quiet",
+            "--fullStacks",
+            "--atExit",
+            "--",
+            "/bin/sh",
+            "-c",
+            LEAKS_EXEC_SCRIPT,
+            "fluent-bit-leaks-target",
+            self.leaks_target_pid_file,
+            self.log_file,
+        ] + command
+
+    def _wait_for_leaks_target_pid(self):
+        deadline = time.time() + LEAKS_TARGET_PID_TIMEOUT
+
+        while time.time() < deadline:
+            try:
+                pid_text = Path(self.leaks_target_pid_file).read_text(encoding="utf-8").strip()
+                target_pid = int(pid_text)
+                if target_pid > 0:
+                    return target_pid
+            except (FileNotFoundError, ValueError):
+                pass
+
+            if self.process.poll() is not None:
+                raise FluentBitStartupError(
+                    f"leaks exited before Fluent Bit started with code {self.process.returncode}. "
+                    f"See log file {self.leaks_log_file}"
+                )
+            time.sleep(0.05)
+
+        raise FluentBitStartupError(
+            f"Timed out waiting for the Fluent Bit PID from leaks. See {self.leaks_log_file}"
+        )
+
+    def _force_stop(self):
+        if leaks_enabled() and self.target_pid:
+            try:
+                os.kill(self.target_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                self.process.wait(timeout=10)
+                return
+            except subprocess.TimeoutExpired:
+                pass
+
+        self.process.kill()
+        self.process.wait(timeout=5)
 
     def get_version_info(self):
         try:
@@ -172,15 +344,14 @@ class FluentBitManager:
             suite_root = Path(__file__).resolve().parents[2]
             base_dir = suite_root / "results"
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        results_dir = os.path.join(base_dir, f"fluent_bit_results_{timestamp}")
-        os.makedirs(results_dir, exist_ok=True)
-        return results_dir
+        os.makedirs(base_dir, exist_ok=True)
+        return tempfile.mkdtemp(prefix=f"fluent_bit_results_{timestamp}_", dir=base_dir)
 
     # Check if Fluent Bit is running by trying to reach the uptime endpoint, it waits until
     # the value of `uptime_sec` is greater than 1
     def wait_for_fluent_bit(self, timeout=None):
         if timeout is None:
-            timeout = 30 if os.environ.get("VALGRIND") else 10
+            timeout = 30 if memory_check_enabled() else 10
         url = f"http://127.0.0.1:{self.http_monitoring_port}/api/v1/uptime"
         start_time = time.time()
         while time.time() - start_time < timeout:

--- a/tests/integration/src/utils/leaks.py
+++ b/tests/integration/src/utils/leaks.py
@@ -1,0 +1,27 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+def assert_leaks_clean(return_code, log_path):
+    if return_code == 0:
+        return
+
+    if return_code == 1:
+        problem = "memory leaks were detected"
+    else:
+        problem = f"the leaks command failed with exit code {return_code}"
+
+    raise AssertionError(f"macOS leaks check failed: {problem}. See {log_path}")

--- a/tests/integration/src/utils/memory_check.py
+++ b/tests/integration/src/utils/memory_check.py
@@ -1,0 +1,29 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+
+def valgrind_enabled():
+    return bool(os.environ.get("VALGRIND"))
+
+
+def leaks_enabled():
+    return bool(os.environ.get("LEAKS"))
+
+
+def memory_check_enabled():
+    return valgrind_enabled() or leaks_enabled()

--- a/tests/integration/test_leaks_utils.py
+++ b/tests/integration/test_leaks_utils.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pytest
+
+from utils.leaks import assert_leaks_clean
+
+
+def test_assert_leaks_clean_accepts_clean_exit(tmp_path):
+    log_path = tmp_path / "leaks.log"
+
+    assert_leaks_clean(0, log_path)
+
+
+@pytest.mark.parametrize(
+    ("return_code", "message"),
+    [
+        (1, "memory leaks were detected"),
+        (2, "leaks command failed with exit code 2"),
+    ],
+)
+def test_assert_leaks_clean_rejects_nonzero_exit(tmp_path, return_code, message):
+    log_path = tmp_path / "leaks.log"
+
+    with pytest.raises(AssertionError, match=message) as exc_info:
+        assert_leaks_clean(return_code, log_path)
+
+    assert str(Path(log_path)) in str(exc_info.value)

--- a/tests/integration/test_macos_leaks_manager.py
+++ b/tests/integration/test_macos_leaks_manager.py
@@ -90,9 +90,9 @@ def test_leaks_supervisor_signals_fluent_bit_target(monkeypatch, tmp_path):
     assert manager.target_pid == 4321
     assert popen_calls[0]["command"] == [
         "/usr/bin/leaks",
-        "--quiet",
-        "--fullStacks",
-        "--atExit",
+        "-quiet",
+        "-fullStacks",
+        "-atExit",
         "--",
         "/bin/sh",
         "-c",
@@ -158,6 +158,22 @@ def test_leaks_rejects_non_macos_host(monkeypatch):
 
     with pytest.raises(FluentBitStartupError, match="only supported on macOS"):
         manager._build_leaks_command(["/tmp/fluent-bit"])
+
+
+def test_leaks_target_pid_timeout_force_stops_supervisor(monkeypatch, tmp_path):
+    process = FakeProcess()
+    monkeypatch.setenv("LEAKS", "1")
+    monkeypatch.setattr(manager_module, "LEAKS_TARGET_PID_TIMEOUT", 0)
+
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", "/tmp/fluent-bit")
+    manager.process = process
+    manager.leaks_target_pid_file = str(tmp_path / "missing.pid")
+    manager.leaks_log_file = str(tmp_path / "leaks.log")
+
+    with pytest.raises(FluentBitStartupError, match="Timed out waiting"):
+        manager._wait_for_leaks_target_pid()
+
+    assert process.killed is True
 
 
 def test_results_directories_are_unique_for_concurrent_supervisors(tmp_path):

--- a/tests/integration/test_macos_leaks_manager.py
+++ b/tests/integration/test_macos_leaks_manager.py
@@ -1,0 +1,149 @@
+import signal
+
+import pytest
+
+from utils import fluent_bit_manager as manager_module
+from utils.fluent_bit_manager import FluentBitManager, FluentBitStartupError
+
+
+class FakeProcess:
+    def __init__(self, return_code=0):
+        self.pid = 1234
+        self.return_code = return_code
+        self.returncode = None
+        self.killed = False
+        self.signals = []
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.returncode = self.return_code
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -signal.SIGKILL
+
+    def send_signal(self, signal_number):
+        self.signals.append(signal_number)
+
+
+def _prepare_start(monkeypatch, tmp_path, process):
+    config_path = tmp_path / "fluent-bit.yaml"
+    binary_path = tmp_path / "fluent-bit"
+    config_path.write_text("service:\n  flush: 1\n", encoding="utf-8")
+    binary_path.write_text("binary", encoding="utf-8")
+    binary_path.chmod(0o755)
+
+    monkeypatch.setenv("LEAKS", "1")
+    monkeypatch.setattr(manager_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        manager_module.shutil,
+        "which",
+        lambda command: "/usr/bin/leaks" if command == "leaks" else None,
+    )
+    monkeypatch.setattr(manager_module, "find_available_port", lambda starting_port: 40200)
+    monkeypatch.setattr(manager_module.requests, "get", lambda url, timeout: FakeResponse())
+    monkeypatch.setattr(FluentBitManager, "get_version_info", lambda self: ("vtest", "commit"))
+    monkeypatch.setattr(FluentBitManager, "_wait_for_leaks_target_pid", lambda self: 4321)
+    monkeypatch.setattr(manager_module, "wait_for_port_to_be_free", lambda port, timeout: None)
+
+    popen_calls = []
+
+    def fake_popen(command, stdout=None, stderr=None, text=None):
+        popen_calls.append(
+            {
+                "command": command,
+                "output_path": stdout.name,
+                "stderr": stderr,
+                "text": text,
+            }
+        )
+        return process
+
+    monkeypatch.setattr(manager_module.subprocess, "Popen", fake_popen)
+
+    return config_path, binary_path, popen_calls
+
+
+class FakeResponse:
+    status_code = 200
+
+    def json(self):
+        return {"uptime_sec": 2}
+
+
+def test_leaks_supervisor_signals_fluent_bit_target(monkeypatch, tmp_path):
+    process = FakeProcess()
+    config_path, binary_path, popen_calls = _prepare_start(monkeypatch, tmp_path, process)
+    delivered_signals = []
+    monkeypatch.setattr(
+        manager_module.os,
+        "kill",
+        lambda pid, signal_number: delivered_signals.append((pid, signal_number)),
+    )
+
+    manager = FluentBitManager(str(config_path), str(binary_path))
+    manager.start()
+
+    assert manager.target_pid == 4321
+    assert popen_calls[0]["command"] == [
+        "/usr/bin/leaks",
+        "--quiet",
+        "--fullStacks",
+        "--atExit",
+        "--",
+        "/bin/sh",
+        "-c",
+        manager_module.LEAKS_EXEC_SCRIPT,
+        "fluent-bit-leaks-target",
+        manager.leaks_target_pid_file,
+        manager.log_file,
+        str(binary_path),
+        "-c",
+        str(config_path),
+        "-l",
+        manager.log_file,
+    ]
+    assert popen_calls[0]["output_path"] == manager.leaks_log_file
+
+    manager.send_sighup()
+    manager.stop()
+
+    assert delivered_signals == [
+        (4321, signal.SIGHUP),
+        (4321, signal.SIGTERM),
+    ]
+    assert process.signals == []
+    assert process.returncode == 0
+
+
+def test_leaks_strict_fails_when_leaks_reports_leak(monkeypatch, tmp_path):
+    process = FakeProcess(return_code=1)
+    config_path, binary_path, _ = _prepare_start(monkeypatch, tmp_path, process)
+    monkeypatch.setenv("LEAKS_STRICT", "1")
+    monkeypatch.setattr(manager_module.os, "kill", lambda pid, signal_number: None)
+
+    manager = FluentBitManager(str(config_path), str(binary_path))
+    manager.start()
+
+    with pytest.raises(AssertionError, match="memory leaks were detected"):
+        manager.stop()
+
+
+def test_leaks_rejects_non_macos_host(monkeypatch):
+    monkeypatch.setattr(manager_module.platform, "system", lambda: "Linux")
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", "/tmp/fluent-bit")
+
+    with pytest.raises(FluentBitStartupError, match="only supported on macOS"):
+        manager._build_leaks_command(["/tmp/fluent-bit"])
+
+
+def test_results_directories_are_unique_for_concurrent_supervisors(tmp_path):
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", "/tmp/fluent-bit")
+
+    first = manager.create_results_directory(tmp_path)
+    second = manager.create_results_directory(tmp_path)
+
+    assert first != second

--- a/tests/integration/test_macos_leaks_manager.py
+++ b/tests/integration/test_macos_leaks_manager.py
@@ -132,6 +132,26 @@ def test_leaks_strict_fails_when_leaks_reports_leak(monkeypatch, tmp_path):
         manager.stop()
 
 
+def test_leaks_supervisor_failure_still_terminates_target(monkeypatch):
+    process = FakeProcess(return_code=255)
+    process.returncode = 255
+    delivered_signals = []
+    monkeypatch.setenv("LEAKS", "1")
+    monkeypatch.setattr(
+        manager_module.os,
+        "kill",
+        lambda pid, signal_number: delivered_signals.append((pid, signal_number)),
+    )
+
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", "/tmp/fluent-bit")
+    manager.process = process
+    manager.target_pid = 4321
+
+    manager.stop()
+
+    assert delivered_signals == [(4321, signal.SIGTERM)]
+
+
 def test_leaks_rejects_non_macos_host(monkeypatch):
     monkeypatch.setattr(manager_module.platform, "system", lambda: "Linux")
     manager = FluentBitManager("/tmp/fluent-bit.yaml", "/tmp/fluent-bit")

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -132,6 +132,20 @@ def test_fluent_bit_binary_version_uses_selected_binary(monkeypatch, tmp_path):
     assert fluent_bit_binary_version(str(binary_path)) == (5, 1, 0)
 
 
+def test_fluent_bit_binary_version_is_cached(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"binary")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="Fluent Bit v5.1.0\nGit commit: abc123", stderr="")
+    run = Mock(return_value=result)
+    monkeypatch.setattr(manager_module.subprocess, "run", run)
+
+    assert fluent_bit_binary_version(str(binary_path)) == (5, 1, 0)
+    manager = FluentBitManager("/tmp/fluent-bit.yaml", binary_path=str(binary_path))
+    assert manager.get_version_info() == ("v5.1.0", "abc123")
+    run.assert_called_once()
+
+
 def test_send_signal_raises_when_process_is_missing():
     manager = FluentBitManager("/tmp/fluent-bit.yaml")
 

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -23,6 +23,7 @@ import requests
 from src.utils import fluent_bit_manager as manager_module
 from src.utils.fluent_bit_manager import ENV_FLB_BINARY_PATH
 from src.utils.fluent_bit_manager import FluentBitManager
+from src.utils.fluent_bit_manager import fluent_bit_binary_supports_config_property
 
 
 def test_binary_path_uses_environment_override(monkeypatch):
@@ -33,6 +34,42 @@ def test_binary_path_uses_environment_override(monkeypatch):
 
     assert manager.binary_path == "/opt/fluent-bit/bin/fluent-bit"
     assert manager.binary_absolute_path == "/resolved//opt/fluent-bit/bin/fluent-bit"
+
+
+def test_binary_capability_detects_config_property_in_help(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"binary without the marker")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="Options: hot_reload.watch", stderr="")
+    monkeypatch.setattr(manager_module.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert fluent_bit_binary_supports_config_property(
+        "hot_reload.watch", str(binary_path)
+    ) is True
+
+
+def test_binary_capability_detects_compiled_config_property(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"prefix Hot_Reload.Watch suffix")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="", stderr="")
+    monkeypatch.setattr(manager_module.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert fluent_bit_binary_supports_config_property(
+        "hot_reload.watch", str(binary_path)
+    ) is True
+
+
+def test_binary_capability_rejects_missing_config_property(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"binary without the marker")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="", stderr="")
+    monkeypatch.setattr(manager_module.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert fluent_bit_binary_supports_config_property(
+        "hot_reload.watch", str(binary_path)
+    ) is False
 
 
 def test_send_signal_raises_when_process_is_missing():
@@ -75,8 +112,14 @@ def test_start_uses_unique_valgrind_log_path(monkeypatch, tmp_path):
 
     monkeypatch.setenv("VALGRIND", "1")
     monkeypatch.setattr(manager_module.os.path, "exists", lambda path: True)
+    monkeypatch.setattr(manager_module.os.path, "isfile", lambda path: True)
+    monkeypatch.setattr(manager_module.os, "access", lambda path, mode: True)
     monkeypatch.setattr(manager_module, "find_available_port", lambda starting_port: 40200)
-    monkeypatch.setattr(manager_module.requests, "get", lambda url: Mock(status_code=200, json=lambda: {"uptime_sec": 2}))
+    monkeypatch.setattr(
+        manager_module.requests,
+        "get",
+        lambda url, timeout=0.5: Mock(status_code=200, json=lambda: {"uptime_sec": 2}),
+    )
 
     created_dirs = iter([
         str(tmp_path / "run-1"),
@@ -89,6 +132,7 @@ def test_start_uses_unique_valgrind_log_path(monkeypatch, tmp_path):
 
     popen_result = Mock()
     popen_result.pid = 1234
+    popen_result.poll.return_value = None
 
     monkeypatch.setattr(FluentBitManager, "create_results_directory", fake_create_results_directory)
     monkeypatch.setattr(FluentBitManager, "get_version_info", lambda self: ("vtest", "commit"))
@@ -108,6 +152,7 @@ def test_start_uses_unique_valgrind_log_path(monkeypatch, tmp_path):
         "valgrind",
         f"--log-file={manager.valgrind_log_file}",
         "--leak-check=full",
+        "--show-leak-kinds=all",
         "/usr/bin/fluent-bit",
         "-c", str(config_path),
         "-l", str(tmp_path / "run-1" / "fluent_bit.log")

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -24,6 +24,7 @@ from src.utils import fluent_bit_manager as manager_module
 from src.utils.fluent_bit_manager import ENV_FLB_BINARY_PATH
 from src.utils.fluent_bit_manager import FluentBitManager
 from src.utils.fluent_bit_manager import fluent_bit_binary_supports_config_property
+from src.utils.fluent_bit_manager import fluent_bit_input_supports_config_property
 
 
 def test_binary_path_uses_environment_override(monkeypatch):
@@ -69,6 +70,35 @@ def test_binary_capability_rejects_missing_config_property(monkeypatch, tmp_path
 
     assert fluent_bit_binary_supports_config_property(
         "hot_reload.watch", str(binary_path)
+    ) is False
+
+
+def test_input_capability_detects_plugin_config_property(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"binary")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="workers  Set the number of listener workers", stderr="")
+
+    def fake_run(command, **kwargs):
+        assert command == [str(binary_path), "-i", "forward", "-h"]
+        return result
+
+    monkeypatch.setattr(manager_module.subprocess, "run", fake_run)
+
+    assert fluent_bit_input_supports_config_property(
+        "forward", "workers", str(binary_path)
+    ) is True
+
+
+def test_input_capability_rejects_property_from_other_plugins(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"binary containing inotify_watcher elsewhere")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="path  Path to tail", stderr="")
+    monkeypatch.setattr(manager_module.subprocess, "run", lambda *args, **kwargs: result)
+
+    assert fluent_bit_input_supports_config_property(
+        "tail", "inotify_watcher", str(binary_path)
     ) is False
 
 

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -23,8 +23,10 @@ import requests
 from src.utils import fluent_bit_manager as manager_module
 from src.utils.fluent_bit_manager import ENV_FLB_BINARY_PATH
 from src.utils.fluent_bit_manager import FluentBitManager
+from src.utils.fluent_bit_manager import fluent_bit_binary_version
 from src.utils.fluent_bit_manager import fluent_bit_binary_supports_config_property
 from src.utils.fluent_bit_manager import fluent_bit_input_supports_config_property
+from src.utils.fluent_bit_manager import parse_fluent_bit_version
 
 
 def test_binary_path_uses_environment_override(monkeypatch):
@@ -100,6 +102,34 @@ def test_input_capability_rejects_property_from_other_plugins(monkeypatch, tmp_p
     assert fluent_bit_input_supports_config_property(
         "tail", "inotify_watcher", str(binary_path)
     ) is False
+
+
+@pytest.mark.parametrize(
+    "version_text,expected",
+    [
+        ("Fluent Bit v5.1.0", (5, 1, 0)),
+        ("Fluent Bit 5.0.9\nGit commit: abc", (5, 0, 9)),
+        ("v6.2.1-dev", (6, 2, 1)),
+        ("unknown", None),
+    ],
+)
+def test_parse_fluent_bit_version(version_text, expected):
+    assert parse_fluent_bit_version(version_text) == expected
+
+
+def test_fluent_bit_binary_version_uses_selected_binary(monkeypatch, tmp_path):
+    binary_path = tmp_path / "fluent-bit"
+    binary_path.write_bytes(b"binary")
+    binary_path.chmod(0o755)
+    result = Mock(stdout="Fluent Bit v5.1.0", stderr="")
+
+    def fake_run(command, **kwargs):
+        assert command == [str(binary_path), "--version"]
+        return result
+
+    monkeypatch.setattr(manager_module.subprocess, "run", fake_run)
+
+    assert fluent_bit_binary_version(str(binary_path)) == (5, 1, 0)
 
 
 def test_send_signal_raises_when_process_is_missing():

--- a/tests/integration/tests/test_fluent_bit_manager.py
+++ b/tests/integration/tests/test_fluent_bit_manager.py
@@ -167,8 +167,9 @@ def test_trigger_http_reload_posts_to_reload_endpoint(monkeypatch):
     response.json.return_value = {"reload": "done"}
     response.raise_for_status.return_value = None
 
-    def fake_post(url):
+    def fake_post(url, timeout):
         assert url == "http://127.0.0.1:2020/api/v2/reload"
+        assert timeout == 0.5
         return response
 
     monkeypatch.setattr(manager_module.requests, "post", fake_post)


### PR DESCRIPTION
<!-- Provide summary of changes -->

  ## Description

  ### Problem

  The integration suite supported Valgrind-based memory checking but lacked an equivalent workflow for macOS. It also needed
  additional isolation and lifecycle handling to run reliably with multiple pytest workers.

  ### Changes

  - Add macOS leaks --atExit support through --leaks, --leaks-strict, LEAKS, and LEAKS_STRICT.
  - Supervise Fluent Bit under leaks, signal the actual Fluent Bit child during reload and shutdown, and preserve separate Fluent
    Bit and leak reports.

  - Reject incompatible memory-check configurations and require serial execution for macOS leak checks.
  - Add pytest-xdist and document file-level parallel execution with -n <workers> --dist loadfile.
  - Generate unique result directories for concurrent Fluent Bit processes.
  - Centralize Valgrind/macOS-leaks detection and apply memory-check-aware timeouts across scenarios.
  - Cache Fluent Bit version information and add helpers for detecting supported service and input-plugin properties.
  - Skip scenarios cleanly when the selected binary lacks required configuration properties.
  - Wait for OTLP gRPC servers and their threads to stop completely during teardown.
  - Improve macOS portability with shorter Unix socket paths, page-size-aware storage limits, and longer TLS connection timeouts.
  - Stabilize timing-sensitive scenarios:
      - tolerate chunk files disappearing during storage eviction;
      - verify that updated aged tail files resume from their stored offsets;
      - accept curl HTTP/2 framing errors for intentionally truncated Elasticsearch responses;
      - cap OpenTelemetry client concurrency at the configured four listener workers.

  ### Verification

  Focused verification completed:

  - in_forward multi-output storage eviction: 1 passed
  - OpenTelemetry four-protocol worker matrix: 4 passed
  - OpenTelemetry HTTP/2 TLS worker case: 10 consecutive isolated passes
  - Tail, Kafka, and related focused regressions: 3 passed

  Strict Valgrind verification was started but interrupted before completion. A full-suite rerun after the final OpenTelemetry
  concurrency adjustment has not yet been completed.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional macOS memory-leak diagnostics with strict failure mode, improved log-based reporting, and focused-scenario guidance.
  * Enabled parallel integration test execution via pytest-xdist, with macOS leak-check constraints and validation.
  * Added automatic Fluent Bit binary/version and capability detection to skip unsupported configurations.
* **Bug Fixes**
  * Improved integration reliability: safer OTLP shutdown, guaranteed runtime-directory cleanup, hardened file-reading, and better timeout selection when memory diagnostics are enabled.
  * Updated tail behavior coverage to confirm ingestion resumes after aging.
* **Documentation**
  * Expanded integration test docs for macOS `leaks`, including environment options and supervision details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->