### PR TITLE
filter_geoip2: fix lookup key comparison

### DIFF
--- a/plugins/filter_geoip2/geoip2.c
+++ b/plugins/filter_geoip2/geoip2.c
@@ -165,8 +165,7 @@ static struct flb_hash_table *prepare_lookup_keys(msgpack_object *map,
         }
         
         flb_config_map_foreach(head, lookup_key, ctx->lookup_keys) {
-            if (strncasecmp(key->via.str.ptr, lookup_key->val.str, 
-                flb_sds_len(lookup_key->val.str)) == 0) {
+            if (flb_sds_casecmp(lookup_key->val.str, key->via.str.ptr, key->via.str.size) == 0) {
                 flb_hash_table_add(ht, lookup_key->val.str, flb_sds_len(lookup_key->val.str),
                                    (void *) val->via.str.ptr, val->via.str.size);
             }


### PR DESCRIPTION
This patch fixes the problem that when a key with the same prefix as the lookup key existed, the filter could choose the wrong one, as the comparison was limited to the length of the specified lookup key.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [x] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<details><summary>Output prior to the change</summary>

----

Attachments:

```
$ echo '{"address": "8.8.8.8", "bddress_type": "ipv4"}'"\n"'{"address": "8.8.8.8", "address_type": "ipv4"}' | podman run --rm -i -v /tmp/dbip-asn-lite.mmdb:/tmp/dbip-asn-lite.mmdb fluent-bit /fluent-bit/bin/fluent-bit -i stdin -F geoip2 -m "*" -p database=/tmp/dbip-asn-lite.mmdb -p lookup_key=address -p record="address_asn address %{autonomous_system_number}" -o stdout
Fluent Bit v5.1.0
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/08/05 20:07:05.750] [ info] [fluent bit] version=5.1.0, commit=fe293d4270, pid=1
[2026/08/05 20:07:05.751] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/05 20:07:05.751] [ info] [simd    ] SSE2
[2026/08/05 20:07:05.751] [ info] [cmetrics] version=2.2.1
[2026/08/05 20:07:05.751] [ info] [ctraces ] version=0.7.1
[2026/08/05 20:07:05.751] [ info] [input:stdin:stdin.0] initializing
[2026/08/05 20:07:05.751] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2026/08/05 20:07:05.751] [ info] [sp] stream processor started
[2026/08/05 20:07:05.751] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/05 20:07:05.751] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/05 20:07:05.768] [error] [filter:geoip2:geoip2.0] getaddrinfo failed: Name or service not known
[2026/08/05 20:07:05.768] [ warn] [input:stdin:stdin.0] end of file (stdin closed by remote end)
[2026/08/05 20:07:05.768] [ warn] [engine] service will shutdown in max 5 seconds
[2026/08/05 20:07:05.768] [ info] [engine] pausing all inputs..
[0] stdin.0: [[1785960425.768110083, {}], {"address"=>"8.8.8.8", "bddress_type"=>"ipv4", "address_asn"=>15169}]
[1] stdin.0: [[1785960425.768117527, {}], {"address"=>"8.8.8.8", "address_type"=>"ipv4", "address_asn"=>nil}]
[2026/08/05 20:07:06.562] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/05 20:07:06.562] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/05 20:07:06.562] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

</details>

<details><summary>Output after the change</summary>

```
$ echo '{"address": "8.8.8.8", "bddress_type": "ipv4"}'"\n"'{"address": "8.8.8.8", "address_type": "ipv4"}' | podman run --rm -i -v /tmp/dbip-asn-lite.mmdb:/tmp/dbip-asn-lite.mmdb fluent-bit /fluent-bit/bin/fluent-bit -i stdin -F geoip2 -m "*" -p database=/tmp/dbip-asn-lite.mmdb -p lookup_key=address -p record="address_asn address %{autonomous_system_number}" -o stdout 
Fluent Bit v5.1.0
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/08/05 20:08:31.055] [ info] [fluent bit] version=5.1.0, commit=fe293d4270, pid=1
[2026/08/05 20:08:31.056] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/05 20:08:31.056] [ info] [simd    ] SSE2
[2026/08/05 20:08:31.056] [ info] [cmetrics] version=2.2.1
[2026/08/05 20:08:31.056] [ info] [ctraces ] version=0.7.1
[2026/08/05 20:08:31.056] [ info] [input:stdin:stdin.0] initializing
[2026/08/05 20:08:31.056] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2026/08/05 20:08:31.056] [ info] [sp] stream processor started
[2026/08/05 20:08:31.056] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/05 20:08:31.056] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/05 20:08:31.068] [ warn] [input:stdin:stdin.0] end of file (stdin closed by remote end)
[2026/08/05 20:08:31.068] [ warn] [engine] service will shutdown in max 5 seconds
[2026/08/05 20:08:31.068] [ info] [engine] pausing all inputs..
[0] stdin.0: [[1785960511.068764694, {}], {"address"=>"8.8.8.8", "bddress_type"=>"ipv4", "address_asn"=>15169}]
[1] stdin.0: [[1785960511.068769403, {}], {"address"=>"8.8.8.8", "address_type"=>"ipv4", "address_asn"=>15169}]
[2026/08/05 20:08:31.561] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/05 20:08:31.562] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/05 20:08:31.562] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```

</details>

<details><summary>Valgrind output</summary>

```
$ echo '{"address": "8.8.8.8", "bddress_type": "ipv4"}'"\n"'{"address": "8.8.8.8", "address_type": "ipv4"}' | podman run --rm -i -v /tmp/dbip-asn-lite.mmdb:/tmp/dbip-asn-lite.mmdb fluent-bit valgrind --leak-check=full /fluent-bit/bin/fluent-bit -i stdin -F geoip2 -m "*" -p database=/tmp/dbip-asn-lite.mmdb -p lookup_key=address -p record="address_asn address %{autonomous_system_number}" -o stdout
==1== Memcheck, a memory error detector
==1== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==1== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==1== Command: /fluent-bit/bin/fluent-bit -i stdin -F geoip2 -m * -p database=/tmp/dbip-asn-lite.mmdb -p lookup_key=address -p record=address_asn\ address\ %{autonomous_system_number} -o stdout
==1== 
Fluent Bit v5.1.0
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


==1== Warning: client switching stacks?  SP change: 0x9114558 --> 0x64ab5c0
==1==          to suppress, use: --max-stackframe=46567320 or greater
==1== Warning: client switching stacks?  SP change: 0x64ab558 --> 0x9114558
==1==          to suppress, use: --max-stackframe=46567424 or greater
==1== Warning: client switching stacks?  SP change: 0x9114558 --> 0x64ab558
==1==          to suppress, use: --max-stackframe=46567424 or greater
==1==          further instances of this message will not be shown.
[0] stdin.0: [[1785960310.971641418, {}], {"address"=>"8.8.8.8", "bddress_type"=>"ipv4", "address_asn"=>15169}]
[1] stdin.0: [[1785960310.975738255, {}], {"address"=>"8.8.8.8", "address_type"=>"ipv4", "address_asn"=>15169}]
[2026/08/05 20:05:10.843] [ info] [fluent bit] version=5.1.0, commit=fe293d4270, pid=1
[2026/08/05 20:05:10.873] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/05 20:05:10.874] [ info] [simd    ] SSE2
[2026/08/05 20:05:10.874] [ info] [cmetrics] version=2.2.1
[2026/08/05 20:05:10.875] [ info] [ctraces ] version=0.7.1
[2026/08/05 20:05:10.886] [ info] [input:stdin:stdin.0] initializing
[2026/08/05 20:05:10.887] [ info] [input:stdin:stdin.0] storage_strategy='memory' (memory only)
[2026/08/05 20:05:10.956] [ info] [sp] stream processor started
[2026/08/05 20:05:10.958] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/05 20:05:11.009] [ warn] [input:stdin:stdin.0] end of file (stdin closed by remote end)
[2026/08/05 20:05:11.017] [ warn] [engine] service will shutdown in max 5 seconds
[2026/08/05 20:05:11.018] [ info] [engine] pausing all inputs..
[2026/08/05 20:05:11.024] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/05 20:05:11.569] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/05 20:05:11.580] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/05 20:05:11.583] [ info] [output:stdout:stdout.0] thread worker #0 stopped
==1== 
==1== HEAP SUMMARY:
==1==     in use at exit: 0 bytes in 0 blocks
==1==   total heap usage: 6,407 allocs, 6,407 frees, 1,355,693 bytes allocated
==1== 
==1== All heap blocks were freed -- no leaks are possible
==1== 
==1== For lists of detected and suppressed errors, rerun with: -s
==1== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GeoIP2 lookup matching to compare complete keys without regard to letter casing.
  * Prevented partial or prefix matches from returning incorrect results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->