### PR TITLE
out_syslog: tls feature glitches for selecting protocols

### DIFF
--- a/plugins/out_syslog/syslog.c
+++ b/plugins/out_syslog/syslog.c
@@ -162,14 +162,14 @@ static int syslog_configure_tls_options(struct flb_output_instance *ins)
     return 0;
 }
 
-static int syslog_configure_dtls_context(struct flb_output_instance *ins)
+static int syslog_configure_tls_context(struct flb_output_instance *ins, int mode)
 {
     if (ins->tls != NULL) {
         flb_tls_destroy(ins->tls);
         ins->tls = NULL;
     }
 
-    ins->tls = flb_tls_create(FLB_TLS_CLIENT_MODE_DGRAM,
+    ins->tls = flb_tls_create(mode,
                               ins->tls_verify,
                               ins->tls_debug,
                               ins->tls_vhost,
@@ -1013,8 +1013,18 @@ static int cb_syslog_init(struct flb_output_instance *ins, struct flb_config *co
     }
     else {
 #ifdef FLB_HAVE_TLS
-        if (ctx->parsed_mode == FLB_SYSLOG_DTLS) {
-            ret = syslog_configure_dtls_context(ins);
+        if (ctx->parsed_mode == FLB_SYSLOG_TLS && ins->use_tls == FLB_FALSE) {
+            ins->use_tls = FLB_TRUE;
+            ret = syslog_configure_tls_context(ins, FLB_TLS_CLIENT_MODE);
+            if (ret != 0) {
+                flb_plg_error(ins, "could not initialize TLS context");
+                flb_syslog_config_destroy(ctx);
+                return -1;
+            }
+        }
+        else if (ctx->parsed_mode == FLB_SYSLOG_DTLS) {
+            ins->use_tls = FLB_TRUE;
+            ret = syslog_configure_tls_context(ins, FLB_TLS_CLIENT_MODE_DGRAM);
             if (ret != 0) {
                 flb_plg_error(ins, "could not initialize DTLS context");
                 flb_syslog_config_destroy(ctx);
@@ -1022,8 +1032,9 @@ static int cb_syslog_init(struct flb_output_instance *ins, struct flb_config *co
             }
         }
 #else
-        if (ctx->parsed_mode == FLB_SYSLOG_DTLS) {
-            flb_plg_error(ins, "could not initialize DTLS context");
+        if (ctx->parsed_mode == FLB_SYSLOG_TLS ||
+            ctx->parsed_mode == FLB_SYSLOG_DTLS) {
+            flb_plg_error(ins, "TLS support is unavailable");
             flb_syslog_config_destroy(ctx);
             return -1;
         }
@@ -1154,7 +1165,7 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "mode", "udp",
      0, FLB_TRUE, offsetof(struct flb_syslog, mode),
      "Set the desired transport type, the available options are udp, tcp, tls and dtls. "
-     "Use tls=on together with mode=dtls."
+     "Modes tls and dtls enable TLS automatically."
     },
 
     {

--- a/plugins/out_syslog/syslog_conf.c
+++ b/plugins/out_syslog/syslog_conf.c
@@ -117,13 +117,6 @@ struct flb_syslog *flb_syslog_config_create(struct flb_output_instance *ins,
         return NULL;
     }
 
-    if (ctx->parsed_mode == FLB_SYSLOG_DTLS && ins->use_tls == FLB_FALSE) {
-        flb_plg_error(ctx->ins,
-                      "invalid configuration: mode=dtls requires tls=on");
-        flb_syslog_config_destroy(ctx);
-        return NULL;
-    }
-
     /* syslog_format */
     tmp = flb_output_get_property("syslog_format", ins);
     if (tmp) {

--- a/tests/integration/scenarios/out_syslog/config/out_syslog_tls.yaml
+++ b/tests/integration/scenarios/out_syslog/config/out_syslog_tls.yaml
@@ -16,6 +16,6 @@ pipeline:
       match: out_syslog
       host: 127.0.0.1
       port: ${SYSLOG_RECEIVER_PORT}
-      mode: dtls
+      mode: tls
       tls.verify: off
       syslog_message_key: message

--- a/tests/integration/scenarios/out_syslog/tests/test_out_syslog_001.py
+++ b/tests/integration/scenarios/out_syslog/tests/test_out_syslog_001.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import socket
+import ssl
 import subprocess
 import threading
 import time
@@ -109,6 +110,45 @@ class TcpReceiver:
         return self.message
 
 
+class TlsReceiver(TcpReceiver):
+    def __init__(self, host, port, cert_file, key_file):
+        super().__init__(host, port)
+        self.cert_file = cert_file
+        self.key_file = key_file
+
+    def _run(self):
+        try:
+            tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            tls_context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+                server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                server.bind((self.host, self.port))
+                server.listen(1)
+                server.settimeout(120)
+                self._ready.set()
+                conn, _ = server.accept()
+
+                with tls_context.wrap_socket(conn, server_side=True) as tls_conn:
+                    tls_conn.settimeout(20)
+                    chunks = []
+
+                    while True:
+                        chunk = tls_conn.recv(4096)
+                        if not chunk:
+                            break
+                        chunks.append(chunk)
+                        if b"\n" in chunk:
+                            break
+
+                    self.message = b"".join(chunks)
+                    self._done.set()
+        except Exception as exc:
+            self.error = exc
+            self._ready.set()
+            self._done.set()
+
+
 class DtlsReceiver:
     def __init__(self, port, cert_file, key_file):
         self.port = port
@@ -204,6 +244,13 @@ class Service:
             self.receiver = UdpReceiver("127.0.0.1", self.receiver_port)
         elif self.receiver_type == "tcp":
             self.receiver = TcpReceiver("127.0.0.1", self.receiver_port)
+        elif self.receiver_type == "tls":
+            self.receiver = TlsReceiver(
+                "127.0.0.1",
+                self.receiver_port,
+                self.tls_crt_file,
+                self.tls_key_file,
+            )
         elif self.receiver_type == "dtls":
             self.receiver = DtlsReceiver(self.receiver_port, self.tls_crt_file, self.tls_key_file)
         else:
@@ -258,8 +305,20 @@ def test_out_syslog_tcp():
     _assert_syslog_payload(payload)
 
 
+def test_out_syslog_tls_auto_enable():
+    service = Service("out_syslog_tls.yaml", "tls")
+    service.start()
+
+    try:
+        payload = service.receiver.wait_message(timeout=20)
+    finally:
+        service.stop()
+
+    _assert_syslog_payload(payload)
+
+
 @pytest.mark.skipif(not shutil.which("openssl"), reason="openssl is required for DTLS test")
-def test_out_syslog_dtls():
+def test_out_syslog_dtls_auto_enable():
     service = Service("out_syslog_dtls.yaml", "dtls")
     service.start()
 

--- a/tests/runtime/out_syslog.c
+++ b/tests/runtime/out_syslog.c
@@ -23,6 +23,9 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_socket.h>
+#ifdef FLB_HAVE_TLS
+#include <fluent-bit/tls/flb_tls.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -1638,6 +1641,56 @@ void flb_test_udp_mode_rejects_tls()
     flb_free(ctx);
 }
 
+#ifdef FLB_HAVE_TLS
+static void test_secure_mode_enables_tls(const char *mode, int tls_mode)
+{
+    struct test_ctx *ctx;
+    struct flb_output_instance *ins;
+    int ret;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd,
+                         "match", "*",
+                         "mode", mode,
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        flb_destroy(ctx->flb);
+        flb_free(ctx);
+        return;
+    }
+
+    ins = flb_output_get_instance(ctx->flb->config, ctx->o_ffd);
+    TEST_CHECK(ins != NULL);
+    if (ins != NULL) {
+        TEST_CHECK(ins->use_tls == FLB_TRUE);
+        TEST_CHECK(ins->tls != NULL);
+        if (ins->tls != NULL) {
+            TEST_CHECK(ins->tls->mode == tls_mode);
+        }
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+void flb_test_tls_mode_enables_tls()
+{
+    test_secure_mode_enables_tls("tls", FLB_TLS_CLIENT_MODE);
+}
+
+void flb_test_dtls_mode_enables_tls()
+{
+    test_secure_mode_enables_tls("dtls", FLB_TLS_CLIENT_MODE_DGRAM);
+}
+#endif
+
 TEST_LIST = {
     /* rfc3164 */
     /* procid_key, msgid_key, sd_key are not supported */
@@ -1670,5 +1723,9 @@ TEST_LIST = {
     {"allow_longer_sd_id_rfc5424", flb_test_allow_longer_sd_id_rfc5424},
     {"malformed_longer_sd_id_rfc5424", flb_test_malformed_longer_sd_id_rfc5424},
     {"udp_mode_rejects_tls", flb_test_udp_mode_rejects_tls},
+#ifdef FLB_HAVE_TLS
+    {"tls_mode_enables_tls", flb_test_tls_mode_enables_tls},
+    {"dtls_mode_enables_tls", flb_test_dtls_mode_enables_tls},
+#endif
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

Implemented the syslog TLS validation and integration coverage.

- `mode=tls` automatically enables TLS over TCP.
- `mode=dtls` automatically enables DTLS over UDP.
- Plain `tcp`/`udp` remain unchanged.
- `mode=udp` with `tls on` remains rejected.

Coverage:

- Full syslog runtime test: passed.
- Syslog integration suite: 4/4 passed, including real TLS and DTLS mock receivers without `tls on`.
- Commit-prefix linter: passed.
- Valgrind unavailable on this macOS host.

The review’s commit-splitting requirement is addressed:

- `f32b9e05f` — implementation
- `9b35b8365` — runtime tests
- `ee6b8058e` — integration tests

No `AGENTS.md` change is needed.

The remote still has the previous three commits. Updating the PR requires a `--force-with-lease` push because the local history was rewritten; I have not pushed because force-pushing requires explicit authorization.

Closes https://github.com/fluent/fluent-bit/issues/12193.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS and DTLS syslog modes now automatically enable secure transport.
  * Added TLS syslog integration coverage, including certificate-based connection testing.

* **Bug Fixes**
  * DTLS configurations no longer require an explicit TLS setting.
  * Builds without TLS support now consistently reject both secure transport modes.

* **Tests**
  * Added runtime validation for TLS and DTLS mode behavior.
  * Updated integration scenarios to verify automatic secure transport enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->