### PR TITLE
dockerfile: windows: Create an image of windows nano server ltsc2025

### DIFF
--- a/.github/workflows/call-build-images.yaml
+++ b/.github/workflows/call-build-images.yaml
@@ -381,7 +381,7 @@ jobs:
 
   # This takes a long time...
   call-build-windows-container:
-    name: Windows container images
+    name: Windows ${{ matrix.windows-container-type }} ${{ matrix.windows-base-version }} container image
     runs-on: windows-${{ matrix.windows-base-version }}
     environment: ${{ inputs.environment }}
     needs:
@@ -389,14 +389,24 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        windows-base-version:
-          - '2022'
-          - '2025'
+        include:
+          - windows-base-version: '2022'
+            windows-container-type: servercore
+            dockerfile: Dockerfile.windows
+            image-tag-prefix: windows-2022
+          - windows-base-version: '2025'
+            windows-container-type: servercore
+            dockerfile: Dockerfile.windows
+            image-tag-prefix: windows-2025
+          - windows-base-version: '2025'
+            windows-container-type: nanoserver
+            dockerfile: Dockerfile.windows.nano
+            image-tag-prefix: windows-nano-2025
     permissions:
       contents: read
       packages: write
     env:
-      IMAGE: ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-${{ inputs.version }}
+      IMAGE: ${{ inputs.registry }}/${{ inputs.image }}:${{ matrix.image-tag-prefix }}-${{ inputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -438,20 +448,44 @@ jobs:
         run: |
           VERSION=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest)|.tagName | sub("^v"; "")')
           echo VERSION="$VERSION"
-          docker pull ${{ inputs.registry }}/${{ inputs.image }}:windows-${{ matrix.windows-base-version }}-$VERSION
+          docker pull ${{ inputs.registry }}/${{ inputs.image }}:${{ matrix.image-tag-prefix }}-$VERSION
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.token }}
 
       - name: Build the production images
         run: |
-          docker build -t $IMAGE --build-arg FLB_NIGHTLY_BUILD=${{ inputs.unstable }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/Dockerfile.windows .
+          docker build -t $IMAGE --build-arg FLB_NIGHTLY_BUILD=${{ inputs.unstable }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/${{ matrix.dockerfile }} .
         shell: bash
 
       - name: Sanity check of the production images
         run: |
           docker run --rm -t $IMAGE --help
         shell: bash
+
+      - name: Sanity check the Nano Server default configuration
+        if: matrix.windows-container-type == 'nanoserver'
+        run: |
+          $containerName = "fluent-bit-nano-${{ matrix.windows-base-version }}"
+
+          try {
+            docker run --detach --name $containerName $env:IMAGE
+            Start-Sleep -Seconds 5
+
+            $running = docker inspect --format '{{.State.Running}}' $containerName
+            docker logs $containerName
+
+            if ($running -ne "true") {
+              throw "Nano Server container did not remain running"
+            }
+          }
+          finally {
+            $containerId = docker ps --all --quiet --filter "name=^/${containerName}$"
+            if ($containerId) {
+              docker rm --force $containerName | Out-Null
+            }
+          }
+        shell: pwsh
 
       - name: Push the production images
         if: inputs.push

--- a/.github/workflows/pr-image-tests.yaml
+++ b/.github/workflows/pr-image-tests.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'dockerfiles/Dockerfile'
       - 'dockerfiles/Dockerfile.windows'
+      - 'dockerfiles/Dockerfile.windows.nano'
       - 'conf/**'
 
   workflow_dispatch:
@@ -85,15 +86,24 @@ jobs:
           DOCKER_BUILDKIT: 0
         shell: bash
     pr-image-tests-build-windows-images:
-      name: PR - Docker windows build test, windows 2022 and 2025
+      name: PR - Docker ${{ matrix.windows-container-type }} build, Windows ${{ matrix.windows-base-version }}
       runs-on: windows-${{ matrix.windows-base-version }}
       strategy:
         fail-fast: true
         matrix:
-          windows-base-version:
-            # https://github.com/fluent/fluent-bit/blob/1d366594a889624ec3003819fe18588aac3f17cd/dockerfiles/Dockerfile.windows#L3
-            - '2022'
-            - '2025'
+          include:
+            - windows-base-version: '2022'
+              windows-container-type: servercore
+              dockerfile: Dockerfile.windows
+              image-tag-suffix: windows-2022
+            - windows-base-version: '2025'
+              windows-container-type: servercore
+              dockerfile: Dockerfile.windows
+              image-tag-suffix: windows-2025
+            - windows-base-version: '2025'
+              windows-container-type: nanoserver
+              dockerfile: Dockerfile.windows.nano
+              image-tag-suffix: windows-nano-2025
       permissions:
         contents: read
       steps:
@@ -108,7 +118,7 @@ jobs:
             tags: |
               type=sha
             flavor: |
-              suffix=-windows-${{ matrix.windows-base-version }}
+              suffix=-${{ matrix.image-tag-suffix }}
 
         # https://github.com/actions/runner-images/issues/12199
         # https://github.com/moby/moby/issues/48093
@@ -133,11 +143,35 @@ jobs:
         - name: Build the windows images
           id: build
           run: |
-            docker build -t ${{ steps.meta.outputs.tags }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/Dockerfile.windows .
+            docker build -t ${{ steps.meta.outputs.tags }} --build-arg WINDOWS_VERSION=ltsc${{ matrix.windows-base-version }} -f ./dockerfiles/${{ matrix.dockerfile }} .
 
         - name: Sanity check it runs
           # We do this for a simple check of dependencies
           run: |
             docker run --rm -t ${{ steps.meta.outputs.tags }} --help
           shell: bash
+
+        - name: Sanity check the Nano Server default configuration
+          if: matrix.windows-container-type == 'nanoserver'
+          run: |
+            $containerName = "fluent-bit-nano-${{ matrix.windows-base-version }}"
+
+            try {
+              docker run --detach --name $containerName ${{ steps.meta.outputs.tags }}
+              Start-Sleep -Seconds 5
+
+              $running = docker inspect --format '{{.State.Running}}' $containerName
+              docker logs $containerName
+
+              if ($running -ne "true") {
+                throw "Nano Server container did not remain running"
+              }
+            }
+            finally {
+              $containerId = docker ps --all --quiet --filter "name=^/${containerName}$"
+              if ($containerId) {
+                docker rm --force $containerName | Out-Null
+              }
+            }
+          shell: pwsh
 

--- a/.github/workflows/staging-release.yaml
+++ b/.github/workflows/staging-release.yaml
@@ -672,6 +672,8 @@ jobs:
             runs_on: windows-latest
           - tag: "windows-2025-${{ github.event.inputs.version }}"
             runs_on: windows-2025
+          - tag: "windows-nano-2025-${{ github.event.inputs.version }}"
+            runs_on: windows-2025
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0

--- a/conf/fluent-bit-nano.conf
+++ b/conf/fluent-bit-nano.conf
@@ -1,0 +1,19 @@
+[SERVICE]
+    Flush           1
+    Daemon          Off
+    Log_Level       info
+    Parsers_File    parsers.conf
+    Plugins_File    plugins.conf
+    HTTP_Server     Off
+    HTTP_Listen     0.0.0.0
+    HTTP_Port       2020
+    Storage.Metrics On
+
+[INPUT]
+    Name   forward
+    Listen 0.0.0.0
+    Port   24224
+
+[OUTPUT]
+    Name  stdout
+    Match *

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -11,10 +11,11 @@
 # - dockerfiles/Dockerfile.windows
 #
 
+ARG WINDOWS_SERVER_TYPE=servercore
 ARG WINDOWS_VERSION=ltsc2025
 
 # Builder Image - Windows Server Core
-FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION AS builder-base
+FROM mcr.microsoft.com/windows/$WINDOWS_SERVER_TYPE:$WINDOWS_VERSION AS builder-base
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -228,7 +229,7 @@ RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
 #
 # Runtime Image - Windows Server Core
 #
-FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION AS runtime
+FROM mcr.microsoft.com/windows/$WINDOWS_SERVER_TYPE:$WINDOWS_VERSION AS runtime
 
 ARG FLUENTBIT_VERSION=master
 ARG IMAGE_CREATE_DATE

--- a/dockerfiles/Dockerfile.windows.nano
+++ b/dockerfiles/Dockerfile.windows.nano
@@ -209,6 +209,7 @@ RUN call "%MSVS_HOME%\VC\Auxiliary\Build\vcvars64.bat" && `
       -DCMAKE_BUILD_TYPE=Release `
       -DFLB_SHARED_LIB=Off `
       -DFLB_EXAMPLES=Off `
+      -DFLB_IN_WINDOWS_EXPORTER_METRICS=Off `
       -DFLB_DEBUG=Off `
       -DFLB_RELEASE=On `
       ..\ && `

--- a/dockerfiles/Dockerfile.windows.nano
+++ b/dockerfiles/Dockerfile.windows.nano
@@ -1,0 +1,261 @@
+# escape=`
+
+# This Dockerfile will only build on Docker for Windows.
+#
+# If you change dependencies etc here, please also check and update
+# the other Windows build resources:
+#
+# - DEVELOPER_GUIDE.md "Windows" section
+# - appveyor.yml
+# - .github/workflows/call-build-windows.yaml
+# - dockerfiles/Dockerfile.windows
+#
+
+ARG WINDOWS_BUILDER_SERVER_TYPE=servercore
+ARG WINDOWS_SERVER_TYPE=nanoserver
+ARG WINDOWS_VERSION=ltsc2025
+
+# Builder Image - Windows Server Core
+# Nano Server does not include PowerShell or support the Visual Studio Build Tools installer.
+FROM mcr.microsoft.com/windows/$WINDOWS_BUILDER_SERVER_TYPE:$WINDOWS_VERSION AS builder-base
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Clean up any existing temp files and create fresh temp directory
+RUN Remove-Item -Path $env:TEMP\* -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path C:\Windows\Temp\* -Recurse -Force -ErrorAction SilentlyContinue; `
+    New-Item -ItemType Directory -Path $env:TEMP -Force -ErrorAction SilentlyContinue;
+
+# Install Visual Studio Build Tools 2019 (MSVS_VERSION=16) / 2022 (MSVS_VERSION=17)
+WORKDIR /local
+ARG MSVS_VERSION="17"
+ENV MSVS_BUILD_TOOLS_VERSION="$MSVS_VERSION" `
+    MSVS_BUILD_TOOLS_DOWNLOAD_URL="https://aka.ms/vs" `
+    MSVS_HOME="C:\BuildTools"
+
+RUN $msvs_build_tools_dist_name=\"vs_buildtools.exe\"; `
+    $msvs_build_tools_dist=\"${env:TMP}\${msvs_build_tools_dist_name}\"; `
+    $msvs_build_tools_channel=\"C:\local\VisualStudio.chman\"; `
+    $msvs_build_tools_dist_url=\"${env:MSVS_BUILD_TOOLS_DOWNLOAD_URL}/${env:MSVS_BUILD_TOOLS_VERSION}/release/${msvs_build_tools_dist_name}\"; `
+    $msvs_build_tools_channel_url=\"${env:MSVS_BUILD_TOOLS_DOWNLOAD_URL}/${env:MSVS_BUILD_TOOLS_VERSION}/release/channel\"; `
+    Write-Host \"Downloading Visual Studio Build Tools...\"; `
+    Write-Host \"${msvs_build_tools_dist_url} -> ${msvs_build_tools_dist}\"; `
+    Write-Host \"${msvs_build_tools_channel_url} -> ${msvs_build_tools_channel}\"; `
+    Invoke-WebRequest -OutFile \"${msvs_build_tools_dist}\" \"${msvs_build_tools_dist_url}\"; `
+    Invoke-WebRequest -OutFile \"${msvs_build_tools_channel}\" \"${msvs_build_tools_channel_url}\"; `
+    Write-Host \"Installing Visual Studio Build Tools into ${env:MSVS_HOME}...\"; `
+    $p = Start-Process \"${msvs_build_tools_dist}\" `
+      -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
+      \"--installPath ${env:MSVS_HOME}\", `
+      \"--channelUri ${msvs_build_tools_channel}\", `
+      \"--installChannelUri ${msvs_build_tools_channel}\", `
+      '--add Microsoft.VisualStudio.Workload.VCTools', `
+      '--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64', `
+      '--add Microsoft.VisualStudio.Component.Windows10SDK.19041' `
+      -NoNewWindow -Wait -PassThru; `
+    if (${p}.ExitCode -ne 0 -and ${p}.ExitCode -ne 3010) { `
+      throw \"Visual Studio Build Tools installer failed with exit code $(${p}.ExitCode)\" `
+    }; `
+    if (-not (Test-Path \"${env:MSVS_HOME}\VC\Auxiliary\Build\vcvars64.bat\")) { `
+      throw \"Visual Studio Build Tools installation is incomplete: ${env:MSVS_HOME}\VC\Auxiliary\Build\vcvars64.bat not found\" `
+    }; `
+    Remove-Item -Force \"${msvs_build_tools_dist}\"; `
+    Remove-Item -Path \"${msvs_build_tools_channel}\" -Force;
+
+ENV CMAKE_HOME="C:\cmake"
+ARG CMAKE_VERSION="3.31.6"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+
+RUN if ([System.Version] \"${env:CMAKE_VERSION}\" -ge [System.Version] \"3.20.0\") { `
+      $cmake_dist_base_name=\"cmake-${env:CMAKE_VERSION}-windows-x86_64\" `
+    } else { `
+      if ([System.Version] \"${env:CMAKE_VERSION}\" -ge [System.Version] \"3.6.0\") { `
+        $cmake_dist_base_name=\"cmake-${env:CMAKE_VERSION}-win64-x64\" `
+      } else { `
+        $cmake_dist_base_name=\"cmake-${env:CMAKE_VERSION}-win32-x86\" `
+      } `
+    }; `
+    $cmake_dist_name=\"${cmake_dist_base_name}.zip\"; `
+    $cmake_dist=\"${env:TMP}\${cmake_dist_name}\"; `
+    $cmake_download_url=\"${env:CMAKE_URL}/v${env:CMAKE_VERSION}/${cmake_dist_name}\"; `
+    Write-Host \"Downloading CMake...\"; `
+    Write-Host \"${cmake_download_url} -> ${cmake_dist}\"; `
+    Invoke-WebRequest -OutFile \"${cmake_dist}\" \"${cmake_download_url}\"; `
+    $cmake_temp_dir=\"${env:TMP}\${cmake_dist_base_name}\"; `
+    Write-Host \"Extracting CMake...\"; `
+    Write-Host \"${cmake_dist} -> ${cmake_temp_dir}\"; `
+    Expand-Archive \"${cmake_dist}\" -Destination \"${env:TMP}\"; `
+    Remove-Item -Force \"${cmake_dist}\"; `
+    Write-Host \"Moving CMake...\"; `
+    Write-Host \"${cmake_temp_dir} -> ${env:CMAKE_HOME}\"; `
+    [System.IO.Directory]::Move(\"${cmake_temp_dir}\", \"${env:CMAKE_HOME}\"); `
+    $env:PATH=\"${env:PATH};${env:CMAKE_HOME}\bin\"; `
+    Write-Host \"Setting PATH...\"; `
+    Write-Host \"${env:PATH}\"; `
+    [Environment]::SetEnvironmentVariable(\"PATH\", \"${env:PATH}\", [EnvironmentVariableTarget]::Machine);
+
+ENV NINJA_HOME="C:\ninja"
+ARG NINJA_VERSION="1.13.2"
+ARG NINJA_URL="https://github.com/ninja-build/ninja/releases/download"
+
+RUN $ninja_dist_name=\"ninja-win.zip\"; `
+    $ninja_dist=\"${env:TMP}\${ninja_dist_name}\"; `
+    $ninja_download_url=\"${env:NINJA_URL}/v${env:NINJA_VERSION}/${ninja_dist_name}\"; `
+    Write-Host \"Downloading Ninja...\"; `
+    Write-Host \"${ninja_download_url} -> ${ninja_dist}\"; `
+    Invoke-WebRequest -OutFile \"${ninja_dist}\" \"${ninja_download_url}\"; `
+    New-Item -Path \"${env:NINJA_HOME}\" -ItemType \"directory\"; `
+    Write-Host \"Extracting Ninja...\"; `
+    Write-Host \"${ninja_dist} -> ${env:NINJA_HOME}\"; `
+    Expand-Archive \"${ninja_dist}\" -Destination \"${env:NINJA_HOME}\"; `
+    Remove-Item -Force \"${ninja_dist}\"; `
+    $env:PATH=\"${env:PATH};${env:NINJA_HOME}\"; `
+    Write-Host \"Setting PATH...\"; `
+    Write-Host \"${env:PATH}\"; `
+    [Environment]::SetEnvironmentVariable(\"PATH\", \"${env:PATH}\", [EnvironmentVariableTarget]::Machine);
+
+ENV WIN_FLEX_BISON_VERSION="2.5.22" `
+    WIN_FLEX_BISON_HOME="C:\WinFlexBison" `
+    WIN_FLEX_BISON_DOWNLOAD_URL="https://github.com/lexxmark/winflexbison/releases/download"
+
+RUN $win_flex_bison_dist_base_name=\"win_flex_bison-${env:WIN_FLEX_BISON_VERSION}\"; `
+    $win_flex_bison_dist_name=\"${win_flex_bison_dist_base_name}.zip\"; `
+    $win_flex_bison_dist=\"${env:TMP}\${win_flex_bison_dist_name}\"; `
+    $win_flex_bison_url=\"${env:WIN_FLEX_BISON_DOWNLOAD_URL}/v${env:WIN_FLEX_BISON_VERSION}/${win_flex_bison_dist_name}\"; `
+    Write-Host \"Downloading WinFlexBison...\"; `
+    Write-Host \"${win_flex_bison_url} -> ${win_flex_bison_dist}\"; `
+    Invoke-WebRequest -OutFile \"${win_flex_bison_dist}\" \"${win_flex_bison_url}\"; `
+    Write-Host \"Extracting WinFlexBison...\"; `
+    Write-Host \"${win_flex_bison_dist} -> ${env:WIN_FLEX_BISON_HOME}\"; `
+    Expand-Archive \"${win_flex_bison_dist}\" -Destination \"${env:WIN_FLEX_BISON_HOME}\"; `
+    Remove-Item -Force \"${win_flex_bison_dist}\"; `
+    Write-Host \"Copying...\"; `
+    Write-Host \"${env:WIN_FLEX_BISON_HOME}\win_bison.exe -> ${env:WIN_FLEX_BISON_HOME}\bison.exe\"; `
+    Copy-Item -Path \"${env:WIN_FLEX_BISON_HOME}\win_bison.exe\" \"${env:WIN_FLEX_BISON_HOME}\bison.exe\"; `
+    Write-Host \"Copying...\"; `
+    Write-Host \"${env:WIN_FLEX_BISON_HOME}\win_flex.exe -> ${env:WIN_FLEX_BISON_HOME}\flex.exe\"; `
+    Copy-Item -Path \"${env:WIN_FLEX_BISON_HOME}\win_flex.exe\" \"${env:WIN_FLEX_BISON_HOME}\flex.exe\"; `
+    $env:PATH=\"${env:PATH};${env:WIN_FLEX_BISON_HOME}\"; `
+    Write-Host \"Setting PATH...\"; `
+    Write-Host \"${env:PATH}\"; `
+    [Environment]::SetEnvironmentVariable(\"PATH\", \"${env:PATH}\", [EnvironmentVariableTarget]::Machine);
+
+# https://github.com/microsoft/vcpkg/blob/2025.10.17/scripts/bootstrap.ps1
+ENV VCPKG_VERSION=2025.10.17 `
+    VCPKG_DOWNLOAD_URL="https://github.com/microsoft/vcpkg/archive/refs/tags" `
+    VCPKG_DISABLE_METRICS="ON" `
+    VCPKG_ROOT=/dev/vcpkg
+
+WORKDIR /dev
+
+RUN $vcpkg_dist_base_name=\"vcpkg-${env:VCPKG_VERSION}\"; `
+    $vcpkg_dist=\"${env:TMP}\${vcpkg_dist_base_name}.zip\"; `
+    $vcpkg_url=\"${env:VCPKG_DOWNLOAD_URL}/${env:VCPKG_VERSION}.zip\"; `
+    Write-Host \"Downloading vcpkg...\"; `
+    Write-Host \"${vcpkg_url} -> ${vcpkg_dist}\"; `
+    Invoke-WebRequest -OutFile \"${vcpkg_dist}\" \"${vcpkg_url}\"; `
+    $vcpkg_temp_dir=\"${env:TMP}\${vcpkg_dist_base_name}\"; `
+    Write-Host \"Extracting vcpkg...\"; `
+    Write-Host \"${vcpkg_dist} -> ${vcpkg_temp_dir}\"; `
+    Expand-Archive \"${vcpkg_dist}\" -Destination \"${env:TMP}\"; `
+    Remove-Item -Force \"${vcpkg_dist}\"; `
+    $vcpkg_home_dir=\"${env:VCPKG_ROOT}\" -replace \"/\", \"\\\"; `
+    $vcpkg_home_dir=\"C:${vcpkg_home_dir}\"; `
+    Write-Host \"Moving vcpkg...\"; `
+    Write-Host \"${vcpkg_temp_dir} -> ${vcpkg_home_dir}\"; `
+    [System.IO.Directory]::Move(\"${vcpkg_temp_dir}\", \"${vcpkg_home_dir}\"); `
+    $env:PATH=\"${env:PATH};${vcpkg_home_dir}\"; `
+    Write-Host \"Setting PATH...\"; `
+    Write-Host \"${env:PATH}\"; `
+    [Environment]::SetEnvironmentVariable(\"PATH\", \"${env:PATH}\", [EnvironmentVariableTarget]::Machine); `
+    Write-Host \"Bootstrapping vcpkg...\"; `
+    & \"${vcpkg_home_dir}\bootstrap-vcpkg.bat\";
+
+# Ensure we only attempt to build release and static linking
+ENV VCPKG_BUILD_TYPE=release `
+    VCPKG_LIBRARY_LINKAGE=static `
+    VCPKG_VISUAL_STUDIO_PATH="C:\BuildTools"
+
+# Install dependencies and clean temporary files to save space
+RUN vcpkg install --recurse openssl --triplet x64-windows-static; `
+    Remove-Item -Path $env:TEMP\* -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path C:\dev\vcpkg\buildtrees -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path C:\dev\vcpkg\downloads\tools\* -Recurse -Force -ErrorAction SilentlyContinue;
+
+RUN vcpkg install --recurse libyaml --triplet x64-windows-static; `
+    Remove-Item -Path $env:TEMP\* -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path C:\dev\vcpkg\buildtrees -Recurse -Force -ErrorAction SilentlyContinue;
+
+# Final vcpkg cleanup to remove all build artifacts and save space
+RUN Remove-Item -Path C:\dev\vcpkg\downloads -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path C:\dev\vcpkg\buildtrees -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path $env:TEMP\* -Recurse -Force -ErrorAction SilentlyContinue; `
+    Remove-Item -Path C:\Windows\Temp\* -Recurse -Force -ErrorAction SilentlyContinue;
+
+FROM builder-base AS builder
+
+# Build Fluent Bit from source - context must be the root of the Git repo
+WORKDIR /src/build
+COPY . /src/
+
+ARG BUILD_PARALLEL=1
+SHELL ["cmd", "/S", "/C"]
+RUN call "%MSVS_HOME%\VC\Auxiliary\Build\vcvars64.bat" && `
+    cmake -G "Ninja" `
+      -DOPENSSL_ROOT_DIR='C:\dev\vcpkg\packages\openssl_x64-windows-static' `
+      -DFLB_LIBYAML_DIR='C:\dev\vcpkg\packages\libyaml_x64-windows-static' `
+      -DCMAKE_C_STANDARD_LIBRARIES=OneCore.lib `
+      -DFLB_SIMD=On `
+      -DCMAKE_BUILD_TYPE=Release `
+      -DFLB_SHARED_LIB=Off `
+      -DFLB_EXAMPLES=Off `
+      -DFLB_DEBUG=Off `
+      -DFLB_RELEASE=On `
+      ..\ && `
+    cmake --build . -j "%BUILD_PARALLEL%"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /fluent-bit/bin
+# Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage
+RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
+    Copy-Item -Path /src/conf/fluent-bit-win32.conf /fluent-bit/etc/fluent-bit.conf; `
+    Copy-Item -Path /src/conf/parsers.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_ambassador.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_java.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_extra.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_openstack.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/parsers_cinder.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/conf/plugins.conf /fluent-bit/etc/; `
+    Copy-Item -Path /src/build/bin/fluent-bit.exe /fluent-bit/bin/;
+
+#
+# Runtime Image - Windows Nano Server
+#
+FROM mcr.microsoft.com/windows/$WINDOWS_SERVER_TYPE:$WINDOWS_VERSION AS runtime
+
+ARG FLUENTBIT_VERSION=master
+ARG IMAGE_CREATE_DATE
+ARG IMAGE_SOURCE_REVISION
+
+# Metadata as defined in OCI image spec annotations
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL org.opencontainers.image.title="Fluent Bit" `
+    org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+    org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+    org.opencontainers.image.version=$FLUENTBIT_VERSION `
+    org.opencontainers.image.authors="Eduardo Silva <eduardo.silva@chronosphere.io>" `
+    org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+    org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+    org.opencontainers.image.vendor="Fluent Organization" `
+    org.opencontainers.image.licenses="Apache-2.0" `
+    org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+    org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+
+# Copy only the built artifacts from builder stage
+COPY --from=builder /fluent-bit /fluent-bit
+
+ENTRYPOINT [ "C:\\fluent-bit\\bin\\fluent-bit.exe" ]
+# Hadolint gets confused by Windows it seems
+# hadolint ignore=DL3025
+CMD [ "-c", "C:\\fluent-bit\\etc\\fluent-bit.conf" ]

--- a/dockerfiles/Dockerfile.windows.nano
+++ b/dockerfiles/Dockerfile.windows.nano
@@ -220,7 +220,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 WORKDIR /fluent-bit/bin
 # Set up config files and binaries in single /fluent-bit hierarchy for easy copy in later stage
 RUN New-Item -Path  /fluent-bit/etc/ -ItemType "directory"; `
-    Copy-Item -Path /src/conf/fluent-bit-win32.conf /fluent-bit/etc/fluent-bit.conf; `
+    Copy-Item -Path /src/conf/fluent-bit-nano.conf /fluent-bit/etc/fluent-bit.conf; `
     Copy-Item -Path /src/conf/parsers.conf /fluent-bit/etc/; `
     Copy-Item -Path /src/conf/parsers_ambassador.conf /fluent-bit/etc/; `
     Copy-Item -Path /src/conf/parsers_java.conf /fluent-bit/etc/; `
@@ -255,6 +255,8 @@ LABEL org.opencontainers.image.title="Fluent Bit" `
 
 # Copy only the built artifacts from builder stage
 COPY --from=builder /fluent-bit /fluent-bit
+
+EXPOSE 24224
 
 ENTRYPOINT [ "C:\\fluent-bit\\bin\\fluent-bit.exe" ]
 # Hadolint gets confused by Windows it seems

--- a/dockerfiles/Dockerfile.windows.nano
+++ b/dockerfiles/Dockerfile.windows.nano
@@ -7,7 +7,8 @@
 #
 # - DEVELOPER_GUIDE.md "Windows" section
 # - appveyor.yml
-# - .github/workflows/call-build-windows.yaml
+# - .github/workflows/call-build-images.yaml
+# - .github/workflows/pr-image-tests.yaml
 # - dockerfiles/Dockerfile.windows
 #
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

To create Windows Nano Server, we needed the following things:

- Link OneCore.dll instead of the default dlls that are specified by cmake implicitly
- Write the full path of Fluent Bit as an entrypoint
- Disable not provided relying on plugins such as in_windows_exporter_metrics because of lacking WMI, perflib, and PDH functionality on NanoServer
- Do not use winlog due to lack of the default Windows EventLog channel of Setup on Nano Server

After fulfilling these conditions, we're able to run Fluent Bit on Windows Nano Server.
In this PR, we just enabled only for Nano Server ltsc2025.
This is because ltsc2022 will be EOL within 6 months (until January 12th 2027).

Closes https://github.com/fluent/fluent-bit/issues/10255.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running Fluent Bit in Windows Nano Server containers.
  * Added a preconfigured logging setup that accepts forwarded records and outputs them for inspection.
  * Windows container builds now support Server Core 2022, Server Core 2025, and Nano Server 2025 variants.
  * Added the Windows Nano Server 2025 image to staging releases.

* **Tests**
  * Added automated validation to confirm Nano Server containers start successfully, remain running, and clean up after testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->