### PR TITLE
 engine: http_server: Add on-demand flush mechanism

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -21,6 +21,7 @@
 #define FLB_CONFIG_H
 
 #include <time.h>
+#include <stdint.h>
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_pipe.h>
@@ -73,6 +74,8 @@ struct flb_config {
     int grace_count;          /* Count of grace shutdown tries              */
     int grace_input;          /* Shutdown grace to keep inputs ingesting    */
     flb_pipefd_t flush_fd;    /* Timer FD associated to flush               */
+    uint64_t flush_now_count; /* On-demand flush requests received          */
+    uint64_t flush_now_acked; /* Highest request covered by a full flush    */
     int convert_nan_to_null;  /* Convert null to nan ?                      */
 
     int daemon;               /* Run as a daemon ?              */

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -21,6 +21,7 @@
 #define FLB_CONFIG_H
 
 #include <time.h>
+#include <stdint.h>
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_pipe.h>
@@ -73,7 +74,7 @@ struct flb_config {
     int grace_count;              /* Count of grace shutdown tries           */
     int grace_input;              /* Shutdown grace to keep inputs ingesting */
     flb_pipefd_t flush_fd;        /* Timer FD associated to flush            */
-    unsigned int flush_now_count; /* count of on-demand flush requests       */
+    uint64_t flush_now_count;     /* count of on-demand flush requests       */
     int convert_nan_to_null;      /* Convert null to nan ?                   */
 
     int daemon;               /* Run as a daemon ?              */

--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -70,10 +70,11 @@ struct flb_config {
      * shutdown when all remaining tasks are flushed
      */
     int grace;
-    int grace_count;          /* Count of grace shutdown tries              */
-    int grace_input;          /* Shutdown grace to keep inputs ingesting    */
-    flb_pipefd_t flush_fd;    /* Timer FD associated to flush               */
-    int convert_nan_to_null;  /* Convert null to nan ?                      */
+    int grace_count;              /* Count of grace shutdown tries           */
+    int grace_input;              /* Shutdown grace to keep inputs ingesting */
+    flb_pipefd_t flush_fd;        /* Timer FD associated to flush            */
+    unsigned int flush_now_count; /* count of on-demand flush requests       */
+    int convert_nan_to_null;      /* Convert null to nan ?                   */
 
     int daemon;               /* Run as a daemon ?              */
     flb_pipefd_t shutdown_fd; /* Shutdown FD, 5 seconds         */

--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -34,6 +34,7 @@ int flb_engine_flush(struct flb_config *config,
                      struct flb_input_plugin *in_force);
 int flb_engine_exit(struct flb_config *config);
 int flb_engine_exit_status(struct flb_config *config, int status);
+int flb_engine_flush_request(struct flb_config *config, int reschedule_retries);
 int flb_engine_shutdown(struct flb_config *config);
 int flb_engine_destroy_tasks(struct mk_list *tasks);
 void flb_engine_reschedule_retries(struct flb_config *config);

--- a/include/fluent-bit/flb_engine.h
+++ b/include/fluent-bit/flb_engine.h
@@ -34,6 +34,7 @@ int flb_engine_flush(struct flb_config *config,
                      struct flb_input_plugin *in_force);
 int flb_engine_exit(struct flb_config *config);
 int flb_engine_exit_status(struct flb_config *config, int status);
+int flb_engine_flush_request(struct flb_config *config);
 int flb_engine_shutdown(struct flb_config *config);
 int flb_engine_destroy_tasks(struct mk_list *tasks);
 void flb_engine_reschedule_retries(struct flb_config *config);

--- a/include/fluent-bit/flb_engine_macros.h
+++ b/include/fluent-bit/flb_engine_macros.h
@@ -42,16 +42,20 @@
 #define FLB_ENGINE_EV_NOTIFICATION  (1 << 19)                          /* 524288 */
 
 /* Engine events: all engine events set the left 32 bits to '1' */
-#define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */
-#define FLB_ENGINE_EV_FAILED    FLB_BITS_U64_SET(1, 2) /* Engine started    */
-#define FLB_ENGINE_EV_STOP      FLB_BITS_U64_SET(1, 3) /* Requested to stop */
-#define FLB_ENGINE_EV_SHUTDOWN  FLB_BITS_U64_SET(1, 4) /* Engine shutdown   */
+#define FLB_ENGINE_EV_STARTED         FLB_BITS_U64_SET(1, 1) /* Engine started           */
+#define FLB_ENGINE_EV_FAILED          FLB_BITS_U64_SET(1, 2) /* Engine started           */
+#define FLB_ENGINE_EV_STOP            FLB_BITS_U64_SET(1, 3) /* Requested to stop        */
+#define FLB_ENGINE_EV_SHUTDOWN        FLB_BITS_U64_SET(1, 4) /* Engine shutdown          */
+#define FLB_ENGINE_EV_FLUSH_NOW       FLB_BITS_U64_SET(1, 5) /* On-demand flush          */
+#define FLB_ENGINE_EV_FLUSH_NOW_RETRY FLB_BITS_U64_SET(1, 6) /* On-demand flush w/ retry */
 
 /* Similar to engine events, but used as return values */
-#define FLB_ENGINE_STARTED      FLB_BITS_U64_LOW(FLB_ENGINE_EV_STARTED)
-#define FLB_ENGINE_FAILED       FLB_BITS_U64_LOW(FLB_ENGINE_EV_FAILED)
-#define FLB_ENGINE_STOP         FLB_BITS_U64_LOW(FLB_ENGINE_EV_STOP)
-#define FLB_ENGINE_SHUTDOWN     FLB_BITS_U64_LOW(FLB_ENGINE_EV_SHUTDOWN)
+#define FLB_ENGINE_STARTED         FLB_BITS_U64_LOW(FLB_ENGINE_EV_STARTED)
+#define FLB_ENGINE_FAILED          FLB_BITS_U64_LOW(FLB_ENGINE_EV_FAILED)
+#define FLB_ENGINE_STOP            FLB_BITS_U64_LOW(FLB_ENGINE_EV_STOP)
+#define FLB_ENGINE_SHUTDOWN        FLB_BITS_U64_LOW(FLB_ENGINE_EV_SHUTDOWN)
+#define FLB_ENGINE_FLUSH_NOW       FLB_BITS_U64_LOW(FLB_ENGINE_EV_FLUSH_NOW)
+#define FLB_ENGINE_FLUSH_NOW_RETRY FLB_BITS_U64_LOW(FLB_ENGINE_EV_FLUSH_NOW_RETRY)
 
 /* Engine signals: Task, it only refer to the type */
 #define FLB_ENGINE_TASK         2

--- a/include/fluent-bit/flb_engine_macros.h
+++ b/include/fluent-bit/flb_engine_macros.h
@@ -42,16 +42,18 @@
 #define FLB_ENGINE_EV_NOTIFICATION  (1 << 19)                          /* 524288 */
 
 /* Engine events: all engine events set the left 32 bits to '1' */
-#define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started    */
-#define FLB_ENGINE_EV_FAILED    FLB_BITS_U64_SET(1, 2) /* Engine started    */
-#define FLB_ENGINE_EV_STOP      FLB_BITS_U64_SET(1, 3) /* Requested to stop */
-#define FLB_ENGINE_EV_SHUTDOWN  FLB_BITS_U64_SET(1, 4) /* Engine shutdown   */
+#define FLB_ENGINE_EV_STARTED   FLB_BITS_U64_SET(1, 1) /* Engine started          */
+#define FLB_ENGINE_EV_FAILED    FLB_BITS_U64_SET(1, 2) /* Engine started          */
+#define FLB_ENGINE_EV_STOP      FLB_BITS_U64_SET(1, 3) /* Requested to stop       */
+#define FLB_ENGINE_EV_SHUTDOWN  FLB_BITS_U64_SET(1, 4) /* Engine shutdown         */
+#define FLB_ENGINE_EV_FLUSH_NOW FLB_BITS_U64_SET(1, 5) /* On-demand flush request */
 
 /* Similar to engine events, but used as return values */
 #define FLB_ENGINE_STARTED      FLB_BITS_U64_LOW(FLB_ENGINE_EV_STARTED)
 #define FLB_ENGINE_FAILED       FLB_BITS_U64_LOW(FLB_ENGINE_EV_FAILED)
 #define FLB_ENGINE_STOP         FLB_BITS_U64_LOW(FLB_ENGINE_EV_STOP)
 #define FLB_ENGINE_SHUTDOWN     FLB_BITS_U64_LOW(FLB_ENGINE_EV_SHUTDOWN)
+#define FLB_ENGINE_FLUSH_NOW    FLB_BITS_U64_LOW(FLB_ENGINE_EV_FLUSH_NOW)
 
 /* Engine signals: Task, it only refer to the type */
 #define FLB_ENGINE_TASK         2

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include <monkey/mk_core.h>
+#include <cfl/cfl_atomic.h>
 #include <fluent-bit/flb_bucket_queue.h>
 #include <fluent-bit/flb_event_loop.h>
 #include <fluent-bit/flb_time.h>
@@ -676,6 +677,7 @@ static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
     uint32_t type;
     uint32_t key;
     uint64_t val;
+    uint64_t seq;
 
     /* read the event */
     bytes = flb_pipe_r(fd, &val, sizeof(val));
@@ -704,6 +706,20 @@ static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
             flb_trace("[engine] flush enqueued data");
             flb_engine_flush(config, NULL);
             return FLB_ENGINE_STOP;
+        }
+        else if (key == FLB_ENGINE_FLUSH_NOW ||
+                 key == FLB_ENGINE_FLUSH_NOW_RETRY) {
+            flb_trace("[engine] on-demand flush requested");
+            seq = cfl_atomic_load(&config->flush_now_count);
+
+            if (key == FLB_ENGINE_FLUSH_NOW_RETRY) {
+                flb_engine_reschedule_retries(config);
+            }
+
+            flb_input_chunk_ring_buffer_collector(config, NULL);
+            flb_engine_flush(config, NULL);
+            cfl_atomic_store(&config->flush_now_acked, seq);
+            return 0;
         }
     }
 
@@ -1417,6 +1433,18 @@ int flb_engine_exit(struct flb_config *config)
     uint64_t val;
 
     val = FLB_ENGINE_EV_STOP;
+    ret = flb_pipe_w(config->ch_manager[1], &val, sizeof(uint64_t));
+    return ret;
+}
+
+int flb_engine_flush_request(struct flb_config *config, int reschedule_retries)
+{
+    int ret;
+    uint64_t val;
+
+    val = reschedule_retries == FLB_TRUE ? FLB_ENGINE_EV_FLUSH_NOW_RETRY :
+                                           FLB_ENGINE_EV_FLUSH_NOW;
+
     ret = flb_pipe_w(config->ch_manager[1], &val, sizeof(uint64_t));
     return ret;
 }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -705,6 +705,13 @@ static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
             flb_engine_flush(config, NULL);
             return FLB_ENGINE_STOP;
         }
+        else if (key == FLB_ENGINE_FLUSH_NOW) {
+            flb_trace("[engine] on-demand flush requested");
+            flb_engine_reschedule_retries(config);
+            flb_engine_flush(config, NULL);
+            config->flush_now_count++;
+            return 0;
+        }
     }
 
     return 0;
@@ -1417,6 +1424,16 @@ int flb_engine_exit(struct flb_config *config)
     uint64_t val;
 
     val = FLB_ENGINE_EV_STOP;
+    ret = flb_pipe_w(config->ch_manager[1], &val, sizeof(uint64_t));
+    return ret;
+}
+
+int flb_engine_flush_request(struct flb_config *config)
+{
+    int ret;
+    uint64_t val;
+
+    val = FLB_ENGINE_EV_FLUSH_NOW;
     ret = flb_pipe_w(config->ch_manager[1], &val, sizeof(uint64_t));
     return ret;
 }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include <monkey/mk_core.h>
+#include <cfl/cfl_atomic.h>
 #include <fluent-bit/flb_bucket_queue.h>
 #include <fluent-bit/flb_event_loop.h>
 #include <fluent-bit/flb_time.h>
@@ -709,7 +710,8 @@ static inline int flb_engine_manager(flb_pipefd_t fd, struct flb_config *config)
             flb_trace("[engine] on-demand flush requested");
             flb_engine_reschedule_retries(config);
             flb_engine_flush(config, NULL);
-            config->flush_now_count++;
+            cfl_atomic_store(&config->flush_now_count,
+                             cfl_atomic_load(&config->flush_now_count) + 1);
             return 0;
         }
     }

--- a/src/http_server/api/v2/CMakeLists.txt
+++ b/src/http_server/api/v2/CMakeLists.txt
@@ -3,6 +3,7 @@ set(src
   health.c
   metrics.c
   reload.c
+  flush.c
   register.c
   )
 

--- a/src/http_server/api/v2/flush.c
+++ b/src/http_server/api/v2/flush.c
@@ -1,0 +1,200 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <string.h>
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/http_server/flb_hs_utils.h>
+#include <cfl/cfl_atomic.h>
+#include "flush.h"
+
+#include <fluent-bit/flb_http_server.h>
+
+/* Bounded wait for the engine thread to acknowledge a dispatched flush */
+#define FLB_HS_FLUSH_ACK_TIMEOUT_MS 2000
+
+static int wait_for_flush_ack(uint64_t *acked, uint64_t ticket, int timeout_ms)
+{
+    int waited_ms = 0;
+    const int interval_ms = 2;
+
+    while (cfl_atomic_load(acked) < ticket) {
+        if (waited_ms >= timeout_ms) {
+            return FLB_FALSE;
+        }
+        flb_time_msleep(interval_ms);
+        waited_ms += interval_ms;
+    }
+
+    return FLB_TRUE;
+}
+
+static int handle_flush_request(struct flb_http_request *request,
+                                struct flb_http_response *response,
+                                struct flb_config *config)
+{
+    int ret;
+    int acked;
+    int reschedule_retries;
+    uint64_t ticket;
+    flb_sds_t out_buf;
+    size_t out_size;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    int http_status;
+
+    reschedule_retries = request->query_string != NULL &&
+        strstr(request->query_string, "reschedule_retries=true") != NULL;
+
+    do {
+        ticket = cfl_atomic_load(&config->flush_now_count);
+    } while (cfl_atomic_compare_exchange(&config->flush_now_count,
+                                         ticket, ticket + 1) == 0);
+    ++ticket;
+
+    ret = flb_engine_flush_request(config, reschedule_retries);
+    if (ret == -1) {
+        flb_http_response_set_status(response, 500);
+        return flb_http_response_commit(response);
+    }
+
+    acked = wait_for_flush_ack(&config->flush_now_acked, ticket,
+                               FLB_HS_FLUSH_ACK_TIMEOUT_MS);
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&mp_pck, 3);
+    msgpack_pack_str(&mp_pck, 5);
+    msgpack_pack_str_body(&mp_pck, "flush", 5);
+
+    if (acked == FLB_TRUE) {
+        http_status = 200;
+        msgpack_pack_str(&mp_pck, 10);
+        msgpack_pack_str_body(&mp_pck, "dispatched", 10);
+    }
+    else {
+        /* dispatch was requested but not acknowledged within the timeout */
+        http_status = 503;
+        msgpack_pack_str(&mp_pck, 7);
+        msgpack_pack_str_body(&mp_pck, "timeout", 7);
+    }
+
+    msgpack_pack_str(&mp_pck, 16);
+    msgpack_pack_str_body(&mp_pck, "flush_now_ticket", 16);
+    msgpack_pack_uint64(&mp_pck, ticket);
+
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "flush_now_acked", 15);
+    msgpack_pack_uint64(&mp_pck, cfl_atomic_load(&config->flush_now_acked));
+
+    /* Export to JSON */
+    out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    if (!out_buf) {
+        flb_http_response_set_status(response, 500);
+        return flb_http_response_commit(response);
+    }
+    out_size = flb_sds_len(out_buf);
+
+    flb_hs_response_set_payload(response, http_status,
+                                FLB_HS_CONTENT_TYPE_JSON,
+                                out_buf, out_size);
+
+    flb_sds_destroy(out_buf);
+    return 0;
+}
+
+static int handle_get_flush_status(struct flb_http_response *response,
+                                   struct flb_config *config)
+{
+    flb_sds_t out_buf;
+    size_t out_size;
+    uint64_t acked;
+    uint64_t count;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* Ensures acked and count are coherent with one another */
+    do {
+        acked = cfl_atomic_load(&config->flush_now_acked);
+        count = cfl_atomic_load(&config->flush_now_count);
+    } while (acked != cfl_atomic_load(&config->flush_now_acked));
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&mp_pck, 2);
+
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "flush_now_count", 15);
+    msgpack_pack_uint64(&mp_pck, count);
+
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "flush_now_acked", 15);
+    msgpack_pack_uint64(&mp_pck, acked);
+
+    /* Export to JSON */
+    out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    if (!out_buf) {
+        flb_http_response_set_status(response, 500);
+        return flb_http_response_commit(response);
+    }
+    out_size = flb_sds_len(out_buf);
+
+    flb_hs_response_set_payload(response, 200,
+                                FLB_HS_CONTENT_TYPE_JSON,
+                                out_buf, out_size);
+
+    flb_sds_destroy(out_buf);
+    return 0;
+}
+
+static int cb_flush(struct flb_hs *hs,
+                    struct flb_http_request *request,
+                    struct flb_http_response *response)
+{
+    struct flb_config *config = hs->config;
+
+    if (request->method == HTTP_METHOD_POST ||
+        request->method == HTTP_METHOD_PUT) {
+        return handle_flush_request(request, response, config);
+    }
+    else if (request->method == HTTP_METHOD_GET) {
+        return handle_get_flush_status(response, config);
+    }
+
+    flb_http_response_set_status(response, 405);
+    flb_http_response_set_header(response, "Allow", 5, "GET, POST, PUT", 14);
+    return flb_http_response_commit(response);
+}
+
+/* Perform registration */
+int api_v2_flush(struct flb_hs *hs)
+{
+    return flb_hs_register_endpoint(hs, "/api/v2/flush",
+                                    FLB_HS_ROUTE_EXACT, cb_flush);
+}

--- a/src/http_server/api/v2/flush.c
+++ b/src/http_server/api/v2/flush.c
@@ -23,6 +23,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/http_server/flb_hs_utils.h>
+#include <cfl/cfl_atomic.h>
 #include "flush.h"
 
 #include <fluent-bit/flb_http_server.h>
@@ -30,13 +31,13 @@
 /* Bounded wait for the engine thread to acknowledge a dispatched flush */
 #define FLB_HS_FLUSH_ACK_TIMEOUT_MS 2000
 
-static int wait_for_flush_ack(unsigned int *counter, unsigned int baseline,
+static int wait_for_flush_ack(uint64_t *counter, uint64_t baseline,
                               int timeout_ms)
 {
     int waited_ms = 0;
     const int interval_ms = 2;
 
-    while (*counter == baseline) {
+    while (cfl_atomic_load(counter) == baseline) {
         if (waited_ms >= timeout_ms) {
             return FLB_FALSE;
         }
@@ -52,14 +53,14 @@ static int handle_flush_request(struct flb_http_response *response,
 {
     int ret;
     int acked;
-    unsigned int baseline;
+    uint64_t baseline;
     flb_sds_t out_buf;
     size_t out_size;
     msgpack_packer mp_pck;
     msgpack_sbuffer mp_sbuf;
     int http_status;
 
-    baseline = config->flush_now_count;
+    baseline = cfl_atomic_load(&config->flush_now_count);
 
     ret = flb_engine_flush_request(config);
     if (ret == -1) {
@@ -92,7 +93,7 @@ static int handle_flush_request(struct flb_http_response *response,
 
     msgpack_pack_str(&mp_pck, 15);
     msgpack_pack_str_body(&mp_pck, "flush_now_count", 15);
-    msgpack_pack_int64(&mp_pck, config->flush_now_count);
+    msgpack_pack_int64(&mp_pck, cfl_atomic_load(&config->flush_now_count));
 
     /* Export to JSON */
     out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);
@@ -126,7 +127,7 @@ static int handle_get_flush_status(struct flb_http_response *response,
     msgpack_pack_map(&mp_pck, 1);
     msgpack_pack_str(&mp_pck, 15);
     msgpack_pack_str_body(&mp_pck, "flush_now_count", 15);
-    msgpack_pack_int64(&mp_pck, config->flush_now_count);
+    msgpack_pack_int64(&mp_pck, cfl_atomic_load(&config->flush_now_count));
 
     /* Export to JSON */
     out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);

--- a/src/http_server/api/v2/flush.c
+++ b/src/http_server/api/v2/flush.c
@@ -1,0 +1,172 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/http_server/flb_hs_utils.h>
+#include "flush.h"
+
+#include <fluent-bit/flb_http_server.h>
+
+/* Bounded wait for the engine thread to acknowledge a dispatched flush */
+#define FLB_HS_FLUSH_ACK_TIMEOUT_MS 2000
+
+static int wait_for_flush_ack(unsigned int *counter, unsigned int baseline,
+                              int timeout_ms)
+{
+    int waited_ms = 0;
+    const int interval_ms = 2;
+
+    while (*counter == baseline) {
+        if (waited_ms >= timeout_ms) {
+            return FLB_FALSE;
+        }
+        flb_time_msleep(interval_ms);
+        waited_ms += interval_ms;
+    }
+
+    return FLB_TRUE;
+}
+
+static int handle_flush_request(struct flb_http_response *response,
+                                struct flb_config *config)
+{
+    int ret;
+    int acked;
+    unsigned int baseline;
+    flb_sds_t out_buf;
+    size_t out_size;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+    int http_status;
+
+    baseline = config->flush_now_count;
+
+    ret = flb_engine_flush_request(config);
+    if (ret == -1) {
+        flb_http_response_set_status(response, 500);
+        return flb_http_response_commit(response);
+    }
+
+    acked = wait_for_flush_ack(&config->flush_now_count, baseline,
+                               FLB_HS_FLUSH_ACK_TIMEOUT_MS);
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&mp_pck, 2);
+    msgpack_pack_str(&mp_pck, 5);
+    msgpack_pack_str_body(&mp_pck, "flush", 5);
+
+    if (acked == FLB_TRUE) {
+        http_status = 200;
+        msgpack_pack_str(&mp_pck, 4);
+        msgpack_pack_str_body(&mp_pck, "done", 4);
+    }
+    else {
+        /* dispatch was requested but not acknowledged within the timeout */
+        http_status = 503;
+        msgpack_pack_str(&mp_pck, 7);
+        msgpack_pack_str_body(&mp_pck, "timeout", 7);
+    }
+
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "flush_now_count", 15);
+    msgpack_pack_int64(&mp_pck, config->flush_now_count);
+
+    /* Export to JSON */
+    out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    if (!out_buf) {
+        flb_http_response_set_status(response, 500);
+        return flb_http_response_commit(response);
+    }
+    out_size = flb_sds_len(out_buf);
+
+    flb_hs_response_set_payload(response, http_status,
+                                FLB_HS_CONTENT_TYPE_JSON,
+                                out_buf, out_size);
+
+    flb_sds_destroy(out_buf);
+    return 0;
+}
+
+static int handle_get_flush_status(struct flb_http_response *response,
+                                   struct flb_config *config)
+{
+    flb_sds_t out_buf;
+    size_t out_size;
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* initialize buffers */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&mp_pck, 1);
+    msgpack_pack_str(&mp_pck, 15);
+    msgpack_pack_str_body(&mp_pck, "flush_now_count", 15);
+    msgpack_pack_int64(&mp_pck, config->flush_now_count);
+
+    /* Export to JSON */
+    out_buf = flb_msgpack_raw_to_json_sds(mp_sbuf.data, mp_sbuf.size, FLB_TRUE);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+    if (!out_buf) {
+        flb_http_response_set_status(response, 500);
+        return flb_http_response_commit(response);
+    }
+    out_size = flb_sds_len(out_buf);
+
+    flb_hs_response_set_payload(response, 200,
+                                FLB_HS_CONTENT_TYPE_JSON,
+                                out_buf, out_size);
+
+    flb_sds_destroy(out_buf);
+    return 0;
+}
+
+static int cb_flush(struct flb_hs *hs,
+                    struct flb_http_request *request,
+                    struct flb_http_response *response)
+{
+    struct flb_config *config = hs->config;
+
+    if (request->method == HTTP_METHOD_POST ||
+        request->method == HTTP_METHOD_PUT) {
+        return handle_flush_request(response, config);
+    }
+    else if (request->method == HTTP_METHOD_GET) {
+        return handle_get_flush_status(response, config);
+    }
+
+    flb_http_response_set_status(response, 405);
+    flb_http_response_set_header(response, "Allow", 5, "GET, POST, PUT", 14);
+    return flb_http_response_commit(response);
+}
+
+/* Perform registration */
+int api_v2_flush(struct flb_hs *hs)
+{
+    return flb_hs_register_endpoint(hs, "/api/v2/flush",
+                                    FLB_HS_ROUTE_EXACT, cb_flush);
+}

--- a/src/http_server/api/v2/flush.h
+++ b/src/http_server/api/v2/flush.h
@@ -17,37 +17,12 @@
  *  limitations under the License.
  */
 
+#ifndef FLB_HS_API_V2_FLUSH_H
+#define FLB_HS_API_V2_FLUSH_H
+
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_http_server.h>
 
-#include "health.h"
-#include "metrics.h"
-#include "reload.h"
-#include "flush.h"
+int api_v2_flush(struct flb_hs *hs);
 
-int api_v2_registration(struct flb_hs *hs)
-{
-    int ret;
-
-    ret = api_v2_reload(hs);
-    if (ret != 0) {
-        return ret;
-    }
-
-    ret = api_v2_metrics(hs);
-    if (ret != 0) {
-        return ret;
-    }
-
-    ret = api_v2_health(hs);
-    if (ret != 0) {
-        return ret;
-    }
-
-    ret = api_v2_flush(hs);
-    if (ret != 0) {
-        return ret;
-    }
-
-    return 0;
-}
+#endif

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -32,7 +32,9 @@ if(NOT FLB_SYSTEM_WINDOWS)
   FLB_RT_CORE_TEST(FLB_CORE_SHUTDOWN_SPIN   "core_shutdown_spin.c")
 endif()
 FLB_RT_CORE_TEST(1 "http_client_chunked.c")
-FLB_RT_CORE_TEST(1 "core_engine_flush_now.c")
+if(FLB_IN_LIB AND FLB_OUT_LIB)
+  FLB_RT_TEST(1 "core_engine_flush_now.c")
+endif()
 
 FLB_RT_TEST(FLB_CHUNK_TRACE "core_chunk_trace.c")
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -32,6 +32,7 @@ if(NOT FLB_SYSTEM_WINDOWS)
   FLB_RT_CORE_TEST(FLB_CORE_SHUTDOWN_SPIN   "core_shutdown_spin.c")
 endif()
 FLB_RT_CORE_TEST(1 "http_client_chunked.c")
+FLB_RT_CORE_TEST(1 "core_engine_flush_now.c")
 
 FLB_RT_TEST(FLB_CHUNK_TRACE "core_chunk_trace.c")
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -32,6 +32,9 @@ if(NOT FLB_SYSTEM_WINDOWS)
   FLB_RT_CORE_TEST(FLB_CORE_SHUTDOWN_SPIN   "core_shutdown_spin.c")
 endif()
 FLB_RT_CORE_TEST(1 "http_client_chunked.c")
+if(FLB_IN_LIB AND FLB_OUT_LIB)
+  FLB_RT_TEST(1 "core_engine_flush_now.c")
+endif()
 
 FLB_RT_TEST(FLB_CHUNK_TRACE "core_chunk_trace.c")
 
@@ -396,6 +399,7 @@ endfunction()
 # Most runtime tests can run concurrently under `ctest -j`.
 # Only serialize executables that bind the same well-known port.
 flb_runtime_lock_tests("runtime-port-2020"
+  flb-rt-core_engine_flush_now
   flb-rt-core_internal_logger
   flb-rt-filter_wasm)
 

--- a/tests/runtime/core_engine_flush_now.c
+++ b/tests/runtime/core_engine_flush_now.c
@@ -1,0 +1,900 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_http_client.h>
+#include <fluent-bit/flb_sds.h>
+#include <fluent-bit/flb_time.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "flb_tests_runtime.h"
+
+/*
+ * Long enough that the periodic flush timer cannot plausibly fire during
+ * the test window, so a record only arrives if an on-demand flush actually
+ * dispatched it.
+ */
+#define TEST_FLUSH_INTERVAL_SEC "60"
+#define TEST_WAIT_TIMEOUT_MS    3000
+#define TEST_HTTP_HOST          "127.0.0.1"
+#define TEST_HTTP_PORT          2020
+#define TEST_HTTP_PORT_STR      "2020"
+#define TEST_HTTP_READY_TRIES   30
+#define TEST_CONCURRENT_CLIENTS 5
+
+/* Must exceed the endpoint's 2000ms acknowledgement timeout */
+#define TEST_SLOW_OUTPUT_MS     3000
+#define TEST_RECOVERY_TRIES     60
+
+static pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int result_count = 0;
+
+static int get_result_count(void)
+{
+    int ret;
+
+    pthread_mutex_lock(&result_mutex);
+    ret = result_count;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void reset_result_count(void)
+{
+    pthread_mutex_lock(&result_mutex);
+    result_count = 0;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static void inc_result_count(void)
+{
+    pthread_mutex_lock(&result_mutex);
+    result_count++;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static int cb_count_record(void *record, size_t size, void *data)
+{
+    (void) size;
+    (void) data;
+
+    inc_result_count();
+    flb_free(record);
+    return 0;
+}
+
+/*
+ * The lib output declares no workers, so it runs as a coroutine on the engine
+ * thread: stalling here stalls the whole engine, which is what lets this
+ * exercise a slow output and the acknowledgement timeout.
+ */
+static int slow_output_armed = FLB_FALSE;
+
+static int cb_slow_record(void *record, size_t size, void *data)
+{
+    (void) size;
+    (void) data;
+
+    if (slow_output_armed == FLB_TRUE) {
+        slow_output_armed = FLB_FALSE;
+        flb_time_msleep(TEST_SLOW_OUTPUT_MS);
+    }
+
+    inc_result_count();
+    flb_free(record);
+    return 0;
+}
+
+static void wait_for_result(uint32_t timeout_ms, int expected, int *count)
+{
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_ms;
+
+    flb_time_get(&start_time);
+
+    while (true) {
+        *count = get_result_count();
+        if (*count >= expected) {
+            return;
+        }
+
+        flb_time_msleep(20);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+
+        if (elapsed_ms > timeout_ms) {
+            return;
+        }
+    }
+}
+
+struct http_client_ctx {
+    struct flb_upstream *u;
+    struct flb_connection *u_conn;
+    struct flb_config *config;
+    struct mk_event_loop *evl;
+};
+
+static struct http_client_ctx *http_client_ctx_create(void)
+{
+    struct http_client_ctx *ret_ctx;
+    struct mk_event_loop *evl;
+
+    ret_ctx = flb_calloc(1, sizeof(struct http_client_ctx));
+    if (ret_ctx == NULL) {
+        return NULL;
+    }
+
+    evl = mk_event_loop_create(16);
+    if (evl == NULL) {
+        flb_free(ret_ctx);
+        return NULL;
+    }
+    ret_ctx->evl = evl;
+    flb_engine_evl_init();
+    flb_engine_evl_set(evl);
+
+    ret_ctx->config = flb_config_init();
+    if (ret_ctx->config == NULL) {
+        mk_event_loop_destroy(evl);
+        flb_free(ret_ctx);
+        return NULL;
+    }
+
+    ret_ctx->u = flb_upstream_create(ret_ctx->config, TEST_HTTP_HOST,
+                                     TEST_HTTP_PORT, 0, NULL);
+    if (ret_ctx->u == NULL) {
+        flb_config_exit(ret_ctx->config);
+        mk_event_loop_destroy(evl);
+        flb_free(ret_ctx);
+        return NULL;
+    }
+
+    ret_ctx->u_conn = flb_upstream_conn_get(ret_ctx->u);
+    if (ret_ctx->u_conn == NULL) {
+        flb_upstream_destroy(ret_ctx->u);
+        flb_config_exit(ret_ctx->config);
+        mk_event_loop_destroy(evl);
+        flb_free(ret_ctx);
+        return NULL;
+    }
+
+    ret_ctx->u_conn->upstream = ret_ctx->u;
+
+    return ret_ctx;
+}
+
+static void http_client_ctx_destroy(struct http_client_ctx *http_ctx)
+{
+    flb_upstream_conn_release(http_ctx->u_conn);
+    flb_upstream_destroy(http_ctx->u);
+    mk_event_loop_destroy(http_ctx->evl);
+    flb_config_exit(http_ctx->config);
+    flb_free(http_ctx);
+}
+
+static int http_request(struct http_client_ctx *http_ctx, int method,
+                        const char *uri, int *status, flb_sds_t *payload)
+{
+    struct flb_http_client *http_client;
+    size_t b_sent;
+
+    if (payload != NULL) {
+        *payload = NULL;
+    }
+
+    http_client = flb_http_client(http_ctx->u_conn, method, uri, "", 0,
+                                  TEST_HTTP_HOST, TEST_HTTP_PORT, NULL, 0);
+    if (http_client == NULL) {
+        return -1;
+    }
+
+    if (flb_http_do(http_client, &b_sent) != 0) {
+        flb_http_client_destroy(http_client);
+        return -1;
+    }
+
+    *status = http_client->resp.status;
+
+    if (payload != NULL && http_client->resp.payload != NULL &&
+        http_client->resp.payload_size > 0) {
+        *payload = flb_sds_create_len(http_client->resp.payload,
+                                      http_client->resp.payload_size);
+    }
+
+    flb_http_client_destroy(http_client);
+    return 0;
+}
+
+static int parse_counter(const char *payload, const char *key, uint64_t *out)
+{
+    const char *p;
+
+    p = strstr(payload, key);
+    if (p == NULL) {
+        return -1;
+    }
+
+    p = strchr(p, ':');
+    if (p == NULL) {
+        return -1;
+    }
+
+    if (sscanf(p + 1, "%" SCNu64, out) != 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int read_counters(struct http_client_ctx *http_ctx, uint64_t *count,
+                         uint64_t *acked)
+{
+    flb_sds_t payload = NULL;
+    int status = 0;
+    int ret = -1;
+
+    if (http_request(http_ctx, FLB_HTTP_GET, "/api/v2/flush",
+                     &status, &payload) != 0 || status != 200) {
+        if (payload != NULL) {
+            flb_sds_destroy(payload);
+        }
+        return -1;
+    }
+
+    if (payload != NULL) {
+        if (parse_counter(payload, "flush_now_count", count) == 0 &&
+            parse_counter(payload, "flush_now_acked", acked) == 0) {
+            ret = 0;
+        }
+        flb_sds_destroy(payload);
+    }
+
+    return ret;
+}
+
+static flb_ctx_t *flush_test_start(int *in_ffd, struct flb_lib_out_cb *cb_data)
+{
+    flb_ctx_t *ctx;
+    int out_ffd;
+
+    reset_result_count();
+
+    ctx = flb_create();
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    if (flb_service_set(ctx,
+                        "Flush",       TEST_FLUSH_INTERVAL_SEC,
+                        "Grace",       "1",
+                        "Log_Level",   "error",
+                        "HTTP_Server", "On",
+                        "HTTP_Listen", TEST_HTTP_HOST,
+                        "HTTP_Port",   TEST_HTTP_PORT_STR,
+                        NULL) != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    *in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    if (*in_ffd < 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    cb_data->cb = cb_count_record;
+    cb_data->data = NULL;
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) cb_data);
+    if (out_ffd < 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    if (flb_output_set(ctx, out_ffd, "match", "*", NULL) != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    if (flb_start(ctx) != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+static struct http_client_ctx *wait_for_http_server(void)
+{
+    struct http_client_ctx *http_ctx;
+    flb_sds_t payload;
+    int status;
+    int i;
+
+    for (i = 0; i < TEST_HTTP_READY_TRIES; i++) {
+        http_ctx = http_client_ctx_create();
+        if (http_ctx != NULL) {
+            if (http_request(http_ctx, FLB_HTTP_GET, "/api/v2/flush",
+                             &status, &payload) == 0 && status == 200) {
+                if (payload != NULL) {
+                    flb_sds_destroy(payload);
+                }
+                return http_ctx;
+            }
+            if (payload != NULL) {
+                flb_sds_destroy(payload);
+            }
+            http_client_ctx_destroy(http_ctx);
+        }
+        flb_time_msleep(100);
+    }
+
+    return NULL;
+}
+
+/*
+ * flb_engine_flush_request() must dispatch a buffered record immediately,
+ * without waiting for the (deliberately very long) periodic flush timer.
+ */
+void flb_test_flush_now_dispatches_immediately(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    int in_ffd;
+    int out_ffd;
+    int ret;
+    int count = 0;
+    char *input_json = "[1, {\"msg\": \"flush now test\"}]";
+
+    reset_result_count();
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    TEST_CHECK(flb_service_set(ctx,
+                               "Flush",     TEST_FLUSH_INTERVAL_SEC,
+                               "Grace",     "1",
+                               "Log_Level", "error",
+                               NULL) == 0);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    cb_data.cb = cb_count_record;
+    cb_data.data = NULL;
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "*", NULL) == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret == 0, "starting engine");
+
+    ret = flb_lib_push(ctx, in_ffd, input_json, strlen(input_json));
+    TEST_CHECK_(ret >= 0, "pushing record");
+
+    TEST_CHECK(flb_engine_flush_request(ctx->config, FLB_FALSE) >= 0);
+
+    wait_for_result(TEST_WAIT_TIMEOUT_MS, 1, &count);
+    TEST_CHECK_(count > 0,
+               "expected the record to arrive within %dms via on-demand "
+               "flush (flush interval is %ss); got count=%d",
+               TEST_WAIT_TIMEOUT_MS, TEST_FLUSH_INTERVAL_SEC, count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * POST /api/v2/flush must dispatch every buffered chunk and report the
+ * request as dispatched.
+ */
+void flb_test_flush_now_http_dispatches(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    struct http_client_ctx *http_ctx;
+    flb_sds_t payload = NULL;
+    int in_ffd = -1;
+    int status = 0;
+    int count = 0;
+    int i;
+    uint64_t acked = 0;
+    uint64_t ticket = 0;
+    char input_json[64];
+
+    ctx = flush_test_start(&in_ffd, &cb_data);
+    TEST_CHECK_(ctx != NULL, "starting engine with HTTP server");
+    if (ctx == NULL) {
+        return;
+    }
+
+    http_ctx = wait_for_http_server();
+    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
+    if (http_ctx == NULL) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    for (i = 0; i < 4; i++) {
+        snprintf(input_json, sizeof(input_json) - 1,
+                 "[1, {\"msg\": \"chunk %d\"}]", i);
+        TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
+                                strlen(input_json)) >= 0);
+    }
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                            &status, &payload) == 0);
+    TEST_CHECK_(status == 200, "expected 200, got %d", status);
+    TEST_CHECK(payload != NULL);
+
+    if (payload != NULL) {
+        TEST_CHECK_(strstr(payload, "dispatched") != NULL,
+                    "expected a dispatched response, got: %s", payload);
+        TEST_CHECK(parse_counter(payload, "flush_now_ticket", &ticket) == 0);
+        TEST_CHECK_(ticket == 1, "expected ticket 1, got %" PRIu64, ticket);
+        TEST_CHECK(parse_counter(payload, "flush_now_acked", &acked) == 0);
+        TEST_CHECK_(acked >= ticket,
+                    "acked (%" PRIu64 ") must cover the ticket (%" PRIu64 ")",
+                    acked, ticket);
+        flb_sds_destroy(payload);
+    }
+
+    wait_for_result(TEST_WAIT_TIMEOUT_MS, 4, &count);
+    TEST_CHECK_(count >= 4,
+                "expected 4 records dispatched via HTTP flush, got %d", count);
+
+    http_client_ctx_destroy(http_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* GET must report the counters without triggering a flush. */
+void flb_test_flush_now_http_get_status(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    struct http_client_ctx *http_ctx;
+    flb_sds_t payload = NULL;
+    int in_ffd = -1;
+    int status = 0;
+    int count = 0;
+    uint64_t requested = 0;
+    char *input_json = "[1, {\"msg\": \"not flushed\"}]";
+
+    ctx = flush_test_start(&in_ffd, &cb_data);
+    TEST_CHECK_(ctx != NULL, "starting engine with HTTP server");
+    if (ctx == NULL) {
+        return;
+    }
+
+    http_ctx = wait_for_http_server();
+    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
+    if (http_ctx == NULL) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
+                            strlen(input_json)) >= 0);
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_GET, "/api/v2/flush",
+                            &status, &payload) == 0);
+    TEST_CHECK_(status == 200, "expected 200, got %d", status);
+    TEST_CHECK(payload != NULL);
+
+    if (payload != NULL) {
+        TEST_CHECK(parse_counter(payload, "flush_now_count", &requested) == 0);
+        TEST_CHECK_(requested == 0,
+                    "GET must not request a flush, got flush_now_count=%"
+                    PRIu64, requested);
+        TEST_CHECK(strstr(payload, "flush_now_acked") != NULL);
+        flb_sds_destroy(payload);
+    }
+
+    flb_time_msleep(300);
+    count = get_result_count();
+    TEST_CHECK_(count == 0,
+                "GET must not dispatch records, got %d", count);
+
+    http_client_ctx_destroy(http_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Unsupported methods must be rejected. */
+void flb_test_flush_now_http_method_not_allowed(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    struct http_client_ctx *http_ctx;
+    int in_ffd = -1;
+    int status = 0;
+
+    ctx = flush_test_start(&in_ffd, &cb_data);
+    TEST_CHECK_(ctx != NULL, "starting engine with HTTP server");
+    if (ctx == NULL) {
+        return;
+    }
+
+    http_ctx = wait_for_http_server();
+    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
+    if (http_ctx == NULL) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_DELETE, "/api/v2/flush",
+                            &status, NULL) == 0);
+    TEST_CHECK_(status == 405, "expected 405, got %d", status);
+
+    http_client_ctx_destroy(http_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* The retry rescheduling opt-in must be accepted. */
+void flb_test_flush_now_http_reschedule_retries(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    struct http_client_ctx *http_ctx;
+    flb_sds_t payload = NULL;
+    int in_ffd = -1;
+    int status = 0;
+    int count = 0;
+    char *input_json = "[1, {\"msg\": \"retry opt-in\"}]";
+
+    ctx = flush_test_start(&in_ffd, &cb_data);
+    TEST_CHECK_(ctx != NULL, "starting engine with HTTP server");
+    if (ctx == NULL) {
+        return;
+    }
+
+    http_ctx = wait_for_http_server();
+    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
+    if (http_ctx == NULL) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
+                            strlen(input_json)) >= 0);
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST,
+                            "/api/v2/flush?reschedule_retries=true",
+                            &status, &payload) == 0);
+    TEST_CHECK_(status == 200, "expected 200, got %d", status);
+
+    if (payload != NULL) {
+        TEST_CHECK(strstr(payload, "dispatched") != NULL);
+        flb_sds_destroy(payload);
+    }
+
+    wait_for_result(TEST_WAIT_TIMEOUT_MS, 1, &count);
+    TEST_CHECK_(count >= 1, "expected the record to be dispatched, got %d",
+                count);
+
+    http_client_ctx_destroy(http_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+struct concurrent_worker {
+    pthread_t thread;
+    struct http_client_ctx *http_ctx;
+    int status;
+    int dispatched;
+    uint64_t ticket;
+    uint64_t acked;
+};
+
+static void *concurrent_flush_worker(void *arg)
+{
+    struct concurrent_worker *worker = (struct concurrent_worker *) arg;
+    flb_sds_t payload = NULL;
+
+    flb_engine_evl_init();
+    flb_engine_evl_set(worker->http_ctx->evl);
+
+    if (http_request(worker->http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                     &worker->status, &payload) == 0) {
+        if (worker->status == 200 && payload != NULL &&
+            strstr(payload, "dispatched") != NULL) {
+            worker->dispatched = FLB_TRUE;
+            parse_counter(payload, "flush_now_ticket", &worker->ticket);
+            parse_counter(payload, "flush_now_acked", &worker->acked);
+        }
+    }
+
+    if (payload != NULL) {
+        flb_sds_destroy(payload);
+    }
+
+    return NULL;
+}
+
+/*
+ * Concurrent requests must each be acknowledged by a flush that started
+ * after they were issued, never by one another.
+ */
+void flb_test_flush_now_http_concurrent(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    struct http_client_ctx *status_ctx;
+    struct concurrent_worker workers[TEST_CONCURRENT_CLIENTS];
+    flb_sds_t payload = NULL;
+    int in_ffd = -1;
+    int status = 0;
+    int started = 0;
+    int i;
+    int j;
+    uint64_t requested = 0;
+    uint64_t acked = 0;
+    char *input_json = "[1, {\"msg\": \"concurrent\"}]";
+
+    ctx = flush_test_start(&in_ffd, &cb_data);
+    TEST_CHECK_(ctx != NULL, "starting engine with HTTP server");
+    if (ctx == NULL) {
+        return;
+    }
+
+    status_ctx = wait_for_http_server();
+    TEST_CHECK_(status_ctx != NULL, "HTTP server did not become ready");
+    if (status_ctx == NULL) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
+                            strlen(input_json)) >= 0);
+
+    for (i = 0; i < TEST_CONCURRENT_CLIENTS; i++) {
+        workers[i].status = 0;
+        workers[i].dispatched = FLB_FALSE;
+        workers[i].ticket = 0;
+        workers[i].acked = 0;
+        workers[i].http_ctx = http_client_ctx_create();
+        TEST_CHECK(workers[i].http_ctx != NULL);
+        if (workers[i].http_ctx == NULL) {
+            break;
+        }
+        if (pthread_create(&workers[i].thread, NULL,
+                           concurrent_flush_worker, &workers[i]) != 0) {
+            http_client_ctx_destroy(workers[i].http_ctx);
+            workers[i].http_ctx = NULL;
+            break;
+        }
+        started++;
+    }
+
+    TEST_CHECK_(started == TEST_CONCURRENT_CLIENTS,
+                "expected %d workers, started %d", TEST_CONCURRENT_CLIENTS,
+                started);
+
+    for (i = 0; i < started; i++) {
+        pthread_join(workers[i].thread, NULL);
+    }
+
+    for (i = 0; i < started; i++) {
+        TEST_CHECK_(workers[i].status == 200,
+                    "worker %d expected 200, got %d", i, workers[i].status);
+        TEST_CHECK_(workers[i].dispatched == FLB_TRUE,
+                    "worker %d was not acknowledged as dispatched", i);
+        TEST_CHECK_(workers[i].ticket >= 1 &&
+                    workers[i].ticket <= (uint64_t) started,
+                    "worker %d got out of range ticket %" PRIu64,
+                    i, workers[i].ticket);
+        TEST_CHECK_(workers[i].acked >= workers[i].ticket,
+                    "worker %d acked (%" PRIu64 ") must cover its own ticket "
+                    "(%" PRIu64 ")", i, workers[i].acked, workers[i].ticket);
+
+        for (j = 0; j < i; j++) {
+            TEST_CHECK_(workers[i].ticket != workers[j].ticket,
+                        "workers %d and %d share ticket %" PRIu64,
+                        i, j, workers[i].ticket);
+        }
+    }
+
+    for (i = 0; i < started; i++) {
+        http_client_ctx_destroy(workers[i].http_ctx);
+    }
+
+    flb_engine_evl_init();
+    flb_engine_evl_set(status_ctx->evl);
+
+    TEST_CHECK(http_request(status_ctx, FLB_HTTP_GET, "/api/v2/flush",
+                            &status, &payload) == 0);
+    TEST_CHECK_(status == 200, "expected 200, got %d", status);
+
+    if (payload != NULL) {
+        TEST_CHECK(parse_counter(payload, "flush_now_count", &requested) == 0);
+        TEST_CHECK(parse_counter(payload, "flush_now_acked", &acked) == 0);
+
+        TEST_CHECK_(requested == (uint64_t) started,
+                    "expected %d requests recorded, got %" PRIu64,
+                    started, requested);
+        TEST_CHECK_(acked >= (uint64_t) started,
+                    "every acknowledged request must be covered by a flush: "
+                    "acked=%" PRIu64 " started=%d", acked, started);
+        flb_sds_destroy(payload);
+    }
+
+    http_client_ctx_destroy(status_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * A slow output stalls the engine past the acknowledgement timeout, so the
+ * request must report a timeout rather than block forever. The flush still
+ * completes afterwards, and the caller can discover that by polling until
+ * flush_now_acked catches up with the ticket it was given.
+ */
+void flb_test_flush_now_http_slow_output_timeout(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    struct http_client_ctx *http_ctx;
+    flb_sds_t payload = NULL;
+    int in_ffd;
+    int out_ffd;
+    int status = 0;
+    int count = 0;
+    int i;
+    uint64_t ticket = 0;
+    uint64_t acked = 0;
+    uint64_t requested = 0;
+    char *input_json = "[1, {\"msg\": \"slow output\"}]";
+
+    reset_result_count();
+    slow_output_armed = FLB_TRUE;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    TEST_CHECK(flb_service_set(ctx,
+                               "Flush",       TEST_FLUSH_INTERVAL_SEC,
+                               "Grace",       "1",
+                               "Log_Level",   "error",
+                               "HTTP_Server", "On",
+                               "HTTP_Listen", TEST_HTTP_HOST,
+                               "HTTP_Port",   TEST_HTTP_PORT_STR,
+                               NULL) == 0);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    cb_data.cb = cb_slow_record;
+    cb_data.data = NULL;
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "*", NULL) == 0);
+
+    TEST_CHECK(flb_start(ctx) == 0);
+
+    http_ctx = wait_for_http_server();
+    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
+    if (http_ctx == NULL) {
+        slow_output_armed = FLB_FALSE;
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
+                            strlen(input_json)) >= 0);
+
+    /*
+     * The first flush only dispatches: it returns before the output
+     * coroutine runs, which is the dispatch/delivery distinction.
+     */
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                            &status, &payload) == 0);
+    TEST_CHECK_(status == 200, "dispatch must not wait on the output, got %d",
+                status);
+    if (payload != NULL) {
+        flb_sds_destroy(payload);
+        payload = NULL;
+    }
+
+    /*
+     * The output is now stalling the engine thread, so this request cannot
+     * be acknowledged in time and must report a timeout.
+     */
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                            &status, &payload) == 0);
+
+    TEST_CHECK_(status == 503,
+                "a stalled engine must report a timeout, got %d", status);
+
+    if (payload != NULL) {
+        TEST_CHECK_(strstr(payload, "timeout") != NULL,
+                    "expected a timeout response, got: %s", payload);
+        TEST_CHECK(parse_counter(payload, "flush_now_ticket", &ticket) == 0);
+        TEST_CHECK_(ticket >= 1, "a timed out request still owns a ticket");
+        flb_sds_destroy(payload);
+        payload = NULL;
+    }
+
+    /*
+     * The request was not cancelled: once the engine is free the flush
+     * completes and the caller can observe it through its ticket.
+     */
+    for (i = 0; i < TEST_RECOVERY_TRIES; i++) {
+        if (read_counters(http_ctx, &requested, &acked) == 0 &&
+            acked >= ticket) {
+            break;
+        }
+        flb_time_msleep(100);
+    }
+
+    TEST_CHECK_(acked >= ticket,
+                "the timed out flush must still complete: acked=%" PRIu64
+                " ticket=%" PRIu64, acked, ticket);
+
+    wait_for_result(TEST_SLOW_OUTPUT_MS + TEST_WAIT_TIMEOUT_MS, 1, &count);
+    TEST_CHECK_(count >= 1,
+                "the record must survive a slow output, got %d", count);
+
+    /* The engine recovered, so a new request succeeds normally */
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                            &status, &payload) == 0);
+    TEST_CHECK_(status == 200, "engine must recover, got %d", status);
+
+    if (payload != NULL) {
+        TEST_CHECK(strstr(payload, "dispatched") != NULL);
+        flb_sds_destroy(payload);
+    }
+
+    slow_output_armed = FLB_FALSE;
+    http_client_ctx_destroy(http_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"flush_now_dispatches_immediately", flb_test_flush_now_dispatches_immediately},
+    {"flush_now_http_dispatches", flb_test_flush_now_http_dispatches},
+    {"flush_now_http_get_status", flb_test_flush_now_http_get_status},
+    {"flush_now_http_method_not_allowed", flb_test_flush_now_http_method_not_allowed},
+    {"flush_now_http_reschedule_retries", flb_test_flush_now_http_reschedule_retries},
+    {"flush_now_http_concurrent", flb_test_flush_now_http_concurrent},
+    {"flush_now_http_slow_output_timeout", flb_test_flush_now_http_slow_output_timeout},
+    {NULL, NULL}
+};

--- a/tests/runtime/core_engine_flush_now.c
+++ b/tests/runtime/core_engine_flush_now.c
@@ -47,6 +47,14 @@
 #define TEST_RECOVERY_TRIES     60
 #define TEST_STALL_TRIES        200
 
+/* Backoff far enough out that no retry can fire on its own during the test */
+#define TEST_SCHED_BASE_SEC     "30"
+#define TEST_SCHED_CAP_SEC      "120"
+#define TEST_DEAD_PORT_STR      "1"
+#define TEST_RETRY_TRIES        50
+#define TEST_HTTP_BUFFER_SIZE   (256 * 1024)
+#define TEST_BACKOFF_SETTLE_MS  1500
+
 static pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int result_count = 0;
 
@@ -215,6 +223,8 @@ static int http_request(struct http_client_ctx *http_ctx, int method,
     if (http_client == NULL) {
         return -1;
     }
+
+    flb_http_buffer_size(http_client, TEST_HTTP_BUFFER_SIZE);
 
     if (flb_http_do(http_client, &b_sent) != 0) {
         flb_http_client_destroy(http_client);
@@ -564,54 +574,6 @@ void flb_test_flush_now_http_method_not_allowed(void)
     flb_destroy(ctx);
 }
 
-/* The retry rescheduling opt-in must be accepted. */
-void flb_test_flush_now_http_reschedule_retries(void)
-{
-    flb_ctx_t *ctx;
-    struct flb_lib_out_cb cb_data;
-    struct http_client_ctx *http_ctx;
-    flb_sds_t payload = NULL;
-    int in_ffd = -1;
-    int status = 0;
-    int count = 0;
-    char *input_json = "[1, {\"msg\": \"retry opt-in\"}]";
-
-    ctx = flush_test_start(&in_ffd, &cb_data);
-    TEST_CHECK_(ctx != NULL, "starting engine with HTTP server");
-    if (ctx == NULL) {
-        return;
-    }
-
-    http_ctx = wait_for_http_server();
-    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
-    if (http_ctx == NULL) {
-        flb_stop(ctx);
-        flb_destroy(ctx);
-        return;
-    }
-
-    TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
-                            strlen(input_json)) >= 0);
-
-    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST,
-                            "/api/v2/flush?reschedule_retries=true",
-                            &status, &payload) == 0);
-    TEST_CHECK_(status == 200, "expected 200, got %d", status);
-
-    if (payload != NULL) {
-        TEST_CHECK(strstr(payload, "dispatched") != NULL);
-        flb_sds_destroy(payload);
-    }
-
-    wait_for_result(TEST_WAIT_TIMEOUT_MS, 1, &count);
-    TEST_CHECK_(count >= 1, "expected the record to be dispatched, got %d",
-                count);
-
-    http_client_ctx_destroy(http_ctx);
-    flb_stop(ctx);
-    flb_destroy(ctx);
-}
-
 struct concurrent_worker {
     pthread_t thread;
     struct http_client_ctx *http_ctx;
@@ -902,14 +864,161 @@ void flb_test_flush_now_http_slow_output_timeout(void)
     flb_destroy(ctx);
 }
 
+static int read_retries_total(struct http_client_ctx *http_ctx, uint64_t *out)
+{
+    flb_sds_t payload = NULL;
+    const char *p;
+    int status = 0;
+    int ret = -1;
+
+    if (http_request(http_ctx, FLB_HTTP_GET, "/api/v2/metrics/prometheus",
+                     &status, &payload) != 0 || status != 200) {
+        if (payload != NULL) {
+            flb_sds_destroy(payload);
+        }
+        return -1;
+    }
+
+    if (payload != NULL) {
+        p = strstr(payload, "fluentbit_output_retries_total{");
+        if (p != NULL) {
+            p = strchr(p, '}');
+            if (p != NULL && sscanf(p + 1, " %" SCNu64, out) == 1) {
+                ret = 0;
+            }
+        }
+        flb_sds_destroy(payload);
+    }
+
+    return ret;
+}
+
+/*
+ * A failing output leaves a chunk waiting on its backoff timer. The default
+ * flush must leave that timer alone, and only reschedule_retries=true may
+ * force the retry to happen now.
+ */
+void flb_test_flush_now_http_forces_retry(void)
+{
+    flb_ctx_t *ctx;
+    struct http_client_ctx *http_ctx;
+    int in_ffd;
+    int out_ffd;
+    int status = 0;
+    int ret;
+    int i;
+    uint64_t baseline = 0;
+    uint64_t retries = 0;
+    char *input_json = "[1, {\"msg\": \"retry probe\"}]";
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    TEST_CHECK(flb_service_set(ctx,
+                               "Flush",          TEST_FLUSH_INTERVAL_SEC,
+                               "Grace",          "1",
+                               "Log_Level",      "error",
+                               "scheduler.base", TEST_SCHED_BASE_SEC,
+                               "scheduler.cap",  TEST_SCHED_CAP_SEC,
+                               "HTTP_Server",    "On",
+                               "HTTP_Listen",    TEST_HTTP_HOST,
+                               "HTTP_Port",      TEST_HTTP_PORT_STR,
+                               NULL) == 0);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    out_ffd = flb_output(ctx, (char *) "http", NULL);
+    if (out_ffd < 0) {
+        TEST_MSG("out_http is not available, skipping");
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(flb_output_set(ctx, out_ffd,
+                              "match", "*",
+                              "host", TEST_HTTP_HOST,
+                              "port", TEST_DEAD_PORT_STR,
+                              "retry_limit", "20",
+                              NULL) == 0);
+
+    TEST_CHECK(flb_start(ctx) == 0);
+
+    http_ctx = wait_for_http_server();
+    TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
+    if (http_ctx == NULL) {
+        flb_stop(ctx);
+        flb_destroy(ctx);
+        return;
+    }
+
+    TEST_CHECK(flb_lib_push(ctx, in_ffd, input_json,
+                            strlen(input_json)) >= 0);
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                            &status, NULL) == 0);
+    TEST_CHECK_(status == 200, "initial flush expected 200, got %d", status);
+
+    ret = -1;
+    for (i = 0; i < TEST_RETRY_TRIES; i++) {
+        ret = read_retries_total(http_ctx, &baseline);
+        if (ret == 0 && baseline >= 1) {
+            break;
+        }
+        flb_time_msleep(100);
+    }
+
+    TEST_CHECK_(ret == 0, "could not read the retries metric");
+    TEST_CHECK_(baseline >= 1,
+                "the failing output should have scheduled a retry, got %"
+                PRIu64, baseline);
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST, "/api/v2/flush",
+                            &status, NULL) == 0);
+    TEST_CHECK_(status == 200, "default flush expected 200, got %d", status);
+    flb_time_msleep(TEST_BACKOFF_SETTLE_MS);
+
+    TEST_CHECK_(read_retries_total(http_ctx, &retries) == 0,
+                "could not read the retries metric");
+    TEST_CHECK_(retries == baseline,
+                "a default flush must leave the backoff intact: %" PRIu64
+                " -> %" PRIu64, baseline, retries);
+
+    TEST_CHECK(http_request(http_ctx, FLB_HTTP_POST,
+                            "/api/v2/flush?reschedule_retries=true",
+                            &status, NULL) == 0);
+    TEST_CHECK_(status == 200, "opt-in flush expected 200, got %d", status);
+
+    ret = -1;
+    for (i = 0; i < TEST_RETRY_TRIES; i++) {
+        ret = read_retries_total(http_ctx, &retries);
+        if (ret == 0 && retries > baseline) {
+            break;
+        }
+        flb_time_msleep(100);
+    }
+
+    TEST_CHECK_(ret == 0, "could not read the retries metric");
+    TEST_CHECK_(retries > baseline,
+                "reschedule_retries=true must force a retry now: %" PRIu64
+                " -> %" PRIu64, baseline, retries);
+
+    http_client_ctx_destroy(http_ctx);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"flush_now_dispatches_immediately", flb_test_flush_now_dispatches_immediately},
     {"flush_now_http_dispatches", flb_test_flush_now_http_dispatches},
     {"flush_now_http_get_status", flb_test_flush_now_http_get_status},
     {"flush_now_http_method_not_allowed", flb_test_flush_now_http_method_not_allowed},
-    {"flush_now_http_reschedule_retries", flb_test_flush_now_http_reschedule_retries},
     {"flush_now_http_concurrent", flb_test_flush_now_http_concurrent},
     {"flush_now_http_slow_output_timeout", flb_test_flush_now_http_slow_output_timeout},
+    {"flush_now_http_forces_retry", flb_test_flush_now_http_forces_retry},
     {NULL, NULL}
 };

--- a/tests/runtime/core_engine_flush_now.c
+++ b/tests/runtime/core_engine_flush_now.c
@@ -22,6 +22,7 @@
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_time.h>
+#include <cfl/cfl_atomic.h>
 #include <inttypes.h>
 #include <pthread.h>
 #include <string.h>
@@ -44,6 +45,7 @@
 /* Must exceed the endpoint's 2000ms acknowledgement timeout */
 #define TEST_SLOW_OUTPUT_MS     3000
 #define TEST_RECOVERY_TRIES     60
+#define TEST_STALL_TRIES        200
 
 static pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int result_count = 0;
@@ -88,15 +90,17 @@ static int cb_count_record(void *record, size_t size, void *data)
  * thread: stalling here stalls the whole engine, which is what lets this
  * exercise a slow output and the acknowledgement timeout.
  */
-static int slow_output_armed = FLB_FALSE;
+static uint64_t slow_output_armed = FLB_FALSE;
+static uint64_t slow_output_stalling = FLB_FALSE;
 
 static int cb_slow_record(void *record, size_t size, void *data)
 {
     (void) size;
     (void) data;
 
-    if (slow_output_armed == FLB_TRUE) {
-        slow_output_armed = FLB_FALSE;
+    if (cfl_atomic_compare_exchange(&slow_output_armed,
+                                    FLB_TRUE, FLB_FALSE) != 0) {
+        cfl_atomic_store(&slow_output_stalling, FLB_TRUE);
         flb_time_msleep(TEST_SLOW_OUTPUT_MS);
     }
 
@@ -778,7 +782,8 @@ void flb_test_flush_now_http_slow_output_timeout(void)
     char *input_json = "[1, {\"msg\": \"slow output\"}]";
 
     reset_result_count();
-    slow_output_armed = FLB_TRUE;
+    cfl_atomic_store(&slow_output_stalling, FLB_FALSE);
+    cfl_atomic_store(&slow_output_armed, FLB_TRUE);
 
     ctx = flb_create();
     TEST_CHECK(ctx != NULL);
@@ -810,7 +815,7 @@ void flb_test_flush_now_http_slow_output_timeout(void)
     http_ctx = wait_for_http_server();
     TEST_CHECK_(http_ctx != NULL, "HTTP server did not become ready");
     if (http_ctx == NULL) {
-        slow_output_armed = FLB_FALSE;
+        cfl_atomic_store(&slow_output_armed, FLB_FALSE);
         flb_stop(ctx);
         flb_destroy(ctx);
         return;
@@ -831,6 +836,16 @@ void flb_test_flush_now_http_slow_output_timeout(void)
         flb_sds_destroy(payload);
         payload = NULL;
     }
+
+    for (i = 0; i < TEST_STALL_TRIES; i++) {
+        if (cfl_atomic_load(&slow_output_stalling) == FLB_TRUE) {
+            break;
+        }
+        flb_time_msleep(10);
+    }
+
+    TEST_CHECK_(cfl_atomic_load(&slow_output_stalling) == FLB_TRUE,
+                "the slow output never entered its stall");
 
     /*
      * The output is now stalling the engine thread, so this request cannot
@@ -881,7 +896,7 @@ void flb_test_flush_now_http_slow_output_timeout(void)
         flb_sds_destroy(payload);
     }
 
-    slow_output_armed = FLB_FALSE;
+    cfl_atomic_store(&slow_output_armed, FLB_FALSE);
     http_client_ctx_destroy(http_ctx);
     flb_stop(ctx);
     flb_destroy(ctx);

--- a/tests/runtime/core_engine_flush_now.c
+++ b/tests/runtime/core_engine_flush_now.c
@@ -1,0 +1,147 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_time.h>
+#include <string.h>
+
+#include "flb_tests_runtime.h"
+
+/*
+ * Long enough that the periodic flush timer cannot plausibly fire during
+ * the test window, so a record only arrives if flb_engine_flush_request()
+ * actually dispatched it on demand.
+ */
+#define TEST_FLUSH_INTERVAL_SEC "60"
+#define TEST_WAIT_TIMEOUT_MS    3000
+
+static pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int result_count = 0;
+
+static int get_result_count(void)
+{
+    int ret;
+
+    pthread_mutex_lock(&result_mutex);
+    ret = result_count;
+    pthread_mutex_unlock(&result_mutex);
+
+    return ret;
+}
+
+static void inc_result_count(void)
+{
+    pthread_mutex_lock(&result_mutex);
+    result_count++;
+    pthread_mutex_unlock(&result_mutex);
+}
+
+static int cb_count_record(void *record, size_t size, void *data)
+{
+    (void) size;
+    (void) data;
+
+    inc_result_count();
+    flb_free(record);
+    return 0;
+}
+
+static void wait_for_result(uint32_t timeout_ms, int *count)
+{
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_ms;
+
+    flb_time_get(&start_time);
+
+    while (true) {
+        *count = get_result_count();
+        if (*count > 0) {
+            return;
+        }
+
+        flb_time_msleep(20);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_ms = flb_time_to_nanosec(&diff_time) / 1000000;
+
+        if (elapsed_ms > timeout_ms) {
+            return;
+        }
+    }
+}
+
+/*
+ * flb_engine_flush_request() must dispatch a buffered record immediately,
+ * without waiting for the (deliberately very long) periodic flush timer.
+ */
+void flb_test_flush_now_dispatches_immediately(void)
+{
+    flb_ctx_t *ctx;
+    struct flb_lib_out_cb cb_data;
+    int in_ffd;
+    int out_ffd;
+    int ret;
+    int count = 0;
+    char *input_json = "[1, {\"msg\": \"flush now test\"}]";
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    TEST_CHECK(flb_service_set(ctx,
+                               "Flush",     TEST_FLUSH_INTERVAL_SEC,
+                               "Grace",     "1",
+                               "Log_Level", "error",
+                               NULL) == 0);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+
+    cb_data.cb = cb_count_record;
+    cb_data.data = NULL;
+
+    out_ffd = flb_output(ctx, (char *) "lib", (void *) &cb_data);
+    TEST_CHECK(out_ffd >= 0);
+    TEST_CHECK(flb_output_set(ctx, out_ffd, "match", "*", NULL) == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK_(ret == 0, "starting engine");
+
+    ret = flb_lib_push(ctx, in_ffd, input_json, strlen(input_json));
+    TEST_CHECK_(ret >= 0, "pushing record");
+
+    TEST_CHECK(flb_engine_flush_request(ctx->config) >= 0);
+
+    wait_for_result(TEST_WAIT_TIMEOUT_MS, &count);
+    TEST_CHECK_(count > 0,
+               "expected the record to arrive within %dms via on-demand "
+               "flush (flush interval is %ss); got count=%d",
+               TEST_WAIT_TIMEOUT_MS, TEST_FLUSH_INTERVAL_SEC, count);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"flush_now_dispatches_immediately", flb_test_flush_now_dispatches_immediately},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds a `/api/v2/flush` route to the HTTP server to handle an on-demand flush request. This would be required for specific cases such as event-driven environments.

The route supports `POST` and `PUT` to initiate a flush, as well as `GET` to retrieve the number of flushes that have been issued so far. Currently an on-demand flush forces chunks in a backoff to be retried regardless of their timer. This may not be appropriate in every cases and could be addressed with a URL parameter if needed.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
This PR adds a feature in itself, but is a building block to make fluent-bit working with AWS Lambda extensions, as outlined in https://github.com/fluent/fluent-bit/issues/12191.

Following the configuration + valgrind run showcasing the feature:

```conf
[SERVICE]
    Flush         30
    Log_Level     info
    HTTP_Server   On
    HTTP_Listen   0.0.0.0
    HTTP_PORT     2020

[INPUT]
    Name    dummy
    Tag     test.dummy
    Dummy   {"message": "on-demand flush test"}
    Rate    1

[OUTPUT]
    Name    stdout
    Match   *
    Format  json_lines
```

```bash
$ docker build --target builder  -t flb-test-build .
[...]
$ docker run --rm -it -p 2020:2020 -v ./fb.conf:/fb.conf flb-test-build bash -c "(apt-get update && apt-get install -y valgrind)>/dev/null && valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes /fluent-bit/bin/fluent-bit -c /fb.conf"
==1== Memcheck, a memory error detector
==1== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==1== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==1== Command: /fluent-bit/bin/fluent-bit -c /fb.conf
==1== 
Fluent Bit v5.1.0
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/08/01 08:29:38.570] [ info] [fluent bit] version=5.1.0, commit=, pid=1
[2026/08/01 08:29:38.613] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/01 08:29:38.614] [ info] [simd    ] SSE2
[2026/08/01 08:29:38.614] [ info] [cmetrics] version=2.2.1
[2026/08/01 08:29:38.615] [ info] [ctraces ] version=0.7.1
[2026/08/01 08:29:38.631] [ info] [input:dummy:dummy.0] initializing
[2026/08/01 08:29:38.631] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/08/01 08:29:38.779] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/01 08:29:38.781] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
[2026/08/01 08:29:38.782] [ info] [sp] stream processor started
[2026/08/01 08:29:38.784] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
==1== Warning: client switching stacks?  SP change: 0x87fd558 --> 0x9038fc0
==1==          to suppress, use: --max-stackframe=8632936 or greater
==1== Warning: client switching stacks?  SP change: 0x9038f58 --> 0x87fd558
==1==          to suppress, use: --max-stackframe=8632832 or greater
==1== Warning: client switching stacks?  SP change: 0x87fd558 --> 0x9038f58
==1==          to suppress, use: --max-stackframe=8632832 or greater
==1==          further instances of this message will not be shown.
# First flush-now triggered
{"date":1785572979.422088,"message":"on-demand flush test"}
{"date":1785572980.409847,"message":"on-demand flush test"}
{"date":1785572981.409755,"message":"on-demand flush test"}
{"date":1785572982.409762,"message":"on-demand flush test"}
{"date":1785572983.421976,"message":"on-demand flush test"}
{"date":1785572984.409824,"message":"on-demand flush test"}
{"date":1785572985.409862,"message":"on-demand flush test"}
# Second flush-now triggered
{"date":1785572986.409839,"message":"on-demand flush test"}
{"date":1785572987.421188,"message":"on-demand flush test"}
{"date":1785572988.425044,"message":"on-demand flush test"}
{"date":1785572989.425176,"message":"on-demand flush test"}
{"date":1785572990.409848,"message":"on-demand flush test"}
{"date":1785572991.410025,"message":"on-demand flush test"}
{"date":1785572992.409828,"message":"on-demand flush test"}
{"date":1785572993.41025,"message":"on-demand flush test"}
# Regular flush from clock
{"date":1785572994.410283,"message":"on-demand flush test"}
{"date":1785572995.409827,"message":"on-demand flush test"}
{"date":1785572996.409802,"message":"on-demand flush test"}
{"date":1785572997.409989,"message":"on-demand flush test"}
{"date":1785572998.411321,"message":"on-demand flush test"}
{"date":1785572999.409794,"message":"on-demand flush test"}
{"date":1785573000.410043,"message":"on-demand flush test"}
{"date":1785573001.409791,"message":"on-demand flush test"}
{"date":1785573002.409835,"message":"on-demand flush test"}
{"date":1785573003.41133,"message":"on-demand flush test"}
{"date":1785573004.409793,"message":"on-demand flush test"}
{"date":1785573005.423899,"message":"on-demand flush test"}
{"date":1785573006.430092,"message":"on-demand flush test"}
{"date":1785573007.429388,"message":"on-demand flush test"}
^C[2026/08/01 08:30:11] [engine] caught signal (SIGINT)
{"date":1785573008.423449,"message":"on-demand flush test"}
{"date":1785573009.423997,"message":"on-demand flush test"}
{"date":1785573010.423483,"message":"on-demand flush test"}
[2026/08/01 08:30:11.151] [ warn] [engine] service will shutdown in max 5 seconds
[2026/08/01 08:30:11.153] [ info] [engine] pausing all inputs..
[2026/08/01 08:30:11.155] [ info] [input] pausing dummy.0
[2026/08/01 08:30:11.423] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/01 08:30:11.424] [ info] [input] pausing dummy.0
[2026/08/01 08:30:11.426] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/01 08:30:11.431] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==1== 
==1== HEAP SUMMARY:
==1==     in use at exit: 0 bytes in 0 blocks
==1==   total heap usage: 82,045 allocs, 82,045 frees, 11,884,906 bytes allocated
==1== 
==1== All heap blocks were freed -- no leaks are possible
==1== 
==1== For lists of detected and suppressed errors, rerun with: -s
==1== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
In another terminal issuing flush commands:
```bash
$ date -u && curl localhost:2020/api/v2/flush -d ''
Sat 01 Aug 2026 08:29:45 AM UTC
{"flush":"done","flush_now_count":1}
$ date -u && curl localhost:2020/api/v2/flush -d ''
Sat 01 Aug 2026 08:29:53 AM UTC
{"flush":"done","flush_now_count":2}
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->
https://github.com/fluent/fluent-bit-docs/pull/2642

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an HTTP API for triggering immediate flushes and checking flush status.
- Added a public engine API for requesting immediate flushes.
- POST and PUT support optional retry rescheduling and report completion status and flush counters.
- GET returns current flush ticket and acknowledgment counters.

## Bug Fixes
- Buffered records can now be dispatched without waiting for the scheduled interval.
- Added clear responses for timeouts, unsupported methods, and processing errors.

## Tests
- Added runtime coverage for immediate, concurrent, retry, and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->