### PR TITLE
engine: fail startup when HTTP server cannot start

### DIFF
--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1322,7 +1322,16 @@ int flb_engine_start(struct flb_config *config)
     if (config->http_server == FLB_TRUE) {
         config->http_ctx = flb_hs_create(config->http_listen, config->http_port,
                                          config);
-        flb_hs_start(config->http_ctx);
+        if (!config->http_ctx) {
+            flb_error("[engine] could not initialize HTTP server");
+            return -1;
+        }
+
+        ret = flb_hs_start(config->http_ctx);
+        if (ret != 0) {
+            flb_error("[engine] could not start HTTP server");
+            return -1;
+        }
     }
 #endif
 

--- a/tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_001.py
+++ b/tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_001.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import os
+import socket
 import subprocess
 
 import pytest
+from utils.fluent_bit_manager import FluentBitManager, FluentBitStartupError
 from utils.http_matrix import curl_supports_http2, run_curl_request
 from utils.test_service import FluentBitTestService
 
@@ -146,3 +148,28 @@ def test_internal_http_server_http2_subset():
             assert result["http_version"] == "2"
     finally:
         service.stop()
+
+
+def test_internal_http_server_bind_failure_fails_startup(monkeypatch):
+    config_file = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../config/internal_http_server.yaml")
+    )
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.bind(("127.0.0.1", 0))
+    port = holder.getsockname()[1]
+    fluent_bit = FluentBitManager(config_file)
+
+    monkeypatch.setenv("FLUENT_BIT_HTTP_MONITORING_PORT", str(port))
+
+    def use_occupied_monitoring_port(_env_var_name, starting_port=0):
+        fluent_bit.http_monitoring_port = str(port)
+
+    fluent_bit.set_http_monitoring_port = use_occupied_monitoring_port
+
+    try:
+        with pytest.raises(FluentBitStartupError, match="exited early with code"):
+            fluent_bit.start()
+        assert fluent_bit.process.returncode != 0
+    finally:
+        holder.close()
+        fluent_bit.stop()


### PR DESCRIPTION
## Problem

When the built-in HTTP server is enabled but cannot bind its configured address or port, Fluent Bit logs the listener error and continues running without its health and metrics endpoints.

Fixes #12167.

## Root cause

`flb_engine_start()` created and started the HTTP server without checking either operation's return value. A listener bind failure was therefore discarded and the engine still announced successful startup.

## Changes

- Fail engine startup if the built-in HTTP server cannot be initialized.
- Fail engine startup if the HTTP server cannot start, including bind failures.
- Add Python integration coverage that occupies the monitoring port and verifies that Fluent Bit exits with a non-zero status.

## User impact

Configurations that explicitly enable the built-in HTTP server will no longer run in a partially initialized state when that server is unavailable. A bind failure now causes a non-zero process exit so supervisors and container runtimes can detect the startup failure.

## Validation

- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_001.py -q` — 4 passed
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_001.py -q` — 4 passed, strict valgrind clean
- `ctest --test-dir build -R '^flb-it-http_server$' --output-on-failure` — passed
- Full PR commit-prefix validation against `master` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup error handling for the internal HTTP server.
  * Fluent Bit now reports a clear startup failure when the monitoring port is unavailable or the HTTP server cannot start.

* **Tests**
  * Added coverage for port conflicts during internal HTTP server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->