### PR TITLE
multiline: add built-in json parser for JSON multiline objects

### DIFF
--- a/include/fluent-bit/multiline/flb_ml_parser.h
+++ b/include/fluent-bit/multiline/flb_ml_parser.h
@@ -89,5 +89,6 @@ struct flb_ml_parser *flb_ml_parser_java(struct flb_config *config, char *key);
 struct flb_ml_parser *flb_ml_parser_go(struct flb_config *config, char *key);
 struct flb_ml_parser *flb_ml_parser_ruby(struct flb_config *config, char *key);
 struct flb_ml_parser *flb_ml_parser_python(struct flb_config *config, char *key);
+struct flb_ml_parser *flb_ml_parser_json(struct flb_config *config, char *key);
 
 #endif

--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -1023,7 +1023,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_CLIST, "multiline.parser", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct ml_ctx, multiline_parsers),
-     "specify one or multiple multiline parsers: docker, cri, go, java, etc."
+     "specify one or multiple multiline parsers: docker, cri, go, java, json, etc."
     },
 
     {

--- a/plugins/in_tail/tail.c
+++ b/plugins/in_tail/tail.c
@@ -826,7 +826,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_CLIST, "multiline.parser", NULL,
      FLB_CONFIG_MAP_MULT, FLB_TRUE, offsetof(struct flb_tail_config, multiline_parsers),
-     "specify one or multiple multiline parsers: docker, cri, go, java, etc."
+     "specify one or multiple multiline parsers: docker, cri, go, java, json, etc."
     },
 #endif
 

--- a/src/multiline/CMakeLists.txt
+++ b/src/multiline/CMakeLists.txt
@@ -6,6 +6,7 @@ set(src_multiline
   multiline/flb_ml_parser_java.c
   multiline/flb_ml_parser_go.c
   multiline/flb_ml_parser_ruby.c
+  multiline/flb_ml_parser_json.c
   # core
   multiline/flb_ml_stream.c
   multiline/flb_ml_parser.c

--- a/src/multiline/flb_ml_parser.c
+++ b/src/multiline/flb_ml_parser.c
@@ -188,6 +188,13 @@ int flb_ml_parser_builtin_create(struct flb_config *config)
         goto error;
     }
 
+    /* JSON */
+    mlp = flb_ml_parser_json(config, NULL);
+    if (!mlp) {
+        flb_error("[multiline] could not init 'json' built-in parser");
+        goto error;
+    }
+
     ret = 0;
     return ret;
 

--- a/src/multiline/flb_ml_parser_json.c
+++ b/src/multiline/flb_ml_parser_json.c
@@ -1,0 +1,95 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/multiline/flb_ml.h>
+#include <fluent-bit/multiline/flb_ml_rule.h>
+#include <fluent-bit/multiline/flb_ml_parser.h>
+
+#define rule flb_ml_rule_create
+
+static void rule_error(struct flb_ml_parser *ml_parser)
+{
+    int id;
+
+    id = mk_list_size(&ml_parser->regex_rules);
+    flb_error("[multiline: json] rule #%i could not be created", id);
+    flb_ml_parser_destroy(ml_parser);
+}
+
+/*
+ * Built-in multiline mode for pretty-printed JSON objects.
+ *
+ * Tail reads line-by-line, so a formatted JSON object is not valid JSON per
+ * line. This parser groups lines from an opening '{' until the next object
+ * starts or flush_timeout expires.
+ *
+ * Do not attach a JSON parser here: per-line JSON parsing fails on partial
+ * lines (see ml_append_try_parser_type_text). Use filter_parser on the
+ * assembled 'log' field after grouping.
+ */
+struct flb_ml_parser *flb_ml_parser_json(struct flb_config *config, char *key)
+{
+    int ret;
+    struct flb_ml_parser *mlp;
+
+    mlp = flb_ml_parser_create(config,               /* Fluent Bit context */
+                               "json",               /* name      */
+                               FLB_ML_REGEX,         /* type      */
+                               NULL,                 /* match_str */
+                               FLB_FALSE,            /* negate    */
+                               FLB_ML_FLUSH_TIMEOUT, /* flush_ms  */
+                               key,                  /* key_content */
+                               NULL,                 /* key_group   */
+                               NULL,                 /* key_pattern */
+                               NULL,                 /* parser ctx  */
+                               NULL);                /* parser name */
+
+    if (!mlp) {
+        flb_error("[multiline] could not create 'json mode'");
+        return NULL;
+    }
+
+    ret = rule(mlp,
+               "start_state",
+               "/^\\{.*/",
+               "cont", NULL);
+    if (ret != 0) {
+        rule_error(mlp);
+        return NULL;
+    }
+
+    ret = rule(mlp,
+               "cont",
+               "/^([^\\S\\r\\n].*|})$/",
+               "cont", NULL);
+    if (ret != 0) {
+        rule_error(mlp);
+        return NULL;
+    }
+
+    ret = flb_ml_parser_init(mlp);
+    if (ret != 0) {
+        flb_error("[multiline: json] error on mapping rules");
+        flb_ml_parser_destroy(mlp);
+        return NULL;
+    }
+
+    return mlp;
+}

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -378,6 +378,15 @@ struct record_check json_input[] = {
     {"  \"level\": \"error\","},
     {"  \"msg\": \"multiline record D\""},
     {"}"},
+    /* invalid boundary: unindented line after opening brace */
+    {"{"},
+    {"\"bad\": true"},
+    /* invalid boundary: closing brace with trailing content */
+    {"{"},
+    {"  \"ok\": 1"},
+    {"} trailing"},
+    /* valid single-line object after invalid boundaries */
+    {"{\"id\":105,\"level\":\"info\",\"msg\":\"after boundaries\"}"},
 };
 
 struct record_check json_output[] = {
@@ -397,6 +406,16 @@ struct record_check json_output[] = {
         "  \"msg\": \"multiline record D\"\n"
         "}\n"
     },
+    /* unindented continuation must not merge into buffered '{' */
+    {"{\n"},
+    {"\"bad\": true\n"},
+    /* trailing content on '}' line must not merge into partial object */
+    {
+        "{\n"
+        "  \"ok\": 1\n"
+    },
+    {"} trailing\n"},
+    {"{\"id\":105,\"level\":\"info\",\"msg\":\"after boundaries\"}\n"},
 };
 
 /*

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -364,6 +364,41 @@ struct record_check go_output[] = {
     {"one more line, no multiline\n"}
 };
 
+/* JSON (pretty-printed and single-line objects) */
+struct record_check json_input[] = {
+    {"{\"id\":101,\"level\":\"info\",\"msg\":\"single-line record A\"}"},
+    {"{"},
+    {"  \"id\": 102,"},
+    {"  \"level\": \"warn\","},
+    {"  \"msg\": \"multiline record B\""},
+    {"}"},
+    {"{\"id\":103,\"level\":\"info\",\"msg\":\"single-line record C\"}"},
+    {"{"},
+    {"  \"id\": 104,"},
+    {"  \"level\": \"error\","},
+    {"  \"msg\": \"multiline record D\""},
+    {"}"},
+};
+
+struct record_check json_output[] = {
+    {"{\"id\":101,\"level\":\"info\",\"msg\":\"single-line record A\"}\n"},
+    {
+        "{\n"
+        "  \"id\": 102,\n"
+        "  \"level\": \"warn\",\n"
+        "  \"msg\": \"multiline record B\"\n"
+        "}\n"
+    },
+    {"{\"id\":103,\"level\":\"info\",\"msg\":\"single-line record C\"}\n"},
+    {
+        "{\n"
+        "  \"id\": 104,\n"
+        "  \"level\": \"error\",\n"
+        "  \"msg\": \"multiline record D\"\n"
+        "}\n"
+    },
+};
+
 /*
  * Issue 3817 (case: 1)
  * --------------------
@@ -1198,6 +1233,55 @@ static void test_parser_go()
     if (ml) {
         flb_ml_destroy(ml);
     }
+
+    flb_config_exit(config);
+}
+
+static void test_parser_json()
+{
+    int i;
+    int len;
+    int ret;
+    int entries;
+    uint64_t stream_id = 0;
+    struct record_check *r;
+    struct flb_config *config;
+    struct flb_time tm;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct expected_result res = {0};
+
+    res.key = "log";
+    res.out_records = json_output;
+
+    config = flb_config_init();
+
+    ml = flb_ml_create(config, "json-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "json");
+    TEST_CHECK(mlp_i != NULL);
+
+    ret = flb_ml_stream_create(ml, "json", -1, flush_callback, (void *) &res,
+                               &stream_id);
+    TEST_CHECK(ret == 0);
+
+    entries = sizeof(json_input) / sizeof(struct record_check);
+    for (i = 0; i < entries; i++) {
+        r = &json_input[i];
+        len = strlen(r->buf);
+
+        flb_time_get(&tm);
+        flb_ml_append_text(ml, stream_id, &tm, r->buf, len);
+    }
+
+    flb_ml_flush_pending_now(ml);
+
+    if (ml) {
+        flb_ml_destroy(ml);
+    }
+
+    TEST_CHECK(res.current_record == (sizeof(json_output) / sizeof(struct record_check)));
 
     flb_config_exit(config);
 }
@@ -2129,6 +2213,7 @@ TEST_LIST = {
     { "parser_ruby",    test_parser_ruby},
     { "parser_elastic", test_parser_elastic},
     { "parser_go",      test_parser_go},
+    { "parser_json",    test_parser_json},
     { "container_mix",  test_container_mix},
     { "endswith",       test_endswith},
     { "buffer_limit_truncation", test_buffer_limit_truncation},


### PR DESCRIPTION
Add built-in multiline parser `json` for tail inputs that read JSON objects split across lines.

The parser groups lines only (regex start `^\{.*`, continuation on
whitespace-indented lines or a lone `}`). It does not embed a JSON parser;
per-line JSON parsing fails on partial lines such as `{` or `"id": 102,`.

Expected usage:

- Pretty-printed / mixed files: `multiline.parser: json` on tail, then
  `filter_parser` with `key_name: log` and `parser: json`.
- JSON Lines (one object per line): `parser: json` on tail; no multiline
  parser.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses #2418, #8232

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
<details><summary>config</summary>
<p>

```yaml
service:
  flush: 1
  log_level: debug
parsers:
  - name: json
    format: json
    time_key: time
    time_format: "%Y-%m-%dT%H:%M:%S.%L"

pipeline:
  inputs:
    - name: tail
      tag: json.oneline
      path: ./oneline.json
      parser: json
      read_from_head: true
      path_key: file

    - name: tail
      tag: json.mixed
      path: ./mixed.json
      read_from_head: true
      multiline.parser: json
      path_key: file

  filters:
    - name: parser
      match: json.mixed
      key_name: log
      parser: json
      preserve_key: false

  outputs:
    - name: stdout
      match: json.*
      format: json_lines
```

</p>
</details> 

<details><summary>oneline.json</summary>
<p>

```json
{"id":1,"time":"2026-08-11T10:00:00.000","level":"info","msg":"oneline record one"}
{"id":2,"time":"2026-08-11T10:00:01.000","level":"warn","msg":"oneline record two"}
{"id":3,"time":"2026-08-11T10:00:02.000","level":"error","msg":"oneline record three"}

```

</p>
</details> 

<details><summary>mixed.json</summary>
<p>

```json
{"id":101,"time":"2026-08-11T11:00:00.000","level":"info","msg":"single-line record A"}
{
  "id": 102,
  "time": "2026-08-11T11:00:01.000",
  "level": "warn",
  "msg": "multiline record B",
  "details": {
    "user": "alice",
    "action": "login"
  }
}
{"id":103,"time":"2026-08-11T11:00:02.000","level":"info","msg":"single-line record C"}
{"id": 104,
  "time": "2026-08-11T11:00:03.000",
  "level": "error",
  "msg": "multiline record D",
  "stack": [
    "frame1",
    "frame2"
  ]
}
{"id":105,"time":"2026-08-11T11:00:04.000","level":"info","msg":"single-line record E"}
```

</p>
</details> 
- [x] Debug log output from testing the change
<details><summary>debug output</summary>
<p>

```text
Fluent Bit v5.1.0
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  _____ 
|  ___| |                | |   | ___ (_) |         |  ___||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ | |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \|  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)\___/


[2026/08/11 14:34:16.730] [ info] Configuration:
[2026/08/11 14:34:16.730] [ info]  flush time     | 1.000000 seconds
[2026/08/11 14:34:16.730] [ info]  grace          | 5 seconds
[2026/08/11 14:34:16.730] [ info]  daemon         | 0
[2026/08/11 14:34:16.730] [ info] ___________
[2026/08/11 14:34:16.730] [ info]  inputs:
[2026/08/11 14:34:16.730] [ info]      tail
[2026/08/11 14:34:16.730] [ info]      tail
[2026/08/11 14:34:16.730] [ info] ___________
[2026/08/11 14:34:16.730] [ info]  filters:
[2026/08/11 14:34:16.730] [ info]      parser.0
[2026/08/11 14:34:16.730] [ info] ___________
[2026/08/11 14:34:16.730] [ info]  outputs:
[2026/08/11 14:34:16.730] [ info]      stdout.0
[2026/08/11 14:34:16.730] [ info] ___________
[2026/08/11 14:34:16.730] [ info]  collectors:
[2026/08/11 14:34:16.730] [ info] [fluent bit] version=5.1.0, commit=ae51533a2d, pid=70087
[2026/08/11 14:34:16.731] [debug] [engine] coroutine stack size: 65536 bytes (64.0K)
[2026/08/11 14:34:16.731] [ info] [storage] ver=1.1.6, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/11 14:34:16.731] [ info] [simd    ] NEON
[2026/08/11 14:34:16.731] [ info] [cmetrics] version=2.2.1
[2026/08/11 14:34:16.731] [ info] [ctraces ] version=0.7.1
[2026/08/11 14:34:16.731] [ info] [input:tail:tail.0] initializing
[2026/08/11 14:34:16.731] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2026/08/11 14:34:16.731] [debug] [tail:tail.0] created event channels: read=21 write=22
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] flb_tail_fs_stat_init() initializing stat tail input
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] scanning path ./oneline.json
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] inode=1288433329 with offset=0 appended as ./oneline.json
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] scan_glob add(): ./oneline.json, inode 1288433329
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] 1 new files found on path './oneline.json'
[2026/08/11 14:34:16.731] [ info] [input:tail:tail.1] initializing
[2026/08/11 14:34:16.731] [ info] [input:tail:tail.1] storage_strategy='memory' (memory only)
[2026/08/11 14:34:16.731] [debug] [tail:tail.1] created event channels: read=28 write=29
[2026/08/11 14:34:16.731] [ info] [input:tail:tail.1] multiline core started
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] flb_tail_fs_stat_init() initializing stat tail input
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] scanning path ./mixed.json
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] inode=1288433424 with offset=0 appended as ./mixed.json
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] scan_glob add(): ./mixed.json, inode 1288433424
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] 1 new files found on path './mixed.json'
[2026/08/11 14:34:16.731] [debug] [stdout:stdout.0] created event channels: read=36 write=37
[2026/08/11 14:34:16.731] [debug] [router] match rule tail.0:stdout.0
[2026/08/11 14:34:16.731] [debug] [router] match rule tail.1:stdout.0
[2026/08/11 14:34:16.731] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/11 14:34:16.731] [ info] [sp] stream processor started
[2026/08/11 14:34:16.731] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] [static files] processed 255b
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] [static files] processed 576b
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] inode=1288433329 file=./oneline.json promote to TAIL_EVENT
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.0] [static files] processed 0b, done
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] inode=1288433424 file=./mixed.json promote to TAIL_EVENT
[2026/08/11 14:34:16.731] [debug] [input:tail:tail.1] [static files] processed 0b, done
[2026/08/11 14:34:17.733] [debug] [task] created task=0x1025c03a0 id=0 OK
[2026/08/11 14:34:17.733] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
{"date":1786442400.0,"id":1,"level":"info","msg":"oneline record one","file":"./oneline.json"}
{"date":1786442401.0,"id":2,"level":"warn","msg":"oneline record two","file":"./oneline.json"}
{"date":1786442402.0,"id":3,"level":"error","msg":"oneline record three","file":"./oneline.json"}
[2026/08/11 14:34:17.733] [debug] [task] created task=0x1025c0460 id=1 OK
[2026/08/11 14:34:17.733] [debug] [output:stdout:stdout.0] task_id=1 assigned to thread #0
{"date":1786446000.0,"id":101,"level":"info","msg":"single-line record A"}
{"date":1786446001.0,"id":102,"level":"warn","msg":"multiline record B","details":{"user":"alice","action":"login"}}
{"date":1786446002.0,"id":103,"level":"info","msg":"single-line record C"}
{"date":1786446003.0,"id":104,"level":"error","msg":"multiline record D","stack":["frame1","frame2"]}
[2026/08/11 14:34:17.734] [debug] [out flush] cb_destroy coro_id=0
[2026/08/11 14:34:17.734] [debug] [out flush] cb_destroy coro_id=1
[2026/08/11 14:34:17.734] [debug] [task] destroy task=0x1025c03a0 (task_id=0)
[2026/08/11 14:34:17.734] [debug] [task] destroy task=0x1025c0460 (task_id=1)
[2026/08/11 14:34:20.735] [debug] [task] created task=0x77dc00000 id=0 OK
{"date":1786446004.0,"id":105,"level":"info","msg":"single-line record E"}
[2026/08/11 14:34:20.736] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
[2026/08/11 14:34:20.736] [debug] [out flush] cb_destroy coro_id=2
[2026/08/11 14:34:20.736] [debug] [task] destroy task=0x77dc00000 (task_id=0)
^C[2026/08/11 14:34:27] [engine] caught signal (SIGINT)
[2026/08/11 14:34:27.297] [ info] [input] pausing tail.0
[2026/08/11 14:34:27.297] [ info] [input] pausing tail.1
[2026/08/11 14:34:27.297] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/11 14:34:27.297] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/08/11 14:34:27.297] [debug] [input:tail:tail.1] inode=1288433424 removing file name ./mixed.json
[2026/08/11 14:34:27.297] [debug] [input:tail:tail.0] inode=1288433329 removing file name ./oneline.json
```

</p>
</details> 


**Documentation**
- [x] Documentation required for this feature. https://github.com/fluent/fluent-bit-docs/pull/2671


**Backporting**
- [ ] Backport to latest stable release.

**Valgrind output**

<details><summary>output</summary>
<p>

```shell
==1640303== Memcheck, a memory error detector
==1640303== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==1640303== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==1640303== Command: ./build/bin/flb-it-multiline parser_json
==1640303==
Test parser_json...
----- MULTILINE FLUSH -----
[0] [[1786562895.414402768, {}], {"log"=>"{"id":101,"level":"info","msg":"single-line record A"}
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.484916609, {}], {"log"=>"{
  "id": 102,
  "level": "warn",
  "msg": "multiline record B"
}
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.484939580, {}], {"log"=>"{"id":103,"level":"info","msg":"single-line record C"}
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.486272734, {}], {"log"=>"{
  "id": 104,
  "level": "error",
  "msg": "multiline record D"
}
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.486293395, {}], {"log"=>"{
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.486717910, {}], {"log"=>""bad": true
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.491682517, {}], {"log"=>"{
  "ok": 1
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.491714595, {}], {"log"=>"} trailing
"}]
----------- EOF -----------

----- MULTILINE FLUSH -----
[0] [[1786562895.492978816, {}], {"log"=>"{"id":105,"level":"info","msg":"after boundaries"}
"}]
----------- EOF -----------
==1640303== Warning: invalid file descriptor -1 in syscall close()
[ OK ]
==1640303== Warning: invalid file descriptor -1 in syscall close()
SUCCESS: All unit tests have passed.
==1640303==
==1640303== HEAP SUMMARY:
==1640303==     in use at exit: 0 bytes in 0 blocks
==1640303==   total heap usage: 2,046 allocs, 2,046 frees, 586,762 bytes allocated
==1640303==
==1640303== All heap blocks were freed -- no leaks are possible
==1640303==
==1640303== For lists of detected and suppressed errors, rerun with: -s
==1640303== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


</p>
</details> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in JSON multiline parser for grouping single-line and pretty-printed JSON records.
  * Added `json` to the supported multiline parser configuration options.

* **Bug Fixes**
  * Improved handling of invalid JSON continuation boundaries while preserving subsequent valid records.

* **Tests**
  * Added coverage for single-line objects, formatted JSON, flush behavior, and invalid continuations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->