### PR TITLE
in_forward: batch Forward mode worker ingress

### DIFF
--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -948,13 +948,10 @@ static int get_options_chunk(msgpack_object *arr, int expected, int *idx)
     return 0;
 }
 
-static int fw_process_forward_mode_entry(
-                struct fw_conn *conn,
-                const char *tag, int tag_len,
-                msgpack_object *entry,
-                int chunk_id)
+static int fw_encode_forward_mode_entry(struct fw_conn *conn,
+                                        msgpack_object *entry)
 {
-    int                  result;
+    int result;
     struct flb_log_event event;
 
     result = flb_event_decoder_decode_object(conn->ctx->log_decoder,
@@ -985,21 +982,149 @@ static int fw_process_forward_mode_entry(
         result = flb_log_event_encoder_commit_record(conn->ctx->log_encoder);
     }
 
-    if (result == FLB_EVENT_ENCODER_SUCCESS) {
-        result = fw_ingest_logs(conn->ctx, tag, tag_len,
-                                conn->ctx->log_encoder->output_buffer,
-                                conn->ctx->log_encoder->output_length);
-    }
-
-    flb_log_event_encoder_reset(conn->ctx->log_encoder);
-
     if (result != FLB_EVENT_ENCODER_SUCCESS) {
-        flb_plg_warn(conn->ctx->ins, "Event decoder failure : %d", result);
+        flb_plg_warn(conn->ctx->ins, "event decoder or encoder failure: %d", result);
 
         return -1;
     }
 
     return 0;
+}
+
+static int fw_ingest_forward_mode_chunk(struct fw_conn *conn,
+                                        const char *tag, size_t tag_len,
+                                        const void *buffer, size_t length)
+{
+    int result;
+    struct flb_input_instance *ins;
+    struct flb_in_fw_config *ctx;
+
+    ctx = conn->ctx;
+    ins = ctx->ins;
+
+    do {
+        result = fw_ingest_logs(ctx, tag, tag_len, buffer, length);
+    } while (result == FLB_INPUT_INGRESS_BUSY &&
+             ins->ingress_queue_enabled == FLB_TRUE &&
+             ins->config->is_ingestion_active == FLB_TRUE &&
+             ctx->is_paused == FLB_FALSE &&
+             (ins->ingress_queue_byte_limit == 0 ||
+              length <= ins->ingress_queue_byte_limit));
+
+    return result;
+}
+
+static int fw_ingest_forward_mode_batch(struct fw_conn *conn,
+                                        const char *tag, size_t tag_len,
+                                        const void *buffer, size_t length)
+{
+    int decode_result;
+    int ingest_result;
+    size_t batch_length;
+    size_t byte_limit;
+    const char *batch;
+    struct flb_log_event event;
+    struct flb_log_event_decoder decoder;
+
+    byte_limit = conn->ctx->ins->ingress_queue_byte_limit;
+
+    if (byte_limit == 0 || length <= byte_limit) {
+        return fw_ingest_forward_mode_chunk(conn, tag, tag_len, buffer, length);
+    }
+
+    decode_result = flb_log_event_decoder_init(&decoder, (char *) buffer, length);
+    if (decode_result != FLB_EVENT_DECODER_SUCCESS) {
+        return -1;
+    }
+
+    batch = NULL;
+    batch_length = 0;
+    ingest_result = 0;
+
+    while ((decode_result = flb_log_event_decoder_next(&decoder, &event)) ==
+           FLB_EVENT_DECODER_SUCCESS) {
+        if (batch_length > 0 &&
+            (batch_length > byte_limit ||
+             decoder.record_length > byte_limit - batch_length)) {
+            ingest_result = fw_ingest_forward_mode_chunk(
+                                conn, tag, tag_len, batch, batch_length);
+            if (ingest_result != 0) {
+                break;
+            }
+
+            batch_length = 0;
+        }
+
+        if (batch_length == 0) {
+            batch = decoder.record_base;
+        }
+
+        batch_length += decoder.record_length;
+    }
+
+    if (ingest_result == 0) {
+        decode_result = flb_log_event_decoder_get_last_result(&decoder);
+
+        if (decode_result != FLB_EVENT_DECODER_SUCCESS) {
+            ingest_result = -1;
+        }
+        else if (batch_length > 0) {
+            ingest_result = fw_ingest_forward_mode_chunk(
+                                conn, tag, tag_len, batch, batch_length);
+        }
+    }
+
+    flb_log_event_decoder_destroy(&decoder);
+
+    return ingest_result;
+}
+
+static int fw_process_forward_mode(struct fw_conn *conn,
+                                   const char *tag, size_t tag_len,
+                                   msgpack_object *entries)
+{
+    int encode_result;
+    int ingest_result;
+    size_t index;
+    struct flb_log_event_encoder *encoder;
+
+    encoder = conn->ctx->log_encoder;
+    flb_log_event_encoder_reset(encoder);
+
+    encode_result = 0;
+
+    for (index = 0;
+         index < entries->via.array.size && encode_result == 0;
+         index++) {
+        encode_result = fw_encode_forward_mode_entry(
+                            conn,
+                            &entries->via.array.ptr[index]);
+    }
+
+    ingest_result = 0;
+
+    /*
+     * Preserve the existing partial-frame behavior: entries encoded before a
+     * malformed entry are ingested before the connection is rejected.
+     */
+    if (encoder->output_length > 0) {
+        ingest_result = fw_ingest_forward_mode_batch(
+                            conn,
+                            tag,
+                            tag_len,
+                            encoder->output_buffer,
+                            encoder->output_length);
+    }
+
+    flb_log_event_encoder_reset(encoder);
+
+    if (ingest_result != 0) {
+        flb_plg_warn(conn->ctx->ins,
+                     "could not ingest Forward mode batch: %d", ingest_result);
+        return -1;
+    }
+
+    return encode_result;
 }
 
 static int fw_process_message_mode_entry(
@@ -1282,7 +1407,6 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
     int contain_options = FLB_FALSE;
     int chunk_id = -1;
     int metadata_id = -1;
-    size_t index = 0;
     const char *stag;
     flb_sds_t out_tag = NULL;
     size_t bytes;
@@ -1478,19 +1602,12 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                     return -1;
                 }
 
-                /* Process array */
-                ret = 0;
-
-                for(index = 0 ;
-                    index < entry.via.array.size &&
-                    ret == 0 ;
-                    index++) {
-                    ret = fw_process_forward_mode_entry(
-                            conn,
-                            out_tag, flb_sds_len(out_tag),
-                            &entry.via.array.ptr[index],
-                            chunk_id);
-                }
+                /* Encode and ingest the complete Forward mode frame. */
+                ret = fw_process_forward_mode(
+                          conn,
+                          out_tag,
+                          flb_sds_len(out_tag),
+                          &entry);
 
                 if (ret == 0 && chunk_id != -1) {
                     msgpack_object options;

--- a/tests/integration/scenarios/in_forward/config/in_forward_workers_tiny_ingress_queue.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_workers_tiny_ingress_queue.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      workers: 4
+      mem_buf_limit: 256
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -966,6 +966,95 @@ def test_in_forward_workers_concurrent_message_mode_records():
     assert values == list(range(total_records))
 
 
+def test_in_forward_workers_forward_mode_batch():
+    total_records = 256
+    chunk = "workers-forward-batch-001"
+    service = Service("in_forward_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        payload = _pack_obj([
+            TEST_TAG,
+            [
+                [
+                    TEST_TS,
+                    {"message": f"forward-batch-{index}", "value": index},
+                ]
+                for index in range(total_records)
+            ],
+            {"chunk": chunk},
+        ])
+        with socket.create_connection(
+            ("127.0.0.1", service.flb_listener_port), timeout=5
+        ) as sock:
+            sock.sendall(payload)
+            ack = _recv_msgpack_value(sock)
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    assert ack == {"ack": chunk}
+    assert len(records) == total_records
+    assert [record["value"] for record in records[:total_records]] == list(
+        range(total_records)
+    )
+
+
+def test_in_forward_workers_forward_mode_batch_respects_ingress_queue_byte_limit():
+    total_records = 8
+    chunk = "workers-forward-limited-batch-001"
+    service = Service("in_forward_workers_tiny_ingress_queue.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        payload = _pack_obj([
+            TEST_TAG,
+            [
+                [
+                    TEST_TS,
+                    {"message": f"limited-batch-{index}", "value": index},
+                ]
+                for index in range(total_records)
+            ],
+            {"chunk": chunk},
+        ])
+        with socket.create_connection(
+            ("127.0.0.1", service.flb_listener_port), timeout=5
+        ) as sock:
+            sock.sendall(payload)
+            ack = _recv_msgpack_value(sock)
+        records = service.wait_for_record_count(total_records, timeout=20)
+    finally:
+        service.stop()
+
+    assert ack == {"ack": chunk}
+    assert len(records) == total_records
+    assert [record["value"] for record in records] == list(range(total_records))
+
+
+def test_in_forward_workers_forward_mode_preserves_valid_prefix():
+    service = Service("in_forward_workers.yaml")
+    service.start()
+
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        payload = _pack_obj([
+            TEST_TAG,
+            [
+                [TEST_TS, {"message": "valid-prefix"}],
+                [TEST_TS],
+            ],
+        ])
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1, timeout=20)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "valid-prefix"
+
+
 def test_in_forward_workers_drop_partial_connections_and_continue():
     dropped_connections = 8
     valid_records = 8

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -750,11 +750,23 @@ def _send_forward_payload(service, payload, use_tls):
 
 def _recv_msgpack_value(sock):
     sock.settimeout(5)
-    data = sock.recv(4096)
-    assert data
-    value, offset = _unpack_obj(data, 0)
-    assert offset == len(data)
-    return value
+    data = bytearray()
+
+    while True:
+        chunk = sock.recv(4096)
+        assert chunk
+        data.extend(chunk)
+
+        try:
+            value, offset = _unpack_obj(data, 0)
+        except IndexError:
+            continue
+
+        if offset > len(data):
+            continue
+
+        assert offset == len(data)
+        return value
 
 
 def _decode_str_like(raw):
@@ -1048,10 +1060,13 @@ def test_in_forward_workers_forward_mode_preserves_valid_prefix():
             ],
         ])
         _send_tcp_payload(service.flb_listener_port, payload)
-        records = service.wait_for_record_count(1, timeout=20)
+        service.wait_for_log_message("event decoder or encoder failure", timeout=20)
+        service.wait_for_record_count(1, timeout=20)
     finally:
         service.stop()
 
+    records = service.flattened_records()
+    assert len(records) == 1
     assert records[0]["message"] == "valid-prefix"
 
 


### PR DESCRIPTION
## Problem

Forward array mode processed and submitted every record independently. With listener workers, a 100-record Forward frame therefore produced 100 deferred-ingress allocations, payload copies, queue lock operations, and main-thread append calls. The listener threads were balanced, but the main ingestion thread saturated and four-worker throughput barely exceeded one worker.

## Change

- Encode all entries from one Forward-mode frame into the connection's reusable log encoder.
- Submit the encoded frame through the ingress queue once.
- Apply TCP backpressure while the worker ingress queue is temporarily full instead of dropping the claimed batch and resetting the connection.
- Preserve existing valid-prefix behavior for malformed frames.
- Preserve chunk ACK ordering: ACK is sent only after successful ingestion.

Message mode, PackedForward, gzip/zstd PackedForward, TLS, Unix sockets, tags, metadata, and secure-forward negotiation remain on their existing paths.

## Performance

On the same 10-million-record, 16-client benchmark with 100 records per Forward frame:

- Fluent Bit 5.0, one worker: 476,161 end-to-end records/s, 19.52 CPU seconds.
- Fluent Bit 5.1, four workers with this change: 2,498,897 end-to-end records/s, 7.20 CPU seconds.

That is a 5.25x throughput increase while using 63% less total CPU time for the workload.

## Validation

- Full build: `cmake --build build -j8`
- Selected Forward integration matrix covering Message, Forward, PackedForward, gzip, zstd, ACK, TLS, Unix socket, secure-forward, and workers: 13 passed
- Same matrix with `VALGRIND=1 VALGRIND_STRICT=1`: 13 passed, zero Valgrind errors
- Final batching and malformed-prefix tests: 2 passed normally
- Final batching and malformed-prefix tests with strict Valgrind: 2 passed, zero Valgrind errors
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master python .github/scripts/commit_prefix_check.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced forward-mode processing for whole frames with improved encode/ingest behavior and safer handling of partial results.
  * Improved handling of large forwarded payloads using chunking/batching, including respect for ingress queue byte limits.
  * Improved reliability of forwarded event acknowledgement behavior.
* **Bug Fixes**
  * Fixed edge cases to preserve valid first records when encoding/decoding fails.
* **Tests**
  * Added integration tests covering large forward-mode batches, ingress queue byte-limit behavior, and valid-prefix preservation.
  * Added a dedicated tiny ingress-queue scenario configuration for the above coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->