### PR TITLE
filter_expect: validate all records in batches

### DIFF
--- a/plugins/filter_expect/expect.c
+++ b/plugins/filter_expect/expect.c
@@ -405,7 +405,8 @@ static int cb_expect_filter(const void *data, size_t bytes,
 {
     int ret;
     int i;
-    int rule_matched = FLB_TRUE;
+    int rule_matched;
+    int32_t record_type;
     msgpack_object_kv *kv;
     struct flb_expect *ctx = filter_context;
     struct flb_log_event_encoder log_encoder;
@@ -427,25 +428,25 @@ static int cb_expect_filter(const void *data, size_t bytes,
         return FLB_FILTER_NOTOUCH;
     }
 
-    while ((ret = flb_log_event_decoder_next(
-                    &log_decoder,
-                    &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
-        ret = rule_apply(ctx, *log_event.body, config);
-        if (ret == FLB_TRUE) {
-            /* rule matches, we are good */
-            continue;
-        }
-        else {
-            if (ctx->action == FLB_EXP_WARN) {
-                flb_plg_warn(ctx->ins, "expect check failed");
+    if (ctx->action != FLB_EXP_RESULT_KEY) {
+        while ((ret = flb_log_event_decoder_next(
+                        &log_decoder,
+                        &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+            ret = rule_apply(ctx, *log_event.body, config);
+            if (ret == FLB_TRUE) {
+                /* rule matches, we are good */
+                continue;
             }
-            else if (ctx->action == FLB_EXP_EXIT) {
-                flb_engine_exit_status(config, 255);
+            else {
+                if (ctx->action == FLB_EXP_WARN) {
+                    flb_plg_warn(ctx->ins, "expect check failed");
+                    continue;
+                }
+                else if (ctx->action == FLB_EXP_EXIT) {
+                    flb_engine_exit_status(config, 255);
+                }
+                break;
             }
-            else if (ctx->action == FLB_EXP_RESULT_KEY) {
-                rule_matched = FLB_FALSE;
-            }
-            break;
         }
     }
 
@@ -453,6 +454,13 @@ static int cb_expect_filter(const void *data, size_t bytes,
     /* Append result key when action is "result_key"*/
     if (ctx->action == FLB_EXP_RESULT_KEY) {
         flb_log_event_decoder_reset(&log_decoder, (char *) data, bytes);
+
+        ret = flb_log_event_decoder_read_groups(&log_decoder, FLB_TRUE);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed to enable group marker decoding");
+            flb_log_event_decoder_destroy(&log_decoder);
+            return FLB_FILTER_NOTOUCH;
+        }
 
         ret = flb_log_event_encoder_init(&log_encoder,
                                          FLB_LOG_EVENT_FORMAT_DEFAULT);
@@ -469,6 +477,26 @@ static int cb_expect_filter(const void *data, size_t bytes,
         while ((ret = flb_log_event_decoder_next(
                         &log_decoder,
                         &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+            ret = flb_log_event_decoder_get_record_type(&log_event, &record_type);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "record has invalid event type");
+                break;
+            }
+
+            if (record_type == FLB_LOG_EVENT_GROUP_START ||
+                record_type == FLB_LOG_EVENT_GROUP_END) {
+                ret = flb_log_event_encoder_emit_raw_record(
+                        &log_encoder,
+                        log_decoder.record_base,
+                        log_decoder.record_length);
+                if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+                    break;
+                }
+                continue;
+            }
+
+            rule_matched = rule_apply(ctx, *log_event.body, config);
+
             ret = flb_log_event_encoder_begin_record(&log_encoder);
 
             if (ret == FLB_EVENT_ENCODER_SUCCESS) {

--- a/tests/integration/scenarios/in_opentelemetry/config/expect_batch.yaml
+++ b/tests/integration/scenarios/in_opentelemetry/config/expect_batch.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 0.2
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  filters:
+    - name: expect
+      match: "*"
+      key_exists:
+        - field1
+        - field2
+        - field3
+        - field4
+      action: warn
+
+  outputs:
+    - name: null
+      match: "*"

--- a/tests/integration/scenarios/in_opentelemetry/config/expect_group_result_key.yaml
+++ b/tests/integration/scenarios/in_opentelemetry/config/expect_group_result_key.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 0.2
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  filters:
+    - name: expect
+      match: "*"
+      key_exists:
+        - field1
+        - field2
+        - field3
+        - field4
+      action: result_key
+      result_key: matched
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      logs_uri: /v1/logs

--- a/tests/integration/scenarios/in_opentelemetry/tests/data_files/test_logs_expect_batch.in.json
+++ b/tests/integration/scenarios/in_opentelemetry/tests/data_files/test_logs_expect_batch.in.json
@@ -1,0 +1,131 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my-service"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field1",
+                      "value": {
+                        "stringValue": "1"
+                      }
+                    },
+                    {
+                      "key": "field2",
+                      "value": {
+                        "stringValue": "2"
+                      }
+                    },
+                    {
+                      "key": "field3",
+                      "value": {
+                        "stringValue": "3"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field1",
+                      "value": {
+                        "stringValue": "1"
+                      }
+                    },
+                    {
+                      "key": "field2",
+                      "value": {
+                        "stringValue": "2"
+                      }
+                    },
+                    {
+                      "key": "field4",
+                      "value": {
+                        "stringValue": "4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field1",
+                      "value": {
+                        "stringValue": "1"
+                      }
+                    },
+                    {
+                      "key": "field3",
+                      "value": {
+                        "stringValue": "3"
+                      }
+                    },
+                    {
+                      "key": "field4",
+                      "value": {
+                        "stringValue": "4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field2",
+                      "value": {
+                        "stringValue": "2"
+                      }
+                    },
+                    {
+                      "key": "field3",
+                      "value": {
+                        "stringValue": "3"
+                      }
+                    },
+                    {
+                      "key": "field4",
+                      "value": {
+                        "stringValue": "4"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -230,6 +230,14 @@ def read_stdout_otlp_json_text(service, root_key, timeout=10, interval=0.25):
     raise TimeoutError(f"Timed out waiting for stdout OTLP JSON payload with root key {root_key}")
 
 
+def read_fluent_bit_log(service):
+    if not service.flb or not service.flb.log_file or not os.path.exists(service.flb.log_file):
+        return ""
+
+    with open(service.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+        return log_file.read()
+
+
 def read_prometheus_metric_value(metrics_text, metric_name, input_name):
     label = f'name="{input_name}"'
 
@@ -1749,3 +1757,100 @@ def test_in_opentelemetry_http_workers_account_metrics_payload_bytes():
         service.stop()
 
     assert len(data_storage["metrics"]) == metrics_before + 1
+
+
+def test_expect_warn_validates_each_otlp_log_record_in_batch():
+    service = Service("expect_batch.yaml")
+    payload = read_json_file(
+        os.path.join(
+            os.path.dirname(__file__),
+            "data_files",
+            "test_logs_expect_batch.in.json",
+        )
+    )
+
+    service.start()
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/v1/logs",
+            json=payload,
+            timeout=5,
+        )
+        assert response.status_code == 201
+
+        log_text = service.service.wait_for_condition(
+            lambda: (
+                content
+                if content.count("expect check failed") >= 4
+                else None
+            ) if (content := read_fluent_bit_log(service)) else None,
+            timeout=10,
+            interval=0.25,
+            description="one expect warning per invalid OTLP log record",
+        )
+    finally:
+        service.stop()
+
+    assert log_text.count("expect check failed") == 4
+    for field_name in ("field1", "field2", "field3", "field4"):
+        assert log_text.count(f"key '{field_name}' not found") == 1
+
+
+def test_expect_result_key_preserves_otlp_log_groups():
+    service = Service("expect_group_result_key.yaml")
+    payload = read_json_file(
+        os.path.join(
+            os.path.dirname(__file__),
+            "data_files",
+            "test_logs_expect_batch.in.json",
+        )
+    )
+    scope_logs = payload["resourceLogs"][0]["scopeLogs"][0]
+    scope_logs["scope"] = {"name": "issue.scope"}
+    scope_logs["logRecords"].append(
+        {
+            "timeUnixNano": "1784797967000450100",
+            "body": {
+                "kvlistValue": {
+                    "values": [
+                        {
+                            "key": f"field{index}",
+                            "value": {"stringValue": str(index)},
+                        }
+                        for index in range(1, 5)
+                    ]
+                }
+            },
+        }
+    )
+
+    service.start()
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/v1/logs",
+            json=payload,
+            timeout=5,
+        )
+        assert response.status_code == 201
+        output = service.read_response("logs")
+    finally:
+        service.stop()
+
+    records = list(iter_log_records(output))
+    assert len(records) == 5
+
+    matched_values = []
+    for record in records:
+        assert record["resource_attributes"] == {"service.name": "my-service"}
+        assert record["scope_name"] == "issue.scope"
+
+        values = record["record"]["body"]["kvlistValue"]["values"]
+        fields = {
+            item["key"]: next(iter(item["value"].values()))
+            for item in values
+        }
+        matched_values.append(fields["matched"])
+
+    assert matched_values == [False, False, False, False, True]


### PR DESCRIPTION
## Summary

Fix the Expect filter so every log record in a batch is evaluated instead of stopping after the first failed record.

When `action: result_key` rewrites records, preserve log group markers so OpenTelemetry resource and scope context remains intact, and compute the result independently for each record.

## Root cause

The filter unconditionally stopped processing after the first failed expectation. The `result_key` path also reused one batch-wide match value and rebuilt only normal records, dropping group boundaries.

## User impact

Batched records now produce one warning per failed record. The `result_key` action reports the correct result on each record while retaining OpenTelemetry resource and scope metadata.

Fixes #12166

## Validation

- `ctest --test-dir build -R '^flb-rt-filter_expect$' --output-on-failure`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_expect_warn_validates_each_otlp_log_record_in_batch tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_expect_result_key_preserves_otlp_log_groups -q`
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_expect_warn_validates_each_otlp_log_record_in_batch tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py::test_expect_result_key_preserves_otlp_log_groups -q`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`

All focused tests passed. Both Valgrind runs completed with zero errors and no leaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for batched OpenTelemetry log records.
  - Preserved resource and scope grouping while applying validation results.
  - Ensured group markers remain intact and invalid records stop processing safely.

- **Tests**
  - Added integration coverage for per-record validation warnings.
  - Added coverage for result fields and grouping across multiple OpenTelemetry log records.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->