### PR TITLE
http_server: inherit worker ALPN configuration

### DIFF
--- a/src/http_server/flb_http_server.c
+++ b/src/http_server/flb_http_server.c
@@ -668,6 +668,8 @@ static int flb_http_server_worker_initialize(struct flb_downstream_worker *worke
         return result;
     }
 
+    context->server.tls_alpn_configured = parent->tls_alpn_configured;
+
     result = flb_http_server_start(&context->server);
     if (result != 0) {
         flb_http_server_destroy(&context->server);


### PR DESCRIPTION
## Problem

The parent HTTP server configures ALPN on its shared TLS provider before
starting listener workers. Each worker initializes a child server whose local
`tls_alpn_configured` flag is reset, causing every worker to configure the same
shared OpenSSL `SSL_CTX` again while sibling workers can already perform TLS
handshakes.

Helgrind identified the concurrent `SSL_CTX_set_alpn_select_cb()` mutation and
TLS handshake access. Under instrumentation, clients intermittently reported
`unexpected message` during concurrent HTTP/2 TLS ingestion.

## Change

Propagate the parent's ALPN-configured state to each worker server. Workers
continue using the already configured shared TLS provider without mutating it.

## Impact

Multi-worker HTTP servers can negotiate HTTP/2 over TLS without racing on
shared ALPN configuration.

This PR is stacked on #12278 because that PR fixes the separate downstream TLS
descriptor lifecycle defect found by the same reproducer.

## Validation

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`
- `ctest --test-dir build -R 'flb-it-(downstream_worker|http_server|opentelemetry)' --output-on-failure`
- Focused OpenTelemetry HTTP/2 TLS worker test: passed normally
- Focused OpenTelemetry HTTP/2 TLS worker test: 3/3 passes with `VALGRIND=1 VALGRIND_STRICT=1`
- CI-style commit-prefix validation against the stack base

All checks passed.
