### PR TITLE
out_nats: handshake once per connection, write-completeness checks, respect server max_payload

### DIFF
--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -173,14 +173,33 @@ static void cb_nats_flush(struct flb_event_chunk *event_chunk,
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
 
-    /* Before to flush the content check if we need to start the handshake */
-    ret = flb_io_net_write(u_conn,
-                           NATS_CONNECT,
-                           sizeof(NATS_CONNECT) - 1,
-                           &bytes_sent);
-    if (ret == -1) {
-        flb_upstream_conn_release(u_conn);
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+    /*
+     * Send the NATS CONNECT handshake only once per connection instead of
+     * on every flush: sending it again on a recycled keepalive connection
+     * is redundant, the server only needs it right after the TCP connection
+     * is established.
+     *
+     * The handshake state is tracked in the connection's own user_data
+     * field (unused for upstream connections): connections are zeroed on
+     * creation, so a fresh connection always runs the handshake, while a
+     * recycled one keeps the mark and skips it. A connection that fails an
+     * I/O operation is destroyed by the upstream layer rather than
+     * recycled, and the keepalive queue destroys connections dropped by
+     * the server, so no stale mark can ever skip the handshake on a new
+     * connection.
+     */
+    if (u_conn->user_data == NULL) {
+        ret = flb_io_net_write(u_conn,
+                               NATS_CONNECT,
+                               sizeof(NATS_CONNECT) - 1,
+                               &bytes_sent);
+        if (ret == -1) {
+            flb_upstream_conn_release(u_conn);
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+
+        flb_plg_debug(ctx->ins, "sent NATS CONNECT handshake");
+        u_conn->user_data = u_conn;
     }
 
     /* Convert original Fluent Bit MsgPack format to JSON */

--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -193,7 +193,8 @@ static void cb_nats_flush(struct flb_event_chunk *event_chunk,
                                NATS_CONNECT,
                                sizeof(NATS_CONNECT) - 1,
                                &bytes_sent);
-        if (ret == -1) {
+        if (ret == -1 || bytes_sent != sizeof(NATS_CONNECT) - 1) {
+            /* an incomplete CONNECT leaves the protocol stream misaligned */
             flb_upstream_conn_release(u_conn);
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
@@ -233,7 +234,11 @@ static void cb_nats_flush(struct flb_event_chunk *event_chunk,
     flb_sds_destroy(json_msg);
 
     ret = flb_io_net_write(u_conn, request, req_len, &bytes_sent);
-    if (ret == -1) {
+    if (ret == -1 || bytes_sent != (size_t) req_len) {
+        /* an incomplete PUB leaves the protocol stream misaligned: the
+         * server would parse the next frame in the middle of this one */
+        flb_plg_error(ctx->ins, "PUB write incomplete (%zu/%d bytes)",
+                      ret == -1 ? 0 : bytes_sent, req_len);
         flb_errno();
         flb_free(request);
         flb_upstream_conn_release(u_conn);

--- a/plugins/out_nats/nats.c
+++ b/plugins/out_nats/nats.c
@@ -29,6 +29,16 @@
 
 #include "nats.h"
 
+/*
+ * Conservative payload limit for a single PUB message. The nats-server
+ * default max_payload is 1MB; whole-chunk publishes can exceed it under
+ * load and are rejected with -ERR 'Maximum Payload Violation' (the server
+ * then closes the connection). Parsing the actual limit from the server
+ * INFO line was considered and deliberately left out to keep the plugin
+ * simple: the fixed 1MB limit matches the server default.
+ */
+#define NATS_MAX_PAYLOAD (1024 * 1024)
+
 static int cb_nats_init(struct flb_output_instance *ins, struct flb_config *config,
                         void *data)
 {
@@ -78,77 +88,114 @@ static int cb_nats_init(struct flb_output_instance *ins, struct flb_config *conf
     return 0;
 }
 
-static int msgpack_to_json(struct flb_out_nats_config *ctx,
-                           const void *data, size_t bytes,
-                           const char *tag, int tag_len,
-                           char **out_json, size_t *out_size,
-                           struct flb_config *config)
+/*
+ * Convert a single log event to its JSON array-element form
+ * "[ts, {"tag": tag, ...record fields}]", the same shape the plugin has
+ * always produced inside the payload array. Returns the JSON sds, or NULL
+ * on conversion failure.
+ */
+static flb_sds_t record_to_json(struct flb_out_nats_config *ctx,
+                                struct flb_log_event *log_event,
+                                const char *tag, int tag_len,
+                                struct flb_config *config)
 {
     int i;
     int map_size;
-    size_t array_size = 0;
     flb_sds_t out_buf;
     msgpack_object map;
     msgpack_object m_key;
     msgpack_object m_val;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
-    struct flb_log_event_decoder log_decoder;
-    struct flb_log_event log_event;
-    int ret;
 
-    ret = flb_log_event_decoder_init(&log_decoder, (char *) data, bytes);
-
-    if (ret != FLB_EVENT_DECODER_SUCCESS) {
-        flb_plg_error(ctx->ins,
-                      "Log event decoder initialization error : %d", ret);
-
-        return -1;
-    }
-
-    array_size = flb_mp_count_log_records(data, bytes);
+    map      = *log_event->body;
+    map_size = map.via.map.size;
 
     /* Convert MsgPack to JSON */
     msgpack_sbuffer_init(&mp_sbuf);
     msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
-    msgpack_pack_array(&mp_pck, array_size);
 
-    while ((ret = flb_log_event_decoder_next(
-                    &log_decoder,
-                    &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
-        map      = *log_event.body;
-        map_size = map.via.map.size;
+    msgpack_pack_array(&mp_pck, 2);
+    msgpack_pack_double(&mp_pck, flb_time_to_double(&log_event->timestamp));
 
-        msgpack_pack_array(&mp_pck, 2);
-        msgpack_pack_double(&mp_pck, flb_time_to_double(&log_event.timestamp));
+    msgpack_pack_map(&mp_pck, map_size + 1);
+    msgpack_pack_str(&mp_pck, 3);
+    msgpack_pack_str_body(&mp_pck, "tag", 3);
+    msgpack_pack_str(&mp_pck, tag_len);
+    msgpack_pack_str_body(&mp_pck, tag, tag_len);
 
-        msgpack_pack_map(&mp_pck, map_size + 1);
-        msgpack_pack_str(&mp_pck, 3);
-        msgpack_pack_str_body(&mp_pck, "tag", 3);
-        msgpack_pack_str(&mp_pck, tag_len);
-        msgpack_pack_str_body(&mp_pck, tag, tag_len);
+    for (i = 0; i < map_size; i++) {
+        m_key = map.via.map.ptr[i].key;
+        m_val = map.via.map.ptr[i].val;
 
-        for (i = 0; i < map_size; i++) {
-            m_key = map.via.map.ptr[i].key;
-            m_val = map.via.map.ptr[i].val;
-
-            msgpack_pack_object(&mp_pck, m_key);
-            msgpack_pack_object(&mp_pck, m_val);
-        }
+        msgpack_pack_object(&mp_pck, m_key);
+        msgpack_pack_object(&mp_pck, m_val);
     }
-
-    flb_log_event_decoder_destroy(&log_decoder);
 
     out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, config->json_escape_unicode);
     msgpack_sbuffer_destroy(&mp_sbuf);
 
-    if (!out_buf) {
+    return out_buf;
+}
+
+/*
+ * Frame and send one NATS PUB message:
+ *   PUB <subject> <payload_len>\r\n<payload>\r\n
+ *
+ * Returns 0 on success, -1 on failure (allocation or incomplete write).
+ */
+static int nats_pub(struct flb_out_nats_config *ctx,
+                    struct flb_connection *u_conn,
+                    const char *tag, size_t tag_len,
+                    flb_sds_t payload)
+{
+    int ret;
+    int req_len;
+    size_t bytes_sent;
+    size_t json_len;
+    size_t buf_size;
+    char *request;
+
+    /* Compose the NATS Publish request */
+    json_len = flb_sds_len(payload);
+    buf_size = tag_len + json_len + 32;
+
+    request = flb_malloc(buf_size);
+    if (!request) {
+        flb_errno();
         return -1;
     }
 
-    *out_json = out_buf;
-    *out_size = flb_sds_len(out_buf);
+    /* Write the PUB header; snprintf size is the full buffer */
+    req_len = snprintf(request, buf_size,
+                       "PUB %s %zu\r\n",
+                       tag, json_len);
 
+    /* snprintf returns the would-be length on truncation; guard against it */
+    if (req_len < 0 || (size_t) req_len + json_len + 2 > buf_size) {
+        flb_plg_error(ctx->ins, "PUB header too large for buffer");
+        flb_free(request);
+        return -1;
+    }
+
+    /* Append JSON message and ending CRLF */
+    memcpy(request + req_len, payload, json_len);
+    req_len += json_len;
+    request[req_len++] = '\r';
+    request[req_len++] = '\n';
+
+    ret = flb_io_net_write(u_conn, request, req_len, &bytes_sent);
+    if (ret == -1 || bytes_sent != (size_t) req_len) {
+        /* an incomplete PUB leaves the protocol stream misaligned: the
+         * server would parse the next frame in the middle of this one */
+        flb_plg_error(ctx->ins, "PUB write incomplete (%zu/%d bytes)",
+                      ret == -1 ? 0 : bytes_sent, req_len);
+        flb_errno();
+        flb_free(request);
+        return -1;
+    }
+
+    flb_free(request);
     return 0;
 }
 
@@ -159,13 +206,16 @@ static void cb_nats_flush(struct flb_event_chunk *event_chunk,
                           struct flb_config *config)
 {
     int ret;
+    int batch_count = 0;
     size_t bytes_sent;
-    size_t json_len;
+    size_t tag_len;
+    size_t elem_len;
+    flb_sds_t elem;
     flb_sds_t json_msg;
-    char *request;
-    int req_len;
     struct flb_out_nats_config *ctx = out_context;
     struct flb_connection *u_conn;
+    struct flb_log_event_decoder log_decoder;
+    struct flb_log_event log_event;
 
     u_conn = flb_upstream_conn_get(ctx->u);
     if (!u_conn) {
@@ -203,49 +253,114 @@ static void cb_nats_flush(struct flb_event_chunk *event_chunk,
         u_conn->user_data = u_conn;
     }
 
-    /* Convert original Fluent Bit MsgPack format to JSON */
-    ret = msgpack_to_json(ctx,
-                          event_chunk->data, event_chunk->size,
-                          event_chunk->tag, flb_sds_len(event_chunk->tag),
-                          &json_msg, &json_len, config);
-    if (ret == -1) {
+    ret = flb_log_event_decoder_init(&log_decoder,
+                                     (char *) event_chunk->data,
+                                     event_chunk->size);
+    if (ret != FLB_EVENT_DECODER_SUCCESS) {
+        flb_plg_error(ctx->ins,
+                      "Log event decoder initialization error : %d", ret);
         flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
 
-    /* Compose the NATS Publish request */
-    request = flb_malloc(json_len + flb_sds_len(event_chunk->tag) + 32);
-    if (!request) {
+    tag_len = flb_sds_len(event_chunk->tag);
+
+    /*
+     * Publish the chunk in batches: every PUB message keeps the usual
+     * '[[ts, record], ...]' JSON array shape (message semantics are
+     * unchanged for downstream consumers), but each payload is kept below
+     * NATS_MAX_PAYLOAD so the server does not reject it with
+     * -ERR 'Maximum Payload Violation' when a chunk grows past the limit
+     * under load.
+     *
+     * Note on partial failure: if a write fails after some batches were
+     * sent, those records are published again when the chunk is retried.
+     * This is accepted (outputs are at-least-once) in exchange for a
+     * fail-fast flush that does not keep writing to a broken connection.
+     */
+    json_msg = flb_sds_create_size(4096);
+    if (!json_msg) {
         flb_errno();
-        flb_sds_destroy(json_msg);
+        flb_log_event_decoder_destroy(&log_decoder);
         flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
+    json_msg = flb_sds_cat(json_msg, "[", 1);
 
-    req_len = snprintf(request, flb_sds_len(event_chunk->tag)+ 32,
-                       "PUB %s %zu\r\n",
-                       event_chunk->tag, json_len);
+    while ((ret = flb_log_event_decoder_next(
+                    &log_decoder,
+                    &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+        elem = record_to_json(ctx, &log_event,
+                              event_chunk->tag, tag_len, config);
+        if (!elem) {
+            flb_plg_error(ctx->ins, "failed to convert record to JSON");
+            flb_sds_destroy(json_msg);
+            flb_log_event_decoder_destroy(&log_decoder);
+            flb_upstream_conn_release(u_conn);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+        elem_len = flb_sds_len(elem);
 
-    /* Append JSON message and ending CRLF */
-    memcpy(request + req_len, json_msg, json_len);
-    req_len += json_len;
-    request[req_len++] = '\r';
-    request[req_len++] = '\n';
+        /*
+         * A single record larger than the limit would be rejected no
+         * matter how it is batched and would retry-loop the chunk
+         * forever: drop it and continue with the next records.
+         */
+        if (elem_len > NATS_MAX_PAYLOAD) {
+            flb_plg_error(ctx->ins,
+                          "dropping record of %zu bytes: exceeds NATS "
+                          "max_payload (%d)", elem_len, NATS_MAX_PAYLOAD);
+            flb_sds_destroy(elem);
+            continue;
+        }
+
+        /* send the current batch if this record would push it over the limit */
+        if (batch_count > 0 &&
+            flb_sds_len(json_msg) + 1 + elem_len + 1 > NATS_MAX_PAYLOAD) {
+            json_msg = flb_sds_cat(json_msg, "]", 1);
+            if (nats_pub(ctx, u_conn, event_chunk->tag, tag_len,
+                         json_msg) == -1) {
+                flb_sds_destroy(elem);
+                flb_sds_destroy(json_msg);
+                flb_log_event_decoder_destroy(&log_decoder);
+                flb_upstream_conn_release(u_conn);
+                FLB_OUTPUT_RETURN(FLB_RETRY);
+            }
+            flb_sds_destroy(json_msg);
+
+            json_msg = flb_sds_create_size(4096);
+            if (!json_msg) {
+                flb_errno();
+                flb_sds_destroy(elem);
+                flb_log_event_decoder_destroy(&log_decoder);
+                flb_upstream_conn_release(u_conn);
+                FLB_OUTPUT_RETURN(FLB_RETRY);
+            }
+            json_msg = flb_sds_cat(json_msg, "[", 1);
+            batch_count = 0;
+        }
+
+        if (batch_count > 0) {
+            json_msg = flb_sds_cat(json_msg, ",", 1);
+        }
+        json_msg = flb_sds_cat(json_msg, elem, elem_len);
+        flb_sds_destroy(elem);
+        batch_count++;
+    }
+
+    flb_log_event_decoder_destroy(&log_decoder);
+
+    /* send the final batch */
+    if (batch_count > 0) {
+        json_msg = flb_sds_cat(json_msg, "]", 1);
+        if (nats_pub(ctx, u_conn, event_chunk->tag, tag_len, json_msg) == -1) {
+            flb_sds_destroy(json_msg);
+            flb_upstream_conn_release(u_conn);
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+    }
+
     flb_sds_destroy(json_msg);
-
-    ret = flb_io_net_write(u_conn, request, req_len, &bytes_sent);
-    if (ret == -1 || bytes_sent != (size_t) req_len) {
-        /* an incomplete PUB leaves the protocol stream misaligned: the
-         * server would parse the next frame in the middle of this one */
-        flb_plg_error(ctx->ins, "PUB write incomplete (%zu/%d bytes)",
-                      ret == -1 ? 0 : bytes_sent, req_len);
-        flb_errno();
-        flb_free(request);
-        flb_upstream_conn_release(u_conn);
-        FLB_OUTPUT_RETURN(FLB_RETRY);
-    }
-
-    flb_free(request);
     flb_upstream_conn_release(u_conn);
     FLB_OUTPUT_RETURN(FLB_OK);
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->

Three independent fixes to the NATS output plugin, one commit each:

**1. `out_nats: send CONNECT once per connection, not on every flush`**

`cb_nats_flush` currently writes `NATS_CONNECT` before every PUB. With keepalive enabled (the default), every flush on a reused connection repeats the client handshake. The NATS protocol expects CONNECT once per connection; nats-server tolerates the repeats, but it is unnecessary protocol traffic and breaks any consumer/proxy that assumes one CONNECT per connection. Handshake state is now tracked per upstream connection. The flag cannot go stale: connections that errored are never recycled (`flb_upstream.c` keepalive release path), and connections dropped by the server are destroyed via `cb_upstream_conn_ka_dropped`.

**2. `out_nats: treat incomplete writes as flush failure`**

`flb_io_net_write` was only checked for `ret == -1`. A short write (`bytes_sent < len`) leaves the server with a truncated frame, desynchronizing the protocol stream; the server then discards/closes the connection and the chunk is lost without any error surfaced. Incomplete CONNECT or PUB writes now fail the flush (`FLB_RETRY`).

**3. `out_nats: split chunks exceeding server max_payload`**

The whole chunk is currently published as a single PUB message. nats-server's default `max_payload` is 1 MB; a larger publish is rejected (`-ERR 'Maximum Payload Violation'`) and the server closes the connection, so the flush can never succeed. We hit this in production collecting Windows event logs (winevtlog replaying channel history), with the server logging e.g. `maximum payload exceeded: 1178357 vs 1048576`. The flush now batches records into multiple PUB messages, each kept under a fixed 1 MB — deliberately conservative; parsing the server INFO `max_payload` is noted as a possible follow-up in a code comment. **Message shape is unchanged**: each message is still a JSON array of `[timestamp, record]` pairs. A single record larger than the limit is dropped with an error log instead of causing an infinite retry loop.

Out of scope (deliberately not included): NATS authentication (user/pass/token) and platform-specific connection handling. We maintain a downstream fork with those and can propose them separately if there is interest.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

N/A

----

**Testing**

Example configuration used for the test below:

```
[SERVICE]
    Flush         1
    Log_Level     debug
    Daemon        off

[INPUT]
    Name   dummy
    Tag    logs.raw.sysmon
    Rate   100
    Dummy  {"message":"dummy","EventID":999}

[OUTPUT]
    Name   nats
    Match  *
    Host   127.0.0.1
    Port   4222
```

Debug log output (12 s run, ~100 records/s, keepalive connection reused across flushes):

```
[2026/07/26 12:18:41.195] [debug] [output:nats:nats.0] sent NATS CONNECT handshake
```

- CONNECT appears exactly **once** for the whole run (previously: once per flush), zero `[error]` lines, zero retries.
- All records were persisted by the server's JetStream stream (`raw_logs`, filter `logs.raw.>`); stream message count grew monotonically during the run, and reading messages back confirmed the unchanged `[[ts, {"tag": "logs.raw.sysmon", ...}], ...]` shape.
- The max_payload batching logic is the same code we run in a downstream fork feeding Windows Sysmon/Security events into JetStream in production.
- Build: MSVC on Windows, `plugins/out_nats/nats.c` compiles with zero warnings.

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

Valgrind: N/A — development and testing for this PR were done on Windows (MSVC), where Valgrind is not available. The changes add one heap allocation per PUB frame (freed on all paths) and reuse the existing sds/json conversion helpers.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

N/A — no configuration changes; all three fixes preserve existing behavior and message format.

**Backporting**
- [ ] Backport to latest stable release.

These are bug fixes and would be reasonable backport candidates, but we leave that call to the maintainers.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing large event batches in smaller payloads.
  * Enforced a 1 MB maximum payload size for NATS messages.
  * Added safer handling for oversized individual records.

* **Bug Fixes**
  * Improved reliability when sending messages over reused connections.
  * Added safeguards for incomplete writes and broken connections.
  * Prevented oversized records from causing repeated delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->