### PR TITLE
ci: pin google/oss-fuzz actions to commit SHA in pr-fuzz workflow

### DIFF
--- a/.github/workflows/pr-fuzz.yaml
+++ b/.github/workflows/pr-fuzz.yaml
@@ -15,13 +15,13 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@4f0e722c2e974d4d61bec0e937cce4e710507cc6 # master
       with:
         oss-fuzz-project-name: 'fluent-bit'
         dry-run: false
         language: c
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@4f0e722c2e974d4d61bec0e937cce4e710507cc6 # master
       with:
         oss-fuzz-project-name: 'fluent-bit'
         fuzz-seconds: 600


### PR DESCRIPTION
### Summary
Pins the `google/oss-fuzz` action references in `.github/workflows/pr-fuzz.yaml` from `@master` to immutable full-length commit SHAs.

### Rationale & Security Posture
Referencing mutable branch tags like `@master` poses supply-chain security risks, as upstream changes can introduce unexpected pipeline behaviors or vulnerabilities. Pinning actions to explicit commit hashes guarantees reproducible, audited execution.

### Changes Made
- Updated `google/oss-fuzz/infra/cifuzz/actions/build_fuzzers` to use full commit SHA with inline `# master` comment.
- Updated `google/oss-fuzz/infra/cifuzz/actions/run_fuzzers` to use full commit SHA with inline `# master` comment.
- Verified locally using `zizmor`; `error[unpinned-uses]` findings are resolved.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ N/A ] Example configuration file for the change
- [ N/A ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ N/A ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ N/A ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ N/A ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ N/A ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ N/A ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned fuzz-testing workflow actions to a specific version for more consistent and reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->