### PR TITLE
tests: runtime: Adopt the test config path for Windows and others

### DIFF
--- a/tests/runtime/in_calyptia_fleet_test.c
+++ b/tests/runtime/in_calyptia_fleet_test.c
@@ -136,8 +136,9 @@ static void test_in_fleet_timestamped_config_format(void)
     t_ctx = init_test_context();
     TEST_CHECK(t_ctx != NULL);
 
-    ret = snprintf(expectedValue, sizeof(expectedValue), "%s/%s/%s/123.conf",
-                   FLEET_DEFAULT_CONFIG_DIR, t_ctx->ctx->machine_id, t_ctx->ctx->fleet_name);
+    ret = snprintf(expectedValue, sizeof(expectedValue), "%s" PATH_SEPARATOR "%s"
+                   PATH_SEPARATOR "%s" PATH_SEPARATOR "123.conf", TEST_FLEET_CONFIG_DIR,
+                   t_ctx->ctx->machine_id, t_ctx->ctx->fleet_name);
     TEST_CHECK(ret > 0 && ret < (int) sizeof(expectedValue));
 
     value = time_fleet_config_filename(t_ctx->ctx, 123);
@@ -149,8 +150,9 @@ static void test_in_fleet_timestamped_config_format(void)
 
     t_ctx->ctx->fleet_config_legacy_format = FLB_FALSE;
 
-    ret = snprintf(expectedValue, sizeof(expectedValue), "%s/%s/%s/123/config.yaml",
-                   FLEET_DEFAULT_CONFIG_DIR, t_ctx->ctx->machine_id, t_ctx->ctx->fleet_name);
+    ret = snprintf(expectedValue, sizeof(expectedValue), "%s" PATH_SEPARATOR "%s"
+                   PATH_SEPARATOR "%s" PATH_SEPARATOR "123" PATH_SEPARATOR "config.yaml",
+                   TEST_FLEET_CONFIG_DIR, t_ctx->ctx->machine_id, t_ctx->ctx->fleet_name);
     TEST_CHECK(ret > 0 && ret < (int) sizeof(expectedValue));
 
     value = time_fleet_config_filename(t_ctx->ctx, 123);


### PR DESCRIPTION
<!-- Provide summary of changes -->
Without this patch, one of the runtime test cases is failing:

```
flb-rt-in_calyptia_fleet_test ....................***Failed    0.08 sec
Test in_calyptia_fleet_format...                [ OK ]
Test in_calyptia_fleet_timestamped_config_format... [ FAILED ]
  in_calyptia_fleet_test.c:146: Check value && strcmp(value, expectedValue) == 0... failed
  in_calyptia_fleet_test.c:159: Check value && strcmp(value, expectedValue) == 0... failed
FAILED: 1 of 2 unit tests has failed.
```

Fixed the Windows path expectations in [in_calyptia_fleet_test.c](C:\Users\cosmo\Documents\GitHub\fluent-bit\tests\runtime\in_calyptia_fleet_test.c:139). Both cases now use `TEST_FLEET_CONFIG_DIR` and `PATH_SEPARATOR`.

Verification:

- Focused target rebuilt successfully.
- Exact timestamped test: passed, all assertions.
- `ctest --test-dir build -R "^flb-rt-in_calyptia_fleet_test$" --output-on-failure`: passed, 1/1.
- Valgrind was not run because it is unavailable on Windows; no corresponding Python integration scenario exists.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet configuration path handling across platforms.
  * Updated validation for timestamped legacy `.conf` and YAML configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->