### PR TITLE
tls: yield downstream read retries to the event loop [Backport to 5.0]

### DIFF
--- a/include/fluent-bit/flb_io.h
+++ b/include/fluent-bit/flb_io.h
@@ -39,6 +39,15 @@
 /* Other features */
 #define FLB_IO_IPV6       32  /* network I/O uses IPv6                  */
 
+/* Retryable network I/O results */
+#define FLB_IO_WANT_READ   -0x7e4
+#define FLB_IO_WANT_WRITE  -0x7e6
+
+static inline int flb_io_net_is_retry(ssize_t result)
+{
+    return result == FLB_IO_WANT_READ || result == FLB_IO_WANT_WRITE;
+}
+
 struct flb_connection;
 
 int flb_io_net_accept(struct flb_connection *connection,

--- a/include/fluent-bit/tls/flb_tls.h
+++ b/include/fluent-bit/tls/flb_tls.h
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_coro.h>
+#include <fluent-bit/flb_io.h>
 #include <stddef.h>
 
 #define FLB_TLS_ALPN_MAX_LENGTH 16
@@ -32,8 +33,8 @@
 #define FLB_TLS_CLIENT   "Fluent Bit"
 
 /* TLS backend return status on read/write */
-#define FLB_TLS_WANT_READ   -0x7e4
-#define FLB_TLS_WANT_WRITE  -0x7e6
+#define FLB_TLS_WANT_READ   FLB_IO_WANT_READ
+#define FLB_TLS_WANT_WRITE  FLB_IO_WANT_WRITE
 
 /* Cert Flags */
 #define FLB_TLS_CA_ROOT          1

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -62,6 +62,10 @@ static int fw_conn_event_internal(struct flb_connection *connection)
             flb_plg_trace(ctx->ins, "handshake status = %d", conn->handshake_status);
 
             ret = fw_prot_secure_forward_handshake(ctx->ins, conn);
+            if (flb_io_net_is_retry(ret)) {
+                return 0;
+            }
+
             if (ret == -1) {
                 flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);
                 fw_conn_del(conn);
@@ -107,6 +111,10 @@ static int fw_conn_event_internal(struct flb_connection *connection)
         bytes = flb_io_net_read(connection,
                                 (void *) &conn->buf[conn->buf_len],
                                 available);
+
+        if (flb_io_net_is_retry(bytes)) {
+            return 0;
+        }
 
         if (bytes > 0) {
             read_bytes = (size_t) bytes;

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -140,38 +140,46 @@ static inline void print_msgpack_error_code(struct flb_input_instance *in,
 
 /* Read a secure forward msgpack message for handshake */
 static int secure_forward_read(struct flb_input_instance *in,
-                               struct flb_connection *connection,
-                               char *buf, size_t size, size_t *out_len)
+                               struct fw_conn *conn, size_t size,
+                               size_t *out_len)
 {
     int ret;
     size_t off;
     size_t avail;
-    size_t buf_off = 0;
     msgpack_unpacked result;
 
     msgpack_unpacked_init(&result);
     while (1) {
-        avail = size - buf_off;
-        if (avail < 1) {
+        if (conn->buf_len >= size) {
             goto error;
         }
 
+        avail = size - conn->buf_len;
+
         /* Read the message */
-        ret = flb_io_net_read(connection, buf + buf_off, size - buf_off);
+        ret = flb_io_net_read(conn->connection,
+                              conn->buf + conn->buf_len, avail);
+        if (flb_io_net_is_retry(ret)) {
+            msgpack_unpacked_destroy(&result);
+            return ret;
+        }
+
         if (ret <= 0) {
             flb_plg_debug(in, "read %d byte(s)", ret);
             goto error;
         }
-        buf_off += ret;
+        conn->buf_len += ret;
 
         /* Validate */
         off = 0;
-        ret = msgpack_unpack_next(&result, buf, buf_off, &off);
+        ret = msgpack_unpack_next(&result, conn->buf, conn->buf_len, &off);
         switch (ret) {
         case MSGPACK_UNPACK_SUCCESS:
             msgpack_unpacked_destroy(&result);
-            *out_len = buf_off;
+            *out_len = conn->buf_len;
             return 0;
+        case MSGPACK_UNPACK_CONTINUE:
+            break;
         default:
             print_msgpack_error_code(in, ret, "handshake");
             goto error;
@@ -179,6 +187,7 @@ static int secure_forward_read(struct flb_input_instance *in,
     }
 
  error:
+    conn->buf_len = 0;
     msgpack_unpacked_destroy(&result);
     return -1;
 }
@@ -506,7 +515,6 @@ static int check_ping(struct flb_input_instance *ins,
                       flb_sds_t *out_shared_key_salt)
 {
     int ret;
-    char buf[1024];
     size_t out_len;
     size_t off;
     msgpack_unpacked result;
@@ -531,7 +539,12 @@ static int check_ping(struct flb_input_instance *ins,
     }
 
     /* Wait for client PING */
-    ret = secure_forward_read(ins, conn->connection, buf, sizeof(buf) - 1, &out_len);
+    ret = secure_forward_read(ins, conn, 1023, &out_len);
+    if (flb_io_net_is_retry(ret)) {
+        flb_free(serverside);
+        return ret;
+    }
+
     if (ret == -1) {
         flb_free(serverside);
         flb_plg_error(ins, "handshake error expecting PING");
@@ -541,7 +554,8 @@ static int check_ping(struct flb_input_instance *ins,
     /* Unpack message and validate */
     off = 0;
     msgpack_unpacked_init(&result);
-    ret = msgpack_unpack_next(&result, buf, out_len, &off);
+    ret = msgpack_unpack_next(&result, conn->buf, out_len, &off);
+    conn->buf_len = 0;
     if (ret != MSGPACK_UNPACK_SUCCESS) {
         flb_free(serverside);
         print_msgpack_error_code(ins, ret, "PING");
@@ -1206,6 +1220,11 @@ int fw_prot_secure_forward_handshake(struct flb_input_instance *ins,
     reason = flb_sds_create_size(32);
     flb_plg_debug(ins, "protocol: checking PING");
     ping_ret = check_ping(ins, conn, &shared_key_salt);
+    if (flb_io_net_is_retry(ping_ret)) {
+        flb_sds_destroy(reason);
+        return ping_ret;
+    }
+
     if (ping_ret == -1) {
         flb_plg_error(ins, "handshake error checking PING");
 

--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -107,6 +107,10 @@ static int http_conn_event(void *data)
                                 (void *) &conn->buf_data[conn->buf_len],
                                 available);
 
+        if (flb_io_net_is_retry(bytes)) {
+            return 0;
+        }
+
         if (bytes <= 0) {
             flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);
             http_conn_del(conn);

--- a/plugins/in_mqtt/mqtt_conn.c
+++ b/plugins/in_mqtt/mqtt_conn.c
@@ -54,6 +54,10 @@ int mqtt_conn_event(void *data)
                                 (void *) &conn->buf[conn->buf_len],
                                 available);
 
+        if (flb_io_net_is_retry(bytes)) {
+            return 0;
+        }
+
         if (bytes > 0) {
             conn->buf_len += bytes;
             flb_plg_trace(ctx->ins, "[fd=%i] read()=%i bytes",

--- a/plugins/in_syslog/syslog_conn.c
+++ b/plugins/in_syslog/syslog_conn.c
@@ -97,6 +97,10 @@ int syslog_stream_conn_event(void *data)
                                 (void *) &conn->buf_data[conn->buf_len],
                                 available);
 
+        if (flb_io_net_is_retry(bytes)) {
+            return 0;
+        }
+
         if (bytes > 0) {
             flb_plg_trace(ctx->ins, "read()=%i pre_len=%zu now_len=%zu",
                           bytes, conn->buf_len, conn->buf_len + bytes);

--- a/plugins/in_tcp/tcp_conn.c
+++ b/plugins/in_tcp/tcp_conn.c
@@ -452,6 +452,11 @@ int tcp_conn_event(void *data)
                                 (void *) &conn->buf_data[conn->buf_len],
                                 available);
 
+        if (flb_io_net_is_retry(bytes)) {
+            conn->busy = FLB_FALSE;
+            return 0;
+        }
+
         if (bytes <= 0) {
             flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);
             conn->busy = FLB_FALSE;

--- a/plugins/in_unix_socket/unix_socket_conn.c
+++ b/plugins/in_unix_socket/unix_socket_conn.c
@@ -269,6 +269,10 @@ int unix_socket_conn_event(void *data)
                                 (void *) &conn->buf_data[conn->buf_len],
                                 available);
 
+        if (flb_io_net_is_retry(bytes)) {
+            return 0;
+        }
+
         if (bytes <= 0) {
             if (!ctx->dgram_mode_flag) {
                 flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);

--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -247,6 +247,10 @@ static int flb_http_server_session_read(struct flb_http_server_session *session)
                              (void *) session->read_buffer,
                              session->read_buffer_size);
 
+    if (flb_io_net_is_retry(result)) {
+        return 0;
+    }
+
     if (result <= 0) {
         return -1;
     }

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -162,7 +162,7 @@ static inline int io_tls_event_switch(struct flb_tls_session *session,
     event = &session->connection->event;
     event_loop = session->connection->evl;
 
-    if ((event->mask & mask) == 0) {
+    if ((event->mask & (MK_EVENT_READ | MK_EVENT_WRITE)) != mask) {
         ret = mk_event_add(event_loop,
                            event->fd,
                            FLB_ENGINE_EV_THREAD,
@@ -345,12 +345,19 @@ int flb_tls_set_client_thumbprints(struct flb_tls *tls, const char *thumbprints)
 
 int flb_tls_net_read(struct flb_tls_session *session, void *buf, size_t len)
 {
+    int             event_driven;
     time_t          timeout_timestamp;
     time_t          current_timestamp;
     struct flb_tls *tls;
     int             ret;
 
     tls = session->tls;
+    event_driven = FLB_FALSE;
+
+    if (session->connection->type == FLB_DOWNSTREAM_CONNECTION &&
+        MK_EVENT_IS_REGISTERED((&session->connection->event))) {
+        event_driven = FLB_TRUE;
+    }
 
     if (session->connection->net->io_timeout > 0) {
         timeout_timestamp = time(NULL) + session->connection->net->io_timeout;
@@ -365,6 +372,14 @@ int flb_tls_net_read(struct flb_tls_session *session, void *buf, size_t len)
     current_timestamp = time(NULL);
 
     if (ret == FLB_TLS_WANT_READ) {
+        if (event_driven) {
+            if (io_tls_event_switch(session, MK_EVENT_READ) == -1) {
+                return -1;
+            }
+
+            return FLB_TLS_WANT_READ;
+        }
+
         if (timeout_timestamp > 0 &&
             timeout_timestamp <= current_timestamp) {
             return ret;
@@ -373,12 +388,24 @@ int flb_tls_net_read(struct flb_tls_session *session, void *buf, size_t len)
         goto retry_read;
     }
     else if (ret == FLB_TLS_WANT_WRITE) {
+        if (event_driven) {
+            if (io_tls_event_switch(session, MK_EVENT_READ | MK_EVENT_WRITE) == -1) {
+                return -1;
+            }
+
+            return FLB_TLS_WANT_WRITE;
+        }
+
         goto retry_read;
     }
     else if (ret < 0) {
         return -1;
     }
     else if (ret == 0) {
+        return -1;
+    }
+
+    if (event_driven && io_tls_event_switch(session, MK_EVENT_READ) == -1) {
         return -1;
     }
 

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -165,7 +165,7 @@ static inline int io_tls_event_switch(struct flb_tls_session *session,
     if ((event->mask & (MK_EVENT_READ | MK_EVENT_WRITE)) != mask) {
         ret = mk_event_add(event_loop,
                            event->fd,
-                           FLB_ENGINE_EV_THREAD,
+                           event->type,
                            mask, event);
 
         event->priority = FLB_ENGINE_PRIORITY_CONNECT;
@@ -175,6 +175,8 @@ static inline int io_tls_event_switch(struct flb_tls_session *session,
 
             return -1;
         }
+
+        event->mask = mask;
     }
 
     return 0;

--- a/tests/internal/upstream_tls.c
+++ b/tests/internal/upstream_tls.c
@@ -4,6 +4,7 @@
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_upstream_conn.h>
 #include <fluent-bit/flb_connection.h>
+#include <fluent-bit/flb_engine_macros.h>
 #include <fluent-bit/flb_pipe.h>
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/tls/flb_tls.h>
@@ -20,6 +21,23 @@ struct test_backend_ctx {
     int invalidate_calls;
     int destroy_calls;
 };
+
+static int test_event_handler(void *data)
+{
+    (void) data;
+
+    return 0;
+}
+
+static int test_net_read_want_write(struct flb_tls_session *session,
+                                    void *buffer, size_t length)
+{
+    (void) session;
+    (void) buffer;
+    (void) length;
+
+    return FLB_TLS_WANT_WRITE;
+}
 
 static void test_session_invalidate(void *session)
 {
@@ -161,12 +179,70 @@ void test_tls_session_destroy_no_double_free(void)
 #endif
 }
 
+void test_tls_read_retry_preserves_custom_event(void)
+{
+    int ret;
+    char buffer[1];
+    flb_pipefd_t socket_pair[2];
+    struct mk_event_loop *event_loop;
+    struct flb_tls_backend backend_api = {0};
+    struct flb_tls tls_context = {0};
+    struct flb_tls_session tls_session = {0};
+    struct flb_connection connection = {0};
+    struct flb_net_setup net_setup = {0};
+
+#ifdef FLB_SYSTEM_WINDOWS
+    WSADATA wsa_data;
+    WSAStartup(0x0201, &wsa_data);
+#endif
+
+    TEST_CHECK(flb_pipe_create(socket_pair) == 0);
+
+    event_loop = mk_event_loop_create(8);
+    TEST_CHECK(event_loop != NULL);
+
+    MK_EVENT_NEW(&connection.event);
+    connection.fd = socket_pair[0];
+    connection.evl = event_loop;
+    connection.type = FLB_DOWNSTREAM_CONNECTION;
+    connection.net = &net_setup;
+    connection.event.handler = test_event_handler;
+
+    ret = mk_event_add(event_loop,
+                       connection.fd,
+                       FLB_ENGINE_EV_CUSTOM,
+                       MK_EVENT_READ,
+                       &connection.event);
+    TEST_CHECK(ret == 0);
+
+    backend_api.net_read = test_net_read_want_write;
+    tls_context.api = &backend_api;
+    tls_session.tls = &tls_context;
+    tls_session.connection = &connection;
+
+    ret = flb_tls_net_read(&tls_session, buffer, sizeof(buffer));
+    TEST_CHECK(ret == FLB_TLS_WANT_WRITE);
+    TEST_CHECK(connection.event.type == FLB_ENGINE_EV_CUSTOM);
+    TEST_CHECK(connection.event.handler == test_event_handler);
+    TEST_CHECK(connection.event.mask == (MK_EVENT_READ | MK_EVENT_WRITE));
+
+    TEST_CHECK(mk_event_del(event_loop, &connection.event) == 0);
+    mk_event_loop_destroy(event_loop);
+    flb_pipe_close(socket_pair[0]);
+    flb_pipe_close(socket_pair[1]);
+
+#ifdef FLB_SYSTEM_WINDOWS
+    WSACleanup();
+#endif
+}
+
 #endif
 
 TEST_LIST = {
 #ifdef FLB_HAVE_TLS
     {"prepare_destroy_conn_marks_tls_session_stale", test_prepare_destroy_conn_marks_tls_session_stale},
     {"tls_session_destroy_no_double_free", test_tls_session_destroy_no_double_free},
+    {"tls_read_retry_preserves_custom_event", test_tls_read_retry_preserves_custom_event},
 #endif
     {0}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Partially backporting of https://github.com/fluent/fluent-bit/pull/12140 due to lack of integration testing infrastructure.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
