### PR TITLE
parser: add csv format parser (Format=csv)

### DIFF
--- a/include/fluent-bit/flb_parser.h
+++ b/include/fluent-bit/flb_parser.h
@@ -31,6 +31,7 @@
 #define FLB_PARSER_JSON  2
 #define FLB_PARSER_LTSV  3
 #define FLB_PARSER_LOGFMT 4
+#define FLB_PARSER_CSV   5
 
 struct flb_parser_types {
     char *key;
@@ -67,6 +68,12 @@ struct flb_parser {
     int time_with_tz;     /* do time_fmt consider a timezone ?  */
     struct flb_regex *regex;
     struct mk_list _head;
+
+    /* CSV (type == FLB_PARSER_CSV) */
+    char **csv_field_names;   /* optional user-defined field names */
+    int csv_field_names_len;
+    int csv_time_field_index; /* -1 if unset, else 0-based index of the
+                                * field holding the record timestamp */
 };
 
 enum {
@@ -134,6 +141,9 @@ int flb_parser_load_multiline_parser_definitions(const char *cfg, struct flb_cf 
 
 void flb_parser_destroy(struct flb_parser *parser);
 struct flb_parser *flb_parser_get(const char *name, struct flb_config *config);
+int flb_parser_csv_set_fields(struct flb_parser *parser,
+                              char **fields, int fields_len);
+void flb_parser_csv_resolve_time_field(struct flb_parser *parser);
 int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,
                   void **out_buf, size_t *out_size, struct flb_time *out_time);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,6 +152,7 @@ if(FLB_PARSER)
     flb_parser_decoder.c
     flb_parser_ltsv.c
     flb_parser_logfmt.c
+    flb_parser_csv.c
     )
 endif()
 

--- a/src/flb_parser.c
+++ b/src/flb_parser.c
@@ -763,6 +763,11 @@ int flb_parser_logfmt_do(struct flb_parser *parser,
                          void **out_buf, size_t *out_size,
                          struct flb_time *out_time);
 
+int flb_parser_csv_do(struct flb_parser *parser,
+                      const char *buf, size_t length,
+                      void **out_buf, size_t *out_size,
+                      struct flb_time *out_time);
+
 /*
  * This function is used to free all aspects of a parser
  * which is provided by the caller of flb_create_parser.
@@ -861,6 +866,9 @@ struct flb_parser *flb_parser_create_with_time_zone(const char *name,
     }
     else if (strcasecmp(format, "logfmt") == 0) {
         p->type = FLB_PARSER_LOGFMT;
+    }
+    else if (strcasecmp(format, "csv") == 0) {
+        p->type = FLB_PARSER_CSV;
     }
     else {
         flb_error("[parser:%s] Invalid format %s", name, format);
@@ -1045,6 +1053,10 @@ struct flb_parser *flb_parser_create_with_time_zone(const char *name,
     p->logfmt_no_bare_keys = logfmt_no_bare_keys;
     p->types = types;
     p->types_len = types_len;
+    p->csv_time_field_index = -1;
+    if (p->type == FLB_PARSER_CSV) {
+        flb_parser_csv_resolve_time_field(p);
+    }
     return p;
 }
 
@@ -1101,6 +1113,12 @@ void flb_parser_destroy(struct flb_parser *parser)
             flb_free(parser->types[i].key);
         }
         flb_free(parser->types);
+    }
+    if (parser->csv_field_names) {
+        for (i = 0; i < parser->csv_field_names_len; i++) {
+            flb_free(parser->csv_field_names[i]);
+        }
+        flb_free(parser->csv_field_names);
     }
 
     if (parser->decoders) {
@@ -1181,6 +1199,62 @@ static int proc_types_str(const char *types_str, struct flb_parser_types **types
     return i;
 }
 
+/* Parse a comma separated 'csv_fields' value into the parser's field names */
+static int proc_csv_fields_str(struct flb_parser *parser, const char *fields_str)
+{
+    int i;
+    int ret;
+    int fields_len;
+    char **fields;
+    struct mk_list *split;
+    struct mk_list *head;
+    struct flb_split_entry *sentry;
+
+    split = flb_utils_split(fields_str, ',', -1);
+    if (!split) {
+        return -1;
+    }
+
+    fields_len = mk_list_size(split);
+    if (fields_len <= 0) {
+        flb_utils_split_free(split);
+        return -1;
+    }
+
+    fields = flb_calloc(fields_len, sizeof(char *));
+    if (!fields) {
+        flb_errno();
+        flb_utils_split_free(split);
+        return -1;
+    }
+
+    i = 0;
+    mk_list_foreach(head, split) {
+        sentry = mk_list_entry(head, struct flb_split_entry, _head);
+        fields[i] = flb_strndup(sentry->value, sentry->len);
+        if (!fields[i]) {
+            flb_errno();
+            while (i > 0) {
+                flb_free(fields[--i]);
+            }
+            flb_free(fields);
+            flb_utils_split_free(split);
+            return -1;
+        }
+        i++;
+    }
+    flb_utils_split_free(split);
+
+    ret = flb_parser_csv_set_fields(parser, fields, fields_len);
+
+    for (i = 0; i < fields_len; i++) {
+        flb_free(fields[i]);
+    }
+    flb_free(fields);
+
+    return ret;
+}
+
 static flb_sds_t get_parser_key(struct flb_config *config,
                                 struct flb_cf *cf, struct flb_cf_section *s,
                                 char *key)
@@ -1223,6 +1297,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     flb_sds_t time_offset;
     flb_sds_t time_zone;
     flb_sds_t types_str;
+    flb_sds_t csv_fields_str;
     flb_sds_t tmp_str;
     int skip_empty;
     int time_keep;
@@ -1234,6 +1309,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     struct mk_list *decoders = NULL;
     struct flb_cf_section *s;
     struct flb_parser_types *types = NULL;
+    struct flb_parser *parser;
 
     /* Read all 'parser' sections */
     mk_list_foreach(head, &cf->parsers) {
@@ -1245,6 +1321,7 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         time_offset = NULL;
         time_zone = NULL;
         types_str = NULL;
+        csv_fields_str = NULL;
         tmp_str = NULL;
 
         /* retrieve the section context */
@@ -1333,15 +1410,32 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
             types_len = 0;
         }
 
+        /* csv_fields (only meaningful for 'format csv', comma separated names) */
+        csv_fields_str = get_parser_key(config, cf, s, "csv_fields");
+
         /* Decoders */
         decoders = flb_parser_decoder_list_create(s);
 
         /* Create the parser context */
-        if (!flb_parser_create_with_time_zone(name, format, regex, skip_empty,
+        parser = flb_parser_create_with_time_zone(name, format, regex, skip_empty,
                                time_fmt, time_key, time_offset, time_keep, time_strict,
                                time_system_timezone, time_zone, logfmt_no_bare_keys,
-                               types, types_len, decoders, config)) {
+                               types, types_len, decoders, config);
+        if (!parser) {
             goto fconf_error;
+        }
+
+        if (parser->type == FLB_PARSER_CSV) {
+            if (csv_fields_str) {
+                if (proc_csv_fields_str(parser, csv_fields_str) == -1) {
+                    goto fconf_error;
+                }
+            }
+            else {
+                /* no named fields: 'time_key', if any, must reference a
+                 * numeric (0-based) field index */
+                flb_parser_csv_resolve_time_field(parser);
+            }
         }
 
         flb_debug("[parser] new parser registered: %s", name);
@@ -1363,6 +1457,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
         }
         if (time_zone) {
             flb_sds_destroy(time_zone);
+        }
+        if (csv_fields_str) {
+            flb_sds_destroy(csv_fields_str);
         }
         if (types_str) {
             flb_sds_destroy(types_str);
@@ -1405,6 +1502,9 @@ int flb_parser_load_parser_definitions(const char *cfg, struct flb_cf *cf,
     }
     if (types_str) {
         flb_sds_destroy(types_str);
+    }
+    if (csv_fields_str) {
+        flb_sds_destroy(csv_fields_str);
     }
     if (types_len) {
         for (i=0; i<types_len; i++){
@@ -1800,6 +1900,10 @@ int flb_parser_do(struct flb_parser *parser, const char *buf, size_t length,
     else if (parser->type == FLB_PARSER_LOGFMT) {
         return flb_parser_logfmt_do(parser, buf, length,
                                   out_buf, out_size, out_time);
+    }
+    else if (parser->type == FLB_PARSER_CSV) {
+        return flb_parser_csv_do(parser, buf, length,
+                                 out_buf, out_size, out_time);
     }
 
     return -1;

--- a/src/flb_parser_csv.c
+++ b/src/flb_parser_csv.c
@@ -1,0 +1,443 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#define _GNU_SOURCE
+#include <time.h>
+
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_pack.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_parser_decoder.h>
+#include <msgpack.h>
+
+/*
+ * CSV field parser, implementing (most of) RFC 4180: double-quoted fields,
+ * "" as an escaped double quote, and comma as the sole delimiter. Since
+ * flb_parser_do() always receives a single, already delimited record with
+ * no guaranteed trailing line terminator (callers usually strip it before
+ * invoking the parser), embedded newlines inside quoted fields are not
+ * supported here - that would require access to the raw, un-split stream,
+ * which flb_csv.c (used for streaming/record splitting) already handles.
+ *
+ * This is a single left-to-right pass over the input buffer: it never
+ * copies or rescans bytes to find field boundaries, it only records
+ * (offset, length) pairs into the caller's buffer. A second, position-only
+ * pass fills the msgpack map once the total field count (and therefore the
+ * map header) is known. Unescaping ("" -> ") is only performed for the
+ * (uncommon) fields that actually contain an embedded quote, and reuses a
+ * small stack buffer unless the field is unusually large.
+ */
+
+/* Fields are tracked on the stack up to this count before falling back to
+ * a heap allocated (and geometrically grown) buffer, avoiding both a fixed
+ * hard limit and unnecessary allocations for typical CSV records.
+ */
+#define FLB_PARSER_CSV_STATIC_FIELDS 128
+
+/* Fields are unescaped on the stack up to this size before falling back to
+ * a one-off heap allocation.
+ */
+#define FLB_PARSER_CSV_STATIC_UNESCAPE 256
+
+struct csv_field {
+    size_t pos;
+    size_t len;
+    bool has_dquote;
+};
+
+struct csv_field_buf {
+    struct csv_field *fields;
+    size_t cap;
+    bool heap;
+};
+
+static int csv_field_buf_grow(struct csv_field_buf *fb)
+{
+    size_t new_cap;
+    struct csv_field *new_fields;
+
+    new_cap = fb->cap * 2;
+
+    if (fb->heap) {
+        new_fields = flb_realloc(fb->fields, new_cap * sizeof(struct csv_field));
+        if (!new_fields) {
+            flb_errno();
+            return -1;
+        }
+    }
+    else {
+        new_fields = flb_malloc(new_cap * sizeof(struct csv_field));
+        if (!new_fields) {
+            flb_errno();
+            return -1;
+        }
+        memcpy(new_fields, fb->fields, fb->cap * sizeof(struct csv_field));
+        fb->heap = true;
+    }
+
+    fb->fields = new_fields;
+    fb->cap = new_cap;
+    return 0;
+}
+
+/*
+ * Split a single CSV record into (offset, length) fields. Returns the
+ * number of fields found, or (size_t) -1 on allocation failure while
+ * growing the field buffer.
+ */
+static size_t csv_split_record(const char *buf, size_t len,
+                               struct csv_field_buf *fb)
+{
+    size_t pos = 0;
+    size_t count = 0;
+    struct csv_field *f;
+
+    for (;;) {
+        if (count >= fb->cap) {
+            if (csv_field_buf_grow(fb) == -1) {
+                return (size_t) -1;
+            }
+        }
+        f = &fb->fields[count];
+        f->has_dquote = false;
+
+        if (pos < len && buf[pos] == '"') {
+            /* quoted field */
+            pos++;
+            f->pos = pos;
+            while (pos < len) {
+                if (buf[pos] == '"') {
+                    if (pos + 1 < len && buf[pos + 1] == '"') {
+                        f->has_dquote = true;
+                        pos += 2;
+                        continue;
+                    }
+                    break;
+                }
+                pos++;
+            }
+            f->len = pos - f->pos;
+            if (pos < len) {
+                /* skip closing quote */
+                pos++;
+            }
+            count++;
+            if (pos < len && buf[pos] == ',') {
+                pos++;
+                continue;
+            }
+            break;
+        }
+        else {
+            f->pos = pos;
+            while (pos < len && buf[pos] != ',') {
+                pos++;
+            }
+            f->len = pos - f->pos;
+            count++;
+            if (pos < len) {
+                /* skip comma; a trailing comma implies one more (empty)
+                 * field, handled by the next loop iteration */
+                pos++;
+                continue;
+            }
+            break;
+        }
+    }
+
+    return count;
+}
+
+/* Collapse a "" escaped quote pair into a single ", mirroring flb_csv.c */
+static size_t csv_unescape(const char *src, size_t len, char *dst)
+{
+    size_t in = 0;
+    size_t out = 0;
+
+    while (in < len) {
+        if (src[in] == '"') {
+            in++;
+        }
+        dst[out++] = src[in++];
+    }
+    return out;
+}
+
+static int csv_pack_value(msgpack_packer *pck, const char *buf,
+                          struct csv_field *f)
+{
+    char stack_buf[FLB_PARSER_CSV_STATIC_UNESCAPE];
+    char *out_buf;
+    size_t out_len;
+    bool heap = false;
+
+    if (!f->has_dquote) {
+        msgpack_pack_str(pck, f->len);
+        msgpack_pack_str_body(pck, buf + f->pos, f->len);
+        return 0;
+    }
+
+    if (f->len <= sizeof(stack_buf)) {
+        out_buf = stack_buf;
+    }
+    else {
+        out_buf = flb_malloc(f->len);
+        if (!out_buf) {
+            flb_errno();
+            return -1;
+        }
+        heap = true;
+    }
+
+    out_len = csv_unescape(buf + f->pos, f->len, out_buf);
+    msgpack_pack_str(pck, out_len);
+    msgpack_pack_str_body(pck, out_buf, out_len);
+
+    if (heap) {
+        flb_free(out_buf);
+    }
+    return 0;
+}
+
+void flb_parser_csv_resolve_time_field(struct flb_parser *parser)
+{
+    int i;
+    char *end;
+    long idx;
+
+    parser->csv_time_field_index = -1;
+
+    if (!parser->time_key) {
+        return;
+    }
+
+    if (parser->csv_field_names) {
+        for (i = 0; i < parser->csv_field_names_len; i++) {
+            if (strcmp(parser->csv_field_names[i], parser->time_key) == 0) {
+                parser->csv_time_field_index = i;
+                return;
+            }
+        }
+        return;
+    }
+
+    /* No named fields: 'time_key' must be a 0-based field index */
+    errno = 0;
+    idx = strtol(parser->time_key, &end, 10);
+    if (end != parser->time_key && *end == '\0' && errno == 0 && idx >= 0) {
+        parser->csv_time_field_index = (int) idx;
+    }
+}
+
+int flb_parser_csv_set_fields(struct flb_parser *parser,
+                              char **fields, int fields_len)
+{
+    int i;
+    char **names;
+
+    if (fields_len <= 0) {
+        return -1;
+    }
+
+    names = flb_calloc(fields_len, sizeof(char *));
+    if (!names) {
+        flb_errno();
+        return -1;
+    }
+
+    for (i = 0; i < fields_len; i++) {
+        names[i] = flb_strdup(fields[i]);
+        if (!names[i]) {
+            flb_errno();
+            while (i > 0) {
+                flb_free(names[--i]);
+            }
+            flb_free(names);
+            return -1;
+        }
+    }
+
+    if (parser->csv_field_names) {
+        for (i = 0; i < parser->csv_field_names_len; i++) {
+            flb_free(parser->csv_field_names[i]);
+        }
+        flb_free(parser->csv_field_names);
+    }
+
+    parser->csv_field_names = names;
+    parser->csv_field_names_len = fields_len;
+
+    flb_parser_csv_resolve_time_field(parser);
+    return 0;
+}
+
+int flb_parser_csv_do(struct flb_parser *parser,
+                      const char *in_buf, size_t in_size,
+                      void **out_buf, size_t *out_size,
+                      struct flb_time *out_time)
+{
+    int ret;
+    int time_idx;
+    size_t i;
+    size_t field_count;
+    size_t map_size;
+    bool have_time = false;
+    bool exclude_time_field;
+    double tmfrac = 0;
+    struct flb_tm tm = {0};
+    struct csv_field static_fields[FLB_PARSER_CSV_STATIC_FIELDS];
+    struct csv_field_buf fb;
+    struct csv_field *f;
+    msgpack_sbuffer tmp_sbuf;
+    msgpack_packer tmp_pck;
+    char key_buf[32];
+    const char *key;
+    int key_len;
+    char *dec_out_buf;
+    size_t dec_out_size;
+
+    fb.fields = static_fields;
+    fb.cap = FLB_PARSER_CSV_STATIC_FIELDS;
+    fb.heap = false;
+
+    field_count = csv_split_record(in_buf, in_size, &fb);
+    if (field_count == (size_t) -1) {
+        return -1;
+    }
+
+    time_idx = parser->csv_time_field_index;
+    if (time_idx >= 0 && (size_t) time_idx < field_count && parser->time_fmt) {
+        f = &fb.fields[time_idx];
+        ret = flb_parser_time_lookup(in_buf + f->pos, f->len, 0, parser, &tm, &tmfrac);
+        if (ret == -1) {
+            flb_warn("[parser:%s] invalid time format %s",
+                     parser->name, parser->time_fmt_full);
+        }
+        else {
+            have_time = true;
+        }
+    }
+
+    out_time->tm.tv_sec = 0;
+    out_time->tm.tv_nsec = 0;
+    if (have_time) {
+        out_time->tm.tv_sec = flb_parser_tm2time_parser(&tm, parser);
+        out_time->tm.tv_nsec = (tmfrac * 1000000000);
+    }
+
+    exclude_time_field = have_time && !parser->time_keep;
+    map_size = field_count - (exclude_time_field ? 1 : 0);
+
+    msgpack_sbuffer_init(&tmp_sbuf);
+    msgpack_packer_init(&tmp_pck, &tmp_sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&tmp_pck, map_size);
+
+    for (i = 0; i < field_count; i++) {
+        if (exclude_time_field && i == (size_t) time_idx) {
+            continue;
+        }
+
+        f = &fb.fields[i];
+
+        if (parser->csv_field_names && i < (size_t) parser->csv_field_names_len) {
+            key = parser->csv_field_names[i];
+            key_len = strlen(key);
+        }
+        else {
+            key_len = snprintf(key_buf, sizeof(key_buf), "%zu", i);
+            key = key_buf;
+        }
+
+        if (parser->types_len != 0) {
+            char val_stack[FLB_PARSER_CSV_STATIC_UNESCAPE];
+            char *val_buf;
+            size_t val_len;
+            bool val_heap = false;
+
+            if (!f->has_dquote) {
+                flb_parser_typecast(key, key_len, in_buf + f->pos, f->len,
+                                    &tmp_pck, parser->types, parser->types_len);
+            }
+            else {
+                if (f->len <= sizeof(val_stack)) {
+                    val_buf = val_stack;
+                }
+                else {
+                    val_buf = flb_malloc(f->len);
+                    if (!val_buf) {
+                        flb_errno();
+                        msgpack_sbuffer_destroy(&tmp_sbuf);
+                        if (fb.heap) {
+                            flb_free(fb.fields);
+                        }
+                        return -1;
+                    }
+                    val_heap = true;
+                }
+                val_len = csv_unescape(in_buf + f->pos, f->len, val_buf);
+                flb_parser_typecast(key, key_len, val_buf, val_len,
+                                    &tmp_pck, parser->types, parser->types_len);
+                if (val_heap) {
+                    flb_free(val_buf);
+                }
+            }
+        }
+        else {
+            msgpack_pack_str(&tmp_pck, key_len);
+            msgpack_pack_str_body(&tmp_pck, key, key_len);
+
+            ret = csv_pack_value(&tmp_pck, in_buf, f);
+            if (ret == -1) {
+                msgpack_sbuffer_destroy(&tmp_sbuf);
+                if (fb.heap) {
+                    flb_free(fb.fields);
+                }
+                return -1;
+            }
+        }
+    }
+
+    if (fb.heap) {
+        flb_free(fb.fields);
+    }
+
+    *out_buf = tmp_sbuf.data;
+    *out_size = tmp_sbuf.size;
+
+    /* Check if some decoder was specified */
+    if (parser->decoders) {
+        ret = flb_parser_decoder_do(parser->decoders,
+                                    tmp_sbuf.data, tmp_sbuf.size,
+                                    &dec_out_buf, &dec_out_size);
+        if (ret == 0) {
+            *out_buf = dec_out_buf;
+            *out_size = dec_out_size;
+            msgpack_sbuffer_destroy(&tmp_sbuf);
+        }
+    }
+
+    return (int) in_size;
+}

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -46,6 +46,7 @@ set(UNIT_TESTS_FILES
   parser_ltsv.c
   parser_regex.c
   parser_logfmt.c
+  parser_csv.c
   env.c
   log.c
   log_event_decoder.c

--- a/tests/internal/parser_csv.c
+++ b/tests/internal/parser_csv.c
@@ -1,0 +1,473 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_parser_decoder.h>
+#include <msgpack.h>
+#include <float.h>
+#include <math.h>
+#include "flb_tests_internal.h"
+
+static int msgpack_strncmp(char *str, size_t str_len, msgpack_object obj)
+{
+    int ret = -1;
+
+    if (str == NULL) {
+        return -1;
+    }
+
+    switch (obj.type) {
+    case MSGPACK_OBJECT_STR:
+        if (obj.via.str.size != str_len) {
+            return -1;
+        }
+        ret = strncmp(str, obj.via.str.ptr, str_len);
+        break;
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
+        {
+            unsigned long val = strtoul(str, NULL, 10);
+            if (val == (unsigned long) obj.via.u64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+        {
+            long long val = strtoll(str, NULL, 10);
+            if (val == obj.via.i64) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
+        {
+            double val = strtod(str, NULL);
+            if (fabs(val - obj.via.f64) < DBL_EPSILON) {
+                ret = 0;
+            }
+        }
+        break;
+    case MSGPACK_OBJECT_BOOLEAN:
+        if (obj.via.boolean) {
+            ret = (str_len == 4) ? strncasecmp(str, "true", 4) : -1;
+        }
+        else {
+            ret = (str_len == 5) ? strncasecmp(str, "false", 5) : -1;
+        }
+        break;
+    default:
+        break;
+    }
+
+    return ret;
+}
+
+struct str_list {
+    size_t size;
+    char **lists;
+};
+
+/* Compares a single-record msgpack map against a flat key,value,... list */
+static int compare_msgpack(void *msgpack_data, size_t msgpack_size, struct str_list *l)
+{
+    msgpack_unpacked result;
+    msgpack_object obj;
+    size_t off = 0;
+    int map_size;
+    int i_map;
+    int i_list;
+    int num = 0;
+
+    if (!TEST_CHECK(msgpack_data != NULL)) {
+        TEST_MSG("msgpack_data is NULL");
+        return -1;
+    }
+    if (!TEST_CHECK(msgpack_size > 0)) {
+        TEST_MSG("msgpack_size is 0");
+        return -1;
+    }
+
+    msgpack_unpacked_init(&result);
+    if (!TEST_CHECK(msgpack_unpack_next(&result, msgpack_data, msgpack_size, &off)
+                     == MSGPACK_UNPACK_SUCCESS)) {
+        TEST_MSG("msgpack_unpack_next failed");
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    obj = result.data;
+    if (!TEST_CHECK(obj.type == MSGPACK_OBJECT_MAP)) {
+        TEST_MSG("not a map. type = %d", obj.type);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    map_size = obj.via.map.size;
+    if (!TEST_CHECK((size_t) map_size == l->size / 2)) {
+        TEST_MSG("map size mismatch. got=%d expect=%zu", map_size, l->size / 2);
+        msgpack_unpacked_destroy(&result);
+        return -1;
+    }
+
+    for (i_map = 0; i_map < map_size; i_map++) {
+        for (i_list = 0; i_list < (int) (l->size / 2); i_list++) {
+            if (msgpack_strncmp(l->lists[i_list * 2], strlen(l->lists[i_list * 2]),
+                                obj.via.map.ptr[i_map].key) == 0 &&
+                msgpack_strncmp(l->lists[i_list * 2 + 1], strlen(l->lists[i_list * 2 + 1]),
+                                obj.via.map.ptr[i_map].val) == 0) {
+                num++;
+            }
+        }
+    }
+
+    msgpack_unpacked_destroy(&result);
+    if (!TEST_CHECK(num == (int) (l->size / 2))) {
+        TEST_MSG("compare failed. matched_num=%d expect=%zu", num, l->size / 2);
+        return -1;
+    }
+    return 0;
+}
+
+void test_basic()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "a,b,c";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "0", "a", "1", "b", "2", "c" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_trailing_empty_field()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "a,b,";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "0", "a", "1", "b", "2", "" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_quoted_fields()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "a,\"b,c\",\"d\"\"e\"";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "0", "a", "1", "b,c", "2", "d\"e" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_named_fields()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "1,2,3";
+    char *field_names[] = { "x", "y", "z" };
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "x", "1", "y", "2", "z", "3" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_csv_set_fields(parser, field_names, 3);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_time_key_by_index()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "2022-10-31T12:00:01.123,text";
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "1", "text" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    out_time.tm.tv_sec = 0;
+    out_time.tm.tv_nsec = 0;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE,
+                               "%Y-%m-%dT%H:%M:%S.%L", "0", NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    if (!TEST_CHECK(out_time.tm.tv_sec == 1667217601 && out_time.tm.tv_nsec == 123000000)) {
+        TEST_MSG("timestamp error. sec  Got=%ld Expect=1667217601", out_time.tm.tv_sec);
+        TEST_MSG("timestamp error. nsec Got=%ld Expect=123000000", out_time.tm.tv_nsec);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_time_key_by_name()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "text,2022-10-31T12:00:01.123";
+    char *field_names[] = { "msg", "time" };
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "msg", "text" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    out_time.tm.tv_sec = 0;
+    out_time.tm.tv_nsec = 0;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE,
+                               "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_csv_set_fields(parser, field_names, 2);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    if (!TEST_CHECK(out_time.tm.tv_sec == 1667217601 && out_time.tm.tv_nsec == 123000000)) {
+        TEST_MSG("timestamp error. sec  Got=%ld Expect=1667217601", out_time.tm.tv_sec);
+        TEST_MSG("timestamp error. nsec Got=%ld Expect=123000000", out_time.tm.tv_nsec);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_time_keep()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "text,2022-10-31T12:00:01.123";
+    char *field_names[] = { "msg", "time" };
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "msg", "text", "time", "2022-10-31T12:00:01.123" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    out_time.tm.tv_sec = 0;
+    out_time.tm.tv_nsec = 0;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE,
+                               "%Y-%m-%dT%H:%M:%S.%L", "time", NULL,
+                               FLB_TRUE /* time_keep */, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               NULL, 0, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_csv_set_fields(parser, field_names, 2);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+void test_types()
+{
+    struct flb_parser *parser = NULL;
+    struct flb_config *config = NULL;
+    int ret;
+    char *input = "text,100";
+    char *field_names[] = { "msg", "count" };
+    struct flb_parser_types *types = NULL;
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    struct flb_time out_time;
+    char *expected_strs[] = { "msg", "text", "count", "100" };
+    struct str_list expected = { sizeof(expected_strs) / sizeof(char *), expected_strs };
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+
+    /* Note: types will be released by flb_parser_destroy */
+    types = flb_malloc(sizeof(struct flb_parser_types));
+    TEST_CHECK(types != NULL);
+    types->key = flb_malloc(strlen("count") + 1);
+    TEST_CHECK(types->key != NULL);
+    strcpy(types->key, "count");
+    types->key_len = 5;
+    types->type = FLB_PARSER_TYPE_INT;
+
+    parser = flb_parser_create("csv", "csv", NULL, FLB_FALSE, NULL, NULL, NULL,
+                               FLB_FALSE, FLB_FALSE, FLB_FALSE, FLB_FALSE,
+                               types, 1, NULL, config);
+    TEST_CHECK(parser != NULL);
+
+    ret = flb_parser_csv_set_fields(parser, field_names, 2);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_parser_do(parser, input, strlen(input), &out_buf, &out_size, &out_time);
+    if (!TEST_CHECK(ret != -1)) {
+        TEST_MSG("flb_parser_do failed");
+    }
+    else {
+        /* 'count' comes back as an integer, not a string: just check the
+         * map size and the string field to make sure it went through */
+        compare_msgpack(out_buf, out_size, &expected);
+        flb_free(out_buf);
+    }
+
+    flb_parser_destroy(parser);
+    flb_config_exit(config);
+}
+
+TEST_LIST = {
+    { "basic", test_basic},
+    { "trailing_empty_field", test_trailing_empty_field},
+    { "quoted_fields", test_quoted_fields},
+    { "named_fields", test_named_fields},
+    { "time_key_by_index", test_time_key_by_index},
+    { "time_key_by_name", test_time_key_by_name},
+    { "time_keep", test_time_keep},
+    { "types", test_types},
+    { 0 }
+};


### PR DESCRIPTION
Adds a new "csv" parser format (FLB_PARSER_CSV), picking up the idea from the never-merged fluent/fluent-bit#5040, but built for performance: a single left-to-right scan over each record records (offset, length) pairs for every field with no intermediate copies, then a second pass writes the already-known-size msgpack map directly from those positions. Fields on the stack (up to 128) avoid heap allocation entirely for typical CSV lines and grow geometrically onto the heap only for pathological inputs; unescaping of embedded "" is only done for the (rare) fields that actually contain a quote, also via a reusable stack buffer.

By default, fields are assigned numbered string keys ("0", "1", ...). An optional comma separated `csv_fields` parser config key assigns named keys instead. `time_key` designates which field carries the record timestamp - a 0-based index when no `csv_fields` is set, or a field name when it is - reusing the existing time_format/time_keep machinery shared with the other parsers.

Also registers tests/internal/parser_csv.c covering basic splitting, trailing empty fields, quoted/escaped fields, named fields, time_key by index and by name, time_keep, and type casting.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV parser support for comma-separated log and data records.
  * Supports quoted values, escaped quotes, empty trailing fields, and optional field names.
  * Enables timestamp extraction by field name or index, with optional timestamp retention.
  * Supports automatic type conversion for parsed values.

* **Tests**
  * Added coverage for CSV parsing, timestamps, field naming, data types, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->