### PR TITLE
http_client: fix use-after-free of resp.payload after buffer growth

### DIFF
--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -1222,7 +1222,7 @@ int flb_http_buffer_increase(struct flb_http_client *c, size_t size,
      * The payload is a reference to a position of 'data' buffer,
      * we need to adjust the pointer after a memory buffer size change.
      */
-    if (c->resp.payload_size > 0) {
+    if (c->resp.payload != NULL) {
         off_payload = c->resp.payload - c->resp.data;
     }
 
@@ -1242,7 +1242,7 @@ int flb_http_buffer_increase(struct flb_http_client *c, size_t size,
         if (off_chunk_processed_end > 0) {
             c->resp.chunk_processed_end = c->resp.data + off_chunk_processed_end;
         }
-        if (off_payload > 0) {
+        if (c->resp.payload != NULL) {
             c->resp.payload = c->resp.data + off_payload;
         }
     }

--- a/tests/internal/http_client.c
+++ b/tests/internal/http_client.c
@@ -138,6 +138,45 @@ void test_http_buffer_increase()
     test_ctx_destroy(ctx);
 }
 
+void test_http_buffer_increase_consumed_payload()
+{
+    int ret;
+    size_t s;
+    size_t off;
+    struct test_ctx *ctx;
+    struct flb_http_client *c;
+
+    ctx = test_ctx_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        exit(EXIT_FAILURE);
+    }
+
+    c = flb_http_client(ctx->u_conn, FLB_HTTP_GET, "/", NULL, 0,
+                        "127.0.0.1", 80, NULL, 0);
+    TEST_CHECK(c != NULL);
+
+    flb_http_buffer_size(c, 0);
+    ret = flb_http_buffer_increase(c, 64, &s);
+    TEST_CHECK(ret == 0);
+
+    memcpy(c->resp.data, "00abc11def22ghi__PAYLOAD__8yz9900", 33);
+    c->resp.data[33] = '\0';
+    c->resp.data_len = 33;
+    c->resp.payload = c->resp.data + 15;
+    c->resp.payload_size = 0;
+    off = c->resp.payload - c->resp.data;
+
+    ret = flb_http_buffer_increase(c, 819200, &s);
+    TEST_CHECK(ret == 0);
+
+    TEST_CHECK(c->resp.payload == c->resp.data + off);
+    ret = strncmp(c->resp.payload, "__PAYLOAD__", 11);
+    TEST_CHECK(ret == 0);
+
+    flb_http_client_destroy(c);
+    test_ctx_destroy(ctx);
+}
+
 void test_http_add_get_header()
 {
     struct test_ctx *ctx;
@@ -1115,6 +1154,7 @@ void test_http_timeout_setters_preserve_upstream_io_timeout()
 
 TEST_LIST = {
     { "http_buffer_increase"  , test_http_buffer_increase},
+    { "http_buffer_increase_consumed_payload"  , test_http_buffer_increase_consumed_payload},
     { "add_get_header"        , test_http_add_get_header},
     { "set_keepalive"         , test_http_set_keepalive},
     { "strip_port_from_host"  , test_http_strip_port_from_host},


### PR DESCRIPTION
## Summary

`in_kubernetes_events` intermittently crashes with SIGSEGV while reading the Kubernetes watch stream, because `resp.payload` can be left dangling after the response buffer is grown.

Fixes #12283

## Root cause

`in_kubernetes_events` is the only caller of the streaming `flb_http_get_response_data()` that passes a non-zero `bytes_consumed`. When a watch chunk is fully consumed, `flb_http_get_response_data()` sets `resp.payload_size` to 0 but leaves `resp.payload` non-NULL.

`flb_http_buffer_increase()` then only rebased `resp.payload` across its `realloc` when `payload_size > 0`, so in that zero-size window the pointer was not relocated and dangled into the freed buffer. On the next read `process_data()` does not re-mark a non-NULL payload, and `process_chunked_data()` sets `payload_size` back above zero on the still-dangling pointer. `process_http_chunk()` then runs `strpbrk()` over freed memory and crashes.

Confirmed with AddressSanitizer: `heap-use-after-free` read in `process_http_chunk`, with the region freed by `realloc` in `flb_http_buffer_increase`. Observed intermittently on production clusters (exit 134, self-recovers on restart).

## Fix

Rebase `resp.payload` on buffer growth whenever it is non-NULL, instead of only when `payload_size > 0`. This is a no-op for one-shot `flb_http_do()` consumers (their `payload` is either NULL or has `payload_size > 0`) and only ever rebases a pointer that would otherwise be left stale.

## Tests

Adds `test_http_buffer_increase_consumed_payload` in `tests/internal/http_client.c`, which drives the real `flb_http_buffer_increase()` through the consumed-payload (`payload_size == 0`) growth path and asserts the pointer is rebased. It fails before the fix and passes after.

```
$ ./bin/flb-it-http_client
Test http_buffer_increase_consumed_payload...   [ OK ]
SUCCESS: All unit tests have passed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or consumed HTTP response payloads during buffer expansion.
  * Preserved payload positioning and contents when responses trigger buffer growth.

* **Tests**
  * Added regression coverage for buffer expansion with consumed response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->