### PR TITLE
out_azure_kusto: avoid logging workload identity token

### DIFF
--- a/plugins/out_azure_kusto/azure_msiauth.c
+++ b/plugins/out_azure_kusto/azure_msiauth.c
@@ -162,8 +162,6 @@ int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *to
         return -1;
     }
 
-    flb_info("[azure workload identity] after read token from file %s", federated_token);
-
     /* Build the form data for token exchange *before* creating the client */
     body = flb_sds_create_size(4096);
     if (!body) {


### PR DESCRIPTION
## Summary

- Prevent the federated workload identity token from being included in an INFO log.

Fixes https://github.com/fluent/fluent-bit/issues/12145

----

**Testing**

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
- [x] `ctest --test-dir build -R flb-rt-out_azure_kusto --output-on-failure` (1/1 passed)
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature

**Backporting**

- [N/A] Backport to latest stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary informational log message during Azure workload identity authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->