### PR TITLE
config: config_format: address wrongly specified parameter on service section

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -369,6 +369,7 @@ struct flb_config {
 struct flb_config *flb_config_init();
 void flb_config_exit(struct flb_config *config);
 const char *flb_config_prop_get(const char *key, struct mk_list *list);
+int flb_config_service_property_is_valid(const char *k);
 int flb_config_set_property(struct flb_config *config,
                             const char *k, const char *v);
 int flb_config_set_program_name(struct flb_config *config, char *name);

--- a/src/config_format/flb_config_format.c
+++ b/src/config_format/flb_config_format.c
@@ -187,40 +187,56 @@ int flb_cf_set_origin_format(struct flb_cf *cf, int format)
     return 0;
 }
 
+static int section_name_check(char *name, int len, const char *expected)
+{
+    size_t expected_length;
+
+    expected_length = strlen(expected);
+    if (len < 0 || (size_t) len != expected_length) {
+        return FLB_FALSE;
+    }
+
+    if (strncasecmp(name, expected, expected_length) == 0) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 static enum section_type get_section_type(char *name, int len)
 {
-    if (strncasecmp(name, "service", len) == 0) {
+    if (section_name_check(name, len, "service") == FLB_TRUE) {
         return FLB_CF_SERVICE;
     }
-    else if (strncasecmp(name, "parser", len) == 0) {
+    else if (section_name_check(name, len, "parser") == FLB_TRUE) {
         return FLB_CF_PARSER;
     }
-    else if (strncasecmp(name, "multiline_parser", len) == 0) {
+    else if (section_name_check(name, len, "multiline_parser") == FLB_TRUE) {
         return FLB_CF_MULTILINE_PARSER;
     }
-    else if (strncasecmp(name, "stream_processor", len) == 0) {
+    else if (section_name_check(name, len, "stream_processor") == FLB_TRUE) {
         return FLB_CF_STREAM_PROCESSOR;
     }
-    else if (strncasecmp(name, "plugins", len) == 0) {
+    else if (section_name_check(name, len, "plugins") == FLB_TRUE) {
         return FLB_CF_PLUGINS;
     }
-    else if (strncasecmp(name, "upstream_servers", len) == 0) {
+    else if (section_name_check(name, len, "upstream_servers") == FLB_TRUE) {
         return FLB_CF_UPSTREAM_SERVERS;
     }
-    else if (strncasecmp(name, "custom", len) == 0 ||
-             strncasecmp(name, "customs", len) == 0) {
+    else if (section_name_check(name, len, "custom") == FLB_TRUE ||
+             section_name_check(name, len, "customs") == FLB_TRUE) {
         return FLB_CF_CUSTOM;
     }
-    else if (strncasecmp(name, "input", len) == 0 ||
-             strncasecmp(name, "inputs", len) == 0) {
+    else if (section_name_check(name, len, "input") == FLB_TRUE ||
+             section_name_check(name, len, "inputs") == FLB_TRUE) {
         return FLB_CF_INPUT;
     }
-    else if (strncasecmp(name, "filter", len) == 0 ||
-             strncasecmp(name, "filters", len) == 0) {
+    else if (section_name_check(name, len, "filter") == FLB_TRUE ||
+             section_name_check(name, len, "filters") == FLB_TRUE) {
         return FLB_CF_FILTER;
     }
-    else if (strncasecmp(name, "output", len) == 0 ||
-             strncasecmp(name, "outputs", len) == 0) {
+    else if (section_name_check(name, len, "output") == FLB_TRUE ||
+             section_name_check(name, len, "outputs") == FLB_TRUE) {
         return FLB_CF_OUTPUT;
     }
 

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -830,6 +830,26 @@ int set_log_level_from_env(struct flb_config *config)
     return -1;
 }
 
+int flb_config_service_property_is_valid(const char *k)
+{
+    int i = 0;
+    size_t len;
+    char *key;
+
+    len = strnlen(k, 256);
+    key = service_configs[0].key;
+
+    while (key != NULL) {
+        if (prop_key_check(key, k, len) == 0) {
+            return FLB_TRUE;
+        }
+
+        key = service_configs[++i].key;
+    }
+
+    return FLB_FALSE;
+}
+
 int flb_config_set_property(struct flb_config *config,
                             const char *k, const char *v)
 {
@@ -927,6 +947,8 @@ int flb_config_set_property(struct flb_config *config,
         }
         key = service_configs[++i].key;
     }
+
+    flb_warn("[config] unknown service property '%s', it has been ignored", k);
     return 0;
 }
 
@@ -1544,6 +1566,12 @@ int flb_config_load_config_format(struct flb_config *config, struct flb_cf *cf)
             else {
                 /* Yaml allow parsers definitions in any Yaml file, all good */
             }
+        }
+
+        if (s->type == FLB_CF_OTHER &&
+            strcasecmp(s->name, "processor") != 0) {
+            flb_warn("[config] unknown configuration section '%s', it has been ignored",
+                     s->name);
         }
     }
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UNIT_TESTS_FILES
   zstd.c
   random.c
   thread_storage.c
+  config_service.c
   config_map.c
   mp.c
   mp_chunk_cobj.c

--- a/tests/internal/config_service.c
+++ b/tests/internal/config_service.c
@@ -1,0 +1,133 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_config_format.h>
+
+#include "flb_tests_internal.h"
+
+#define UNKNOWN_YAML_CONFIG \
+    FLB_TESTS_DATA_PATH "/data/config_format/yaml/unknown_service.yaml"
+
+static void test_service_property_validation(void)
+{
+    TEST_CHECK(flb_config_service_property_is_valid("flush") == FLB_TRUE);
+    TEST_CHECK(flb_config_service_property_is_valid("Log_Level") == FLB_TRUE);
+    TEST_CHECK(flb_config_service_property_is_valid("log_livel") == FLB_FALSE);
+    TEST_CHECK(flb_config_service_property_is_valid("another_param") == FLB_FALSE);
+}
+
+static void test_unknown_service_property_compatibility(void)
+{
+    int ret;
+    int verbose;
+    struct flb_log *log;
+    struct flb_config *config;
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (config == NULL) {
+        return;
+    }
+
+    log = config->log;
+    verbose = config->verbose;
+
+    ret = flb_config_set_property(config, "log_livel", "debug");
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(config->log == log);
+    TEST_CHECK(config->verbose == verbose);
+
+    flb_config_exit(config);
+}
+
+static void test_section_name_validation(void)
+{
+    struct flb_cf *cf;
+    struct flb_cf_section *section;
+
+    cf = flb_cf_create();
+    TEST_CHECK(cf != NULL);
+    if (cf == NULL) {
+        return;
+    }
+
+    section = flb_cf_section_create(cf, "SERVIC", 0);
+    TEST_CHECK(section != NULL);
+    TEST_CHECK(section->type == FLB_CF_OTHER);
+    TEST_CHECK(cf->service == NULL);
+
+    flb_cf_destroy(cf);
+}
+
+static void test_classic_unknown_configuration_load(void)
+{
+    int ret;
+    struct cfl_variant *property;
+    struct flb_cf *cf;
+    struct flb_cf_section *section;
+    struct flb_config *config;
+
+    cf = flb_cf_create();
+    TEST_CHECK(cf != NULL);
+    if (cf == NULL) {
+        return;
+    }
+
+    flb_cf_set_origin_format(cf, FLB_CF_CLASSIC);
+
+    section = flb_cf_section_create(cf, "service", 0);
+    TEST_CHECK(section != NULL);
+    property = flb_cf_section_property_add(cf, section->properties,
+                                           "another_param", 0, "0", 0);
+    TEST_CHECK(property != NULL);
+
+    section = flb_cf_section_create(cf, "something", 0);
+    TEST_CHECK(section != NULL);
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (config != NULL) {
+        ret = flb_config_load_config_format(config, cf);
+        TEST_CHECK(ret == 0);
+        flb_config_exit(config);
+    }
+
+    flb_cf_destroy(cf);
+}
+
+#ifdef FLB_HAVE_LIBYAML
+static void test_yaml_unknown_configuration_load(void)
+{
+    int ret;
+    struct flb_cf *cf;
+    struct flb_config *config;
+
+    cf = flb_cf_yaml_create(NULL, UNKNOWN_YAML_CONFIG, NULL, 0);
+    TEST_CHECK(cf != NULL);
+    if (cf == NULL) {
+        return;
+    }
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (config != NULL) {
+        ret = flb_config_load_config_format(config, cf);
+        TEST_CHECK(ret == 0);
+        flb_config_exit(config);
+    }
+
+    flb_cf_destroy(cf);
+}
+#endif
+
+TEST_LIST = {
+    { "service_property_validation", test_service_property_validation },
+    { "unknown_service_property_compatibility",
+      test_unknown_service_property_compatibility },
+    { "section_name_validation", test_section_name_validation },
+    { "classic_unknown_configuration_load", test_classic_unknown_configuration_load },
+#ifdef FLB_HAVE_LIBYAML
+    { "yaml_unknown_configuration_load", test_yaml_unknown_configuration_load },
+#endif
+    { 0 }
+};

--- a/tests/internal/data/config_format/yaml/unknown_service.yaml
+++ b/tests/internal/data/config_format/yaml/unknown_service.yaml
@@ -1,0 +1,5 @@
+service:
+  another_param: 0
+
+something:
+  property: value


### PR DESCRIPTION
<!-- Provide summary of changes -->

- Unknown `[SERVICE]` properties now warn while preserving success behavior.
- Unknown configuration sections now warn and are ignored.
- Section names require exact case-insensitive matches, so `[SERVIC]` is correctly rejected.
- Added classic/YAML and compatibility regression tests in [config_service.c](C:/Users/cosmo/Documents/GitHub/fluent-bit/tests/internal/config_service.c).

Verification:

- `ctest --test-dir build -R '^flb-it-config_(service|format|format_fluentbit|format_yaml)$' --output-on-failure`
  - 4/4 passed.
- Classic, YAML, and `[SERVIC]` executable `--dry-run` checks succeeded with the expected warnings.
- Memory checker: not run; Valgrind and macOS Leaks are unavailable on Windows.
- Working tree is clean.

Closes #8819

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing to prevent partial matches for section names.
  * Unknown service properties and configuration sections are now reported with warnings and safely ignored.
  * Added validation for supported service properties across configuration formats.

* **Tests**
  * Added coverage for unknown properties, invalid sections, and classic/YAML configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->