### PR TITLE
log: make consistency for suppress log feature

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -124,6 +124,7 @@ struct flb_log {
 struct flb_log_cache_entry {
     flb_sds_t buf;
     uint64_t timestamp;
+    int interval;
     struct mk_list _head;
 };
 

--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -193,6 +193,9 @@ struct flb_log_cache_entry *flb_log_cache_exists(struct flb_log_cache *cache, ch
 struct flb_log_cache_entry *flb_log_cache_get_target(struct flb_log_cache *cache, uint64_t ts);
 
 int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, size_t msg_size);
+int flb_log_cache_check_suppress_interval(struct flb_log_cache *cache,
+                                          char *msg_buf, size_t msg_size,
+                                          int interval_seconds);
 
 
 static inline int flb_log_suppress_check(int log_suppress_interval, const char *fmt, ...)
@@ -220,7 +223,8 @@ static inline int flb_log_suppress_check(int log_suppress_interval, const char *
         return FLB_FALSE;
     }
 
-    ret = flb_log_cache_check_suppress(w->log_cache, buf, size);
+    ret = flb_log_cache_check_suppress_interval(w->log_cache, buf, size,
+                                                log_suppress_interval);
     return ret;
 }
 

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -695,7 +695,9 @@ struct flb_log_cache_entry *flb_log_cache_get_target(struct flb_log_cache *cache
  *
  * if no similar message exists, then the incoming message is added to the cache.
  */
-int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, size_t msg_size)
+int flb_log_cache_check_suppress_interval(struct flb_log_cache *cache,
+                                          char *msg_buf, size_t msg_size,
+                                          int interval_seconds)
 {
     uint64_t now = 0;
     flb_sds_t buf;
@@ -729,7 +731,7 @@ int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, siz
         return FLB_FALSE;
     }
     else {
-        if (entry->timestamp + cache->timeout > now) {
+        if (entry->timestamp + interval_seconds > now) {
             return FLB_TRUE;
         }
         else {
@@ -738,6 +740,13 @@ int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, siz
         }
     }
     return FLB_TRUE;
+}
+
+int flb_log_cache_check_suppress(struct flb_log_cache *cache,
+                                 char *msg_buf, size_t msg_size)
+{
+    return flb_log_cache_check_suppress_interval(cache, msg_buf, msg_size,
+                                                 cache->timeout);
 }
 
 int flb_log_worker_destroy(struct flb_worker *worker)

--- a/src/flb_log.c
+++ b/src/flb_log.c
@@ -676,7 +676,7 @@ struct flb_log_cache_entry *flb_log_cache_get_target(struct flb_log_cache *cache
         }
 
         /* expired entry */
-        if (entry->timestamp + cache->timeout < ts) {
+        if (entry->timestamp + entry->interval <= ts) {
             return entry;
         }
 
@@ -728,14 +728,17 @@ int flb_log_cache_check_suppress_interval(struct flb_log_cache *cache,
 
         entry->buf = buf;
         entry->timestamp = now;
+        entry->interval = interval_seconds;
         return FLB_FALSE;
     }
     else {
         if (entry->timestamp + interval_seconds > now) {
+            entry->interval = interval_seconds;
             return FLB_TRUE;
         }
         else {
             entry->timestamp = now;
+            entry->interval = interval_seconds;
             return FLB_FALSE;
         }
     }

--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -2,6 +2,7 @@
 #include <fluent-bit/flb_mem.h>
 #include <fluent-bit/flb_log.h>
 #include <fluent-bit/flb_time.h>
+#include <fluent-bit/flb_worker.h>
 #include <inttypes.h>
 
 #include "flb_tests_internal.h"
@@ -164,8 +165,62 @@ static void cache_one_slot()
     flb_log_cache_destroy(cache);
 }
 
+static void check_suppress_interval(int cache_timeout, int suppress_interval,
+                                    int message_age, int expected)
+{
+    int ret;
+    struct flb_worker worker = {0};
+    struct flb_worker *previous_worker;
+    struct flb_log_cache_entry *entry;
+
+    worker.log_cache = flb_log_cache_create(cache_timeout, 1);
+    TEST_CHECK(worker.log_cache != NULL);
+    if (!worker.log_cache) {
+        return;
+    }
+
+    previous_worker = flb_worker_get();
+    FLB_TLS_SET(flb_worker_ctx, &worker);
+
+    ret = flb_log_suppress_check(suppress_interval, TEST_RECORD_01);
+    TEST_CHECK(ret == FLB_FALSE);
+
+    entry = flb_log_cache_exists(worker.log_cache,
+                                 TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    TEST_CHECK(entry != NULL);
+    if (entry) {
+        entry->timestamp = time(NULL) - message_age;
+    }
+
+    ret = flb_log_suppress_check(suppress_interval, TEST_RECORD_01);
+    if (!TEST_CHECK(ret == expected)) {
+        TEST_MSG("cache timeout=%d, suppress interval=%d, message age=%d, "
+                 "expected=%d, actual=%d",
+                 cache_timeout, suppress_interval, message_age, expected, ret);
+    }
+
+    FLB_TLS_SET(flb_worker_ctx, previous_worker);
+    flb_log_cache_destroy(worker.log_cache);
+}
+
+static void suppress_interval_longer_than_cache_timeout()
+{
+    /* A two-second-old message is still within the configured interval. */
+    check_suppress_interval(1, 3, 2, FLB_TRUE);
+}
+
+static void suppress_interval_shorter_than_cache_timeout()
+{
+    /* A two-second-old message is outside the configured interval. */
+    check_suppress_interval(3, 1, 2, FLB_FALSE);
+}
+
 TEST_LIST = {
     { "cache_basic_timeout" , cache_basic_timeout },
     { "cache_one_slot"      , cache_one_slot      },
+    { "suppress_interval_longer_than_cache_timeout",
+      suppress_interval_longer_than_cache_timeout },
+    { "suppress_interval_shorter_than_cache_timeout",
+      suppress_interval_shorter_than_cache_timeout },
     { 0 }
 };

--- a/tests/internal/log.c
+++ b/tests/internal/log.c
@@ -14,6 +14,9 @@
 #define TEST_RECORD_02      "other type of message"
 #define TEST_RECORD_02_SIZE sizeof(TEST_RECORD_02) - 1
 
+#define TEST_RECORD_03      "third type of message"
+#define TEST_RECORD_03_SIZE sizeof(TEST_RECORD_03) - 1
+
 static int check_clock(uint64_t timeout, struct flb_time *tm_start)
 {
 	struct flb_time tm_now;
@@ -215,6 +218,60 @@ static void suppress_interval_shorter_than_cache_timeout()
     check_suppress_interval(3, 1, 2, FLB_FALSE);
 }
 
+static void suppress_interval_preserved_during_cache_replacement()
+{
+    int ret;
+    struct flb_worker worker = {0};
+    struct flb_worker *previous_worker;
+    struct flb_log_cache_entry *entry;
+
+    worker.log_cache = flb_log_cache_create(1, 2);
+    TEST_CHECK(worker.log_cache != NULL);
+    if (!worker.log_cache) {
+        return;
+    }
+
+    previous_worker = flb_worker_get();
+    FLB_TLS_SET(flb_worker_ctx, &worker);
+
+    ret = flb_log_suppress_check(3, TEST_RECORD_01);
+    TEST_CHECK(ret == FLB_FALSE);
+
+    entry = flb_log_cache_exists(worker.log_cache,
+                                 TEST_RECORD_01, TEST_RECORD_01_SIZE);
+    TEST_CHECK(entry != NULL);
+    if (entry) {
+        entry->timestamp = time(NULL) - 2;
+    }
+
+    ret = flb_log_suppress_check(1, TEST_RECORD_02);
+    TEST_CHECK(ret == FLB_FALSE);
+
+    entry = flb_log_cache_exists(worker.log_cache,
+                                 TEST_RECORD_02, TEST_RECORD_02_SIZE);
+    TEST_CHECK(entry != NULL);
+    if (entry) {
+        entry->timestamp = time(NULL) - 2;
+    }
+
+    ret = flb_log_suppress_check(3, TEST_RECORD_03);
+    TEST_CHECK(ret == FLB_FALSE);
+
+    entry = flb_log_cache_exists(worker.log_cache,
+                                 TEST_RECORD_03, TEST_RECORD_03_SIZE);
+    TEST_CHECK(entry != NULL);
+
+    entry = flb_log_cache_exists(worker.log_cache,
+                                 TEST_RECORD_02, TEST_RECORD_02_SIZE);
+    TEST_CHECK(entry == NULL);
+
+    ret = flb_log_suppress_check(3, TEST_RECORD_01);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    FLB_TLS_SET(flb_worker_ctx, previous_worker);
+    flb_log_cache_destroy(worker.log_cache);
+}
+
 TEST_LIST = {
     { "cache_basic_timeout" , cache_basic_timeout },
     { "cache_one_slot"      , cache_one_slot      },
@@ -222,5 +279,7 @@ TEST_LIST = {
       suppress_interval_longer_than_cache_timeout },
     { "suppress_interval_shorter_than_cache_timeout",
       suppress_interval_shorter_than_cache_timeout },
+    { "suppress_interval_preserved_during_cache_replacement",
+      suppress_interval_preserved_during_cache_replacement },
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed. `log_suppress_interval` now controls suppression expiry instead of the worker cache’s hard-coded timeout.

Changes:

- Added interval-aware cache checking in src/flb_log.c.
- Passed the configured interval through flb_log.h.
- Preserved the original cache API for existing callers.
- Added bidirectional regression coverage in tests/internal/log.c.

Verification:

```sh
ctest --test-dir build -R '^flb-it-log$' --output-on-failure
```

Passed: `1/1`.

The original HTTP reproduction also passed after rebuilding `fluent-bit-bin`:

```text
15:12:53.977 no upstream connections available
15:13:08.981 no upstream connections available
```

That is approximately 15 seconds, replacing the previous 10-second behavior. `git diff --check` also passed. No applicable Python integration scenario or Leaks pass exists for this internal log-cache component.

Addresses https://github.com/fluent/fluent-bit/issues/7051

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom log suppression interval for individual checks.
  * Existing suppression behavior continues to use the configured cache timeout by default.
  * Suppression intervals are tracked independently for cached messages.

* **Bug Fixes**
  * Improved suppression decisions as cached messages approach or exceed their expiration interval.
  * Ensured refreshed and replaced cache entries use the correct suppression interval.

* **Tests**
  * Added coverage for custom intervals, cache expiration, and cache replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->