### PR TITLE
in_kubernetes_events: fix OOB reads from non-NUL-terminated msgpack strings

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <ctype.h>
 
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_network.h>
@@ -296,6 +297,18 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         }
         memcpy(buf, v->via.str.ptr, len);
         buf[len] = '\0';
+
+        /*
+         * strtoull() itself accepts a leading '+'/'-' and skips leading
+         * whitespace, which would let a value like "-5" silently wrap
+         * around into a huge positive number instead of being rejected.
+         * Kubernetes resourceVersion (the only caller) is always a plain,
+         * unsigned, digits-only decimal string, so require that directly
+         * before parsing.
+         */
+        if (!isdigit((unsigned char) buf[0])) {
+            return -1;
+        }
 
         errno = 0;
         *val = strtoull(buf, &end, 10);

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <inttypes.h>
+#include <errno.h>
 
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_network.h>
@@ -253,8 +254,13 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
     memcpy(buf, v->via.str.ptr, v->via.str.size);
     buf[v->via.str.size] = '\0';
 
-    if (flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL) {
-        return -2;
+    {
+        char *end;
+
+        end = flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm);
+        if (end == NULL || *end != '\0') {
+            return -2;
+        }
     }
 
     val->tm.tv_sec = flb_parser_tm2time(&tm, FLB_FALSE);
@@ -291,8 +297,9 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         memcpy(buf, v->via.str.ptr, len);
         buf[len] = '\0';
 
-        *val = strtoul(buf, &end, 10);
-        if (end == NULL || end == buf || *end != '\0') {
+        errno = 0;
+        *val = strtoull(buf, &end, 10);
+        if (errno == ERANGE || end == buf || *end != '\0') {
             return -1;
         }
         return 0;
@@ -302,8 +309,7 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         return 0;
     }
     if (v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
-        *val = (uint64_t)v->via.i64;
-        return 0;
+        return -1;
     }
     return -1;
 }
@@ -317,12 +323,12 @@ static int item_get_timestamp(msgpack_object *obj, struct flb_time *event_time)
      * NULL while having metadata.creationTimestamp set.
      */
     ret = record_get_field_time(obj, "lastTimestamp", event_time);
-    if (ret != -1) {
+    if (ret == 0) {
         return FLB_TRUE;
     }
 
     ret = record_get_field_time(obj, "firstTimestamp", event_time);
-    if (ret != -1) {
+    if (ret == 0) {
         return FLB_TRUE;
     }
 
@@ -332,7 +338,7 @@ static int item_get_timestamp(msgpack_object *obj, struct flb_time *event_time)
     }
 
     ret = record_get_field_time(metadata, "creationTimestamp", event_time);
-    if (ret != -1) {
+    if (ret == 0) {
         return FLB_TRUE;
     }
 

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -179,6 +179,7 @@ static int refresh_token_if_needed(struct k8s_events *ctx)
 static msgpack_object *record_get_field_ptr(msgpack_object *obj, const char *fieldname)
 {
     int i;
+    size_t fieldname_len;
     msgpack_object *k;
     msgpack_object *v;
 
@@ -186,13 +187,23 @@ static msgpack_object *record_get_field_ptr(msgpack_object *obj, const char *fie
         return NULL;
     }
 
+    fieldname_len = strlen(fieldname);
+
     for (i = 0; i < obj->via.map.size; i++) {
         k = &obj->via.map.ptr[i].key;
         if (k->type != MSGPACK_OBJECT_STR) {
             continue;
         }
 
-        if (strncmp(k->via.str.ptr, fieldname, strlen(fieldname)) == 0) {
+        /*
+         * msgpack strings are not NUL terminated: k->via.str.ptr points
+         * directly into the decode buffer for exactly k->via.str.size
+         * bytes. Require an exact length match before comparing so we
+         * never read past that boundary, and so a key that merely shares
+         * a prefix with fieldname cannot match.
+         */
+        if ((size_t) k->via.str.size == fieldname_len &&
+            strncmp(k->via.str.ptr, fieldname, fieldname_len) == 0) {
             v = &obj->via.map.ptr[i].val;
             return v;
         }
@@ -220,6 +231,7 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
 {
     msgpack_object *v;
     struct flb_tm tm = { 0 };
+    char buf[64];
 
     v = record_get_field_ptr(obj, fieldname);
     if (v == NULL) {
@@ -229,7 +241,19 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
         return -1;
     }
 
-    if (flb_strptime(v->via.str.ptr, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL) {
+    /*
+     * msgpack strings are not NUL terminated: v->via.str.ptr points
+     * directly into the decode buffer for exactly v->via.str.size bytes.
+     * Copy it into a bounded, NUL-terminated stack buffer before handing
+     * it to flb_strptime(), instead of scanning the raw buffer directly.
+     */
+    if (v->via.str.size == 0 || v->via.str.size >= sizeof(buf)) {
+        return -2;
+    }
+    memcpy(buf, v->via.str.ptr, v->via.str.size);
+    buf[v->via.str.size] = '\0';
+
+    if (flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL) {
         return -2;
     }
 
@@ -242,7 +266,9 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
 static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, uint64_t *val)
 {
     msgpack_object *v;
+    char buf[32];
     char *end;
+    size_t len;
 
     v = record_get_field_ptr(obj, fieldname);
     if (v == NULL) {
@@ -251,8 +277,22 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
 
     /* attempt to parse string as number... */
     if (v->type == MSGPACK_OBJECT_STR) {
-        *val = strtoul(v->via.str.ptr, &end, 10);
-        if (end == NULL || (end < v->via.str.ptr + v->via.str.size)) {
+        /*
+         * msgpack strings are not NUL terminated: v->via.str.ptr points
+         * directly into the decode buffer for exactly v->via.str.size
+         * bytes. Copy it into a bounded, NUL-terminated stack buffer
+         * before calling strtoul() on it, instead of scanning the raw
+         * buffer directly (no valid uint64 needs more than 20 digits).
+         */
+        len = v->via.str.size;
+        if (len == 0 || len > sizeof(buf) - 1) {
+            return -1;
+        }
+        memcpy(buf, v->via.str.ptr, len);
+        buf[len] = '\0';
+
+        *val = strtoul(buf, &end, 10);
+        if (end == NULL || end == buf || *end != '\0') {
             return -1;
         }
         return 0;


### PR DESCRIPTION
## Summary

`record_get_field_uint64()` and `record_get_field_time()` in `plugins/in_kubernetes_events/kubernetes_events.c` call `strtoul()` / `flb_strptime()` directly on `msgpack_object.via.str.ptr`. msgpack strings are raw, length-prefixed bytes pointing directly into the decode buffer, they are **not NUL-terminated**, so these C-string functions can read past the field's true boundary. `record_get_field_ptr()`'s key match via `strncmp(k->via.str.ptr, fieldname, strlen(fieldname))` had the same class of issue: no exact-length check, so a key that's a prefix of `fieldname` could false-match, and comparison length wasn't bounded by the key's own size.

A spec-compliant Kubernetes Event field (e.g. `resourceVersion` as a digit-only JSON string, per the Kubernetes API docs) placed near the edge of the decode buffer is enough to trigger an out-of-bounds read. Reproduced locally with a harness that calls the real `flb_pack_json()` on `{"resourceVersion":"999999"}`, places the resulting buffer against a `PROT_NONE` guard page, and calls the real (recompiled) plugin function on it, confirmed via `lldb`: `EXC_BAD_ACCESS` inside `strtoul_l`, called from `record_get_field_uint64` at the line doing the unbounded `strtoul` call.

This is the same bug class fixed same-day for the sibling `out_stackdriver` plugin (#12022, backported in #12170), and the same class that produced a real CVE in this project before (GHSA-5rjf-prwh-pp7q).

A prior contributor flagged the same underlying issue in #12073 but self-closed it without a fix landing; the vulnerable code is still present at HEAD.

Supersedes #12180, closed by GitHub after a force-push rewrote that branch's
history (stripped an unrelated commit trailer) while the PR was closed, which
blocks reopening. Same fixes, clean history on top of current `master`.

## Fix

Same pattern the maintainers already established for the sibling `out_stackdriver` fix: copy the field into a bounded, NUL-terminated stack buffer before parsing (`strtoul`, `flb_strptime`), and require an exact length match before the key `strncmp`.

On top of that, addresses a CodeRabbit review comment from the original PR: `strtoull()` accepts a leading `+`/`-` and would silently wrap a value like `"-5"` into a huge positive number instead of rejecting it. `resourceVersion` is always a plain unsigned digits-only decimal string, so the fix now requires the first byte to be a digit before parsing.

## Test plan

- [x] Full internal `ctest` suite (90 tests) passes clean after the fix.
- [x] `in_kubernetes_events` runtime test suite (`flb-rt-in_kubernetes_events`) passes clean after the fix.
- [x] Reproduced the crash on unmodified code with a guard-page harness (`lldb`-confirmed `EXC_BAD_ACCESS` in `strtoul_l`); same harness runs clean (`resource_version=999999`, exit 0) after the fix.
- [x] Same harness extended with `"-5"`/`"+5"` cases: rejected after the fix, previously accepted (`"-5"` silently wrapped to `UINT64_MAX-4`).

Happy to share the repro harness if useful for a permanent regression test, it needs an `mmap`'d guard page, which doesn't fit cleanly into the existing runtime-test infra (same constraint the maintainers' own #12022 fix had, which also didn't add a crash-reproducing test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed or non-terminated event data.
  - Ensured field matching requires exact key lengths.
  - Strengthened timestamp validation and fallback behavior.
  - Improved numeric parsing to reject invalid, out-of-range, or negative values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->