### PR TITLE
in_tail: drop multiline records whose reassembled content is empty (fixes #6703)

### DIFF
--- a/include/fluent-bit/multiline/flb_ml.h
+++ b/include/fluent-bit/multiline/flb_ml.h
@@ -254,6 +254,9 @@ struct flb_ml_parser_ins {
 
     /* Link to struct flb_ml_group->parsers */
     struct mk_list _head;
+
+    /* drop a flush whose key_content is an empty string (off) */
+    int drop_empty_content;
 };
 
 struct flb_ml_group {

--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -69,6 +69,8 @@ static int multiline_load_parsers(struct flb_tail_config *ctx)
             if (!parser_i) {
                 return -1;
             }
+
+            parser_i->drop_empty_content = ctx->skip_empty_lines;
         }
     }
 

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -1596,6 +1596,7 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
     int ret;
     int size;
     int len;
+    int key_id;
     size_t off = 0;
     msgpack_object map;
     msgpack_object k;
@@ -1682,8 +1683,17 @@ int flb_ml_flush_stream_group(struct flb_ml_parser *ml_parser,
             }
         }
         else {
-            /* The buffer is empty, so just pack the original map from the context */
-            msgpack_pack_object(&mp_pck, map);
+            key_id = -1;
+            if (parser_i->drop_empty_content) {
+                key_id = get_key_id(&map, parser_i->key_content);
+            }
+
+            if (key_id == -1 ||
+                map.via.map.ptr[key_id].val.type != MSGPACK_OBJECT_STR ||
+                map.via.map.ptr[key_id].val.via.str.size > 0) {
+                /* The buffer is empty, so just pack the original map from the context */
+                msgpack_pack_object(&mp_pck, map);
+            }
         }
 
         msgpack_unpacked_destroy(&result);

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -82,6 +82,37 @@ struct record_check cri_output[] = {
   {"4b. non multiline 2"}
 };
 
+/* CRI, empty payload dropped via drop_empty_content */
+struct record_check issue_6703_input[] = {
+  {"2025-01-01T00:00:00.000000000Z stdout F hello world"},
+  {"2025-01-01T00:00:00.000000001Z stdout F "},
+  {"2025-01-01T00:00:00.000000002Z stdout F goodbye world"}
+};
+
+struct record_check issue_6703_output[] = {
+  {"hello world"},
+  {"goodbye world"}
+};
+
+/* Same input, drop_empty_content left off (default): behavior is unchanged */
+struct record_check issue_6703_disabled_output[] = {
+  {"hello world"},
+  {""},
+  {"goodbye world"}
+};
+
+/* CRI, every line in isolation is an empty payload */
+struct record_check issue_6703_all_empty_input[] = {
+  {"2025-01-01T00:00:00.000000000Z stdout F "},
+  {"2025-01-01T00:00:00.000000001Z stdout F "},
+  {"2025-01-01T00:00:00.000000002Z stdout F "}
+};
+
+/* Sink for issue_6703_all_empty: only read if the fix regresses */
+struct record_check issue_6703_all_empty_output[] = {
+  {""}, {""}, {""}
+};
+
 /* ENDSWITH */
 struct record_check endswith_input[] = {
   {"1a. some multiline log \\"},
@@ -577,6 +608,150 @@ static void test_parser_cri()
         /* Package as msgpack */
         flb_ml_append_text(ml, stream_id, &tm, r->buf, len);
     }
+
+    if (ml) {
+        flb_ml_destroy(ml);
+    }
+
+    flb_config_exit(config);
+}
+
+static void test_issue_6703()
+{
+    int i;
+    int len;
+    int ret;
+    int entries;
+    uint64_t stream_id;
+    struct record_check *r;
+    struct flb_config *config;
+    struct flb_time tm;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct expected_result res = {0};
+
+    res.key = "log";
+    res.out_records = issue_6703_output;
+
+    config = flb_config_init();
+
+    ml = flb_ml_create(config, "cri-drop-empty-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "cri");
+    TEST_CHECK(mlp_i != NULL);
+    mlp_i->drop_empty_content = FLB_TRUE;
+
+    ret = flb_ml_stream_create(ml, "cri-drop-empty", -1, flush_callback,
+                               (void *) &res, &stream_id);
+    TEST_CHECK(ret == 0);
+
+    entries = sizeof(issue_6703_input) / sizeof(struct record_check);
+    for (i = 0; i < entries; i++) {
+        r = &issue_6703_input[i];
+        len = strlen(r->buf);
+        flb_time_get(&tm);
+        ret = flb_ml_append_text(ml, stream_id, &tm, r->buf, len);
+        TEST_CHECK(ret == FLB_MULTILINE_OK);
+    }
+
+    TEST_CHECK(res.current_record == 2);
+
+    if (ml) {
+        flb_ml_destroy(ml);
+    }
+
+    flb_config_exit(config);
+}
+
+static void test_issue_6703_disabled()
+{
+    int i;
+    int len;
+    int ret;
+    int entries;
+    uint64_t stream_id;
+    struct record_check *r;
+    struct flb_config *config;
+    struct flb_time tm;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct expected_result res = {0};
+
+    res.key = "log";
+    res.out_records = issue_6703_disabled_output;
+
+    config = flb_config_init();
+
+    ml = flb_ml_create(config, "cri-drop-empty-disabled-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "cri");
+    TEST_CHECK(mlp_i != NULL);
+    TEST_CHECK(mlp_i->drop_empty_content == FLB_FALSE);
+
+    ret = flb_ml_stream_create(ml, "cri-drop-empty-disabled", -1, flush_callback,
+                               (void *) &res, &stream_id);
+    TEST_CHECK(ret == 0);
+
+    entries = sizeof(issue_6703_input) / sizeof(struct record_check);
+    for (i = 0; i < entries; i++) {
+        r = &issue_6703_input[i];
+        len = strlen(r->buf);
+        flb_time_get(&tm);
+        ret = flb_ml_append_text(ml, stream_id, &tm, r->buf, len);
+        TEST_CHECK(ret == FLB_MULTILINE_OK);
+    }
+
+    TEST_CHECK(res.current_record == 3);
+
+    if (ml) {
+        flb_ml_destroy(ml);
+    }
+
+    flb_config_exit(config);
+}
+
+static void test_issue_6703_all_empty()
+{
+    int i;
+    int len;
+    int ret;
+    int entries;
+    uint64_t stream_id;
+    struct record_check *r;
+    struct flb_config *config;
+    struct flb_time tm;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct expected_result res = {0};
+
+    res.key = "log";
+    res.out_records = issue_6703_all_empty_output;
+
+    config = flb_config_init();
+
+    ml = flb_ml_create(config, "cri-drop-empty-all-empty-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "cri");
+    TEST_CHECK(mlp_i != NULL);
+    mlp_i->drop_empty_content = FLB_TRUE;
+
+    ret = flb_ml_stream_create(ml, "cri-drop-empty-all-empty", -1, flush_callback,
+                               (void *) &res, &stream_id);
+    TEST_CHECK(ret == 0);
+
+    entries = sizeof(issue_6703_all_empty_input) / sizeof(struct record_check);
+    for (i = 0; i < entries; i++) {
+        r = &issue_6703_all_empty_input[i];
+        len = strlen(r->buf);
+        flb_time_get(&tm);
+        ret = flb_ml_append_text(ml, stream_id, &tm, r->buf, len);
+        TEST_CHECK(ret == FLB_MULTILINE_OK);
+    }
+
+    TEST_CHECK(res.current_record == 0);
 
     if (ml) {
         flb_ml_destroy(ml);
@@ -2149,5 +2324,8 @@ TEST_LIST = {
     { "issue_5504"    , test_issue_5504},
     { "issue_10576"   , test_issue_10576},
     { "issue_truncation_10576", test_issue_truncation_10576 },
+    { "issue_6703"    , test_issue_6703},
+    { "issue_6703_disabled", test_issue_6703_disabled},
+    { "issue_6703_all_empty", test_issue_6703_all_empty},
     { 0 }
 };


### PR DESCRIPTION
Fixes #6703.

`Skip_Empty_Lines` (`tail_file.c`) only inspects the raw line as read from
disk, before multiline reassembly. A CRI-framed empty-payload line
(`<ts> stdout F ` with nothing after it) still has a non-zero raw length
(timestamp/stream/tag prefix), so it never trips that check, and the
reassembled record is emitted with an empty content field regardless.

This adds an opt-in `drop_empty_content` field to `struct flb_ml_parser_ins`,
wired from `in_tail`'s existing `Skip_Empty_Lines` option (default off, no
behavior change unless already set), checked in `flb_ml_flush_stream_group()`
at the point that has visibility into the final reassembled content.

Verified with a real CRI-format log file on disk. Before: emits a record
with `"log":""`; after: dropped, surrounding valid lines untouched (no
truncation or merge). Full existing internal multiline test suite passes
(gcc and clang), plus 3 new tests covering the fix, backward compatibility
(option off = unchanged behavior), and an all-empty group. Valgrind clean.

Known limitation: only verified for the CRI parser (the one reported in
#6703). The built-in `docker`/JSON parser has its own, separate
`skip_empty=TRUE` behavior at the JSON-decode level that drops the key before
this code runs; not addressed here, and not the same failure mode.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering out multiline records with empty content.
  * Non-empty records continue to be processed normally.
  * Streams containing only empty payloads now produce no records when filtering is enabled.

* **Bug Fixes**
  * Improved multiline flushing behavior for empty payloads.
  * Preserved existing behavior when empty-content filtering is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->