### PR TITLE
in_winevtlog: Plug a crash path

### DIFF
--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -310,7 +310,12 @@ static int pack_systemtime(struct winevtlog_config *ctx, SYSTEMTIME *st)
 
     _tzset();
 
-    GetDynamicTimeZoneInformation(&dtzi);
+    if (GetDynamicTimeZoneInformation(&dtzi) == TIME_ZONE_ID_INVALID) {
+        flb_plg_debug(ctx->ins,
+                      "failed to get dynamic timezone information: error=%u",
+                      GetLastError());
+        return -1;
+    }
 
     if (!SystemTimeToTzSpecificLocalTimeEx(&dtzi, st, &st_local)) {
         flb_plg_debug(ctx->ins,
@@ -324,9 +329,10 @@ static int pack_systemtime(struct winevtlog_config *ctx, SYSTEMTIME *st)
      * parameter handler when _strftime_l() receives an out-of-range
      * struct tm, which terminates the whole process with
      * STATUS_STACK_BUFFER_OVERRUN (0xc0000409, FAST_FAIL_INVALID_ARG).
-     * Validate every field before formatting.
+     * Validate every field before formatting. The UCRT only accepts
+     * tm_year values up to 8099, so cap the year at 9999.
      */
-    if (st_local.wYear < 1601  || st_local.wYear > 30827 ||
+    if (st_local.wYear < 1601  || st_local.wYear > 9999  ||
         st_local.wMonth < 1    || st_local.wMonth > 12   ||
         st_local.wDay < 1      || st_local.wDay > 31     ||
         st_local.wHour > 23    || st_local.wMinute > 59  ||

--- a/plugins/in_winevtlog/pack.c
+++ b/plugins/in_winevtlog/pack.c
@@ -302,38 +302,69 @@ static int pack_systemtime(struct winevtlog_config *ctx, SYSTEMTIME *st)
     _locale_t locale;
     DYNAMIC_TIME_ZONE_INFORMATION dtzi;
     SYSTEMTIME st_local;
+    struct tm tm;
+
+    if (st == NULL) {
+        return -1;
+    }
 
     _tzset();
 
     GetDynamicTimeZoneInformation(&dtzi);
 
+    if (!SystemTimeToTzSpecificLocalTimeEx(&dtzi, st, &st_local)) {
+        flb_plg_debug(ctx->ins,
+                      "failed to convert SYSTEMTIME to local time: error=%u",
+                      GetLastError());
+        return -1;
+    }
+
+    /* SYSTEMTIME values come straight from event data, so they can hold
+     * out-of-range fields. The MSVC secure CRT invokes the invalid
+     * parameter handler when _strftime_l() receives an out-of-range
+     * struct tm, which terminates the whole process with
+     * STATUS_STACK_BUFFER_OVERRUN (0xc0000409, FAST_FAIL_INVALID_ARG).
+     * Validate every field before formatting.
+     */
+    if (st_local.wYear < 1601  || st_local.wYear > 30827 ||
+        st_local.wMonth < 1    || st_local.wMonth > 12   ||
+        st_local.wDay < 1      || st_local.wDay > 31     ||
+        st_local.wHour > 23    || st_local.wMinute > 59  ||
+        st_local.wSecond > 59  || st_local.wDayOfWeek > 6) {
+        flb_plg_debug(ctx->ins,
+                      "dropping out-of-range SYSTEMTIME value: "
+                      "%u-%u-%u %u:%u:%u (dow=%u)",
+                      st_local.wYear, st_local.wMonth, st_local.wDay,
+                      st_local.wHour, st_local.wMinute, st_local.wSecond,
+                      st_local.wDayOfWeek);
+        return -1;
+    }
+
     locale = _get_current_locale();
     if (locale == NULL) {
         return -1;
     }
-    if (st != NULL) {
-        SystemTimeToTzSpecificLocalTimeEx(&dtzi, st, &st_local);
 
-        struct tm tm = {st_local.wSecond,
-                        st_local.wMinute,
-                        st_local.wHour,
-                        st_local.wDay,
-                        st_local.wMonth-1,
-                        st_local.wYear-1900,
-                        st_local.wDayOfWeek, 0, -1};
-        len = _strftime_l(buf, 64, FORMAT_ISO8601, &tm, locale);
-        if (len == 0) {
-            flb_errno();
-            _free_locale(locale);
-            return -1;
-        }
+    memset(&tm, 0, sizeof(tm));
+    tm.tm_sec   = st_local.wSecond;
+    tm.tm_min   = st_local.wMinute;
+    tm.tm_hour  = st_local.wHour;
+    tm.tm_mday  = st_local.wDay;
+    tm.tm_mon   = st_local.wMonth - 1;
+    tm.tm_year  = st_local.wYear - 1900;
+    tm.tm_wday  = st_local.wDayOfWeek;
+    tm.tm_yday  = 0;
+    tm.tm_isdst = -1;
+
+    len = _strftime_l(buf, 64, FORMAT_ISO8601, &tm, locale);
+    if (len == 0) {
+        flb_errno();
         _free_locale(locale);
-
-        flb_log_event_encoder_append_body_string(ctx->log_encoder, buf, len);
-    }
-    else {
         return -1;
     }
+    _free_locale(locale);
+
+    flb_log_event_encoder_append_body_string(ctx->log_encoder, buf, len);
 
     return 0;
 }
@@ -402,7 +433,7 @@ static int pack_filetime(struct winevtlog_config *ctx, ULONGLONG filetime)
                       offset_hours,
                       offset_minutes);
 
-    if (len <= 0) {
+    if ((int) len <= 0) {
         return -1;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
I did an experiment and fix with fable5.

Below the result and the root cause of this crash:

<p><strong>1. Ruled out the printf-family theories</strong> (test program with <code>_set_invalid_parameter_handler</code>, built <code>/MT</code> like the official binary):</p>
<ul>
<li><code>%s</code> with NULL in <code>_snprintf_s</code> does <strong>not</strong> fail-fast in the modern UCRT — it prints <code>(null)</code> and returns normally. Same for <code>%ls</code> NULL and for plain <code>snprintf</code> with an unknown specifier.</li>
<li>Only an <em>unknown conversion specifier</em> in a <code>*_s</code> function fail-fasts through the printf engine — and every <code>_snprintf_s</code> format string in the winevtlog path is a compile-time constant, so that mode has no trigger.</li>
</ul>
<p><strong>2. <code>_strftime_l</code> with an out-of-range <code>struct tm</code> fail-fasts</strong> through: <code>_strftime_l</code> → <code>_Strftime_l</code> → <code>_Wcsftime_l</code> → <code>expand_time</code> → <code>_invalid_parameter_noinfo</code> → <code>_invalid_parameter</code> → fastfail. Reproduced directly, including with a <code>tm</code> filled from a <code>SYSTEMTIME</code> whose fields are garbage (e.g., <code>0xCCCC</code>).</p>
<p><strong>3. Resolved the address-space confusion with a real PDB.</strong> Mapping our locally built <code>fluent-bit.exe</code> (same link structure, <code>sprintf_s</code> export at 0x1dec20 vs. 0x1e2400 official, <code>mk_main</code> 0x9659a0 vs. 0x975570 — layouts nearly aligned):</p>

Dump frame | WinDbg label (export-relative) | What's actually there (per local PDB layout)
-- | -- | --
00–03 | mk_main+0x7b0xx | __fastfail(5) / _invoke_watson / _invalid_parameter / _invalid_parameter_noinfo — proven by the disassembly in the log (mov ecx,5; int 29h)
04–05 | mk_main+0x7fc02, +0x6c90c | UCRT strftime internals — locally _strftime_l/_Strftime_l/_Wcsftime_l/expand_time all live in exactly this region (0x9c0xxx–0x9e5xxx, next to the _invalid_parameter cluster)
06–09 | vsnprintf_s_l+0x1243/0x147c/0x318e, sprintf_s+0xe74 | in_winevtlog plugin code. The plugin's statics sit immediately after those two CRT exports: locally pack_event_value=0x1e4e30, filetime_to_string≈0x1e48d0, winevtlog_pack_text_event≈0x1e66b0, i.e., precisely the 0x1e3xxx–0x1e6xxx band the dump frames fall into
0a–0e | wasm_*, mk_main+... | fluent-bit core / worker bootstrap (locally, wasm_module_delete even resolves to an unrelated aliased function — these export names carry no real information)


<p>So the stack was never "sprintf machinery called from wasm code" — it's the winevtlog pack chain (frames 06–09) calling into strftime internals (04–05) which raise the invalid-parameter fail-fast (00–03). The <code>vsnprintf_s_l</code>/<code>sprintf_s</code> attribution was an artifact of the plugin code being linked right after those exports.</p>
<p>That means the fix in <code>pack_systemtime</code> (check <code>SystemTimeToTzSpecificLocalTimeEx</code>, validate all <code>SYSTEMTIME</code> fields before <code>_strftime_l</code>) targets the exact crash path in the dump. 
</body>
</html>
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Closes https://github.com/fluent/fluent-bit/issues/12309.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for Windows event logs.
  * Invalid, incomplete, or unsupported system times are now rejected safely.
  * Timezone conversion failures are detected and reported more clearly.
  * Enhanced validation prevents malformed timestamps from being processed.
  * Timestamp year limits are enforced to improve reliability.
  * Added clearer diagnostic details for timestamp conversion and formatting errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->