### PR TITLE
out_azure_kusto: stop logging federated and access tokens

### DIFF
--- a/plugins/out_azure_kusto/azure_msiauth.c
+++ b/plugins/out_azure_kusto/azure_msiauth.c
@@ -77,7 +77,9 @@ char *flb_azure_msiauth_token_get(struct flb_oauth2 *ctx)
          flb_info("[azure msi auth] HTTP Status=%i", c->resp.status);
          if (c->resp.payload_size > 0) {
              if (c->resp.status == 200) {
-                 flb_debug("[azure msi auth] payload:\n%s", c->resp.payload);
+                 /* the payload carries the access token, never log its content */
+                 flb_debug("[azure msi auth] token response received (%zu bytes)",
+                           c->resp.payload_size);
              }
              else {
                  flb_info("[azure msi auth] payload:\n%s", c->resp.payload);
@@ -162,7 +164,9 @@ int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *to
         return -1;
     }
 
-    flb_info("[azure workload identity] after read token from file %s", federated_token);
+    /* the federated token is a credential, only log its size */
+    flb_debug("[azure workload identity] federated token read from %s (%zu bytes)",
+              token_file, flb_sds_len(federated_token));
 
     /* Build the form data for token exchange *before* creating the client */
     body = flb_sds_create_size(4096);
@@ -249,8 +253,9 @@ int flb_azure_workload_identity_token_get(struct flb_oauth2 *ctx, const char *to
     /* c->body_buf = body; */
     /* c->body_len = flb_sds_len(body); */
 
-    /* Add a debug log to verify the body content just before sending */
-    flb_debug("[azure workload identity] Sending request body (len=%zu): %s", flb_sds_len(body), body);
+    /* the body embeds the client assertion, never log its content */
+    flb_debug("[azure workload identity] sending token exchange request (body len=%zu)",
+              flb_sds_len(body));
 
     /* Issue request */
     ret = flb_http_do(c, &b_sent);


### PR DESCRIPTION
## Problem

`plugins/out_azure_kusto/azure_msiauth.c` writes Azure credentials into the
Fluent Bit log in three places.

**1. The federated token is logged at `info` level** — i.e. with the *default*
log level, no debug required:

```c
flb_info("[azure workload identity] after read token from file %s", federated_token);
```

`federated_token` is the projected service account token read from
`/var/run/secrets/azure/tokens/azure-identity-token`. It is a live Entra ID
client assertion that can be exchanged for an access token for the Kusto
ingestion identity. On a Kubernetes deployment using Azure Workload Identity,
this JWT is emitted on every token refresh and ends up wherever the pod logs are
shipped.

**2. The token exchange request body is logged**, which embeds the same
assertion via `client_assertion=`:

```c
flb_debug("[azure workload identity] Sending request body (len=%zu): %s", flb_sds_len(body), body);
```

**3. The managed identity token response payload is logged**, which contains the
issued `access_token`:

```c
flb_debug("[azure msi auth] payload:\n%s", c->resp.payload);
```

## Fix

Log the token file path and the body/payload sizes instead of the contents, so
the auth flow stays debuggable without writing credentials to the log. The
federated token log is also demoted from `info` to `debug`, matching the
surrounding auth logging.

The non-200 branches are deliberately left untouched: those payloads carry the
Entra ID / IMDS error description, which is what you actually need when auth
fails, and contain no credential.

## Before / after

Before, at default `log_level info`:

```text
[ info] [azure workload identity] after read token from file eyJhbGciOiJSUzI1NiIsImtpZCI6Ii1LSTNROVNOTlQ3Y1FTLTU3aE1oRDZfM3g2bE1lWk9pWmxLcGhOTG1JZmMifQ.eyJhdWQiOlsiYXBpOi8vQXp1cmVBRFRva2VuRXhjaGFuZ2UiXSwiZXhwIjoxNzY0NzE...
```

After:

```text
[debug] [azure workload identity] federated token read from /var/run/secrets/azure/tokens/azure-identity-token (1102 bytes)
[debug] [azure workload identity] sending token exchange request (body len=1284)
[debug] [azure msi auth] token response received (1583 bytes)
```

## Scope

- Single file: `plugins/out_azure_kusto/azure_msiauth.c`
- Three log statements, +9 / −4
- No config, schema or API change; no change to the auth flow itself
- Failure-path diagnostics preserved

## Compatibility

Fully backward compatible. Nothing parses these debug lines; only their text
changes. Users who were relying on the payload dump for troubleshooting still
get status codes, sizes and the full error payload on failures.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**

- [x] Example configuration file for the change

```ini
[SERVICE]
    log_level    debug

[INPUT]
    name         dummy
    tag          kusto.test

[OUTPUT]
    name                        azure_kusto
    match                       kusto.*
    ingestion_endpoint          https://ingest-<cluster>.<region>.kusto.windows.net
    database_name               <db>
    table_name                  <table>
    ingestion_mapping_reference <mapping>
```

- [x] Debug log output from testing the change

See the before/after section above. Build and focused runtime test:

```text
$ cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On -DFLB_OUT_AZURE_KUSTO=On
$ cmake --build build --target flb-plugin-out_azure_kusto -j8
[100%] Built target flb-plugin-out_azure_kusto      # no new warnings

$ cmake --build build --target flb-rt-out_azure_kusto -j8
$ ctest --test-dir build -R flb-rt-out_azure_kusto --output-on-failure
    Start 57: flb-rt-out_azure_kusto
1/1 Test #57: flb-rt-out_azure_kusto ...........   Passed    2.68 sec
100% tests passed, 0 tests failed out of 1
```

- [N/A] Attached Valgrind output that shows no leaks or memory corruption was found

  Valgrind is unavailable on the macOS arm64 host used here. The change only
  removes format arguments from existing `flb_debug()`/`flb_info()` calls and
  allocates nothing, so it cannot affect memory behavior.

- [N/A] Run local packaging test showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature

**Backporting**

- [x] Backport to latest stable release.

  This is a credential-disclosure fix and applies to every release line that
  ships `out_azure_kusto` with managed identity / workload identity auth. Happy
  to open backport PRs for the active branches if maintainers want them.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I
understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication security by preventing sensitive Azure credentials and tokens from appearing in debug logs.
  * Authentication diagnostics now report safe metadata, such as payload sizes and file paths, while retaining error-response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->