### PR TITLE
lib: monkey: prevent libevent timer socket deadlock

### DIFF
--- a/lib/monkey/mk_core/mk_event_libevent.c
+++ b/lib/monkey/mk_core/mk_event_libevent.c
@@ -28,9 +28,11 @@
 
 #ifdef _WIN32
 #define ERR(e) (WSA##e)
+#define MK_EVENT_LIBEVENT_WOULD_BLOCK(e) ((e) == WSAEWOULDBLOCK)
 static LONG mk_event_libevent_wsa_initialized = 0;
 #else
 #define ERR(e) (e)
+#define MK_EVENT_LIBEVENT_WOULD_BLOCK(e) ((e) == EAGAIN || (e) == EWOULDBLOCK)
 #endif
 
 struct ev_map {
@@ -309,6 +311,7 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
  */
 static void cb_timeout(evutil_socket_t fd, short flags, void *data)
 {
+    int error;
     int ret;
     uint64_t val = 1;
     struct ev_map *ev_map = data;
@@ -316,7 +319,11 @@ static void cb_timeout(evutil_socket_t fd, short flags, void *data)
     ret = send(ev_map->pipe[1], (char *) &val, sizeof(uint64_t), 0);
 
     if (ret == -1) {
-        if (evutil_socket_geterror(fd) != ERR(ECONNABORTED)) {
+        error = evutil_socket_geterror(ev_map->pipe[1]);
+        if (MK_EVENT_LIBEVENT_WOULD_BLOCK(error)) {
+            return;
+        }
+        if (error != ERR(ECONNABORTED)) {
             perror("write");
         }
         evutil_closesocket(ev_map->pipe[1]);
@@ -346,6 +353,13 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
     if (mk_event_libevent_socketpair(fd) == -1) {
         perror("socketpair");
+        return -1;
+    }
+
+    if (evutil_make_socket_nonblocking(fd[1]) == -1) {
+        perror("nonblocking");
+        evutil_closesocket(fd[0]);
+        evutil_closesocket(fd[1]);
         return -1;
     }
 

--- a/lib/monkey/test/event_timeout.c
+++ b/lib/monkey/test/event_timeout.c
@@ -19,6 +19,12 @@
 
 #include "mk_tests.h"
 
+#ifdef _WIN32
+struct test_event_map {
+    evutil_socket_t pipe[2];
+};
+#endif
+
 static int consume_timer_tick(int fd, uint64_t *val)
 {
 #ifdef _WIN32
@@ -71,10 +77,64 @@ void test_timeout_tick_destroy(void)
     mk_event_loop_destroy(evl);
 }
 
+#ifdef _WIN32
+void test_timeout_notification_backpressure(void)
+{
+    int fd;
+    int ret;
+    int error;
+    DWORD send_timeout;
+    uint64_t tick;
+    struct test_event_map *event_map;
+    struct mk_event_loop *evl;
+    struct mk_event ev = {0};
+
+    TEST_CHECK(mk_event_init() == 0);
+
+    evl = mk_event_loop_create(4);
+    TEST_ASSERT(evl != NULL);
+
+    fd = mk_event_timeout_create(evl, 0, 1000, &ev);
+    TEST_ASSERT(fd >= 0);
+
+    event_map = ev.data;
+    TEST_ASSERT(event_map != NULL);
+
+    send_timeout = 100;
+    ret = setsockopt(event_map->pipe[1], SOL_SOCKET, SO_SNDTIMEO,
+                     (const char *) &send_timeout, sizeof(send_timeout));
+    TEST_ASSERT(ret == 0);
+
+    tick = 1;
+    do {
+        ret = send(event_map->pipe[1], (char *) &tick, sizeof(tick), 0);
+    } while (ret > 0);
+
+    error = WSAGetLastError();
+    TEST_ASSERT(ret == SOCKET_ERROR);
+    TEST_ASSERT(error == WSAEWOULDBLOCK);
+
+    ret = mk_event_wait_2(evl, 100);
+    TEST_ASSERT(ret == 1);
+    TEST_ASSERT(ev.data == event_map);
+
+    ret = mk_event_timeout_destroy(evl, &ev);
+    TEST_ASSERT(ret == 0);
+
+    mk_event_loop_destroy(evl);
+}
+#endif
+
 TEST_LIST = {
     {
         "timeout_create_tick_destroy",
         test_timeout_tick_destroy,
     },
+#ifdef _WIN32
+    {
+        "timeout_notification_backpressure",
+        test_timeout_notification_backpressure,
+    },
+#endif
     {NULL, NULL}
 };


### PR DESCRIPTION
## Problem

On Windows, the libevent timer callback writes notifications to a socket pair from the event-loop thread. When the socket buffer fills, the blocking `send()` waits for the same event loop to drain the read side, deadlocking Fluent Bit. WPR captured the engine thread blocked in `cb_timeout()` through `WSPSend()` and `SockWaitForSingleObject()`.

## Change

- make the timer notification write socket nonblocking
- treat `EAGAIN`/`EWOULDBLOCK` as an already-pending timer notification
- read socket errors from the actual write socket rather than libevent's timer callback fd
- add a Windows regression test that fills the notification socket and verifies the timer survives backpressure

## Compatibility

Normal timer delivery is unchanged. Under backpressure, redundant notifications are coalesced instead of blocking the engine thread.

## Testing

Local Windows build environment was unavailable; GitHub Actions CI will run the Windows regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling when notification pipes are full or temporarily unable to accept data.
  * Preserved reliable timeout event delivery across Windows and non-Windows environments.
  * Ensured notification resources are properly closed when timeout setup fails.

* **Tests**
  * Added coverage for Windows pipe backpressure and nonblocking timeout notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->