### PR TITLE
out_splunk: Add auto_extract_timestamp parameter

### DIFF
--- a/plugins/out_splunk/splunk.c
+++ b/plugins/out_splunk/splunk.c
@@ -431,13 +431,15 @@ static int pack_map(struct flb_splunk *ctx, msgpack_packer *mp_pck,
     else {
         flb_mp_map_header_init(&mh, mp_pck);
 
-        /* Append the time key */
-        flb_mp_map_header_append(&mh);
-        msgpack_pack_str(mp_pck, sizeof(FLB_SPLUNK_DEFAULT_TIME) -1);
-        msgpack_pack_str_body(mp_pck,
-                              FLB_SPLUNK_DEFAULT_TIME,
-                              sizeof(FLB_SPLUNK_DEFAULT_TIME) - 1);
-        msgpack_pack_double(mp_pck, t);
+        if (ctx->auto_extract_timestamp == FLB_FALSE) {
+            /* Append the time key */
+            flb_mp_map_header_append(&mh);
+            msgpack_pack_str(mp_pck, sizeof(FLB_SPLUNK_DEFAULT_TIME) -1);
+            msgpack_pack_str_body(mp_pck,
+                                  FLB_SPLUNK_DEFAULT_TIME,
+                                  sizeof(FLB_SPLUNK_DEFAULT_TIME) - 1);
+            msgpack_pack_double(mp_pck, t);
+        }
 
         /* Pack Splunk metadata */
         pack_map_meta(ctx, &mh, mp_pck, map, tag, tag_len);
@@ -502,13 +504,15 @@ static inline int pack_event_key(struct flb_splunk *ctx, msgpack_packer *mp_pck,
     if (ctx->splunk_send_raw == FLB_FALSE) {
         flb_mp_map_header_init(&mh, mp_pck);
 
-        /* Append the time key */
-        flb_mp_map_header_append(&mh);
-        msgpack_pack_str(mp_pck, sizeof(FLB_SPLUNK_DEFAULT_TIME) -1);
-        msgpack_pack_str_body(mp_pck,
-                              FLB_SPLUNK_DEFAULT_TIME,
-                              sizeof(FLB_SPLUNK_DEFAULT_TIME) - 1);
-        msgpack_pack_double(mp_pck, t);
+        if (ctx->auto_extract_timestamp == FLB_FALSE) {
+            /* Append the time key */
+            flb_mp_map_header_append(&mh);
+            msgpack_pack_str(mp_pck, sizeof(FLB_SPLUNK_DEFAULT_TIME) -1);
+            msgpack_pack_str_body(mp_pck,
+                                  FLB_SPLUNK_DEFAULT_TIME,
+                                  sizeof(FLB_SPLUNK_DEFAULT_TIME) - 1);
+            msgpack_pack_double(mp_pck, t);
+        }
 
         /* Pack Splunk metadata */
         pack_map_meta(ctx, &mh, mp_pck, map, tag, tag_len);
@@ -869,6 +873,7 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
     flb_sds_t buf_data;
     size_t resp_size;
     size_t buf_size;
+    const char *endpoint;
     struct flb_splunk *ctx = out_context;
     struct flb_connection *u_conn;
     struct flb_http_client *c;
@@ -928,8 +933,13 @@ static void cb_splunk_flush(struct flb_event_chunk *event_chunk,
         }
     }
 
+    endpoint = FLB_SPLUNK_DEFAULT_ENDPOINT;
+    if (ctx->auto_extract_timestamp == FLB_TRUE) {
+        endpoint = FLB_SPLUNK_AUTO_EXTRACT_ENDPOINT;
+    }
+
     /* Compose HTTP Client request */
-    c = flb_http_client(u_conn, FLB_HTTP_POST, FLB_SPLUNK_DEFAULT_ENDPOINT,
+    c = flb_http_client(u_conn, FLB_HTTP_POST, endpoint,
                         payload_buf, payload_size, NULL, 0, NULL, 0);
 
     /* HTTP Response buffer size, honor value set by the user */
@@ -1160,6 +1170,14 @@ static struct flb_config_map config_map[] = {
      "When enabled, the record keys and values are set in the top level of the "
      "map instead of under the event key. Refer to the Sending Raw Events section "
      "from the docs for more details to make this option work properly."
+    },
+
+    {
+     FLB_CONFIG_MAP_BOOL, "auto_extract_timestamp", "off",
+     0, FLB_TRUE, offsetof(struct flb_splunk, auto_extract_timestamp),
+     "Ask Splunk to extract the timestamp from the event data by setting "
+     "auto_extract_timestamp=true in the HTTP Event Collector URL and omitting "
+     "the time field from the event envelope."
     },
 
     {

--- a/plugins/out_splunk/splunk.h
+++ b/plugins/out_splunk/splunk.h
@@ -23,6 +23,8 @@
 #define FLB_SPLUNK_DEFAULT_HOST          "127.0.0.1"
 #define FLB_SPLUNK_DEFAULT_PORT          8088
 #define FLB_SPLUNK_DEFAULT_ENDPOINT      "/services/collector/event"
+#define FLB_SPLUNK_AUTO_EXTRACT_ENDPOINT \
+    "/services/collector/event?auto_extract_timestamp=true"
 #define FLB_SPLUNK_DEFAULT_TIME          "time"
 #define FLB_SPLUNK_DEFAULT_EVENT_HOST    "host"
 #define FLB_SPLUNK_DEFAULT_EVENT_SOURCE  "source"
@@ -107,6 +109,9 @@ struct flb_splunk {
 
     /* Send fields directly or pack data into "event" object */
     int splunk_send_raw;
+
+    /* Ask Splunk to extract the timestamp from the event data */
+    int auto_extract_timestamp;
 
     /* HTTP Client Setup */
     size_t buffer_size;

--- a/tests/integration/scenarios/out_splunk/config/out_splunk_auto_extract_timestamp.yaml
+++ b/tests/integration/scenarios/out_splunk/config/out_splunk_auto_extract_timestamp.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_splunk
+      dummy: '{"message":"2022-06-13 12:34:56 example event"}'
+      samples: 1
+  outputs:
+    - name: splunk
+      match: out_splunk
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      tls: off
+      splunk_token: secret-token
+      auto_extract_timestamp: true

--- a/tests/integration/scenarios/out_splunk/config/out_splunk_auto_extract_timestamp_event_key.yaml
+++ b/tests/integration/scenarios/out_splunk/config/out_splunk_auto_extract_timestamp_event_key.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_splunk
+      dummy: '{"message":"2022-06-13 12:34:56 example event"}'
+      samples: 1
+  outputs:
+    - name: splunk
+      match: out_splunk
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      tls: off
+      splunk_token: secret-token
+      event_key: $message
+      auto_extract_timestamp: true

--- a/tests/integration/scenarios/out_splunk/config/out_splunk_default.yaml
+++ b/tests/integration/scenarios/out_splunk/config/out_splunk_default.yaml
@@ -1,0 +1,18 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_splunk
+      dummy: '{"message":"2022-06-13 12:34:56 example event"}'
+      samples: 1
+  outputs:
+    - name: splunk
+      match: out_splunk
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      tls: off
+      splunk_token: secret-token

--- a/tests/integration/scenarios/out_splunk/tests/test_out_splunk_001.py
+++ b/tests/integration/scenarios/out_splunk/tests/test_out_splunk_001.py
@@ -1,0 +1,94 @@
+import os
+
+import pytest
+import requests
+
+from server.http_server import configure_http_response, data_storage, http_server_run
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config", config_file)
+        )
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads", "requests"],
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        configure_http_response(status_code=200, body={"text": "Success", "code": 0})
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(
+                f"http://127.0.0.1:{service.test_suite_http_port}/shutdown",
+                timeout=2,
+            )
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_requests(self, minimum_count, timeout=10):
+        if os.environ.get("VALGRIND"):
+            timeout = max(timeout * 3, 30)
+
+        return self.service.wait_for_condition(
+            lambda: data_storage["requests"]
+            if len(data_storage["requests"]) >= minimum_count
+            else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} outbound Splunk requests",
+        )
+
+
+@pytest.mark.parametrize(
+    ("config_file", "expected_query", "expected_event_type"),
+    [
+        ("out_splunk_default.yaml", "", dict),
+        (
+            "out_splunk_auto_extract_timestamp.yaml",
+            "auto_extract_timestamp=true",
+            dict,
+        ),
+        (
+            "out_splunk_auto_extract_timestamp_event_key.yaml",
+            "auto_extract_timestamp=true",
+            str,
+        ),
+    ],
+    ids=["default", "auto_extract_timestamp", "auto_extract_timestamp_event_key"],
+)
+def test_out_splunk_auto_extract_timestamp(
+    config_file, expected_query, expected_event_type
+):
+    service = Service(config_file)
+    service.start()
+
+    try:
+        requests_seen = service.wait_for_requests(1)
+    finally:
+        service.stop()
+
+    first_request = requests_seen[0]
+    assert first_request["path"] == "/services/collector/event"
+    assert first_request["query_string"] == expected_query
+    assert first_request["headers"].get("Authorization") == "Splunk secret-token"
+    assert isinstance(first_request["json"]["event"], expected_event_type)
+    assert ("time" in first_request["json"]) == (expected_query == "")


### PR DESCRIPTION
<!-- Provide summary of changes -->
Closes https://github.com/fluent/fluent-bit/issues/5566.

- Added auto_extract_timestamp boolean to splunk.c, defaulting to off.
- When enabled, requests use /services/collector/event?auto_extract_timestamp=true, matching [[Splunk’s HEC documentation](https://help.splunk.com/en/data-management/collect-http-event-data/use-hec-in-splunk-cloud-platform/http-event-collector-rest-api-endpoints)](https://help.splunk.com/en/data-management/collect-http-event-data/use-hec-in-splunk-cloud-platform/http-event-collector-rest-api-endpoints).
- Added default and enabled request-capture coverage under the dedicated out_splunk scenario.
- Wrapped `wait_for_requests(1)` in `try/finally`, ensuring `Service.stop()` always runs.
- Suppressed the HEC envelope `time` field when `auto_extract_timestamp` is enabled in both `pack_map()` and `pack_event_key()`. This matches [[Splunk’s documented timestamp precedence](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/9.4/get-data-with-http-event-collector/http-event-collector-rest-api-endpoints)](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/9.4/get-data-with-http-event-collector/http-event-collector-rest-api-endpoints).
- Added integration coverage confirming:
  - Default mode retains envelope `time`.
  - Auto-extraction omits `time`.
  - Auto-extraction also works with `event_key`.

Validation:

- `cmake --build build --target fluent-bit-bin flb-rt-out_splunk` — passed.
- `ctest --test-dir build -R '^flb-rt-out_splunk$' --output-on-failure` — passed.
- Focused `out_splunk` integration suite — 3 passed.
- Diff whitespace checks — passed.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `auto_extract_timestamp` option for the Splunk output (off by default).
  * When enabled, the Splunk payload omits the top-level `time` field so Splunk can extract timestamps from event data (including when using `event_key`).
  * The output automatically uses the correct HTTP Event Collector endpoint and includes the required `auto_extract_timestamp=true` URL parameter.

* **Tests**
  * Added integration scenarios and coverage for default, `auto_extract_timestamp`, and `event_key` timestamp extraction.
  * Validates request path, query string, headers, and whether `time` is present in captured events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->