### PR TITLE
http_server: accept empty HTTP header values

### DIFF
--- a/src/http_server/flb_http_server_http1.c
+++ b/src/http_server/flb_http_server_http1.c
@@ -566,6 +566,12 @@ int flb_http1_server_session_ingest(struct flb_http1_server_session *session,
          * performance overhead in exchange for ensuring safety.
          */
     }
+    else if (result == MK_HTTP_PARSER_ERROR) {
+        /* The caller closes the session when a parser error is returned. */
+        session->stream.status = HTTP_STREAM_STATUS_ERROR;
+
+        return HTTP_SERVER_PROVIDER_ERROR;
+    }
 
     dummy_mk_http_request_init(&session->inner_session, &session->inner_request);
     mk_http_parser_init(&session->inner_parser);

--- a/tests/integration/scenarios/in_http/tests/test_in_http_001.py
+++ b/tests/integration/scenarios/in_http/tests/test_in_http_001.py
@@ -2,6 +2,7 @@ import http.client
 import json
 import os
 import logging
+import socket
 import time
 
 import pytest
@@ -64,6 +65,28 @@ def send_requests(conn, num_requests, headers, json_payload):
             'data': response.read().decode()
         })
     return responses
+
+
+def send_raw_http1_request(port, request):
+    response = bytearray()
+
+    with socket.create_connection(("127.0.0.1", port), timeout=2) as connection:
+        connection.settimeout(2)
+        connection.sendall(request)
+
+        while len(response) < 4096 and b"\r\n" not in response:
+            try:
+                data = connection.recv(4096 - len(response))
+            except ConnectionResetError:
+                break
+            except socket.timeout:
+                pytest.fail("HTTP/1 server did not respond or close the connection")
+
+            if not data:
+                break
+            response.extend(data)
+
+    return bytes(response)
 
 
 def test_send_data():
@@ -148,6 +171,88 @@ def test_in_http_rejects_get_requests():
     service.stop()
 
     assert result["status_code"] >= 400
+
+
+def test_in_http_accepts_post_with_empty_generic_headers():
+    service = Service("in_http_config")
+    body = b'{"message":"empty-header"}'
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode()
+        + b"X-Empty:\r\n"
+        b"X-Empty-Whitespace: \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        + body
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request)
+        forwarded_payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    assert b"HTTP/1.1 201" in response
+    assert len(forwarded_payloads) == 1
+    assert forwarded_payloads[0][0]["message"] == "empty-header"
+
+
+def test_in_http_accepts_empty_connection_and_transfer_encoding():
+    service = Service("in_http_config")
+    body = b'{"message":"empty-semantic-headers"}'
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode()
+        + b"Connection:\r\n"
+        b"Transfer-Encoding: \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        + body
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request)
+        forwarded_payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    assert b"HTTP/1.1 201" in response
+    assert len(forwarded_payloads) == 1
+    assert forwarded_payloads[0][0]["message"] == "empty-semantic-headers"
+
+
+@pytest.mark.parametrize("header_value", [b"", b" \t"], ids=["empty", "whitespace"])
+@pytest.mark.parametrize(
+    "following_data",
+    [b"1-X: value\r\nConnection: close\r\n\r\n1", b"\r\n1"],
+    ids=["numeric-header", "numeric-body"],
+)
+def test_in_http_rejects_empty_content_length(header_value, following_data):
+    service = Service("in_http_config")
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length:" + header_value + b"\r\n"
+        + following_data
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request)
+        time.sleep(0.5)
+        forwarded_payloads = list(data_storage["payloads"])
+    finally:
+        service.stop()
+
+    assert response == b"" or b"HTTP/1.1 400" in response
+    assert forwarded_payloads == []
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -413,6 +413,158 @@ static void test_ctx_destroy(struct test_ctx *ctx)
     flb_free(ctx);
 }
 
+static int send_raw_http_request(const char *request,
+                                 char *response,
+                                 size_t response_size)
+{
+    struct sockaddr_in address;
+    struct timeval timeout;
+    fd_set read_fds;
+    flb_sockfd_t fd;
+    size_t request_length;
+    size_t request_offset;
+    int ret;
+    int written;
+    int received;
+    int response_length;
+
+    if (response_size < 2) {
+        return -1;
+    }
+
+    response[0] = '\0';
+    request_length = strlen(request);
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd == FLB_INVALID_SOCKET) {
+        return -1;
+    }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = htons(9880);
+
+    ret = connect(fd, (struct sockaddr *) &address, sizeof(address));
+    if (ret != 0) {
+        flb_socket_close(fd);
+        return -1;
+    }
+
+    request_offset = 0;
+    while (request_offset < request_length) {
+        written = send(fd,
+                       request + request_offset,
+                       (int) (request_length - request_offset),
+                       0);
+        if (written <= 0) {
+            flb_socket_close(fd);
+            return -1;
+        }
+        request_offset += (size_t) written;
+    }
+
+    response_length = 0;
+    while (response_length < (int) response_size - 1) {
+        FD_ZERO(&read_fds);
+        FD_SET(fd, &read_fds);
+        timeout.tv_sec = 2;
+        timeout.tv_usec = 0;
+
+        ret = select((int) (fd + 1), &read_fds, NULL, NULL, &timeout);
+        if (ret <= 0) {
+            flb_socket_close(fd);
+            return -1;
+        }
+
+        received = recv(fd,
+                        response + response_length,
+                        (int) response_size - 1 - response_length,
+                        0);
+        if (received <= 0) {
+            break;
+        }
+
+        response_length += received;
+        response[response_length] = '\0';
+        if (strstr(response, "\r\n") != NULL) {
+            break;
+        }
+    }
+
+    flb_socket_close(fd);
+    response[response_length] = '\0';
+
+    if (response_length > 0 && strstr(response, "\r\n") == NULL) {
+        return -1;
+    }
+
+    return response_length;
+}
+
+static int send_empty_header_request(void)
+{
+    const char *body = "{\"test\":\"msg\"}";
+    const char *request_template =
+        "POST / HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Content-Length: %zu\r\n"
+        "Content-Type: application/json\r\n"
+        "X-Empty:\r\n"
+        "X-Empty-Whitespace: \t\r\n"
+        "\r\n"
+        "%s";
+    char request[512];
+    char response[256];
+    int ret;
+    int response_length;
+
+    ret = snprintf(request, sizeof(request), request_template,
+                   strlen(body), body);
+    if (ret <= 0 || (size_t) ret >= sizeof(request)) {
+        return -1;
+    }
+
+    response_length = send_raw_http_request(request, response, sizeof(response));
+    if (response_length <= 0) {
+        return -1;
+    }
+
+    return strstr(response, "HTTP/1.1 201") != NULL ? 0 : -1;
+}
+
+static int send_invalid_header_request(void)
+{
+    const char *body = "{\"test\":\"msg\"}";
+    const char *request_template =
+        "POST / HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Content-Length: %zu\r\n"
+        "Content-Type: application/json\r\n"
+        "Upgrade:\r\n"
+        "\r\n"
+        "%s";
+    char request[512];
+    char response[256];
+    int ret;
+    int response_length;
+
+    ret = snprintf(request, sizeof(request), request_template,
+                   strlen(body), body);
+    if (ret <= 0 || (size_t) ret >= sizeof(request)) {
+        return -1;
+    }
+
+    response_length = send_raw_http_request(request, response, sizeof(response));
+    if (response_length < 0) {
+        return -1;
+    }
+    if (response_length == 0) {
+        return 0;
+    }
+
+    return strstr(response, "HTTP/1.1 4") != NULL ? 0 : -1;
+}
+
 void flb_test_http(void)
 {
     struct flb_lib_out_cb cb_data;
@@ -469,13 +621,25 @@ void flb_test_http(void)
         TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
     }
 
+    /* Ensure the first request has reached the callback before the regression. */
+    flb_time_msleep(1500);
+    num = get_output_num();
+    TEST_CHECK(num > 0);
+
+    TEST_CHECK(send_empty_header_request() == 0);
+
     /* waiting to flush */
     flb_time_msleep(1500);
 
-    num = get_output_num();
-    if (!TEST_CHECK(num > 0))  {
-        TEST_MSG("no outputs");
+    if (!TEST_CHECK(get_output_num() > num)) {
+        TEST_MSG("empty-header request did not reach the callback");
     }
+
+    num = get_output_num();
+    TEST_CHECK(send_invalid_header_request() == 0);
+    flb_time_msleep(500);
+    TEST_CHECK(get_output_num() == num);
+
     flb_http_client_destroy(c);
     flb_upstream_conn_release(ctx->httpc->u_conn);
     test_ctx_destroy(ctx);


### PR DESCRIPTION
Fixes #12174.

> [!IMPORTANT]
> This PR depends on #12212, which bundles Monkey 1.8.9. It is temporarily
> based on `lib-monkey-1.8.9` so its diff contains only Fluent Bit-owned
> changes. After #12212 merges, this PR will be rebased and retargeted to
> `master` before merge.

## Summary

The Monkey HTTP/1 parser fix was merged upstream in monkey/monkey#444 and is
being imported into Fluent Bit by #12212. This PR therefore no longer changes
any files under `lib/monkey`.

The remaining Fluent Bit-specific work:

- propagates Monkey HTTP/1 parser errors to the server provider so invalid
  requests are closed instead of being reset and left pending;
- adds portable runtime coverage for accepted empty generic headers and a
  rejected empty semantic header;
- adds real-server `in_http` integration coverage for the original POST/body
  report and bounded Content-Length parsing regressions.

## Testing

GCC 13.3, Ubuntu 24.04 Docker:

```text
cmake -S . -B build-docker -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On
cmake --build build-docker -j8
ctest --test-dir build-docker -R 'flb-rt-in_http|flb-it-http_server|in_http_tls_expect' --output-on-failure
```

Result: build passed; focused CTest passed 3/3.

```text
FLUENT_BIT_BINARY=/workspace/build-docker/bin/fluent-bit \
tests/integration/.venv/bin/python -m pytest \
tests/integration/scenarios/in_http/tests/test_in_http_001.py -q
```

Result: 32 passed.

```text
FLUENT_BIT_BINARY=/workspace/build-docker/bin/fluent-bit \
VALGRIND=1 VALGRIND_STRICT=1 \
tests/integration/.venv/bin/python -m pytest \
tests/integration/scenarios/in_http/tests/test_in_http_001.py -q
```

Result: 32 passed with strict Valgrind enabled.

Clang 18.1.3 additional verification:

- `flb-rt-in_http` and `flb-it-http_server`: 2/2 passed;
- all six new real-server integration cases: 6/6 passed.

The CI-style commit-prefix checker passes against `lib-monkey-1.8.9`.

## Compatibility

No configuration, packaging, or bundled-library changes are included in this
PR. The runtime socket regression uses Fluent Bit's portable socket types so it
can compile on supported Windows runtime-test targets. Native Windows and macOS
execution remain delegated to CI.
