### PR TITLE
oauth2: fix request body ownership on allocation failure

### DIFF
--- a/src/flb_oauth2.c
+++ b/src/flb_oauth2.c
@@ -579,67 +579,45 @@ int flb_oauth2_parse_json_response(const char *json_data, size_t json_size,
     return 0;
 }
 
-static flb_sds_t oauth2_append_kv(flb_sds_t buffer, const char *key,
-                                  const char *value)
+static int oauth2_append_kv(flb_sds_t *buffer, const char *key,
+                            const char *value)
 {
     flb_sds_t tmp;
-    flb_sds_t result;
 
     if (!value) {
-        return buffer;
+        return 0;
     }
 
     tmp = flb_uri_encode(value, strlen(value));
     if (!tmp) {
         flb_errno();
-        if (buffer) {
-            flb_sds_destroy(buffer);
-        }
-        return NULL;
+        return -1;
     }
 
-    if (flb_sds_len(buffer) > 0) {
-        result = flb_sds_cat(buffer, "&", 1);
-        if (!result) {
+    if (flb_sds_len(*buffer) > 0) {
+        if (flb_sds_cat_safe(buffer, "&", 1) == -1) {
             flb_sds_destroy(tmp);
-            if (buffer) {
-                flb_sds_destroy(buffer);
-            }
-            return NULL;
+            return -1;
         }
-        buffer = result;
     }
 
-    result = flb_sds_cat(buffer, key, strlen(key));
-    if (!result) {
+    if (flb_sds_cat_safe(buffer, key, strlen(key)) == -1) {
         flb_sds_destroy(tmp);
-        if (buffer) {
-            flb_sds_destroy(buffer);
-        }
-        return NULL;
+        return -1;
     }
-    buffer = result;
 
-    result = flb_sds_cat(buffer, "=", 1);
-    if (!result) {
+    if (flb_sds_cat_safe(buffer, "=", 1) == -1) {
         flb_sds_destroy(tmp);
-        if (buffer) {
-            flb_sds_destroy(buffer);
-        }
-        return NULL;
+        return -1;
     }
-    buffer = result;
 
-    result = flb_sds_cat(buffer, tmp, flb_sds_len(tmp));
+    if (flb_sds_cat_safe(buffer, tmp, flb_sds_len(tmp)) == -1) {
+        flb_sds_destroy(tmp);
+        return -1;
+    }
     flb_sds_destroy(tmp);
-    if (!result) {
-        if (buffer) {
-            flb_sds_destroy(buffer);
-        }
-        return NULL;
-    }
 
-    return result;
+    return 0;
 }
 
 static int oauth2_base64_url_encode(const unsigned char *input, size_t input_size,
@@ -982,8 +960,8 @@ error:
 
 static flb_sds_t oauth2_build_body(struct flb_oauth2 *ctx)
 {
+    int ret;
     flb_sds_t body;
-    flb_sds_t tmp;
     flb_sds_t assertion = NULL;
 
     if (ctx->payload_manual == FLB_TRUE && ctx->payload) {
@@ -1002,76 +980,60 @@ static flb_sds_t oauth2_build_body(struct flb_oauth2 *ctx)
         return NULL;
     }
 
-    tmp = oauth2_append_kv(body, "grant_type", "client_credentials");
-    if (!tmp) {
+    if (oauth2_append_kv(&body, "grant_type", "client_credentials") == -1) {
         flb_sds_destroy(body);
         return NULL;
     }
-    body = tmp;
 
     if (ctx->cfg.scope) {
-        tmp = oauth2_append_kv(body, "scope", ctx->cfg.scope);
-        if (!tmp) {
+        if (oauth2_append_kv(&body, "scope", ctx->cfg.scope) == -1) {
             flb_sds_destroy(body);
             return NULL;
         }
-        body = tmp;
     }
 
     if (ctx->cfg.audience) {
-        tmp = oauth2_append_kv(body, "audience", ctx->cfg.audience);
-        if (!tmp) {
+        if (oauth2_append_kv(&body, "audience", ctx->cfg.audience) == -1) {
             flb_sds_destroy(body);
             return NULL;
         }
-        body = tmp;
     }
 
     if (ctx->cfg.resource) {
-        tmp = oauth2_append_kv(body, "resource", ctx->cfg.resource);
-        if (!tmp) {
+        if (oauth2_append_kv(&body, "resource", ctx->cfg.resource) == -1) {
             flb_sds_destroy(body);
             return NULL;
         }
-        body = tmp;
     }
 
     if (ctx->cfg.auth_method == FLB_OAUTH2_AUTH_METHOD_POST) {
         if (ctx->cfg.client_id) {
-            tmp = oauth2_append_kv(body, "client_id", ctx->cfg.client_id);
-            if (!tmp) {
+            if (oauth2_append_kv(&body, "client_id", ctx->cfg.client_id) == -1) {
                 flb_sds_destroy(body);
                 return NULL;
             }
-            body = tmp;
         }
 
         if (ctx->cfg.client_secret) {
-            tmp = oauth2_append_kv(body, "client_secret", ctx->cfg.client_secret);
-            if (!tmp) {
+            if (oauth2_append_kv(&body, "client_secret", ctx->cfg.client_secret) == -1) {
                 flb_sds_destroy(body);
                 return NULL;
             }
-            body = tmp;
         }
     }
     else if (ctx->cfg.auth_method == FLB_OAUTH2_AUTH_METHOD_PRIVATE_KEY_JWT) {
         if (ctx->cfg.client_id) {
-            tmp = oauth2_append_kv(body, "client_id", ctx->cfg.client_id);
-            if (!tmp) {
+            if (oauth2_append_kv(&body, "client_id", ctx->cfg.client_id) == -1) {
                 flb_sds_destroy(body);
                 return NULL;
             }
-            body = tmp;
         }
 
-        tmp = oauth2_append_kv(body, "client_assertion_type",
-                               "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
-        if (!tmp) {
+        if (oauth2_append_kv(&body, "client_assertion_type",
+                             "urn:ietf:params:oauth:client-assertion-type:jwt-bearer") == -1) {
             flb_sds_destroy(body);
             return NULL;
         }
-        body = tmp;
 
         assertion = oauth2_private_key_jwt_create_assertion(ctx);
         if (!assertion) {
@@ -1079,13 +1041,12 @@ static flb_sds_t oauth2_build_body(struct flb_oauth2 *ctx)
             return NULL;
         }
 
-        tmp = oauth2_append_kv(body, "client_assertion", assertion);
+        ret = oauth2_append_kv(&body, "client_assertion", assertion);
         flb_sds_destroy(assertion);
-        if (!tmp) {
+        if (ret == -1) {
             flb_sds_destroy(body);
             return NULL;
         }
-        body = tmp;
     }
 
     return body;


### PR DESCRIPTION
## Summary

Fix OAuth2 request-body ownership when URI encoding or SDS concatenation fails.

`oauth2_append_kv()` previously destroyed the request body on failure while `oauth2_build_body()` also retained and destroyed its pointer. This could double-free the buffer. Successful SDS reallocations could also leave the caller holding a stale pointer.

The helper now receives the body by reference, updates it through `flb_sds_cat_safe()`, and leaves request-body cleanup exclusively to the caller.

Fixes #12201.

## Validation

- `make -j 8`
- `ctest --test-dir build -R '^flb-it-oauth2$' --output-on-failure`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_http/tests/test_out_http_001.py::test_out_http_oauth2_basic_adds_bearer_token tests/integration/scenarios/out_http/tests/test_out_http_001.py::test_out_http_oauth2_private_key_jwt_adds_bearer_token -q`
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_http/tests/test_out_http_001.py::test_out_http_oauth2_basic_adds_bearer_token tests/integration/scenarios/out_http/tests/test_out_http_001.py::test_out_http_oauth2_private_key_jwt_adds_bearer_token -q`
- Full PR-range commit-prefix validation against `master`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 request form construction for more reliable handling of encoded values.
  * Added clearer error handling when request fields cannot be appended.
  * Improved cleanup of temporary authentication data after private-key authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->