### PR TITLE
in_emitter: reject self-referential senders to prevent recursive pause SIGSEGV

### DIFF
--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -55,6 +55,8 @@ struct flb_emitter {
     struct flb_ring_buffer *msgs;       /* ring buffer for cross-thread messages */
     int ring_buffer_size;               /* size of the ring buffer */
     struct mk_list i_ins_list;          /* instance list of linked/sending inputs */
+    int cycle_reported;                 /* self-emission cycle already logged ? */
+    int propagating;                    /* pause/resume propagation in progress */
 };
 
 struct em_chunk *em_chunk_create(const char *tag, int tag_len,
@@ -160,6 +162,27 @@ int in_emitter_add_record(const char *tag, int tag_len,
 
     ctx = (struct flb_emitter *) in->context;
     ec = NULL;
+
+    /*
+     * Reject records that this emitter is trying to send to itself: the filter
+     * that owns the emitter matched a record that the emitter injected. Keeping
+     * the emitter in its own sender list makes pause/resume recurse into this
+     * same instance until the stack is exhausted, and the emission itself is an
+     * endless tag rewrite cycle.
+     */
+    if (i_ins == ctx->ins) {
+        if (ctx->cycle_reported == FLB_FALSE) {
+            ctx->cycle_reported = FLB_TRUE;
+            flb_plg_error(ctx->ins,
+                          "emitter cycle detected: the filter attached to this "
+                          "emitter matches the records it emits (tag=%.*s), "
+                          "the emission is rejected. Adjust the filter 'Match' "
+                          "or its rules so emitted records are not processed "
+                          "again", tag_len, tag);
+        }
+        return -1;
+    }
+
     /* Iterate over list of already known (source) inputs */
     /* If new, add it to the list to be able to pause it later on */
     ref_found = false;
@@ -421,12 +444,23 @@ static void cb_emitter_pause(void *data, struct flb_config *config)
     struct mk_list *head;
     struct input_ref *i_ref;
 
+    /*
+     * A sender can be another emitter that references this one back, the guard
+     * keeps the propagation from recursing into this instance again.
+     */
+    if (ctx->propagating == FLB_TRUE) {
+        return;
+    }
+    ctx->propagating = FLB_TRUE;
+
     /* Pause all known senders */
     flb_input_collector_pause(ctx->coll_fd, ctx->ins);
     mk_list_foreach_safe(head, tmp, &ctx->i_ins_list) {
         i_ref = mk_list_entry(head, struct input_ref, _head);
         flb_input_pause(i_ref->i_ins);
     }
+
+    ctx->propagating = FLB_FALSE;
 }
 
 static void cb_emitter_resume(void *data, struct flb_config *config)
@@ -436,12 +470,19 @@ static void cb_emitter_resume(void *data, struct flb_config *config)
     struct mk_list *head;
     struct input_ref *i_ref;
 
+    if (ctx->propagating == FLB_TRUE) {
+        return;
+    }
+    ctx->propagating = FLB_TRUE;
+
     /* Resume all known senders */
     flb_input_collector_resume(ctx->coll_fd, ctx->ins);
     mk_list_foreach_safe(head, tmp, &ctx->i_ins_list) {
         i_ref = mk_list_entry(head, struct input_ref, _head);
         flb_input_resume(i_ref->i_ins);
     }
+
+    ctx->propagating = FLB_FALSE;
 }
 
 static int cb_emitter_exit(void *data, struct flb_config *config)

--- a/tests/runtime/filter_rewrite_tag.c
+++ b/tests/runtime/filter_rewrite_tag.c
@@ -633,6 +633,68 @@ static void flb_test_issue_5846()
     filter_test_destroy(ctx);
 }
 
+/*
+ * A rule that rewrites a record to the tag it already has makes the emitter
+ * re-inject the record into the same filter. The emitter used to register
+ * itself as one of its own senders, so pausing it (hot reload or shutdown)
+ * recursed until the stack was exhausted.
+ */
+static void flb_test_self_cycle_issue_12189()
+{
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    int ret;
+    int not_used = 0;
+    int bytes;
+    int got;
+    char *p = "[0, {\"key\":\"cycle\"}]";
+
+    /* Prepare output callback with expected result */
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &not_used;
+
+    /* Create test context */
+    ctx = filter_test_create((void *) &cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+    clear_output_num();
+
+    /* The new tag is the tag the filter is matching, so it emits to itself */
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "Rule", "$key ^(cycle)$ rewrite false",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Configure output */
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "Match", "rewrite",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Start the engine */
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* ingest record */
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, strlen(p));
+    TEST_CHECK(bytes == strlen(p));
+
+    flb_time_msleep(1500); /* waiting flush */
+    got = get_output_num();
+
+    /*
+     * The record emitted once is kept by the filter on the second evaluation,
+     * the self-emission is rejected instead of looping.
+     */
+    if (!TEST_CHECK(got == 1)) {
+        TEST_MSG("expect: 1 got: %d", got);
+    }
+
+    /* Shutdown pauses the inputs, it must not recurse into the emitter */
+    filter_test_destroy(ctx);
+}
+
 TEST_LIST = {
     {"matched",          flb_test_matched},
     {"not_matched",      flb_test_not_matched},
@@ -642,5 +704,6 @@ TEST_LIST = {
     {"issue_4518", flb_test_issue_4518},
     {"issue_4793", flb_test_issue_4793},
     {"sigsegv_issue_5846", flb_test_issue_5846},
+    {"self_cycle_issue_12189", flb_test_self_cycle_issue_12189},
     {NULL, NULL}
 };


### PR DESCRIPTION
A `rewrite_tag` rule that matches the records its own emitter injects makes the emitter register itself as one of its senders. Everything looks fine while data flows, but the next pause (hot reload or shutdown) recurses through the emitter until the stack is gone and Fluent Bit dies with SIGSEGV.

Fixes #12189

**Root cause**

`in_emitter_add_record()` adds `i_ins` to `ctx->i_ins_list` without checking whether `i_ins` is the emitter itself. When the emitter re-injects a record and the filter matches it again, the emitter ends up in its own sender list.

On pause, `cb_emitter_pause()` walks that list and calls `flb_input_pause()` on each sender, including itself. `flb_input_pause()` only returns early if the instance is already flagged as paused, and that flag is set by the caller *after* `cb_pause` returns (`flb_input_pause_all()` never sets it at all), so nothing stops the recursion.

Both `flb_engine_shutdown()` and `flb_engine_stop_ingestion()` go through `flb_input_pause_all()`, which is why SIGHUP and SIGTERM both crash.

`filter_multiline` already skips records coming from its emitter, `rewrite_tag` does not, and the emitter never enforced it on its side either.

**Solution**

Reject the emission when the source input is the emitter itself, before the sender gets registered. `rewrite_tag` forces `keep_record` when the emitter returns an error, so the record in flight is kept with its current tag and only the recursive emission is dropped. The cycle is logged once per emitter instead of once per record.

Wildcard `Match` is still accepted at startup (see #4288), since it can be perfectly valid. Only the actual runtime cycle is rejected.

Also added a small re-entry guard to the pause/resume propagation so a cycle between two emitters can't recurse either.

One behavior change worth calling out: a chained rewrite through a single emitter (record leaves the emitter as tag B, the same filter rewrites B to C through that same emitter) is now rejected with the cycle error. That config self-registers and crashes on pause today, so no working setup loses anything, but I'd rather flag it than have it found in review. Happy to narrow it to the strict self-loop if you prefer.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [x] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented emitter self-cycles from producing repeated records or recursive shutdown behavior.
  * Improved pause and resume handling to avoid recursive propagation.
  * Added a clear, one-time error notification when self-emission is detected.

* **Tests**
  * Added regression coverage for rewrite-tag self-cycles, including output handling and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->