### PR TITLE
build: add options for plugins at group granularity

### DIFF
--- a/cmake/plugins_options.cmake
+++ b/cmake/plugins_options.cmake
@@ -3,10 +3,36 @@ macro(DEFINE_OPTION option_name description default_value)
     if(FLB_MINIMAL)
         set(temp_value OFF)
     endif()
-    if(NOT "${FLB_GROUP_OVERRIDE}" STREQUAL "Inherit")
+    string(TOLOWER "${FLB_GROUP_OVERRIDE}" group_override)
+    if(NOT group_override STREQUAL "inherit")
         set(temp_value ${FLB_GROUP_OVERRIDE})
     endif()
+
+    if(temp_value)
+        set(temp_value ON)
+    else()
+        set(temp_value OFF)
+    endif()
+
+    get_property(option_type CACHE ${option_name} PROPERTY TYPE)
+    if(option_type STREQUAL "UNINITIALIZED")
+        set(_FLB_PINNED_${option_name} ON CACHE INTERNAL "")
+    endif()
+
     option(${option_name} "${description}" ${temp_value})
+
+    if(NOT DEFINED _FLB_INHERITED_${option_name})
+        set(_FLB_INHERITED_${option_name} "${${option_name}}" CACHE INTERNAL "")
+    else()
+        if(NOT _FLB_PINNED_${option_name} AND
+           NOT "${${option_name}}" STREQUAL "${_FLB_INHERITED_${option_name}}")
+            set(_FLB_PINNED_${option_name} ON CACHE INTERNAL "")
+        endif()
+        if(NOT _FLB_PINNED_${option_name} AND "${${option_name}}" STREQUAL "${_FLB_INHERITED_${option_name}}")
+            set(${option_name} ${temp_value} CACHE BOOL "${description}" FORCE)
+        endif()
+        set(_FLB_INHERITED_${option_name} ${temp_value} CACHE INTERNAL "")
+    endif()
 endmacro()
 
 # Add the FLB_MINIMAL option
@@ -21,6 +47,15 @@ set_property(CACHE FLB_ALL_INPUTS     PROPERTY STRINGS "On;Off;Inherit")
 set_property(CACHE FLB_ALL_PROCESSORS PROPERTY STRINGS "On;Off;Inherit")
 set_property(CACHE FLB_ALL_FILTERS    PROPERTY STRINGS "On;Off;Inherit")
 set_property(CACHE FLB_ALL_OUTPUTS    PROPERTY STRINGS "On;Off;Inherit")
+
+foreach(group_option FLB_ALL_INPUTS FLB_ALL_PROCESSORS FLB_ALL_FILTERS FLB_ALL_OUTPUTS)
+    string(TOLOWER "${${group_option}}" group_value)
+    if(NOT group_value MATCHES "^(on|off|inherit)$")
+        message(FATAL_ERROR
+            "${group_option} must be one of On, Off or Inherit "
+            "(got '${${group_option}}')")
+    endif()
+endforeach()
 
 # Inputs (sources, data collectors)
 # =================================

--- a/cmake/plugins_options.cmake
+++ b/cmake/plugins_options.cmake
@@ -3,14 +3,28 @@ macro(DEFINE_OPTION option_name description default_value)
     if(FLB_MINIMAL)
         set(temp_value OFF)
     endif()
+    if(NOT "${FLB_GROUP_OVERRIDE}" STREQUAL "Inherit")
+        set(temp_value ${FLB_GROUP_OVERRIDE})
+    endif()
     option(${option_name} "${description}" ${temp_value})
 endmacro()
 
 # Add the FLB_MINIMAL option
 option(FLB_MINIMAL "Enable minimal build configuration" No)
 
+# Add options to enable/disable plugins at a group granularity
+set(FLB_ALL_INPUTS     "Inherit" CACHE STRING "Enable/Disable all Input plugins (On, Off, Inherit)")
+set(FLB_ALL_PROCESSORS "Inherit" CACHE STRING "Enable/Disable all Processor plugins (On, Off, Inherit)")
+set(FLB_ALL_FILTERS    "Inherit" CACHE STRING "Enable/Disable all Filter plugins (On, Off, Inherit)")
+set(FLB_ALL_OUTPUTS    "Inherit" CACHE STRING "Enable/Disable all Output plugins (On, Off, Inherit)")
+set_property(CACHE FLB_ALL_INPUTS     PROPERTY STRINGS "On;Off;Inherit")
+set_property(CACHE FLB_ALL_PROCESSORS PROPERTY STRINGS "On;Off;Inherit")
+set_property(CACHE FLB_ALL_FILTERS    PROPERTY STRINGS "On;Off;Inherit")
+set_property(CACHE FLB_ALL_OUTPUTS    PROPERTY STRINGS "On;Off;Inherit")
+
 # Inputs (sources, data collectors)
 # =================================
+set(FLB_GROUP_OVERRIDE ${FLB_ALL_INPUTS})
 DEFINE_OPTION(FLB_IN_BLOB                     "Enable Blob input plugin"                     ON)
 DEFINE_OPTION(FLB_IN_CALYPTIA_FLEET           "Enable Calyptia Fleet input plugin"           ON)
 DEFINE_OPTION(FLB_IN_COLLECTD                 "Enable Collectd input plugin"                 ON)
@@ -70,6 +84,7 @@ DEFINE_OPTION(FLB_IN_EBPF                     "Enable Linux eBPF input plugin"  
 
 # Processors
 # ==========
+set(FLB_GROUP_OVERRIDE ${FLB_ALL_PROCESSORS})
 DEFINE_OPTION(FLB_PROCESSOR_CONTENT_MODIFIER  "Enable content modifier processor"            ON)
 DEFINE_OPTION(FLB_PROCESSOR_CUMULATIVE_TO_DELTA "Enable cumulative to delta metrics processor" ON)
 DEFINE_OPTION(FLB_PROCESSOR_LABELS            "Enable metrics label manipulation processor"  ON)
@@ -81,6 +96,7 @@ DEFINE_OPTION(FLB_PROCESSOR_TDA               "Enable TDA processor"            
 
 # Filters
 # =======
+set(FLB_GROUP_OVERRIDE ${FLB_ALL_FILTERS})
 DEFINE_OPTION(FLB_FILTER_ALTER_SIZE           "Enable alter_size filter"                     ON)
 DEFINE_OPTION(FLB_FILTER_AWS                  "Enable aws filter"                            ON)
 DEFINE_OPTION(FLB_FILTER_CHECKLIST            "Enable checklist filter"                      ON)
@@ -108,6 +124,7 @@ DEFINE_OPTION(FLB_FILTER_WASM                 "Enable WASM filter"              
 
 # Outputs (destinations)
 # ======================
+set(FLB_GROUP_OVERRIDE ${FLB_ALL_OUTPUTS})
 DEFINE_OPTION(FLB_OUT_AZURE                   "Enable Azure output plugin"                   ON)
 DEFINE_OPTION(FLB_OUT_AZURE_BLOB              "Enable Azure output plugin"                   ON)
 DEFINE_OPTION(FLB_OUT_AZURE_KUSTO             "Enable Azure Kusto output plugin"             ON)
@@ -156,3 +173,5 @@ DEFINE_OPTION(FLB_OUT_TCP                     "Enable TCP output plugin"        
 DEFINE_OPTION(FLB_OUT_UDP                     "Enable UDP output plugin"                     ON)
 DEFINE_OPTION(FLB_OUT_VIVO_EXPORTER           "Enable Vivo exporter output plugin"           ON)
 DEFINE_OPTION(FLB_OUT_WEBSOCKET               "Enable Websocket output plugin"               ON)
+
+unset(FLB_GROUP_OVERRIDE)


### PR DESCRIPTION
Add `FLB_ALL_INPUTS`, `FLB_ALL_PROCESSORS`, `FLB_ALL_FILTERS`, and `FLB_ALL_OUTPUTS` options to control the build for each plugins group individually.

Three options for each variable:
- `Inherit`: Default, doesn't do anything.
- `On`: Plugins for the entire group enabled.
- `Off`: Plugins for the entire group disabled.

Respects precedence from least to most specific (right overrides left):

```
  FLB_MINIMAL => FLB_ALL_* => Individual Option
```

e.g to disable everything except outputs and HTTP input:

```
  -DFLB_MINIMAL=On -DFLB_ALL_OUTPUTS=On -DFLB_IN_HTTP=On
```

The above configuration results in:
```
$ docker run --rm -it tmp /fluent-bit/bin/fluent-bit --help
[...]

Inputs
  http                    HTTP

Processors

Filters

Outputs
  azure                   Send events to Azure HTTP Event Collector
  azure_blob              Azure Blob Storage
  azure_logs_ingestion    Send logs to Log Analytics with Log Ingestion API
  azure_kusto             Send events to Kusto (Azure Data Explorer)
  bigquery                Send events to BigQuery via streaming insert
  counter                 Records counter
  datadog                 Send events to DataDog HTTP Event Collector
  es                      Elasticsearch
  exit                    Exit after a number of flushes (test purposes)
  file                    Generate log file
  forward                 Forward (Fluentd protocol)
  http                    HTTP Output
  influxdb                InfluxDB Time Series
  logdna                  LogDNA
  loki                    Loki
  kafka                   Kafka
  kafka-rest              Kafka REST Proxy
  nats                    NATS Server
  nrlogs                  New Relic
  null                    Throws away events
  opensearch              OpenSearch
  oracle_log_analytics    Oracle log analytics
  plot                    Generate data file for GNU Plot
  pgsql                   PostgreSQL
  retry                   Issue a retry upon flush request
  skywalking              Send logs into log collector on SkyWalking OAP
  slack                   Send events to a Slack channel
  splunk                  Send events to Splunk HTTP Event Collector
  stackdriver             Send events to Google Stackdriver Logging
  stdout                  Prints events to STDOUT
  syslog                  Syslog
  tcp                     TCP Output
  udp                     UDP Output
  td                      Treasure Data
  flowcounter             FlowCounter
  gelf                    GELF Output
  websocket               Websocket
  cloudwatch_logs         Send logs to Amazon CloudWatch
  kinesis_firehose        Send logs to Amazon Kinesis Firehose
  kinesis_streams         Send logs to Amazon Kinesis Streams
  opentelemetry           OpenTelemetry
  prometheus_exporter     Prometheus Exporter
  prometheus_remote_write Prometheus remote write
  s3                      Send to S3
  vivo_exporter           Vivo Exporter
  chronicle               Send logs to Google Chronicle as unstructured log

[...]
```


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

https://github.com/fluent/fluent-bit-docs/pull/2632
<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added group-level controls for enabling or disabling all input, processor, filter, or output plugins.
* Each group supports `On`, `Off`, or `Inherit` settings, allowing broad defaults while preserving individual plugin choices.
* Explicitly configured plugin options remain unchanged when group defaults are applied.
* Configuration values are validated to ensure only supported settings are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->