### PR TITLE
wamrc: Build with LLVM-17

### DIFF
--- a/src/wamrc/CMakeLists.txt
+++ b/src/wamrc/CMakeLists.txt
@@ -173,6 +173,11 @@ if (LLVM_FOUND)
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+  # LLVM 16 and later require C++17 to consume their headers.
+  if (LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL 16)
+    set (CMAKE_CXX_STANDARD 17)
+  endif ()
+
   set (WAMR_ROOT_DIR ../../${FLB_PATH_LIB_WASM_MICRO_RUNTIME})
   set (SHARED_DIR ${WAMR_ROOT_DIR}/core/shared)
   set (IWASM_DIR ${WAMR_ROOT_DIR}/core/iwasm)
@@ -224,10 +229,35 @@ if (LLVM_FOUND)
     ${IWASM_INTERP_SOURCE}
     ${IWASM_AOT_SOURCE})
   add_library (aotclib-static STATIC ${IWASM_COMPL_SOURCE})
+
+  # LLVM 17 and older headers don't compile with GCC 14+ when assertions are
+  # enabled: the assert() in llvm::cast_if_present<> instantiates
+  # isa<llvm::Metadata>() and fails with
+  # "'classof' is not a member of 'llvm::Metadata'".
+  # Keep this narrowed to the affected compiler so that debug builds elsewhere
+  # keep their assertions.
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+      AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14
+      AND LLVM_PACKAGE_VERSION VERSION_LESS 18)
+    target_compile_definitions (aotclib-static
+      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:NDEBUG>)
+  endif ()
   add_executable (flb-wamrc-bin ${WAMR_ROOT_DIR}/wamr-compiler/main.c)
 
+  # Debian/Ubuntu's llvm-<N>-dev packages export the omptarget imported targets
+  # in LLVM_AVAILABLE_LIBS although their shared objects are shipped by the
+  # libomp-<N>-dev package, which may not be installed. Linking against them
+  # then breaks the build with:
+  #
+  #   No rule to make target '/usr/lib/llvm-17/lib/libomptarget.so.17',
+  #   needed by 'bin/flb-wamrc'
+  #
+  # wamrc doesn't need them, so drop them.
+  set (FLB_WAMRC_LLVM_LIBS ${LLVM_AVAILABLE_LIBS})
+  list (FILTER FLB_WAMRC_LLVM_LIBS EXCLUDE REGEX "^omptarget")
+
   if (NOT MSVC)
-    target_link_libraries (flb-wamrc-bin aotclib-static vmlib-wamrc-static LLVMDemangle ${LLVM_AVAILABLE_LIBS} ${lib_ubsan}
+    target_link_libraries (flb-wamrc-bin aotclib-static vmlib-wamrc-static LLVMDemangle ${FLB_WAMRC_LLVM_LIBS} ${lib_ubsan}
       -lm -lpthread ${lib_lldb} ${UV_A_LIBS})
     if (MINGW)
       target_link_libraries (flb-wamrc-bin -lssp -lWs2_32)
@@ -235,7 +265,7 @@ if (LLVM_FOUND)
       target_link_libraries (flb-wamrc-bin -ldl)
     endif()
   else()
-    target_link_libraries (flb-wamrc-bin aotclib-static vmlib-wamrc-static  ${lib_lldb} ${LLVM_AVAILABLE_LIBS} ${lib_ubsan}
+    target_link_libraries (flb-wamrc-bin aotclib-static vmlib-wamrc-static  ${lib_lldb} ${FLB_WAMRC_LLVM_LIBS} ${lib_ubsan}
       ${UV_A_LIBS})
   endif()
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Ubuntu 26.04 (Resolute Racoon) does not provide to install llvm-15. So, I adopted to build with llvm-17.

Minimal exclusion works and the binary runs. Tidying the comment to match:

Simplified. Three version-gated hunks, verified by a clean rebuild — `wamrc 2.4.1`, no shared `libLLVM` in `DT_NEEDED`.

You committed the intermediate version as `ff8382463`; the working tree now amends it in two places.

## 1. C++17 only where it's needed

Moved out of the unconditional header (line 11 stays at `14`) into the `LLVM_FOUND` block, gated on LLVM ≥ 16 — LLVM 15 headers build fine at C++14, 16+ require 17.

```cmake
  if (LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL 16)
    set (CMAKE_CXX_STANDARD 17)
  endif ()
```

## 2. Library filter narrowed to just `omptarget`

The `^LLVM.` include-regex in `ff8382463` builds, but the binary **aborts at startup**:

```
: CommandLine Error: Option 'verify-dom-info' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```

Dropping `LTO`/`Remarks`/`Polly`/`LLVM` reshuffles the link line enough that `--as-needed` *keeps* `libLLVM-17.so.1` (pulled in transitively via `LLVMDebuginfod`, whose `INTERFACE_LINK_LIBRARIES` is `CURL::libcurl;LLVM`) alongside the static components — so LLVM's cl::opt registry gets populated twice. Excluding only the genuinely-missing targets leaves the link order intact and `--as-needed` drops `libLLVM` entirely:

```cmake
  set (FLB_WAMRC_LLVM_LIBS ${LLVM_AVAILABLE_LIBS})
  list (FILTER FLB_WAMRC_LLVM_LIBS EXCLUDE REGEX "^omptarget")
```

Also correcting something I got wrong earlier: I reported `Polly` as missing. `libPolly.a` and `libPollyISL.a` are both present — `omptarget*` are the only actually-missing entries, which is why the one-line exclusion is sufficient.

## 3. NDEBUG guard

Kept, but reduced to a single LLVM-version clause (covers 15 and 17):

```cmake
  if (LLVM_PACKAGE_VERSION VERSION_LESS 18)
    target_compile_definitions (aotclib-static
      PRIVATE $<$<COMPILE_LANGUAGE:CXX>:NDEBUG>)
  endif ()
```

`list(FILTER)` needs CMake 3.6; the project requires 3.12, so that's fine.

One caveat on the LLVM 15 claim: `llvm-15-dev` has no install candidate on this box, so I could only build against LLVM 17 and probe the export-list shape against LLVM 21. Debian/Ubuntu's `llvm-15-dev` exports the same `omptarget` targets, so the filter applies there too — but LLVM 15 is untested end-to-end here. If CI covers it, that's the place it'll show.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer LLVM and GCC toolchains.
  * Prevented unsupported OpenMP target libraries from being included during linking.
  * Resolved build failures caused by debug assertions in older LLVM configurations.

* **Build Improvements**
  * Updated compilation to use C++17 with LLVM 16 and newer.
  * Improved build consistency across supported compiler environments, including MSVC and GNU toolchains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->