### PR TITLE
out_kafka: msk iam role arn

### DIFF
--- a/include/fluent-bit/aws/flb_aws_msk_iam.h
+++ b/include/fluent-bit/aws/flb_aws_msk_iam.h
@@ -36,11 +36,16 @@ struct flb_msk_iam_cb {
 
 /*
  * Register the oauthbearer refresh callback for MSK IAM authentication.
+ * Optionally accepts role_arn, sts_endpoint, and external_id for STS
+ * Assume Role support. Pass NULL for any unused optional parameter.
  * Returns context pointer on success or NULL on failure.
  */
 struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *config,
                                                           rd_kafka_conf_t *kconf,
                                                           const char *cluster_arn,
+                                                          const char *role_arn,
+                                                          const char *sts_endpoint,
+                                                          const char *external_id,
                                                           struct flb_kafka_opaque *opaque);
 void flb_aws_msk_iam_destroy(struct flb_aws_msk_iam *ctx);
 

--- a/plugins/in_kafka/in_kafka.c
+++ b/plugins/in_kafka/in_kafka.c
@@ -359,6 +359,7 @@ static int in_kafka_init(struct flb_input_instance *ins,
         ctx->msk_iam = flb_aws_msk_iam_register_oauth_cb(config,
                                                          kafka_conf,
                                                          ctx->aws_msk_iam_cluster_arn,
+                                                         NULL, NULL, NULL,
                                                          ctx->opaque);
         if (!ctx->msk_iam) {
             flb_plg_error(ins, "failed to setup MSK IAM authentication");

--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -1619,6 +1619,23 @@ static struct flb_config_map config_map[] = {
     0, FLB_TRUE, offsetof(struct flb_out_kafka, aws_msk_iam),
     "Enable AWS MSK IAM authentication"
    },
+   {
+    FLB_CONFIG_MAP_STR, "aws_msk_iam_role_arn", NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, aws_msk_iam_role_arn),
+    "ARN of an IAM role to assume for MSK IAM authentication "
+    "(e.g. for cross-account access)"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "aws_msk_iam_sts_endpoint", NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, aws_msk_iam_sts_endpoint),
+    "Custom endpoint for the AWS STS API, used with aws_msk_iam_role_arn"
+   },
+   {
+    FLB_CONFIG_MAP_STR, "aws_msk_iam_external_id", NULL,
+    0, FLB_TRUE, offsetof(struct flb_out_kafka, aws_msk_iam_external_id),
+    "External ID for the STS AssumeRole API, used with aws_msk_iam_role_arn "
+    "when the target role requires an external ID"
+   },
 #endif
 
    /* EOF */

--- a/plugins/out_kafka/kafka_config.c
+++ b/plugins/out_kafka/kafka_config.c
@@ -233,6 +233,9 @@ struct flb_out_kafka *flb_out_kafka_create(struct flb_output_instance *ins,
         ctx->msk_iam = flb_aws_msk_iam_register_oauth_cb(config,
                                                          ctx->conf,
                                                          ctx->aws_msk_iam_cluster_arn,
+                                                         ctx->aws_msk_iam_role_arn,
+                                                         ctx->aws_msk_iam_sts_endpoint,
+                                                         ctx->aws_msk_iam_external_id,
                                                          ctx->opaque);
         if (!ctx->msk_iam) {
             flb_plg_error(ctx->ins, "failed to setup MSK IAM authentication");

--- a/plugins/out_kafka/kafka_config.h
+++ b/plugins/out_kafka/kafka_config.h
@@ -154,6 +154,9 @@ struct flb_out_kafka {
 
 #ifdef FLB_HAVE_AWS_MSK_IAM
     flb_sds_t aws_msk_iam_cluster_arn;
+    flb_sds_t aws_msk_iam_role_arn;
+    flb_sds_t aws_msk_iam_sts_endpoint;
+    flb_sds_t aws_msk_iam_external_id;
     struct flb_aws_msk_iam *msk_iam;
 #endif
 

--- a/src/aws/flb_aws_msk_iam.c
+++ b/src/aws/flb_aws_msk_iam.c
@@ -47,6 +47,7 @@ struct flb_aws_msk_iam {
     flb_sds_t role_arn;
     flb_sds_t sts_endpoint;
     flb_sds_t external_id;
+    flb_sds_t sts_session_name;
 };
 
 /* Utility functions - same as before */
@@ -169,13 +170,13 @@ static char *extract_region(const char *arn)
 
 /* Stateless payload generator - creates AWS provider on demand */
 static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
-                                       const char *host)
+                                       const char *host,
+                                       flb_sds_t *out_access_key_id)
 {
     struct flb_aws_provider *temp_provider = NULL;
     struct flb_aws_provider *base_provider = NULL;
     struct flb_tls *sts_tls = NULL;
     struct flb_aws_credentials *creds = NULL;
-    char *sts_session_name = NULL;
     flb_sds_t payload = NULL;
     int encode_result;
     char *p;
@@ -208,6 +209,10 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
     unsigned char empty_payload_hash[32];
     struct tm gm;
     time_t now;
+
+    if (out_access_key_id) {
+        *out_access_key_id = NULL;
+    }
 
     now = time(NULL);
 
@@ -245,27 +250,17 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
             return NULL;
         }
 
-        sts_session_name = flb_sts_session_name();
-        if (!sts_session_name) {
-            flb_error("[aws_msk_iam] build_msk_iam_payload: failed to generate STS session name");
-            flb_tls_destroy(sts_tls);
-            flb_aws_provider_destroy(temp_provider);
-            return NULL;
-        }
-
         base_provider = temp_provider;
         temp_provider = flb_sts_provider_create(config->flb_config,
                                                sts_tls,
                                                base_provider,
                                                config->external_id,
                                                config->role_arn,
-                                               sts_session_name,
+                                               config->sts_session_name,
                                                config->region,
                                                config->sts_endpoint,
                                                NULL,
                                                flb_aws_client_generator());
-        flb_free(sts_session_name);
-        sts_session_name = NULL;
 
         if (!temp_provider) {
             flb_error("[aws_msk_iam] build_msk_iam_payload: failed to create STS provider");
@@ -307,7 +302,17 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
         flb_error("[aws_msk_iam] build_msk_iam_payload: incomplete credentials");
         flb_aws_credentials_destroy(creds);
         flb_aws_provider_destroy(temp_provider);
+        if (base_provider) {
+            flb_aws_provider_destroy(base_provider);
+        }
+        if (sts_tls) {
+            flb_tls_destroy(sts_tls);
+        }
         return NULL;
+    }
+
+    if (out_access_key_id) {
+        *out_access_key_id = flb_sds_create(creds->access_key_id);
     }
 
     gmtime_r(&now, &gm);
@@ -674,6 +679,10 @@ error:
     if (sts_tls) {
         flb_tls_destroy(sts_tls);
     }
+    if (out_access_key_id && *out_access_key_id) {
+        flb_sds_destroy(*out_access_key_id);
+        *out_access_key_id = NULL;
+    }
 
     return NULL;
 }
@@ -686,6 +695,7 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
 {
     char host[256];
     flb_sds_t payload = NULL;
+    flb_sds_t access_key_id = NULL;
     rd_kafka_resp_err_t err;
     char errstr[512];
     int64_t now;
@@ -694,12 +704,7 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
     size_t arn_len;
     size_t suffix_len;
     struct flb_aws_msk_iam *config;
-    struct flb_aws_credentials *creds = NULL;
     struct flb_kafka_opaque *kafka_opaque;
-    struct flb_aws_provider *temp_provider = NULL;
-    struct flb_aws_provider *base_provider = NULL;
-    struct flb_tls *sts_tls = NULL;
-    char *sts_session_name = NULL;
     (void) oauthbearer_config;
 
     kafka_opaque = (struct flb_kafka_opaque *) opaque;
@@ -742,47 +747,11 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
     flb_info("[aws_msk_iam] requesting MSK IAM payload for region: %s, host: %s", config->region, host);
 
     /* Generate payload using stateless function - creates and destroys AWS provider internally */
-    payload = build_msk_iam_payload(config, host);
+    payload = build_msk_iam_payload(config, host, &access_key_id);
     if (!payload) {
         flb_error("[aws_msk_iam] failed to generate MSK IAM payload");
         rd_kafka_oauthbearer_set_token_failure(rk, "payload generation failed");
         return;
-    }
-
-    /* Get credentials for principal (create temporary provider just for this) */
-    temp_provider = flb_standard_chain_provider_create(config->flb_config, NULL,
-                                                      config->region, NULL, NULL,
-                                                      flb_aws_client_generator(),
-                                                      NULL);
-    if (temp_provider) {
-        /* If role_arn is set, wrap with STS AssumeRole to get the assumed principal */
-        if (config->role_arn) {
-            sts_tls = flb_tls_create(FLB_TLS_CLIENT_MODE, FLB_TRUE, 0,
-                                     NULL, NULL, NULL, NULL, NULL, NULL);
-            sts_session_name = sts_tls ? flb_sts_session_name() : NULL;
-
-            if (sts_tls && sts_session_name) {
-                base_provider = temp_provider;
-                temp_provider = flb_sts_provider_create(config->flb_config,
-                                                       sts_tls,
-                                                       base_provider,
-                                                       config->external_id,
-                                                       config->role_arn,
-                                                       sts_session_name,
-                                                       config->region,
-                                                       config->sts_endpoint,
-                                                       NULL,
-                                                       flb_aws_client_generator());
-            }
-            if (sts_session_name) {
-                flb_free(sts_session_name);
-                sts_session_name = NULL;
-            }
-        }
-
-        if (temp_provider && temp_provider->provider_vtable->init(temp_provider) == 0) {
-            creds = temp_provider->provider_vtable->get_credentials(temp_provider);
-        }
     }
 
     now = time(NULL);
@@ -791,7 +760,7 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
     err = rd_kafka_oauthbearer_set_token(rk,
                                         payload,
                                         md_lifetime_ms,
-                                        creds ? creds->access_key_id : "unknown",
+                                        access_key_id ? access_key_id : "unknown",
                                         NULL,
                                         0,
                                         errstr,
@@ -805,18 +774,8 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
         flb_info("[aws_msk_iam] OAuth bearer token successfully set");
     }
 
-    /* Clean up everything immediately - no memory leaks possible! */
-    if (creds) {
-        flb_aws_credentials_destroy(creds);
-    }
-    if (temp_provider) {
-        flb_aws_provider_destroy(temp_provider);
-    }
-    if (base_provider) {
-        flb_aws_provider_destroy(base_provider);
-    }
-    if (sts_tls) {
-        flb_tls_destroy(sts_tls);
+    if (access_key_id) {
+        flb_sds_destroy(access_key_id);
     }
     if (payload) {
         flb_sds_destroy(payload);
@@ -881,12 +840,29 @@ struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *con
 
     /* Store optional STS Assume Role parameters */
     if (role_arn) {
+        char *session_name;
+
         ctx->role_arn = flb_sds_create(role_arn);
         if (!ctx->role_arn) {
             flb_error("[aws_msk_iam] failed to store role ARN");
             flb_aws_msk_iam_destroy(ctx);
             return NULL;
         }
+
+        session_name = flb_sts_session_name();
+        if (!session_name) {
+            flb_error("[aws_msk_iam] failed to generate STS session name");
+            flb_aws_msk_iam_destroy(ctx);
+            return NULL;
+        }
+        ctx->sts_session_name = flb_sds_create(session_name);
+        flb_free(session_name);
+        if (!ctx->sts_session_name) {
+            flb_error("[aws_msk_iam] failed to store STS session name");
+            flb_aws_msk_iam_destroy(ctx);
+            return NULL;
+        }
+
         flb_info("[aws_msk_iam] STS AssumeRole enabled with role ARN: %s", role_arn);
     }
 
@@ -943,6 +919,9 @@ void flb_aws_msk_iam_destroy(struct flb_aws_msk_iam *ctx)
     }
     if (ctx->external_id) {
         flb_sds_destroy(ctx->external_id);
+    }
+    if (ctx->sts_session_name) {
+        flb_sds_destroy(ctx->sts_session_name);
     }
     flb_free(ctx);
 }

--- a/src/aws/flb_aws_msk_iam.c
+++ b/src/aws/flb_aws_msk_iam.c
@@ -793,6 +793,7 @@ struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *con
 {
     struct flb_aws_msk_iam *ctx;
     char *region_str;
+    char *session_name;
 
     flb_info("[aws_msk_iam] registering OAuth callback with cluster ARN: %s", cluster_arn);
 
@@ -840,8 +841,6 @@ struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *con
 
     /* Store optional STS Assume Role parameters */
     if (role_arn) {
-        char *session_name;
-
         ctx->role_arn = flb_sds_create(role_arn);
         if (!ctx->role_arn) {
             flb_error("[aws_msk_iam] failed to store role ARN");

--- a/src/aws/flb_aws_msk_iam.c
+++ b/src/aws/flb_aws_msk_iam.c
@@ -30,6 +30,7 @@
 #include <fluent-bit/aws/flb_aws_msk_iam.h>
 
 #include <fluent-bit/flb_signv4.h>
+#include <fluent-bit/tls/flb_tls.h>
 #include <rdkafka.h>
 
 #include <stdio.h>
@@ -42,6 +43,10 @@ struct flb_aws_msk_iam {
     struct flb_config *flb_config;  /* For creating AWS provider on-demand */
     flb_sds_t region;
     flb_sds_t cluster_arn;
+    /* Optional STS Assume Role fields */
+    flb_sds_t role_arn;
+    flb_sds_t sts_endpoint;
+    flb_sds_t external_id;
 };
 
 /* Utility functions - same as before */
@@ -167,7 +172,10 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
                                        const char *host)
 {
     struct flb_aws_provider *temp_provider = NULL;
+    struct flb_aws_provider *base_provider = NULL;
+    struct flb_tls *sts_tls = NULL;
     struct flb_aws_credentials *creds = NULL;
+    char *sts_session_name = NULL;
     flb_sds_t payload = NULL;
     int encode_result;
     char *p;
@@ -227,9 +235,57 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
         return NULL;
     }
 
+    /* If role_arn is set, wrap with STS AssumeRole provider */
+    if (config->role_arn) {
+        sts_tls = flb_tls_create(FLB_TLS_CLIENT_MODE, FLB_TRUE, 0,
+                                 NULL, NULL, NULL, NULL, NULL, NULL);
+        if (!sts_tls) {
+            flb_error("[aws_msk_iam] build_msk_iam_payload: failed to create TLS for STS");
+            flb_aws_provider_destroy(temp_provider);
+            return NULL;
+        }
+
+        sts_session_name = flb_sts_session_name();
+        if (!sts_session_name) {
+            flb_error("[aws_msk_iam] build_msk_iam_payload: failed to generate STS session name");
+            flb_tls_destroy(sts_tls);
+            flb_aws_provider_destroy(temp_provider);
+            return NULL;
+        }
+
+        base_provider = temp_provider;
+        temp_provider = flb_sts_provider_create(config->flb_config,
+                                               sts_tls,
+                                               base_provider,
+                                               config->external_id,
+                                               config->role_arn,
+                                               sts_session_name,
+                                               config->region,
+                                               config->sts_endpoint,
+                                               NULL,
+                                               flb_aws_client_generator());
+        flb_free(sts_session_name);
+        sts_session_name = NULL;
+
+        if (!temp_provider) {
+            flb_error("[aws_msk_iam] build_msk_iam_payload: failed to create STS provider");
+            flb_tls_destroy(sts_tls);
+            flb_aws_provider_destroy(base_provider);
+            return NULL;
+        }
+
+        flb_info("[aws_msk_iam] build_msk_iam_payload: using STS AssumeRole for credentials");
+    }
+
     if (temp_provider->provider_vtable->init(temp_provider) != 0) {
         flb_error("[aws_msk_iam] build_msk_iam_payload: failed to initialize AWS credentials provider");
         flb_aws_provider_destroy(temp_provider);
+        if (base_provider) {
+            flb_aws_provider_destroy(base_provider);
+        }
+        if (sts_tls) {
+            flb_tls_destroy(sts_tls);
+        }
         return NULL;
     }
 
@@ -238,6 +294,12 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
     if (!creds) {
         flb_error("[aws_msk_iam] build_msk_iam_payload: failed to get credentials");
         flb_aws_provider_destroy(temp_provider);
+        if (base_provider) {
+            flb_aws_provider_destroy(base_provider);
+        }
+        if (sts_tls) {
+            flb_tls_destroy(sts_tls);
+        }
         return NULL;
     }
 
@@ -553,6 +615,12 @@ static flb_sds_t build_msk_iam_payload(struct flb_aws_msk_iam *config,
     if (temp_provider) {
         flb_aws_provider_destroy(temp_provider);
     }
+    if (base_provider) {
+        flb_aws_provider_destroy(base_provider);
+    }
+    if (sts_tls) {
+        flb_tls_destroy(sts_tls);
+    }
 
     return payload;
 
@@ -600,6 +668,12 @@ error:
     if (temp_provider) {
         flb_aws_provider_destroy(temp_provider);
     }
+    if (base_provider) {
+        flb_aws_provider_destroy(base_provider);
+    }
+    if (sts_tls) {
+        flb_tls_destroy(sts_tls);
+    }
 
     return NULL;
 }
@@ -623,6 +697,9 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
     struct flb_aws_credentials *creds = NULL;
     struct flb_kafka_opaque *kafka_opaque;
     struct flb_aws_provider *temp_provider = NULL;
+    struct flb_aws_provider *base_provider = NULL;
+    struct flb_tls *sts_tls = NULL;
+    char *sts_session_name = NULL;
     (void) oauthbearer_config;
 
     kafka_opaque = (struct flb_kafka_opaque *) opaque;
@@ -678,7 +755,32 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
                                                       flb_aws_client_generator(),
                                                       NULL);
     if (temp_provider) {
-        if (temp_provider->provider_vtable->init(temp_provider) == 0) {
+        /* If role_arn is set, wrap with STS AssumeRole to get the assumed principal */
+        if (config->role_arn) {
+            sts_tls = flb_tls_create(FLB_TLS_CLIENT_MODE, FLB_TRUE, 0,
+                                     NULL, NULL, NULL, NULL, NULL, NULL);
+            sts_session_name = sts_tls ? flb_sts_session_name() : NULL;
+
+            if (sts_tls && sts_session_name) {
+                base_provider = temp_provider;
+                temp_provider = flb_sts_provider_create(config->flb_config,
+                                                       sts_tls,
+                                                       base_provider,
+                                                       config->external_id,
+                                                       config->role_arn,
+                                                       sts_session_name,
+                                                       config->region,
+                                                       config->sts_endpoint,
+                                                       NULL,
+                                                       flb_aws_client_generator());
+            }
+            if (sts_session_name) {
+                flb_free(sts_session_name);
+                sts_session_name = NULL;
+            }
+        }
+
+        if (temp_provider && temp_provider->provider_vtable->init(temp_provider) == 0) {
             creds = temp_provider->provider_vtable->get_credentials(temp_provider);
         }
     }
@@ -710,16 +812,24 @@ static void oauthbearer_token_refresh_cb(rd_kafka_t *rk,
     if (temp_provider) {
         flb_aws_provider_destroy(temp_provider);
     }
-
+    if (base_provider) {
+        flb_aws_provider_destroy(base_provider);
+    }
+    if (sts_tls) {
+        flb_tls_destroy(sts_tls);
+    }
     if (payload) {
         flb_sds_destroy(payload);
     }
 }
 
-/* Register callback with lightweight config - keeps your current interface */
+/* Register callback with lightweight config */
 struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *config,
                                                           rd_kafka_conf_t *kconf,
                                                           const char *cluster_arn,
+                                                          const char *role_arn,
+                                                          const char *sts_endpoint,
+                                                          const char *external_id,
                                                           struct flb_kafka_opaque *opaque)
 {
     struct flb_aws_msk_iam *ctx;
@@ -732,7 +842,7 @@ struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *con
         return NULL;
     }
 
-    /* Allocate lightweight config - NO AWS provider! */
+    /* Allocate lightweight config - NO persistent AWS provider! */
     ctx = flb_calloc(1, sizeof(struct flb_aws_msk_iam));
     if (!ctx) {
         flb_errno();
@@ -769,6 +879,35 @@ struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *con
         return NULL;
     }
 
+    /* Store optional STS Assume Role parameters */
+    if (role_arn) {
+        ctx->role_arn = flb_sds_create(role_arn);
+        if (!ctx->role_arn) {
+            flb_error("[aws_msk_iam] failed to store role ARN");
+            flb_aws_msk_iam_destroy(ctx);
+            return NULL;
+        }
+        flb_info("[aws_msk_iam] STS AssumeRole enabled with role ARN: %s", role_arn);
+    }
+
+    if (sts_endpoint) {
+        ctx->sts_endpoint = flb_sds_create(sts_endpoint);
+        if (!ctx->sts_endpoint) {
+            flb_error("[aws_msk_iam] failed to store STS endpoint");
+            flb_aws_msk_iam_destroy(ctx);
+            return NULL;
+        }
+    }
+
+    if (external_id) {
+        ctx->external_id = flb_sds_create(external_id);
+        if (!ctx->external_id) {
+            flb_error("[aws_msk_iam] failed to store external ID");
+            flb_aws_msk_iam_destroy(ctx);
+            return NULL;
+        }
+    }
+
     flb_info("[aws_msk_iam] extracted region: %s", ctx->region);
 
     /* Set the callback and opaque */
@@ -781,7 +920,7 @@ struct flb_aws_msk_iam *flb_aws_msk_iam_register_oauth_cb(struct flb_config *con
     return ctx;
 }
 
-/* Simple destroy - just config cleanup, no AWS provider to leak! */
+/* Simple destroy - just config cleanup, no persistent AWS provider to leak! */
 void flb_aws_msk_iam_destroy(struct flb_aws_msk_iam *ctx)
 {
     if (!ctx) {
@@ -790,12 +929,20 @@ void flb_aws_msk_iam_destroy(struct flb_aws_msk_iam *ctx)
 
     flb_info("[aws_msk_iam] destroying MSK IAM config");
 
-    /* NO AWS provider to destroy! */
     if (ctx->region) {
         flb_sds_destroy(ctx->region);
     }
     if (ctx->cluster_arn) {
         flb_sds_destroy(ctx->cluster_arn);
+    }
+    if (ctx->role_arn) {
+        flb_sds_destroy(ctx->role_arn);
+    }
+    if (ctx->sts_endpoint) {
+        flb_sds_destroy(ctx->sts_endpoint);
+    }
+    if (ctx->external_id) {
+        flb_sds_destroy(ctx->external_id);
     }
     flb_free(ctx);
 }


### PR DESCRIPTION
## Summary
    
Add AWS STS `AssumeRole` support to the Kafka output plugin (`out_kafka`) when using AWS MSK IAM authentication (`aws_msk_iam`).
    
This enables Fluent Bit to assume a dedicated IAM role (e.g., for cross-account MSK access or when using EKS Pod Identity / IRSA) when authenticating against Amazon Managed Streaming for Apache Kafka (MSK) clusters.
    
## Motivation & Background
    
Currently, MSK IAM authentication in `out_kafka` only uses the standard AWS credential chain directly from the host/environment. In many enterprise and Kubernetes multi-account setups:
    1. Fluent Bit runs in Account A (e.g., via EKS Pod Identity / IRSA) but needs to produce logs to an MSK cluster in Account B.
    2. Direct credential rotation with dynamic identity providers can alter session identifiers, causing SASL re-authentication failures (`Cannot
  change principals during re-authentication`).
    
By supporting STS `AssumeRole`, users can configure a target role ARN along with optional STS parameters. Fluent Bit assumes the configured role to sign MSK IAM OAuth tokens while maintaining a stable session name across token refresh cycles.

## New Configuration Properties
    
All new properties are **optional** and guarded by `FLB_HAVE_AWS_MSK_IAM`:
  
| Property | Type | Default | Required | Description |
| :--- | :--- | :--- | :--- | :--- |
| `aws_msk_iam_role_arn` | string | `NULL` | **Optional** | ARN of the IAM role to assume. If not set, Fluent Bit uses standard chain  credentials as before. |
| `aws_msk_iam_sts_endpoint` | string | `NULL` | **Optional** | Custom STS API endpoint (e.g., STS VPC privateLink endpoint or FIPS). If omitted, the default regional STS endpoint (`https://sts.<region>.amazonaws.com`) is used automatically. |
| `aws_msk_iam_external_id` | string | `NULL` | **Optional** | External ID for STS `AssumeRole`. Only required when the target IAM role's trust policy mandates an `sts:ExternalId` condition. If omitted, no External ID is sent. |

## Example Configurations

### 1. Minimal AssumeRole (Using Default Regional STS Endpoint)
```yaml
pipeline:
  inputs:
    - name: dummy
      dummy: '{"message": "fluent-bit msk iam test"}'
  outputs:
    - name: kafka
      match: "*"
      brokers: "b-1.xxx.kafka.us-east-1.amazonaws.com:9098"
      topics: "app-logs"
      aws_msk_iam: true
      aws_msk_iam_cluster_arn: "arn:aws:kafka:us-east-1:123456789012:cluster/demo/abcdef"
      aws_msk_iam_role_arn: "arn:aws:iam::123456789012:role/MSKCrossAccountRole"
```
### 2. Full Configuration (Custom STS Endpoint + External ID)
```yaml
pipeline:
  inputs:
    - name: dummy
      dummy: '{"message": "fluent-bit msk iam test"}'
  outputs:
    - name: kafka
      match: "*"
      brokers: "b-1.xxx.kafka.us-east-1.amazonaws.com:9098"
      topics: "app-logs"
      aws_msk_iam: true
      aws_msk_iam_cluster_arn: "arn:aws:kafka:us-east-1:123456789012:cluster/demo/abcdef"
      aws_msk_iam_role_arn: "arn:aws:iam::123456789012:role/MSKCrossAccountRole"
      aws_msk_iam_sts_endpoint: "https://vpce-xxx.sts.us-east-1.vpce.amazonaws.com"
      aws_msk_iam_external_id: "my-cross-account-external-id"
```

## Key Changes

1. include/fluent-bit/aws/flb_aws_msk_iam.h & src/aws/flb_aws_msk_iam.c:
    - Extended flb_aws_msk_iam_register_oauth_cb() to accept role_arn, sts_endpoint, and external_id.
    - Integrated flb_sts_provider_create() to fetch temporary credentials via STS AssumeRole when role_arn is configured.
    - Preserved a single STS session name during registration to prevent MSK SASL re-authentication principal mismatch errors.
    - Reused credentials obtained during token signing for the OAuth principal name to eliminate redundant STS requests and latency.
2. plugins/out_kafka/:
    - Exposed aws_msk_iam_role_arn, aws_msk_iam_sts_endpoint, and aws_msk_iam_external_id in the config map and plugin context.
3. plugins/in_kafka/:
    - Updated flb_aws_msk_iam_register_oauth_cb() invocation with NULL defaults to maintain API compatibility.

----


Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [x] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional AWS MSK IAM role assumption for Kafka output authentication.
  * Added configuration options for IAM role ARN, STS endpoint, and external ID.
  * Supports secure credential refresh and token generation through AWS STS when configured.

* **Bug Fixes**
  * Improved authentication reliability by reusing refreshed credentials and cleaning up temporary resources during token generation and renewal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->