### PR TITLE
tests: integration: cover kubernetes pod association isolation

### DIFF
--- a/tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py
+++ b/tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py
@@ -2,6 +2,7 @@ import contextlib
 import http.server
 import os
 import shlex
+import ssl
 import sys
 import threading
 
@@ -33,6 +34,47 @@ def _run_kube_api_server():
 
     try:
         yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+class _PodAssociationServer(http.server.ThreadingHTTPServer):
+    def __init__(self, server_address, handler_class):
+        super().__init__(server_address, handler_class)
+        self.request_count = 0
+        self.request_count_lock = threading.Lock()
+
+
+class _PodAssociationHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = b"{}"
+
+        with self.server.request_count_lock:
+            self.server.request_count += 1
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, fmt, *args):
+        return
+
+
+@contextlib.contextmanager
+def _run_pod_association_server(cert_file, key_file):
+    server = _PodAssociationServer(("127.0.0.1", 0), _PodAssociationHandler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_file, key_file)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield server
     finally:
         server.shutdown()
         server.server_close()
@@ -114,6 +156,59 @@ def _write_config(tmp_path, name, script_file, kube_api_port):
     return config_file
 
 
+def _write_pod_association_config(tmp_path, servers, cert_file, key_file):
+    config_lines = [
+        "[SERVICE]",
+        "    Flush 1",
+        "    Grace 1",
+        "    Log_Level info",
+        "    HTTP_Server On",
+        "    HTTP_Port ${FLUENT_BIT_HTTP_MONITORING_PORT}",
+        "",
+        "[INPUT]",
+        "    Name dummy",
+        "    Tag application.test",
+        "    Samples 1",
+        "",
+        "[INPUT]",
+        "    Name dummy",
+        "    Tag dataplane.test",
+        "    Samples 1",
+        "",
+    ]
+
+    for match, server in zip(("application.*", "dataplane.*"), servers):
+        config_lines.extend(
+            [
+                "[FILTER]",
+                "    Name kubernetes",
+                f"    Match {match}",
+                "    Dummy_Meta On",
+                "    Use_Pod_Association On",
+                "    AWS_Pod_Association_Host 127.0.0.1",
+                f"    AWS_Pod_Association_Port {server.server_address[1]}",
+                "    AWS_Pod_Service_Map_Refresh_Interval 1",
+                "    AWS_Pod_Association_Host_TLS_Verify Off",
+                f"    AWS_Pod_Association_Host_Server_CA_File {cert_file}",
+                f"    AWS_Pod_Association_Host_Client_Cert_File {cert_file}",
+                f"    AWS_Pod_Association_Host_Client_Key_File {key_file}",
+                "",
+            ]
+        )
+
+    config_lines.extend(
+        [
+            "[OUTPUT]",
+            "    Name null",
+            "    Match *",
+        ]
+    )
+
+    config_file = tmp_path / "pod_association_multiple_filters.conf"
+    config_file.write_text("\n".join(config_lines), encoding="utf-8")
+    return config_file
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="Kube_Token_Command test is Linux-only")
 def test_filter_kubernetes_token_command_accepts_multiline_output_over_8kb(tmp_path):
     script_file = _write_script(tmp_path, "token_large.py", 3000)
@@ -146,3 +241,31 @@ def test_filter_kubernetes_token_command_rejects_multiline_output_over_limit(tmp
 
     assert "failed to run command" in log_text
     assert "kube token command test" in log_text
+
+
+def test_filter_kubernetes_pod_association_is_independent_per_instance(tmp_path):
+    cert_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate")
+    )
+    cert_file = os.path.join(cert_dir, "certificate.pem")
+    key_file = os.path.join(cert_dir, "private_key.pem")
+
+    with _run_pod_association_server(cert_file, key_file) as application_server, \
+            _run_pod_association_server(cert_file, key_file) as dataplane_server:
+        servers = (application_server, dataplane_server)
+        config_file = _write_pod_association_config(
+            tmp_path, servers, cert_file, key_file
+        )
+        service = Service(str(config_file))
+        service.start()
+        try:
+            service.service.wait_for_condition(
+                lambda: all(server.request_count >= 2 for server in servers),
+                timeout=20,
+                interval=0.25,
+                description="two refreshes from each pod association filter",
+            )
+        finally:
+            service.stop()
+
+    assert all(server.request_count >= 2 for server in servers)


### PR DESCRIPTION
## Summary

Add focused Python integration coverage for Kubernetes pod association when two filter instances are configured.

Each filter targets an independent local TLS endpoint. The test requires both instances to complete repeated refresh cycles and verifies clean shutdown.

## Context

PR #12153 fixed the process-global pod-association thread, mutex, event loop, and context state that allowed multiple Kubernetes filter instances to overwrite and concurrently destroy shared state.

This follow-up protects that per-instance ownership and lifecycle behavior from regression.

Refs #12152
Follow-up to #12153

## Verification

- `make -j 8`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py::test_filter_kubernetes_pod_association_is_independent_per_instance -q`
  - 1 passed
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py::test_filter_kubernetes_pod_association_is_independent_per_instance -q`
  - 1 passed
  - 0 errors, 0 leaks
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py -q`
  - 3 passed
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`
  - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for Kubernetes filters using secure mutual TLS connections.
  * Verified that multiple filters independently refresh their associated pod endpoints.
  * Added synchronized request tracking to confirm repeated refresh behavior across separate filter configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->