### PR TITLE
downstream: add coroutine-based event dispatch

### DIFF
--- a/include/fluent-bit/flb_connection.h
+++ b/include/fluent-bit/flb_connection.h
@@ -157,6 +157,7 @@ struct flb_connection {
     struct flb_coro *event_coroutine;
     flb_connection_event_callback event_callback;
     int event_wakeup_pending;
+    int event_release_pending;
 
     /* Per-connection I/O flags */
     int flags;

--- a/include/fluent-bit/flb_connection.h
+++ b/include/fluent-bit/flb_connection.h
@@ -62,6 +62,7 @@ struct flb_connection;
 
 typedef void (*flb_connection_drop_notification_callback)(
                  struct flb_connection *connection);
+typedef int (*flb_connection_event_callback)(void *data);
 
 /* Base network connection */
 struct flb_connection {
@@ -152,6 +153,14 @@ struct flb_connection {
     /* Coroutine in charge of this connection */
     struct flb_coro *coroutine;
 
+    /* Downstream-owned event callback coroutine */
+    struct flb_coro *event_coroutine;
+    flb_connection_event_callback event_callback;
+    int event_wakeup_pending;
+
+    /* Per-connection I/O flags */
+    int flags;
+
     /* Connection type : FLB_UPSTREAM_CONNECTION or FLB_DOWNSTREAM_CONNECTION */
     int type;
 
@@ -189,6 +198,8 @@ void flb_connection_set_remote_host(struct flb_connection *connection,
 char *flb_connection_get_remote_address(struct flb_connection *connection);
 
 int flb_connection_get_flags(struct flb_connection *connection);
+void flb_connection_enable_flags(struct flb_connection *connection, int flags);
+void flb_connection_disable_flags(struct flb_connection *connection, int flags);
 void flb_connection_reset_connection_timeout(struct flb_connection *connection);
 void flb_connection_unset_connection_timeout(struct flb_connection *connection);
 

--- a/include/fluent-bit/flb_coro.h
+++ b/include/fluent-bit/flb_coro.h
@@ -74,7 +74,14 @@ struct flb_coro {
 #ifdef FLB_CORO_STACK_SIZE
 #define FLB_CORO_STACK_SIZE_BYTE      FLB_CORO_STACK_SIZE
 #else
-#define FLB_CORO_STACK_SIZE_BYTE      ((3 * STACK_FACTOR * PTHREAD_STACK_MIN) / 2)
+#define FLB_CORO_STACK_SIZE_PLATFORM_BYTE \
+    ((3 * STACK_FACTOR * PTHREAD_STACK_MIN) / 2)
+/* Leave headroom for parser frames which can exceed the platform default. */
+#define FLB_CORO_STACK_SIZE_MIN_BYTE  (64 * 1024)
+#define FLB_CORO_STACK_SIZE_BYTE                                      \
+    (FLB_CORO_STACK_SIZE_PLATFORM_BYTE > FLB_CORO_STACK_SIZE_MIN_BYTE \
+     ? FLB_CORO_STACK_SIZE_PLATFORM_BYTE                              \
+     : FLB_CORO_STACK_SIZE_MIN_BYTE)
 #endif
 
 #define FLB_CORO_DATA(coro)      (((char *) coro) + sizeof(struct flb_coro))

--- a/include/fluent-bit/flb_downstream.h
+++ b/include/fluent-bit/flb_downstream.h
@@ -31,6 +31,9 @@
 
 struct flb_connection;
 
+#define FLB_DOWNSTREAM_CONN_RELEASED  0
+#define FLB_DOWNSTREAM_CONN_DEFERRED  1
+
 /* Downstream handler */
 struct flb_downstream {
     struct flb_stream      base;
@@ -83,6 +86,15 @@ void flb_downstream_pause(struct flb_downstream *stream);
 void flb_downstream_resume(struct flb_downstream *stream);
 
 int flb_downstream_conn_release(struct flb_connection *connection);
+
+/*
+ * The callback and any ingestion it invokes run on config->coro_stack_size.
+ * Callers must size that stack for their complete callback path.
+ */
+int flb_downstream_conn_event_register(struct flb_connection *connection,
+                                       int (*callback)(void *data),
+                                       int mask);
+void flb_downstream_conn_event_resume(struct flb_connection *connection);
 
 int flb_downstream_conn_pending_destroy_list(struct mk_list *list);
 int flb_downstream_conn_pending_destroy(struct flb_downstream *stream);

--- a/plugins/in_forward/fw.c
+++ b/plugins/in_forward/fw.c
@@ -661,11 +661,9 @@ static void in_fw_pause(void *data, struct flb_config *config)
             return;
         }
 
-        if (ctx->state == FW_INSTANCE_STATE_RUNNING) {
-            fw_conn_del_all(ctx);
-        }
-
+        ctx->state = FW_INSTANCE_STATE_PAUSED;
         ctx->is_paused = FLB_TRUE;
+        fw_conn_del_all(ctx);
         ret = pthread_mutex_unlock(&ctx->conn_mutex);
         if (ret != 0) {
             flb_plg_error(ctx->ins, "cannot unlock collector mutex");

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -225,9 +225,7 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     conn->helo       = helo;
 
     /* Set data for the event-loop */
-    connection->user_data     = conn;
-    connection->event.type    = FLB_ENGINE_EV_CUSTOM;
-    connection->event.handler = fw_conn_event;
+    connection->user_data = conn;
 
     /* Connection info */
     conn->ctx     = ctx;
@@ -251,12 +249,22 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     conn->compression_type = FLB_COMPRESSION_ALGORITHM_NONE;
     conn->d_ctx = NULL;
 
-    /* Register instance into the event loop */
-    ret = mk_event_add(flb_engine_evl_get(),
-                       connection->fd,
-                       FLB_ENGINE_EV_CUSTOM,
-                       MK_EVENT_READ,
-                       &connection->event);
+    /* Run TLS connection callbacks in a downstream-owned coroutine. */
+    if (connection->tls_session != NULL) {
+        ret = flb_downstream_conn_event_register(connection,
+                                                 fw_conn_event,
+                                                 MK_EVENT_READ);
+    }
+    else {
+        connection->event.type = FLB_ENGINE_EV_CUSTOM;
+        connection->event.handler = fw_conn_event;
+
+        ret = mk_event_add(flb_engine_evl_get(),
+                           connection->fd,
+                           FLB_ENGINE_EV_CUSTOM,
+                           MK_EVENT_READ,
+                           &connection->event);
+    }
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not register new connection");
         if (conn->helo != NULL) {
@@ -338,21 +346,22 @@ static void fw_conn_drop(struct flb_connection *connection)
 
 int fw_conn_del(struct fw_conn *conn)
 {
+    int ret;
     struct flb_connection *connection = conn->connection;
 
     /*
-     * Detach the wrapper from the connection first so the drop
-     * notification callback becomes a no-op during the release below and
-     * cannot double-free the wrapper.
+     * Downstream may need to wake a callback suspended in asynchronous I/O
+     * before releasing it. Keep the wrapper alive until that callback
+     * unwinds; the drop notification owns wrapper cleanup in both the
+     * immediate and deferred paths.
      */
     if (connection != NULL) {
-        connection->drop_notification_callback = NULL;
-        connection->user_data = NULL;
+        ret = flb_downstream_conn_release(connection);
+        if (ret == FLB_DOWNSTREAM_CONN_DEFERRED) {
+            return 0;
+        }
 
-        /* The downstream unregisters the file descriptor from the
-         * event-loop so there's nothing else to be done by the plugin.
-         */
-        flb_downstream_conn_release(connection);
+        return 0;
     }
 
     fw_conn_release(conn);

--- a/plugins/in_forward/fw_conn.c
+++ b/plugins/in_forward/fw_conn.c
@@ -249,22 +249,10 @@ struct fw_conn *fw_conn_add(struct flb_connection *connection, struct flb_in_fw_
     conn->compression_type = FLB_COMPRESSION_ALGORITHM_NONE;
     conn->d_ctx = NULL;
 
-    /* Run TLS connection callbacks in a downstream-owned coroutine. */
-    if (connection->tls_session != NULL) {
-        ret = flb_downstream_conn_event_register(connection,
-                                                 fw_conn_event,
-                                                 MK_EVENT_READ);
-    }
-    else {
-        connection->event.type = FLB_ENGINE_EV_CUSTOM;
-        connection->event.handler = fw_conn_event;
-
-        ret = mk_event_add(flb_engine_evl_get(),
-                           connection->fd,
-                           FLB_ENGINE_EV_CUSTOM,
-                           MK_EVENT_READ,
-                           &connection->event);
-    }
+    /* Run connection callbacks in a downstream-owned coroutine. */
+    ret = flb_downstream_conn_event_register(connection,
+                                             fw_conn_event,
+                                             MK_EVENT_READ);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "could not register new connection");
         if (conn->helo != NULL) {
@@ -339,6 +327,7 @@ static void fw_conn_drop(struct flb_connection *connection)
     connection->user_data = NULL;
 
     if (conn != NULL) {
+        flb_plg_trace(conn->ctx->ins, "drop connection fd=%i", connection->fd);
         conn->connection = NULL;
         fw_conn_release(conn);
     }

--- a/src/flb_connection.c
+++ b/src/flb_connection.c
@@ -27,6 +27,7 @@ int flb_connection_setup(struct flb_connection *connection,
     connection->busy_flag               = FLB_FALSE;
     connection->shutdown_flag           = FLB_FALSE;
     connection->event_wakeup_pending     = FLB_FALSE;
+    connection->event_release_pending    = FLB_FALSE;
 
     connection->net = &connection->stream->net;
 

--- a/src/flb_connection.c
+++ b/src/flb_connection.c
@@ -26,6 +26,7 @@ int flb_connection_setup(struct flb_connection *connection,
     connection->ts_assigned             = time(NULL);
     connection->busy_flag               = FLB_FALSE;
     connection->shutdown_flag           = FLB_FALSE;
+    connection->event_wakeup_pending     = FLB_FALSE;
 
     connection->net = &connection->stream->net;
 
@@ -196,7 +197,17 @@ char *flb_connection_get_remote_address(struct flb_connection *connection)
 
 int flb_connection_get_flags(struct flb_connection *connection)
 {
-    return flb_stream_get_flags(connection->stream);
+    return flb_stream_get_flags(connection->stream) | connection->flags;
+}
+
+void flb_connection_enable_flags(struct flb_connection *connection, int flags)
+{
+    connection->flags |= flags;
+}
+
+void flb_connection_disable_flags(struct flb_connection *connection, int flags)
+{
+    connection->flags &= ~flags;
 }
 
 void flb_connection_reset_connection_timeout(struct flb_connection *connection)

--- a/src/flb_coro.c
+++ b/src/flb_coro.c
@@ -23,12 +23,11 @@
 
 FLB_TLS_DEFINE(struct flb_coro, flb_coro_key);
 
-static pthread_mutex_t coro_mutex_init;
+static pthread_mutex_t coro_mutex_init = PTHREAD_MUTEX_INITIALIZER;
 
 void flb_coro_init()
 {
     FLB_TLS_INIT(flb_coro_key);
-    pthread_mutex_init(&coro_mutex_init, NULL);
 }
 
 void flb_coro_thread_init()

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -33,6 +33,8 @@
 #include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_thread_storage.h>
 
+static inline int prepare_destroy_conn_safe(struct flb_connection *connection);
+
 static void flb_downstream_conn_event_coro(void)
 {
     struct flb_coro *coro;
@@ -48,6 +50,16 @@ static void flb_downstream_conn_event_coro(void)
         connection->event_callback(connection);
 
         connection->busy_flag = FLB_FALSE;
+
+        /*
+         * A pause or shutdown can be requested recursively while ingestion
+         * is still using the plugin wrapper. Defer the drop notification
+         * until the complete callback has unwound.
+         */
+        if (connection->event_release_pending == FLB_TRUE) {
+            connection->event_release_pending = FLB_FALSE;
+            prepare_destroy_conn_safe(connection);
+        }
 
         if (connection->fd == FLB_INVALID_SOCKET) {
             connection->coroutine = NULL;
@@ -348,6 +360,8 @@ static int destroy_conn(struct flb_connection *connection, int force)
     }
 
     if (connection->event_coroutine != NULL) {
+        flb_trace("[downstream] destroy event coroutine for connection #%i",
+                  connection->fd);
         flb_coro_destroy(connection->event_coroutine);
         connection->event_coroutine = NULL;
         connection->coroutine = NULL;
@@ -546,10 +560,14 @@ int flb_downstream_conn_release(struct flb_connection *connection)
     flb_stream_acquire_lock(connection->stream, FLB_TRUE);
 
     if (connection->event_coroutine != NULL &&
-        connection->busy_flag == FLB_TRUE &&
-        flb_coro_get() != connection->event_coroutine) {
-        wake_event_coroutine(connection, ECANCELED);
-        resume = flb_stream_is_thread_safe(connection->stream);
+        connection->busy_flag == FLB_TRUE) {
+        connection->event_release_pending = FLB_TRUE;
+
+        if (flb_coro_get() != connection->event_coroutine) {
+            wake_event_coroutine(connection, ECANCELED);
+            resume = flb_stream_is_thread_safe(connection->stream);
+        }
+
         ret = FLB_DOWNSTREAM_CONN_DEFERRED;
     }
     else {
@@ -616,6 +634,9 @@ int flb_downstream_conn_event_register(struct flb_connection *connection,
     connection->event_callback = callback;
     connection->coroutine = coro;
     flb_connection_enable_flags(connection, FLB_IO_ASYNC);
+
+    flb_trace("[downstream] register event coroutine for connection #%i",
+              connection->fd);
 
     previous_coro = flb_coro_get();
     flb_coro_resume(coro);

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -577,7 +577,13 @@ int flb_downstream_conn_event_register(struct flb_connection *connection,
     struct flb_config *config;
 
     if (connection == NULL || callback == NULL ||
+        (mask & (MK_EVENT_READ | MK_EVENT_WRITE)) == 0 ||
         connection->type != FLB_DOWNSTREAM_CONNECTION) {
+        return -1;
+    }
+
+    if (connection->stream->transport != FLB_TRANSPORT_TCP &&
+        connection->stream->transport != FLB_TRANSPORT_UNIX_STREAM) {
         return -1;
     }
 

--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -30,7 +30,33 @@
 #include <fluent-bit/flb_downstream.h>
 #include <fluent-bit/flb_connection.h>
 #include <fluent-bit/flb_config_map.h>
+#include <fluent-bit/flb_coro.h>
 #include <fluent-bit/flb_thread_storage.h>
+
+static void flb_downstream_conn_event_coro(void)
+{
+    struct flb_coro *coro;
+    struct flb_connection *connection;
+
+    coro = flb_coro_get();
+    connection = coro->data;
+
+    while (FLB_TRUE) {
+        flb_coro_yield(coro, FLB_FALSE);
+
+        connection->busy_flag = FLB_TRUE;
+        connection->event_callback(connection);
+
+        connection->busy_flag = FLB_FALSE;
+
+        if (connection->fd == FLB_INVALID_SOCKET) {
+            connection->coroutine = NULL;
+        }
+        else {
+            connection->coroutine = coro;
+        }
+    }
+}
 
 /* Config map for Downstream networking setup */
 struct flb_config_map downstream_net[] = {
@@ -270,22 +296,61 @@ static inline int prepare_destroy_conn_safe(struct flb_connection *connection)
     return result;
 }
 
-static int destroy_conn(struct flb_connection *connection)
+static void shutdown_connection(struct flb_connection *connection)
+{
+    if (connection->fd != FLB_INVALID_SOCKET &&
+        connection->shutdown_flag == FLB_FALSE) {
+        shutdown(connection->fd, SHUT_RDWR);
+        connection->shutdown_flag = FLB_TRUE;
+    }
+}
+
+static int wake_event_coroutine(struct flb_connection *connection, int error)
+{
+    int ret;
+
+    connection->net_error = error;
+    connection->event_wakeup_pending = FLB_TRUE;
+    shutdown_connection(connection);
+
+    /* Thread-owned streams are resumed directly after their lock is released. */
+    if (flb_stream_is_thread_safe(connection->stream)) {
+        return 0;
+    }
+
+    if (!MK_EVENT_IS_REGISTERED((&connection->event))) {
+        return 0;
+    }
+
+    ret = mk_event_inject(connection->evl,
+                          &connection->event,
+                          connection->event.mask,
+                          FLB_TRUE);
+    if (ret == -1) {
+        flb_warn("[downstream] could not inject wake-up event for connection #%i",
+                 connection->fd);
+    }
+
+    return ret;
+}
+
+static int destroy_conn(struct flb_connection *connection, int force)
 {
     /*
-     * Delay the destruction if the connection is still marked busy or if
-     * there are pending events referencing it (e.g. an event still linked
-     * in the priority bucket queue after mk_event_inject). Freeing the
-     * connection while its event is queued would leave a dangling
-     * _priority_head in the bucket queue, causing a use-after-free and a
-     * stuck event that spins the input thread at 100% CPU.
-     *
-     * The connection stays in the destroy_queue and is retried on the next
-     * pending-destroy sweep, by which point the event has been drained.
+     * Normal sweeps defer destruction while a callback or injected event can
+     * still reference the connection. Terminal downstream teardown owns the
+     * event loop and coroutine stacks, so it must release them immediately.
      */
-    if (connection->busy_flag ||
-        !mk_list_entry_is_orphan(&connection->event._priority_head)) {
+    if (force == FLB_FALSE &&
+        (connection->busy_flag ||
+         !mk_list_entry_is_orphan(&connection->event._priority_head))) {
         return 0;
+    }
+
+    if (connection->event_coroutine != NULL) {
+        flb_coro_destroy(connection->event_coroutine);
+        connection->event_coroutine = NULL;
+        connection->coroutine = NULL;
     }
 
     if (connection->tls_session != NULL) {
@@ -425,19 +490,13 @@ void flb_downstream_destroy(struct flb_downstream *stream)
         mk_list_foreach_safe(head, tmp, &stream->destroy_queue) {
             connection = mk_list_entry(head, struct flb_connection, _head);
 
-            /*
-             * This is the terminal cleanup: there is no later
-             * pending-destroy sweep. destroy_conn() defers connections
-             * whose event is still linked in the priority bucket queue, so
-             * unlink any lingering event here (the bucket queue is still
-             * alive at this point) to make sure the connection is freed
-             * instead of leaked.
-             */
+            /* No event may retain a connection after terminal cleanup. */
             if (!mk_list_entry_is_orphan(&connection->event._priority_head)) {
                 mk_list_del(&connection->event._priority_head);
             }
 
-            destroy_conn(connection);
+            destroy_conn(connection,
+                         connection->event_coroutine != NULL);
         }
 
         /* If the simulated UDP connection reference is set then
@@ -480,7 +539,139 @@ void flb_downstream_destroy(struct flb_downstream *stream)
 
 int flb_downstream_conn_release(struct flb_connection *connection)
 {
-    return prepare_destroy_conn_safe(connection);
+    int ret;
+    int resume;
+
+    resume = FLB_FALSE;
+    flb_stream_acquire_lock(connection->stream, FLB_TRUE);
+
+    if (connection->event_coroutine != NULL &&
+        connection->busy_flag == FLB_TRUE &&
+        flb_coro_get() != connection->event_coroutine) {
+        wake_event_coroutine(connection, ECANCELED);
+        resume = flb_stream_is_thread_safe(connection->stream);
+        ret = FLB_DOWNSTREAM_CONN_DEFERRED;
+    }
+    else {
+        prepare_destroy_conn(connection);
+        ret = FLB_DOWNSTREAM_CONN_RELEASED;
+    }
+
+    flb_stream_release_lock(connection->stream);
+
+    if (resume == FLB_TRUE) {
+        flb_downstream_conn_event_resume(connection);
+    }
+
+    return ret;
+}
+
+int flb_downstream_conn_event_register(struct flb_connection *connection,
+                                       flb_connection_event_callback callback,
+                                       int mask)
+{
+    int ret;
+    size_t stack_size;
+    struct flb_coro *coro;
+    struct flb_coro *previous_coro;
+    struct flb_config *config;
+
+    if (connection == NULL || callback == NULL ||
+        connection->type != FLB_DOWNSTREAM_CONNECTION) {
+        return -1;
+    }
+
+    config = connection->stream->config;
+    if (config == NULL || connection->event_coroutine != NULL) {
+        return -1;
+    }
+
+    coro = flb_coro_create(connection);
+    if (coro == NULL) {
+        return -1;
+    }
+
+    coro->caller = co_active();
+    coro->callee = co_create(config->coro_stack_size,
+                             flb_downstream_conn_event_coro,
+                             &stack_size);
+    if (coro->callee == NULL) {
+        flb_coro_destroy(coro);
+        return -1;
+    }
+
+#ifdef FLB_HAVE_VALGRIND
+    coro->valgrind_stack_id = VALGRIND_STACK_REGISTER(
+                                  coro->callee,
+                                  ((char *) coro->callee) + stack_size);
+#endif
+
+    connection->event_coroutine = coro;
+    connection->event_callback = callback;
+    connection->coroutine = coro;
+    flb_connection_enable_flags(connection, FLB_IO_ASYNC);
+
+    previous_coro = flb_coro_get();
+    flb_coro_resume(coro);
+    flb_coro_set(previous_coro);
+
+    ret = mk_event_add(connection->evl,
+                       connection->fd,
+                       FLB_ENGINE_EV_THREAD,
+                       mask,
+                       &connection->event);
+    if (ret == -1) {
+        flb_connection_disable_flags(connection, FLB_IO_ASYNC);
+        connection->event_callback = NULL;
+        connection->event_coroutine = NULL;
+        connection->coroutine = NULL;
+        flb_coro_destroy(coro);
+        return -1;
+    }
+
+    return 0;
+}
+
+void flb_downstream_conn_event_resume(struct flb_connection *connection)
+{
+    struct flb_coro *previous_coro;
+
+    previous_coro = flb_coro_get();
+    connection->event_wakeup_pending = FLB_FALSE;
+    flb_coro_resume(connection->event_coroutine);
+    flb_coro_set(previous_coro);
+}
+
+static void resume_pending_event_coroutines(struct flb_downstream *stream)
+{
+    struct flb_connection *connection;
+    struct mk_list *head;
+
+    while (FLB_TRUE) {
+        connection = NULL;
+
+        flb_stream_acquire_lock(&stream->base, FLB_TRUE);
+
+        mk_list_foreach(head, &stream->busy_queue) {
+            connection = mk_list_entry(head, struct flb_connection, _head);
+
+            if (connection->event_coroutine != NULL &&
+                connection->event_wakeup_pending == FLB_TRUE) {
+                connection->event_wakeup_pending = FLB_FALSE;
+                break;
+            }
+
+            connection = NULL;
+        }
+
+        flb_stream_release_lock(&stream->base);
+
+        if (connection == NULL) {
+            break;
+        }
+
+        flb_downstream_conn_event_resume(connection);
+    }
 }
 
 int flb_downstream_conn_timeouts_stream(struct flb_downstream *stream)
@@ -490,7 +681,7 @@ int flb_downstream_conn_timeouts_stream(struct flb_downstream *stream)
     const char            *reason;
     struct mk_list        *s_head;
     int                    drop;
-    int                  inject;
+    int                    inject;
     struct mk_list        *tmp;
     time_t                 now;
 
@@ -545,22 +736,38 @@ int flb_downstream_conn_timeouts_stream(struct flb_downstream *stream)
                 }
             }
 
-            inject = FLB_FALSE;
-            if (connection->event.status != MK_EVENT_NONE) {
-                inject = FLB_TRUE;
+            if (connection->event_coroutine != NULL &&
+                MK_EVENT_IS_REGISTERED((&connection->event))) {
+                wake_event_coroutine(connection, ETIMEDOUT);
             }
-            connection->net_error = ETIMEDOUT;
-            prepare_destroy_conn(connection);
-            if (inject == FLB_TRUE) {
-                mk_event_inject(connection->evl,
-                                &connection->event,
-                                connection->event.mask,
-                                FLB_TRUE);
+            else {
+                connection->net_error = ETIMEDOUT;
+                inject = FLB_FALSE;
+                if (connection->event.status != MK_EVENT_NONE) {
+                    inject = FLB_TRUE;
+                }
+
+                prepare_destroy_conn(connection);
+                if (inject == FLB_TRUE) {
+                    mk_event_inject(connection->evl,
+                                    &connection->event,
+                                    connection->event.mask,
+                                    FLB_TRUE);
+                }
             }
         }
     }
 
     flb_stream_release_lock(&stream->base);
+
+    /*
+     * Worker and threaded-input streams own their event loop. Resume timeout
+     * wakeups here, after releasing the stream lock, so a maintenance callback
+     * cannot leave an injected event to be overwritten by the next wait.
+     */
+    if (flb_stream_is_thread_safe(&stream->base)) {
+        resume_pending_event_coroutines(stream);
+    }
 
     return 0;
 }
@@ -591,7 +798,7 @@ int flb_downstream_conn_pending_destroy(struct flb_downstream *stream)
     mk_list_foreach_safe(head, tmp, &stream->destroy_queue) {
         connection = mk_list_entry(head, struct flb_connection, _head);
 
-        destroy_conn(connection);
+        destroy_conn(connection, FLB_FALSE);
     }
 
     flb_stream_release_lock(&stream->base);

--- a/src/flb_downstream_worker.c
+++ b/src/flb_downstream_worker.c
@@ -20,6 +20,9 @@
 #include <cfl/cfl_atomic.h>
 
 #include <fluent-bit/flb_downstream_worker.h>
+#include <fluent-bit/flb_connection.h>
+#include <fluent-bit/flb_coro.h>
+#include <fluent-bit/flb_downstream.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_mem.h>
@@ -203,6 +206,26 @@ static int downstream_worker_control_event(struct flb_downstream_worker *worker)
     return 0;
 }
 
+static void downstream_worker_dispatch_event(struct mk_event *event)
+{
+    struct flb_connection *connection;
+
+    if (event->type == FLB_ENGINE_EV_CUSTOM) {
+        event->handler(event);
+    }
+    else if (event->type == FLB_ENGINE_EV_THREAD) {
+        connection = (struct flb_connection *) event;
+        if (connection->coroutine != NULL) {
+            if (connection->event_coroutine != NULL) {
+                flb_downstream_conn_event_resume(connection);
+            }
+            else {
+                flb_coro_resume(connection->coroutine);
+            }
+        }
+    }
+}
+
 static void *downstream_worker_thread(void *data)
 {
     int ret;
@@ -234,6 +257,7 @@ static void *downstream_worker_thread(void *data)
 
     flb_engine_evl_init();
     flb_engine_evl_set(worker->event_loop);
+    flb_coro_thread_init();
     flb_net_dns_ctx_set(&dns_ctx);
 
     ret = runtime->cb_init(worker, runtime->parent, &worker->context);
@@ -266,9 +290,7 @@ signal_and_exit:
 
         {
             mk_event_foreach(event, worker->event_loop) {
-                if (event->type == FLB_ENGINE_EV_CUSTOM) {
-                    event->handler(event);
-                }
+                downstream_worker_dispatch_event(event);
             }
         }
 

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1292,7 +1292,12 @@ int flb_engine_start(struct flb_config *config)
                 if (connection->coroutine) {
                     flb_trace("[engine] resuming coroutine=%p", connection->coroutine);
 
-                    flb_coro_resume(connection->coroutine);
+                    if (connection->event_coroutine != NULL) {
+                        flb_downstream_conn_event_resume(connection);
+                    }
+                    else {
+                        flb_coro_resume(connection->coroutine);
+                    }
                 }
             }
             else if (event->type == FLB_ENGINE_EV_OUTPUT) {

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -459,7 +459,12 @@ static void input_thread(void *data)
                     flb_trace("[engine] resuming coroutine=%p",
                               connection->coroutine);
 
-                    flb_coro_resume(connection->coroutine);
+                    if (connection->event_coroutine != NULL) {
+                        flb_downstream_conn_event_resume(connection);
+                    }
+                    else {
+                        flb_coro_resume(connection->coroutine);
+                    }
                 }
             }
             else if (event->type == FLB_ENGINE_EV_INPUT) {

--- a/src/flb_io.c
+++ b/src/flb_io.c
@@ -45,7 +45,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <assert.h>
 
 #include <monkey/mk_core.h>
 #include <fluent-bit/flb_info.h>
@@ -302,31 +301,37 @@ static FLB_INLINE void net_io_backup_event(struct flb_connection *connection,
     }
 }
 
-static FLB_INLINE void net_io_restore_event(struct flb_connection *connection,
-                                            struct mk_event *backup)
+static FLB_INLINE int net_io_restore_event(struct flb_connection *connection,
+                                           struct mk_event *backup)
 {
     int result;
 
-    if (connection != NULL && backup != NULL) {
-        if (MK_EVENT_IS_REGISTERED((&connection->event))) {
-            result = mk_event_del(connection->evl, &connection->event);
+    if (connection == NULL || backup == NULL) {
+        return -1;
+    }
 
-            assert(result == 0);
-        }
-
-        if (MK_EVENT_IS_REGISTERED(backup)) {
-            connection->event.priority = backup->priority;
-            connection->event.handler = backup->handler;
-
-            result = mk_event_add(connection->evl,
-                                  connection->fd,
-                                  backup->type,
-                                  backup->mask,
-                                  &connection->event);
-
-            assert(result == 0);
+    if (MK_EVENT_IS_REGISTERED((&connection->event))) {
+        result = mk_event_del(connection->evl, &connection->event);
+        if (result == -1) {
+            return -1;
         }
     }
+
+    if (MK_EVENT_IS_REGISTERED(backup)) {
+        connection->event.priority = backup->priority;
+        connection->event.handler = backup->handler;
+
+        result = mk_event_add(connection->evl,
+                              connection->fd,
+                              backup->type,
+                              backup->mask,
+                              &connection->event);
+        if (result == -1) {
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 /*
@@ -415,6 +420,13 @@ retry:
              */
             connection->coroutine = NULL;
 
+            if (connection->net_error != -1) {
+                *out_len = total;
+                net_io_restore_event(connection, &event_backup);
+
+                return -1;
+            }
+
             /* Save events mask since mk_event_del() will reset it */
             mask = connection->event.mask;
 
@@ -476,6 +488,8 @@ retry:
     total += bytes;
     if (total < len) {
         if ((connection->event.mask & MK_EVENT_WRITE) == 0) {
+            event_restore_needed = FLB_TRUE;
+
             ret = mk_event_add(connection->evl,
                                connection->fd,
                                FLB_ENGINE_EV_THREAD,
@@ -506,6 +520,13 @@ retry:
          */
         connection->coroutine = NULL;
 
+        if (connection->net_error != -1) {
+            *out_len = total;
+            net_io_restore_event(connection, &event_backup);
+
+            return -1;
+        }
+
         goto retry;
     }
 
@@ -520,7 +541,12 @@ retry:
          * the same event.
          */
 
-        net_io_restore_event(connection, &event_backup);
+        ret = net_io_restore_event(connection, &event_backup);
+        if (ret == -1) {
+            *out_len = total;
+
+            return -1;
+        }
     }
 
     *out_len = total;
@@ -635,6 +661,12 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
              */
             connection->coroutine = NULL;
 
+            if (connection->net_error != -1) {
+                net_io_restore_event(connection, &event_backup);
+
+                return -1;
+            }
+
             goto retry_read;
         }
         else {
@@ -658,7 +690,9 @@ static FLB_INLINE ssize_t net_io_read_async(struct flb_coro *co,
          * the same event.
          */
 
-        net_io_restore_event(connection, &event_backup);
+        if (net_io_restore_event(connection, &event_backup) == -1) {
+            return -1;
+        }
     }
 
     return ret;

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -124,31 +124,37 @@ static inline void io_tls_backup_event(struct flb_connection *connection,
     }
 }
 
-static inline void io_tls_restore_event(struct flb_connection *connection,
-                                        struct mk_event *backup)
+static inline int io_tls_restore_event(struct flb_connection *connection,
+                                       struct mk_event *backup)
 {
     int result;
 
-    if (connection != NULL && backup != NULL) {
-        if (MK_EVENT_IS_REGISTERED((&connection->event))) {
-            result = mk_event_del(connection->evl, &connection->event);
+    if (connection == NULL || backup == NULL) {
+        return -1;
+    }
 
-            assert(result == 0);
-        }
-
-        if (MK_EVENT_IS_REGISTERED(backup)) {
-            connection->event.priority = backup->priority;
-            connection->event.handler = backup->handler;
-
-            result = mk_event_add(connection->evl,
-                                  connection->fd,
-                                  backup->type,
-                                  backup->mask,
-                                  &connection->event);
-
-            assert(result == 0);
+    if (MK_EVENT_IS_REGISTERED((&connection->event))) {
+        result = mk_event_del(connection->evl, &connection->event);
+        if (result == -1) {
+            return -1;
         }
     }
+
+    if (MK_EVENT_IS_REGISTERED(backup)) {
+        connection->event.priority = backup->priority;
+        connection->event.handler = backup->handler;
+
+        result = mk_event_add(connection->evl,
+                              connection->fd,
+                              backup->type,
+                              backup->mask,
+                              &connection->event);
+        if (result == -1) {
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 
@@ -408,7 +414,11 @@ int flb_tls_net_read_async(struct flb_coro *co,
 
         session->connection->coroutine = co;
 
-        io_tls_event_switch(session, MK_EVENT_READ);
+        ret = io_tls_event_switch(session, MK_EVENT_READ);
+        if (ret == -1) {
+            goto read_finished;
+        }
+
         flb_coro_yield(co, FLB_FALSE);
 
         if (session->connection->net_error != -1) {
@@ -423,7 +433,11 @@ int flb_tls_net_read_async(struct flb_coro *co,
 
         session->connection->coroutine = co;
 
-        io_tls_event_switch(session, MK_EVENT_WRITE);
+        ret = io_tls_event_switch(session, MK_EVENT_WRITE);
+        if (ret == -1) {
+            goto read_finished;
+        }
+
         flb_coro_yield(co, FLB_FALSE);
 
         if (session->connection->net_error != -1) {
@@ -454,7 +468,9 @@ read_finished:
          * the same event.
          */
 
-        io_tls_restore_event(session->connection, &event_backup);
+        if (io_tls_restore_event(session->connection, &event_backup) == -1) {
+            ret = -1;
+        }
     }
 
     return ret;
@@ -526,7 +542,13 @@ retry_write:
     if (ret == FLB_TLS_WANT_WRITE) {
         event_restore_needed = FLB_TRUE;
 
-        io_tls_event_switch(session, MK_EVENT_WRITE);
+        ret = io_tls_event_switch(session, MK_EVENT_WRITE);
+        if (ret == -1) {
+            session->connection->coroutine = NULL;
+            *out_len = total;
+            io_tls_restore_event(session->connection, &event_backup);
+            return -1;
+        }
 
         flb_coro_yield(co, FLB_FALSE);
 
@@ -542,7 +564,13 @@ retry_write:
     else if (ret == FLB_TLS_WANT_READ) {
         event_restore_needed = FLB_TRUE;
 
-        io_tls_event_switch(session, MK_EVENT_READ);
+        ret = io_tls_event_switch(session, MK_EVENT_READ);
+        if (ret == -1) {
+            session->connection->coroutine = NULL;
+            *out_len = total;
+            io_tls_restore_event(session->connection, &event_backup);
+            return -1;
+        }
 
         flb_coro_yield(co, FLB_FALSE);
 
@@ -572,7 +600,15 @@ retry_write:
     total += ret;
 
     if (total < len) {
-        io_tls_event_switch(session, MK_EVENT_WRITE);
+        event_restore_needed = FLB_TRUE;
+
+        ret = io_tls_event_switch(session, MK_EVENT_WRITE);
+        if (ret == -1) {
+            session->connection->coroutine = NULL;
+            *out_len = total;
+            io_tls_restore_event(session->connection, &event_backup);
+            return -1;
+        }
 
         flb_coro_yield(co, FLB_FALSE);
 
@@ -605,7 +641,9 @@ retry_write:
          * the same event.
          */
 
-        io_tls_restore_event(session->connection, &event_backup);
+        if (io_tls_restore_event(session->connection, &event_backup) == -1) {
+            return -1;
+        }
     }
 
     return total;
@@ -784,7 +822,10 @@ cleanup:
          * the same event.
          */
 
-        io_tls_restore_event(session->connection, &event_backup);
+        if (io_tls_restore_event(session->connection, &event_backup) == -1 &&
+            result == 0) {
+            result = -1;
+        }
     }
 
     if (result != 0) {

--- a/src/tls/flb_tls.c
+++ b/src/tls/flb_tls.c
@@ -411,6 +411,11 @@ int flb_tls_net_read_async(struct flb_coro *co,
         io_tls_event_switch(session, MK_EVENT_READ);
         flb_coro_yield(co, FLB_FALSE);
 
+        if (session->connection->net_error != -1) {
+            ret = -1;
+            goto read_finished;
+        }
+
         goto retry_read;
     }
     else if (ret == FLB_TLS_WANT_WRITE) {
@@ -421,18 +426,21 @@ int flb_tls_net_read_async(struct flb_coro *co,
         io_tls_event_switch(session, MK_EVENT_WRITE);
         flb_coro_yield(co, FLB_FALSE);
 
+        if (session->connection->net_error != -1) {
+            ret = -1;
+            goto read_finished;
+        }
+
         goto retry_read;
     }
-    else
-    {
-        /* We want this field to hold NULL at all times unless we are explicitly
-         * waiting to be resumed.
-         */
-        session->connection->coroutine = NULL;
+read_finished:
+    /* We want this field to hold NULL at all times unless we are explicitly
+     * waiting to be resumed.
+     */
+    session->connection->coroutine = NULL;
 
-        if (ret <= 0) {
-            ret = -1;
-        }
+    if (ret <= 0) {
+        ret = -1;
     }
 
     if (event_restore_needed) {
@@ -522,6 +530,13 @@ retry_write:
 
         flb_coro_yield(co, FLB_FALSE);
 
+        if (session->connection->net_error != -1) {
+            session->connection->coroutine = NULL;
+            *out_len = total;
+            io_tls_restore_event(session->connection, &event_backup);
+            return -1;
+        }
+
         goto retry_write;
     }
     else if (ret == FLB_TLS_WANT_READ) {
@@ -530,6 +545,13 @@ retry_write:
         io_tls_event_switch(session, MK_EVENT_READ);
 
         flb_coro_yield(co, FLB_FALSE);
+
+        if (session->connection->net_error != -1) {
+            session->connection->coroutine = NULL;
+            *out_len = total;
+            io_tls_restore_event(session->connection, &event_backup);
+            return -1;
+        }
 
         goto retry_write;
     }
@@ -553,6 +575,13 @@ retry_write:
         io_tls_event_switch(session, MK_EVENT_WRITE);
 
         flb_coro_yield(co, FLB_FALSE);
+
+        if (session->connection->net_error != -1) {
+            session->connection->coroutine = NULL;
+            *out_len = total;
+            io_tls_restore_event(session->connection, &event_backup);
+            return -1;
+        }
 
         goto retry_write;
     }

--- a/tests/integration/scenarios/in_forward/config/in_forward_pause.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_pause.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 60
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      mem_buf_limit: 1K
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_threaded.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_threaded.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      threaded: true
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_threaded_pause.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_threaded_pause.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 60
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      mem_buf_limit: 1K
+      threaded: true
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_tls_pause.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_tls_pause.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 60
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      mem_buf_limit: 1K
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_tls_threaded.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_tls_threaded.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      threaded: true
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_tls_threaded_pause.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_tls_threaded_pause.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 60
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      mem_buf_limit: 1K
+      threaded: true
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_tls_workers_timeout.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_tls_workers_timeout.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      net.io_timeout: 2
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      workers: 4
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/config/in_forward_workers_timeout.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_workers_timeout.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: trace
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      net.io_timeout: 2
+      workers: 4
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -684,6 +684,45 @@ def _create_tls_memory_bio_client(port, cafile):
     return raw_sock, tls, outgoing
 
 
+def _create_partial_forward_client(service, payload, use_tls):
+    if use_tls:
+        sock, tls, outgoing = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        tls.write(payload)
+        wire_payload = outgoing.read()
+
+        def send_payload(next_payload):
+            tls.write(next_payload)
+            sock.sendall(outgoing.read())
+    else:
+        sock = socket.create_connection(
+            ("127.0.0.1", service.flb_listener_port),
+            timeout=5,
+        )
+        wire_payload = payload
+
+        def send_payload(next_payload):
+            sock.sendall(next_payload)
+
+    assert len(wire_payload) > 1
+    sock.sendall(wire_payload[:-1])
+
+    return sock, wire_payload[-1:], send_payload
+
+
+def _send_forward_payload(service, payload, use_tls):
+    if use_tls:
+        _send_tls_payload(
+            service.flb_listener_port,
+            payload,
+            service.tls_crt_file,
+        )
+    else:
+        _send_tcp_payload(service.flb_listener_port, payload)
+
+
 def _recv_msgpack_value(sock):
     sock.settimeout(5)
     data = sock.recv(4096)
@@ -1120,14 +1159,21 @@ def test_in_forward_tls_message_mode():
 
 
 @pytest.mark.parametrize(
-    "config_file,worker_log",
+    "config_file,use_tls,worker_log",
     [
-        ("in_forward_tls.yaml", None),
-        ("in_forward_tls_threaded.yaml", None),
-        ("in_forward_tls_workers.yaml", "with 4 workers"),
+        ("in_forward.yaml", False, None),
+        ("in_forward_threaded.yaml", False, None),
+        ("in_forward_workers.yaml", False, "with 4 workers"),
+        ("in_forward_tls.yaml", True, None),
+        ("in_forward_tls_threaded.yaml", True, None),
+        ("in_forward_tls_workers.yaml", True, "with 4 workers"),
     ],
 )
-def test_in_forward_tls_partial_record_keeps_listener_responsive(config_file, worker_log):
+def test_in_forward_downstream_coro_partial_record_keeps_listener_responsive(
+    config_file,
+    use_tls,
+    worker_log,
+):
     service = Service(config_file)
     service.start()
 
@@ -1137,71 +1183,122 @@ def test_in_forward_tls_partial_record_keeps_listener_responsive(config_file, wo
         if worker_log is not None:
             service.wait_for_log_message(worker_log, timeout=10)
 
-        partial_payload = _message_mode_payload(TEST_TAG, {"message": "partial-tls-record"})
-        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
-            service.flb_listener_port,
-            service.tls_crt_file,
+        partial_payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "partial-coroutine-record"},
         )
-
-        tls.write(partial_payload)
-        encrypted_payload = outgoing.read()
-        assert len(encrypted_payload) > 1
-
-        partial_sock.sendall(encrypted_payload[:-1])
+        partial_sock, final_byte, send_on_partial_connection = (
+            _create_partial_forward_client(
+                service,
+                partial_payload,
+                use_tls,
+            )
+        )
         time.sleep(0.5)
 
         responsive_payload = _message_mode_payload(
             TEST_TAG,
             {"message": "second-connection-remains-responsive"},
         )
-        _send_tls_payload(
-            service.flb_listener_port,
+        _send_forward_payload(
+            service,
             responsive_payload,
-            service.tls_crt_file,
+            use_tls,
         )
         records = service.wait_for_record_count(1, timeout=10)
 
         assert records[0]["message"] == "second-connection-remains-responsive"
 
-        partial_sock.sendall(encrypted_payload[-1:])
+        partial_sock.sendall(final_byte)
         records = service.wait_for_record_count(2, timeout=10)
+
+        restored_payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "same-connection-after-resume"},
+        )
+        send_on_partial_connection(restored_payload)
+        records = service.wait_for_record_count(3, timeout=10)
     finally:
         if partial_sock is not None:
             partial_sock.close()
         service.stop()
 
-    assert any(record.get("message") == "partial-tls-record" for record in records)
+    assert any(
+        record.get("message") == "partial-coroutine-record"
+        for record in records
+    )
+    assert any(
+        record.get("message") == "same-connection-after-resume"
+        for record in records
+    )
 
 
-def test_in_forward_tls_eof_and_protocol_error_keep_listener_responsive():
-    service = Service("in_forward_tls.yaml")
+@pytest.mark.parametrize(
+    "config_file,use_tls",
+    [
+        ("in_forward.yaml", False),
+        ("in_forward_threaded.yaml", False),
+        ("in_forward_workers.yaml", False),
+        ("in_forward_tls.yaml", True),
+        ("in_forward_tls_threaded.yaml", True),
+        ("in_forward_tls_workers.yaml", True),
+    ],
+)
+def test_in_forward_downstream_coro_eof_and_error_keep_listener_responsive(
+    config_file,
+    use_tls,
+):
+    service = Service(config_file)
     service.start()
 
     try:
-        eof_sock, _, _ = _create_tls_memory_bio_client(
-            service.flb_listener_port,
-            service.tls_crt_file,
-        )
+        if use_tls:
+            eof_sock, _, _ = _create_tls_memory_bio_client(
+                service.flb_listener_port,
+                service.tls_crt_file,
+            )
+        else:
+            eof_sock = socket.create_connection(
+                ("127.0.0.1", service.flb_listener_port),
+                timeout=5,
+            )
         eof_sock.close()
 
-        error_sock, _, _ = _create_tls_memory_bio_client(
-            service.flb_listener_port,
-            service.tls_crt_file,
-        )
-        error_sock.sendall(b"\x17\x03\x03\x00\x06broken")
-        error_sock.close()
+        if use_tls:
+            error_sock, _, _ = _create_tls_memory_bio_client(
+                service.flb_listener_port,
+                service.tls_crt_file,
+            )
+            error_sock.sendall(b"\x17\x03\x03\x00\x06broken")
+            error_sock.close()
+        else:
+            _send_tcp_payload(service.flb_listener_port, b"\xc1")
 
-        payload = _message_mode_payload(TEST_TAG, {"message": "after-tls-errors"})
-        _send_tls_payload(service.flb_listener_port, payload, service.tls_crt_file)
+        payload = _message_mode_payload(TEST_TAG, {"message": "after-io-errors"})
+        _send_forward_payload(service, payload, use_tls)
         records = service.wait_for_record_count(1, timeout=10)
     finally:
         service.stop()
 
-    assert records[0]["message"] == "after-tls-errors"
+    assert records[0]["message"] == "after-io-errors"
 
 
-def test_in_forward_tls_partial_record_shutdown_is_clean():
-    service = Service("in_forward_tls.yaml")
+@pytest.mark.parametrize(
+    "config_file,use_tls",
+    [
+        ("in_forward.yaml", False),
+        ("in_forward_threaded.yaml", False),
+        ("in_forward_workers.yaml", False),
+        ("in_forward_tls.yaml", True),
+        ("in_forward_tls_threaded.yaml", True),
+        ("in_forward_tls_workers.yaml", True),
+    ],
+)
+def test_in_forward_downstream_coro_partial_record_shutdown_is_clean(
+    config_file,
+    use_tls,
+):
+    service = Service(config_file)
     service.start()
     process = service.flb.process
 
@@ -1209,14 +1306,11 @@ def test_in_forward_tls_partial_record_shutdown_is_clean():
 
     try:
         payload = _message_mode_payload(TEST_TAG, {"message": "shutdown-partial"})
-        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
-            service.flb_listener_port,
-            service.tls_crt_file,
+        partial_sock, _, _ = _create_partial_forward_client(
+            service,
+            payload,
+            use_tls,
         )
-        tls.write(payload)
-        encrypted_payload = outgoing.read()
-        assert len(encrypted_payload) > 1
-        partial_sock.sendall(encrypted_payload[:-1])
         time.sleep(0.5)
     finally:
         service.stop()
@@ -1226,8 +1320,20 @@ def test_in_forward_tls_partial_record_shutdown_is_clean():
     assert process.returncode == 0
 
 
-def test_in_forward_tls_partial_record_pause_and_shutdown_is_clean():
-    service = Service("in_forward_tls_pause.yaml")
+@pytest.mark.parametrize(
+    "config_file,use_tls",
+    [
+        ("in_forward_pause.yaml", False),
+        ("in_forward_threaded_pause.yaml", False),
+        ("in_forward_tls_pause.yaml", True),
+        ("in_forward_tls_threaded_pause.yaml", True),
+    ],
+)
+def test_in_forward_downstream_coro_pause_unwinds_connections(
+    config_file,
+    use_tls,
+):
+    service = Service(config_file)
     service.start()
     process = service.flb.process
 
@@ -1235,28 +1341,26 @@ def test_in_forward_tls_partial_record_pause_and_shutdown_is_clean():
 
     try:
         log_file = service.service.flb.log_file
-        destroyed_before_pause = read_file(log_file).count("[coro] destroy coroutine")
+        drop_log = "drop connection fd="
+        dropped_before_pause = read_file(log_file).count(drop_log)
 
         partial_payload = _message_mode_payload(TEST_TAG, {"message": "pause-partial"})
-        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
-            service.flb_listener_port,
-            service.tls_crt_file,
+        partial_sock, _, _ = _create_partial_forward_client(
+            service,
+            partial_payload,
+            use_tls,
         )
-        tls.write(partial_payload)
-        encrypted_payload = outgoing.read()
-        assert len(encrypted_payload) > 1
-        partial_sock.sendall(encrypted_payload[:-1])
 
         large_payload = _message_mode_payload(
             TEST_TAG,
             {"message": "trigger-pause", "payload": "x" * 4096},
         )
-        _send_tls_payload(service.flb_listener_port, large_payload, service.tls_crt_file)
+        _send_forward_payload(service, large_payload, use_tls)
         service.wait_for_log_contains("paused (mem buf overlimit", timeout=10)
         service.service.wait_for_condition(
             lambda: read_file(log_file)
-            if read_file(log_file).count("[coro] destroy coroutine")
-            >= destroyed_before_pause + 2
+            if read_file(log_file).count(drop_log)
+            >= dropped_before_pause + 2
             else None,
             timeout=10,
             interval=0.2,
@@ -1270,35 +1374,54 @@ def test_in_forward_tls_partial_record_pause_and_shutdown_is_clean():
     assert process.returncode == 0
 
 
-def test_in_forward_tls_worker_idle_timeout_wakes_coroutine():
-    service = Service("in_forward_tls_workers_timeout.yaml")
+@pytest.mark.parametrize(
+    "config_file,use_tls",
+    [
+        ("in_forward_workers_timeout.yaml", False),
+        ("in_forward_tls_workers_timeout.yaml", True),
+    ],
+)
+def test_in_forward_downstream_coro_worker_timeout_unwinds_connection(
+    config_file,
+    use_tls,
+):
+    service = Service(config_file)
     service.start()
 
     partial_sock = None
 
     try:
         service.wait_for_log_message("with 4 workers", timeout=10)
+        log_file = service.service.flb.log_file
+        drop_log = "drop connection fd="
+        dropped_before_timeout = read_file(log_file).count(drop_log)
 
         payload = _message_mode_payload(TEST_TAG, {"message": "worker-timeout"})
-        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
-            service.flb_listener_port,
-            service.tls_crt_file,
+        partial_sock, _, _ = _create_partial_forward_client(
+            service,
+            payload,
+            use_tls,
         )
-        tls.write(payload)
-        encrypted_payload = outgoing.read()
-        assert len(encrypted_payload) > 1
-        partial_sock.sendall(encrypted_payload[:-1])
 
         service.wait_for_log_contains("timed out after 2 seconds (IO timeout)", timeout=10)
+        service.service.wait_for_condition(
+            lambda: read_file(log_file)
+            if read_file(log_file).count(drop_log)
+            >= dropped_before_timeout + 1
+            else None,
+            timeout=10,
+            interval=0.2,
+            description="timed-out Forward coroutine to unwind",
+        )
 
         responsive_payload = _message_mode_payload(
             TEST_TAG,
             {"message": "after-worker-timeout"},
         )
-        _send_tls_payload(
-            service.flb_listener_port,
+        _send_forward_payload(
+            service,
             responsive_payload,
-            service.tls_crt_file,
+            use_tls,
         )
         records = service.wait_for_record_count(1, timeout=10)
     finally:

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -653,6 +653,37 @@ def _send_tls_payload(port, payload, cafile):
             tls_sock.sendall(payload)
 
 
+def _create_tls_memory_bio_client(port, cafile):
+    context = ssl.create_default_context(cafile=cafile)
+    incoming = ssl.MemoryBIO()
+    outgoing = ssl.MemoryBIO()
+    tls = context.wrap_bio(incoming, outgoing, server_hostname="localhost")
+    raw_sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+
+    while True:
+        try:
+            tls.do_handshake()
+            break
+        except ssl.SSLWantReadError:
+            encrypted = outgoing.read()
+            if encrypted:
+                raw_sock.sendall(encrypted)
+
+            encrypted = raw_sock.recv(65536)
+            assert encrypted
+            incoming.write(encrypted)
+        except ssl.SSLWantWriteError:
+            encrypted = outgoing.read()
+            if encrypted:
+                raw_sock.sendall(encrypted)
+
+    encrypted = outgoing.read()
+    if encrypted:
+        raw_sock.sendall(encrypted)
+
+    return raw_sock, tls, outgoing
+
+
 def _recv_msgpack_value(sock):
     sock.settimeout(5)
     data = sock.recv(4096)
@@ -1086,6 +1117,196 @@ def test_in_forward_tls_message_mode():
         service.stop()
 
     assert records[0]["message"] == "tls-message"
+
+
+@pytest.mark.parametrize(
+    "config_file,worker_log",
+    [
+        ("in_forward_tls.yaml", None),
+        ("in_forward_tls_threaded.yaml", None),
+        ("in_forward_tls_workers.yaml", "with 4 workers"),
+    ],
+)
+def test_in_forward_tls_partial_record_keeps_listener_responsive(config_file, worker_log):
+    service = Service(config_file)
+    service.start()
+
+    partial_sock = None
+
+    try:
+        if worker_log is not None:
+            service.wait_for_log_message(worker_log, timeout=10)
+
+        partial_payload = _message_mode_payload(TEST_TAG, {"message": "partial-tls-record"})
+        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+
+        tls.write(partial_payload)
+        encrypted_payload = outgoing.read()
+        assert len(encrypted_payload) > 1
+
+        partial_sock.sendall(encrypted_payload[:-1])
+        time.sleep(0.5)
+
+        responsive_payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "second-connection-remains-responsive"},
+        )
+        _send_tls_payload(
+            service.flb_listener_port,
+            responsive_payload,
+            service.tls_crt_file,
+        )
+        records = service.wait_for_record_count(1, timeout=10)
+
+        assert records[0]["message"] == "second-connection-remains-responsive"
+
+        partial_sock.sendall(encrypted_payload[-1:])
+        records = service.wait_for_record_count(2, timeout=10)
+    finally:
+        if partial_sock is not None:
+            partial_sock.close()
+        service.stop()
+
+    assert any(record.get("message") == "partial-tls-record" for record in records)
+
+
+def test_in_forward_tls_eof_and_protocol_error_keep_listener_responsive():
+    service = Service("in_forward_tls.yaml")
+    service.start()
+
+    try:
+        eof_sock, _, _ = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        eof_sock.close()
+
+        error_sock, _, _ = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        error_sock.sendall(b"\x17\x03\x03\x00\x06broken")
+        error_sock.close()
+
+        payload = _message_mode_payload(TEST_TAG, {"message": "after-tls-errors"})
+        _send_tls_payload(service.flb_listener_port, payload, service.tls_crt_file)
+        records = service.wait_for_record_count(1, timeout=10)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "after-tls-errors"
+
+
+def test_in_forward_tls_partial_record_shutdown_is_clean():
+    service = Service("in_forward_tls.yaml")
+    service.start()
+    process = service.flb.process
+
+    partial_sock = None
+
+    try:
+        payload = _message_mode_payload(TEST_TAG, {"message": "shutdown-partial"})
+        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        tls.write(payload)
+        encrypted_payload = outgoing.read()
+        assert len(encrypted_payload) > 1
+        partial_sock.sendall(encrypted_payload[:-1])
+        time.sleep(0.5)
+    finally:
+        service.stop()
+        if partial_sock is not None:
+            partial_sock.close()
+
+    assert process.returncode == 0
+
+
+def test_in_forward_tls_partial_record_pause_and_shutdown_is_clean():
+    service = Service("in_forward_tls_pause.yaml")
+    service.start()
+    process = service.flb.process
+
+    partial_sock = None
+
+    try:
+        log_file = service.service.flb.log_file
+        destroyed_before_pause = read_file(log_file).count("[coro] destroy coroutine")
+
+        partial_payload = _message_mode_payload(TEST_TAG, {"message": "pause-partial"})
+        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        tls.write(partial_payload)
+        encrypted_payload = outgoing.read()
+        assert len(encrypted_payload) > 1
+        partial_sock.sendall(encrypted_payload[:-1])
+
+        large_payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "trigger-pause", "payload": "x" * 4096},
+        )
+        _send_tls_payload(service.flb_listener_port, large_payload, service.tls_crt_file)
+        service.wait_for_log_contains("paused (mem buf overlimit", timeout=10)
+        service.service.wait_for_condition(
+            lambda: read_file(log_file)
+            if read_file(log_file).count("[coro] destroy coroutine")
+            >= destroyed_before_pause + 2
+            else None,
+            timeout=10,
+            interval=0.2,
+            description="paused Forward TLS coroutines to unwind",
+        )
+    finally:
+        service.stop()
+        if partial_sock is not None:
+            partial_sock.close()
+
+    assert process.returncode == 0
+
+
+def test_in_forward_tls_worker_idle_timeout_wakes_coroutine():
+    service = Service("in_forward_tls_workers_timeout.yaml")
+    service.start()
+
+    partial_sock = None
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+
+        payload = _message_mode_payload(TEST_TAG, {"message": "worker-timeout"})
+        partial_sock, tls, outgoing = _create_tls_memory_bio_client(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        tls.write(payload)
+        encrypted_payload = outgoing.read()
+        assert len(encrypted_payload) > 1
+        partial_sock.sendall(encrypted_payload[:-1])
+
+        service.wait_for_log_contains("timed out after 2 seconds (IO timeout)", timeout=10)
+
+        responsive_payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "after-worker-timeout"},
+        )
+        _send_tls_payload(
+            service.flb_listener_port,
+            responsive_payload,
+            service.tls_crt_file,
+        )
+        records = service.wait_for_record_count(1, timeout=10)
+    finally:
+        if partial_sock is not None:
+            partial_sock.close()
+        service.stop()
+
+    assert records[0]["message"] == "after-worker-timeout"
 
 
 def test_in_forward_tls_idle_connection_timeout_churn(monkeypatch):


### PR DESCRIPTION
## Purpose

Add coroutine-based event dispatch to the downstream core and use Forward as
the first end-to-end consumer for both TLS and plain stream connections.

This PR is based on `master` (`cb7256c28`), replaces #11547, and fixes #11551.
Instead of bounding TLS retry loops in plugin code, it fixes the downstream
execution model: callbacks can suspend on read/write readiness and resume when
the connection has data, reaches EOF, fails, times out, or is cancelled.

## Design

- Downstream owns a persistent callback coroutine per registered connection.
- Engine, threaded-input, and downstream-worker loops dispatch through the same
  core abstraction.
- Plugins remain unaware of `WANT_READ`, `WANT_WRITE`, and retry sentinels.
- Shared async I/O switches the descriptor to the required readiness mask and
  restores its original type, mask, priority, and handler after completion.
- Timeout, pause, shutdown, and connection release wake suspended callbacks and
  unwind the wrapper, event, TLS session, and coroutine safely.
- Reentrant release from inside an active callback is deferred until the
  callback returns, preventing use-after-free during backpressure pause.
- Registration is limited to stream transports; datagram semantics are
  intentionally outside this interface.

There is no retry cap when `net.io_timeout` is zero. The coroutine is dormant
until descriptor readiness or cancellation, so indefinite waits do not spin.
Configured idle timeouts wake and terminate the pending operation.

## Forward integration

Forward TLS and plain TCP now use the downstream dispatch interface. Unrelated
server inputs remain unchanged and can migrate separately after this core path
is proven.

The plain-TCP event ownership changes internally, but its protocol behavior and
configuration remain compatible.

## Coroutine stack safety

The default coroutine stack now has a 64 KiB minimum while preserving explicit
`FLB_CORO_STACK_SIZE` overrides and larger platform defaults.

The former glibc-derived default could be only 24 KiB. That is insufficient
headroom for the full parser/processor ingestion path now reachable from a
downstream callback; historical yyjson parser frames alone have approached
38 KiB. The same safe default applies consistently to upstream, downstream,
input, output, and scheduler coroutines.

On systems that previously selected 24 KiB, the cost is approximately 40 KiB
of additional virtual stack reservation per coroutine.

## Integration coverage

The focused Forward matrix contains 24 downstream-coroutine scenarios, each
run normally and under strict Valgrind:

- TLS and plain TCP
- engine, threaded-input, and four-worker dispatch
- partial data and listener responsiveness while a callback is suspended
- completion and reuse of the same suspended connection
- EOF, Forward protocol errors, and TLS handshake/protocol errors
- idle timeout with connection-drop proof before shutdown
- pause/backpressure unwind with connection-drop proof before shutdown
- shutdown with a suspended coroutine

The timeout and pause tests assert that the connection wrapper is dropped
before process shutdown, so they cannot pass by leaking until teardown.

```text
tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py \
  -q -k 'downstream_coro'
```

Result across the final matrix: 24 passed.

```text
VALGRIND=1 VALGRIND_STRICT=1 \
  tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py \
  -q -k 'downstream_coro'
```

Result across the final matrix: 24 passed with strict Valgrind.

## Core validation

```text
cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On
cmake --build build -j8
ctest --test-dir build \
  -R '^(flb-rt-in_forward|flb-it-network|flb-it-downstream_worker|flb-it-upstream_tls)$' \
  --output-on-failure
```

`flb-it-network`, `flb-it-downstream_worker`, and `flb-it-upstream_tls`
passed. `flb-rt-in_forward` could not bind port 24224 because the host
`fluentd.service` owns it; that service was not disrupted.

The full PR range passes commit-prefix lint, DCO, and `git diff --check`.
Windows x86, x64, and ARM64 builds are covered by PR CI because a local MSVC
toolchain is unavailable.

## Compatibility

- No configuration properties or defaults change.
- `net.io_timeout: 0` retains indefinite, readiness-driven waiting.
- Forward plain and TLS protocol behavior is preserved.
- Existing downstream plugins are not migrated implicitly.
- Explicit coroutine stack-size overrides remain authoritative.

## Related

- Replaces #11547
- Fixes #11551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of Forward input connections during partial records, EOFs, TLS errors, pauses, shutdowns, and worker timeouts.
  * Improved cleanup and recovery of stalled or interrupted network connections, including safer async event restoration and more consistent teardown behavior.
  * Reduced the risk of listener unresponsiveness during connection recovery.
* **New Features**
  * Added support for connection-level event callbacks and per-connection flag management to enable async event-driven handling.
* **Tests**
  * Added/expanded integration coverage for threaded, worker-based, paused, timed-out, and TLS-enabled Forward scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->