### PR TITLE
in_tail: fix ignore_older config description

### DIFF
--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -655,10 +655,9 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_TIME, "ignore_older", "0",
      0, FLB_TRUE, offsetof(struct flb_tail_config, ignore_older),
-     "ignore records older than 'ignore_older'. Supports m,h,d (minutes, "
-     "hours, days) syntax. Default behavior is to read all records. Option "
-     "only available when a Parser is specified and it can parse the time "
-     "of a record."
+     "ignore files with modification times older than 'ignore_older'. "
+     "Supports m,h,d (minutes, hours, days) syntax. Default behavior is to "
+     "read all files. "
     },
     {
      FLB_CONFIG_MAP_BOOL, "ignore_active_older_files", "false",

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -90,7 +90,7 @@ struct flb_tail_config {
     int read_from_head;        /* read new files from head     */
     int rotate_wait;           /* sec to wait on rotated files */
     int watcher_interval;      /* watcher interval             */
-    int ignore_older;          /* ignore fields older than X seconds */
+    int ignore_older;          /* ignore files older than X seconds */
     int ignore_active_older_files; /* ignore files that exceed the ignore
                                     * older limit even if they are already
                                     * being ingested */


### PR DESCRIPTION
Update some comments and docs. Motivation is described in https://github.com/fluent/fluent-bit/issues/12155.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `ignore_older` filters files based on modification time.
  * Documented supported duration formats, including minutes, hours, and days.
  * Clarified that all files are read by default when the option is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->