### PR TITLE
maintenance: update v5.1 stable status

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,18 +4,19 @@ This document outlines the maintenance strategy and version support for Fluent B
 
 ## Active Branches and Maintainers
 
-| Branch     | Version            | Status              | Maintainer                                                  | Notes                                                              |
-|------------|--------------------|---------------------|-------------------------------------------------------------|--------------------------------------------------------------------|
-| `master`   | v5.1 (development) | Active development  | [Eduardo Silva](https://github.com/edsiper)                 | Next minor development line. All new features and bug fixes land here first |
-| `5.0`      | v5.0.x             | Stable              | [Eduardo Silva](https://github.com/edsiper) [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920) | Current stable release series. Receives bug fixes, security fixes, and selected low-risk backports. |
-| `4.2`      | v4.2.x             | Maintenance only    | [Eduardo Silva](https://github.com/edsiper) [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920) | Critical fixes and safe backports only. Maintained until **July 30, 2026** |
-| `4.1`      | v4.1.x             | Maintenance only    | [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920) | Critical fixes and safe backports only. Maintained until **February 28, 2026** |
+| Branch     | Version | Status           | Maintainer                                                  | Notes                                                              |
+|------------|---------|------------------|-------------------------------------------------------------|--------------------------------------------------------------------|
+| `master`   | v5.1.x  | Stable           | [Eduardo Silva](https://github.com/edsiper)                 | Current stable release series. All new features and bug fixes land here first. |
+| `5.0`      | v5.0.x  | Maintenance only | [Eduardo Silva](https://github.com/edsiper) [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920) | Bug fixes, security fixes, and selected low-risk backports until **November 30, 2026**. |
 
 ---
 
 ## Maintenance Policy
 
-Active development is currently on the next Fluent Bit **v5.1** line (tracked in the `master` branch). The **v5.0** branch is the current stable release series and receives stable branch updates. Previous release lines enter **maintenance mode** after the next major/minor release.
+Fluent Bit **v5.1** is the current stable release series and is tracked in the
+`master` branch. The **v5.0** branch is in maintenance mode and receives bug
+fixes, security updates, and selected low-risk backports until its
+End-of-Maintenance date. Older release lines are End-of-Life (EOL).
 
 ### Accepted Changes for Maintenance Branches
 
@@ -27,21 +28,28 @@ Active development is currently on the next Fluent Bit **v5.1** line (tracked in
 
 Maintenance releases continue on an as-needed basis depending on urgency and impact.
 
-### v5.0 Stable Series
+### v5.1 Stable Series
 
-**v5.0** is the current stable release series and receives bug fixes, security updates, and selected low-risk backports. This is the recommended version for production use.
+**v5.1** is the current stable release series and is recommended for production
+use. New features and bug fixes land in `master` first.
 
-### v4.2 Maintenance
+### v5.0 Maintenance
 
-**v4.2** has entered **maintenance mode** and receives critical fixes and safe backports until **July 30, 2026** (as specified in [SECURITY.md](SECURITY.md)).
+**v5.0** is in **maintenance mode** and receives bug fixes, security updates,
+and selected low-risk backports until **November 30, 2026** (as specified in
+[SECURITY.md](SECURITY.md)).
 
-### v4.1 Maintenance
+### v4.2 End-of-Life
 
-**v4.1** has entered **maintenance mode**, now maintained by [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920), a long-time Fluent Bit contributor and core developer.
+**v4.2** reached **End-of-Life (EOL)** on **July 30, 2026** and is no longer
+maintained.
 
-**v4.1** will receive security updates and critical fixes until **February 28, 2026** (as specified in [SECURITY.md](SECURITY.md)).
+### v4.1 End-of-Life
 
-### v4.0 Maintenance
+**v4.1** reached **End-of-Life (EOL)** on **February 28, 2026** and is no longer
+maintained.
+
+### v4.0 End-of-Life
 
 **v4.0** reached **End-of-Life (EOL)** on **December 23, 2025** and is no longer maintained. No further security patches or bug fixes will be provided for this version line.
 
@@ -49,13 +57,14 @@ Maintenance releases continue on an as-needed basis depending on urgency and imp
 
 ## How to Contribute to Maintained Versions
 
-If you're submitting a fix or feature relevant to a stable or maintenance branch (v5.0, v4.2, or v4.1):
+If you're submitting a fix or feature relevant to a stable or maintenance
+branch:
 
 - Open your PR against the `master` branch
-- Add a note in the PR or issue: `Target: v5.0`, `Target: v4.2`, or `Target: v4.1`
-- Tag the branch maintainer to request backport consideration:
-  - For v5.0: [@edsiper](https://github.com/edsiper) [@cosmo0920](https://github.com/cosmo0920)
-  - For v4.2: [@edsiper](https://github.com/edsiper) [@cosmo0920](https://github.com/cosmo0920)
-  - For v4.1: [@cosmo0920](https://github.com/cosmo0920)
+- For a v5.0 backport, add `Target: v5.0` to the PR or issue and tag
+  [@edsiper](https://github.com/edsiper) or
+  [@cosmo0920](https://github.com/cosmo0920)
 
-> **Note:** v4.0 is End-of-Life and no longer accepts backports. For security-related issues, please follow the process outlined in [SECURITY.md](SECURITY.md).
+> **Note:** v4.2 and earlier are End-of-Life and no longer accept backports. For
+> security-related issues, follow the process outlined in
+> [SECURITY.md](SECURITY.md).

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -7,7 +7,7 @@ This document outlines the maintenance strategy and version support for Fluent B
 | Branch     | Version | Status           | Maintainer                                                  | Notes                                                              |
 |------------|---------|------------------|-------------------------------------------------------------|--------------------------------------------------------------------|
 | `master`   | v5.1.x  | Stable           | [Eduardo Silva](https://github.com/edsiper)                 | Current stable release series. All new features and bug fixes land here first. |
-| `5.0`      | v5.0.x  | Maintenance only | [Eduardo Silva](https://github.com/edsiper) [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920) | Bug fixes, security fixes, and selected low-risk backports until **November 30, 2026**. |
+| `5.0`      | v5.0.x  | Maintenance only | [Eduardo Silva](https://github.com/edsiper) [Hiroshi Hatake (@cosmo0920)](https://github.com/cosmo0920) | Critical bug fixes, security fixes, and selected low-risk backports until **November 30, 2026**. |
 
 ---
 
@@ -35,9 +35,9 @@ use. New features and bug fixes land in `master` first.
 
 ### v5.0 Maintenance
 
-**v5.0** is in **maintenance mode** and receives bug fixes, security updates,
-and selected low-risk backports until **November 30, 2026** (as specified in
-[SECURITY.md](SECURITY.md)).
+**v5.0** is in **maintenance mode** and receives critical bug fixes, security
+updates, and selected low-risk backports until **November 30, 2026** (as
+specified in [SECURITY.md](SECURITY.md)).
 
 ### v4.2 End-of-Life
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Fluent Bit supports a wide array of platforms, including Linux, Windows, MacOS, 
 ## 📌 Roadmap & Maintenance
 
 We follow a fast-paced development cycle, with major releases every 3–4 months.
-The active development branch (`master`) is currently focused on **v5.1** (development).
+The `master` branch currently tracks **v5.1**, the current stable release series.
 
 For version-specific maintenance timelines and policies, see our [MAINTENANCE.md](https://github.com/fluent/fluent-bit/blob/master/MAINTENANCE.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,14 +6,16 @@ Fluent Bit maintains active security support for a limited set of release lines.
 
 | Version   | Status     | Security Updates Until |
 |-----------|------------|------------------------|
+| **5.1.x** | ✅ Active  | To be announced        |
 | **5.0.x** | ✅ Active  | **November 30, 2026**  |
-| **4.2.x** | ✅ Active  | **July 30, 2026**      |
+| **4.2.x** | ❌ EOL     | **July 30, 2026**      |
 | **4.1.x** | ❌ EOL     | **February 28, 2026**  |
 | **4.0.x** | ❌ EOL     | **December 23, 2025**  |
 | **3.2.x** | ❌ EOL     | —                      |
 | **< 3.2** | ❌ EOL     | —                      |
 
-> **Note:** 4.1 and earlier are End-of-Life (EOL) and receive no further fixes.
+> **Note:** 4.2 and earlier are End-of-Life (EOL) and receive no further fixes.
+> The v5.1 End-of-Maintenance date will be published when it is finalized.
 
 ---
 
@@ -22,7 +24,7 @@ Fluent Bit maintains active security support for a limited set of release lines.
 - We backport **critical** and **high-severity** security fixes to all **Active** branches listed above.
 - Medium/low-severity fixes may be backported at the maintainers’ discretion.
 - After a branch reaches **EOM**, no further patches are published for that line.
-- Users are strongly encouraged to keep current with the latest **4.x** release line.
+- Users are strongly encouraged to use the latest **5.1.x** release.
 
 ---
 
@@ -59,4 +61,4 @@ For third-party CVEs that may impact Fluent Bit, we will post an assessment and 
 
 ---
 
-_Last updated: December 18, 2025_
+_Last updated: August 14, 2026_


### PR DESCRIPTION
## Summary

- identify v5.1 on `master` as the current stable release series
- move v5.0 to maintenance-only status and update its backport guidance
- mark v4.2 and earlier release lines as End-of-Life
- add v5.1 to the security support table without inventing an unannounced EOM date

## Why

The repository documentation still described v5.1 as under development and v5.0 as the current stable release after v5.1 became stable. Related maintenance, backport, and security guidance had become inconsistent.

## Impact

Users and contributors now see consistent release lifecycle and backport guidance across `README.md`, `MAINTENANCE.md`, and `SECURITY.md`.

## Validation

- `git diff --check origin/master...HEAD`
- `python3 .github/scripts/commit_prefix_check.py`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master python3 .github/scripts/commit_prefix_check.py`

Both commit-prefix checks passed. No runtime tests were run because this change only updates documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated maintenance guidance to identify v5.1 as stable and v5.0 as receiving maintenance through November 30, 2026.
  - Marked v4.1 and v4.2 as end-of-life.
  - Updated contribution and security-reporting guidance.
  - Revised the README and security policy to reflect the current v5.1 release series and support status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->