### PR TITLE
http_client: anchor response header lookup to line start

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -141,8 +141,30 @@ static int header_lookup(struct flb_http_client *c,
         return FLB_HTTP_MORE;
     }
 
-    /* Lookup the beginning of the header */
-    p = strcasestr(c->resp.data, header);
+    /*
+     * Lookup the beginning of the header: only accept a match placed at
+     * the beginning of a line, otherwise a header name that embeds the
+     * name of another header is matched by mistake, e.g. searching for
+     * 'Content-Length: ' matches the tail of the GCS response header
+     * 'x-goog-stored-content-length: '.
+     */
+    p = c->resp.data;
+    while ((p = strcasestr(p, header)) != NULL) {
+        if (p == c->resp.data || *(p - 1) == '\n') {
+            break;
+        }
+
+        /*
+         * Rejected match: no line-start match can exist before the next
+         * newline, skip the rest of the current line to avoid rescanning
+         * it (a large body could repeat the pattern many times).
+         */
+        p = strchr(p, '\n');
+        if (p == NULL) {
+            break;
+        }
+        p++;
+    }
     end = strstr(c->resp.data, "\r\n\r\n");
     if (!p) {
         if (end) {


### PR DESCRIPTION
# PR Title

http_client: anchor response header lookup to line start

# PR Body

Fixes #12267 (also explains #8525)

`header_lookup()` located response headers with an unanchored
`strcasestr()` over the response buffer. A header whose name embeds the
name of another header is matched by mistake: GCS S3-compatible
PutObject 200 responses include `x-goog-stored-content-length: <N>`
(the size of the stored object, always > 0) before the real
`Content-Length: 0`. The lookup for `Content-Length: ` matched the tail
of `x-goog-stored-content-length: `, so `content_length` was parsed as
`N` and the client kept waiting for a response body that never arrives.
With the default `net.io_timeout 0` the wait lasted until the server
reset the idle connection (~4 minutes on GCS), and every successful
upload was reported as a failure (`http_do=-1` with `HTTP Status: 200`)
and retried — producing one duplicate object per attempt, indefinitely.

This change only accepts a match placed at the beginning of a line
(start of buffer or right after `\n`), so embedded header names are
skipped. Behavior for well-formed matches is unchanged.

Verified against a captured GCS PutObject response header block:
before: `content_length = 26` (from `x-goog-stored-content-length`),
after: `content_length = 0` (real header). AWS S3-style responses are
unaffected (no header embeds another header name).

----

## Testing
Before we can approve your change; please submit the following in a comment:
- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [ ] Attached Valgrind output that shows no leaks or memory corruption was found

(예: 여기에 이슈 #12267 의 재현 config / debug 로그를 코멘트로 첨부)

## Documentation
- [ ] N/A — bug fix, no user-facing configuration change

## Backporting
- [ ] Backport to latest stable release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP header matching to recognize only complete header names at the start of a header line.
  * Prevented incorrect matches when a requested header name appears within another header’s name.
  * Continued searching when earlier occurrences are invalid, ensuring later valid matches are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->