### PR TITLE
in_opentelemetry: optimize batched protobuf ingestion

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -878,6 +878,11 @@ int flb_input_ingress_queue_log_take(struct flb_input_instance *ins,
                                      const char *tag, size_t tag_len,
                                      void *buf, size_t buf_size,
                                      size_t allocation_size);
+int flb_input_ingress_queue_log_take_records(struct flb_input_instance *ins,
+                                             size_t records,
+                                             const char *tag, size_t tag_len,
+                                             void *buf, size_t buf_size,
+                                             size_t allocation_size);
 int flb_input_ingress_queue_metrics(struct flb_input_instance *ins,
                                     const char *tag, size_t tag_len,
                                     struct cmt *cmt, size_t payload_size);

--- a/plugins/in_opentelemetry/opentelemetry.h
+++ b/plugins/in_opentelemetry/opentelemetry.h
@@ -69,6 +69,7 @@ static inline int opentelemetry_ingest_logs(struct flb_opentelemetry *ctx,
 }
 
 static inline int opentelemetry_ingest_logs_take(struct flb_opentelemetry *ctx,
+                                                 size_t records,
                                                  const char *tag,
                                                  size_t tag_len,
                                                  void *buf,
@@ -76,12 +77,18 @@ static inline int opentelemetry_ingest_logs_take(struct flb_opentelemetry *ctx,
                                                  size_t allocation_size)
 {
     if (opentelemetry_uses_worker_ingress_queue(ctx)) {
-        return flb_input_ingress_queue_log_take(ctx->ins,
-                                                tag,
-                                                tag_len,
-                                                buf,
-                                                buf_size,
-                                                allocation_size);
+        return flb_input_ingress_queue_log_take_records(ctx->ins,
+                                                        records,
+                                                        tag,
+                                                        tag_len,
+                                                        buf,
+                                                        buf_size,
+                                                        allocation_size);
+    }
+
+    if (records > 0) {
+        return flb_input_log_append_records(ctx->ins, records,
+                                            tag, tag_len, buf, buf_size);
     }
 
     return flb_input_log_append(ctx->ins, tag, tag_len, buf, buf_size);

--- a/plugins/in_opentelemetry/opentelemetry_logs.c
+++ b/plugins/in_opentelemetry/opentelemetry_logs.c
@@ -31,7 +31,12 @@
 #include "opentelemetry.h"
 #include "opentelemetry_utils.h"
 
-#define OTEL_PROTOBUF_ARENA_MIN_PAYLOAD_SIZE 65536
+/*
+ * Small requests use protobuf-c's default allocator to avoid reserving an
+ * arena chunk. Realistic batched requests use the arena to amortize the large
+ * number of short-lived allocations performed by protobuf-c.
+ */
+#define OTEL_PROTOBUF_ARENA_MIN_PAYLOAD_SIZE 8192
 #define OTEL_PROTOBUF_ARENA_INITIAL_CHUNK_SIZE 4096
 #define OTEL_PROTOBUF_ARENA_MAX_CHUNK_SIZE 65536
 
@@ -384,7 +389,8 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
                                      struct flb_log_event_encoder *encoder,
                                      char *tag, size_t tag_len,
                                      uint8_t *in_buf,
-                                     size_t in_size)
+                                     size_t in_size,
+                                     size_t *record_count)
 {
     int ret = 0;
     int len;
@@ -419,6 +425,7 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
     input_logs = NULL;
     protobuf_arena = NULL;
     protobuf_allocator = NULL;
+    *record_count = 0;
 
     if (in_size >= OTEL_PROTOBUF_ARENA_MIN_PAYLOAD_SIZE) {
         protobuf_arena = protobuf_arena_create();
@@ -741,6 +748,9 @@ static int binary_payload_to_msgpack(struct flb_opentelemetry *ctx,
 
                 if (ret == FLB_EVENT_ENCODER_SUCCESS) {
                     ret = flb_log_event_encoder_commit_record(encoder);
+                    if (ret == FLB_EVENT_ENCODER_SUCCESS) {
+                        (*record_count)++;
+                    }
                 }
                 else {
                     flb_plg_error(ctx->ins, "marshalling error");
@@ -782,11 +792,13 @@ int opentelemetry_process_logs(struct flb_opentelemetry *ctx,
     char *buf;
     uint8_t *payload;
     uint64_t payload_size;
+    size_t record_count;
     struct flb_log_event_encoder *encoder;
 
     buf = (char *) data;
     payload = data;
     payload_size = size;
+    record_count = 0;
 
     /* Detect the type of payload */
     if (content_type) {
@@ -814,7 +826,8 @@ int opentelemetry_process_logs(struct flb_opentelemetry *ctx,
     if (is_proto == FLB_TRUE) {
         ret = binary_payload_to_msgpack(ctx, encoder,
                                         tag, tag_len,
-                                        (uint8_t *) payload, payload_size);
+                                        (uint8_t *) payload, payload_size,
+                                        &record_count);
         if (ret < 0) {
             flb_plg_error(ctx->ins, "failed to process logs from protobuf payload");
         }
@@ -852,6 +865,7 @@ int opentelemetry_process_logs(struct flb_opentelemetry *ctx,
             }
 
             ret = opentelemetry_ingest_logs_take(ctx,
+                                                 record_count,
                                                  tag,
                                                  flb_sds_len(tag),
                                                  encoder->output_buffer,

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -651,6 +651,7 @@ static int ingest_profiles_context_as_log_entry(struct flb_opentelemetry *ctx,
         }
 
         ret = opentelemetry_ingest_logs_take(ctx,
+                                             0,
                                              tag,
                                              flb_sds_len(tag),
                                              encoder->output_buffer,

--- a/src/flb_input_ingest.c
+++ b/src/flb_input_ingest.c
@@ -51,6 +51,7 @@ struct flb_input_ingress_event {
         struct {
             void   *buf;
             size_t  size;
+            size_t  records;
         } log;
         struct ctrace *traces;
         struct cprof  *profiles;
@@ -381,11 +382,23 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
             mk_list_entry_init(&event->_head);
 
             if (event->type == FLB_INPUT_INGRESS_LOG) {
-                result = flb_input_log_append(ins,
-                                              event->tag,
-                                              event->tag != NULL ? flb_sds_len(event->tag) : 0,
-                                              event->data.log.buf,
-                                              event->data.log.size);
+                if (event->data.log.records > 0) {
+                    result = flb_input_log_append_records(
+                                ins,
+                                event->data.log.records,
+                                event->tag,
+                                event->tag != NULL ? flb_sds_len(event->tag) : 0,
+                                event->data.log.buf,
+                                event->data.log.size);
+                }
+                else {
+                    result = flb_input_log_append(
+                                ins,
+                                event->tag,
+                                event->tag != NULL ? flb_sds_len(event->tag) : 0,
+                                event->data.log.buf,
+                                event->data.log.size);
+                }
             }
             else if (event->type == FLB_INPUT_INGRESS_METRICS) {
                 result = 0;
@@ -562,6 +575,23 @@ int flb_input_ingress_queue_log_take(struct flb_input_instance *ins,
                                      size_t buf_size,
                                      size_t allocation_size)
 {
+    return flb_input_ingress_queue_log_take_records(ins,
+                                                    0,
+                                                    tag,
+                                                    tag_len,
+                                                    buf,
+                                                    buf_size,
+                                                    allocation_size);
+}
+
+int flb_input_ingress_queue_log_take_records(struct flb_input_instance *ins,
+                                             size_t records,
+                                             const char *tag,
+                                             size_t tag_len,
+                                             void *buf,
+                                             size_t buf_size,
+                                             size_t allocation_size)
+{
     struct flb_input_ingress_event *event;
 
     if (buf == NULL || buf_size == 0) {
@@ -579,6 +609,7 @@ int flb_input_ingress_queue_log_take(struct flb_input_instance *ins,
 
     event->data.log.buf = buf;
     event->data.log.size = buf_size;
+    event->data.log.records = records;
     if (allocation_size < buf_size) {
         allocation_size = buf_size;
     }

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -721,6 +721,74 @@ def test_in_opentelemetry_large_protobuf_logs():
     assert received_record_count == expected_record_count
 
 
+def test_in_opentelemetry_batched_protobuf_logs_with_workers():
+    service = Service(IN_OPENTELEMETRY_WORKER_PROTOCOL_CONFIGS["http1_cleartext"])
+    source = ExportLogsServiceRequest()
+    source.ParseFromString(service.build_otel_payload("test_logs_001.in.json", "logs"))
+
+    payload = ExportLogsServiceRequest()
+    payload.CopyFrom(source)
+    source_records = list(source.resource_logs[0].scope_logs[0].log_records)
+
+    while payload.ByteSize() < 16 * 1024:
+        payload.resource_logs[0].scope_logs[0].log_records.extend(source_records)
+
+    assert payload.ByteSize() < 64 * 1024
+
+    expected_record_count = sum(
+        len(scope_logs.log_records)
+        for resource_logs in payload.resource_logs
+        for scope_logs in resource_logs.scope_logs
+    )
+
+    service.start()
+    try:
+        service.wait_for_log_message("with 4 workers", timeout=10)
+        logs_before = len(data_storage["logs"])
+        response = service.send_raw_request("/v1/logs", payload.SerializeToString())
+
+        assert response.status_code == 201
+        received_record_count = service.service.wait_for_condition(
+            lambda: count if (
+                count := sum(
+                    len(scope_logs.log_records)
+                    for received in data_storage["logs"][logs_before:]
+                    for resource_logs in received.resource_logs
+                    for scope_logs in resource_logs.scope_logs
+                )
+            ) >= expected_record_count else None,
+            timeout=20,
+            interval=0.25,
+            description="all batched protobuf log records",
+        )
+
+        metrics_text = service.service.wait_for_condition(
+            lambda: (
+                metrics if maybe_read_prometheus_metric_value(
+                    metrics,
+                    "fluentbit_input_records_total",
+                    "opentelemetry.0",
+                ) is not None and maybe_read_prometheus_metric_value(
+                    metrics,
+                    "fluentbit_input_records_total",
+                    "opentelemetry.0",
+                ) >= expected_record_count else None
+            ) if (metrics := service.scrape_prometheus_metrics()) else None,
+            timeout=10,
+            interval=0.25,
+            description="protobuf input record accounting",
+        )
+    finally:
+        service.stop()
+
+    assert received_record_count == expected_record_count
+    assert read_prometheus_metric_value(
+        metrics_text,
+        "fluentbit_input_records_total",
+        "opentelemetry.0",
+    ) == expected_record_count
+
+
 # Start a Fluent Bit Pipeline with Dummy message and then it gets handle by OpenTelemetry output, the config
 # aims to populate traceId and spanId fields with the values from the Dummy message.
 #


### PR DESCRIPTION
## Problem

Batched OTLP/HTTP Protobuf logs performed avoidable allocation and record-accounting work. The Protobuf arena was only enabled for payloads at least 64 KiB, excluding realistic medium batches, and the worker decoded every logical record only for the central ingress thread to scan the resulting MessagePack again to count records.

## Changes

- Enable the request-scoped protobuf arena for payloads of at least 8 KiB while retaining protobuf-c's default allocator for small requests.
- Count successfully committed log records during OTLP Protobuf conversion.
- Carry a known record count through the worker ingress queue and use `flb_input_log_append_records()` in the central input thread.
- Preserve the existing fallback recount for JSON and other producers without a known count.
- Preserve the existing `flb_input_ingress_queue_log_take()` API for out-of-tree callers and add a separate counted variant for OpenTelemetry.
- Add an integration regression covering four-worker batched Protobuf ingestion and input-record accounting.

## Caller and compatibility audit

The generic log queue is used by Forward, TCP, UDP, HTTP, Splunk, Elasticsearch, ETW, and OpenTelemetry. Ingress events are zero-initialized with `flb_calloc()`, so existing callers retain `records == 0` and the established MessagePack recount path. The ownership, busy-queue, queue-drain, and destruction paths are unchanged.

The initial patch changed the positional signature of `flb_input_ingress_queue_log_take()`. Although OpenTelemetry was its only in-tree caller, this could break out-of-tree plugins. The original function signature and symbol are now preserved; `flb_input_ingress_queue_log_take_records()` is the opt-in counted interface.

## Impact

In the controlled four-worker benchmark, these changes improved Fluent Bit Protobuf ingest-only end-to-end throughput from 1.25M to 1.67M records/s (+33.4%) and records per CPU-second by 74.6%. With 256 persistent connections balancing all four listeners, Fluent Bit accepted 3.03M records/s at 376.9% aggregate CPU.

No configuration or wire-protocol behavior changes. JSON, profiles-as-logs, and unknown-count ingestion continue through the existing counting path.

## Validation

### Build and internal/runtime CTest

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`: passed; all in-tree input callers compiled.
- `ctest --test-dir build --output-on-failure -j8`: 194/197 passed directly.
- `flb-rt-in_forward` and `flb-rt-out_http` were blocked by the host `fluentd.service` owning ports 24224 and 8888. Both passed in isolation after rebuilding with temporary unused test ports; those test-only edits were removed.
- `flb-rt-out_td` remains blocked by its external `/tmp/td.conf` credential-file requirement.

### Complete Python integration suite

- `cd tests/integration && ./run_tests.py`
- Result: 365 passed, 6 skipped, 4 unrelated failures in 29m28s.
- Every covered ingress-queue consumer passed, including four-worker Forward, TCP, UDP, HTTP, Splunk, Elasticsearch, Prometheus remote write, and the complete OpenTelemetry protocol/worker matrix.
- Three unrelated hot-reload tests fail because the current `FluentBitManager` harness lacks `wait_for_hot_reload_count()`.
- One unrelated Tail `ignore_active_older_files` case consistently accepts a second line after aging; it also failed when rerun alone.

### Focused memory safety and lint

- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_in_opentelemetry_batched_protobuf_logs_with_workers -q`: passed.
- Full PR-range commit-prefix validation against `master`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced OpenTelemetry log ingestion to support batched protobuf payloads when worker processing is enabled.
  - Deferred ingestion can now queue and process multiple log records per request.

- **Bug Fixes**
  - Correctly counts and records the number of log records delivered for batched OpenTelemetry protobuf logs.
  - Prometheus metrics now align with the number of processed records.
  - Profile-based log entries continue to work properly through worker queues.

- **Tests**
  - Added an integration test covering batched protobuf logs with workers, validating delivery, record counts, and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->