### PR TITLE
in_tail: restrict file_cache_advise eviction to the consumed range

### DIFF
--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -1907,6 +1907,11 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
     char                   *tmp;
     int                     ret;
     int                     lines;
+#ifdef __linux__
+    int64_t                 advise_end;
+    long                    page_size;
+    int                     advise_ret;
+#endif
     struct flb_tail_config *ctx;
 
     /* Check if we the engine issued a pause */
@@ -2001,9 +2006,40 @@ int flb_tail_file_chunk(struct flb_tail_file *file)
 
     #ifdef __linux__
     if (ctx->file_cache_advise) {
-        if (posix_fadvise(file->fd, 0, 0, POSIX_FADV_DONTNEED) == -1) {
-            flb_errno();
-            flb_plg_error(ctx->ins, "error during posix_fadvise");
+        /*
+         * Advise only the page-aligned byte range that has already been
+         * consumed (up to file->offset).
+         *
+         * Advising the whole file would also hit the last page, which the
+         * writer is still appending to: POSIX_FADV_DONTNEED starts
+         * writeback of dirty pages, so the same tail page would be flushed
+         * to disk over and over (write amplification). It would also evict
+         * pages that other readers of the file (e.g. log rotation
+         * compressors) have not consumed yet, turning their cache hits
+         * into physical reads.
+         *
+         * The advice is repeated over the whole consumed range on every
+         * cycle on purpose: the kernel cannot drop pages that are still
+         * dirty when advised, it only starts their writeback, so they can
+         * only be evicted by a later call once they are clean. Consumed
+         * pages are never re-dirtied (the writer only appends), so each
+         * page is still written back at most once, and re-advising a
+         * mostly evicted range is cheap.
+         */
+        page_size = sysconf(_SC_PAGESIZE);
+        if (page_size > 0) {
+            advise_end = file->offset & ~((int64_t) page_size - 1);
+            if (advise_end > 0) {
+                advise_ret = posix_fadvise(file->fd, 0, (off_t) advise_end,
+                                           POSIX_FADV_DONTNEED);
+                if (advise_ret != 0) {
+                    /* posix_fadvise() returns the error number, it does
+                     * not set errno */
+                    flb_plg_error(ctx->ins,
+                                  "posix_fadvise error=%i file=%s",
+                                  advise_ret, file->name);
+                }
+            }
         }
     }
     #endif


### PR DESCRIPTION
Since #8422, `file_cache_advise` (default on, Linux) runs `posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED)` over the **whole file on every read cycle**. On actively written files this has two unintended side effects:

1. **Write amplification** — `POSIX_FADV_DONTNEED` starts writeback of dirty pages. The tail page of an actively appended log file is almost always dirty, so the same page is flushed to disk on every read cycle instead of once by the kernel flusher.
2. **Cold reads for other consumers** — the advice evicts pages other readers still need. E.g. on Kubernetes, kubelet compresses rotated container log files; with the cache evicted it re-reads every rotated file from disk. Steady-state extra reads ≈ 1× the log production rate.

Measured on GKE (3 × n2-standard-8 nodes, ~2.6 MB/s of logs per node, whole-file advise vs no advise, identical log throughput):

| Metric | advise whole file | no advise |
|---|---|---|
| node disk reads | 2.55 MB/s | 0.00 MB/s |
| node disk write IOPS | 110 | 76 |
| log file page-cache residency | ~0% | ~100% |

**This PR keeps the feature and its intent** (consumed log data does not accumulate in the page cache) but caps the advised range at the last page boundary below the consumed offset: `posix_fadvise(fd, 0, aligned_end, POSIX_FADV_DONTNEED)`. The still-appended (dirty) tail page is never advised, so no page is flushed to disk more than once, and data not yet read by fluent-bit is never evicted. The advice is still issued on every read cycle, so pages that were dirty (and therefore not droppable) when first advised are evicted by a later call once their writeback completes — consumed pages are never re-dirtied by the writer, so the repetition causes no additional writes. Per-file cache footprint stays bounded at roughly the trailing writeback window plus unconsumed data.

Also fixes the error check: `posix_fadvise()` returns the error number and does not set `errno`, so the previous `== -1` + `flb_errno()` check could never report a real failure.

**Scope note:** this change removes the write amplification and the eviction of not-yet-read data, but it intentionally keeps the feature's core semantics: consumed data is still dropped from the page cache. Deployments where another process re-reads the log files afterwards (e.g. kubelet compressing rotated container logs on Kubernetes) will still see those readers go to disk, and should set `file_cache_advise false`. Given the measurements above, it may also be worth discussing whether the option should remain enabled by default; that question is left out of this PR.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] `[N/A]` Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] `[N/A]` Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [ ] `[N/A]` Documentation required for this feature (no configuration surface change; `file_cache_advise` semantics are preserved, only the advised range is narrowed)

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management while processing tailed files on Linux.
  * Prevented incomplete pages from being discarded prematurely.
  * Added clearer error reporting when system file-advice operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->