### PR TITLE
out_prometheus_remote_write: Add 1-hour cut-off for expiring staled metrics

### DIFF
--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -33,6 +33,8 @@
 #include "remote_write.h"
 #include "remote_write_conf.h"
 
+#define FLB_PROMETHEUS_REMOTE_WRITE_METRIC_MAX_AGE_SECONDS 3600
+
 static int http_post(struct prometheus_remote_write_context *ctx,
                      const void *body, size_t body_len,
                      const char *tag, int tag_len)
@@ -296,6 +298,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     flb_sds_t buf = NULL;
     size_t diff = 0;
     size_t off = 0;
+    uint64_t expiration;
     struct cmt *cmt;
     struct prometheus_remote_write_context *ctx = out_context;
 
@@ -303,6 +306,9 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     ctx = out_context;
     ok = CMT_DECODE_MSGPACK_SUCCESS;
     result = FLB_OK;
+    expiration = cfl_time_now() -
+                 (FLB_PROMETHEUS_REMOTE_WRITE_METRIC_MAX_AGE_SECONDS *
+                  FLB_NSEC_IN_SEC);
 
     /* Buffer to concatenate multiple metrics contexts */
     buf = flb_sds_create_size(event_chunk->size);
@@ -319,6 +325,9 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     while ((ret = cmt_decode_msgpack_create(&cmt,
                                             (char *) event_chunk->data,
                                             event_chunk->size, &off)) == ok) {
+        /* Exclude samples that remote write backends consider stale. */
+        cmt_expire(cmt, expiration);
+
         /* append labels set by config */
         append_labels(ctx, cmt);
 


### PR DESCRIPTION
Implemented the one-hour stale-metric cutoff in remote_write.c.

Before Prometheus remote-write encoding, `cmt_expire()` now removes samples older than `cfl_time_now() - 3600 seconds`. Other metric outputs remain unchanged.

Verification:

- `cmake --build build -j8 --target flb-plugin-out_prometheus_remote_write` — passed
- `ctest --test-dir build -R '^flb-rt-in_fluentbit_metrics$' --output-on-failure` — passed
- `git diff --check` — passed
- Platform memory checker — not run; no `out_prometheus_remote_write` integration scenario currently exists (the available scenario tests the separate input plugin).


Closes https://github.com/fluent/fluent-bit/issues/11082.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excludes metrics older than one hour before sending them to the remote-write destination.
  * Prevents stale samples from being included in flushed metric data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->