### PR TITLE
multiline: enforce multiline_buffer_limit for EQ and ENDSWITH types

### DIFF
--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -310,6 +310,9 @@ static int package_content(struct flb_ml_stream *mst,
             if (ret == FLB_MULTILINE_TRUNCATED) {
                 /* Buffer limit reached. Flush now to emit the truncated record. */
                 truncated = FLB_TRUE;
+                if (metadata != NULL) {
+                    flb_ml_stream_group_add_metadata(stream_group, metadata);
+                }
                 ret = flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
                 if (ret == -1) {
                     return -1;
@@ -355,6 +358,9 @@ static int package_content(struct flb_ml_stream *mst,
         if (ret == FLB_MULTILINE_TRUNCATED) {
             /* Buffer limit reached. Flush now to emit the truncated record. */
             truncated = FLB_TRUE;
+            if (metadata != NULL) {
+                flb_ml_stream_group_add_metadata(stream_group, metadata);
+            }
             ret = flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
             if (ret == -1) {
                 return -1;

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -310,7 +310,10 @@ static int package_content(struct flb_ml_stream *mst,
             if (ret == FLB_MULTILINE_TRUNCATED) {
                 /* Buffer limit reached. Flush now to emit the truncated record. */
                 truncated = FLB_TRUE;
-                flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
+                ret = flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
+                if (ret == -1) {
+                    return -1;
+                }
             }
             else if (rule_match) {
                 /* On ENDSWITH mode, a rule match means flush the content. */
@@ -352,7 +355,10 @@ static int package_content(struct flb_ml_stream *mst,
         if (ret == FLB_MULTILINE_TRUNCATED) {
             /* Buffer limit reached. Flush now to emit the truncated record. */
             truncated = FLB_TRUE;
-            flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
+            ret = flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
+            if (ret == -1) {
+                return -1;
+            }
         }
         else if (rule_match) {
             /* On EQ mode, a rule match means flush the content. */

--- a/src/multiline/flb_ml.c
+++ b/src/multiline/flb_ml.c
@@ -294,18 +294,26 @@ static int package_content(struct flb_ml_stream *mst,
             /* Prepare concatenation */
             breakline_prepare(parser_i, stream_group);
 
-            /* Concatenate value */
+            /* Concatenate value, while honoring the buffer limit. */
             if (val_content) {
-                flb_sds_cat_safe(&stream_group->buf,
-                                 val_content->via.str.ptr,
-                                 val_content->via.str.size);
+                ret = flb_ml_group_cat(stream_group,
+                                       val_content->via.str.ptr,
+                                       val_content->via.str.size);
             }
             else {
-                flb_sds_cat_safe(&stream_group->buf, buf_data, buf_size);
+                ret = flb_ml_group_cat(stream_group, buf_data, buf_size);
+            }
+            if (ret == -1) {
+                return -1;
             }
 
-            /* on ENDSWITH mode, a rule match means flush the content */
-            if (rule_match) {
+            if (ret == FLB_MULTILINE_TRUNCATED) {
+                /* Buffer limit reached. Flush now to emit the truncated record. */
+                truncated = FLB_TRUE;
+                flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
+            }
+            else if (rule_match) {
+                /* On ENDSWITH mode, a rule match means flush the content. */
                 flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
             }
             processed = FLB_TRUE;
@@ -328,18 +336,26 @@ static int package_content(struct flb_ml_stream *mst,
         /* Prepare concatenation */
         breakline_prepare(parser_i, stream_group);
 
-        /* Concatenate value */
+        /* Concatenate value, while honoring the buffer limit. */
         if (val_content) {
-            flb_sds_cat_safe(&stream_group->buf,
-                             val_content->via.str.ptr,
-                             val_content->via.str.size);
+            ret = flb_ml_group_cat(stream_group,
+                                   val_content->via.str.ptr,
+                                   val_content->via.str.size);
         }
         else {
-            flb_sds_cat_safe(&stream_group->buf, buf_data, buf_size);
+            ret = flb_ml_group_cat(stream_group, buf_data, buf_size);
+        }
+        if (ret == -1) {
+            return -1;
         }
 
-        /* on ENDSWITH mode, a rule match means flush the content */
-        if (rule_match) {
+        if (ret == FLB_MULTILINE_TRUNCATED) {
+            /* Buffer limit reached. Flush now to emit the truncated record. */
+            truncated = FLB_TRUE;
+            flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
+        }
+        else if (rule_match) {
+            /* On EQ mode, a rule match means flush the content. */
             flb_ml_flush_stream_group(parser, mst, stream_group, FLB_FALSE);
         }
         processed = FLB_TRUE;

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -2119,6 +2119,138 @@ static void test_issue_truncation_10576()
     flb_config_exit(config);
 }
 
+/*
+ * Verifies multiline_buffer_limit truncation for FLB_ML_EQ, using the
+ * built-in 'cri' parser.
+ */
+static void test_buffer_limit_truncation_cri()
+{
+    int ret;
+    uint64_t stream_id;
+    struct flb_config *config;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct flb_time tm;
+    struct expected_result res = {0};
+
+    char *line1 = "2026-08-14T18:57:50.904275087+00:00 stdout P AAAAAAAAAA";
+    char *line2 = "2026-08-14T18:57:51.904275088+00:00 stdout P BBBBBBBBBB";
+    char *line3 = "2026-08-14T18:57:52.904275089+00:00 stdout P CCCCCCCCCC";
+    char *line4 = "2026-08-14T18:57:53.904275090+00:00 stdout F DDDDDDDDDD";
+
+    struct record_check cri_buffer_limit_output[] = {
+      {"AAAAAAAAAABBBBBBBBBBCCCCC"},
+      {"DDDDDDDDDD"},
+    };
+
+    res.key = "log";
+    res.out_records = cri_buffer_limit_output;
+
+    config = flb_config_init();
+    if (config->multiline_buffer_limit) {
+        flb_free(config->multiline_buffer_limit);
+    }
+    config->multiline_buffer_limit = flb_strdup("25");
+
+    ml = flb_ml_create(config, "cri-limit-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "cri");
+    TEST_CHECK(mlp_i != NULL);
+
+    ret = flb_ml_stream_create(ml, "cri", -1, flush_callback, (void *) &res,
+                               &stream_id);
+    TEST_CHECK(ret == 0);
+
+    flb_time_get(&tm);
+
+    ret = flb_ml_append_text(ml, stream_id, &tm, line1, strlen(line1));
+    TEST_CHECK(ret == FLB_MULTILINE_OK);
+
+    ret = flb_ml_append_text(ml, stream_id, &tm, line2, strlen(line2));
+    TEST_CHECK(ret == FLB_MULTILINE_OK);
+
+    /* 20 bytes buffered so far, this line pushes it past the 25 byte limit. */
+    ret = flb_ml_append_text(ml, stream_id, &tm, line3, strlen(line3));
+    TEST_CHECK(ret == FLB_MULTILINE_TRUNCATED);
+
+    ret = flb_ml_append_text(ml, stream_id, &tm, line4, strlen(line4));
+    TEST_CHECK(ret == FLB_MULTILINE_OK);
+
+    TEST_CHECK(res.current_record == 2);
+
+    flb_ml_destroy(ml);
+    flb_config_exit(config);
+}
+
+/*
+ * Verifies multiline_buffer_limit truncation for FLB_ML_ENDSWITH, using the
+ * built-in 'docker' parser.
+ */
+static void test_buffer_limit_truncation_docker()
+{
+    int ret;
+    uint64_t stream_id;
+    struct flb_config *config;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct flb_time tm;
+    struct expected_result res = {0};
+
+    char *line1 = "{\"log\": \"AAAAAAAAAA\", \"stream\": \"stdout\", "
+                  "\"time\": \"2026-08-14T16:45:03.01231z\"}";
+    char *line2 = "{\"log\": \"BBBBBBBBBB\", \"stream\": \"stdout\", "
+                  "\"time\": \"2026-08-14T16:45:03.01232z\"}";
+    char *line3 = "{\"log\": \"CCCCCCCCCC\", \"stream\": \"stdout\", "
+                  "\"time\": \"2026-08-14T16:45:03.01233z\"}";
+    char *line4 = "{\"log\": \"DDDDDDDDDD\\n\", \"stream\": \"stdout\", "
+                  "\"time\": \"2026-08-14T16:45:03.01234z\"}";
+
+    struct record_check docker_buffer_limit_output[] = {
+      {"AAAAAAAAAABBBBBBBBBBCCCCC"},
+      {"DDDDDDDDDD\n"},
+    };
+
+    res.key = "log";
+    res.out_records = docker_buffer_limit_output;
+
+    config = flb_config_init();
+    if (config->multiline_buffer_limit) {
+        flb_free(config->multiline_buffer_limit);
+    }
+    config->multiline_buffer_limit = flb_strdup("25");
+
+    ml = flb_ml_create(config, "docker-limit-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "docker");
+    TEST_CHECK(mlp_i != NULL);
+
+    ret = flb_ml_stream_create(ml, "docker", -1, flush_callback, (void *) &res,
+                               &stream_id);
+    TEST_CHECK(ret == 0);
+
+    flb_time_get(&tm);
+
+    ret = flb_ml_append_text(ml, stream_id, &tm, line1, strlen(line1));
+    TEST_CHECK(ret == FLB_MULTILINE_OK);
+
+    ret = flb_ml_append_text(ml, stream_id, &tm, line2, strlen(line2));
+    TEST_CHECK(ret == FLB_MULTILINE_OK);
+
+    /* 20 bytes buffered so far, this line pushes it past the 25 byte limit. */
+    ret = flb_ml_append_text(ml, stream_id, &tm, line3, strlen(line3));
+    TEST_CHECK(ret == FLB_MULTILINE_TRUNCATED);
+
+    ret = flb_ml_append_text(ml, stream_id, &tm, line4, strlen(line4));
+    TEST_CHECK(ret == FLB_MULTILINE_OK);
+
+    TEST_CHECK(res.current_record == 2);
+
+    flb_ml_destroy(ml);
+    flb_config_exit(config);
+}
+
 TEST_LIST = {
     /* Normal features tests */
     { "parser_docker",  test_parser_docker},
@@ -2132,6 +2264,8 @@ TEST_LIST = {
     { "container_mix",  test_container_mix},
     { "endswith",       test_endswith},
     { "buffer_limit_truncation", test_buffer_limit_truncation},
+    { "buffer_limit_truncation_cri", test_buffer_limit_truncation_cri},
+    { "buffer_limit_truncation_docker", test_buffer_limit_truncation_docker},
     { "buffer_limit_disabled", test_buffer_limit_disabled},
     { "known_bug_multi_group_flush_only_first_group",
       test_known_bug_multi_group_flush_only_first_group},

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -2251,6 +2251,125 @@ static void test_buffer_limit_truncation_docker()
     flb_config_exit(config);
 }
 
+/*
+ * Verifies multiline_buffer_limit truncation preserves metadata from
+ * fragments already processed.
+ */
+static void test_buffer_limit_truncation_metadata()
+{
+    int ret;
+    int i;
+    uint64_t stream_id;
+    struct flb_config *config;
+    struct flb_ml *ml;
+    struct flb_ml_parser_ins *mlp_i;
+    struct flb_time tm;
+    int root_type;
+    char body_json[128];
+    char meta_json[64];
+    char *body_buf;
+    char *meta_buf;
+    size_t body_size;
+    size_t meta_size;
+    msgpack_sbuffer out_sbuf;
+    msgpack_unpacked body_result;
+    msgpack_unpacked meta_result;
+    flb_sds_t json;
+    size_t off;
+
+    struct {
+        char *log;
+        char *tag;
+    } frags[4] = {
+        {"2026-08-14T18:57:50.904275087+00:00 stdout P AAAAAAAAAA", "frag1"},
+        {"2026-08-14T18:57:51.904275088+00:00 stdout P BBBBBBBBBB", "frag2"},
+        /*
+         * The third fragment pushes past the 25 limit and should cause
+         * truncation.
+         */
+        {"2026-08-14T18:57:52.904275089+00:00 stdout P CCCCCCCCCC", "frag3"},
+        {"2026-08-14T18:57:53.904275090+00:00 stdout F DDDDDDDDDD", "frag4"},
+    };
+
+    config = flb_config_init();
+    if (config->multiline_buffer_limit) {
+        flb_free(config->multiline_buffer_limit);
+    }
+    config->multiline_buffer_limit = flb_strdup("25");
+
+    ml = flb_ml_create(config, "cri-metadata-test");
+    TEST_CHECK(ml != NULL);
+
+    mlp_i = flb_ml_parser_instance_create(ml, "cri");
+    TEST_CHECK(mlp_i != NULL);
+
+    msgpack_sbuffer_init(&out_sbuf);
+
+    ret = flb_ml_stream_create(ml, "cri", -1, flush_callback_to_buf,
+                               (void *) &out_sbuf, &stream_id);
+    TEST_CHECK(ret == 0);
+
+    flb_time_get(&tm);
+
+    for (i = 0; i < 4; i++) {
+        snprintf(body_json, sizeof(body_json), "{\"log\": \"%s\"}", frags[i].log);
+        ret = flb_pack_json(body_json, strlen(body_json), &body_buf, &body_size,
+                            &root_type, NULL);
+        TEST_CHECK(ret != -1);
+
+        /*
+         * Add individual metadata in each fragment, different from one
+         * another.
+         */
+        snprintf(meta_json, sizeof(meta_json), "{\"container_id\": \"%s\"}",
+                 frags[i].tag);
+        ret = flb_pack_json(meta_json, strlen(meta_json), &meta_buf, &meta_size,
+                            &root_type, NULL);
+        TEST_CHECK(ret != -1);
+
+        off = 0;
+        msgpack_unpacked_init(&body_result);
+        ret = msgpack_unpack_next(&body_result, body_buf, body_size, &off);
+        TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+
+        off = 0;
+        msgpack_unpacked_init(&meta_result);
+        ret = msgpack_unpack_next(&meta_result, meta_buf, meta_size, &off);
+        TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+
+        ret = flb_ml_append_object(ml, stream_id, &tm, &meta_result.data,
+                                   &body_result.data);
+        if (i == 2) {
+            /*
+             * Expect a truncation happening while processing the third
+             * fragment.
+             */
+            TEST_CHECK(ret == FLB_MULTILINE_TRUNCATED);
+        }
+        else {
+            TEST_CHECK(ret == FLB_MULTILINE_OK);
+        }
+
+        msgpack_unpacked_destroy(&body_result);
+        msgpack_unpacked_destroy(&meta_result);
+        flb_free(body_buf);
+        flb_free(meta_buf);
+    }
+
+    /*
+     * Confirm that the third fragment's metadata is preserved after
+     * truncation.
+     */
+    json = flb_msgpack_raw_to_json_sds(out_sbuf.data, out_sbuf.size, FLB_FALSE);
+    TEST_CHECK(json != NULL);
+    TEST_CHECK(json && strstr(json, "frag3") != NULL);
+    flb_sds_destroy(json);
+    msgpack_sbuffer_destroy(&out_sbuf);
+
+    flb_ml_destroy(ml);
+    flb_config_exit(config);
+}
+
 TEST_LIST = {
     /* Normal features tests */
     { "parser_docker",  test_parser_docker},
@@ -2266,6 +2385,7 @@ TEST_LIST = {
     { "buffer_limit_truncation", test_buffer_limit_truncation},
     { "buffer_limit_truncation_cri", test_buffer_limit_truncation_cri},
     { "buffer_limit_truncation_docker", test_buffer_limit_truncation_docker},
+    { "buffer_limit_truncation_metadata", test_buffer_limit_truncation_metadata},
     { "buffer_limit_disabled", test_buffer_limit_disabled},
     { "known_bug_multi_group_flush_only_first_group",
       test_known_bug_multi_group_flush_only_first_group},


### PR DESCRIPTION
The built-in multiline `cri` and `docker` parsers don't respect the configured value of `multiline_buffer_limit`, allowing their memory usage to grow unbounded, which can lead to OOM-kills. This appears to be a bug and not just a documentation mismatch. [The document](https://docs.fluentbit.io/manual/data-pipeline/parsers/multiline-parsing#additional-configuration-for-buffer-limit-of-multiline) states:

```yaml
service:
  multiline_buffer_limit: 2MB # default; limit concatenated multiline message size
```
> If the limit is reached, Fluent Bit flushes the partial record with `multiline_truncated: true` metadata immediately to prevent Out-Of-Memory (OOM) conditions. This option ensures predictable memory usage in Kubernetes or other constrained environments, particularly when using built-in parsers such as `cri` or `docker`.

This PR aims to fix this problem by routing `FLB_ML_EQ` and `FLB_ML_ENDSWITH` through the same `flb_ml_group_cat()` call the `FLB_ML_REGEX` path already uses.

No issue opened. Found this while investigating OOM-kills of Fluent Bit's pods in our production Kubernetes clusters, due to application containers dumping very long CRI-formatted lines.

----

Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- `[N/A]` Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- `[N/A]` Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- `[N/A]` Documentation required for this feature

**Backporting**
Looking back at the documentation in earlier releases, the following releases mention this behavior/expectation and therefore need a backport:
- [ ] `4.1`
- [ ] `4.2`
- [ ] `5.0`

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multiline log handling when configured buffer limits are exceeded.
  - Truncated records are now flushed promptly, preventing later fragments from being incorrectly combined.
  - Enhanced behavior for CRI and Docker multiline parsers.
  - Records following truncated entries are emitted separately with expected content.
  - Preserved metadata from fragments that exceed the buffer limit.

- **Tests**
  - Added regression coverage for truncation, record separation, and metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->