### PR TITLE
out_s3: guard current_buffer_size subtraction against underflow

### DIFF
--- a/plugins/out_s3/s3_store.c
+++ b/plugins/out_s3/s3_store.c
@@ -476,7 +476,19 @@ int s3_store_file_delete(struct flb_s3 *ctx, struct s3_file *s3_file)
     struct flb_fstore_file *fsf;
 
     fsf = s3_file->fsf;
-    ctx->current_buffer_size -= s3_file->size;
+
+    /*
+     * Files recovered from a previous run are not accounted into
+     * current_buffer_size at startup, so guard the subtraction to keep
+     * the unsigned counter from underflowing; a wrapped counter makes
+     * the store_dir_limit_size check reject every new chunk.
+     */
+    if (ctx->current_buffer_size >= s3_file->size) {
+        ctx->current_buffer_size -= s3_file->size;
+    }
+    else {
+        ctx->current_buffer_size = 0;
+    }
 
     /* permanent deletion */
     flb_fstore_file_delete(ctx->fs, fsf);


### PR DESCRIPTION

Fixes #12270

`s3_store_file_delete()` subtracted `s3_file->size` from
`ctx->current_buffer_size` unconditionally. Buffer files recovered from
a previous run are not accounted into `current_buffer_size` at startup,
so deleting them after upload wraps the unsigned counter around to
~2^64. The `store_dir_limit_size` check then treats the buffer as
permanently full and rejects every new chunk ("Buffer is full",
"chunk cannot be retried"), causing data loss until restart.

Clamp the subtraction at zero, using the same pattern already applied
on the quarantine accounting path in `s3.c`.

Observed in production on 5.0.9 (Kubernetes DaemonSet, `store_dir` on a
hostPath volume surviving pod restarts):

```
[error] Buffer is full: current_buffer_size=18446744073709314048, new_data=4931, store_dir_limit_size=20000000000 bytes
```

`18446744073709314048 == 2^64 - 237568` — the counter went "negative"
by exactly the size of the recovered-and-deleted files.

----

## Testing
- [x] Example configuration file for the change
- [x] Debug log output from testing the change

## Documentation
- [ ] N/A — bug fix, no user-facing configuration change

## Backporting
- [ ] Backport to latest stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting certain files could cause storage usage tracking to become inaccurate.
  * Storage counters now remain at zero instead of dropping below zero when file sizes are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->