### PR TITLE
engine_dispatch: re-schedule retry when chunk content cannot be read

### DIFF
--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -90,6 +90,7 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
     char *buf_data;
     size_t buf_size;
     struct flb_task *task;
+    struct flb_output_instance *ins;
 
     task = retry->parent;
 
@@ -116,12 +117,38 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
     /* There is a match, get the buffer */
     buf_data = (char *) flb_input_chunk_flush(task->ic, &buf_size);
     if (!buf_data) {
-        /* Could not retrieve chunk content */
-        flb_error("[engine_dispatch] could not retrieve chunk content, removing retry");
-        record_retry_failure_metrics(task, retry->o_ins, config);
-        flb_task_retry_destroy(retry);
-        flb_task_users_release(task);
-        return -1;
+        /*
+         * The chunk is up but its content could not be read. That is usually
+         * transient, so spend a delivery attempt on it instead of discarding
+         * records a later attempt could still deliver.
+         *
+         * Destroying the retry without releasing the task would leave the task
+         * with no users and no retries, a state nothing reaps.
+         */
+        ins = retry->o_ins;
+
+        if (retry->attempts >= ins->retry_limit && ins->retry_limit >= 0) {
+            flb_error("[engine_dispatch] could not retrieve chunk content, "
+                      "task_id=%i reached retry-attempts limit %i/%i, dropping",
+                      task->id, retry->attempts, ins->retry_limit);
+            record_retry_failure_metrics(task, ins, config);
+            flb_task_retry_destroy(retry);
+            flb_task_users_release(task);
+            return -1;
+        }
+
+        retry->attempts++;
+        flb_warn("[engine_dispatch] could not retrieve chunk content, "
+                 "re-scheduling task_id=%i attempts=%i",
+                 task->id, retry->attempts);
+
+        ret = flb_task_retry_reschedule(retry, config);
+        if (ret == -1) {
+            return -1;
+        }
+
+        /* Just return because it has been re-scheduled */
+        return 0;
     }
 
     /* Update the buffer reference */

--- a/tests/internal/engine_dispatch.c
+++ b/tests/internal/engine_dispatch.c
@@ -518,9 +518,83 @@ static void test_retry_flush_failure_preserves_pending_retry(void)
     test_ctx_destroy(ctx);
 }
 
+/*
+ * With retry budget left the chunk must be kept and the attempt re-scheduled,
+ * otherwise a transient read failure would delete records a later attempt
+ * could still deliver.
+ */
+static void test_retry_flush_failure_reschedules_within_retry_limit(void)
+{
+    int ret;
+    int task_id;
+    double value;
+    char *chunk_buffer;
+    char *output_name;
+    struct test_ctx *ctx;
+    struct flb_task *task;
+    struct flb_task_retry *retry;
+    struct flb_output_instance output;
+
+    ctx = test_ctx_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    ret = test_output_init(&output, "output_a");
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return;
+    }
+
+    /* the retry starts with attempts=1, so this leaves budget available */
+    output.retry_limit = 5;
+
+    retry = create_retry_dispatch_task(ctx, &output, &task_id, &chunk_buffer);
+    TEST_CHECK(retry != NULL);
+    if (retry == NULL) {
+        test_output_destroy(&output);
+        test_ctx_destroy(ctx);
+        return;
+    }
+    task = retry->parent;
+
+    ret = flb_engine_dispatch_retry(retry, ctx->config);
+    TEST_CHECK(ret == 0);
+
+    /* the task keeps its slot, its chunk and a pending retry */
+    TEST_CHECK(ctx->config->task_map[task_id].task == task);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 1);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 1);
+    TEST_CHECK(mk_list_size(&task->retries) == 1);
+    TEST_CHECK(retry->attempts == 2);
+
+    /*
+     * Nothing was dropped, so no drop accounting must be recorded. An untouched
+     * counter has no series yet, so cmt_counter_get_val() reports a failure.
+     */
+    output_name = (char *) flb_output_name(&output);
+    ret = cmt_counter_get_val(output.cmt_retries_failed,
+                              1, (char *[]) {output_name}, &value);
+    TEST_CHECK(ret != 0 || value == 0);
+
+    ret = cmt_counter_get_val(output.cmt_dropped_records,
+                              1, (char *[]) {output_name}, &value);
+    TEST_CHECK(ret != 0 || value == 0);
+
+    flb_task_destroy(task, FLB_TRUE);
+    free(chunk_buffer);
+
+    test_output_destroy(&output);
+    test_ctx_destroy(ctx);
+}
+
 TEST_LIST = {
     { "retry_flush_failure_releases_last_task_owner",
       test_retry_flush_failure_releases_last_task_owner },
+    { "retry_flush_failure_reschedules_within_retry_limit",
+      test_retry_flush_failure_reschedules_within_retry_limit },
     { "retry_flush_failure_preserves_active_task_owner",
       test_retry_flush_failure_preserves_active_task_owner },
     { "retry_flush_failure_preserves_pending_retry",


### PR DESCRIPTION
<!-- Provide summary of changes -->

Stacked on #12254, so the base branch is `cosmo0920-plug-stale-failed-tasks-on-dispatch`
and the diff here is only my two commits.

#12254 fixes the task leak reported in #12252, and I verified that it does. This PR keeps
that fix and changes one thing: when the chunk content cannot be read, spend a delivery
attempt on it before giving up, instead of dropping on the first failure. With the default
`retry_limit` of 1 the behaviour is identical to #12254, so the change only takes effect
when the user has explicitly raised their retry budget.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Builds on #12254, which closes #12252.

## Problem

Releasing the task on the first read failure deletes the chunk file. The call chain is
`flb_task_users_release()` -> `flb_task_destroy(task, FLB_TRUE)` ->
`flb_input_chunk_destroy(ic, FLB_TRUE)` -> `cio_chunk_close(ch, CIO_TRUE)` ->
`cio_file_native_delete()`.

`flb_input_chunk_flush()` returns `NULL` when `cio_chunk_up()` or `cio_chunk_get_content()`
fails. Those failures are typically transient under memory or descriptor pressure rather
than permanent corruption, so the records would very likely have been delivered by a later
attempt. The leak being fixed here is bad, but it does at least keep the records on disk
for a restart to flush, which is the behaviour I measured while investigating #12252.

## Summary

The give-up path is unchanged from #12254, including its drop accounting. What is new is
that a read failure first consumes a delivery attempt and re-schedules through
`flb_task_retry_reschedule()`, which is what the failure case a few lines above already
does for the same reason. On both paths the task is never left with no users and no
retries, so the leak stays fixed.

Reusing `Retry_Limit` keeps the decision where the user already expressed it, so no new
configuration option or constant is introduced.

| `Retry_Limit` | Behaviour on a read failure |
|---|---|
| `1` (default) | Drops immediately, same as #12254 |
| `no_retries` (0) | Drops immediately |
| `5` | Re-schedules up to 4 times, then drops with accounting |
| `no_limits` | Re-schedules until the chunk becomes readable |

## Verification

The three tests added by #12254 pass unchanged, so this does not alter the cases they
cover. `flb-it-task_map` passes as well. I added one test for the re-scheduled path that
asserts the task keeps its task-map slot, its chunk and a pending retry, and that no drop
accounting is recorded.

End to end on a build with 8 `dummy` inputs and 8 `forward` outputs, 20 read failures
injected with gdb produced 20 re-schedules and 0 drops, and the busy chunk gauge settled
back to 0 over three hours. The same injection against unpatched v5.1.0 pinned 20 chunks
permanently. Throughput was 3998 records per second against 3971 for the unpatched build,
and no crash, assertion or signal appeared in roughly three hours of continuous operation.

## Trade-offs

A read failure now consumes one delivery attempt, so `retry->attempts` covers both delivery
and read failures. It never drops earlier than #12254 does.

A permanently unreadable chunk under `no_limits` stays on disk until
`storage.total_limit_size` evicts it.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
