### PR TITLE
in_node_exporter_metrics: fix netstat file reads

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_netstat_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_netstat_linux.c
@@ -417,7 +417,7 @@ static int netstat_update(struct flb_ne *ctx)
     flb_slist_destroy(&list);
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/netstat", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/netstat", &list);
     if (ret == 0) {
         prev_line = NULL;
         prev_proto = NETSTAT_PROTO_NONE;
@@ -457,7 +457,7 @@ static int netstat_update(struct flb_ne *ctx)
     flb_slist_destroy(&list);
 
     mk_list_init(&list);
-    ret = ne_utils_file_read_lines(ctx->path_procfs, "/net/snmp6", &list);
+    ret = ne_utils_file_read_lines(ctx, ctx->path_procfs, "/net/snmp6", &list);
     if (ret == 0) {
         mk_list_foreach(head, &list) {
             int i;


### PR DESCRIPTION
## Problem

Linux builds fail in the node exporter netstat collector because two `ne_utils_file_read_lines()` calls still use the old three-argument signature. The helper now requires the plugin context before the mount and path arguments.

## Change

Pass `ctx` to the `/net/netstat` and `/net/snmp6` reads, matching the existing `/net/snmp` call and every other node exporter caller.

This restores compilation and preserves contextual plugin error logging for those files.

## Validation

- `cmake -S . -B build -DFLB_DEV=on -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8 --target flb-plugin-in_node_exporter_metrics`
- `cmake --build build -j8`
- Five-second `node_exporter_metrics` netstat smoke run against the host `/proc`; IPv4, TcpExt/IpExt, and IPv6 metrics were emitted.
- Equivalent Valgrind smoke run: zero errors.
- Full PR-range commit-prefix lint.
- `git diff --check`

There is currently no node exporter pytest or CTest scenario in-tree for this compile-time regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when collecting network statistics from system metric files.
  * Preserved existing parsing behavior while making metric updates more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->