### PR TITLE
out_cloudwatch_logs: fix log stream leak when group allocation fails

### DIFF
--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -1717,6 +1717,7 @@ struct log_stream *get_or_create_log_stream(struct flb_cloudwatch *ctx,
     new_stream->group = flb_sds_create(group_name);
     if (new_stream->group == NULL) {
         flb_errno();
+        log_stream_destroy(new_stream);
         return NULL;
     }
 


### PR DESCRIPTION
In `get_or_create_log_stream()`, the branch handling a failed `flb_sds_create()` for the group name returns without releasing the partially initialised `log_stream`, leaking both the struct and the already allocated `name` field:

```c
new_stream->name = flb_sds_create(stream_name);
if (new_stream->name == NULL) {
    flb_errno();
    flb_free(new_stream);      /* frees */
    return NULL;
}
new_stream->group = flb_sds_create(group_name);
if (new_stream->group == NULL) {
    flb_errno();
    return NULL;               /* frees nothing */
}
```

The asymmetry with the branch directly above, and with the `create_log_stream()` failure path below which already calls `log_stream_destroy()`, suggests this was an oversight rather than intentional.

This change uses `log_stream_destroy()` in that branch as well. It null checks every field, so it handles the partially initialised struct correctly.

The path is only reached when an allocation fails, which in practice means the process is already under memory pressure, so the leak compounds exactly when it can least be afforded.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when creating CloudWatch log streams to ensure partially initialized resources are properly released if setup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->