### PR TITLE
aws: compression: validate valid columnar formats

### DIFF
--- a/src/aws/compression/arrow/compress.c
+++ b/src/aws/compression/arrow/compress.c
@@ -39,6 +39,34 @@ static GArrowCompressionType compression_type_to_garrow(int compression_type)
         }
 }
 
+static int validate_columnar_compression(int columnar_format,
+                                         int compression_type)
+{
+        if (columnar_format == FLB_AWS_COMPRESS_FORMAT_PARQUET) {
+                switch (compression_type) {
+                case FLB_AWS_COMPRESS_NONE:
+                case FLB_AWS_COMPRESS_SNAPPY:
+                case FLB_AWS_COMPRESS_GZIP:
+                case FLB_AWS_COMPRESS_ZSTD:
+                        return 0;
+                default:
+                        return -1;
+                }
+        }
+
+        if (columnar_format == FLB_AWS_COMPRESS_FORMAT_ARROW) {
+                switch (compression_type) {
+                case FLB_AWS_COMPRESS_NONE:
+                case FLB_AWS_COMPRESS_ZSTD:
+                        return 0;
+                default:
+                        return -1;
+                }
+        }
+
+        return -1;
+}
+
 static int choose_block_size(size_t size)
 {
     int block_size = 8 * 1024 * 1024;
@@ -250,6 +278,14 @@ int flb_aws_compression_compress_columnar(int columnar_format,
         gconstpointer ptr;
         gsize len;
         uint8_t *buf;
+
+        if (validate_columnar_compression(columnar_format,
+                                          compression_type) != 0) {
+                flb_error("[aws][compress] unsupported compression type %d "
+                          "for columnar format %d",
+                          compression_type, columnar_format);
+                return -1;
+        }
 
         table = parse_json((uint8_t *) json, size);
         if (table == NULL) {

--- a/tests/internal/aws_compress.c
+++ b/tests/internal/aws_compress.c
@@ -419,6 +419,22 @@ void test_parquet_format_uncompressed()
     flb_free(out_buf);
 }
 
+void test_parquet_format_invalid_compression()
+{
+    int ret;
+    void *out_buf = NULL;
+    size_t out_size = 0;
+    char *json = "{\"key\":\"value\",\"num\":42}\n";
+    size_t json_len = strlen(json);
+
+    ret = flb_aws_compression_compress_columnar(FLB_AWS_COMPRESS_FORMAT_PARQUET,
+                                                json, json_len,
+                                                &out_buf, &out_size, -1);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(out_buf == NULL);
+    TEST_CHECK(out_size == 0);
+}
+
 void test_parquet_compression_reduces_size()
 {
     int ret;
@@ -545,6 +561,8 @@ TEST_LIST = {
     { "test_parquet_format_zstd", test_parquet_format_zstd },
     { "test_parquet_format_gzip", test_parquet_format_gzip },
     { "test_parquet_format_uncompressed", test_parquet_format_uncompressed },
+    { "test_parquet_format_invalid_compression",
+      test_parquet_format_invalid_compression },
     { "test_parquet_compression_reduces_size",
       test_parquet_compression_reduces_size },
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

- Verified the finding was valid: unknown compression types fell back to uncompressed output through `compression_type_to_garrow()`.
- Added format-specific validation in `flb_aws_compression_compress_columnar()`:
  - Parquet: `NONE`, `SNAPPY`, `GZIP`, `ZSTD`
  - Arrow/Feather: `NONE`, `ZSTD`
  - Unsupported or unknown values now return `-1` before parsing or invoking a writer.
- Added an invalid Parquet codec regression test asserting:
  - Return value is `-1`
  - No output buffer is allocated
  - Output size remains zero
- `git diff --check` passed.
- Built `flb-it-aws_compress` successfully.
- Ran `ctest --test-dir build -R '^flb-it-aws_compress$' --output-on-failure`; 1/1 passed.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent unsupported compression formats for Parquet and Arrow columnar output.
  * Invalid compression combinations now fail safely before processing data.

* **Tests**
  * Added coverage confirming invalid Parquet compression settings are rejected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->