### PR TITLE
blob_db: fix build failure when FLB_SQLDB is flipped off

### DIFF
--- a/include/fluent-bit/flb_blob_db.h
+++ b/include/fluent-bit/flb_blob_db.h
@@ -20,7 +20,11 @@
 #ifndef FLB_BLOB_DB_H
 #define FLB_BLOB_DB_H
 
+#include <stdint.h>
+#include <cfl/cfl_sds.h>
 #include <fluent-bit/flb_lock.h>
+
+struct flb_config;
 
 #define SQL_PRAGMA_FOREIGN_KEYS "PRAGMA foreign_keys = ON;"
 

--- a/plugins/in_systemd/systemd_config.h
+++ b/plugins/in_systemd/systemd_config.h
@@ -23,7 +23,9 @@
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_config.h>
+#ifdef FLB_HAVE_SQLDB
 #include <fluent-bit/flb_sqldb.h>
+#endif
 #include <fluent-bit/flb_log_event_encoder.h>
 
 #include <systemd/sd-journal.h>

--- a/src/flb_blob_db.c
+++ b/src/flb_blob_db.c
@@ -17,10 +17,11 @@
  *  limitations under the License.
  */
 
+#include <fluent-bit/flb_blob_db.h>
+
 #ifdef FLB_HAVE_SQLDB
 
 #include <fluent-bit/flb_sqldb.h>
-#include <fluent-bit/flb_blob_db.h>
 
 static int prepare_stmts(struct flb_blob_db *context)
 {
@@ -1512,7 +1513,8 @@ int flb_blob_db_file_part_get_next(struct flb_blob_db *context,
                                    cfl_sds_t *file_path,
                                    cfl_sds_t *destination,
                                    cfl_sds_t *remote_file_id,
-                                   cfl_sds_t *tag)
+                                   cfl_sds_t *tag,
+                                   int *part_count)
 {
     return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
 }
@@ -1555,6 +1557,30 @@ int flb_blob_db_file_fetch_part_ids(struct flb_blob_db *context,
 
 int flb_blob_db_file_fetch_part_count(struct flb_blob_db *context,
                                       uint64_t file_id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_lock(struct flb_blob_db *context)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_unlock(struct flb_blob_db *context)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_file_update_remote_id(struct flb_blob_db *context,
+                                   uint64_t id,
+                                   cfl_sds_t remote_id)
+{
+    return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
+}
+
+int flb_blob_db_file_part_update_remote_id(struct flb_blob_db *context,
+                                           uint64_t id,
+                                           cfl_sds_t remote_id)
 {
     return FLB_BLOB_DB_ERROR_NO_BACKEND_AVAILABLE;
 }


### PR DESCRIPTION
Building with flag -DFLB_SQLDB=Off would result undeclared types as some gated includes were required for a successful build.

<!-- Provide summary of changes -->

**Reproducing**:
Add `-DDFLB_SQLDB=Off` option to the Dockerfile resulting in build error (logs: [before_fix.txt](https://github.com/user-attachments/files/30370752/before_fix.txt)).

Changes fix the headers as well as including definitions that were previously missing when SQLDB is turned off, successfully building fluentbit (logs: [after_fix.txt](https://github.com/user-attachments/files/30370767/after_fix.txt))


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when database-backed features are unavailable.
  * Prevented build and integration issues in configurations without SQL database support.
  * Ensured blob storage operations return consistent results across supported configurations.
  * Added consistent error handling for unsupported database operations.

* **Refactor**
  * Aligned optional database-related components with their enabled or disabled configuration.
  * Standardized behavior across database-enabled and database-free builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->