### PR TITLE
out_gcs: support application default credentials

### DIFF
--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -593,6 +593,110 @@ error:
     return -1;
 }
 
+static int gcs_fetch_metadata_token(struct flb_gcs *ctx, flb_sds_t *payload)
+{
+    int ret;
+    int result;
+    size_t bytes_sent;
+    const char *test_response;
+    flb_sds_t tmp;
+    struct flb_connection *connection;
+    struct flb_http_client *client;
+
+    if (gcs_under_test_mode() == FLB_TRUE) {
+        test_response = getenv("TEST_GCS_METADATA_RESPONSE");
+        if (!test_response) {
+            return -1;
+        }
+
+        tmp = flb_sds_copy(*payload, test_response, strlen(test_response));
+        if (!tmp) {
+            return -1;
+        }
+        *payload = tmp;
+        mock_gcs_call_increment_counter("MetadataToken");
+        gcs_setenv("TEST_GCS_LAST_METADATA_URI", FLB_GCS_METADATA_TOKEN_URI);
+        return 0;
+    }
+
+    connection = flb_upstream_conn_get(ctx->metadata_u);
+    if (!connection) {
+        flb_plg_error(ctx->ins,
+                      "failed to connect to metadata server at '%s'; "
+                      "provide google_service_credentials when not running on GCE/GKE",
+                      ctx->metadata_server);
+        return -1;
+    }
+
+    client = flb_http_client(connection, FLB_HTTP_GET,
+                             FLB_GCS_METADATA_TOKEN_URI,
+                             "", 0, NULL, 0, NULL, 0);
+    if (!client) {
+        flb_upstream_conn_release(connection);
+        return -1;
+    }
+
+    flb_http_buffer_size(client, FLB_GCS_METADATA_TOKEN_SIZE_MAX);
+    flb_http_add_header(client, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(client, "Metadata-Flavor", 15, "Google", 6);
+
+    ret = flb_http_do(client, &bytes_sent);
+    if (ret != 0) {
+        flb_plg_warn(ctx->ins, "metadata token request failed: http_do=%i", ret);
+        result = -1;
+    }
+    else if (client->resp.status == 200) {
+        tmp = flb_sds_copy(*payload, client->resp.payload,
+                           client->resp.payload_size);
+        if (tmp) {
+            *payload = tmp;
+            result = 0;
+        }
+        else {
+            result = -1;
+        }
+    }
+    else {
+        flb_plg_warn(ctx->ins,
+                     "metadata token request failed with status=%i response='%.*s'",
+                     client->resp.status,
+                     (int) client->resp.payload_size,
+                     client->resp.payload ? client->resp.payload : "");
+        result = -1;
+    }
+
+    flb_http_client_destroy(client);
+    flb_upstream_conn_release(connection);
+
+    return result;
+}
+
+static int gcs_get_metadata_token(struct flb_gcs *ctx)
+{
+    int ret;
+    flb_sds_t payload;
+
+    payload = flb_sds_create_size(FLB_GCS_METADATA_TOKEN_SIZE_MAX);
+    if (!payload) {
+        return -1;
+    }
+
+    ret = gcs_fetch_metadata_token(ctx, &payload);
+    if (ret == 0) {
+        ret = flb_oauth2_parse_json_response(payload, flb_sds_len(payload),
+                                             ctx->o);
+    }
+    flb_sds_destroy(payload);
+
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "could not retrieve a metadata server token");
+        return -1;
+    }
+
+    ctx->o->expires_at = time(NULL) + ctx->o->expires_in;
+    return 0;
+}
+
 static int gcs_get_oauth2_token(struct flb_gcs *ctx)
 {
     int ret;
@@ -603,6 +707,10 @@ static int gcs_get_oauth2_token(struct flb_gcs *ctx)
     char payload[1024];
 
     flb_oauth2_payload_clear(ctx->o);
+    if (ctx->metadata_server_auth == FLB_TRUE) {
+        return gcs_get_metadata_token(ctx);
+    }
+
     issued = time(NULL);
     expires = issued + FLB_GCS_TOKEN_REFRESH;
     snprintf(payload, sizeof(payload) - 1,
@@ -865,7 +973,8 @@ static int upload_data(struct flb_gcs *ctx,
     size_t upload_size;
     char random_hex[9];
 
-    if (gcs_under_test_mode() == FLB_TRUE) {
+    if (gcs_under_test_mode() == FLB_TRUE &&
+        ctx->metadata_server_auth == FLB_FALSE) {
         auth = flb_sds_create("Bearer test-token");
     }
     else {
@@ -1220,6 +1329,7 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
     int ret;
     struct flb_gcs *ctx;
     const char *tmp;
+    const char *legacy_credentials;
     (void) data;
 
     ctx = flb_calloc(1, sizeof(*ctx));
@@ -1275,7 +1385,16 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
         goto error;
     }
 
-    tmp = getenv("GOOGLE_SERVICE_CREDENTIALS");
+    tmp = getenv("GOOGLE_APPLICATION_CREDENTIALS");
+    legacy_credentials = getenv("GOOGLE_SERVICE_CREDENTIALS");
+    if (!ctx->credentials_file && tmp && legacy_credentials) {
+        flb_plg_warn(ins, "GOOGLE_APPLICATION_CREDENTIALS and "
+                     "GOOGLE_SERVICE_CREDENTIALS are both set; using "
+                     "GOOGLE_APPLICATION_CREDENTIALS");
+    }
+    if (!ctx->credentials_file && !tmp) {
+        tmp = legacy_credentials;
+    }
     if (!ctx->credentials_file && tmp) {
         ctx->credentials_file = flb_sds_create(tmp);
         if (!ctx->credentials_file) {
@@ -1284,16 +1403,21 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
         ctx->credentials_file_owned = FLB_TRUE;
     }
 
-    ctx->oauth_credentials = flb_calloc(1, sizeof(struct flb_gcs_oauth_credentials));
-    if (!ctx->oauth_credentials) {
-        flb_errno();
-        goto error;
-    }
+    if (ctx->credentials_file) {
+        ctx->oauth_credentials = flb_calloc(1, sizeof(struct flb_gcs_oauth_credentials));
+        if (!ctx->oauth_credentials) {
+            flb_errno();
+            goto error;
+        }
 
-    if (!ctx->credentials_file ||
-        flb_gcs_read_credentials_file(ctx, ctx->credentials_file, ctx->oauth_credentials) == -1) {
-        flb_errno();
-        goto error;
+        if (flb_gcs_read_credentials_file(ctx, ctx->credentials_file,
+                                          ctx->oauth_credentials) == -1) {
+            goto error;
+        }
+    }
+    else {
+        ctx->metadata_server_auth = FLB_TRUE;
+        flb_plg_info(ins, "using GCE/GKE metadata server authentication");
     }
 
     ctx->o = flb_oauth2_create(config, FLB_GCS_AUTH_URL, FLB_GCS_TOKEN_REFRESH);
@@ -1310,6 +1434,15 @@ static int cb_gcs_init(struct flb_output_instance *ins, struct flb_config *confi
                                  FLB_IO_TLS, ins->tls);
     if (!ctx->u) {
         goto error;
+    }
+    if (ctx->metadata_server_auth == FLB_TRUE) {
+        ctx->metadata_u = flb_upstream_create_url(config, ctx->metadata_server,
+                                                  FLB_IO_TCP, NULL);
+        if (!ctx->metadata_u) {
+            flb_plg_error(ins, "metadata upstream creation failed");
+            goto error;
+        }
+        flb_stream_disable_async_mode(&ctx->metadata_u->base);
     }
     ctx->out_format = FLB_PACK_JSON_FORMAT_LINES;
     ctx->json_date_format = FLB_PACK_JSON_DATE_DOUBLE;
@@ -1432,6 +1565,10 @@ static int gcs_ctx_destroy(void *data, struct flb_config *config)
         flb_upstream_destroy(ctx->u);
     }
 
+    if (ctx->metadata_u) {
+        flb_upstream_destroy(ctx->metadata_u);
+    }
+
     if (ctx->o) {
         flb_oauth2_destroy(ctx->o);
     }
@@ -1521,6 +1658,11 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "google_service_credentials", NULL,
      0, FLB_TRUE, offsetof(struct flb_gcs, credentials_file),
      "Service account JSON file."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "metadata_server", FLB_GCS_METADATA_SERVER,
+     0, FLB_TRUE, offsetof(struct flb_gcs, metadata_server),
+     "GCE/GKE metadata server used when no credentials file is configured."
     },
     {
      FLB_CONFIG_MAP_STR, "store_dir", "/tmp/fluent-bit/gcs",

--- a/plugins/out_gcs/gcs.h
+++ b/plugins/out_gcs/gcs.h
@@ -31,6 +31,10 @@
 #define FLB_GCS_SCOPE "https://www.googleapis.com/auth/devstorage.read_write"
 #define FLB_GCS_AUTH_URL "https://oauth2.googleapis.com/token"
 #define FLB_GCS_TOKEN_REFRESH 3000
+#define FLB_GCS_METADATA_SERVER "http://metadata.google.internal"
+#define FLB_GCS_METADATA_TOKEN_URI \
+    "/computeMetadata/v1/instance/service-accounts/default/token"
+#define FLB_GCS_METADATA_TOKEN_SIZE_MAX 14336
 
 #define FLB_GCS_COMPRESSION_NONE 0
 #define FLB_GCS_COMPRESSION_GZIP 1
@@ -59,14 +63,17 @@ struct flb_gcs {
     struct flb_output_instance *ins;
     struct flb_config *config;
     struct flb_upstream *u;
+    struct flb_upstream *metadata_u;
     struct flb_oauth2 *o;
     pthread_mutex_t token_mutex;
     int token_mutex_initialized;
+    int metadata_server_auth;
 
     flb_sds_t bucket;
     flb_sds_t content_type;
     flb_sds_t credentials_file;
     int credentials_file_owned;
+    flb_sds_t metadata_server;
     flb_sds_t store_dir;
     flb_sds_t gcs_key_format;
     flb_sds_t tag_delimiters;

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -248,6 +248,181 @@ void flb_test_gcs_accepts_extra_credential_fields(void)
     flb_free(store_dir);
 }
 
+void flb_test_gcs_application_default_credentials_env(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    char *store_dir;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-adc-env-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    setenv("GOOGLE_APPLICATION_CREDENTIALS", SERVICE_CREDENTIALS, 1);
+    setenv("GOOGLE_SERVICE_CREDENTIALS", "/does/not/exist", 1);
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    unsetenv("GOOGLE_SERVICE_CREDENTIALS");
+    flb_free(store_dir);
+}
+
+void flb_test_gcs_metadata_server_authentication(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    int metadata_calls;
+    int upload_calls;
+    char *store_dir;
+    char *value;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-metadata-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    unsetenv("GOOGLE_SERVICE_CREDENTIALS");
+    unsetenv("TEST_GCS_MetadataToken_CALL_COUNT");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    setenv("TEST_GCS_METADATA_RESPONSE",
+           "{\"access_token\":\"metadata-token\",\"expires_in\":3600,"
+           "\"token_type\":\"Bearer\"}", 1);
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "1s", NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+        sleep(3);
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+
+    value = getenv("TEST_GCS_MetadataToken_CALL_COUNT");
+    metadata_calls = value ? atoi(value) : 0;
+    TEST_CHECK_(metadata_calls == 1,
+                "Expected 1 metadata token call, got %d", metadata_calls);
+    value = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    upload_calls = value ? atoi(value) : 0;
+    TEST_CHECK_(upload_calls == 1,
+                "Expected 1 UploadObject call, got %d", upload_calls);
+    value = getenv("TEST_GCS_LAST_METADATA_URI");
+    TEST_CHECK_(value != NULL, "Expected the metadata URI to be captured");
+    if (value) {
+        TEST_CHECK(strcmp(value, FLB_GCS_METADATA_TOKEN_URI) == 0);
+    }
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_METADATA_RESPONSE");
+    unsetenv("TEST_GCS_MetadataToken_CALL_COUNT");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_METADATA_URI");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
+void flb_test_gcs_rejects_invalid_metadata_response(void)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    int metadata_calls;
+    int upload_calls;
+    char *store_dir;
+    char *value;
+    flb_ctx_t *ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-metadata-invalid-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    unsetenv("GOOGLE_SERVICE_CREDENTIALS");
+    unsetenv("TEST_GCS_MetadataToken_CALL_COUNT");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+    setenv("TEST_GCS_METADATA_RESPONSE", "{\"invalid\":true}", 1);
+
+    ctx = flb_create();
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "upload_timeout", "1s", NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    if (ret == 0) {
+        flb_lib_push(ctx, in_ffd, (char *) JSON_TD, (int) sizeof(JSON_TD) - 1);
+        sleep(3);
+        flb_stop(ctx);
+    }
+    flb_destroy(ctx);
+
+    value = getenv("TEST_GCS_MetadataToken_CALL_COUNT");
+    metadata_calls = value ? atoi(value) : 0;
+    TEST_CHECK_(metadata_calls >= 1,
+                "Expected at least 1 metadata token call, got %d", metadata_calls);
+    value = getenv("TEST_GCS_UploadObject_CALL_COUNT");
+    upload_calls = value ? atoi(value) : 0;
+    TEST_CHECK_(upload_calls == 0,
+                "Expected no UploadObject calls, got %d", upload_calls);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_METADATA_RESPONSE");
+    unsetenv("TEST_GCS_MetadataToken_CALL_COUNT");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_METADATA_URI");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
 void flb_test_gcs_upload_error(void)
 {
     int ret;
@@ -397,6 +572,9 @@ TEST_LIST = {
     {"rejects_invalid_configuration", flb_test_gcs_rejects_invalid_configuration},
     {"rejects_invalid_compression", flb_test_gcs_rejects_invalid_compression},
     {"accepts_extra_credential_fields", flb_test_gcs_accepts_extra_credential_fields},
+    {"application_default_credentials_env", flb_test_gcs_application_default_credentials_env},
+    {"metadata_server_authentication", flb_test_gcs_metadata_server_authentication},
+    {"rejects_invalid_metadata_response", flb_test_gcs_rejects_invalid_metadata_response},
     {"upload_error", flb_test_gcs_upload_error},
     {"shutdown_preserves_pending_upload", flb_test_gcs_shutdown_preserves_pending_upload},
     {NULL, NULL}


### PR DESCRIPTION
## Summary

The native GCS output currently supports an explicit
`google_service_credentials` file and the legacy
`GOOGLE_SERVICE_CREDENTIALS` environment variable. It does not check Google's
standard `GOOGLE_APPLICATION_CREDENTIALS` variable and fails initialization when
no credentials file is configured, preventing the plugin from using an attached
GCE service account or GKE Workload Identity Federation.

This change adds the relevant Application Default Credentials behavior to
`out_gcs`:

1. explicit `google_service_credentials` configuration;
2. `GOOGLE_APPLICATION_CREDENTIALS`;
3. legacy `GOOGLE_SERVICE_CREDENTIALS`; and
4. the GCE/GKE metadata server when no credentials file is configured.

Metadata tokens are retrieved from the default service-account token endpoint,
parsed through Fluent Bit's existing OAuth2 cache, and refreshed before expiry.
The metadata server URL is configurable for testing and non-default
environments.

Addresses #1032 and #9022.

### Related work

PR #11758 adds `external_account` STS token exchange to `out_stackdriver` for
workloads outside Google Cloud. This PR is complementary: it adds standard ADC
environment lookup and attached GCE/GKE metadata credentials to `out_gcs`. It
does not add `external_account` credential-file support.

## Compatibility

Existing explicit `google_service_credentials` configurations are unchanged.
`GOOGLE_SERVICE_CREDENTIALS` remains supported for backwards compatibility. If
both environment variables are set, `GOOGLE_APPLICATION_CREDENTIALS` takes
precedence and a warning is logged.

`GOOGLE_APPLICATION_CREDENTIALS` uses the service-account JSON format already
supported by `out_gcs`. Other ADC file types, such as `authorized_user` and
`external_account`, are outside this change.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

GKE Workload Identity or an attached GCE service account requires no credential
property:

```ini
[INPUT]
    Name  dummy
    Tag   gcs.test

[OUTPUT]
    Name                    gcs
    Match                   *
    bucket                  my-log-bucket
    gcs_key_format          logs/$TAG/%Y/%m/%d/%H/%M/%S-$UUID
    store_dir               /var/lib/fluent-bit/gcs
    upload_timeout          1m
    compression             gzip
    preserve_data_ordering  On
```

A service-account file can use standard ADC:

```bash
export GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/google/credentials.json
```

- [x] Debug log output from testing the change

```text
[ info] [output:gcs:gcs.0] using GCE/GKE metadata server authentication
[ info] [output:gcs:gcs.0] worker #0 started
```

Focused runtime test:

```text
1/1 Test #8: flb-rt-out_gcs ... Passed
100% tests passed, 0 tests failed out of 1
```

The runtime suite covers standard ADC precedence, successful metadata token
retrieval and upload, and rejection of an invalid metadata response without an
upload attempt.

- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

```text
SUCCESS: All unit tests have passed.
HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
    total heap usage: 36,980 allocs, 36,980 frees, 9,894,221 bytes allocated
All heap blocks were freed -- no leaks are possible
ERROR SUMMARY: 0 errors from 0 contexts
```

Commands:

```bash
cmake --build build --target flb-rt-out_gcs -j8
ctest --test-dir build -R '^flb-rt-out_gcs$' --output-on-failure
valgrind --leak-check=full \
  --show-leak-kinds=definite,indirect \
  --errors-for-leak-kinds=definite,indirect \
  --error-exitcode=99 build/bin/flb-rt-out_gcs
```

If this is a change to packaging of containers or native binaries then please
confirm it works for all targets.

- [x] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build. `[N/A: no packaging changes]`
- [x] Set `ok-package-test` label to test for all targets (requires maintainer to do). `[N/A: no packaging changes]`

**Documentation**

- [x] Documentation required for this feature

A follow-up documentation update should describe the credential precedence and
keyless GCE/GKE configuration. The code config-map description includes the new
`metadata_server` option.

**Backporting**

- [x] Backport to latest stable release. `[N/A: target master for the next release]`

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I
understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud metadata-server authentication for GCS deployments running on GCE or GKE without service-account credential files.
  * Added the `metadata_server` configuration option.
  * Added validation for metadata-server token responses.

* **Bug Fixes**
  * Credential configuration now prefers `GOOGLE_APPLICATION_CREDENTIALS` over the legacy environment variable and warns when both are set.
  * Retained fallback to service-account credentials when metadata authentication is unavailable or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->