### PR TITLE
http_client: anchor response header lookup to line start

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -141,8 +141,20 @@ static int header_lookup(struct flb_http_client *c,
         return FLB_HTTP_MORE;
     }
 
-    /* Lookup the beginning of the header */
-    p = strcasestr(c->resp.data, header);
+    /*
+     * Lookup the beginning of the header: only accept a match placed at
+     * the beginning of a line, otherwise a header name that embeds the
+     * name of another header is matched by mistake, e.g. searching for
+     * 'Content-Length: ' matches the tail of the GCS response header
+     * 'x-goog-stored-content-length: '.
+     */
+    p = c->resp.data;
+    while ((p = strcasestr(p, header)) != NULL) {
+        if (p == c->resp.data || *(p - 1) == '\n') {
+            break;
+        }
+        p++;
+    }
     end = strstr(c->resp.data, "\r\n\r\n");
     if (!p) {
         if (end) {


### PR DESCRIPTION
header_lookup() used an unanchored strcasestr() to find response headers, so a header name that embeds the name of another header is matched by mistake: GCS S3-compatible PutObject 200 responses include 'x-goog-stored-content-length: N' before 'Content-Length: 0', causing content_length to be parsed as N and the client to wait for a body that never arrives - every successful upload was judged as failed and retried, creating duplicate objects.

Only accept a header match placed at the beginning of a line.

Fixes #12267

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP header detection to avoid matching header names embedded within other header values.
  * Header matching is now case-insensitive while respecting valid header boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->