### PR TITLE
out_azure_blob: Plug dangling pointers on exceptions

### DIFF
--- a/plugins/out_azure_blob/azure_blob_db.c
+++ b/plugins/out_azure_blob/azure_blob_db.c
@@ -982,88 +982,91 @@ int azb_db_file_oldest_ready(struct flb_azure_blob *ctx,
 {
     int ret;
     char *tmp = NULL;
+    uint64_t local_file_id;
+    cfl_sds_t local_path = NULL;
+    cfl_sds_t local_part_ids = NULL;
+    cfl_sds_t local_source = NULL;
+    cfl_sds_t local_path_prefix = NULL;
 
-    azb_db_lock(ctx);
+    *file_id = 0;
+    *path = NULL;
+    *part_ids = NULL;
+    *source = NULL;
+    *path_prefix = NULL;
+
+    if (azb_db_lock(ctx) != 0) {
+        return -1;
+    }
 
     /* Run the query */
     ret = sqlite3_step(ctx->stmt_get_oldest_file_with_parts);
     if (ret == SQLITE_ROW) {
         /* file_id */
-        *file_id = sqlite3_column_int64(ctx->stmt_get_oldest_file_with_parts, 0);
+        local_file_id = sqlite3_column_int64(ctx->stmt_get_oldest_file_with_parts, 0);
         tmp = (char *) sqlite3_column_text(ctx->stmt_get_oldest_file_with_parts, 1);
 
         /* path */
-        *path = cfl_sds_create(tmp);
-        if (!*path) {
-            sqlite3_clear_bindings(ctx->stmt_get_oldest_file_with_parts);
-            sqlite3_reset(ctx->stmt_get_oldest_file_with_parts);
-            azb_db_unlock(ctx);
-            return -1;
+        local_path = cfl_sds_create(tmp);
+        if (!local_path) {
+            ret = -1;
+            goto cleanup;
         }
 
         /* part_ids */
         tmp = (char *) sqlite3_column_text(ctx->stmt_get_oldest_file_with_parts, 2);
-        *part_ids = cfl_sds_create(tmp);
-        if (!*part_ids) {
-            cfl_sds_destroy(*path);
-            sqlite3_clear_bindings(ctx->stmt_get_oldest_file_with_parts);
-            sqlite3_reset(ctx->stmt_get_oldest_file_with_parts);
-            azb_db_unlock(ctx);
-            return -1;
+        local_part_ids = cfl_sds_create(tmp);
+        if (!local_part_ids) {
+            ret = -1;
+            goto cleanup;
         }
 
         /* source */
         tmp = (char *) sqlite3_column_text(ctx->stmt_get_oldest_file_with_parts, 3);
-        *source = cfl_sds_create(tmp);
-        if (!*source) {
-            cfl_sds_destroy(*part_ids);
-            cfl_sds_destroy(*path);
-            sqlite3_clear_bindings(ctx->stmt_get_oldest_file_with_parts);
-            sqlite3_reset(ctx->stmt_get_oldest_file_with_parts);
-            azb_db_unlock(ctx);
-            return -1;
+        local_source = cfl_sds_create(tmp);
+        if (!local_source) {
+            ret = -1;
+            goto cleanup;
         }
 
         /* path prefix */
         tmp = (char *) sqlite3_column_text(ctx->stmt_get_oldest_file_with_parts, 4);
         if (tmp) {
-            *path_prefix = cfl_sds_create(tmp);
-            if (!*path_prefix) {
-                cfl_sds_destroy(*source);
-                cfl_sds_destroy(*part_ids);
-                cfl_sds_destroy(*path);
-                sqlite3_clear_bindings(ctx->stmt_get_oldest_file_with_parts);
-                sqlite3_reset(ctx->stmt_get_oldest_file_with_parts);
-                azb_db_unlock(ctx);
-                return -1;
+            local_path_prefix = cfl_sds_create(tmp);
+            if (!local_path_prefix) {
+                ret = -1;
+                goto cleanup;
             }
         }
-        else {
-            *path_prefix = NULL;
-        }
+
+        *file_id = local_file_id;
+        *path = local_path;
+        *part_ids = local_part_ids;
+        *source = local_source;
+        *path_prefix = local_path_prefix;
+        ret = 1;
     }
     else if (ret == SQLITE_DONE) {
         /* no records */
-        sqlite3_clear_bindings(ctx->stmt_get_oldest_file_with_parts);
-        sqlite3_reset(ctx->stmt_get_oldest_file_with_parts);
-        azb_db_unlock(ctx);
-        *path = NULL;
-        *part_ids = NULL;
-        *source = NULL;
-        *path_prefix = NULL;
-        return 0;
+        ret = 0;
     }
     else {
-        azb_db_unlock(ctx);
-        *path = NULL;
-        *part_ids = NULL;
-        *source = NULL;
-        *path_prefix = NULL;
-        return -1;
+        ret = -1;
+    }
+
+cleanup:
+    sqlite3_clear_bindings(ctx->stmt_get_oldest_file_with_parts);
+    sqlite3_reset(ctx->stmt_get_oldest_file_with_parts);
+
+    if (ret == -1) {
+        cfl_sds_destroy(local_path_prefix);
+        cfl_sds_destroy(local_source);
+        cfl_sds_destroy(local_part_ids);
+        cfl_sds_destroy(local_path);
     }
 
     azb_db_unlock(ctx);
-    return 1;
+
+    return ret;
 }
 
 #endif


### PR DESCRIPTION
<!-- Provide summary of changes -->

Closes https://github.com/fluent/fluent-bit/issues/12202

Implemented the stronger ownership fix in azure_blob_db.c.

- Outputs are initialized to NULL on entry.
- SDS allocations use local temporaries.
- Outputs are published only after all allocations succeed.
- Failure cleanup destroys only local allocations, preventing dangling pointers and caller double-frees.
- Database statement cleanup is consolidated across all return paths.

Verification passed:

- `cmake --build build --target flb-plugin-out_azure_blob flb-it-azure_blob_path -j8`
- `ctest --test-dir build -R '^flb-it-azure_blob_path$' --output-on-failure`
- `ctest --test-dir build -R '^flb-rt-out_azure_blob_compression$' --output-on-failure`
- `git diff --check`

No Azure Blob Python integration scenario exists under `tests/integration`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking for the oldest ready Azure Blob file.
  * Added safer handling for database locks, empty results, query failures, and memory-allocation errors.
  * Ensured outputs are consistently initialized and resources are properly cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->