### PR TITLE
tests: runtime: Stabilize out_loki tests to catch EV_THREAD events

### DIFF
--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -224,6 +224,7 @@ static int cb_loki_tenant_policy_server(struct flb_http_request *request,
 
 static void *tenant_policy_server_loop(void *data)
 {
+    struct flb_connection *connection;
     struct mk_event *event;
     struct tenant_policy_server *mock = data;
 
@@ -235,6 +236,18 @@ static void *tenant_policy_server_loop(void *data)
         mk_event_foreach(event, mock->event_loop) {
             if (event->type == FLB_ENGINE_EV_CUSTOM) {
                 event->handler(event);
+            }
+            else if (event->type == FLB_ENGINE_EV_THREAD) {
+                connection = (struct flb_connection *) event;
+
+                if (connection->coroutine != NULL) {
+                    if (connection->event_coroutine != NULL) {
+                        flb_downstream_conn_event_resume(connection);
+                    }
+                    else {
+                        flb_coro_resume(connection->coroutine);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
We need to fix unstable out_loki test cases on runtime tests.

Root cause: after the downstream event-coroutine changes, HTTP connections use `FLB_ENGINE_EV_THREAD`. The Loki mock server handled only `FLB_ENGINE_EV_CUSTOM`, so delayed requests were never resumed—typically every tenant-B request.

The mock loop now dispatches thread events like the main engine.

Verification:

- `cmake --build build -j8 --target flb-rt-out_loki` — passed
- `ctest --test-dir build -R '^flb-rt-out_loki$' --output-on-failure` — passed
- Same test repeated three times with `--repeat until-fail:3` — all passed
- Valgrind not run; there is no Loki scenario under `tests/integration`, and this is test-loop dispatch logic only.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of threaded runtime events to resume downstream connections and their associated processing correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->