### PR TITLE
config: fix startup abort when log_level set via env and config

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -859,6 +859,15 @@ int flb_config_set_property(struct flb_config *config,
                     }
                 #ifndef FLB_HAVE_STATIC_CONF
                 }
+                else {
+                    /*
+                     * FLB_LOG_LEVEL was set in the environment and already
+                     * applied by set_log_level_from_env(), which takes
+                     * precedence over the config value. Record success so the
+                     * caller does not treat this path as a fatal error.
+                     */
+                    ret = 0;
+                }
                 #endif
             }
             else if (!strncasecmp(key, FLB_CONF_STR_PARSERS_FILE, 32)) {

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 # Config format
 set(UNIT_TESTS_FILES
     ${UNIT_TESTS_FILES}
+    config.c
     config_format.c
     config_format_fluentbit.c
 )

--- a/tests/internal/config.c
+++ b/tests/internal/config.c
@@ -1,0 +1,144 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_log.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "flb_tests_internal.h"
+
+#define ENV_LOG_LEVEL "FLB_LOG_LEVEL"
+
+#ifdef FLB_SYSTEM_WINDOWS
+static int flb_test_setenv(const char *name, const char *value, int overwrite)
+{
+    if (overwrite == 0 && getenv(name) != NULL) {
+        return 0;
+    }
+
+    return _putenv_s(name, value);
+}
+
+static int flb_test_unsetenv(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#else
+#define flb_test_setenv(name, value, overwrite) setenv(name, value, overwrite)
+#define flb_test_unsetenv(name) unsetenv(name)
+#endif
+
+static char *save_env_log_level()
+{
+    char *val;
+
+    val = getenv(ENV_LOG_LEVEL);
+    if (val != NULL && val[0] != '\0') {
+        return strdup(val);
+    }
+    return NULL;
+}
+
+static void restore_env_log_level(char *saved)
+{
+    if (saved != NULL) {
+        flb_test_setenv(ENV_LOG_LEVEL, saved, 1);
+        free(saved);
+    }
+    else {
+        flb_test_unsetenv(ENV_LOG_LEVEL);
+    }
+}
+
+/*
+ * Regression test for GitHub issue #12310: when FLB_LOG_LEVEL is set in the
+ * environment and log_level is also present in the [SERVICE] section,
+ * flb_config_set_property() must return success (the environment variable
+ * takes precedence). Before the fix it returned -1 on this path, which
+ * since 5.1.0 aborted startup.
+ */
+static void test_log_level_env_and_config()
+{
+    int ret;
+    char *saved;
+    struct flb_config *config;
+
+    saved = save_env_log_level();
+
+    ret = flb_test_setenv(ENV_LOG_LEVEL, "debug", 1);
+    TEST_CHECK(ret == 0);
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (config == NULL) {
+        restore_env_log_level(saved);
+        return;
+    }
+
+    ret = flb_config_set_property(config, "log_level", "info");
+    TEST_CHECK(ret == 0);
+    TEST_MSG("flb_config_set_property returned %d, expected 0", ret);
+
+#ifndef FLB_HAVE_STATIC_CONF
+    /* the environment variable wins over the configuration value */
+    TEST_CHECK(config->verbose == FLB_LOG_DEBUG);
+    TEST_MSG("verbose is %d, expected %d (debug)",
+             config->verbose, FLB_LOG_DEBUG);
+#endif
+
+    flb_config_exit(config);
+    restore_env_log_level(saved);
+}
+
+static void test_log_level_config_only()
+{
+    int ret;
+    char *saved;
+    struct flb_config *config;
+
+    saved = save_env_log_level();
+    flb_test_unsetenv(ENV_LOG_LEVEL);
+
+    config = flb_config_init();
+    TEST_CHECK(config != NULL);
+    if (config == NULL) {
+        restore_env_log_level(saved);
+        return;
+    }
+
+    ret = flb_config_set_property(config, "log_level", "info");
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(config->verbose == FLB_LOG_INFO);
+
+    /* an invalid value must still be reported as an error */
+    ret = flb_config_set_property(config, "log_level", "invalid_level");
+    TEST_CHECK(ret == -1);
+
+    flb_config_exit(config);
+    restore_env_log_level(saved);
+}
+
+TEST_LIST = {
+    { "log_level_env_and_config", test_log_level_env_and_config },
+    { "log_level_config_only",    test_log_level_config_only },
+    { 0 }
+};


### PR DESCRIPTION
Setting the log level via both the `FLB_LOG_LEVEL` environment variable
  and `Log_Level` in the `[SERVICE]` section causes Fluent Bit to abort at
  startup:

      [error] [config] could not configure service property 'log_level'
      [error] configuration file contains errors, aborting.

  This is a regression: it works on 5.0.9 and earlier, and fails on 5.1.0
  and 5.1.1.

  **Root cause**

  In `src/flb_config.c`, `flb_config_set_property()` initializes
  `ret = -1`. In the `log_level` branch, `ret` is only assigned inside the
  `set_log_level_from_env(config) < 0` block. When `FLB_LOG_LEVEL` is set,
  `set_log_level_from_env()` succeeds (returns 0), so the block is skipped
  and `ret` stays `-1`. The level is applied correctly, but the function
  still returns `-1`.

  Before 5.1.0 the caller discarded this return value, so the latent bug
  was harmless. Since 5.1.0 the caller checks the return value and aborts
  on `-1`, exposing the bug.

  **Fix**

  Add an `else` branch on the environment-variable path that records
  success (`ret = 0`), since the level has already been applied by
  `set_log_level_from_env()`. This restores the pre-5.1.0 behavior where
  the env var takes precedence and startup proceeds normally.

  **Testing**

  <!-- Note: I was unable to run a full CMake build in my environment.
  Please build and run the repro from the issue to confirm before merge. -->

  Fixes #12310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log-level configuration handling when `FLB_LOG_LEVEL` is set through the environment.
  * Environment-provided log levels now consistently take precedence over configuration values.
  * Invalid log-level values now correctly return an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->