### PR TITLE
tests: runtime: Fix errors of incompatible types for in_ebpf tests

### DIFF
--- a/tests/runtime/in_ebpf_exec_handler.c
+++ b/tests/runtime/in_ebpf_exec_handler.c
@@ -141,7 +141,7 @@ static void verify_decoded_values(struct flb_log_event *event,
             seen_argv = FLB_TRUE;
             TEST_CHECK(kv->val.type == MSGPACK_OBJECT_STR);
             TEST_CHECK(kv->val.via.str.size ==
-                       strlen(original->details.execve.argv));
+                       strlen(original->details.execve.argv[0]));
             TEST_CHECK(strncmp(kv->val.via.str.ptr,
                                original->details.execve.argv[0],
                                kv->val.via.str.size) == 0);

--- a/tests/runtime/in_ebpf_sched_handler.c
+++ b/tests/runtime/in_ebpf_sched_handler.c
@@ -86,7 +86,7 @@ static int key_matches(msgpack_object key, const char *str)
 }
 
 static void verify_decoded_values(struct flb_log_event *event,
-                                  const struct event *original)
+                                  const struct sched_sample *original)
 {
     msgpack_object_kv *kv;
     int i;
@@ -102,16 +102,16 @@ static void verify_decoded_values(struct flb_log_event *event,
             TEST_CHECK(strncmp(kv->val.via.str.ptr, "sched", kv->val.via.str.size) == 0);
         }
         else if (key_matches(kv->key, "cpu")) {
-            TEST_CHECK(kv->val.via.u64 == original->details.sched.cpu);
+            TEST_CHECK(kv->val.via.u64 == original->details.cpu);
         }
         else if (key_matches(kv->key, "prev_pid")) {
-            TEST_CHECK(kv->val.via.u64 == original->details.sched.prev_pid);
+            TEST_CHECK(kv->val.via.u64 == original->details.prev_pid);
         }
         else if (key_matches(kv->key, "next_pid")) {
-            TEST_CHECK(kv->val.via.u64 == original->details.sched.next_pid);
+            TEST_CHECK(kv->val.via.u64 == original->details.next_pid);
         }
         else if (key_matches(kv->key, "runq_latency_ns")) {
-            TEST_CHECK(kv->val.via.u64 == original->details.sched.runq_latency_ns);
+            TEST_CHECK(kv->val.via.u64 == original->details.runq_latency_ns);
         }
     }
 }
@@ -120,26 +120,26 @@ void test_sched_event_encoding()
 {
     struct test_context *ctx;
     struct flb_log_event log_event;
-    struct event test_event;
+    struct sched_sample test_event;
     int ret;
 
     ctx = init_test_context();
     TEST_CHECK(ctx != NULL);
 
-    memset(&test_event, 0, sizeof(struct event));
+    memset(&test_event, 0, sizeof(struct sched_sample));
     test_event.type = EVENT_TYPE_SCHED;
     test_event.common.pid = 4321;
     test_event.common.tid = 4321;
     memcpy(test_event.common.comm, "sched_test", strlen("sched_test"));
 
-    test_event.details.sched.prev_pid = 1111;
-    test_event.details.sched.prev_prio = 120;
-    test_event.details.sched.prev_state = 1;
-    test_event.details.sched.next_pid = 4321;
-    test_event.details.sched.next_prio = 90;
-    test_event.details.sched.cpu = 3;
-    test_event.details.sched.runq_latency_ns = 125000;
-    test_event.details.sched.wakeup_tracked = 1;
+    test_event.details.prev_pid = 1111;
+    test_event.details.prev_prio = 120;
+    test_event.details.prev_state = 1;
+    test_event.details.next_pid = 4321;
+    test_event.details.next_prio = 90;
+    test_event.details.cpu = 3;
+    test_event.details.runq_latency_ns = 125000;
+    test_event.details.wakeup_tracked = 1;
 
     ret = encode_sched_event(ctx->event_ctx.log_encoder, &test_event);
     TEST_CHECK(ret == 0);


### PR DESCRIPTION
<!-- Provide summary of changes -->
This error was occurred in Ubuntu 26.04 (Resolute Raccoon).
Ubuntu Reolute's gcc is now gcc-15!!!

```
% gcc --version
gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## Summary

Two compile errors in the `in_ebpf` runtime tests, both type mismatches against the plugin's event structs. Both fixed and verified.

**1. `strlen` on a 2D array — tests/runtime/in_ebpf_exec_handler.c:144**

`struct execve_event.argv` is `char argv[EXECVE_ARG_MAX][EXECVE_ARG_LEN]` plugins/in_ebpf/traces/includes/common/events.h:71, so bare `.argv` decays to `char (*)[256]`, not `char *`. The adjacent `strncmp` already indexed `argv[0]`; only the `strlen` was missing it.

```c
strlen(original->details.execve.argv[0])
```

**2. Wrong struct passed to `encode_sched_event` — tests/runtime/in_ebpf_sched_handler.c, tests/runtime/in_ebpf_sched_handler.c**

The sched handler takes the compact `struct sched_sample` plugins/in_ebpf/traces/includes/common/events.h — flat `{type, common, sched_event details}` — not the tagged-union `struct event`. Switched the test to `sched_sample`, which also meant `details.sched.X` → `details.X`:

- `verify_decoded_values` signature (line 89)
- field reads in the verify loop (lines 104–115)
- `test_event` declaration + `memset` size (lines 123, 129)
- field writes (lines 135–142)

**Verification**

Swept all seven `in_ebpf_*_handler` tests for the same mismatch class rather than just the two reported. All compile clean and pass:

```
bind PASS · exec PASS · malloc PASS · openssl PASS · sched PASS · signal PASS · tcp PASS
```

**Left alone:** `-Wdiscarded-qualifiers` warnings at handler.c, plugins/in_ebpf/traces/exec/handler.c — `flb_log_event_encoder_append_cstring` takes `char *` while the handler passes `const char *`. Pre-existing, warnings only, unrelated to either error.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated runtime validation for exec events to check the first command-line argument.
  * Updated scheduler event tests to use the current event structure and field layout.
  * Preserved coverage for CPU, process, and other scheduler-specific event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->