### PR TITLE
[Canary] Build and test for RISC-V64 libco backend

### DIFF
--- a/lib/cfl/src/cfl_time.c
+++ b/lib/cfl/src/cfl_time.c
@@ -50,7 +50,7 @@ uint64_t cfl_time_now()
     tm.tv_sec = mts.tv_sec;
     tm.tv_nsec = mts.tv_nsec;
     mach_port_deallocate(mach_task_self(), cclock);
-#elif defined CFL_HAVE_TIMESPEC_GET
+#elif defined(CFL_HAVE_TIMESPEC_GET) && defined(TIME_UTC)
     /* C11 supported */
     timespec_get(&tm, TIME_UTC);
 

--- a/lib/flb_libco/libco.c
+++ b/lib/flb_libco/libco.c
@@ -16,6 +16,10 @@
     #include "arm.c"
   #elif defined(__aarch64__)
     #include "aarch64.c"
+  #elif defined(__riscv) && defined(__riscv_xlen) && \
+        __riscv_xlen == 64 && !defined(__riscv_abi_rve) && \
+        !defined(__riscv_float_abi_quad)
+    #include "riscv64.c"
   #elif defined(__powerpc64__) && defined(_CALL_ELF) && _CALL_ELF == 2
     #include "ppc64le.c"
   #elif defined(_ARCH_PPC) && !defined(__LITTLE_ENDIAN__)

--- a/lib/flb_libco/riscv64.c
+++ b/lib/flb_libco/riscv64.c
@@ -1,0 +1,223 @@
+/*
+  libco.riscv64
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+#include "settings.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__riscv_float_abi_double) || defined(__riscv_float_abi_single)
+  #define LIBCO_RISCV64_HARD_FLOAT
+#endif
+
+typedef struct {
+  uintptr_t ra;
+  uintptr_t sp;
+  uintptr_t s[12];
+#ifdef LIBCO_RISCV64_HARD_FLOAT
+  uint64_t fs[12];
+  uintptr_t fcsr;
+#endif
+  void (*entrypoint)(void);
+} co_context;
+
+typedef char co_context_ra_offset[(offsetof(co_context, ra) == 0) ? 1 : -1];
+typedef char co_context_sp_offset[(offsetof(co_context, sp) == 8) ? 1 : -1];
+typedef char co_context_s_offset[(offsetof(co_context, s) == 16) ? 1 : -1];
+#ifdef LIBCO_RISCV64_HARD_FLOAT
+typedef char co_context_fs_offset[(offsetof(co_context, fs) == 112) ? 1 : -1];
+typedef char co_context_fcsr_offset[(offsetof(co_context, fcsr) == 208) ? 1 : -1];
+#endif
+
+static thread_local co_context co_active_context;
+static thread_local cothread_t co_active_handle;
+
+#if defined(__riscv_float_abi_double)
+  #define LIBCO_RISCV64_SAVE_FLOAT                                        \
+    "  fsd fs0, 112(a1)\n"                                               \
+    "  fsd fs1, 120(a1)\n"                                               \
+    "  fsd fs2, 128(a1)\n"                                               \
+    "  fsd fs3, 136(a1)\n"                                               \
+    "  fsd fs4, 144(a1)\n"                                               \
+    "  fsd fs5, 152(a1)\n"                                               \
+    "  fsd fs6, 160(a1)\n"                                               \
+    "  fsd fs7, 168(a1)\n"                                               \
+    "  fsd fs8, 176(a1)\n"                                               \
+    "  fsd fs9, 184(a1)\n"                                               \
+    "  fsd fs10, 192(a1)\n"                                              \
+    "  fsd fs11, 200(a1)\n"                                              \
+    "  csrr t0, fcsr\n"                                                  \
+    "  sd t0, 208(a1)\n"
+  #define LIBCO_RISCV64_RESTORE_FLOAT                                     \
+    "  fld fs0, 112(a0)\n"                                               \
+    "  fld fs1, 120(a0)\n"                                               \
+    "  fld fs2, 128(a0)\n"                                               \
+    "  fld fs3, 136(a0)\n"                                               \
+    "  fld fs4, 144(a0)\n"                                               \
+    "  fld fs5, 152(a0)\n"                                               \
+    "  fld fs6, 160(a0)\n"                                               \
+    "  fld fs7, 168(a0)\n"                                               \
+    "  fld fs8, 176(a0)\n"                                               \
+    "  fld fs9, 184(a0)\n"                                               \
+    "  fld fs10, 192(a0)\n"                                              \
+    "  fld fs11, 200(a0)\n"                                              \
+    "  ld t0, 208(a0)\n"                                                 \
+    "  csrw fcsr, t0\n"
+#elif defined(__riscv_float_abi_single)
+  #define LIBCO_RISCV64_SAVE_FLOAT                                        \
+    "  fsw fs0, 112(a1)\n"                                               \
+    "  fsw fs1, 120(a1)\n"                                               \
+    "  fsw fs2, 128(a1)\n"                                               \
+    "  fsw fs3, 136(a1)\n"                                               \
+    "  fsw fs4, 144(a1)\n"                                               \
+    "  fsw fs5, 152(a1)\n"                                               \
+    "  fsw fs6, 160(a1)\n"                                               \
+    "  fsw fs7, 168(a1)\n"                                               \
+    "  fsw fs8, 176(a1)\n"                                               \
+    "  fsw fs9, 184(a1)\n"                                               \
+    "  fsw fs10, 192(a1)\n"                                              \
+    "  fsw fs11, 200(a1)\n"                                              \
+    "  csrr t0, fcsr\n"                                                  \
+    "  sd t0, 208(a1)\n"
+  #define LIBCO_RISCV64_RESTORE_FLOAT                                     \
+    "  flw fs0, 112(a0)\n"                                               \
+    "  flw fs1, 120(a0)\n"                                               \
+    "  flw fs2, 128(a0)\n"                                               \
+    "  flw fs3, 136(a0)\n"                                               \
+    "  flw fs4, 144(a0)\n"                                               \
+    "  flw fs5, 152(a0)\n"                                               \
+    "  flw fs6, 160(a0)\n"                                               \
+    "  flw fs7, 168(a0)\n"                                               \
+    "  flw fs8, 176(a0)\n"                                               \
+    "  flw fs9, 184(a0)\n"                                               \
+    "  flw fs10, 192(a0)\n"                                              \
+    "  flw fs11, 200(a0)\n"                                              \
+    "  ld t0, 208(a0)\n"                                                 \
+    "  csrw fcsr, t0\n"
+#else
+  #define LIBCO_RISCV64_SAVE_FLOAT
+  #define LIBCO_RISCV64_RESTORE_FLOAT
+#endif
+
+asm(
+  ".text\n"
+  ".p2align 2\n"
+  ".globl co_switch_riscv64\n"
+  ".type co_switch_riscv64, @function\n"
+  "co_switch_riscv64:\n"
+  "  sd ra, 0(a1)\n"
+  "  sd sp, 8(a1)\n"
+  "  sd s0, 16(a1)\n"
+  "  sd s1, 24(a1)\n"
+  "  sd s2, 32(a1)\n"
+  "  sd s3, 40(a1)\n"
+  "  sd s4, 48(a1)\n"
+  "  sd s5, 56(a1)\n"
+  "  sd s6, 64(a1)\n"
+  "  sd s7, 72(a1)\n"
+  "  sd s8, 80(a1)\n"
+  "  sd s9, 88(a1)\n"
+  "  sd s10, 96(a1)\n"
+  "  sd s11, 104(a1)\n"
+  LIBCO_RISCV64_SAVE_FLOAT
+  "  ld ra, 0(a0)\n"
+  "  ld sp, 8(a0)\n"
+  "  ld s0, 16(a0)\n"
+  "  ld s1, 24(a0)\n"
+  "  ld s2, 32(a0)\n"
+  "  ld s3, 40(a0)\n"
+  "  ld s4, 48(a0)\n"
+  "  ld s5, 56(a0)\n"
+  "  ld s6, 64(a0)\n"
+  "  ld s7, 72(a0)\n"
+  "  ld s8, 80(a0)\n"
+  "  ld s9, 88(a0)\n"
+  "  ld s10, 96(a0)\n"
+  "  ld s11, 104(a0)\n"
+  LIBCO_RISCV64_RESTORE_FLOAT
+  "  ret\n"
+  ".size co_switch_riscv64, .-co_switch_riscv64\n"
+  ".previous\n"
+);
+
+void co_switch_riscv64(cothread_t handle, cothread_t current);
+
+static void co_entry_trampoline(void)
+{
+  co_context *context;
+
+  context = (co_context *)co_active_handle;
+  context->entrypoint();
+  abort();
+}
+
+cothread_t co_active(void)
+{
+  if (!co_active_handle) {
+    co_active_handle = &co_active_context;
+  }
+
+  return co_active_handle;
+}
+
+cothread_t co_create(unsigned int size, void (*entrypoint)(void),
+                     size_t *out_size)
+{
+  size_t context_size;
+  size_t stack_size;
+  size_t total_size;
+  co_context *context;
+
+  context_size = (sizeof(co_context) + 15) & ~(size_t)15;
+
+  if ((size_t)size > SIZE_MAX - 15) {
+    return 0;
+  }
+
+  stack_size = ((size_t)size + 15) & ~(size_t)15;
+  if (stack_size > SIZE_MAX - context_size) {
+    return 0;
+  }
+
+  total_size = context_size + stack_size;
+  context = (co_context *)malloc(total_size);
+  if (!context) {
+    return 0;
+  }
+
+  memset(context, 0, context_size);
+  context->ra = (uintptr_t)co_entry_trampoline;
+  context->sp = (uintptr_t)context + total_size;
+  context->entrypoint = entrypoint;
+
+  *out_size = total_size;
+  return (cothread_t)context;
+}
+
+void co_delete(cothread_t handle)
+{
+  free(handle);
+}
+
+void co_switch(cothread_t handle)
+{
+  cothread_t previous_handle;
+
+  previous_handle = co_active();
+  co_active_handle = handle;
+  co_switch_riscv64(handle, previous_handle);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/monkey/deps/flb_libco/libco.c
+++ b/lib/monkey/deps/flb_libco/libco.c
@@ -16,6 +16,10 @@
     #include "arm.c"
   #elif defined(__aarch64__)
     #include "aarch64.c"
+  #elif defined(__riscv) && defined(__riscv_xlen) && \
+        __riscv_xlen == 64 && !defined(__riscv_abi_rve) && \
+        !defined(__riscv_float_abi_quad)
+    #include "riscv64.c"
   #elif defined(_ARCH_PPC)
     #include "ppc.c"
   #elif defined(_WIN32)

--- a/lib/monkey/deps/flb_libco/riscv64.c
+++ b/lib/monkey/deps/flb_libco/riscv64.c
@@ -1,0 +1,223 @@
+/*
+  libco.riscv64
+  license: public domain
+*/
+
+#define LIBCO_C
+#include "libco.h"
+#include "settings.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__riscv_float_abi_double) || defined(__riscv_float_abi_single)
+  #define LIBCO_RISCV64_HARD_FLOAT
+#endif
+
+typedef struct {
+  uintptr_t ra;
+  uintptr_t sp;
+  uintptr_t s[12];
+#ifdef LIBCO_RISCV64_HARD_FLOAT
+  uint64_t fs[12];
+  uintptr_t fcsr;
+#endif
+  void (*entrypoint)(void);
+} co_context;
+
+typedef char co_context_ra_offset[(offsetof(co_context, ra) == 0) ? 1 : -1];
+typedef char co_context_sp_offset[(offsetof(co_context, sp) == 8) ? 1 : -1];
+typedef char co_context_s_offset[(offsetof(co_context, s) == 16) ? 1 : -1];
+#ifdef LIBCO_RISCV64_HARD_FLOAT
+typedef char co_context_fs_offset[(offsetof(co_context, fs) == 112) ? 1 : -1];
+typedef char co_context_fcsr_offset[(offsetof(co_context, fcsr) == 208) ? 1 : -1];
+#endif
+
+static thread_local co_context co_active_context;
+static thread_local cothread_t co_active_handle;
+
+#if defined(__riscv_float_abi_double)
+  #define LIBCO_RISCV64_SAVE_FLOAT                                        \
+    "  fsd fs0, 112(a1)\n"                                               \
+    "  fsd fs1, 120(a1)\n"                                               \
+    "  fsd fs2, 128(a1)\n"                                               \
+    "  fsd fs3, 136(a1)\n"                                               \
+    "  fsd fs4, 144(a1)\n"                                               \
+    "  fsd fs5, 152(a1)\n"                                               \
+    "  fsd fs6, 160(a1)\n"                                               \
+    "  fsd fs7, 168(a1)\n"                                               \
+    "  fsd fs8, 176(a1)\n"                                               \
+    "  fsd fs9, 184(a1)\n"                                               \
+    "  fsd fs10, 192(a1)\n"                                              \
+    "  fsd fs11, 200(a1)\n"                                              \
+    "  csrr t0, fcsr\n"                                                  \
+    "  sd t0, 208(a1)\n"
+  #define LIBCO_RISCV64_RESTORE_FLOAT                                     \
+    "  fld fs0, 112(a0)\n"                                               \
+    "  fld fs1, 120(a0)\n"                                               \
+    "  fld fs2, 128(a0)\n"                                               \
+    "  fld fs3, 136(a0)\n"                                               \
+    "  fld fs4, 144(a0)\n"                                               \
+    "  fld fs5, 152(a0)\n"                                               \
+    "  fld fs6, 160(a0)\n"                                               \
+    "  fld fs7, 168(a0)\n"                                               \
+    "  fld fs8, 176(a0)\n"                                               \
+    "  fld fs9, 184(a0)\n"                                               \
+    "  fld fs10, 192(a0)\n"                                              \
+    "  fld fs11, 200(a0)\n"                                              \
+    "  ld t0, 208(a0)\n"                                                 \
+    "  csrw fcsr, t0\n"
+#elif defined(__riscv_float_abi_single)
+  #define LIBCO_RISCV64_SAVE_FLOAT                                        \
+    "  fsw fs0, 112(a1)\n"                                               \
+    "  fsw fs1, 120(a1)\n"                                               \
+    "  fsw fs2, 128(a1)\n"                                               \
+    "  fsw fs3, 136(a1)\n"                                               \
+    "  fsw fs4, 144(a1)\n"                                               \
+    "  fsw fs5, 152(a1)\n"                                               \
+    "  fsw fs6, 160(a1)\n"                                               \
+    "  fsw fs7, 168(a1)\n"                                               \
+    "  fsw fs8, 176(a1)\n"                                               \
+    "  fsw fs9, 184(a1)\n"                                               \
+    "  fsw fs10, 192(a1)\n"                                              \
+    "  fsw fs11, 200(a1)\n"                                              \
+    "  csrr t0, fcsr\n"                                                  \
+    "  sd t0, 208(a1)\n"
+  #define LIBCO_RISCV64_RESTORE_FLOAT                                     \
+    "  flw fs0, 112(a0)\n"                                               \
+    "  flw fs1, 120(a0)\n"                                               \
+    "  flw fs2, 128(a0)\n"                                               \
+    "  flw fs3, 136(a0)\n"                                               \
+    "  flw fs4, 144(a0)\n"                                               \
+    "  flw fs5, 152(a0)\n"                                               \
+    "  flw fs6, 160(a0)\n"                                               \
+    "  flw fs7, 168(a0)\n"                                               \
+    "  flw fs8, 176(a0)\n"                                               \
+    "  flw fs9, 184(a0)\n"                                               \
+    "  flw fs10, 192(a0)\n"                                              \
+    "  flw fs11, 200(a0)\n"                                              \
+    "  ld t0, 208(a0)\n"                                                 \
+    "  csrw fcsr, t0\n"
+#else
+  #define LIBCO_RISCV64_SAVE_FLOAT
+  #define LIBCO_RISCV64_RESTORE_FLOAT
+#endif
+
+asm(
+  ".text\n"
+  ".p2align 2\n"
+  ".globl co_switch_riscv64\n"
+  ".type co_switch_riscv64, @function\n"
+  "co_switch_riscv64:\n"
+  "  sd ra, 0(a1)\n"
+  "  sd sp, 8(a1)\n"
+  "  sd s0, 16(a1)\n"
+  "  sd s1, 24(a1)\n"
+  "  sd s2, 32(a1)\n"
+  "  sd s3, 40(a1)\n"
+  "  sd s4, 48(a1)\n"
+  "  sd s5, 56(a1)\n"
+  "  sd s6, 64(a1)\n"
+  "  sd s7, 72(a1)\n"
+  "  sd s8, 80(a1)\n"
+  "  sd s9, 88(a1)\n"
+  "  sd s10, 96(a1)\n"
+  "  sd s11, 104(a1)\n"
+  LIBCO_RISCV64_SAVE_FLOAT
+  "  ld ra, 0(a0)\n"
+  "  ld sp, 8(a0)\n"
+  "  ld s0, 16(a0)\n"
+  "  ld s1, 24(a0)\n"
+  "  ld s2, 32(a0)\n"
+  "  ld s3, 40(a0)\n"
+  "  ld s4, 48(a0)\n"
+  "  ld s5, 56(a0)\n"
+  "  ld s6, 64(a0)\n"
+  "  ld s7, 72(a0)\n"
+  "  ld s8, 80(a0)\n"
+  "  ld s9, 88(a0)\n"
+  "  ld s10, 96(a0)\n"
+  "  ld s11, 104(a0)\n"
+  LIBCO_RISCV64_RESTORE_FLOAT
+  "  ret\n"
+  ".size co_switch_riscv64, .-co_switch_riscv64\n"
+  ".previous\n"
+);
+
+void co_switch_riscv64(cothread_t handle, cothread_t current);
+
+static void co_entry_trampoline(void)
+{
+  co_context *context;
+
+  context = (co_context *)co_active_handle;
+  context->entrypoint();
+  abort();
+}
+
+cothread_t co_active(void)
+{
+  if (!co_active_handle) {
+    co_active_handle = &co_active_context;
+  }
+
+  return co_active_handle;
+}
+
+cothread_t co_create(unsigned int size, void (*entrypoint)(void),
+                     size_t *out_size)
+{
+  size_t context_size;
+  size_t stack_size;
+  size_t total_size;
+  co_context *context;
+
+  context_size = (sizeof(co_context) + 15) & ~(size_t)15;
+
+  if ((size_t)size > SIZE_MAX - 15) {
+    return 0;
+  }
+
+  stack_size = ((size_t)size + 15) & ~(size_t)15;
+  if (stack_size > SIZE_MAX - context_size) {
+    return 0;
+  }
+
+  total_size = context_size + stack_size;
+  context = (co_context *)malloc(total_size);
+  if (!context) {
+    return 0;
+  }
+
+  memset(context, 0, context_size);
+  context->ra = (uintptr_t)co_entry_trampoline;
+  context->sp = (uintptr_t)context + total_size;
+  context->entrypoint = entrypoint;
+
+  *out_size = total_size;
+  return (cothread_t)context;
+}
+
+void co_delete(cothread_t handle)
+{
+  free(handle);
+}
+
+void co_switch(cothread_t handle)
+{
+  cothread_t previous_handle;
+
+  previous_handle = co_active();
+  co_active_handle = handle;
+  co_switch_riscv64(handle, previous_handle);
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

## THIS IS CANARY PR. DO NOT MERGE.

Currently, we didn't have riscv64 backend on flb_libco library and bundled library as in monkey HTTP server.
This PR fills the gap of riscv64 coroutine implementation for RISC-V64 Linux environment.
Without this patch, runtime tests of filter_wasm were failed.

After applying this patch, we get on the actual RISC-V64 Linux environment:

```
% bin/flb-rt-filter_wasm                                                           (git)[tmp-fix-cfl-undefined-fix][OK]
Test hello_world...                             [2026/08/06 19:11:24.580] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74259
[2026/08/06 19:11:24.581] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:24.581] [ info] [simd    ] RVV
[2026/08/06 19:11:24.581] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:24.582] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:24.583] [ info] [input:dummy:dummy.0] initializing
[2026/08/06 19:11:24.583] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:24.760] [ info] [sp] stream processor started
[2026/08/06 19:11:24.760] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/06 19:11:24.760] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2026/08/06 19:11:24.760] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:24.761] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:24.761] [ info] [input] pausing dummy.0
[2026/08/06 19:11:25.706] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/06 19:11:25.706] [ info] [input] pausing dummy.0
[2026/08/06 19:11:25.708] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/06 19:11:25.708] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[ OK ]
Test append_tag...                              [2026/08/06 19:11:25.743] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74263
[2026/08/06 19:11:25.743] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:25.744] [ info] [simd    ] RVV
[2026/08/06 19:11:25.744] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:25.744] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:25.745] [ info] [input:lib:lib.0] initializing
[2026/08/06 19:11:25.745] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:25.984] [ info] [sp] stream processor started
[2026/08/06 19:11:25.984] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2026/08/06 19:11:26.785] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:26.785] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:27.706] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test numeric_records...                         [2026/08/06 19:11:27.743] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74266
[2026/08/06 19:11:27.744] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:27.744] [ info] [simd    ] RVV
[2026/08/06 19:11:27.744] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:27.744] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:27.745] [ info] [input:lib:lib.0] initializing
[2026/08/06 19:11:27.745] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:27.980] [ info] [sp] stream processor started
[2026/08/06 19:11:27.981] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2026/08/06 19:11:28.782] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:28.782] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:29.706] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test array_contains_null...                     [2026/08/06 19:11:29.743] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74269
[2026/08/06 19:11:29.744] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:29.744] [ info] [simd    ] RVV
[2026/08/06 19:11:29.744] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:29.744] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:29.745] [ info] [input:lib:lib.0] initializing
[2026/08/06 19:11:29.745] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:29.982] [ info] [sp] stream processor started
[2026/08/06 19:11:29.982] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2026/08/06 19:11:30.784] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:30.784] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:31.706] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test drop_all_records...                        [2026/08/06 19:11:31.743] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74272
[2026/08/06 19:11:31.744] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:31.744] [ info] [simd    ] RVV
[2026/08/06 19:11:31.744] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:31.744] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:31.745] [ info] [input:lib:lib.0] initializing
[2026/08/06 19:11:31.745] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:31.787] [ info] [sp] stream processor started
[2026/08/06 19:11:31.788] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2026/08/06 19:11:33.790] [ warn] [timeout] elapsed_time: 2002
[2026/08/06 19:11:33.790] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:33.790] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:34.706] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test append_kv_on_msgpack_format...             [2026/08/06 19:11:34.741] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74275
[2026/08/06 19:11:34.742] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:34.742] [ info] [simd    ] RVV
[2026/08/06 19:11:34.742] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:34.742] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:34.743] [ info] [input:lib:lib.0] initializing
[2026/08/06 19:11:34.743] [ info] [input:lib:lib.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:34.855] [ info] [sp] stream processor started
[2026/08/06 19:11:34.856] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
[2026/08/06 19:11:35.757] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:35.757] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:36.706] [ info] [engine] service has stopped (0 pending tasks)
[ OK ]
Test wasm_preserve_otlp_group_metadata...       [2026/08/06 19:11:36.743] [ info] [fluent bit] version=5.1.0, commit=69fe0cea8b, pid=74278
[2026/08/06 19:11:36.743] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/06 19:11:36.743] [ info] [simd    ] RVV
[2026/08/06 19:11:36.743] [ info] [cmetrics] version=2.2.1
[2026/08/06 19:11:36.744] [ info] [ctraces ] version=0.7.1
[2026/08/06 19:11:36.745] [ info] [input:opentelemetry:opentelemetry.0] initializing
[2026/08/06 19:11:36.745] [ info] [input:opentelemetry:opentelemetry.0] storage_strategy='memory' (memory only)
[2026/08/06 19:11:36.746] [ info] [input:opentelemetry:opentelemetry.0] listening on 0.0.0.0:41269 with 1 worker
[2026/08/06 19:11:36.923] [ info] [http_server] listen iface=127.0.0.1 tcp_port=2020
[2026/08/06 19:11:36.923] [ info] [sp] stream processor started
[2026/08/06 19:11:36.924] [ info] [engine] Shutdown Grace Period=1, Shutdown Input Grace Period=0
Hello from WASM!
[2026/08/06 19:11:38.453] [ warn] [engine] service will shutdown in max 1 seconds
[2026/08/06 19:11:38.453] [ info] [engine] pausing all inputs..
[2026/08/06 19:11:38.453] [ info] [input] pausing opentelemetry.0
[2026/08/06 19:11:38.710] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/06 19:11:38.710] [ info] [input] pausing opentelemetry.0
[ OK ]
SUCCESS: All unit tests have passed.
```

Plus, the implemented coroutine function can be used as:

```
% nm -g lib/monkey/deps/flb_libco/CMakeFiles/co.dir/libco.c.o
                 U __tls_get_addr
                 U abort
0000000000000104 T co_active
000000000000016a T co_create
0000000000000224 T co_delete
0000000000000246 T co_switch
0000000000000002 T co_switch_riscv64
                 U free
                 U malloc
                 U memset
```

## Background of RISC-V64 implementation

<html>
<body>
<!--StartFragment--><html><head></head><body><p>The backend works because it saves exactly the state that the RISC-V ELF ABI says must survive an ordinary C function call. From each coroutine’s perspective, <code dir="ltr">co_switch()</code> behaves like a function that pauses and later returns normally.</p><div><div><div>
State | Why it is preserved
-- | --
ra | Becomes the resume address for the suspended coroutine
sp | Restores that coroutine’s independent stack
s0–s11 | Integer registers classified as callee-saved
fs0–fs11 | Floating-point callee-saved registers under LP64F/LP64D
fcsr | Preserves floating-point rounding mode and exception flags

</div></div></div><p>The register classification comes from the <a href="https://riscv-non-isa.github.io/riscv-elf-psabi-doc/"><span><span>RISC-V ELF psABI calling convention</span></span></a>.</p><h4>How a context switch happens</h4><p>The C wrapper passes two context pointers to the assembly routine:</p><pre dir="ltr"><code>previous_handle = co_active();
co_active_handle = handle;
co_switch_riscv64(handle, previous_handle);</code></pre><p>By the normal RISC-V calling convention:</p><pre dir="ltr"><code>a0 = target context
a1 = current context</code></pre><p>The assembly first saves the current coroutine:</p><pre dir="ltr"><code>sd ra, 0(a1)
sd sp, 8(a1)
sd s0, 16(a1)
...
sd s11, 104(a1)</code></pre><p>It then loads the target coroutine:</p><pre dir="ltr"><code>ld ra, 0(a0)
ld sp, 8(a0)
ld s0, 16(a0)
...
ld s11, 104(a0)
ret</code></pre><p>The final <code dir="ltr">ret</code> jumps to the <code dir="ltr">ra</code> loaded from the target context.</p><p>For a suspended coroutine, that <code dir="ltr">ra</code> points immediately after its earlier call to <code dir="ltr">co_switch_riscv64()</code>. Execution therefore continues as though <code dir="ltr">co_switch()</code> had just returned.</p><p>For a new coroutine, [co_create() (line 173)](C:/Users/cosmo/Documents/GitHub/fluent-bit/lib/flb_libco/riscv64.c:173) initializes:</p><pre dir="ltr"><code>context-&gt;ra = (uintptr_t) co_entry_trampoline;
context-&gt;sp = (uintptr_t) context + total_size;
context-&gt;entrypoint = entrypoint;</code></pre><p>Its first <code dir="ltr">ret</code> enters the trampoline on the newly allocated stack. The trampoline invokes the actual coroutine entry function and aborts if that function unexpectedly returns.</p><h4>Why caller-saved registers are omitted</h4><p>The backend does not need to save <code dir="ltr">a0</code>–<code dir="ltr">a7</code> or <code dir="ltr">t0</code>–<code dir="ltr">t6</code>. They are caller-saved registers. When the compiler generates a call to <code dir="ltr">co_switch()</code>, it already spills any live caller-saved values that will be needed afterward.</p><p>Likewise:</p><ul><li><code dir="ltr">gp</code> is fixed by the ABI and must not be modified.</li><li><code dir="ltr">tp</code> identifies the current OS thread. Fluent Bit coroutines remain on the same pthread, so it must remain unchanged.</li><li>Standard vector registers are caller-saved. RVV code must spill live vector values before calling <code dir="ltr">co_switch()</code>.</li></ul><p>This backend therefore assumes that a coroutine is never migrated to another pthread, matching Fluent Bit’s current coroutine model.</p><h4>Floating-point ABI handling</h4><p>The compiler exposes the selected ABI through predefined macros:</p><ul><li>LP64: neither floating-point macro is defined.</li><li>LP64F: <code dir="ltr">__riscv_float_abi_single</code></li><li>LP64D: <code dir="ltr">__riscv_float_abi_double</code></li></ul><p>LP64D uses 64-bit operations:</p><pre dir="ltr"><code>fsd fs0, 112(a1)
...
fld fs0, 112(a0)</code></pre><p>LP64F uses 32-bit operations:</p><pre dir="ltr"><code>fsw fs0, 112(a1)
...
flw fs0, 112(a0)</code></pre><p>Soft-float LP64 does not preserve floating-point registers because that ABI does not classify them as callee-saved program state.</p><p>On a typical DC ROMA II LP64D environment, GCC should report:</p><pre dir="ltr"><code>gcc -dM -E - &lt;/dev/null |
grep -E '__riscv($|_)|__riscv_float_abi'</code></pre><p>Expected relevant definitions include:</p><pre dir="ltr"><code>#define __riscv 1
#define __riscv_xlen 64
#define __riscv_float_abi_double 1</code></pre><p>These macros select riscv64.c and enable its double-precision register-save path.</p><h4>Stack correctness</h4><p>RISC-V requires the stack pointer to remain 16-byte aligned. Both the requested stack size and context header are rounded to multiples of 16. Linux RV64 <code dir="ltr">malloc()</code> supplies suitably aligned memory, so the calculated top of the allocation remains 16-byte aligned.</p><p>The stack grows downward from that address, while the saved context resides at the bottom of the allocation:</p><pre dir="ltr"><code>low address
┌──────────────────────────┐
│ Saved context            │
│ ra, sp, s0-s11, FP state │
├──────────────────────────┤
│ Coroutine stack          │
│                          │
│                 ↓ growth │
└──────────────────────────┘ ← initial sp, 16-byte aligned
high address</code></pre><h4>How the focused test proves preservation</h4><p>The test commit does more than verify that switching does not crash:</p><ol start="1"><li>The primary coroutine loads known values into <code dir="ltr">s0</code>–<code dir="ltr">s11</code>, <code dir="ltr">fs0</code>–<code dir="ltr">fs11</code>, and <code dir="ltr">fcsr</code>.</li><li>It switches to a worker coroutine.</li><li>The worker deliberately overwrites those registers with zero.</li><li>The worker switches back.</li><li>The primary coroutine compares every restored register with its original pattern.</li></ol><p>Correct return flow also implicitly verifies <code dir="ltr">ra</code> and <code dir="ltr">sp</code>: an incorrect value for either normally returns to the wrong instruction or accesses the wrong stack and crashes.</p><p>RV64E and LP64Q are excluded because their register sets or floating-point widths require different layouts. They continue to the generic backend instead of silently using an incompatible context representation.</p></body></html><!--EndFragment-->
</body>
</html>

The backend works because it saves exactly the state that the RISC-V ELF ABI says must survive an ordinary C function call. From each coroutine’s perspective, `co_switch()` behaves like a function that pauses and later returns normally.

| State | Why it is preserved |
|---|---|
| `ra` | Becomes the resume address for the suspended coroutine |
| `sp` | Restores that coroutine’s independent stack |
| `s0`–`s11` | Integer registers classified as callee-saved |
| `fs0`–`fs11` | Floating-point callee-saved registers under LP64F/LP64D |
| `fcsr` | Preserves floating-point rounding mode and exception flags |

The register classification comes from the [[RISC-V ELF psABI calling convention](https://riscv-non-isa.github.io/riscv-elf-psabi-doc/)](https://riscv-non-isa.github.io/riscv-elf-psabi-doc/).

#### How a context switch happens

The C wrapper passes two context pointers to the assembly routine:

```c
previous_handle = co_active();
co_active_handle = handle;
co_switch_riscv64(handle, previous_handle);
```

By the normal RISC-V calling convention:

```text
a0 = target context
a1 = current context
```

The assembly first saves the current coroutine:

```asm
sd ra, 0(a1)
sd sp, 8(a1)
sd s0, 16(a1)
...
sd s11, 104(a1)
```

It then loads the target coroutine:

```asm
ld ra, 0(a0)
ld sp, 8(a0)
ld s0, 16(a0)
...
ld s11, 104(a0)
ret
```

The final `ret` jumps to the `ra` loaded from the target context.

For a suspended coroutine, that `ra` points immediately after its earlier call to `co_switch_riscv64()`. Execution therefore continues as though `co_switch()` had just returned.

For a new coroutine, [co_create()](C:/Users/cosmo/Documents/GitHub/fluent-bit/lib/flb_libco/riscv64.c:173) initializes:

```c
context->ra = (uintptr_t) co_entry_trampoline;
context->sp = (uintptr_t) context + total_size;
context->entrypoint = entrypoint;
```

Its first `ret` enters the trampoline on the newly allocated stack. The trampoline invokes the actual coroutine entry function and aborts if that function unexpectedly returns.

#### Why caller-saved registers are omitted

The backend does not need to save `a0`–`a7` or `t0`–`t6`. They are caller-saved registers. When the compiler generates a call to `co_switch()`, it already spills any live caller-saved values that will be needed afterward.

Likewise:

- `gp` is fixed by the ABI and must not be modified.
- `tp` identifies the current OS thread. Fluent Bit coroutines remain on the same pthread, so it must remain unchanged.
- Standard vector registers are caller-saved. RVV code must spill live vector values before calling `co_switch()`.

This backend therefore assumes that a coroutine is never migrated to another pthread, matching Fluent Bit’s current coroutine model.

#### Floating-point ABI handling

The compiler exposes the selected ABI through predefined macros:

- LP64: neither floating-point macro is defined.
- LP64F: `__riscv_float_abi_single`
- LP64D: `__riscv_float_abi_double`

LP64D uses 64-bit operations:

```asm
fsd fs0, 112(a1)
...
fld fs0, 112(a0)
```

LP64F uses 32-bit operations:

```asm
fsw fs0, 112(a1)
...
flw fs0, 112(a0)
```

Soft-float LP64 does not preserve floating-point registers because that ABI does not classify them as callee-saved program state.

On a typical DC ROMA II LP64D environment, GCC should report:

```bash
gcc -dM -E - </dev/null |
grep -E '__riscv($|_)|__riscv_float_abi'
```

Expected relevant definitions include:

```text
#define __riscv 1
#define __riscv_xlen 64
#define __riscv_float_abi_double 1
```

These macros select [riscv64.c](C:/Users/cosmo/Documents/GitHub/fluent-bit/lib/flb_libco/libco.c:18) and enable its double-precision register-save path.

#### Stack correctness

RISC-V requires the stack pointer to remain 16-byte aligned. Both the requested stack size and context header are rounded to multiples of 16. Linux RV64 `malloc()` supplies suitably aligned memory, so the calculated top of the allocation remains 16-byte aligned.

The stack grows downward from that address, while the saved context resides at the bottom of the allocation:

```text
low address
┌──────────────────────────┐
│ Saved context            │
│ ra, sp, s0-s11, FP state │
├──────────────────────────┤
│ Coroutine stack          │
│                          │
│                 ↓ growth │
└──────────────────────────┘ ← initial sp, 16-byte aligned
high address
```

#### How the focused test proves preservation

The test commit does more than verify that switching does not crash:

1. The primary coroutine loads known values into `s0`–`s11`, `fs0`–`fs11`, and `fcsr`.
2. It switches to a worker coroutine.
3. The worker deliberately overwrites those registers with zero.
4. The worker switches back.
5. The primary coroutine compares every restored register with its original pattern.

Correct return flow also implicitly verifies `ra` and `sp`: an incorrect value for either normally returns to the wrong instruction or accesses the wrong stack and crashes.

RV64E and LP64Q are excluded because their register sets or floating-point widths require different layouts. They continue to the generic backend instead of silently using an incompatible context representation.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
