### PR TITLE
http_server: http1: Fix ignored query string

### DIFF
--- a/src/http_server/flb_http_server_http1.c
+++ b/src/http_server/flb_http_server_http1.c
@@ -103,6 +103,7 @@ static int http1_session_process_request(struct flb_http1_server_session *sessio
 {
     struct mk_list         *iterator;
     struct mk_http_header  *header;
+    cfl_sds_t               sds_result;
     int                     result;
     size_t chunked_size;
     size_t written_bytes = 0;
@@ -128,6 +129,27 @@ static int http1_session_process_request(struct flb_http1_server_session *sessio
 
     if (session->stream.request.path == NULL) {
         return -1;
+    }
+
+    if (session->inner_request.query_string.data != NULL &&
+        session->inner_request.query_string.len > 0) {
+        sds_result = cfl_sds_cat(session->stream.request.path, "?", 1);
+
+        if (sds_result == NULL) {
+            return -1;
+        }
+
+        session->stream.request.path = sds_result;
+
+        sds_result = cfl_sds_cat(session->stream.request.path,
+                                 session->inner_request.query_string.data,
+                                 session->inner_request.query_string.len);
+
+        if (sds_result == NULL) {
+            return -1;
+        }
+
+        session->stream.request.path = sds_result;
     }
 
     result = flb_http_request_normalize(&session->stream.request);


### PR DESCRIPTION
## Summary

The HTTP server discards the query string before processing the request, resulting in the query string being entirely missing for downstream plugins. This issue happens on HTTP1 only. The fix re-appends the query string to the path to be processed by `flb_http_request_normalize()` the same way currently done in HTTP2 with the `:path` pseudo-header already containing the query string.

As mentioned the fix re-appends the query string before being split again by the `flb_http_request_normalize()` function. Even though this seems redundant, the idea is to keep the logic consistent between HTTP1 and HTTP2, with the alternative being to simply set the query string ourselves after the call to the normalize function.

Found about this issue when working on https://github.com/fluent/fluent-bit/pull/12192.

<!-- Provide summary of changes -->

## Reproducing
A configuration with `vivo_exporter`, a plugin making use of query strings:
```
[SERVICE]
    Flush         1
    Log_Level     info

[INPUT]
    Name    dummy
    Tag     test.dummy
    Dummy   {"message": "hello"}
    Rate    10

[OUTPUT]   
    Name   vivo_exporter
    Match  *
    Host   0.0.0.0
    Port   2021
```
Querying the plugin using `?limit` query string hoping to limit the output:
```bash
$ curl -s --http1.1 localhost:2021/api/v1/logs?limit=2 | wc -l # HTTP1: Not working, should return two entries
76
$ curl -s --http2-prior-knowledge localhost:2021/api/v1/logs?limit=2 | wc -l # HTTP2: Working as expected
2
```

## Valgrind w/ fix
```
$ docker run --rm -it -p 2020:2020 -p 2021:2021 -v ./fb.conf:/fb.conf flb-test-build bash -c "(apt-get update && apt-get install -y valgrind)>/dev/null && valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes /fluent-bit/bin/fluent-bit -c /fb.conf"
==1== Memcheck, a memory error detector
==1== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==1== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==1== Command: /fluent-bit/bin/fluent-bit -c /fb.conf
==1== 
Fluent Bit v5.1.1
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |  ___|/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/


[2026/08/16 06:22:20.506] [ info] [fluent bit] version=5.1.1, commit=, pid=1
[2026/08/16 06:22:20.546] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/16 06:22:20.546] [ info] [simd    ] SSE2
[2026/08/16 06:22:20.547] [ info] [cmetrics] version=2.2.1
[2026/08/16 06:22:20.547] [ info] [ctraces ] version=0.7.1
[2026/08/16 06:22:20.565] [ info] [input:dummy:dummy.0] initializing
[2026/08/16 06:22:20.566] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2026/08/16 06:22:20.610] [ info] [output:vivo_exporter:vivo_exporter.0] listening iface=0.0.0.0 tcp_port=2021
[2026/08/16 06:22:20.652] [ info] [sp] stream processor started
[2026/08/16 06:22:20.655] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/16 06:22:20.702] [ info] [output:vivo_exporter:vivo_exporter.0] worker #0 started
[...] => Seems like vivo_exporter generates a lot of output, this is present even before my changes
^C[2026/08/16 06:24:17] [engine] caught signal (SIGINT)
[2026/08/16 06:24:17.821] [ warn] [engine] service will shutdown in max 5 seconds
[2026/08/16 06:24:17.824] [ info] [engine] pausing all inputs..
[2026/08/16 06:24:17.826] [ info] [input] pausing dummy.0
[2026/08/16 06:24:18.811] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/16 06:24:18.812] [ info] [input] pausing dummy.0
[2026/08/16 06:24:18.814] [ info] [output:vivo_exporter:vivo_exporter.0] thread worker #0 stopping...
[2026/08/16 06:24:18.822] [ info] [output:vivo_exporter:vivo_exporter.0] thread worker #0 stopped
==1== 
==1== HEAP SUMMARY:
==1==     in use at exit: 0 bytes in 0 blocks
==1==   total heap usage: 33,263 allocs, 33,263 frees, 117,222,285 bytes allocated
==1== 
==1== All heap blocks were freed -- no leaks are possible
==1== 
==1== For lists of detected and suppressed errors, rerun with: -s
==1== ERROR SUMMARY: 53837 errors from 1000 contexts (suppressed: 0 from 0)
```

Now working queries:
```bash
$ curl -s --http1.1 localhost:2021/api/v1/logs?limit=2 | wc -l
2
$ curl -s --http2-prior-knowledge localhost:2021/api/v1/logs?limit=2 | wc -l
2
```


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [X] Example configuration file for the change
- [X] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [X] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request paths now correctly include non-empty query strings during HTTP/1 request processing.
  * Requests without query parameters remain unchanged.
  * Improved error handling prevents processing when query-string construction fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->