### PR TITLE
in_exec: unblock threaded shutdown

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -212,6 +212,14 @@ struct flb_input_plugin {
      */
     int (*cb_ingest) (void *in_context, void *, size_t);
 
+    /*
+     * Notify a threaded input from the parent thread immediately before its
+     * event loop is asked to exit. This callback must only interrupt blocking
+     * work; the input thread remains responsible for releasing its context in
+     * cb_exit.
+     */
+    void (*cb_pre_exit) (void *, struct flb_config *);
+
     /* Exit */
     int (*cb_exit) (void *, struct flb_config *);
 

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -29,9 +29,153 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef FLB_SYSTEM_WINDOWS
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 #include "in_exec_win32_compat.h"
 
 #include "in_exec.h"
+
+#ifndef FLB_SYSTEM_WINDOWS
+static FILE *in_exec_popen(struct flb_exec *ctx)
+{
+    int ret;
+    int pipe_fds[2];
+    pid_t child_pid;
+    FILE *stream;
+
+    ret = pipe(pipe_fds);
+    if (ret == -1) {
+        flb_errno();
+        return NULL;
+    }
+
+    ret = fcntl(pipe_fds[0], F_SETFD, FD_CLOEXEC);
+    if (ret == -1) {
+        flb_errno();
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    ret = fcntl(pipe_fds[1], F_SETFD, FD_CLOEXEC);
+    if (ret == -1) {
+        flb_errno();
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    pthread_mutex_lock(&ctx->child_mutex);
+
+    if (ctx->shutdown_requested == FLB_TRUE) {
+        pthread_mutex_unlock(&ctx->child_mutex);
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    child_pid = fork();
+    if (child_pid == -1) {
+        flb_errno();
+        pthread_mutex_unlock(&ctx->child_mutex);
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    if (child_pid == 0) {
+        close(pipe_fds[0]);
+        setpgid(0, 0);
+
+        if (dup2(pipe_fds[1], STDOUT_FILENO) == -1) {
+            _exit(127);
+        }
+
+        close(pipe_fds[1]);
+        execl("/bin/sh", "sh", "-c", ctx->cmd, (char *) NULL);
+        _exit(127);
+    }
+
+    close(pipe_fds[1]);
+    setpgid(child_pid, child_pid);
+    ctx->child_pid = child_pid;
+    pthread_mutex_unlock(&ctx->child_mutex);
+
+    stream = fdopen(pipe_fds[0], "r");
+    if (stream == NULL) {
+        flb_errno();
+        kill(-child_pid, SIGKILL);
+        waitpid(child_pid, NULL, 0);
+
+        pthread_mutex_lock(&ctx->child_mutex);
+        ctx->child_pid = -1;
+        pthread_mutex_unlock(&ctx->child_mutex);
+
+        close(pipe_fds[0]);
+        return NULL;
+    }
+
+    return stream;
+}
+
+static int in_exec_pclose(struct flb_exec *ctx, FILE *stream)
+{
+    int ret;
+    int status;
+    pid_t child_pid;
+
+    ret = fclose(stream);
+    if (ret == EOF) {
+        flb_errno();
+    }
+
+    pthread_mutex_lock(&ctx->child_mutex);
+    child_pid = ctx->child_pid;
+    pthread_mutex_unlock(&ctx->child_mutex);
+
+    do {
+        ret = waitpid(child_pid, &status, 0);
+    } while (ret == -1 && errno == EINTR);
+
+    pthread_mutex_lock(&ctx->child_mutex);
+    if (ctx->child_pid == child_pid) {
+        ctx->child_pid = -1;
+    }
+    pthread_mutex_unlock(&ctx->child_mutex);
+
+    if (ret == -1) {
+        return -1;
+    }
+
+    return status;
+}
+
+static void in_exec_pre_exit(void *data, struct flb_config *config)
+{
+    int ret;
+    pid_t child_pid;
+    struct flb_exec *ctx = data;
+
+    (void) config;
+
+    pthread_mutex_lock(&ctx->child_mutex);
+    ctx->shutdown_requested = FLB_TRUE;
+    child_pid = ctx->child_pid;
+    if (child_pid > 0) {
+        ret = kill(-child_pid, SIGTERM);
+        if (ret == -1 && errno != ESRCH) {
+            flb_plg_warn(ctx->ins, "could not terminate command process group");
+            flb_errno();
+        }
+    }
+    pthread_mutex_unlock(&ctx->child_mutex);
+}
+#endif
 
 /* cb_collect callback */
 static int in_exec_collect(struct flb_input_instance *ins,
@@ -59,7 +203,11 @@ static int in_exec_collect(struct flb_input_instance *ins,
         }
     }
 
+#ifndef FLB_SYSTEM_WINDOWS
+    cmdp = in_exec_popen(ctx);
+#else
     cmdp = flb_popen(ctx->cmd, "r");
+#endif
     if (cmdp == NULL) {
         flb_plg_debug(ctx->ins, "command %s failed", ctx->cmd);
         goto collect_end;
@@ -178,7 +326,11 @@ static int in_exec_collect(struct flb_input_instance *ins,
          * and
          * https://skarnet.org/software/execline/exitcodes.html
          */
+#ifndef FLB_SYSTEM_WINDOWS
+        cmdret = in_exec_pclose(ctx, cmdp);
+#else
         cmdret = flb_pclose(cmdp);
+#endif
         if (cmdret == -1) {
             flb_errno();
             flb_plg_debug(ctx->ins,
@@ -339,6 +491,10 @@ static void delete_exec_config(struct flb_exec *ctx)
         flb_pipe_close(ctx->ch_manager[1]);
     }
 
+#ifndef FLB_SYSTEM_WINDOWS
+    pthread_mutex_destroy(&ctx->child_mutex);
+#endif
+
     flb_free(ctx);
 }
 
@@ -355,6 +511,15 @@ static int in_exec_init(struct flb_input_instance *in,
         return -1;
     }
     ctx->parser = NULL;
+
+#ifndef FLB_SYSTEM_WINDOWS
+    ret = pthread_mutex_init(&ctx->child_mutex, NULL);
+    if (ret != 0) {
+        flb_free(ctx);
+        return -1;
+    }
+    ctx->child_pid = -1;
+#endif
 
     /* Initialize exec config */
     ret = in_exec_config_read(ctx, in, config);
@@ -486,6 +651,9 @@ struct flb_input_plugin in_exec_plugin = {
     .cb_pre_run   = in_exec_prerun,
     .cb_collect   = in_exec_collect,
     .cb_flush_buf = NULL,
+#ifndef FLB_SYSTEM_WINDOWS
+    .cb_pre_exit  = in_exec_pre_exit,
+#endif
     .cb_exit      = in_exec_exit,
     .config_map   = config_map
 };

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -29,6 +29,10 @@
 
 #include <msgpack.h>
 
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/types.h>
+#endif
+
 #define DEFAULT_BUF_SIZE      "4096"
 #define DEFAULT_INTERVAL_SEC  "1"
 #define DEFAULT_INTERVAL_NSEC "0"
@@ -47,6 +51,11 @@ struct flb_exec {
     struct flb_log_event_encoder log_encoder;
     int exit_after_oneshot;
     int propagate_exit_code;
+#ifndef FLB_SYSTEM_WINDOWS
+    pthread_mutex_t child_mutex;
+    pid_t child_pid;
+    int shutdown_requested;
+#endif
 };
 
 #endif /* FLB_IN_EXEC_H */

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -590,6 +590,10 @@ int flb_input_thread_instance_exit(struct flb_input_instance *ins)
 
     memcpy(&tid, &thi->th->tid, sizeof(pthread_t));
 
+    if (ins->p->cb_pre_exit && ins->context) {
+        ins->p->cb_pre_exit(ins->context, ins->config);
+    }
+
     /* compose message to pause the thread */
     val = FLB_BITS_U64_SET(FLB_INPUT_THREAD_TO_THREAD,
                            FLB_INPUT_THREAD_EXIT);

--- a/tests/integration/scenarios/in_exec/config/threaded_hot_reload.yaml
+++ b/tests/integration/scenarios/in_exec/config/threaded_hot_reload.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  hot_reload: on
+  hot_reload.timeout: 30
+
+pipeline:
+  inputs:
+    - name: exec
+      command: 'echo $$ > "${EXEC_CHILD_PID_FILE}"; exec tail -f /dev/null'
+      interval_sec: 1
+      threaded: on
+      tag: exec
+
+  outputs:
+    - name: null
+      match: "*"

--- a/tests/integration/scenarios/in_exec/tests/test_in_exec_001.py
+++ b/tests/integration/scenarios/in_exec/tests/test_in_exec_001.py
@@ -1,0 +1,105 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+from pathlib import Path
+import signal
+import sys
+import tempfile
+import time
+
+import pytest
+
+from utils.fluent_bit_manager import FluentBitManager
+
+
+def wait_for_child_pid(pid_file, previous_pid=None, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        try:
+            child_pid = int(pid_file.read_text(encoding="utf-8").strip())
+            if child_pid > 0 and child_pid != previous_pid:
+                return child_pid
+        except (FileNotFoundError, ValueError):
+            pass
+
+        time.sleep(0.1)
+
+    raise TimeoutError("Timed out waiting for the exec child PID")
+
+
+def process_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+
+    return True
+
+
+def wait_for_process_exit(pid, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not process_exists(pid):
+            return True
+        time.sleep(0.1)
+
+    return False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX signals and tail")
+def test_threaded_exec_hot_reload_stops_blocking_child():
+    test_path = Path(__file__).resolve().parent
+    config_path = test_path.parent / "config" / "threaded_hot_reload.yaml"
+    child_pids = []
+    new_child_pid = None
+    shutdown_child_exited = False
+
+    with tempfile.TemporaryDirectory(prefix="flb-in-exec-") as runtime_dir:
+        pid_file = Path(runtime_dir) / "child.pid"
+        previous_pid_file = os.environ.get("EXEC_CHILD_PID_FILE")
+        os.environ["EXEC_CHILD_PID_FILE"] = str(pid_file)
+        manager = FluentBitManager(str(config_path))
+
+        try:
+            manager.start()
+            old_child_pid = wait_for_child_pid(pid_file)
+            child_pids.append(old_child_pid)
+
+            manager.send_sighup()
+            manager.wait_for_hot_reload_count(1, timeout=30)
+
+            new_child_pid = wait_for_child_pid(pid_file, old_child_pid)
+            child_pids.append(new_child_pid)
+            assert wait_for_process_exit(old_child_pid)
+        finally:
+            try:
+                manager.stop()
+                if new_child_pid is not None:
+                    shutdown_child_exited = wait_for_process_exit(new_child_pid)
+            finally:
+                if previous_pid_file is None:
+                    os.environ.pop("EXEC_CHILD_PID_FILE", None)
+                else:
+                    os.environ["EXEC_CHILD_PID_FILE"] = previous_pid_file
+
+                for child_pid in child_pids:
+                    if process_exists(child_pid):
+                        os.kill(child_pid, signal.SIGKILL)
+
+        assert shutdown_child_exited


### PR DESCRIPTION
## Summary

- add a parent-thread pre-exit callback for threaded inputs
- track the POSIX `in_exec` child process group and terminate it during shutdown
- prevent an already-fired collector timer from starting another command after shutdown begins
- add focused integration coverage for hot reload and child cleanup

Closes #12185.

## Root cause

A threaded `exec` collector could remain blocked in `fgets()` while hot reload waited for the input thread with `pthread_join()`. The exit event could not be processed until the command closed stdout, but Fluent Bit did not own enough process state to terminate the command. Once the command was interrupted, an already-fired timer could also start another command before the queued exit event was handled.

The POSIX execution path now records the child process group under a mutex. The parent-thread pre-exit callback marks the context as stopping and sends `SIGTERM` to that process group, which unblocks the collector without allowing a replacement command to start. Windows retains its existing `_popen()` path.

## Validation

- `cmake -DFLB_DEV=on ../ && make -j 8`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_exec/tests/test_in_exec_001.py::test_threaded_exec_hot_reload_stops_blocking_child -q`
  - `1 passed in 4.91s`
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_exec/tests/test_in_exec_001.py::test_threaded_exec_hot_reload_stops_blocking_child -q`
  - `1 passed in 6.07s`
- verified periodic commands continue to execute repeatedly
- verified one-shot exit-code propagation returns the child status
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`
  - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exec input plugin now gracefully stops blocking child processes during shutdown and hot reload operations.

* **Tests**
  * Added integration test for exec input plugin hot reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->