### PR TITLE
in_node_exporter_metrics: Implement stat and thermal_zone for macOS

### DIFF
--- a/plugins/in_node_exporter_metrics/ne.h
+++ b/plugins/in_node_exporter_metrics/ne.h
@@ -35,7 +35,7 @@
 #ifdef __linux__
 #define NE_DEFAULT_ENABLED_METRICS "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,timex,loadavg,vmstat,netdev,netstat,sockstat,filefd,systemd,nvme,thermal_zone,hwmon,powersupplyclass"
 #elif __APPLE__
-#define NE_DEFAULT_ENABLED_METRICS "cpu,loadavg,meminfo,diskstats,filesystem,uname,netdev,powersupplyclass"
+#define NE_DEFAULT_ENABLED_METRICS "cpu,loadavg,meminfo,diskstats,filesystem,uname,stat,netdev,thermal_zone,powersupplyclass"
 #endif
 
 /* filesystem: regex for ignoring mount points and filesystem types */
@@ -102,6 +102,12 @@ struct flb_ne {
     struct cmt_gauge *darwin_swap_total_bytes;
     struct cmt_counter *darwin_total_bytes;
 
+    /* thermal_darwin */
+    struct cmt_gauge *darwin_thermal_cpu_scheduler_limit;
+    struct cmt_gauge *darwin_thermal_cpu_available;
+    struct cmt_gauge *darwin_thermal_cpu_speed_limit;
+    struct cmt_gauge *darwin_thermal_temperature;
+
     /* powersupply_darwin */
     struct cmt_gauge *darwin_ps_current_capacity;
     struct cmt_gauge *darwin_ps_max_capacity;
@@ -127,7 +133,7 @@ struct flb_ne {
     /* uname */
     struct cmt_gauge *uname;
 
-    /* stat_linux */
+    /* stat */
     struct cmt_counter *st_intr;
     struct cmt_counter *st_context_switches;
     struct cmt_gauge   *st_boot_time;

--- a/plugins/in_node_exporter_metrics/ne_stat.c
+++ b/plugins/in_node_exporter_metrics/ne_stat.c
@@ -19,6 +19,8 @@
 
 #ifdef __linux__
 #include "ne_stat_linux.c"
+#elif __APPLE__
+#include "ne_stat_darwin.c"
 #else
 
 #include "ne.h"

--- a/plugins/in_node_exporter_metrics/ne_stat_darwin.c
+++ b/plugins/in_node_exporter_metrics/ne_stat_darwin.c
@@ -1,0 +1,71 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <sys/sysctl.h>
+#include <sys/time.h>
+
+#include "ne.h"
+
+static int ne_stat_init(struct flb_ne *ctx)
+{
+    ctx->st_boot_time = cmt_gauge_create(ctx->cmt, "node", "", "boot_time_seconds",
+                                         "Unix time of last boot, including microseconds.",
+                                         0, NULL);
+    if (ctx->st_boot_time == NULL) {
+        flb_plg_error(ctx->ins, "failed to create gauge node_boot_time_seconds");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int ne_stat_update(struct flb_input_instance *ins,
+                          struct flb_config *config, void *in_context)
+{
+    int ret;
+    size_t value_size;
+    double value;
+    uint64_t ts;
+    struct timeval boot_time;
+    struct flb_ne *ctx;
+
+    (void) ins;
+    (void) config;
+
+    ctx = in_context;
+    value_size = sizeof(boot_time);
+    ret = sysctlbyname("kern.boottime", &boot_time, &value_size, NULL, 0);
+    if (ret != 0) {
+        flb_plg_error(ctx->ins, "failed to read kern.boottime");
+        return -1;
+    }
+
+    value = (double) boot_time.tv_sec + ((double) boot_time.tv_usec / 1000000.0);
+    ts = cfl_time_now();
+    cmt_gauge_set(ctx->st_boot_time, ts, value, 0, NULL);
+
+    return 0;
+}
+
+struct flb_ne_collector stat_collector = {
+    .name = "stat",
+    .cb_init = ne_stat_init,
+    .cb_update = ne_stat_update,
+    .cb_exit = NULL
+};

--- a/plugins/in_node_exporter_metrics/ne_thermalzone.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone.c
@@ -19,6 +19,8 @@
 
 #ifdef __linux__
 #include "ne_thermalzone_linux.c"
+#elif __APPLE__
+#include "ne_thermalzone_darwin.c"
 #else
 
 #include "ne.h"

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_darwin.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_darwin.c
@@ -22,7 +22,7 @@
 #include <IOKit/pwr_mgt/IOPMLib.h>
 #include <math.h>
 #include <stdint.h>
-#include <string.h>
+#include <stdio.h>
 #include <sys/sysctl.h>
 
 #include "ne.h"
@@ -219,7 +219,9 @@ static int copy_cf_string(CFStringRef source, char *destination, size_t size)
 static int update_temperatures(struct flb_ne *ctx, uint64_t timestamp)
 {
     int index;
+    int name_result;
     int temperature_count;
+    int unnamed_sensor_count;
     int32_t page;
     int32_t usage;
     double temperature;
@@ -277,11 +279,28 @@ static int update_temperatures(struct flb_ne *ctx, uint64_t timestamp)
 
     service_count = CFArrayGetCount(services);
     temperature_count = 0;
+    unnamed_sensor_count = 0;
 
     for (index = 0; index < service_count; index++) {
         service = (IOHIDServiceClientRef) CFArrayGetValueAtIndex(services, index);
         if (service == NULL) {
             continue;
+        }
+
+        name_result = -1;
+        name_ref = IOHIDServiceClientCopyProperty(service, CFSTR("Product"));
+        if (name_ref != NULL) {
+            if (CFGetTypeID(name_ref) == CFStringGetTypeID()) {
+                name_result = copy_cf_string((CFStringRef) name_ref,
+                                             sensor_name, sizeof(sensor_name));
+            }
+            CFRelease(name_ref);
+        }
+
+        if (name_result != 0) {
+            unnamed_sensor_count++;
+            snprintf(sensor_name, sizeof(sensor_name),
+                     "Unknown #%d", unnamed_sensor_count);
         }
 
         event = IOHIDServiceClientCopyEvent(service, NE_IOHID_EVENT_TYPE_TEMPERATURE,
@@ -296,15 +315,6 @@ static int update_temperatures(struct flb_ne *ctx, uint64_t timestamp)
 
         if (!isfinite(temperature) || temperature < NE_ABSOLUTE_ZERO_CELSIUS) {
             continue;
-        }
-
-        memcpy(sensor_name, "Unknown", sizeof("Unknown"));
-        name_ref = IOHIDServiceClientCopyProperty(service, CFSTR("Product"));
-        if (name_ref != NULL) {
-            if (CFGetTypeID(name_ref) == CFStringGetTypeID()) {
-                copy_cf_string((CFStringRef) name_ref, sensor_name, sizeof(sensor_name));
-            }
-            CFRelease(name_ref);
         }
 
         cmt_gauge_set(ctx->darwin_thermal_temperature, timestamp, temperature,

--- a/plugins/in_node_exporter_metrics/ne_thermalzone_darwin.c
+++ b/plugins/in_node_exporter_metrics/ne_thermalzone_darwin.c
@@ -1,0 +1,405 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/pwr_mgt/IOPM.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/sysctl.h>
+
+#include "ne.h"
+
+#if defined(__arm64__) || defined(__aarch64__)
+
+/* These temperature APIs are exported by IOKit but omitted from its public headers. */
+typedef struct __IOHIDEventSystemClient *IOHIDEventSystemClientRef;
+typedef struct __IOHIDServiceClient *IOHIDServiceClientRef;
+typedef struct __IOHIDEvent *IOHIDEventRef;
+
+#define NE_IOHID_EVENT_TYPE_TEMPERATURE 15
+#define NE_IOHID_EVENT_FIELD_BASE(type) ((type) << 16)
+#define NE_ABSOLUTE_ZERO_CELSIUS -273.15
+
+IOHIDEventSystemClientRef IOHIDEventSystemClientCreate(CFAllocatorRef allocator);
+void IOHIDEventSystemClientSetMatching(IOHIDEventSystemClientRef client,
+                                       CFDictionaryRef matching);
+CFArrayRef IOHIDEventSystemClientCopyServices(IOHIDEventSystemClientRef client);
+IOHIDEventRef IOHIDServiceClientCopyEvent(IOHIDServiceClientRef service,
+                                          int64_t type,
+                                          int32_t options,
+                                          int64_t timestamp);
+double IOHIDEventGetFloatValue(IOHIDEventRef event, int32_t field);
+CFTypeRef IOHIDServiceClientCopyProperty(IOHIDServiceClientRef service,
+                                         CFStringRef key);
+
+#endif
+
+static int read_thermal_number(CFDictionaryRef status,
+                               CFStringRef key,
+                               double *result)
+{
+    double value;
+    CFTypeRef entry;
+
+    entry = CFDictionaryGetValue(status, key);
+    if (entry == NULL || CFGetTypeID(entry) != CFNumberGetTypeID()) {
+        return -1;
+    }
+
+    if (!CFNumberGetValue((CFNumberRef) entry, kCFNumberDoubleType, &value)) {
+        return -1;
+    }
+    else if (!isfinite(value)) {
+        return -1;
+    }
+
+    *result = value;
+
+    return 0;
+}
+
+static int set_thermal_metric(struct flb_ne *ctx,
+                              struct cmt_gauge **gauge,
+                              CFDictionaryRef status,
+                              CFStringRef key,
+                              char *metric_name,
+                              char *help,
+                              uint64_t timestamp,
+                              double divisor,
+                              double minimum,
+                              double maximum)
+{
+    double value;
+
+    if (read_thermal_number(status, key, &value) != 0) {
+        return 0;
+    }
+
+    if (value < minimum || value > maximum) {
+        flb_plg_warn(ctx->ins, "ignoring invalid %s value: %f", metric_name, value);
+        return 0;
+    }
+
+    if (*gauge == NULL) {
+        *gauge = cmt_gauge_create(ctx->cmt, "node", "thermal", metric_name,
+                                  help, 0, NULL);
+    }
+
+    if (*gauge == NULL) {
+        flb_plg_error(ctx->ins, "failed to create gauge node_thermal_%s", metric_name);
+        return -1;
+    }
+
+    cmt_gauge_set(*gauge, timestamp, value / divisor, 0, NULL);
+
+    return 1;
+}
+
+static int update_cpu_power_limits(struct flb_ne *ctx, uint64_t timestamp)
+{
+    int ret;
+    int metric_count;
+    int maximum_cpu_count;
+    size_t maximum_cpu_count_size;
+    IOReturn io_ret;
+    CFDictionaryRef status;
+
+    status = NULL;
+    io_ret = IOPMCopyCPUPowerStatus(&status);
+    if (io_ret == kIOReturnNotFound) {
+        flb_plg_debug(ctx->ins, "no CPU power status has been recorded");
+        if (status != NULL) {
+            CFRelease(status);
+        }
+        return -1;
+    }
+    else if (io_ret != kIOReturnSuccess) {
+        flb_plg_error(ctx->ins, "failed to read CPU power status: 0x%08x", io_ret);
+        if (status != NULL) {
+            CFRelease(status);
+        }
+        return -1;
+    }
+    else if (status == NULL) {
+        flb_plg_error(ctx->ins, "CPU power status is empty");
+        return -1;
+    }
+
+    metric_count = 0;
+    maximum_cpu_count = INT32_MAX;
+    maximum_cpu_count_size = sizeof(maximum_cpu_count);
+    if (sysctlbyname("hw.logicalcpu_max", &maximum_cpu_count,
+                     &maximum_cpu_count_size, NULL, 0) != 0 ||
+        maximum_cpu_count < 1) {
+        maximum_cpu_count = INT32_MAX;
+    }
+
+    ret = set_thermal_metric(
+        ctx, &ctx->darwin_thermal_cpu_scheduler_limit, status,
+        CFSTR(kIOPMCPUPowerLimitSchedulerTimeKey), "cpu_scheduler_limit_ratio",
+        "Represents the percentage (0-100) of CPU time available. 100% at normal "
+        "operation. The OS may limit this time for a percentage less than 100%.",
+        timestamp, 100.0, 0.0, 100.0);
+    if (ret < 0) {
+        CFRelease(status);
+        return -1;
+    }
+    metric_count += ret;
+
+    ret = set_thermal_metric(
+        ctx, &ctx->darwin_thermal_cpu_available, status,
+        CFSTR(kIOPMCPUPowerLimitProcessorCountKey), "cpu_available_cpu",
+        "Reflects how many, if any, CPUs have been taken offline. Represented as an "
+        "integer number of CPUs (0 - Max CPUs).",
+        timestamp, 1.0, 0.0, (double) maximum_cpu_count);
+    if (ret < 0) {
+        CFRelease(status);
+        return -1;
+    }
+    metric_count += ret;
+
+    ret = set_thermal_metric(
+        ctx, &ctx->darwin_thermal_cpu_speed_limit, status,
+        CFSTR(kIOPMCPUPowerLimitProcessorSpeedKey), "cpu_speed_limit_ratio",
+        "Defines the speed & voltage limits placed on the CPU. Represented as a "
+        "percentage (0-100) of maximum CPU speed.",
+        timestamp, 100.0, 0.0, 100.0);
+    if (ret < 0) {
+        CFRelease(status);
+        return -1;
+    }
+    metric_count += ret;
+
+    CFRelease(status);
+
+    if (metric_count == 0) {
+        flb_plg_debug(ctx->ins, "CPU power status contains no supported values");
+        return -1;
+    }
+
+    return 0;
+}
+
+#if defined(__arm64__) || defined(__aarch64__)
+
+static int copy_cf_string(CFStringRef source, char *destination, size_t size)
+{
+    Boolean result;
+
+    if (source == NULL || destination == NULL || size == 0) {
+        return -1;
+    }
+
+    result = CFStringGetCString(source, destination, size, kCFStringEncodingUTF8);
+    if (!result || destination[0] == '\0') {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int update_temperatures(struct flb_ne *ctx, uint64_t timestamp)
+{
+    int index;
+    int temperature_count;
+    int32_t page;
+    int32_t usage;
+    double temperature;
+    CFIndex service_count;
+    CFTypeRef name_ref;
+    CFNumberRef page_number;
+    CFNumberRef usage_number;
+    CFArrayRef services;
+    CFDictionaryRef matching;
+    IOHIDEventRef event;
+    IOHIDServiceClientRef service;
+    IOHIDEventSystemClientRef client;
+    const void *keys[2];
+    const void *values[2];
+    char sensor_name[4096];
+
+    page = 0xff00;
+    usage = 5;
+    page_number = NULL;
+    usage_number = NULL;
+    matching = NULL;
+    services = NULL;
+
+    client = IOHIDEventSystemClientCreate(kCFAllocatorDefault);
+    if (client == NULL) {
+        flb_plg_debug(ctx->ins, "failed to create HID event system client");
+        return -1;
+    }
+
+    page_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &page);
+    usage_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &usage);
+    if (page_number == NULL || usage_number == NULL) {
+        flb_plg_error(ctx->ins, "failed to create HID temperature matching values");
+        goto error;
+    }
+
+    keys[0] = CFSTR("PrimaryUsagePage");
+    keys[1] = CFSTR("PrimaryUsage");
+    values[0] = page_number;
+    values[1] = usage_number;
+    matching = CFDictionaryCreate(kCFAllocatorDefault, keys, values, 2,
+                                  &kCFTypeDictionaryKeyCallBacks,
+                                  &kCFTypeDictionaryValueCallBacks);
+    if (matching == NULL) {
+        flb_plg_error(ctx->ins, "failed to create HID temperature matching dictionary");
+        goto error;
+    }
+
+    IOHIDEventSystemClientSetMatching(client, matching);
+    services = IOHIDEventSystemClientCopyServices(client);
+    if (services == NULL) {
+        flb_plg_debug(ctx->ins, "no HID temperature sensor services found");
+        goto error;
+    }
+
+    service_count = CFArrayGetCount(services);
+    temperature_count = 0;
+
+    for (index = 0; index < service_count; index++) {
+        service = (IOHIDServiceClientRef) CFArrayGetValueAtIndex(services, index);
+        if (service == NULL) {
+            continue;
+        }
+
+        event = IOHIDServiceClientCopyEvent(service, NE_IOHID_EVENT_TYPE_TEMPERATURE,
+                                            0, 0);
+        if (event == NULL) {
+            continue;
+        }
+
+        temperature = IOHIDEventGetFloatValue(
+            event, NE_IOHID_EVENT_FIELD_BASE(NE_IOHID_EVENT_TYPE_TEMPERATURE));
+        CFRelease(event);
+
+        if (!isfinite(temperature) || temperature < NE_ABSOLUTE_ZERO_CELSIUS) {
+            continue;
+        }
+
+        memcpy(sensor_name, "Unknown", sizeof("Unknown"));
+        name_ref = IOHIDServiceClientCopyProperty(service, CFSTR("Product"));
+        if (name_ref != NULL) {
+            if (CFGetTypeID(name_ref) == CFStringGetTypeID()) {
+                copy_cf_string((CFStringRef) name_ref, sensor_name, sizeof(sensor_name));
+            }
+            CFRelease(name_ref);
+        }
+
+        cmt_gauge_set(ctx->darwin_thermal_temperature, timestamp, temperature,
+                      1, (char *[]) {sensor_name});
+        temperature_count++;
+    }
+
+    CFRelease(services);
+    CFRelease(matching);
+    CFRelease(usage_number);
+    CFRelease(page_number);
+    CFRelease(client);
+
+    if (temperature_count == 0) {
+        flb_plg_debug(ctx->ins, "HID temperature services returned no valid readings");
+        return -1;
+    }
+
+    return 0;
+
+error:
+    if (services != NULL) {
+        CFRelease(services);
+    }
+    if (matching != NULL) {
+        CFRelease(matching);
+    }
+    if (usage_number != NULL) {
+        CFRelease(usage_number);
+    }
+    if (page_number != NULL) {
+        CFRelease(page_number);
+    }
+    CFRelease(client);
+
+    return -1;
+}
+
+#else
+
+static int update_temperatures(struct flb_ne *ctx, uint64_t timestamp)
+{
+    (void) ctx;
+    (void) timestamp;
+
+    return -1;
+}
+
+#endif
+
+static int ne_thermalzone_init(struct flb_ne *ctx)
+{
+    ctx->darwin_thermal_cpu_scheduler_limit = NULL;
+    ctx->darwin_thermal_cpu_available = NULL;
+    ctx->darwin_thermal_cpu_speed_limit = NULL;
+
+    ctx->darwin_thermal_temperature = cmt_gauge_create(
+        ctx->cmt, "node", "thermal", "temperature_celsius",
+        "Temperature of the thermal sensor in Celsius.",
+        1, (char *[]) {"sensor"});
+    if (ctx->darwin_thermal_temperature == NULL) {
+        flb_plg_error(ctx->ins, "failed to create gauge node_thermal_temperature_celsius");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int ne_thermalzone_update(struct flb_input_instance *ins,
+                                 struct flb_config *config, void *in_context)
+{
+    int power_limit_result;
+    int temperature_result;
+    uint64_t timestamp;
+    struct flb_ne *ctx;
+
+    (void) ins;
+    (void) config;
+
+    ctx = in_context;
+    timestamp = cfl_time_now();
+
+    power_limit_result = update_cpu_power_limits(ctx, timestamp);
+    temperature_result = update_temperatures(ctx, timestamp);
+
+    if (power_limit_result != 0 && temperature_result != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+struct flb_ne_collector thermalzone_collector = {
+    .name = "thermal_zone",
+    .cb_init = ne_thermalzone_init,
+    .cb_update = ne_thermalzone_update,
+    .cb_exit = NULL
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

Implemented the stricter macOS path for collecting stat and thermal_zone.

Key behavior:

- `thermal_zone` now enumerates Apple Silicon HID temperature sensors and emits:
  `node_thermal_temperature_celsius{sensor="..."}`
- Temperature collection continues even when `IOPMCopyCPUPowerStatus` returns `kIOReturnNotFound`, which Apple documents as valid behavior when power-limit data is unpublished. [[Apple documentation](https://developer.apple.com/documentation/iokit/1557079-iopmcopycpupowerstatus)](https://developer.apple.com/documentation/iokit/1557079-iopmcopycpupowerstatus)
- Legacy CPU limit gauges are created only after valid values are received, eliminating the epoch-zero placeholder metrics.
- Values are type/range/finite checked; physically impossible temperatures are ignored.
- Successful values are retained on later failures. No metric expiration was added.
- Collector succeeds if either legacy power limits or temperature sensors return valid information.
- Boot time remains under the `stat` collector; no separate boottime module exists.

Current node_exporter recently added the same Apple Silicon HID sensor mechanism, although our implementation additionally avoids letting the unsupported legacy call block temperature collection. [[node_exporter changelog](https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md)](https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md), [[known M3 failure](https://github.com/prometheus/node_exporter/issues/2906)](https://github.com/prometheus/node_exporter/issues/2906)

Observed output now includes real readings:

```text
node_boot_time_seconds = 1785842396.5451341
node_thermal_temperature_celsius{sensor="gas gauge battery"} = 32
node_thermal_temperature_celsius{sensor="PMU tdie7"} = 46.28
node_thermal_temperature_celsius{sensor="NAND CH0 temp"} = 37
```

Verification passed:

- `cmake --build build -j8 --target flb-plugin-in_node_exporter_metrics fluent-bit-bin`
- Direct `stat,thermal_zone` end-to-end collection on Apple Silicon
- macOS Leaks using the focused self-exiting Fluent Bit run: `0 leaks for 0 total leaked bytes`
- `git diff --check`

There is no dedicated `node_exporter_metrics` integration scenario in this repository, so the focused binary invocation was used instead.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change

```
$ bin/fluent-bit -i node_exporter_metrics -pmetrics=stat,thermal_zone -o stdout -v
```

- [x] Debug log output from testing the change

```
Fluent Bit v5.1.1
* Copyright (C) 2015-2026 The Fluent Bit Authors
* Fluent Bit is a CNCF graduated project under the Fluent organization
* https://fluentbit.io

______ _                  _    ______ _ _           _____  __  
|  ___| |                | |   | ___ (_) |         |  ___|/  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   _|___ \ `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \ | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V //\__/ /_| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)___/


[2026/08/26 19:15:34.967] [ info] Configuration:
[2026/08/26 19:15:34.967] [ info]  flush time     | 1.000000 seconds
[2026/08/26 19:15:34.967] [ info]  grace          | 5 seconds
[2026/08/26 19:15:34.967] [ info]  daemon         | 0
[2026/08/26 19:15:34.967] [ info] ___________
[2026/08/26 19:15:34.967] [ info]  inputs:
[2026/08/26 19:15:34.967] [ info]      node_exporter_metrics
[2026/08/26 19:15:34.967] [ info] ___________
[2026/08/26 19:15:34.967] [ info]  filters:
[2026/08/26 19:15:34.967] [ info] ___________
[2026/08/26 19:15:34.967] [ info]  outputs:
[2026/08/26 19:15:34.967] [ info]      stdout.0
[2026/08/26 19:15:34.967] [ info] ___________
[2026/08/26 19:15:34.967] [ info]  collectors:
[2026/08/26 19:15:34.967] [ info] [fluent bit] version=5.1.1, commit=3713988105, pid=90898
[2026/08/26 19:15:34.967] [debug] [engine] coroutine stack size: 65536 bytes (64.0K)
[2026/08/26 19:15:34.967] [ info] [storage] ver=1.4.0, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2026/08/26 19:15:34.967] [ info] [simd    ] NEON
[2026/08/26 19:15:34.967] [ info] [cmetrics] version=2.2.1
[2026/08/26 19:15:34.967] [ info] [ctraces ] version=0.7.1
[2026/08/26 19:15:34.967] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] initializing
[2026/08/26 19:15:34.967] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] storage_strategy='memory' (memory only)
[2026/08/26 19:15:34.967] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.rootfs = /
[2026/08/26 19:15:34.967] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.procfs = /proc
[2026/08/26 19:15:34.967] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] path.sysfs  = /sys
[2026/08/26 19:15:34.967] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics stat
[2026/08/26 19:15:34.968] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] no CPU power status has been recorded
[2026/08/26 19:15:35.058] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] enabled metrics thermal_zone
[2026/08/26 19:15:35.058] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] [thread init] initialization OK
[2026/08/26 19:15:35.058] [ info] [input:node_exporter_metrics:node_exporter_metrics.0] thread instance initialized
[2026/08/26 19:15:35.058] [debug] [node_exporter_metrics:node_exporter_metrics.0] created event channels: read=33 write=34
[2026/08/26 19:15:35.058] [debug] [stdout:stdout.0] created event channels: read=37 write=38
[2026/08/26 19:15:35.058] [ info] [output:stdout:stdout.0] worker #0 started
[2026/08/26 19:15:35.058] [ info] [sp] stream processor started
[2026/08/26 19:15:35.058] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2026/08/26 19:15:40.060] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] no CPU power status has been recorded
[2026/08/26 19:15:41.060] [debug] [task] created task=0xbcf0bc300 id=0 OK
[2026/08/26 19:15:41.060] [debug] [output:stdout:stdout.0] task_id=0 assigned to thread #0
2026-08-26T10:15:40.060468260Z node_boot_time_seconds = 1785842396.5451341
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="gas gauge battery"} = 31
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie7"} = 40.20751953125
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie14"} = 39.407928466796875
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie10"} = 38.928176879882812
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie2"} = 39.168045043945312
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tcal"} = 51.82000732421875
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie9"} = 39.567840576171875
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie4"} = 38.848220825195312
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie8"} = 40.607315063476562
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie3"} = 39.088088989257812
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie11"} = 39.487884521484375
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie5"} = 40.047592163085938
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie13"} = 39.487884521484375
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie6"} = 40.047592163085938
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie12"} = 39.407928466796875
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="NAND CH0 temp"} = 36
2026-08-26T10:15:40.060508177Z node_thermal_temperature_celsius{sensor="PMU tdie1"} = 39.327972412109375
[2026/08/26 19:15:41.061] [debug] [output:stdout:stdout.0] cmt decode msgpack returned : 1
[2026/08/26 19:15:41.061] [debug] [out flush] cb_destroy coro_id=0
[2026/08/26 19:15:41.062] [debug] [task] destroy task=0xbcf0bc300 (task_id=0)
[2026/08/26 19:15:41] [engine] caught signal (SIGTERM)
[2026/08/26 19:15:41.339] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread pause instance
[2026/08/26 19:15:41.339] [ info] [output:stdout:stdout.0] thread worker #0 stopping...
[2026/08/26 19:15:41.339] [ info] [output:stdout:stdout.0] thread worker #0 stopped
[2026/08/26 19:15:41.339] [debug] [input:node_exporter_metrics:node_exporter_metrics.0] thread exit instance
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

This is not valgrind but macOS provides leaks command instead:

```
Process 90898 is not debuggable. Due to security restrictions, leaks can only show or save contents of readonly memory of restricted processes.

Process:         fluent-bit [90898]
Path:            /Users/USER/*/fluent-bit
Load Address:    0x104184000
Identifier:      fluent-bit
Version:         0
Code Type:       ARM64
Platform:        macOS
Parent Process:  leaks [90897]
Target Type:     live task

Date/Time:       2026-08-26 19:15:41.344 +0900
Launch Time:     2026-08-26 19:15:34.914 +0900
OS Version:      macOS 26.5.2 (25F84)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         8880K
Physical footprint (peak):  8993K
Idle exit:                  untracked
----

leaks Report Version: 4.0, multi-line stacks
Process 90898: 1503 nodes malloced for 239 KB
Process 90898: 0 leaks for 0 total leaked bytes.

[2026/08/26 19:15:42] [engine] caught signal (SIGCONT)
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS support for `stat` metrics, including system boot time.
  * Added macOS thermal-zone metrics for CPU availability, scheduler limits, speed limits, and temperature.
  * ARM64 Macs now report temperature readings from supported sensors.
* **Improvements**
  * Enabled `stat` and `thermal_zone` metrics by default on macOS.
  * Standardized the statistics section label to `stat`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->