### PR TITLE
downstream: invalidate TLS session before socket close

### DIFF
--- a/src/flb_downstream.c
+++ b/src/flb_downstream.c
@@ -360,6 +360,11 @@ static int prepare_destroy_conn(struct flb_connection *connection)
      */
 
     if (connection->fd != FLB_INVALID_SOCKET) {
+#ifdef FLB_HAVE_TLS
+        if (connection->tls_session != NULL) {
+            flb_tls_session_invalidate(connection->tls_session);
+        }
+#endif
         flb_socket_close(connection->fd);
 
         connection->fd = FLB_INVALID_SOCKET;


### PR DESCRIPTION
## Problem

Downstream teardown closes a TLS socket before invalidating the associated
TLS session. Session destruction is deferred, so the operating system can
reuse the numeric file descriptor before OpenSSL calls `SSL_shutdown()`.
That allows the old TLS session to write a close-notify record into a new
connection, which clients report as `bad record mac` or `unexpected message`.

## Change

Invalidate an active downstream TLS session before closing its socket. This
matches the existing upstream teardown ordering and prevents deferred TLS
cleanup from using a recycled descriptor.

## Impact

Concurrent TLS listeners no longer risk corrupting newly accepted connections
during deferred downstream cleanup.

## Validation

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`
- `ctest --test-dir build -R 'flb-it-(downstream_worker|http_server|opentelemetry)' --output-on-failure`
- Focused OpenTelemetry HTTP/2 TLS worker test with `VALGRIND=1 VALGRIND_STRICT=1`
- CI-style commit-prefix validation against `master`

All checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when closing secure downstream connections by invalidating active TLS sessions.
  * Helps prevent stale security sessions from remaining after a connection is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->