### PR TITLE
out_gcs: add unify_tag option to buffer all tags into one file

### DIFF
--- a/plugins/out_gcs/gcs.c
+++ b/plugins/out_gcs/gcs.c
@@ -1362,6 +1362,8 @@ static void cb_gcs_flush(struct flb_event_chunk *event_chunk, struct flb_output_
 {
     struct flb_gcs *ctx = out_context;
     flb_sds_t payload;
+    flb_sds_t tag_name = NULL;
+    int tag_name_len;
     int ret;
     struct gcs_file *chunk;
 
@@ -1378,20 +1380,29 @@ static void cb_gcs_flush(struct flb_event_chunk *event_chunk, struct flb_output_
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    chunk = gcs_store_file_get(ctx, event_chunk->tag, flb_sds_len(event_chunk->tag));
-    if (gcs_store_buffer_put(ctx, chunk, event_chunk->tag, flb_sds_len(event_chunk->tag),
+    if (ctx->unify_tag == FLB_TRUE) {
+        tag_name = ctx->unify_tag_name;
+        tag_name_len = flb_sds_len(ctx->unify_tag_name);
+    }
+    else {
+        tag_name = event_chunk->tag;
+        tag_name_len = flb_sds_len(event_chunk->tag);
+    }
+
+    chunk = gcs_store_file_get(ctx, tag_name, tag_name_len);
+    if (gcs_store_buffer_put(ctx, chunk, tag_name, tag_name_len,
                              payload, flb_sds_len(payload)) == -1) {
         flb_sds_destroy(payload);
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
     flb_sds_destroy(payload);
 
-    chunk = gcs_store_file_get(ctx, event_chunk->tag, flb_sds_len(event_chunk->tag));
+    chunk = gcs_store_file_get(ctx, tag_name, tag_name_len);
     if (!chunk) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    ret = add_to_queue(ctx, chunk, event_chunk->tag, flb_sds_len(event_chunk->tag));
+    ret = add_to_queue(ctx, chunk, tag_name, tag_name_len);
     if (ret == -1) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
     }
@@ -1531,6 +1542,16 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "compression", "none",
      0, FLB_FALSE, 0,
      "Compression: none or gzip."
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "unify_tag", "false",
+     0, FLB_TRUE, offsetof(struct flb_gcs, unify_tag),
+     "Unify all tags into a single buffer file (disables per-tag buffering)."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "unify_tag_name", "fluent-bit-buffer-file-unify-tag.log",
+     0, FLB_TRUE, offsetof(struct flb_gcs, unify_tag_name),
+     "Buffer file tag used when unify_tag is enabled."
     },
     {0}
 };

--- a/plugins/out_gcs/gcs.h
+++ b/plugins/out_gcs/gcs.h
@@ -98,6 +98,9 @@ struct flb_gcs {
     int timer_ms;
 
     struct flb_gcs_oauth_credentials *oauth_credentials;
+
+    int unify_tag;
+    flb_sds_t unify_tag_name;
 };
 
 int gcs_jwt_encode(struct flb_gcs *ctx, char *payload, char *secret,

--- a/tests/runtime/out_gcs.c
+++ b/tests/runtime/out_gcs.c
@@ -390,6 +390,167 @@ void flb_test_gcs_shutdown_preserves_pending_upload(void)
     flb_free(store_dir);
 }
 
+void flb_test_gcs_unify_tag_buffers_multiple_tags(void)
+{
+    int ret;
+    int i;
+    flb_ctx_t *ctx;
+    int in_a;
+    int in_b;
+    int out_ffd;
+    char *store_dir;
+    char *buf;
+    size_t buf_size;
+    flb_sds_t content;
+    struct flb_output_instance *out_ins;
+    struct flb_gcs *gcs_ctx;
+    struct gcs_file *chunk_unify;
+    int found_a = FLB_FALSE;
+    int found_b = FLB_FALSE;
+    const char *unify_tag = "unified-test-key";
+    const char *rec_a = "[1448403340, {\"src\": \"unify-marker-a\"}]";
+    const char *rec_b = "[1448403340, {\"src\": \"unify-marker-b\"}]";
+
+    store_dir = create_test_store_directory("/flb-gcs-test-unify-tag-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_a = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_a >= 0);
+    flb_input_set(ctx, in_a, "tag", "kube.a", NULL);
+
+    in_b = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_b >= 0);
+    flb_input_set(ctx, in_b, "tag", "kube.b", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "unify_tag", "true", NULL);
+    flb_output_set(ctx, out_ffd, "unify_tag_name", "unified-test-key", NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+    /* keep chunks buffered so the merged result can be inspected */
+    flb_output_set(ctx, out_ffd, "upload_timeout", "60m", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    out_ins = flb_output_get_instance(ctx->config, out_ffd);
+    TEST_CHECK(out_ins != NULL);
+    gcs_ctx = out_ins ? out_ins->context : NULL;
+    TEST_CHECK(gcs_ctx != NULL);
+
+    flb_lib_push(ctx, in_a, (char *) rec_a, (int) strlen(rec_a));
+    flb_lib_push(ctx, in_b, (char *) rec_b, (int) strlen(rec_b));
+
+    /*
+     * Wait (bounded) until both records are present in the single unified
+     * buffer chunk. Distinct markers prove both inputs were processed and
+     * merged, rather than a single record satisfying the check.
+     */
+    for (i = 0; gcs_ctx && i < 10 && !(found_a && found_b); i++) {
+        sleep(1);
+        chunk_unify = gcs_store_file_get(gcs_ctx, (char *) unify_tag,
+                                         strlen(unify_tag));
+        if (!chunk_unify) {
+            continue;
+        }
+        buf = NULL;
+        buf_size = 0;
+        if (gcs_store_file_read(gcs_ctx, chunk_unify, &buf, &buf_size) != 0 || !buf) {
+            continue;
+        }
+        content = flb_sds_create_len(buf, buf_size);
+        if (content) {
+            found_a = strstr(content, "unify-marker-a") != NULL;
+            found_b = strstr(content, "unify-marker-b") != NULL;
+            flb_sds_destroy(content);
+        }
+        flb_free(buf);
+    }
+
+    if (gcs_ctx) {
+        TEST_CHECK(gcs_ctx->unify_tag == FLB_TRUE);
+
+        TEST_CHECK_(gcs_store_file_get(gcs_ctx, "kube.a", 6) == NULL,
+                    "expected no per-tag chunk for kube.a");
+        TEST_CHECK_(gcs_store_file_get(gcs_ctx, "kube.b", 6) == NULL,
+                    "expected no per-tag chunk for kube.b");
+        TEST_CHECK_(found_a, "record from kube.a missing from unified buffer");
+        TEST_CHECK_(found_b, "record from kube.b missing from unified buffer");
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
+void flb_test_gcs_unify_tag_disabled_by_default(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+    char *store_dir;
+    struct flb_output_instance *out_ins;
+    struct flb_gcs *gcs_ctx;
+
+    store_dir = create_test_store_directory("/flb-gcs-test-no-unify-tag-XXXXXX");
+    TEST_CHECK(store_dir != NULL);
+    if (!store_dir) {
+        return;
+    }
+
+    setenv("FLB_GCS_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "gcs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+    flb_output_set(ctx, out_ffd, "bucket", "fluent", NULL);
+    flb_output_set(ctx, out_ffd, "google_service_credentials", SERVICE_CREDENTIALS, NULL);
+    flb_output_set(ctx, out_ffd, "store_dir", store_dir, NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    out_ins = flb_output_get_instance(ctx->config, out_ffd);
+    TEST_CHECK(out_ins != NULL);
+    gcs_ctx = out_ins ? out_ins->context : NULL;
+    TEST_CHECK(gcs_ctx != NULL);
+
+    if (gcs_ctx) {
+        TEST_CHECK(gcs_ctx->unify_tag == FLB_FALSE);
+    }
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    unsetenv("FLB_GCS_PLUGIN_UNDER_TEST");
+    unsetenv("TEST_GCS_UploadObject_CALL_COUNT");
+    unsetenv("TEST_GCS_LAST_URI");
+    unsetenv("TEST_GCS_LAST_BODY_GZIP");
+    flb_free(store_dir);
+}
+
 TEST_LIST = {
     {"jwt_signing", flb_test_gcs_jwt_signing},
     {"uri_encode_object_name", flb_test_gcs_uri_encode_object_name},
@@ -399,5 +560,7 @@ TEST_LIST = {
     {"accepts_extra_credential_fields", flb_test_gcs_accepts_extra_credential_fields},
     {"upload_error", flb_test_gcs_upload_error},
     {"shutdown_preserves_pending_upload", flb_test_gcs_shutdown_preserves_pending_upload},
+    {"unify_tag_buffers_multiple_tags", flb_test_gcs_unify_tag_buffers_multiple_tags},
+    {"unify_tag_disabled_by_default", flb_test_gcs_unify_tag_disabled_by_default},
     {NULL, NULL}
 };


### PR DESCRIPTION
## Summary

Adds a `unify_tag` option to the `out_gcs` output plugin.

By default `out_gcs` buffers by tag: each distinct tag gets its own buffer file and is uploaded as its own object. In environments where every source has a unique tag (for example one tag per Kubernetes container), this produces many small per-tag chunks, which hurts batching and gzip compression ratios.

When `unify_tag` is enabled, all records are buffered into a single file regardless of their tag, so they accumulate together into fewer, larger objects with much better compression. This mirrors the existing `unify_tag` option in `out_azure_blob`.

### New configuration options

| Option | Default | Purpose |
|---|---|---|
| `unify_tag` | `false` | Buffer records of all tags into a single buffer file instead of one file per tag |
| `unify_tag_name` | `fluent-bit-buffer-file-unify-tag.log` | Buffer file tag used when `unify_tag` is enabled |

### Trade-off

With `unify_tag` on, the buffered chunk uses a single fixed tag (configurable via `unify_tag_name`), so `$TAG` in `gcs_key_format` resolves to that fixed value rather than the original per-record tag. To keep object keys unique, add `$UUID` to `gcs_key_format` (and when the format contains no `$UUID`/`$INDEX`, `out_gcs` already appends a random suffix, so objects still do not collide). Keep per-source identity inside the record instead (for example via the `kubernetes` filter), which remains present in the uploaded data.

### Example configuration

```ini
[OUTPUT]
    Name        gcs
    Match       *
    bucket      my-bucket
    unify_tag   true
    compression gzip
```

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change (see above)
- [x] Debug log output from testing the change (runtime tests pass via `flb-rt-out_gcs`: `unify_tag_buffers_multiple_tags` and `unify_tag_disabled_by_default`, alongside the existing suite)
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found (Valgrind 3.22 on Linux over the `flb-rt-out_gcs` suite including the `unify_tag` tests: "All heap blocks were freed -- no leaks are possible", 38,110 allocs / 38,110 frees, 0 errors from 0 contexts. The `unify_tag` test pushes distinct records under two tags and reads back the unified buffer, so `cb_gcs_flush()` and the unified-tag allocate/free path are exercised.)

### Live validation

Verified end to end with Fluent Bit running on a minikube cluster writing to a real GCS bucket. With `unify_tag` disabled the output produced roughly three objects per minute (one per tag) of a few KB each; enabling `unify_tag` consolidated them into a single, larger object per upload window. Object names, bucket, and project are redacted; sizes are in bytes:

```
# unify_tag = false (per-tag): ~3 objects/minute
2026-08-26T10:40:04Z   5206
2026-08-26T10:40:04Z   3434
2026-08-26T10:40:05Z   4511

# unify_tag = true: ~1 object/minute
2026-08-26T15:48:43Z   9200
2026-08-26T15:49:43Z   8999
2026-08-26T15:50:43Z   9536
2026-08-26T15:51:43Z   9185
2026-08-26T15:52:43Z   9062
```

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature (a follow-up PR to fluent-bit-docs will document the option)

**Backporting**
- [N/A] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to buffer records under a single unified tag.
  - Records retain their individual tags by default.
  - Added configuration support for enabling tag unification.

- **Bug Fixes**
  - Improved cleanup handling when buffering or queueing records encounters errors.

- **Tests**
  - Added coverage for enabled tag unification.
  - Added coverage confirming tag unification is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
