### PR TITLE
in_winevtlog: fix crash when all channels are missing and ignore_missing_channels is enabled

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -444,6 +444,10 @@ static int in_winevtlog_collect(struct flb_input_instance *ins,
     struct mk_list *head;
     struct winevtlog_channel *ch;
 
+    if (!ctx->active_channel) {
+        return 0;
+    }
+
     mk_list_foreach(head, ctx->active_channel) {
         ch = mk_list_entry(head, struct winevtlog_channel, _head);
         in_winevtlog_read_channel(ins, ctx, ch);

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -2222,6 +2222,13 @@ struct mk_list *winevtlog_open_all(const char *channels, struct winevtlog_config
 
     if (mk_list_size(list) == 0) {
         flb_free(tmp);
+        if (ctx->ignore_missing_channels) {
+            /*
+             * All channels are missing but tolerated: return the empty
+             * list so the caller can iterate it safely on collect/exit.
+             */
+            return list;
+        }
         winevtlog_close_all(list);
         return NULL;
     }
@@ -2235,6 +2242,10 @@ void winevtlog_close_all(struct mk_list *list)
     struct winevtlog_channel *ch;
     struct mk_list *head;
     struct mk_list *tmp;
+
+    if (!list) {
+        return;
+    }
 
     mk_list_foreach_safe(head, tmp, list) {
         ch = mk_list_entry(head, struct winevtlog_channel, _head);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -37,6 +37,8 @@ FLB_RT_TEST(FLB_CHUNK_TRACE "core_chunk_trace.c")
 
 # Input Plugins
 FLB_RT_TEST(FLB_IN_EVENT_TEST   "in_event_test.c")
+# FLB_IN_WINEVTLOG is only enabled on Windows builds
+FLB_RT_TEST(FLB_IN_WINEVTLOG    "in_winevtlog.c")
 
 if(FLB_OUT_LIB)
   # These plugins works only on Linux

--- a/tests/runtime/in_winevtlog.c
+++ b/tests/runtime/in_winevtlog.c
@@ -1,0 +1,184 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_runtime.h"
+
+/*
+ * Channels that must not exist on the host. The names are deliberately
+ * implausible; the tests rely on subscription to them failing with
+ * ERROR_EVT_CHANNEL_NOT_FOUND.
+ */
+#define MISSING_CHANNEL_A "FlbTestMissingChannelA"
+#define MISSING_CHANNEL_B "FlbTestMissingChannelB"
+
+/*
+ * All channels of the instance are missing and tolerated: the engine must
+ * start, survive collection cycles and stop cleanly. Before the fix,
+ * ctx->active_channel was NULL and the first collection cycle crashed the
+ * process (NULL dereference in mk_list_foreach).
+ */
+void flb_test_winevtlog_all_channels_missing_ignored(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", MISSING_CHANNEL_A,
+                        "ignore_missing_channels", "true",
+                        "interval_sec", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Let at least two collection cycles run (interval_sec=1) */
+    flb_time_msleep(2500);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Same as above but with several missing channels in one instance */
+void flb_test_winevtlog_multiple_missing_channels_ignored(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", MISSING_CHANNEL_A "," MISSING_CHANNEL_B,
+                        "ignore_missing_channels", "true",
+                        "interval_sec", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2500);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * A mix of one existing channel ('Application' always exists on Windows)
+ * and one missing channel: the missing one is skipped, the instance keeps
+ * working. This was already the behavior before the fix and must not
+ * regress.
+ */
+void flb_test_winevtlog_mixed_channels_ignored(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", "Application," MISSING_CHANNEL_A,
+                        "ignore_missing_channels", "true",
+                        "interval_sec", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2500);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Without ignore_missing_channels, a missing channel must keep failing
+ * initialization (documented behavior: "Subscribe at least one").
+ */
+void flb_test_winevtlog_missing_channel_fails_without_ignore(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", MISSING_CHANNEL_A,
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"all_channels_missing_ignored",
+     flb_test_winevtlog_all_channels_missing_ignored},
+    {"multiple_missing_channels_ignored",
+     flb_test_winevtlog_multiple_missing_channels_ignored},
+    {"mixed_channels_ignored",
+     flb_test_winevtlog_mixed_channels_ignored},
+    {"missing_channel_fails_without_ignore",
+     flb_test_winevtlog_missing_channel_fails_without_ignore},
+    {NULL, NULL}
+};


### PR DESCRIPTION
When a `winevtlog` input has `ignore_missing_channels: true` and **every**
configured channel of the instance fails to subscribe (e.g. a single-channel
instance whose channel does not exist on the host), `winevtlog_open_all()`
frees the channel list and returns NULL. `in_winevtlog_init()` tolerates the
NULL when the option is set but still registers the collector, so the first
collection cycle iterates a NULL list (`mk_list_foreach` dereferences
`head->next`) and the whole process crashes with an access violation. The
shutdown path (`in_winevtlog_exit()` → `winevtlog_close_all(NULL)`) crashes
the same way. Running as a Windows service with recovery enabled turns this
into a silent crash/restart loop.

**Note**: This fix and part of the [analysis](https://github.com/fluent/fluent-bit/issues/12315) was done using Fable.

Fixes #12315 

Changes:

* `winevtlog_open_all()`: when `ignore_missing_channels` is enabled and no
  channel could be subscribed, return the **empty list** instead of NULL so
  collect/exit iterate it safely (collecting nothing), which is what the
  option promises.
* `winevtlog_close_all()`: NULL guard (protects the exit path).
* `in_winevtlog_collect()`: NULL guard on `ctx->active_channel` (defense in
  depth).
* New runtime tests `tests/runtime/in_winevtlog.c` (registered under
  `FLB_IN_WINEVTLOG`, so they only build on Windows):
  * `all_channels_missing_ignored` — regression test for this crash: start
    with only a missing channel, survive collect cycles, stop cleanly.
    Crashes the test binary without the fix.
  * `multiple_missing_channels_ignored` — several missing channels.
  * `mixed_channels_ignored` — existing (`Application`) + missing channel
    keeps working (previously-working case, no regression).
  * `missing_channel_fails_without_ignore` — without the option, init still
    fails as documented.

Behavior without the option is unchanged; the mixed existing+missing case is
unchanged. Only the "option enabled and all channels of the instance
missing" case changes: from a process crash to an idle input.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```yaml
service:
  flush: 1
  log_level: debug

pipeline:
  inputs:
    - name: winevtlog
      channels: NonExistentChannel
      ignore_missing_channels: true

  outputs:
    - name: stdout
      match: '*'
```

Without this patch the process dies with an access violation (exit code
`0xC0000005`) on the first collection cycle (~1s after start) and also on
shutdown/hot-reload. With the patch it keeps running, collecting nothing
from that instance, and shuts down cleanly. Control case
(`channels: Application,NonExistentChannel`) behaves the same before and
after the patch.

- [x] Debug log output from testing the change
<details><summary>debug</summary>
<p>

```
C:\support\>C:\dev\fluent-bit\build\bin\fluent-bit.exe -c repro-crash.yml
Fluent Bit v5.1.1
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __
|  ___| |                | |   | ___ (_) |         |  ___|/  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ `| |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/


[2026/08/20 19:12:10.049] [ info] [fluent bit] version=5.1.1, commit=cc313d7204, pid=6780
[2026/08/20 19:12:10.053] [ info] [storage] ver=1.5.4, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/20 19:12:10.053] [ info] [simd    ] SSE2
[2026/08/20 19:12:10.053] [ info] [cmetrics] version=2.2.1
[2026/08/20 19:12:10.053] [ info] [ctraces ] version=0.7.1
[2026/08/20 19:12:10.055] [ info] [input:winevtlog:winevtlog.0] initializing
[2026/08/20 19:12:10.055] [ info] [input:winevtlog:winevtlog.0] storage_strategy='memory' (memory only)
[2026/08/20 19:12:10.057] [error] [input:winevtlog:winevtlog.0] cannot subscribe 'NonExistentChannel' (15007)
[2026/08/20 19:12:10.067] [ info] [sp] stream processor started
[2026/08/20 19:12:10.072] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/20 19:12:10.081] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/20 19:18:50] [engine] caught signal (SIGINT)
[2026/08/20 19:18:50.829] [ warn] [engine] service will shutdown in max 5 seconds
[2026/08/20 19:18:50.829] [ info] [engine] pausing all inputs..
[2026/08/20 19:18:50.829] [ info] [input] pausing winevtlog.0
[2026/08/20 19:18:51.851] [ info] [engine] service has stopped (0 pending tasks)
[2026/08/20 19:18:51.851] [ info] [input] pausing winevtlog.0
[2026/08/20 19:18:51.851] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/20 19:18:51.852] [ info] [output:stdout:stdout.0] thread worker #0 stopped
```


</p>
</details> 


- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

  Valgrind is not available on Windows and `in_winevtlog` is a Windows-only
  plugin (`FLB_IN_WINEVTLOG` is set only in `cmake/windows-setup.cmake`).
  The change removes a NULL dereference and frees nothing new; the empty
  list returned by `winevtlog_open_all()` is released by the existing
  `winevtlog_close_all()` call in `in_winevtlog_exit()`.

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**

- [N/A] Documentation required for this feature

  No new options or behavior beyond making `ignore_missing_channels` work
  as already documented when all channels of an instance are missing.

**Backporting**

- [x] Backport to latest stable release.

  Requested: this is a crash-loop fix for a released, documented option;
  a separate PR against the current stable branch can follow once this is
  approved.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when configured Windows Event Log channels are missing.
  * Prevented collection failures when all requested channels are unavailable and missing channels are allowed.
  * Ensured mixed available and unavailable channels continue operating correctly.
  * Preserved startup failure behavior when missing channels are not allowed.

* **Tests**
  * Added runtime coverage for missing-channel scenarios across multiple collection cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->