### PR TITLE
dockerfile: upgrade base packages to remediate OS CVEs (#12284)

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -36,6 +36,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -236,6 +237,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     libssl3t64 \
     libcurl4t64 \


### PR DESCRIPTION
## Summary

Fixes #12284

A Trivy scan of `docker.io/fluent/fluent-bit:5.1.0` (debian 13.6 trixie) reports **96 OS-package vulnerabilities including 6 HIGH** severity CVEs in `libcurl4t64`, `libssh2-1t64` and `libpq5`. As noted in the issue, the 4.x line (`4.2.8`) is identically affected because the root cause is the base layer, not a 5.x-specific regression.

## Root cause

`dockerfiles/Dockerfile` uses `debian:trixie-slim` as the base for three stages (`builder-base`, `deb-extractor`, `debug`). Each stage runs `apt-get update` but **never upgrades** the base layer, so the packages installed (`apt-get install`) and downloaded (`apt-get download`) are the stale, unpatched versions shipped in the base image rather than the latest available Debian trixie security updates.

## Fix

Add `apt-get upgrade -y` immediately after `apt-get update` in the `builder-base` and `debug` stages:

| Stage | Change |
|-------|--------|
| `builder-base` | `apt-get upgrade -y` before `apt-get install` |
| `deb-extractor` | intentionally unchanged (see below) |
| `debug` | `apt-get upgrade -y` before `apt-get install` |

This ensures the base layer and the installed debs pick up the latest available Debian trixie security patches. It remediates the fixable subset of the reported CVEs today (e.g. **CVE-2026-6473** in `libpq5`, fixed in `17.11-0+deb13u1`) and ensures the remaining HIGH CVEs are resolved automatically as soon as Debian publishes patched packages - without requiring a further Dockerfile change.

The `deb-extractor` stage is intentionally left unchanged: its rootfs is discarded and only `/dpkg` (from `apt-get download` + `dpkg --extract`) is copied into the distroless `production` stage. `apt-get download` already fetches the candidate versions resolved by the existing `apt-get update`, so an upgrade there would not change the production image and could risk a `debconf` prompt hang since that stage does not set `DEBIAN_FRONTEND=noninteractive`.

The `production` stage (`gcr.io/distroless/cc-debian13`) is unchanged because its libraries are copied from the `deb-extractor` stage, which already downloads the latest available versions.

## Verification

```bash
docker build -f dockerfiles/Dockerfile -t fluent-bit:fix .
trivy image --scanners vuln fluent-bit:fix
```

Expected: the fixable HIGH/MEDIUM/LOW CVEs drop to 0 (or near-0), with only CVEs that have no fixed Debian package yet remaining.

## Checklist

- [x] DCO sign-off included in commit
- [x] Commit message follows `dockerfile:` prefix convention used by this repo
- [x] `Fixes #12284` trailer included for auto-close on merge
- [x] No build-flag or runtime behavior changes - only base-layer patching

## Notes for maintainers

- This change should be backported to the supported 4.x release branch as well, since the issue confirms 4.2.8 carries the identical CVE set.
- A longer-term hardening option (out of scope here) would be to pin the base image by digest and run `apt-get upgrade` in CI to detect drift, as discussed in #4457.