### PR TITLE
build: run daemon-reload and restart service in deb postinst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1618,19 +1618,33 @@ if(DPKG_PROGRAM)
     ${PROJECT_SOURCE_DIR}/cpack/debian/conffiles
     )
 
+  set(LDCONFIG_POSTINST_CMDS "")
   if(FLB_RUN_LDCONFIG)
-    set(LDCONFIG_DIR ${FLB_INSTALL_LIBDIR})
-    file(WRITE ${PROJECT_BINARY_DIR}/scripts/postinst "
+    if(IS_ABSOLUTE "${FLB_INSTALL_LIBDIR}")
+      set(LDCONFIG_DIR "${FLB_INSTALL_LIBDIR}")
+    else()
+      set(LDCONFIG_DIR "/${FLB_INSTALL_LIBDIR}")
+    endif()
+    set(LDCONFIG_POSTINST_CMDS "
 mkdir -p /etc/ld.so.conf.d
 echo \"${LDCONFIG_DIR}\" > /etc/ld.so.conf.d/libfluent-bit.conf
 ldconfig
-    ")
-    file(WRITE ${PROJECT_BINARY_DIR}/scripts/prerm "
+")
+    file(WRITE ${PROJECT_BINARY_DIR}/scripts/prerm "#!/bin/sh
+set -e
 rm -f -- /etc/ld.so.conf.d/libfluent-bit.conf
 ldconfig
-    ")
-    set(CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst;${PROJECT_BINARY_DIR}/scripts/prerm")
+")
+    execute_process(COMMAND chmod 0755 "${PROJECT_BINARY_DIR}/scripts/prerm")
+    list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/prerm")
   endif(FLB_RUN_LDCONFIG)
+
+  configure_file(
+    ${PROJECT_SOURCE_DIR}/cpack/debian/postinst.in
+    ${PROJECT_BINARY_DIR}/scripts/postinst
+    @ONLY)
+  execute_process(COMMAND chmod 0755 "${PROJECT_BINARY_DIR}/scripts/postinst")
+  list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst")
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1635,7 +1635,11 @@ set -e
 rm -f -- /etc/ld.so.conf.d/libfluent-bit.conf
 ldconfig
 ")
-    execute_process(COMMAND chmod 0755 "${PROJECT_BINARY_DIR}/scripts/prerm")
+    execute_process(COMMAND chmod 0755 "${PROJECT_BINARY_DIR}/scripts/prerm"
+      RESULT_VARIABLE FLB_CHMOD_PRERM_RESULT)
+    if(NOT FLB_CHMOD_PRERM_RESULT EQUAL 0)
+      message(FATAL_ERROR "Failed to make ${PROJECT_BINARY_DIR}/scripts/prerm executable")
+    endif()
     list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/prerm")
   endif(FLB_RUN_LDCONFIG)
 
@@ -1643,7 +1647,11 @@ ldconfig
     ${PROJECT_SOURCE_DIR}/cpack/debian/postinst.in
     ${PROJECT_BINARY_DIR}/scripts/postinst
     @ONLY)
-  execute_process(COMMAND chmod 0755 "${PROJECT_BINARY_DIR}/scripts/postinst")
+  execute_process(COMMAND chmod 0755 "${PROJECT_BINARY_DIR}/scripts/postinst"
+    RESULT_VARIABLE FLB_CHMOD_POSTINST_RESULT)
+  if(NOT FLB_CHMOD_POSTINST_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to make ${PROJECT_BINARY_DIR}/scripts/postinst executable")
+  endif()
   list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_CONTROL_EXTRA "${PROJECT_BINARY_DIR}/scripts/postinst")
 
 endif()

--- a/cpack/debian/postinst.in
+++ b/cpack/debian/postinst.in
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+@LDCONFIG_POSTINST_CMDS@
+case "$1" in
+    configure)
+        ldconfig
+
+        if [ -z "${DPKG_ROOT:-}" ] && [ -d /run/systemd/system ]; then
+            systemctl --system daemon-reload >/dev/null || true
+
+            if [ -n "$2" ]; then
+                deb-systemd-invoke try-restart @FLB_OUT_NAME@.service >/dev/null || true
+            fi
+        fi
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
The Debian package never runs `systemctl daemon-reload` and never restarts the
service on upgrade, so after an `apt upgrade` the old binary keeps running until
someone restarts it by hand. Earlier attempts: #8330, #8341, #10844, #10899.
This continues #10899 and addresses its review feedback.

The package now ships a postinst (rendered from `cpack/debian/postinst.in`) that
runs `systemctl daemon-reload` and, only on upgrades, restarts the service with
`deb-systemd-invoke try-restart`. This is the same scheme debhelper generates
for packages that neither enable nor start their service: policy-rc.d is
honoured (Debian Policy 9.3.3), fresh installs do not autostart, and a manually
stopped service stays stopped. `deb-systemd-helper daemon-reload` / `invoke-rc.d
reload` from the #10899 review were not usable: the former is not a valid
deb-systemd-helper action, and reload cannot load a new binary (the unit has no
ExecReload and there is no init script).

Notes on the CMake side, based on what broke the earlier attempts:

- `conffiles` is kept (`list(APPEND)` instead of overwriting the control-extra list)
- the ldconfig call from the CPack auto-generated postinst is kept, since
  supplying a custom postinst suppresses it
- generated scripts get chmod 0755; `cmake -E chmod` used by #10899 does not
  exist, so its exec-bit fix silently did nothing
- fixed the `FLB_RUN_LDCONFIG` extras: prerm shebang and exec bit, and the
  ld.so.conf.d entry is now an absolute path

Tested with the bookworm package from `packaging/build.sh` in a systemd
container: fresh install does not start or enable the service; reinstall over a
running service restarts it (new MainPID, no pending daemon-reload); reinstall
over a stopped service leaves it stopped; upgrading from the official 5.0.9
package restarts into the new binary. In a plain docker build container the
restart is skipped via policy-rc.d and the install still succeeds. The control
archive is otherwise identical to the released package.

Fixes #9242

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
  (built and tested debian/bookworm locally; the full matrix did not run here)
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Debian package installation, upgrade, and removal handling.
  * Services are restarted appropriately during upgrades, with systemd reloaded when needed.
  * Library cache updates are handled more reliably through generated package scripts.
  * Package scripts now stop immediately when an operation encounters an error, helping prevent incomplete package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->