### PR TITLE
input_chunk: input_log: in_storage_backlog: address underflowing / overflowing chunk limit size

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -168,6 +168,8 @@ ssize_t flb_input_chunk_get_size(struct flb_input_chunk *ic);
 ssize_t flb_input_chunk_get_real_size(struct flb_input_chunk *ic);
 int flb_input_chunk_release_route(struct flb_input_chunk *ic,
                                   struct flb_output_instance *o_ins);
+void flb_input_chunk_output_size_subtract(struct flb_output_instance *o_ins,
+                                          size_t bytes);
 size_t flb_input_chunk_set_limits(struct flb_input_instance *in);
 size_t flb_input_chunk_total_size(struct flb_input_instance *in);
 struct flb_input_chunk *flb_input_chunk_map(struct flb_input_instance *in,
@@ -178,6 +180,6 @@ int flb_input_chunk_set_up(struct flb_input_chunk *ic);
 int flb_input_chunk_down(struct flb_input_chunk *ic);
 int flb_input_chunk_is_up(struct flb_input_chunk *ic);
 void flb_input_chunk_update_output_instances(struct flb_input_chunk *ic,
-                                             size_t chunk_size);
+                                             ssize_t chunk_size);
 
 #endif

--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -225,7 +225,17 @@ static void sb_remove_chunk_from_segregated_backlog(struct cio_chunk    *target_
         if (chunk->chunk == target_chunk) {
             mk_list_del(&chunk->_head);
 
-            backlog->ins->fs_backlog_chunks_size -= cio_chunk_get_real_size(target_chunk);
+            if (chunk->size > backlog->ins->fs_backlog_chunks_size) {
+                flb_warn("[storage backlog] filesystem chunk accounting underflow for "
+                         "output %s: current=%zu, subtract=%zu; resetting to zero",
+                         flb_output_name(backlog->ins),
+                         backlog->ins->fs_backlog_chunks_size,
+                         chunk->size);
+                backlog->ins->fs_backlog_chunks_size = 0;
+            }
+            else {
+                backlog->ins->fs_backlog_chunks_size -= chunk->size;
+            }
 
             if (destroy) {
                 sb_destroy_chunk(chunk);
@@ -264,7 +274,17 @@ static int sb_append_chunk_to_segregated_backlog(struct cio_chunk    *target_chu
 
     mk_list_add(&chunk->_head, &backlog->chunks);
 
-    backlog->ins->fs_backlog_chunks_size += target_chunk_size;
+    if (target_chunk_size > SIZE_MAX - backlog->ins->fs_backlog_chunks_size) {
+        flb_warn("[storage backlog] filesystem chunk accounting overflow for output %s: "
+                 "current=%zu, add=%zu; saturating at maximum",
+                 flb_output_name(backlog->ins),
+                 backlog->ins->fs_backlog_chunks_size,
+                 target_chunk_size);
+        backlog->ins->fs_backlog_chunks_size = SIZE_MAX;
+    }
+    else {
+        backlog->ins->fs_backlog_chunks_size += target_chunk_size;
+    }
 
     return 0;
 }

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -63,6 +63,34 @@
  */
 #define FLB_INPUT_CHUNK_FILE_HEADER_SIZE 24
 
+void flb_input_chunk_output_size_subtract(struct flb_output_instance *o_ins,
+                                          size_t bytes)
+{
+    if (bytes > o_ins->fs_chunks_size) {
+        flb_warn("[input chunk] filesystem chunk accounting underflow for output %s: "
+                 "current=%zu, subtract=%zu; resetting to zero",
+                 flb_output_name(o_ins), o_ins->fs_chunks_size, bytes);
+        o_ins->fs_chunks_size = 0;
+        return;
+    }
+
+    o_ins->fs_chunks_size -= bytes;
+}
+
+static void input_chunk_output_size_add(struct flb_output_instance *o_ins,
+                                        size_t bytes)
+{
+    if (bytes > SIZE_MAX - o_ins->fs_chunks_size) {
+        flb_warn("[input chunk] filesystem chunk accounting overflow for output %s: "
+                 "current=%zu, add=%zu; saturating at maximum",
+                 flb_output_name(o_ins), o_ins->fs_chunks_size, bytes);
+        o_ins->fs_chunks_size = SIZE_MAX;
+        return;
+    }
+
+    o_ins->fs_chunks_size += bytes;
+}
+
 static int logs_tag_records_metrics_enabled(struct flb_input_instance *in)
 {
     if (in->telemetry_metrics_logs_tag_records != -1) {
@@ -589,7 +617,7 @@ static int flb_input_chunk_release_space(
                                           input_plugin->config->router);
 
                 FS_CHUNK_SIZE_DEBUG_MOD(output_plugin, old_input_chunk, chunk_size);
-                output_plugin->fs_chunks_size -= chunk_size;
+                flb_input_chunk_output_size_subtract(output_plugin, (size_t) chunk_size);
 
                 chunk_destroy_flag = flb_routes_mask_is_empty(
                                                     old_input_chunk->routes_mask,
@@ -807,7 +835,7 @@ int flb_input_chunk_release_route(struct flb_input_chunk *ic,
         }
 
         FS_CHUNK_SIZE_DEBUG_MOD(o_ins, ic, bytes);
-        o_ins->fs_chunks_size -= bytes;
+        flb_input_chunk_output_size_subtract(o_ins, (size_t) bytes);
     }
 
     flb_routes_mask_clear_bit(ic->routes_mask,
@@ -2590,7 +2618,7 @@ int flb_input_chunk_destroy_corrupted(struct flb_input_chunk *ic,
                                     o_ins->config->router) != 0) {
             if (ic->fs_counted == FLB_TRUE) {
                 FS_CHUNK_SIZE_DEBUG_MOD(o_ins, ic, -bytes);
-                o_ins->fs_chunks_size -= bytes;
+                flb_input_chunk_output_size_subtract(o_ins, (size_t) bytes);
                 flb_debug("[input chunk] remove chunk %s with %ld bytes from plugin %s, "
                           "the updated fs_chunks_size is %ld bytes", flb_input_chunk_get_name(ic),
                           bytes, o_ins->name, o_ins->fs_chunks_size);
@@ -2676,7 +2704,7 @@ int flb_input_chunk_destroy(struct flb_input_chunk *ic, int del)
                                     o_ins->config->router) != 0) {
             if (ic->fs_counted == FLB_TRUE) {
                 FS_CHUNK_SIZE_DEBUG_MOD(o_ins, ic, -bytes);
-                o_ins->fs_chunks_size -= bytes;
+                flb_input_chunk_output_size_subtract(o_ins, (size_t) bytes);
                 flb_debug("[input chunk] remove chunk %s with %ld bytes from plugin %s, "
                           "the updated fs_chunks_size is %ld bytes", flb_input_chunk_get_name(ic),
                           bytes, o_ins->name, o_ins->fs_chunks_size);
@@ -3170,9 +3198,9 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     size_t dropped_chunks;
     size_t dropped_bytes;
     size_t content_size;
-    size_t real_diff;
-    size_t real_size;
-    size_t pre_real_size;
+    ssize_t real_diff;
+    ssize_t real_size;
+    ssize_t pre_real_size;
     struct flb_input_chunk *ic;
     struct flb_storage_input *si;
     void  *filtered_data_buffer;
@@ -3464,7 +3492,13 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     }
 
     real_size = flb_input_chunk_get_real_size(ic);
-    real_diff = real_size - pre_real_size;
+    if (real_size >= 0 && pre_real_size >= 0) {
+        real_diff = real_size - pre_real_size;
+    }
+    else {
+        real_diff = 0;
+    }
+
     if (real_diff != 0) {
         flb_trace("[input chunk] update output instances with new chunk size diff=%zd, records=%zu, input=%s",
                   real_diff, n_records, flb_input_name(in));
@@ -3724,8 +3758,8 @@ int flb_input_chunk_ring_buffer_enqueue_log_routing(struct flb_input_instance *i
 const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
 {
     int ret;
-    size_t pre_size;
-    size_t post_size;
+    ssize_t pre_size;
+    ssize_t post_size;
     ssize_t diff_size;
     char *buf = NULL;
 
@@ -3767,7 +3801,7 @@ const void *flb_input_chunk_flush(struct flb_input_chunk *ic, size_t *size)
     ic->busy = FLB_TRUE;
 
     post_size = flb_input_chunk_get_real_size(ic);
-    if (post_size != pre_size) {
+    if (pre_size >= 0 && post_size >= 0 && post_size != pre_size) {
         diff_size = post_size - pre_size;
         flb_input_chunk_update_output_instances(ic, diff_size);
     }
@@ -3858,10 +3892,18 @@ int flb_input_chunk_get_tag(struct flb_input_chunk *ic,
  * the total number of bytes in use after ingesting the new data.
  */
 void flb_input_chunk_update_output_instances(struct flb_input_chunk *ic,
-                                             size_t chunk_size)
+                                             ssize_t chunk_size)
 {
+    size_t bytes;
     struct mk_list *head;
     struct flb_output_instance *o_ins;
+
+    if (chunk_size < 0) {
+        bytes = (size_t) (-(chunk_size + 1)) + 1;
+    }
+    else {
+        bytes = (size_t) chunk_size;
+    }
 
     /* for each output plugin, we update the fs_chunks_size */
     mk_list_foreach(head, &ic->in->config->outputs) {
@@ -3877,12 +3919,21 @@ void flb_input_chunk_update_output_instances(struct flb_input_chunk *ic,
              * if there is match on any index of 1's in the binary, it indicates
              * that the input chunk will flush to this output instance
              */
-            FS_CHUNK_SIZE_DEBUG_MOD(o_ins, ic, chunk_size);
-            o_ins->fs_chunks_size += chunk_size;
-            ic->fs_counted = FLB_TRUE;
+            flb_trace("[input chunk] output %s fs_chunks_size=%zu adjustment=%zd",
+                      o_ins->name, o_ins->fs_chunks_size, chunk_size);
 
-            flb_trace("[input chunk] chunk %s update plugin %s fs_chunks_size by %ld bytes, "
-                      "the current fs_chunks_size is %ld bytes", flb_input_chunk_get_name(ic),
+            if (chunk_size < 0) {
+                flb_input_chunk_output_size_subtract(o_ins, bytes);
+            }
+            else {
+                input_chunk_output_size_add(o_ins, bytes);
+                if (chunk_size > 0) {
+                    ic->fs_counted = FLB_TRUE;
+                }
+            }
+
+            flb_trace("[input chunk] updated plugin %s fs_chunks_size by %zd bytes, "
+                      "the current fs_chunks_size is %zu bytes",
                       o_ins->name, chunk_size, o_ins->fs_chunks_size);
         }
     }

--- a/src/flb_input_log.c
+++ b/src/flb_input_log.c
@@ -166,12 +166,8 @@ static int route_payload_apply_outputs(struct flb_input_instance *ins,
             }
 
             if (route_path->ins->total_limit_size != -1) {
-                if (route_path->ins->fs_chunks_size > chunk_size_sz) {
-                    route_path->ins->fs_chunks_size -= chunk_size_sz;
-                }
-                else {
-                    route_path->ins->fs_chunks_size = 0;
-                }
+                flb_input_chunk_output_size_subtract(route_path->ins,
+                                                     chunk_size_sz);
             }
 
             flb_routes_mask_clear_bit(chunk->routes_mask,
@@ -1059,12 +1055,7 @@ static int input_chunk_apply_base_direct_routes(struct flb_input_instance *ins,
                 continue;
             }
 
-            if (o_ins->fs_chunks_size > chunk_size_sz) {
-                o_ins->fs_chunks_size -= chunk_size_sz;
-            }
-            else {
-                o_ins->fs_chunks_size = 0;
-            }
+            flb_input_chunk_output_size_subtract(o_ins, chunk_size_sz);
         }
 
         chunk->fs_counted = FLB_FALSE;

--- a/tests/internal/input_chunk_routes.c
+++ b/tests/internal/input_chunk_routes.c
@@ -1058,10 +1058,63 @@ cleanup:
     flb_free(stream_path);
 }
 
+static void test_chunk_accounting_underflow_guard(void)
+{
+    struct flb_config config;
+    struct flb_router router;
+    struct flb_input_instance input;
+    struct flb_input_chunk chunk;
+    struct flb_output_instance output;
+    flb_route_mask_element routes_mask[1];
+
+    memset(&config, 0, sizeof(config));
+    memset(&router, 0, sizeof(router));
+    memset(&input, 0, sizeof(input));
+    memset(&chunk, 0, sizeof(chunk));
+    memset(&output, 0, sizeof(output));
+    memset(routes_mask, 0, sizeof(routes_mask));
+
+    mk_list_init(&config.outputs);
+    config.router = &router;
+    router.route_mask_size = 1;
+    router.route_mask_slots = FLB_ROUTES_MASK_ELEMENT_BITS;
+
+    input.config = &config;
+    chunk.in = &input;
+    chunk.routes_mask = routes_mask;
+
+    output.id = 0;
+    output.config = &config;
+    output.total_limit_size = 1024;
+    snprintf(output.name, sizeof(output.name), "null.0");
+    mk_list_init(&output._head);
+    mk_list_add(&output._head, &config.outputs);
+
+    flb_routes_mask_set_bit(routes_mask, output.id, &router);
+
+    flb_input_chunk_update_output_instances(&chunk, 32);
+    TEST_CHECK(output.fs_chunks_size == 32);
+    TEST_CHECK(chunk.fs_counted == FLB_TRUE);
+
+    flb_input_chunk_update_output_instances(&chunk, -64);
+    TEST_CHECK(output.fs_chunks_size == 0);
+
+    output.fs_chunks_size = 16;
+    flb_input_chunk_output_size_subtract(&output, 32);
+    TEST_CHECK(output.fs_chunks_size == 0);
+
+    output.fs_chunks_size = SIZE_MAX - 16;
+    flb_input_chunk_update_output_instances(&chunk, 32);
+    TEST_CHECK(output.fs_chunks_size == SIZE_MAX);
+
+    mk_list_del(&output._head);
+}
+
 TEST_LIST = {
     { "chunk_metadata_direct_routes", test_chunk_metadata_direct_routes },
     { "chunk_restore_alias_plugin_match_multiple", test_chunk_restore_alias_plugin_match_multiple },
     { "chunk_restore_alias_plugin_null_matches_all", test_chunk_restore_alias_plugin_null_matches_all },
     { "chunk_map_grouped_logs_total_records", test_chunk_map_grouped_logs_total_records },
+    { "chunk_accounting_underflow_guard", test_chunk_accounting_underflow_guard },
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

Implemented general filesystem chunk-accounting guards.

- `fs_chunks_size` now uses saturating subtraction: underflow logs a warning and resets the counter to zero instead of wrapping near `SIZE_MAX`.
- Additions are overflow-checked and saturate at `SIZE_MAX`.
- Chunk-size adjustments remain signed, so negative trim deltas correctly subtract rather than becoming huge unsigned additions.
- Per-record routing paths use the centralized guard.
- `fs_backlog_chunks_size` has equivalent guards and subtracts the size recorded when the backlog entry was created.
- Added regression coverage for subtraction underflow, negative adjustments, and addition overflow in `input_chunk_routes.c`.

Verification:

- `cmake --build build --target fluent-bit-bin flb-it-input_chunk_routes` — passed.
- `ctest --test-dir build -R '^flb-it-input_chunk_routes$' --output-on-failure` — 1 passed.
- `.venv\Scripts\python.exe -m pytest scenarios/in_forward/tests/test_in_forward_001.py -q -k storage_limit` — 2 passed, 1 platform skip.
- `.venv\Scripts\python.exe -m pytest scenarios/in_storage_backlog/tests/test_in_storage_backlog_001.py -q` — 2 passed, 2 platform skips.
- `git diff --check` — passed.

Closes https://github.com/fluent/fluent-bit/issues/12220.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filesystem backlog size accounting to prevent underflow and overflow.
  - Added safeguards for invalid or negative chunk-size adjustments.
  - Counters now clamp safely at zero or saturate at the maximum supported value, with warnings for inconsistent values.
  - Improved accounting reliability when chunks are removed or routed through outputs.

- **Tests**
  - Added coverage verifying safe counter decrements and overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->