### PR TITLE
tests: runtime: Plug a SEGV occurrence on macOS

### DIFF
--- a/tests/runtime/core_routes.c
+++ b/tests/runtime/core_routes.c
@@ -74,6 +74,9 @@ void flb_test_basic_functionality_test(void)
         if (olimit < 2) {
             olimit = 2;
         }
+        else if (olimit > sizeof(output_instances) / sizeof(output_instances[0])) {
+            olimit = sizeof(output_instances) / sizeof(output_instances[0]);
+        }
     }
 #endif
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed the SEGV in tests/runtime/core_routes.c:72.

Cause: macOS calculated `olimit` from `RLIMIT_NOFILE`—419,430 on this host—then indexed a 257-element stack array. The limit is now capped to the array capacity.

Verification passed:

- Target rebuild
- `bin/flb-rt-core_routes -v`
- Focused `ctest -R '^flb-rt-core_routes$'`
- Low-descriptor case with `ulimit -n 256`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On macOS, output instance limits are now properly capped to prevent creating more instances than supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->