### PR TITLE
http_server: accept empty HTTP header values

### DIFF
--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -1399,7 +1399,11 @@ int flb_http_server_session_ingest(struct flb_http_server_session *session,
             }
         }
 
-        if (session->version <= HTTP_PROTOCOL_VERSION_11) {
+        if (session->version == HTTP_PROTOCOL_VERSION_AUTODETECT) {
+            /* Wait for the remainder of a split HTTP/2 connection preface. */
+            return HTTP_SERVER_SUCCESS;
+        }
+        else if (session->version <= HTTP_PROTOCOL_VERSION_11) {
             result = flb_http1_server_session_init(&session->http1, session);
 
             if (result != 0) {
@@ -1412,6 +1416,10 @@ int flb_http_server_session_ingest(struct flb_http_server_session *session,
             if (result != 0) {
                 return -1;
             }
+
+            /* Protocol detection may have accumulated the preface over multiple reads. */
+            buffer = (unsigned char *) session->incoming_data;
+            length = cfl_sds_len(session->incoming_data);
         }
     }
 

--- a/src/http_server/flb_http_server_http1.c
+++ b/src/http_server/flb_http_server_http1.c
@@ -566,6 +566,12 @@ int flb_http1_server_session_ingest(struct flb_http1_server_session *session,
          * performance overhead in exchange for ensuring safety.
          */
     }
+    else if (result == MK_HTTP_PARSER_ERROR) {
+        /* The caller closes the session when a parser error is returned. */
+        session->stream.status = HTTP_STREAM_STATUS_ERROR;
+
+        return HTTP_SERVER_PROVIDER_ERROR;
+    }
 
     dummy_mk_http_request_init(&session->inner_session, &session->inner_request);
     mk_http_parser_init(&session->inner_parser);

--- a/tests/integration/scenarios/in_http/tests/test_in_http_001.py
+++ b/tests/integration/scenarios/in_http/tests/test_in_http_001.py
@@ -2,6 +2,7 @@ import http.client
 import json
 import os
 import logging
+import socket
 import time
 
 import pytest
@@ -64,6 +65,28 @@ def send_requests(conn, num_requests, headers, json_payload):
             'data': response.read().decode()
         })
     return responses
+
+
+def send_raw_http1_request(port, request):
+    response = bytearray()
+
+    with socket.create_connection(("127.0.0.1", port), timeout=2) as connection:
+        connection.settimeout(2)
+        connection.sendall(request)
+
+        while len(response) < 4096 and b"\r\n" not in response:
+            try:
+                data = connection.recv(4096 - len(response))
+            except ConnectionResetError:
+                break
+            except socket.timeout:
+                pytest.fail("HTTP/1 server did not respond or close the connection")
+
+            if not data:
+                break
+            response.extend(data)
+
+    return bytes(response)
 
 
 def test_send_data():
@@ -148,6 +171,88 @@ def test_in_http_rejects_get_requests():
     service.stop()
 
     assert result["status_code"] >= 400
+
+
+def test_in_http_accepts_post_with_empty_generic_headers():
+    service = Service("in_http_config")
+    body = b'{"message":"empty-header"}'
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode()
+        + b"X-Empty:\r\n"
+        b"X-Empty-Whitespace: \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        + body
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request)
+        forwarded_payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    assert b"HTTP/1.1 201" in response
+    assert len(forwarded_payloads) == 1
+    assert forwarded_payloads[0][0]["message"] == "empty-header"
+
+
+def test_in_http_accepts_empty_connection_and_transfer_encoding():
+    service = Service("in_http_config")
+    body = b'{"message":"empty-semantic-headers"}'
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode()
+        + b"Connection:\r\n"
+        b"Transfer-Encoding: \t\r\n"
+        b"Connection: close\r\n"
+        b"\r\n"
+        + body
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request)
+        forwarded_payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    assert b"HTTP/1.1 201" in response
+    assert len(forwarded_payloads) == 1
+    assert forwarded_payloads[0][0]["message"] == "empty-semantic-headers"
+
+
+@pytest.mark.parametrize("header_value", [b"", b" \t"], ids=["empty", "whitespace"])
+@pytest.mark.parametrize(
+    "following_data",
+    [b"1-X: value\r\nConnection: close\r\n\r\n1", b"\r\n1"],
+    ids=["numeric-header", "numeric-body"],
+)
+def test_in_http_rejects_empty_content_length(header_value, following_data):
+    service = Service("in_http_config")
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length:" + header_value + b"\r\n"
+        + following_data
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request)
+        time.sleep(0.5)
+        forwarded_payloads = list(data_storage["payloads"])
+    finally:
+        service.stop()
+
+    assert response == b"" or b"HTTP/1.1 400" in response
+    assert forwarded_payloads == []
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/scenarios/in_http/tests/test_in_http_001.py
+++ b/tests/integration/scenarios/in_http/tests/test_in_http_001.py
@@ -89,6 +89,30 @@ def send_raw_http1_request(port, request):
     return bytes(response)
 
 
+def send_split_http2_preface(port):
+    preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+    settings_frame = b"\x00\x00\x00\x04\x00\x00\x00\x00\x00"
+    response = bytearray()
+
+    with socket.create_connection(("127.0.0.1", port), timeout=2) as connection:
+        connection.settimeout(2)
+        connection.sendall(preface[:-2])
+        time.sleep(0.1)
+        connection.sendall(preface[-2:] + settings_frame)
+
+        while len(response) < 9:
+            try:
+                data = connection.recv(4096)
+            except socket.timeout:
+                pytest.fail("HTTP/2 server did not respond to a split connection preface")
+
+            if not data:
+                break
+            response.extend(data)
+
+    return bytes(response)
+
+
 def test_send_data():
     try:
         service = Service("in_http_config")
@@ -139,6 +163,20 @@ def test_in_http_protocol_matrix(case):
     assert result["http_version"] == case["expected_http_version"]
     assert len(forwarded_payloads) == 1
     assert forwarded_payloads[0][0]["message"] == "Este es un mensaje de prueba"
+
+
+def test_in_http_accepts_split_http2_preface():
+    service = Service("in_http_http2_cleartext.yaml")
+
+    try:
+        service.start()
+        response = send_split_http2_preface(service.flb_listener_port)
+    finally:
+        service.stop()
+
+    assert len(response) >= 9
+    assert response[3] == 0x04
+    assert data_storage["payloads"] == []
 
 
 def test_in_http_rejects_bad_json():

--- a/tests/integration/scenarios/in_http/tests/test_in_http_001.py
+++ b/tests/integration/scenarios/in_http/tests/test_in_http_001.py
@@ -246,11 +246,11 @@ def test_in_http_rejects_empty_content_length(header_value, following_data):
     try:
         service.start()
         response = send_raw_http1_request(service.flb_listener_port, request)
-        time.sleep(0.5)
-        forwarded_payloads = list(data_storage["payloads"])
+        service.assert_no_forwarded_payloads_for()
     finally:
         service.stop()
 
+    forwarded_payloads = list(data_storage["payloads"])
     assert response == b"" or b"HTTP/1.1 400" in response
     assert forwarded_payloads == []
 
@@ -509,6 +509,13 @@ class Service:
                 return data_storage["payloads"]
             time.sleep(0.5)
         raise TimeoutError("Timed out waiting for forwarded HTTP payloads")
+
+    def assert_no_forwarded_payloads_for(self, quiet_period=1.5):
+        deadline = time.time() + quiet_period
+
+        while time.time() < deadline:
+            assert data_storage["payloads"] == []
+            time.sleep(0.1)
 
     def stop(self):
         self.service.stop()

--- a/tests/integration/scenarios/in_http/tests/test_in_http_001.py
+++ b/tests/integration/scenarios/in_http/tests/test_in_http_001.py
@@ -67,12 +67,33 @@ def send_requests(conn, num_requests, headers, json_payload):
     return responses
 
 
-def send_raw_http1_request(port, request):
+def assert_connection_open_without_response(connection):
+    connection.settimeout(1)
+
+    try:
+        data = connection.recv(1)
+    except socket.timeout:
+        return
+
+    if not data:
+        pytest.fail("HTTP server closed the connection while the request was incomplete")
+
+    pytest.fail("HTTP server responded before the request was complete")
+
+
+def send_raw_http1_request(port, request, split_at=None):
     response = bytearray()
 
     with socket.create_connection(("127.0.0.1", port), timeout=2) as connection:
         connection.settimeout(2)
-        connection.sendall(request)
+
+        if split_at is None:
+            connection.sendall(request)
+        else:
+            connection.sendall(request[:split_at])
+            assert_connection_open_without_response(connection)
+            connection.settimeout(2)
+            connection.sendall(request[split_at:])
 
         while len(response) < 4096 and b"\r\n" not in response:
             try:
@@ -97,7 +118,8 @@ def send_split_http2_preface(port):
     with socket.create_connection(("127.0.0.1", port), timeout=2) as connection:
         connection.settimeout(2)
         connection.sendall(preface[:-2])
-        time.sleep(0.1)
+        assert_connection_open_without_response(connection)
+        connection.settimeout(2)
         connection.sendall(preface[-2:] + settings_frame)
 
         while len(response) < 9:
@@ -177,6 +199,31 @@ def test_in_http_accepts_split_http2_preface():
     assert len(response) >= 9
     assert response[3] == 0x04
     assert data_storage["payloads"] == []
+
+
+def test_in_http_accepts_http1_request_split_before_autodetect_boundary():
+    service = Service("in_http_http2_cleartext.yaml")
+    body = b'{"message":"split-http1"}'
+    request = (
+        b"POST / HTTP/1.1\r\n"
+        b"Host: localhost\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode()
+        + b"Connection: close\r\n"
+        b"\r\n"
+        + body
+    )
+
+    try:
+        service.start()
+        response = send_raw_http1_request(service.flb_listener_port, request, split_at=1)
+        forwarded_payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    assert b"HTTP/1.1 201" in response
+    assert len(forwarded_payloads) == 1
+    assert forwarded_payloads[0][0]["message"] == "split-http1"
 
 
 def test_in_http_rejects_bad_json():

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -637,7 +637,8 @@ void flb_test_http(void)
 
     num = get_output_num();
     TEST_CHECK(send_invalid_header_request() == 0);
-    flb_time_msleep(500);
+    /* Observe the same full dispatch and flush window as accepted requests. */
+    flb_time_msleep(1500);
     TEST_CHECK(get_output_num() == num);
 
     flb_http_client_destroy(c);

--- a/tests/runtime/in_http.c
+++ b/tests/runtime/in_http.c
@@ -413,6 +413,158 @@ static void test_ctx_destroy(struct test_ctx *ctx)
     flb_free(ctx);
 }
 
+static int send_raw_http_request(const char *request,
+                                 char *response,
+                                 size_t response_size)
+{
+    struct sockaddr_in address;
+    struct timeval timeout;
+    fd_set read_fds;
+    flb_sockfd_t fd;
+    size_t request_length;
+    size_t request_offset;
+    int ret;
+    int written;
+    int received;
+    int response_length;
+
+    if (response_size < 2) {
+        return -1;
+    }
+
+    response[0] = '\0';
+    request_length = strlen(request);
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd == FLB_INVALID_SOCKET) {
+        return -1;
+    }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = htons(9880);
+
+    ret = connect(fd, (struct sockaddr *) &address, sizeof(address));
+    if (ret != 0) {
+        flb_socket_close(fd);
+        return -1;
+    }
+
+    request_offset = 0;
+    while (request_offset < request_length) {
+        written = send(fd,
+                       request + request_offset,
+                       (int) (request_length - request_offset),
+                       0);
+        if (written <= 0) {
+            flb_socket_close(fd);
+            return -1;
+        }
+        request_offset += (size_t) written;
+    }
+
+    response_length = 0;
+    while (response_length < (int) response_size - 1) {
+        FD_ZERO(&read_fds);
+        FD_SET(fd, &read_fds);
+        timeout.tv_sec = 2;
+        timeout.tv_usec = 0;
+
+        ret = select((int) (fd + 1), &read_fds, NULL, NULL, &timeout);
+        if (ret <= 0) {
+            flb_socket_close(fd);
+            return -1;
+        }
+
+        received = recv(fd,
+                        response + response_length,
+                        (int) response_size - 1 - response_length,
+                        0);
+        if (received <= 0) {
+            break;
+        }
+
+        response_length += received;
+        response[response_length] = '\0';
+        if (strstr(response, "\r\n") != NULL) {
+            break;
+        }
+    }
+
+    flb_socket_close(fd);
+    response[response_length] = '\0';
+
+    if (response_length > 0 && strstr(response, "\r\n") == NULL) {
+        return -1;
+    }
+
+    return response_length;
+}
+
+static int send_empty_header_request(void)
+{
+    const char *body = "{\"test\":\"msg\"}";
+    const char *request_template =
+        "POST / HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Content-Length: %zu\r\n"
+        "Content-Type: application/json\r\n"
+        "X-Empty:\r\n"
+        "X-Empty-Whitespace: \t\r\n"
+        "\r\n"
+        "%s";
+    char request[512];
+    char response[256];
+    int ret;
+    int response_length;
+
+    ret = snprintf(request, sizeof(request), request_template,
+                   strlen(body), body);
+    if (ret <= 0 || (size_t) ret >= sizeof(request)) {
+        return -1;
+    }
+
+    response_length = send_raw_http_request(request, response, sizeof(response));
+    if (response_length <= 0) {
+        return -1;
+    }
+
+    return strstr(response, "HTTP/1.1 201") != NULL ? 0 : -1;
+}
+
+static int send_invalid_header_request(void)
+{
+    const char *body = "{\"test\":\"msg\"}";
+    const char *request_template =
+        "POST / HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Content-Length: %zu\r\n"
+        "Content-Type: application/json\r\n"
+        "Upgrade:\r\n"
+        "\r\n"
+        "%s";
+    char request[512];
+    char response[256];
+    int ret;
+    int response_length;
+
+    ret = snprintf(request, sizeof(request), request_template,
+                   strlen(body), body);
+    if (ret <= 0 || (size_t) ret >= sizeof(request)) {
+        return -1;
+    }
+
+    response_length = send_raw_http_request(request, response, sizeof(response));
+    if (response_length < 0) {
+        return -1;
+    }
+    if (response_length == 0) {
+        return 0;
+    }
+
+    return strstr(response, "HTTP/1.1 4") != NULL ? 0 : -1;
+}
+
 void flb_test_http(void)
 {
     struct flb_lib_out_cb cb_data;
@@ -469,13 +621,25 @@ void flb_test_http(void)
         TEST_MSG("http response code error. expect: 201, got: %d\n", c->resp.status);
     }
 
+    /* Ensure the first request has reached the callback before the regression. */
+    flb_time_msleep(1500);
+    num = get_output_num();
+    TEST_CHECK(num > 0);
+
+    TEST_CHECK(send_empty_header_request() == 0);
+
     /* waiting to flush */
     flb_time_msleep(1500);
 
-    num = get_output_num();
-    if (!TEST_CHECK(num > 0))  {
-        TEST_MSG("no outputs");
+    if (!TEST_CHECK(get_output_num() > num)) {
+        TEST_MSG("empty-header request did not reach the callback");
     }
+
+    num = get_output_num();
+    TEST_CHECK(send_invalid_header_request() == 0);
+    flb_time_msleep(500);
+    TEST_CHECK(get_output_num() == num);
+
     flb_http_client_destroy(c);
     flb_upstream_conn_release(ctx->httpc->u_conn);
     test_ctx_destroy(ctx);


### PR DESCRIPTION
Supersedes #12175, which GitHub auto-closed when the temporary base branch
for #12212 was removed after merge.

Fixes #12174.

## Summary

The parser fix was merged upstream in monkey/monkey#444 and bundled in
Fluent Bit with Monkey 1.8.9 by #12212. This PR contains only the remaining
Fluent Bit-owned changes:

- propagate Monkey HTTP/1 parser errors so invalid requests are closed instead
  of being reset and left pending;
- keep protocol autodetection pending for an incomplete HTTP/2 preface and
  pass all accumulated preface bytes to nghttp2;
- add runtime coverage for accepted empty generic headers and rejected empty
  semantic headers;
- add real-server `in_http` coverage for the original POST/body report,
  bounded `Content-Length` parsing, and split HTTP/1 and HTTP/2 requests.

No files under `lib/monkey` are changed.

## Behavior

Before this change, an invalid HTTP/1 request could leave a keep-alive client
without a response, and a split HTTP/2 preface could be routed to the HTTP/1
parser. After this change, invalid requests are rejected and incomplete HTTP/2
autodetection waits for the rest of the preface. Empty generic headers remain
accepted.

## Testing

Ubuntu 24.04 Docker, GCC 13.3:

```text
cmake -S . -B build-pr -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On
cmake --build build-pr -j8
```

Result: full configure and build passed.

```text
ctest --test-dir build-pr \
  -R '^(flb-rt-in_http|in_http_tls_expect.sh|flb-it-http_server)$' \
  --output-on-failure
```

Result: focused CTest passed 3/3.

```text
ctest --test-dir build-pr --output-on-failure
```

Result: 204/205 tests passed. The sole failure was the unrelated legacy
`flb-rt-out_td`, which depends on a hard-coded `/tmp/td.conf` and leaves its
pre-created `td.0` output unconfigured when the repository sample config is
mounted.

Targeted split-boundary regressions:

```text
tests/integration/.venv/bin/python -m pytest -q \
  tests/integration/scenarios/in_http/tests/test_in_http_001.py::test_in_http_accepts_split_http2_preface \
  tests/integration/scenarios/in_http/tests/test_in_http_001.py::test_in_http_accepts_http1_request_split_before_autodetect_boundary
```

Result: 2/2 passed normally and 2/2 passed with
`VALGRIND=1 VALGRIND_STRICT=1`.

Complete affected integration scope:

```text
tests/integration/.venv/bin/python -m pytest -q \
  tests/integration/scenarios/in_http/tests/test_in_http_001.py \
  tests/integration/scenarios/in_http_max_connections/tests/test_in_http_max_connections_001.py
```

Result: 37/37 passed normally and 37/37 passed with
`VALGRIND=1 VALGRIND_STRICT=1`.

The exact six-scenario `Input HTTP pause and lifecycle tests` selection also
passed in both modes: 27 passed and 167 deselected normally, then 27 passed and
167 deselected with strict Valgrind.

The CI-style full-PR commit-prefix checker and `git diff --check` pass against
the current `master` branch.

### PR template evidence

- Example configuration: N/A; the regression uses existing `in_http`
  integration configurations without changing user configuration.
- Debug output: the focused CTest and real-server integration runs start the
  newly built Fluent Bit v5.1.0 binary and exercise actual HTTP listeners.
- Valgrind: the complete affected integration scope and the exact CI selection
  both passed with strict Valgrind handling.

Representative clean Valgrind output:

```text
HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
  total heap usage: 14,898 allocs, 14,898 frees, 3,052,433 bytes allocated
All heap blocks were freed -- no leaks are possible
ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Compatibility

No configuration, packaging, documentation, or bundled-library changes are
included. The runtime socket regression uses Fluent Bit's portable socket
types. Upstream Windows and macOS workflows are pending maintainer approval
for this fork PR.

## Documentation

N/A. This fixes protocol parsing and error handling without changing public
configuration or documented user-facing interfaces. The default
`docs-required` label can be removed if the maintainers agree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed HTTP/1 requests by returning an appropriate server error.
  - Correctly detects HTTP/2 prefaces split across multiple network reads.
  - Rejects empty or whitespace-only `Content-Length` headers without forwarding payloads.
  - Rejects empty `Upgrade` headers without producing unintended output.
  - Accepts valid requests with empty generic, `Connection`, and `Transfer-Encoding` headers.

- **Tests**
  - Added regression coverage for split protocol requests, header validation, payload forwarding, and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
