### PR TITLE
out_azure_blob: increase buffer path buffer size

### DIFF
--- a/plugins/out_azure_blob/azure_blob_store.c
+++ b/plugins/out_azure_blob/azure_blob_store.c
@@ -252,7 +252,7 @@ int azure_blob_store_init(struct flb_azure_blob *ctx)
 {
     int type;
     time_t now;
-    char tmp[64];
+    char tmp[1024];
     struct tm *tm;
     struct flb_fstore *fs;
     struct flb_fstore_stream *fs_stream;


### PR DESCRIPTION
## Summary

In `azure_blob_store_init()`, `buffer_dir` and `azure_blob_buffer_key` are joined into a fixed stack buffer before calling `flb_fstore_create()`. That buffer was only 64 bytes, so longer directory paths were truncated via `snprintf`.

Increase the buffer to 1024 bytes (common path-sized stack buffers elsewhere in the tree). Bounds remain enforced with `snprintf(..., sizeof(tmp), ...)`.

Fixes #12062

## Changes

- `plugins/out_azure_blob/azure_blob_store.c`: `char tmp[64]` → `char tmp[1024]`

## Testing

- Change is a stack buffer size increase only; existing `snprintf` / `strftime` call sites already use `sizeof(tmp)`.
- Not run full Fluent Bit build here (minimal one-line fix).

## Checklist

- [x] Signed-off-by present
- [x] GPG signed commit
- [x] Linked issue with Fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long Azure Blob Storage paths and stream names to reduce the risk of filename truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->