### PR TITLE
avro: out_kakfa: handle empty map even if avro schema defines map type 

### DIFF
--- a/src/flb_avro.c
+++ b/src/flb_avro.c
@@ -103,6 +103,9 @@ avro_value_iface_t  *flb_avro_init(avro_value_t *aobject, char *json, size_t jso
 int msgpack2avro(avro_value_t *val, msgpack_object *o)
 {
     int ret = FLB_FALSE;
+    size_t record_size = 0;
+    avro_type_t type;
+
     flb_debug("in msgpack2avro\n");
 
     assert(val != NULL);
@@ -200,7 +203,19 @@ int msgpack2avro(avro_value_t *val, msgpack_object *o)
 
     case MSGPACK_OBJECT_MAP:
         flb_debug("got a map\n");
-        if(o->via.map.size != 0) {
+        if (o->via.map.size == 0) {
+            type = avro_value_get_type(val);
+
+            if (type == AVRO_MAP) {
+                ret = FLB_TRUE;
+            }
+            else if (type == AVRO_RECORD) {
+                if (avro_value_get_size(val, &record_size) == 0 && record_size == 0) {
+                    ret = FLB_TRUE;
+                }
+            }
+        }
+        else {
             msgpack_object_kv* p = o->via.map.ptr;
             msgpack_object_kv* const pend = o->via.map.ptr + o->via.map.size;
             for(; p < pend; ++p) {

--- a/tests/integration/scenarios/out_kafka/config/out_kafka_avro_empty_map.yaml
+++ b/tests/integration/scenarios/out_kafka/config/out_kafka_avro_empty_map.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"ID":"97789a11215b54828d2c3f50b864afed42543ff8","HTTPHeader":{}}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: avro
+      schema_str: '{"type":"record","name":"EmptyMapRecord","fields":[{"name":"ID","type":"string"},{"name":"HTTPHeader","type":{"type":"map","values":"string"}}]}'
+      schema_id: 42
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -25,6 +25,9 @@ from utils.fluent_bit_manager import FluentBitStartupError
 from utils.test_service import FluentBitTestService
 
 
+EMPTY_MAP_RECORD_ID = "97789a11215b54828d2c3f50b864afed42543ff8"
+
+
 class Service:
     def __init__(self, config_file, *, use_schema_registry=False):
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
@@ -180,6 +183,42 @@ def _decode_simple_msgpack(data, offset=0):
         return data[offset:end].decode("utf-8"), end
 
     raise ValueError(f"Unsupported MessagePack type 0x{first:02x}")
+
+
+def _decode_avro_long(data, offset=0):
+    encoded = 0
+    shift = 0
+
+    while True:
+        if offset >= len(data):
+            raise ValueError("Truncated Avro long")
+
+        byte = data[offset]
+        offset += 1
+
+        if shift == 63 and byte & 0x7E:
+            raise ValueError("Invalid Avro long")
+
+        encoded |= (byte & 0x7F) << shift
+
+        if byte & 0x80 == 0:
+            break
+
+        shift += 7
+        if shift >= 64:
+            raise ValueError("Invalid Avro long")
+
+    return (encoded >> 1) ^ -(encoded & 1), offset
+
+
+def _decode_avro_string(data, offset=0):
+    size, offset = _decode_avro_long(data, offset)
+    end = offset + size
+
+    if size < 0 or end > len(data):
+        raise ValueError("Invalid Avro string")
+
+    return data[offset:end].decode("utf-8"), end
 
 
 def _decode_otlp_proto(data, signal_type):
@@ -475,6 +514,8 @@ def _start_or_skip_without_avro_encoder(service):
         log_contents = _read_fluent_bit_log(service)
         error_message = str(error)
         unsupported_markers = [
+            "unknown configuration property 'schema_str'",
+            "unknown configuration property 'schema_id'",
             "unknown configuration property 'schema_registry_url'",
             "unknown configuration property 'schema_registry_subject'",
             "unknown configuration property 'schema_registry_version'",
@@ -493,6 +534,13 @@ def _start_or_skip_without_avro_encoder(service):
         except Exception:
             pass
         raise
+
+
+def test_decode_avro_long_rejects_out_of_range_terminal_bits():
+    payload = b"\x80" * 9 + b"\x02"
+
+    with pytest.raises(ValueError, match="Invalid Avro long"):
+        _decode_avro_long(payload)
 
 
 def test_out_kafka_sends_json_payload():
@@ -595,6 +643,28 @@ def test_out_kafka_avro_resolves_schema_registry_subject():
     assert requests_seen[0]["method"] == "GET"
     assert requests_seen[0]["path"] == f"/subjects/{SCHEMA_SUBJECT}/versions/latest"
     assert "application/vnd.schemaregistry.v1+json" in requests_seen[0]["headers"]["Accept"]
+
+
+def test_out_kafka_avro_encodes_empty_map():
+    service = Service("out_kafka_avro_empty_map.yaml")
+    _start_or_skip_without_avro_encoder(service)
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    value = message["value"]
+
+    assert message["topic"] == "test"
+    assert value[0] == 0
+    assert int.from_bytes(value[1:5], "big") == SCHEMA_ID
+
+    record_id, offset = _decode_avro_string(value, 5)
+    map_size, offset = _decode_avro_long(value, offset)
+
+    assert record_id == EMPTY_MAP_RECORD_ID
+    assert map_size == 0
+    assert offset == len(value)
 
 
 def test_out_kafka_otlp_json_logs():

--- a/tests/internal/avro.c
+++ b/tests/internal/avro.c
@@ -297,6 +297,123 @@ const char JSON_INT_MULTI_FIELD_SCHEMA[] =
 "{\"name\":\"bad\",\"type\":\"int\"},"
 "{\"name\":\"last\",\"type\":\"string\"}]}";
 
+const char JSON_EMPTY_MAP_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"EmptyMapRecord\","
+"\"fields\":["
+"{\"name\":\"ID\",\"type\":\"string\"},"
+"{\"name\":\"HTTPHeader\",\"type\":{\"type\":\"map\",\"values\":\"string\"}}]}";
+
+const char JSON_EMPTY_RECORD_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"EmptyRecord\","
+"\"fields\":[]}";
+
+const char JSON_STRING_SCHEMA[] = "\"string\"";
+
+/* SHA-1 of the original sample record ID. */
+const char EMPTY_MAP_RECORD_ID[] = "97789a11215b54828d2c3f50b864afed42543ff8";
+
+void test_msgpack_to_avro_empty_map()
+{
+    size_t map_size = 0;
+    size_t id_size = 0;
+    const char *id = NULL;
+    avro_value_t aobject;
+    avro_value_t field;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_EMPTY_MAP_SCHEMA,
+                           strlen(JSON_EMPTY_MAP_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&pk, 2);
+    msgpack_pack_str(&pk, 2);
+    msgpack_pack_str_body(&pk, "ID", 2);
+    msgpack_pack_str(&pk, sizeof(EMPTY_MAP_RECORD_ID) - 1);
+    msgpack_pack_str_body(&pk, EMPTY_MAP_RECORD_ID, sizeof(EMPTY_MAP_RECORD_ID) - 1);
+    msgpack_pack_str(&pk, 10);
+    msgpack_pack_str_body(&pk, "HTTPHeader", 10);
+    msgpack_pack_map(&pk, 0);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_TRUE);
+
+    TEST_CHECK(avro_value_get_by_name(&aobject, "ID", &field, NULL) == 0);
+    TEST_CHECK(avro_value_get_string(&field, &id, &id_size) == 0);
+    TEST_CHECK(id_size == sizeof(EMPTY_MAP_RECORD_ID));
+    TEST_CHECK(strcmp(id, EMPTY_MAP_RECORD_ID) == 0);
+
+    TEST_CHECK(avro_value_get_by_name(&aobject, "HTTPHeader", &field, NULL) == 0);
+    TEST_CHECK(avro_value_get_size(&field, &map_size) == 0);
+    TEST_CHECK(map_size == 0);
+
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+}
+
+void test_msgpack_to_avro_empty_record()
+{
+    size_t record_size = 1;
+    avro_value_t aobject;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&pk, 0);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_EMPTY_RECORD_SCHEMA,
+                           strlen(JSON_EMPTY_RECORD_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_TRUE);
+    TEST_CHECK(avro_value_get_size(&aobject, &record_size) == 0);
+    TEST_CHECK(record_size == 0);
+
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_EMPTY_MAP_SCHEMA,
+                           strlen(JSON_EMPTY_MAP_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_FALSE);
+
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_STRING_SCHEMA,
+                           strlen(JSON_STRING_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_FALSE);
+
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+}
+
 void test_msgpack_to_avro_int64()
 {
     int64_t positive_expected = 4294967296LL;
@@ -537,6 +654,8 @@ TEST_LIST = {
     /* Avro */
     { "msgpack_to_avro_basic", test_unpack_to_avro},
     { "test_parse_reordered_schema", test_parse_reordered_schema},
+    { "test_msgpack_to_avro_empty_map", test_msgpack_to_avro_empty_map},
+    { "test_msgpack_to_avro_empty_record", test_msgpack_to_avro_empty_record},
     { "test_msgpack_to_avro_int64", test_msgpack_to_avro_int64},
     { "test_msgpack_to_avro_int_range", test_msgpack_to_avro_int_range},
     { "test_msgpack_to_avro_int_range_multi_field",


### PR DESCRIPTION
<!-- Provide summary of changes -->

## Summary

Fix Avro encoding of records that contain empty maps, such as:

```json
{"ID":"97789a11215b54828d2c3f50b864afed42543ff8","HTTPHeader":{}}
```

The MessagePack-to-Avro converter previously left its result as failure when a map contained no entries. This caused `out_kafka` to reject valid records even when the corresponding Avro field was a map of strings.

## Behavior

- Accept an empty MessagePack map when the destination is `AVRO_MAP`.
- Accept an empty map as `AVRO_RECORD` only when the record schema has zero fields.
- Reject `{}` for populated Avro records so Avro-c cannot publish fabricated zero or empty values for missing fields.
- Continue rejecting empty maps for incompatible scalar target types.

## Tests

- Add internal conversion coverage for:
  - a populated record containing an empty `HTTPHeader` map;
  - an empty zero-field Avro record;
  - rejection of an empty populated record;
  - rejection of an incompatible scalar target.
- Use the SHA-1 of the original sample ID and derive its MessagePack length with `sizeof`.
- Add a dedicated `in_dummy` to `out_kafka` integration configuration using `schema_str` and `schema_id`.
- Decode the produced Kafka Avro payload and verify its framing, schema ID, record ID, and zero-entry map.
- Harden the test Avro-long decoder against terminal payload bits beyond 64 bits, with malformed coverage for nine continuation bytes followed by `0x02`.

Validation completed successfully:

```console
cmake --build build -j8
ctest --test-dir build -R '^flb-it-avro$' --output-on-failure

tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_decode_avro_long_rejects_out_of_range_terminal_bits \
  -q

tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_avro_encodes_empty_map \
  -q

LEAKS=1 LEAKS_STRICT=1 \
  tests/integration/.venv/bin/python -m pytest \
  tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py::test_out_kafka_avro_encodes_empty_map \
  -q
```

The record key and Avro field name must match exactly. The integration coverage uses `HTTPHeader`; `HTTP-Header` is not a valid Avro field name.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avro serialization now accepts empty MessagePack maps for Avro map fields and zero-field records while rejecting populated records with missing fields.
  * Empty maps are emitted without trailing data, preserving valid Avro output.

* **Tests**
  * Added internal and Kafka integration coverage for empty-map conversion, missing-field rejection, schema framing, record payload validation, and malformed Avro-long input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->