### PR TITLE
out_s3, out_chronicle: grow log_key buffer to avoid dropping oversized values

### DIFF
--- a/plugins/out_chronicle/chronicle.c
+++ b/plugins/out_chronicle/chronicle.c
@@ -526,9 +526,12 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
     int ret;
     struct flb_chronicle *ctx = out_context;
     char *val_buf;
+    char *tmp_buf;
     char *key_str = NULL;
     size_t key_str_size = 0;
     size_t msgpack_size = bytes + bytes / 4;
+    size_t new_size;
+    size_t avail;
     size_t val_offset = 0;
     flb_sds_t out_buf;
     msgpack_object map;
@@ -592,11 +595,31 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, uint64_t by
                     val_offset++;
                 }
                 else {
-                    ret = flb_msgpack_to_json(val_buf + val_offset,
-                                              msgpack_size - val_offset, &val,
-                                              config->json_escape_unicode);
-                    if (ret < 0) {
-                        break;
+                    /*
+                     * Serialize the value as JSON, growing the scratch buffer
+                     * and retrying if it does not fit, so an oversized value
+                     * is neither truncated nor dropped.
+                     */
+                    ret = -1;
+                    while (1) {
+                        avail = msgpack_size - val_offset;
+                        if (avail > 1) {
+                            ret = flb_msgpack_to_json(val_buf + val_offset,
+                                                      avail, &val,
+                                                      config->json_escape_unicode);
+                            if (ret > 0) {
+                                break;
+                            }
+                        }
+                        new_size = msgpack_size * 2;
+                        tmp_buf = flb_realloc(val_buf, new_size);
+                        if (tmp_buf == NULL) {
+                            flb_errno();
+                            flb_free(val_buf);
+                            return NULL;
+                        }
+                        val_buf = tmp_buf;
+                        msgpack_size = new_size;
                     }
                     val_offset += ret;
                     val_buf[val_offset] = '\0';

--- a/plugins/out_s3/s3.c
+++ b/plugins/out_s3/s3.c
@@ -3857,9 +3857,12 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
     int alloc_error = 0;
     struct flb_s3 *ctx = out_context;
     char *val_buf;
+    char *tmp_buf;
     char *key_str = NULL;
     size_t key_str_size = 0;
     size_t msgpack_size = bytes + bytes / 4;
+    size_t new_size;
+    size_t avail;
     size_t val_offset = 0;
     flb_sds_t out_buf;
     msgpack_object map;
@@ -3952,10 +3955,33 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
                         val_offset++;
                     }
                     else {
-                        ret = flb_msgpack_to_json(val_buf + val_offset,
-                                                  msgpack_size - val_offset, &val,
-                                                  config->json_escape_unicode);
-                        if (ret < 0) {
+                        /*
+                         * Serialize the value as JSON, growing the scratch
+                         * buffer and retrying if it does not fit, so an
+                         * oversized value is neither truncated nor dropped.
+                         */
+                        ret = -1;
+                        while (1) {
+                            avail = msgpack_size - val_offset;
+                            if (avail > 1) {
+                                ret = flb_msgpack_to_json(val_buf + val_offset,
+                                                          avail, &val,
+                                                          config->json_escape_unicode);
+                                if (ret > 0) {
+                                    break;
+                                }
+                            }
+                            new_size = msgpack_size * 2;
+                            tmp_buf = flb_realloc(val_buf, new_size);
+                            if (tmp_buf == NULL) {
+                                flb_errno();
+                                alloc_error = 1;
+                                break;
+                            }
+                            val_buf = tmp_buf;
+                            msgpack_size = new_size;
+                        }
+                        if (alloc_error == 1) {
                             break;
                         }
                         val_offset += ret;
@@ -3981,6 +4007,15 @@ static flb_sds_t flb_pack_msgpack_extract_log_key(void *out_context, const char 
     }
 
     flb_log_event_decoder_destroy(&log_decoder);
+
+    /*
+     * If the scratch buffer could not be grown mid-chunk, do not return a
+     * partial payload: fail so the chunk can be retried as a whole.
+     */
+    if (alloc_error == 1) {
+        flb_free(val_buf);
+        return NULL;
+    }
 
     /* If nothing was read, destroy buffer */
     if (val_offset == 0) {


### PR DESCRIPTION
## Problem

The `log_key` extraction paths in `out_s3` and `out_chronicle` allocate a scratch buffer of `bytes + bytes / 4` once and never grow it. When the selected `log_key` value is a non-string (number/array/object) whose JSON encoding does not fit in the remaining space, `flb_msgpack_to_json()` fails and the code simply `break`s out of the loop:

```c
ret = flb_msgpack_to_json(val_buf + val_offset, msgpack_size - val_offset, &val, ...);
if (ret < 0) {
    break;
}
```

As a result the oversized value is silently dropped (and, depending on timing, could previously be emitted truncated). This is a pre-existing data-loss bug independent of any formatting change.

## Fix

Grow the scratch buffer and retry the conversion until the value fits, so an oversized `log_key` value is neither truncated nor dropped. The retry also guards the remaining size so `flb_msgpack_to_json()` is never called with a zero-length buffer.

- `out_s3`: on allocation failure it uses the function's existing `alloc_error` path.
- `out_chronicle`: on allocation failure it frees and returns `NULL`.

## Testing

- [x] Builds cleanly with `-DFLB_OUT_S3=On -DFLB_OUT_CHRONICLE=On` (full `fluent-bit` binary).

## Context

Surfaced during review of #12129 / #12133. #12133 makes `flb_msgpack_to_json()` signal truncation as a negative value (matching its contract); this PR makes these two callers actually recover from it. The two PRs are independent — this fix works whether the helper returns `0` or `-1` on overflow (it checks `ret <= 0`).

---

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized log values during msgpack-to-JSON serialization for Chronicle and S3 outputs.
  * Added automatic buffer growth and retry behavior to prevent truncated or incomplete values.
  * Improved safety when additional memory cannot be allocated by aborting cleanly, allowing data to be retried instead of emitting partial payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->