### PR TITLE
tls: openssl: preserve syscall error details (5.0)

### DIFF
--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -1500,6 +1500,9 @@ static int tls_net_read(struct flb_tls_session *session,
         else if (ssl_ret == SSL_ERROR_WANT_WRITE) {
             ret = FLB_TLS_WANT_WRITE;
         }
+        else if (ssl_ret == SSL_ERROR_ZERO_RETURN) {
+            ret = -1;
+        }
         else if (ssl_ret == SSL_ERROR_SYSCALL) {
             tls_log_io_error(ssl_ret, saved_errno);
 
@@ -1566,6 +1569,9 @@ static int tls_net_write(struct flb_tls_session *session,
         }
         else if (ssl_ret == SSL_ERROR_WANT_READ) {
             ret = FLB_TLS_WANT_READ;
+        }
+        else if (ssl_ret == SSL_ERROR_ZERO_RETURN) {
+            ret = -1;
         }
         else if (ssl_ret == SSL_ERROR_SYSCALL) {
             tls_log_io_error(ssl_ret, saved_errno);

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -1442,7 +1442,7 @@ static const char *tls_session_alpn_get(void *session_)
     return backend_session->alpn;
 }
 
-static void tls_log_syscall_error(int io_ret, int saved_errno)
+static void tls_log_io_error(int ssl_error, int saved_errno)
 {
     unsigned long err_code;
     char err_buf[256];
@@ -1453,14 +1453,14 @@ static void tls_log_syscall_error(int io_ret, int saved_errno)
         ERR_error_string_n(err_code, err_buf, sizeof(err_buf) - 1);
         flb_error("[tls] error: %s", err_buf);
     }
-    else if (saved_errno != 0) {
+    else if (ssl_error == SSL_ERROR_SYSCALL && saved_errno != 0) {
         flb_error("[tls] syscall error: %s", strerror(saved_errno));
     }
-    else if (io_ret == 0) {
+    else if (ssl_error == SSL_ERROR_SYSCALL) {
         flb_error("[tls] error: unexpected EOF");
     }
     else {
-        flb_error("[tls] syscall error without error code");
+        flb_error("[tls] unknown error (ssl_error=%d)", ssl_error);
     }
 }
 
@@ -1470,8 +1470,6 @@ static int tls_net_read(struct flb_tls_session *session,
     int ret;
     int ssl_ret;
     int saved_errno;
-    unsigned long err_code;
-    char err_buf[256];
     struct tls_context *ctx;
     struct tls_session *backend_session;
 
@@ -1503,29 +1501,26 @@ static int tls_net_read(struct flb_tls_session *session,
             ret = FLB_TLS_WANT_WRITE;
         }
         else if (ssl_ret == SSL_ERROR_SYSCALL) {
-            tls_log_syscall_error(ret, saved_errno);
+            tls_log_io_error(ssl_ret, saved_errno);
 
             /* According to the documentation these are non-recoverable
              * errors so we don't need to screen them before saving them
              * to the net_error field.
              */
 
-            session->connection->net_error = saved_errno;
+            if (saved_errno != 0) {
+                session->connection->net_error = saved_errno;
+            }
+            else {
+                session->connection->net_error = ECONNRESET;
+            }
 
             ret = -1;
         }
-        else if (ssl_ret < 0) {
-            err_code = ERR_get_error();
-
-            if (err_code != 0) {
-                ERR_error_string_n(err_code, err_buf, sizeof(err_buf)-1);
-                flb_error("[tls] error: %s", err_buf);
-            }
-            else {
-                flb_error("[tls] error: %s", strerror(saved_errno));
-            }
-        }
         else {
+            tls_log_io_error(ssl_ret, saved_errno);
+            session->connection->net_error = ECONNRESET;
+
             ret = -1;
         }
     }
@@ -1540,8 +1535,6 @@ static int tls_net_write(struct flb_tls_session *session,
     int ret;
     int ssl_ret;
     int saved_errno;
-    unsigned long err_code;
-    char err_buf[256];
     size_t total = 0;
     struct tls_context *ctx;
     struct tls_session *backend_session;
@@ -1575,26 +1568,25 @@ static int tls_net_write(struct flb_tls_session *session,
             ret = FLB_TLS_WANT_READ;
         }
         else if (ssl_ret == SSL_ERROR_SYSCALL) {
-            tls_log_syscall_error(ret, saved_errno);
+            tls_log_io_error(ssl_ret, saved_errno);
 
             /* According to the documentation these are non-recoverable
              * errors so we don't need to screen them before saving them
              * to the net_error field.
              */
 
-            session->connection->net_error = saved_errno;
+            if (saved_errno != 0) {
+                session->connection->net_error = saved_errno;
+            }
+            else {
+                session->connection->net_error = ECONNRESET;
+            }
 
             ret = -1;
         }
         else {
-            err_code = ERR_get_error();
-            if (err_code == 0) {
-                flb_error("[tls] unknown error");
-            }
-            else {
-                ERR_error_string_n(err_code, err_buf, sizeof(err_buf) - 1);
-                flb_error("[tls] error: %s", err_buf);
-            }
+            tls_log_io_error(ssl_ret, saved_errno);
+            session->connection->net_error = ECONNRESET;
 
             ret = -1;
         }

--- a/src/tls/openssl.c
+++ b/src/tls/openssl.c
@@ -1442,10 +1442,34 @@ static const char *tls_session_alpn_get(void *session_)
     return backend_session->alpn;
 }
 
+static void tls_log_syscall_error(int io_ret, int saved_errno)
+{
+    unsigned long err_code;
+    char err_buf[256];
+
+    err_code = ERR_get_error();
+
+    if (err_code != 0) {
+        ERR_error_string_n(err_code, err_buf, sizeof(err_buf) - 1);
+        flb_error("[tls] error: %s", err_buf);
+    }
+    else if (saved_errno != 0) {
+        flb_error("[tls] syscall error: %s", strerror(saved_errno));
+    }
+    else if (io_ret == 0) {
+        flb_error("[tls] error: unexpected EOF");
+    }
+    else {
+        flb_error("[tls] syscall error without error code");
+    }
+}
+
 static int tls_net_read(struct flb_tls_session *session,
                         void *buf, size_t len)
 {
     int ret;
+    int ssl_ret;
+    int saved_errno;
     unsigned long err_code;
     char err_buf[256];
     struct tls_context *ctx;
@@ -1465,40 +1489,32 @@ static int tls_net_read(struct flb_tls_session *session,
 
     ERR_clear_error();
 
+    errno = 0;
     ret = SSL_read(backend_session->ssl, buf, len);
+    saved_errno = errno;
 
     if (ret <= 0) {
-        ret = SSL_get_error(backend_session->ssl, ret);
+        ssl_ret = SSL_get_error(backend_session->ssl, ret);
 
-        if (ret == SSL_ERROR_WANT_READ) {
+        if (ssl_ret == SSL_ERROR_WANT_READ) {
             ret = FLB_TLS_WANT_READ;
         }
-        else if (ret == SSL_ERROR_WANT_WRITE) {
+        else if (ssl_ret == SSL_ERROR_WANT_WRITE) {
             ret = FLB_TLS_WANT_WRITE;
         }
-        else if (ret == SSL_ERROR_SYSCALL) {
-            flb_errno();
-
-            err_code = ERR_get_error();
-
-            if (err_code != 0) {
-                ERR_error_string_n(err_code, err_buf, sizeof(err_buf)-1);
-                flb_error("[tls] syscall error: %s", err_buf);
-            }
-            else {
-                flb_error("[tls] syscall error: %s", strerror(errno));
-            }
+        else if (ssl_ret == SSL_ERROR_SYSCALL) {
+            tls_log_syscall_error(ret, saved_errno);
 
             /* According to the documentation these are non-recoverable
              * errors so we don't need to screen them before saving them
              * to the net_error field.
              */
 
-            session->connection->net_error = errno;
+            session->connection->net_error = saved_errno;
 
             ret = -1;
         }
-        else if (ret < 0) {
+        else if (ssl_ret < 0) {
             err_code = ERR_get_error();
 
             if (err_code != 0) {
@@ -1506,7 +1522,7 @@ static int tls_net_read(struct flb_tls_session *session,
                 flb_error("[tls] error: %s", err_buf);
             }
             else {
-                flb_error("[tls] error: %s", strerror(errno));
+                flb_error("[tls] error: %s", strerror(saved_errno));
             }
         }
         else {
@@ -1523,6 +1539,7 @@ static int tls_net_write(struct flb_tls_session *session,
 {
     int ret;
     int ssl_ret;
+    int saved_errno;
     unsigned long err_code;
     char err_buf[256];
     size_t total = 0;
@@ -1542,9 +1559,11 @@ static int tls_net_write(struct flb_tls_session *session,
 
     ERR_clear_error();
 
+    errno = 0;
     ret = SSL_write(backend_session->ssl,
                     (unsigned char *) data + total,
                     len - total);
+    saved_errno = errno;
 
     if (ret <= 0) {
         ssl_ret = SSL_get_error(backend_session->ssl, ret);
@@ -1556,27 +1575,14 @@ static int tls_net_write(struct flb_tls_session *session,
             ret = FLB_TLS_WANT_READ;
         }
         else if (ssl_ret == SSL_ERROR_SYSCALL) {
-            err_code = ERR_get_error();
-
-            if (err_code == 0) {
-                if (ret == 0) {
-                    flb_debug("[tls] connection closed");
-                }
-                else {
-                    flb_error("[tls] syscall error: %s", strerror(errno));
-                }
-            }
-            else {
-                ERR_error_string_n(err_code, err_buf, sizeof(err_buf) - 1);
-                flb_error("[tls] syscall error: %s", err_buf);
-            }
+            tls_log_syscall_error(ret, saved_errno);
 
             /* According to the documentation these are non-recoverable
              * errors so we don't need to screen them before saving them
              * to the net_error field.
              */
 
-            session->connection->net_error = errno;
+            session->connection->net_error = saved_errno;
 
             ret = -1;
         }

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import socket
 import ssl
+import struct
 import subprocess
 import sys
 import tempfile
@@ -648,6 +649,53 @@ def _send_tls_payload(port, payload, cafile):
             tls_sock.sendall(payload)
 
 
+def _create_tls_memory_bio_client(port, cafile):
+    context = ssl.create_default_context(cafile=cafile)
+    incoming = ssl.MemoryBIO()
+    outgoing = ssl.MemoryBIO()
+    tls = context.wrap_bio(incoming, outgoing, server_hostname="localhost")
+    raw_sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+
+    while True:
+        try:
+            tls.do_handshake()
+            break
+        except ssl.SSLWantReadError:
+            encrypted = outgoing.read()
+            if encrypted:
+                raw_sock.sendall(encrypted)
+
+            encrypted = raw_sock.recv(65536)
+            assert encrypted
+            incoming.write(encrypted)
+        except ssl.SSLWantWriteError:
+            encrypted = outgoing.read()
+            if encrypted:
+                raw_sock.sendall(encrypted)
+
+    encrypted = outgoing.read()
+    if encrypted:
+        raw_sock.sendall(encrypted)
+
+    return raw_sock, tls, outgoing
+
+
+def _reset_tls_connection(port, cafile):
+    raw_sock, tls, outgoing = _create_tls_memory_bio_client(port, cafile)
+
+    tls.write(b"\x91")
+    wire_payload = outgoing.read()
+    raw_sock.sendall(wire_payload[:-1])
+    time.sleep(1)
+
+    raw_sock.setsockopt(
+        socket.SOL_SOCKET,
+        socket.SO_LINGER,
+        struct.pack("ii", 1, 0),
+    )
+    raw_sock.close()
+
+
 def _recv_msgpack_value(sock):
     sock.settimeout(5)
     data = sock.recv(4096)
@@ -1025,6 +1073,35 @@ def test_in_forward_tls_message_mode():
         service.stop()
 
     assert records[0]["message"] == "tls-message"
+
+
+def test_in_forward_tls_syscall_error_preserves_errno():
+    service = Service("in_forward_tls.yaml")
+    service.start()
+
+    try:
+        _reset_tls_connection(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        log_text = service.wait_for_log_contains("[tls] syscall error:", timeout=10)
+
+        payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "after-tls-reset"},
+        )
+        _send_tls_payload(service.flb_listener_port, payload, service.tls_crt_file)
+        records = service.wait_for_record_count(1, timeout=10)
+    finally:
+        service.stop()
+
+    assert "Connection reset by peer" in log_text
+    assert "Inappropriate ioctl for device" not in log_text
+    assert not any(
+        "openssl.c:" in line and "errno=" in line
+        for line in log_text.splitlines()
+    )
+    assert records[0]["message"] == "after-tls-reset"
 
 
 def test_in_forward_tls_idle_connection_timeout_churn(monkeypatch):

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -707,6 +707,20 @@ def _send_corrupted_tls_record(port, cafile):
     return raw_sock
 
 
+def _send_tls_close_notify(port, cafile):
+    raw_sock, tls, outgoing = _create_tls_memory_bio_client(port, cafile)
+
+    try:
+        tls.unwrap()
+    except ssl.SSLWantReadError:
+        pass
+
+    wire_payload = outgoing.read()
+    assert wire_payload
+    raw_sock.sendall(wire_payload)
+    raw_sock.close()
+
+
 def _recv_msgpack_value(sock):
     sock.settimeout(5)
     data = sock.recv(4096)
@@ -1143,6 +1157,31 @@ def test_in_forward_tls_protocol_error_is_reported():
     assert "bad record mac" in log_text.lower()
     assert "unknown error" not in log_text
     assert records[0]["message"] == "after-tls-protocol-error"
+
+
+def test_in_forward_tls_close_notify_is_not_an_error():
+    service = Service("in_forward_tls.yaml")
+    service.start()
+
+    try:
+        _send_tls_close_notify(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        time.sleep(1)
+
+        payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "after-tls-close-notify"},
+        )
+        _send_tls_payload(service.flb_listener_port, payload, service.tls_crt_file)
+        records = service.wait_for_record_count(1, timeout=10)
+        log_text = read_file(service.service.flb.log_file)
+    finally:
+        service.stop()
+
+    assert "[tls] unknown error (ssl_error=6)" not in log_text
+    assert records[0]["message"] == "after-tls-close-notify"
 
 
 def test_in_forward_tls_idle_connection_timeout_churn(monkeypatch):

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -696,6 +696,17 @@ def _reset_tls_connection(port, cafile):
     raw_sock.close()
 
 
+def _send_corrupted_tls_record(port, cafile):
+    raw_sock, tls, outgoing = _create_tls_memory_bio_client(port, cafile)
+
+    tls.write(b"\x91")
+    wire_payload = bytearray(outgoing.read())
+    wire_payload[-1] ^= 1
+    raw_sock.sendall(wire_payload)
+
+    return raw_sock
+
+
 def _recv_msgpack_value(sock):
     sock.settimeout(5)
     data = sock.recv(4096)
@@ -1102,6 +1113,36 @@ def test_in_forward_tls_syscall_error_preserves_errno():
         for line in log_text.splitlines()
     )
     assert records[0]["message"] == "after-tls-reset"
+
+
+def test_in_forward_tls_protocol_error_is_reported():
+    service = Service("in_forward_tls.yaml")
+    protocol_sock = None
+    service.start()
+
+    try:
+        protocol_sock = _send_corrupted_tls_record(
+            service.flb_listener_port,
+            service.tls_crt_file,
+        )
+        log_text = service.wait_for_log_contains("[tls] error:", timeout=10)
+        protocol_sock.close()
+        protocol_sock = None
+
+        payload = _message_mode_payload(
+            TEST_TAG,
+            {"message": "after-tls-protocol-error"},
+        )
+        _send_tls_payload(service.flb_listener_port, payload, service.tls_crt_file)
+        records = service.wait_for_record_count(1, timeout=10)
+    finally:
+        if protocol_sock is not None:
+            protocol_sock.close()
+        service.stop()
+
+    assert "bad record mac" in log_text.lower()
+    assert "unknown error" not in log_text
+    assert records[0]["message"] == "after-tls-protocol-error"
 
 
 def test_in_forward_tls_idle_connection_timeout_churn(monkeypatch):


### PR DESCRIPTION
## Summary

Backport the OpenSSL I/O error-classification fix and deterministic TLS regressions to `5.0`.

- preserve `errno` immediately after `SSL_read()` and `SSL_write()`
- distinguish real syscall failures, legacy unexpected peer EOF, and authoritative OpenSSL protocol/library errors
- report fatal `SSL_ERROR_SSL` failures instead of silently discarding the error queue
- mark fatal OpenSSL I/O results as non-reusable while preserving a meaningful syscall errno when present
- preserve 5.0's existing silent clean-`close_notify` behavior without importing master's separate lifecycle fix
- exercise TCP RST, corrupted TLS record, and clean TLS shutdown paths

## Root cause

The `SSL_ERROR_SYSCALL` path read `errno` after `flb_errno()` and logging operations could replace it with an unrelated value such as `ENOTTY`. The read path also used a dead `ssl_ret < 0` condition; `SSL_get_error()` returns nonnegative constants, so `SSL_ERROR_SSL` and other fatal failures were silently discarded and left `connection->net_error == -1`.

The backport classifies failures as follows:

- non-empty OpenSSL queue: report the OpenSSL protocol/library error
- `SSL_ERROR_SYSCALL` with saved nonzero `errno`: report and preserve the real syscall failure
- `SSL_ERROR_SYSCALL` with an empty queue and zero errno: report legacy unexpected EOF and use `ECONNRESET` as the terminal marker
- other fatal OpenSSL results: report the queued error, or the numeric SSL result if the queue is unexpectedly empty, and prevent reuse
- `SSL_ERROR_ZERO_RETURN`: return terminally without logging, preserving the 5.0 baseline behavior

WANT_READ/WANT_WRITE behavior is unchanged. This branch does not import master's #12079 close-notify recycling fix, #12141's retry work, or any handshake EOF behavior change.

## Compatibility and severity

An established-session peer EOF without `close_notify` is logged at error level. OpenSSL 3.x classifies this as a fatal TLS truncation/protocol error, and older OpenSSL versions already reached the error-level `SSL_ERROR_SYSCALL` path. This may make abrupt disconnects from non-compliant clients more visible, but Fluent Bit does not enable `SSL_OP_IGNORE_UNEXPECTED_EOF` because that would discard TLS truncation protection. An abrupt EOF during an incomplete `SSL_write()` is also error-level because application data may have been lost. A clean `close_notify` remains silent on 5.0.

## Regression proof

The known-broken syscall path emitted the real reset followed by an unrelated `Inappropriate ioctl for device`; it now reports only `Connection reset by peer`. A corrupted encrypted record previously reached `SSL_ERROR_SSL` without a TLS log; it now reports the authoritative `bad record mac` queue entry.

The initial backport catch-all also reported a clean shutdown as:

```text
[tls] unknown error (ssl_error=6)
```

An explicit `SSL_ERROR_ZERO_RETURN` branch removes that regression while preserving the 5.0 baseline. All three tests submit a valid TLS Forward payload afterward and verify responsiveness.

## Validation

```sh
cmake --build build -j8

tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_tls_syscall_error_preserves_errno \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_tls_protocol_error_is_reported \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_tls_close_notify_is_not_an_error -q

VALGRIND=1 VALGRIND_STRICT=1 \
tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_tls_syscall_error_preserves_errno \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_tls_protocol_error_is_reported \
  tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_tls_close_notify_is_not_an_error -q
```

All three normal and strict-Valgrind tests pass. Valgrind reports 0 errors, all heap blocks freed, and no allocations remaining at exit. The full six-commit range passes the repository prefix checker against `5.0`.