### PR TITLE
in_process_exporter_metrics: Fix the reported RSS ram

### DIFF
--- a/plugins/in_process_exporter_metrics/pe.h
+++ b/plugins/in_process_exporter_metrics/pe.h
@@ -46,6 +46,7 @@ struct flb_pe {
     /* configuration */
     flb_sds_t path_procfs;
     int scrape_interval;
+    int page_size;
 
     int coll_fd;                    /* collector fd     */
     struct cmt *cmt;                /* cmetrics context */

--- a/plugins/in_process_exporter_metrics/pe_config.c
+++ b/plugins/in_process_exporter_metrics/pe_config.c
@@ -18,6 +18,9 @@
  */
 
 #include <fluent-bit/flb_input_plugin.h>
+
+#include <unistd.h>
+
 #include "pe.h"
 
 struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
@@ -36,6 +39,9 @@ struct flb_pe *flb_pe_config_create(struct flb_input_instance *ins,
     ctx->ins = ins;
     ctx->process_regex_include_list = NULL;
     ctx->process_regex_exclude_list = NULL;
+
+    /* Cache the system page size for procfs RSS pages-to-bytes conversion. */
+    ctx->page_size = sysconf(_SC_PAGESIZE);
 
     /* Load the config map */
     ret = flb_input_config_map_set(ins, (void *) ctx);

--- a/plugins/in_process_exporter_metrics/pe_process.c
+++ b/plugins/in_process_exporter_metrics/pe_process.c
@@ -1096,19 +1096,19 @@ static int process_update(struct flb_pe *ctx)
 
             /* Memory */
             if (ctx->enabled_flag & METRIC_MEMORY) {
-                /* Memory Size */
                 entry = flb_slist_entry_get(&split_list, 20);
                 tmp = entry->str;
-                /* Collect the number of Virtual Memory per process */
+                /* Collect the number of Virtual Memory per process. This is already being reported in bytes*/
                 if (pe_utils_str_to_uint64(tmp, &val) != -1) {
                     cmt_gauge_set(ctx->memory_bytes, ts, val, 4, (char *[]){ name, pid_str, ppid_str, "virtual_memory" });
                 }
 
                 entry = flb_slist_entry_get(&split_list, 21);
                 tmp = entry->str;
-                /* Collect the number of RSS per process */
-                if (pe_utils_str_to_uint64(tmp, &val) != -1) {
-                    cmt_gauge_set(ctx->memory_bytes, ts, val, 4, (char *[]){ name, pid_str, ppid_str, "rss" });
+                /* The metrics reports the number of pages. So we have to convert by also using the size of the page */
+                if (ctx->page_size > 0 && pe_utils_str_to_uint64(tmp, &val) != -1) {
+                    cmt_gauge_set(ctx->memory_bytes, ts, val * ctx->page_size,
+                                  4, (char *[]){ name, pid_str, ppid_str, "rss" });
                 }
 
                 /* Major Page Faults */


### PR DESCRIPTION
The RSS value exported through process_memory_bytes was taken directly from /proc/pid/stat, which is reported in pages rather than bytes.

So before exposing the metric we have to convert to bytes, by using the size of pages

I tested it with my devices and now the results match the ones from htop

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected process memory RSS metrics so values are accurately converted from system memory pages to bytes.
  * Added safeguards for environments where the system page size cannot be determined, improving metric reliability.
  * Virtual memory metrics remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->