### PR TITLE
avro: out_kakfa: handle empty map even if avro schema defines map type [Backport to 4.2]

### DIFF
--- a/src/flb_avro.c
+++ b/src/flb_avro.c
@@ -103,6 +103,9 @@ avro_value_iface_t  *flb_avro_init(avro_value_t *aobject, char *json, size_t jso
 int msgpack2avro(avro_value_t *val, msgpack_object *o)
 {
     int ret = FLB_FALSE;
+    size_t record_size = 0;
+    avro_type_t type;
+
     flb_debug("in msgpack2avro\n");
 
     assert(val != NULL);
@@ -200,7 +203,19 @@ int msgpack2avro(avro_value_t *val, msgpack_object *o)
 
     case MSGPACK_OBJECT_MAP:
         flb_debug("got a map\n");
-        if(o->via.map.size != 0) {
+        if (o->via.map.size == 0) {
+            type = avro_value_get_type(val);
+
+            if (type == AVRO_MAP) {
+                ret = FLB_TRUE;
+            }
+            else if (type == AVRO_RECORD) {
+                if (avro_value_get_size(val, &record_size) == 0 && record_size == 0) {
+                    ret = FLB_TRUE;
+                }
+            }
+        }
+        else {
             msgpack_object_kv* p = o->via.map.ptr;
             msgpack_object_kv* const pend = o->via.map.ptr + o->via.map.size;
             for(; p < pend; ++p) {

--- a/tests/internal/avro.c
+++ b/tests/internal/avro.c
@@ -297,6 +297,123 @@ const char JSON_INT_MULTI_FIELD_SCHEMA[] =
 "{\"name\":\"bad\",\"type\":\"int\"},"
 "{\"name\":\"last\",\"type\":\"string\"}]}";
 
+const char JSON_EMPTY_MAP_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"EmptyMapRecord\","
+"\"fields\":["
+"{\"name\":\"ID\",\"type\":\"string\"},"
+"{\"name\":\"HTTPHeader\",\"type\":{\"type\":\"map\",\"values\":\"string\"}}]}";
+
+const char JSON_EMPTY_RECORD_SCHEMA[] =
+"{\"type\":\"record\","
+"\"name\":\"EmptyRecord\","
+"\"fields\":[]}";
+
+const char JSON_STRING_SCHEMA[] = "\"string\"";
+
+/* SHA-1 of the original sample record ID. */
+const char EMPTY_MAP_RECORD_ID[] = "97789a11215b54828d2c3f50b864afed42543ff8";
+
+void test_msgpack_to_avro_empty_map()
+{
+    size_t map_size = 0;
+    size_t id_size = 0;
+    const char *id = NULL;
+    avro_value_t aobject;
+    avro_value_t field;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_EMPTY_MAP_SCHEMA,
+                           strlen(JSON_EMPTY_MAP_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_map(&pk, 2);
+    msgpack_pack_str(&pk, 2);
+    msgpack_pack_str_body(&pk, "ID", 2);
+    msgpack_pack_str(&pk, sizeof(EMPTY_MAP_RECORD_ID) - 1);
+    msgpack_pack_str_body(&pk, EMPTY_MAP_RECORD_ID, sizeof(EMPTY_MAP_RECORD_ID) - 1);
+    msgpack_pack_str(&pk, 10);
+    msgpack_pack_str_body(&pk, "HTTPHeader", 10);
+    msgpack_pack_map(&pk, 0);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_TRUE);
+
+    TEST_CHECK(avro_value_get_by_name(&aobject, "ID", &field, NULL) == 0);
+    TEST_CHECK(avro_value_get_string(&field, &id, &id_size) == 0);
+    TEST_CHECK(id_size == sizeof(EMPTY_MAP_RECORD_ID));
+    TEST_CHECK(strcmp(id, EMPTY_MAP_RECORD_ID) == 0);
+
+    TEST_CHECK(avro_value_get_by_name(&aobject, "HTTPHeader", &field, NULL) == 0);
+    TEST_CHECK(avro_value_get_size(&field, &map_size) == 0);
+    TEST_CHECK(map_size == 0);
+
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+}
+
+void test_msgpack_to_avro_empty_record()
+{
+    size_t record_size = 1;
+    avro_value_t aobject;
+    avro_schema_t aschema;
+    avro_value_iface_t *aclass;
+    msgpack_sbuffer sbuf;
+    msgpack_packer pk;
+    msgpack_unpacked msg;
+
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&pk, 0);
+
+    msgpack_unpacked_init(&msg);
+    TEST_CHECK(msgpack_unpack_next(&msg, sbuf.data, sbuf.size, NULL) ==
+               MSGPACK_UNPACK_SUCCESS);
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_EMPTY_RECORD_SCHEMA,
+                           strlen(JSON_EMPTY_RECORD_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_TRUE);
+    TEST_CHECK(avro_value_get_size(&aobject, &record_size) == 0);
+    TEST_CHECK(record_size == 0);
+
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_EMPTY_MAP_SCHEMA,
+                           strlen(JSON_EMPTY_MAP_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_FALSE);
+
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+
+    aclass = flb_avro_init(&aobject, (char *) JSON_STRING_SCHEMA,
+                           strlen(JSON_STRING_SCHEMA), &aschema);
+    TEST_CHECK(aclass != NULL);
+    TEST_CHECK(flb_msgpack_to_avro(&aobject, &msg.data) == FLB_FALSE);
+
+    avro_value_decref(&aobject);
+    avro_value_iface_decref(aclass);
+    avro_schema_decref(aschema);
+    msgpack_unpacked_destroy(&msg);
+    msgpack_sbuffer_destroy(&sbuf);
+}
+
 void test_msgpack_to_avro_int64()
 {
     int64_t positive_expected = 4294967296LL;
@@ -537,6 +654,8 @@ TEST_LIST = {
     /* Avro */
     { "msgpack_to_avro_basic", test_unpack_to_avro},
     { "test_parse_reordered_schema", test_parse_reordered_schema},
+    { "test_msgpack_to_avro_empty_map", test_msgpack_to_avro_empty_map},
+    { "test_msgpack_to_avro_empty_record", test_msgpack_to_avro_empty_record},
     { "test_msgpack_to_avro_int64", test_msgpack_to_avro_int64},
     { "test_msgpack_to_avro_int_range", test_msgpack_to_avro_int_range},
     { "test_msgpack_to_avro_int_range_multi_field",


### PR DESCRIPTION
<!-- Provide summary of changes -->
Partially backporting of https://github.com/fluent/fluent-bit/pull/12181 due to lack of integration testing framework on 4.2 branch.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
