### PR TITLE
ci: sanitize target input to prevent template injection in build build-matrix action

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -99,11 +99,7 @@ runs:
       run: |
         if [ -n "$TARGET_INPUT" ]; then
           echo "Overriding matrix to build: $TARGET_INPUT"
-          matrix=$((
-            echo '{ "distro" : ['
-            echo "\"$TARGET_INPUT\""
-            echo ']}'
-          ) | jq -c .)
+          matrix=$(jq -cn --arg target "$TARGET_INPUT" '{distro: [$target]}')
         fi
         echo "MATRIX=$matrix" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/generate-package-build-matrix/action.yaml
+++ b/.github/actions/generate-package-build-matrix/action.yaml
@@ -94,12 +94,14 @@ runs:
 
     - name: Manual override of target
       if: inputs.target != ''
+      env:
+        TARGET_INPUT: ${{ inputs.target }}
       run: |
-        if [ -n "${{ inputs.target || '' }}" ]; then
-          echo "Overriding matrix to build: ${{ inputs.target }}"
+        if [ -n "$TARGET_INPUT" ]; then
+          echo "Overriding matrix to build: $TARGET_INPUT"
           matrix=$((
             echo '{ "distro" : ['
-            echo '"${{ inputs.target }}"'
+            echo "\"$TARGET_INPUT\""
             echo ']}'
           ) | jq -c .)
         fi


### PR DESCRIPTION
### Summary
This PR remediates a high-confidence GitHub Actions template injection risk (`template-injection`) in `.github/actions/generate-package-build-matrix/action.yaml`.

### Security Impact
Direct inline expansion of `${{ inputs.target }}` inside `run:` shell blocks allows potential code execution if user inputs contain shell metacharacters. 

By mapping `${{ inputs.target }}` to an intermediate environment variable (`TARGET_INPUT`) under an `env:` block, GitHub Actions safely escapes the input string prior to shell execution.

### Changes Made
- Added `env: TARGET_INPUT: ${{ inputs.target }}` to the `Manual override of target` step.
- Replaced inline `${{ inputs.target }}` expansions in the `run:` script with safe environment variable references (`$TARGET_INPUT`).
- Verified locally using `zizmor`; `error[template-injection]` findings are resolved.

### Testing & Validation
- Verified YAML formatting and syntax.
- Audited with `zizmor` locally against `.github/actions/generate-package-build-matrix/action.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of manually specified build targets.
  * Added clearer logging and validation when a target override is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->