### PR TITLE
tests: runtime: Use long json payloads to trigger rotataion easily

### DIFF
--- a/tests/runtime/out_file_rotation.c
+++ b/tests/runtime/out_file_rotation.c
@@ -1549,7 +1549,7 @@ void flb_test_file_rotation_same_second_rotations(void)
     int ret;
     int bytes;
     int rotated_count;
-    char *p = (char *)JSON_SMALL;
+    char *p = (char *)JSON_LONG;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -1621,7 +1621,7 @@ void flb_test_file_rotation_filename_pattern(void)
     int i;
     int ret;
     int bytes;
-    char *p = (char *)JSON_SMALL;
+    char *p = (char *)JSON_LONG;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -1695,7 +1695,7 @@ void flb_test_file_rotation_cleanup_legacy_format(void)
     int ret;
     int bytes;
     int file_count;
-    char *p = (char *)JSON_SMALL;
+    char *p = (char *)JSON_LONG;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -1773,7 +1773,7 @@ void flb_test_file_rotation_gzip_compression(void)
     int i;
     int ret;
     int bytes;
-    char *p = (char *)JSON_SMALL;
+    char *p = (char *)JSON_LONG;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;
@@ -1866,7 +1866,7 @@ void flb_test_file_rotation_max_files_cleanup(void)
     int i;
     int ret;
     int bytes;
-    char *p = (char *)JSON_SMALL;
+    char *p = (char *)JSON_LONG;
     flb_ctx_t *ctx;
     int in_ffd;
     int out_ffd;


### PR DESCRIPTION
<!-- Provide summary of changes -->
Using small json payloads could be difficult to trigger file rotation.
So, we need to use long json payloads instead.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded file-rotation test coverage by using larger input payloads.
  * Improved validation of same-second rotations, filename patterns, legacy cleanup, gzip compression, and maximum-file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->