### PR TITLE
backport: apply selected maintenance fixes to 5.0

### DIFF
--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -206,6 +206,14 @@ struct flb_input_plugin {
      */
     int (*cb_ingest) (void *in_context, void *, size_t);
 
+    /*
+     * Notify a threaded input from the parent thread immediately before its
+     * event loop is asked to exit. This callback must only interrupt blocking
+     * work; the input thread remains responsible for releasing its context in
+     * cb_exit.
+     */
+    void (*cb_pre_exit) (void *, struct flb_config *);
+
     /* Exit */
     int (*cb_exit) (void *, struct flb_config *);
 

--- a/plugins/filter_expect/expect.c
+++ b/plugins/filter_expect/expect.c
@@ -405,7 +405,8 @@ static int cb_expect_filter(const void *data, size_t bytes,
 {
     int ret;
     int i;
-    int rule_matched = FLB_TRUE;
+    int rule_matched;
+    int32_t record_type;
     msgpack_object_kv *kv;
     struct flb_expect *ctx = filter_context;
     struct flb_log_event_encoder log_encoder;
@@ -427,25 +428,25 @@ static int cb_expect_filter(const void *data, size_t bytes,
         return FLB_FILTER_NOTOUCH;
     }
 
-    while ((ret = flb_log_event_decoder_next(
-                    &log_decoder,
-                    &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
-        ret = rule_apply(ctx, *log_event.body, config);
-        if (ret == FLB_TRUE) {
-            /* rule matches, we are good */
-            continue;
-        }
-        else {
-            if (ctx->action == FLB_EXP_WARN) {
-                flb_plg_warn(ctx->ins, "expect check failed");
+    if (ctx->action != FLB_EXP_RESULT_KEY) {
+        while ((ret = flb_log_event_decoder_next(
+                        &log_decoder,
+                        &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+            ret = rule_apply(ctx, *log_event.body, config);
+            if (ret == FLB_TRUE) {
+                /* rule matches, we are good */
+                continue;
             }
-            else if (ctx->action == FLB_EXP_EXIT) {
-                flb_engine_exit_status(config, 255);
+            else {
+                if (ctx->action == FLB_EXP_WARN) {
+                    flb_plg_warn(ctx->ins, "expect check failed");
+                    continue;
+                }
+                else if (ctx->action == FLB_EXP_EXIT) {
+                    flb_engine_exit_status(config, 255);
+                }
+                break;
             }
-            else if (ctx->action == FLB_EXP_RESULT_KEY) {
-                rule_matched = FLB_FALSE;
-            }
-            break;
         }
     }
 
@@ -453,6 +454,13 @@ static int cb_expect_filter(const void *data, size_t bytes,
     /* Append result key when action is "result_key"*/
     if (ctx->action == FLB_EXP_RESULT_KEY) {
         flb_log_event_decoder_reset(&log_decoder, (char *) data, bytes);
+
+        ret = flb_log_event_decoder_read_groups(&log_decoder, FLB_TRUE);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins, "failed to enable group marker decoding");
+            flb_log_event_decoder_destroy(&log_decoder);
+            return FLB_FILTER_NOTOUCH;
+        }
 
         ret = flb_log_event_encoder_init(&log_encoder,
                                          FLB_LOG_EVENT_FORMAT_DEFAULT);
@@ -469,6 +477,26 @@ static int cb_expect_filter(const void *data, size_t bytes,
         while ((ret = flb_log_event_decoder_next(
                         &log_decoder,
                         &log_event)) == FLB_EVENT_DECODER_SUCCESS) {
+            ret = flb_log_event_decoder_get_record_type(&log_event, &record_type);
+            if (ret != 0) {
+                flb_plg_error(ctx->ins, "record has invalid event type");
+                break;
+            }
+
+            if (record_type == FLB_LOG_EVENT_GROUP_START ||
+                record_type == FLB_LOG_EVENT_GROUP_END) {
+                ret = flb_log_event_encoder_emit_raw_record(
+                        &log_encoder,
+                        log_decoder.record_base,
+                        log_decoder.record_length);
+                if (ret != FLB_EVENT_ENCODER_SUCCESS) {
+                    break;
+                }
+                continue;
+            }
+
+            rule_matched = rule_apply(ctx, *log_event.body, config);
+
             ret = flb_log_event_encoder_begin_record(&log_encoder);
 
             if (ret == FLB_EVENT_ENCODER_SUCCESS) {

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -29,6 +29,7 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_regex.h>
 #include <fluent-bit/flb_hash_table.h>
+#include <fluent-bit/flb_pthread.h>
 
 /*
  * Since this filter might get a high number of request per second,
@@ -213,6 +214,13 @@ struct flb_kube {
     int aws_pod_service_map_refresh_interval;
     flb_sds_t aws_pod_service_preload_cache_path;
     struct flb_upstream *aws_pod_association_upstream;
+    pthread_mutex_t aws_pod_service_mutex;
+    pthread_cond_t aws_pod_service_cond;
+    pthread_t aws_pod_service_thread;
+    int aws_pod_service_sync_initialized;
+    int aws_pod_service_thread_created;
+    int aws_pod_service_shutdown;
+    struct mk_event_loop *aws_pod_service_event_loop;
     /*
      * This variable holds the Kubernetes platform type
      * Current checks for EKS or Native Kuberentes

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -35,6 +35,7 @@
 #include "kubernetes_aws.h"
 
 #include <stdio.h>
+#include <errno.h>
 #include <msgpack.h>
 #include <sys/stat.h>
 
@@ -44,31 +45,68 @@
 #define MERGE_MAP         2 /* merge direct binary object (v)            */
 #define FLB_KUBE_LOCAL_LOGS_INPUT "fluentbit_logs"
 
-struct task_args {
-    struct flb_kube *ctx;
-    char *api_server_url;
-};
-
-pthread_mutex_t metadata_mutex;
-pthread_t background_thread;
-struct task_args *task_args = {0};
-struct mk_event_loop *evl;
-
-void *update_pod_service_map(void *arg)
+static int wait_for_pod_service_map_refresh(struct flb_kube *ctx)
 {
+    int ret;
+    int shutdown;
+    struct flb_time current_time;
+    struct timespec deadline;
+
+    pthread_mutex_lock(&ctx->aws_pod_service_mutex);
+
+    flb_time_get(&current_time);
+    deadline = current_time.tm;
+    deadline.tv_sec += ctx->aws_pod_service_map_refresh_interval;
+
+    while (!ctx->aws_pod_service_shutdown) {
+        ret = pthread_cond_timedwait(&ctx->aws_pod_service_cond,
+                                     &ctx->aws_pod_service_mutex,
+                                     &deadline);
+        if (ret == ETIMEDOUT) {
+            break;
+        }
+        else if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "Failed waiting for pod service map refresh");
+            break;
+        }
+    }
+
+    shutdown = ctx->aws_pod_service_shutdown;
+    pthread_mutex_unlock(&ctx->aws_pod_service_mutex);
+
+    return shutdown;
+}
+
+static void *update_pod_service_map(void *arg)
+{
+    struct flb_kube *ctx;
+
+    ctx = arg;
+
     flb_engine_evl_init();
-    evl = mk_event_loop_create(256);
-    if (evl == NULL) {
-        flb_plg_error(task_args->ctx->ins,
+    ctx->aws_pod_service_event_loop = mk_event_loop_create(256);
+    if (ctx->aws_pod_service_event_loop == NULL) {
+        flb_plg_error(ctx->ins,
                       "Failed to create event loop for pod service map");
         return NULL;
     }
-    flb_engine_evl_set(evl);
+    flb_engine_evl_set(ctx->aws_pod_service_event_loop);
+
     while (1) {
-        fetch_pod_service_map(task_args->ctx,task_args->api_server_url,&metadata_mutex);
-        flb_plg_debug(task_args->ctx->ins, "Updating pod to service map after %d seconds", task_args->ctx->aws_pod_service_map_refresh_interval);
-        sleep(task_args->ctx->aws_pod_service_map_refresh_interval);
+        fetch_pod_service_map(ctx,
+                              ctx->aws_pod_association_endpoint,
+                              &ctx->aws_pod_service_mutex);
+        flb_plg_debug(ctx->ins,
+                      "Updating pod to service map after %d seconds",
+                      ctx->aws_pod_service_map_refresh_interval);
+
+        if (wait_for_pod_service_map_refresh(ctx)) {
+            break;
+        }
     }
+
+    return NULL;
 }
 
 static int get_stream(msgpack_object_map map)
@@ -239,24 +277,36 @@ static int cb_kube_init(struct flb_filter_instance *f_ins,
      */
     flb_kube_meta_init(ctx, config);
 
-/*
- * Init separate thread for calling pod to
- * service map
- */
-    pthread_mutex_init(&metadata_mutex, NULL);
-
     if (ctx->aws_use_pod_association) {
-        task_args = flb_malloc(sizeof(struct task_args));
-        if (!task_args) {
-            flb_errno();
+        ret = pthread_mutex_init(&ctx->aws_pod_service_mutex, NULL);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "Failed to initialize pod service map mutex");
             return -1;
         }
-        task_args->ctx = ctx;
-        task_args->api_server_url = ctx->aws_pod_association_endpoint;
-        if (pthread_create(&background_thread, NULL, update_pod_service_map, NULL) != 0) {
-            flb_error("Failed to create background thread");
-            background_thread = 0;
-            flb_free(task_args);
+
+        ret = pthread_cond_init(&ctx->aws_pod_service_cond, NULL);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "Failed to initialize pod service map condition");
+            pthread_mutex_destroy(&ctx->aws_pod_service_mutex);
+            return -1;
+        }
+        ctx->aws_pod_service_sync_initialized = FLB_TRUE;
+
+        ret = pthread_create(&ctx->aws_pod_service_thread,
+                             NULL,
+                             update_pod_service_map,
+                             ctx);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "Failed to create pod service map background thread");
+            pthread_cond_destroy(&ctx->aws_pod_service_cond);
+            pthread_mutex_destroy(&ctx->aws_pod_service_mutex);
+            ctx->aws_pod_service_sync_initialized = FLB_FALSE;
+        }
+        else {
+            ctx->aws_pod_service_thread_created = FLB_TRUE;
         }
     }
 
@@ -824,20 +874,30 @@ static int cb_kube_exit(void *data, struct flb_config *config)
     struct flb_kube *ctx;
 
     ctx = data;
-    
-    flb_kube_conf_destroy(ctx);
-    if (background_thread) {
-        pthread_cancel(background_thread);
-        pthread_join(background_thread, NULL);
-    }
-    pthread_mutex_destroy(&metadata_mutex);
 
-    if (task_args) {
-        flb_free(task_args);
+    if (ctx->aws_pod_service_thread_created) {
+        pthread_mutex_lock(&ctx->aws_pod_service_mutex);
+        ctx->aws_pod_service_shutdown = FLB_TRUE;
+        pthread_cond_signal(&ctx->aws_pod_service_cond);
+        pthread_mutex_unlock(&ctx->aws_pod_service_mutex);
+
+        pthread_join(ctx->aws_pod_service_thread, NULL);
+        ctx->aws_pod_service_thread_created = FLB_FALSE;
     }
-    if (evl) {
-        mk_event_loop_destroy(evl);
+
+    if (ctx->aws_pod_service_event_loop) {
+        mk_event_loop_destroy(ctx->aws_pod_service_event_loop);
+        ctx->aws_pod_service_event_loop = NULL;
     }
+
+    if (ctx->aws_pod_service_sync_initialized) {
+        pthread_cond_destroy(&ctx->aws_pod_service_cond);
+        pthread_mutex_destroy(&ctx->aws_pod_service_mutex);
+        ctx->aws_pod_service_sync_initialized = FLB_FALSE;
+    }
+
+    flb_kube_conf_destroy(ctx);
+
     return 0;
 }
 

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -282,6 +282,7 @@ static int cb_kube_init(struct flb_filter_instance *f_ins,
         if (ret != 0) {
             flb_plg_error(ctx->ins,
                           "Failed to initialize pod service map mutex");
+            flb_kube_conf_destroy(ctx);
             return -1;
         }
 
@@ -290,6 +291,7 @@ static int cb_kube_init(struct flb_filter_instance *f_ins,
             flb_plg_error(ctx->ins,
                           "Failed to initialize pod service map condition");
             pthread_mutex_destroy(&ctx->aws_pod_service_mutex);
+            flb_kube_conf_destroy(ctx);
             return -1;
         }
         ctx->aws_pod_service_sync_initialized = FLB_TRUE;

--- a/plugins/in_exec/in_exec.c
+++ b/plugins/in_exec/in_exec.c
@@ -29,9 +29,153 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef FLB_SYSTEM_WINDOWS
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 #include "in_exec_win32_compat.h"
 
 #include "in_exec.h"
+
+#ifndef FLB_SYSTEM_WINDOWS
+static FILE *in_exec_popen(struct flb_exec *ctx)
+{
+    int ret;
+    int pipe_fds[2];
+    pid_t child_pid;
+    FILE *stream;
+
+    ret = pipe(pipe_fds);
+    if (ret == -1) {
+        flb_errno();
+        return NULL;
+    }
+
+    ret = fcntl(pipe_fds[0], F_SETFD, FD_CLOEXEC);
+    if (ret == -1) {
+        flb_errno();
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    ret = fcntl(pipe_fds[1], F_SETFD, FD_CLOEXEC);
+    if (ret == -1) {
+        flb_errno();
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    pthread_mutex_lock(&ctx->child_mutex);
+
+    if (ctx->shutdown_requested == FLB_TRUE) {
+        pthread_mutex_unlock(&ctx->child_mutex);
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    child_pid = fork();
+    if (child_pid == -1) {
+        flb_errno();
+        pthread_mutex_unlock(&ctx->child_mutex);
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return NULL;
+    }
+
+    if (child_pid == 0) {
+        close(pipe_fds[0]);
+        setpgid(0, 0);
+
+        if (dup2(pipe_fds[1], STDOUT_FILENO) == -1) {
+            _exit(127);
+        }
+
+        close(pipe_fds[1]);
+        execl("/bin/sh", "sh", "-c", ctx->cmd, (char *) NULL);
+        _exit(127);
+    }
+
+    close(pipe_fds[1]);
+    setpgid(child_pid, child_pid);
+    ctx->child_pid = child_pid;
+    pthread_mutex_unlock(&ctx->child_mutex);
+
+    stream = fdopen(pipe_fds[0], "r");
+    if (stream == NULL) {
+        flb_errno();
+        kill(-child_pid, SIGKILL);
+        waitpid(child_pid, NULL, 0);
+
+        pthread_mutex_lock(&ctx->child_mutex);
+        ctx->child_pid = -1;
+        pthread_mutex_unlock(&ctx->child_mutex);
+
+        close(pipe_fds[0]);
+        return NULL;
+    }
+
+    return stream;
+}
+
+static int in_exec_pclose(struct flb_exec *ctx, FILE *stream)
+{
+    int ret;
+    int status;
+    pid_t child_pid;
+
+    ret = fclose(stream);
+    if (ret == EOF) {
+        flb_errno();
+    }
+
+    pthread_mutex_lock(&ctx->child_mutex);
+    child_pid = ctx->child_pid;
+    pthread_mutex_unlock(&ctx->child_mutex);
+
+    do {
+        ret = waitpid(child_pid, &status, 0);
+    } while (ret == -1 && errno == EINTR);
+
+    pthread_mutex_lock(&ctx->child_mutex);
+    if (ctx->child_pid == child_pid) {
+        ctx->child_pid = -1;
+    }
+    pthread_mutex_unlock(&ctx->child_mutex);
+
+    if (ret == -1) {
+        return -1;
+    }
+
+    return status;
+}
+
+static void in_exec_pre_exit(void *data, struct flb_config *config)
+{
+    int ret;
+    pid_t child_pid;
+    struct flb_exec *ctx = data;
+
+    (void) config;
+
+    pthread_mutex_lock(&ctx->child_mutex);
+    ctx->shutdown_requested = FLB_TRUE;
+    child_pid = ctx->child_pid;
+    if (child_pid > 0) {
+        ret = kill(-child_pid, SIGTERM);
+        if (ret == -1 && errno != ESRCH) {
+            flb_plg_warn(ctx->ins, "could not terminate command process group");
+            flb_errno();
+        }
+    }
+    pthread_mutex_unlock(&ctx->child_mutex);
+}
+#endif
 
 /* cb_collect callback */
 static int in_exec_collect(struct flb_input_instance *ins,
@@ -59,7 +203,11 @@ static int in_exec_collect(struct flb_input_instance *ins,
         }
     }
 
+#ifndef FLB_SYSTEM_WINDOWS
+    cmdp = in_exec_popen(ctx);
+#else
     cmdp = flb_popen(ctx->cmd, "r");
+#endif
     if (cmdp == NULL) {
         flb_plg_debug(ctx->ins, "command %s failed", ctx->cmd);
         goto collect_end;
@@ -178,7 +326,11 @@ static int in_exec_collect(struct flb_input_instance *ins,
          * and
          * https://skarnet.org/software/execline/exitcodes.html
          */
+#ifndef FLB_SYSTEM_WINDOWS
+        cmdret = in_exec_pclose(ctx, cmdp);
+#else
         cmdret = flb_pclose(cmdp);
+#endif
         if (cmdret == -1) {
             flb_errno();
             flb_plg_debug(ctx->ins,
@@ -339,6 +491,10 @@ static void delete_exec_config(struct flb_exec *ctx)
         flb_pipe_close(ctx->ch_manager[1]);
     }
 
+#ifndef FLB_SYSTEM_WINDOWS
+    pthread_mutex_destroy(&ctx->child_mutex);
+#endif
+
     flb_free(ctx);
 }
 
@@ -355,6 +511,15 @@ static int in_exec_init(struct flb_input_instance *in,
         return -1;
     }
     ctx->parser = NULL;
+
+#ifndef FLB_SYSTEM_WINDOWS
+    ret = pthread_mutex_init(&ctx->child_mutex, NULL);
+    if (ret != 0) {
+        flb_free(ctx);
+        return -1;
+    }
+    ctx->child_pid = -1;
+#endif
 
     /* Initialize exec config */
     ret = in_exec_config_read(ctx, in, config);
@@ -486,6 +651,9 @@ struct flb_input_plugin in_exec_plugin = {
     .cb_pre_run   = in_exec_prerun,
     .cb_collect   = in_exec_collect,
     .cb_flush_buf = NULL,
+#ifndef FLB_SYSTEM_WINDOWS
+    .cb_pre_exit  = in_exec_pre_exit,
+#endif
     .cb_exit      = in_exec_exit,
     .config_map   = config_map
 };

--- a/plugins/in_exec/in_exec.h
+++ b/plugins/in_exec/in_exec.h
@@ -29,6 +29,10 @@
 
 #include <msgpack.h>
 
+#ifndef FLB_SYSTEM_WINDOWS
+#include <sys/types.h>
+#endif
+
 #define DEFAULT_BUF_SIZE      "4096"
 #define DEFAULT_INTERVAL_SEC  "1"
 #define DEFAULT_INTERVAL_NSEC "0"
@@ -47,6 +51,11 @@ struct flb_exec {
     struct flb_log_event_encoder log_encoder;
     int exit_after_oneshot;
     int propagate_exit_code;
+#ifndef FLB_SYSTEM_WINDOWS
+    pthread_mutex_t child_mutex;
+    pid_t child_pid;
+    int shutdown_requested;
+#endif
 };
 
 #endif /* FLB_IN_EXEC_H */

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1775,7 +1775,7 @@ int fw_prot_process(struct flb_input_instance *ins, struct fw_conn *conn)
                 goto cleanup_msgpack;
             }
 
-            ret = msgpack_unpacker_next(unp, &result);
+            ret = msgpack_unpacker_next_with_size(unp, &result, &bytes);
         }
     }
 

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <inttypes.h>
+#include <errno.h>
 
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_network.h>
@@ -248,8 +249,13 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
     memcpy(buf, v->via.str.ptr, v->via.str.size);
     buf[v->via.str.size] = '\0';
 
-    if (flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL) {
-        return -2;
+    {
+        char *end;
+
+        end = flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm);
+        if (end == NULL || *end != '\0') {
+            return -2;
+        }
     }
 
     val->tm.tv_sec = flb_parser_tm2time(&tm, FLB_FALSE);
@@ -286,8 +292,9 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         memcpy(buf, v->via.str.ptr, len);
         buf[len] = '\0';
 
-        *val = strtoul(buf, &end, 10);
-        if (end == NULL || end == buf || *end != '\0') {
+        errno = 0;
+        *val = strtoull(buf, &end, 10);
+        if (errno == ERANGE || end == buf || *end != '\0') {
             return -1;
         }
         return 0;
@@ -297,8 +304,7 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         return 0;
     }
     if (v->type == MSGPACK_OBJECT_NEGATIVE_INTEGER) {
-        *val = (uint64_t)v->via.i64;
-        return 0;
+        return -1;
     }
     return -1;
 }
@@ -312,12 +318,12 @@ static int item_get_timestamp(msgpack_object *obj, struct flb_time *event_time)
      * NULL while having metadata.creationTimestamp set.
      */
     ret = record_get_field_time(obj, "lastTimestamp", event_time);
-    if (ret != -1) {
+    if (ret == 0) {
         return FLB_TRUE;
     }
 
     ret = record_get_field_time(obj, "firstTimestamp", event_time);
-    if (ret != -1) {
+    if (ret == 0) {
         return FLB_TRUE;
     }
 
@@ -327,7 +333,7 @@ static int item_get_timestamp(msgpack_object *obj, struct flb_time *event_time)
     }
 
     ret = record_get_field_time(metadata, "creationTimestamp", event_time);
-    if (ret != -1) {
+    if (ret == 0) {
         return FLB_TRUE;
     }
 

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <ctype.h>
 
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_network.h>
@@ -291,6 +292,18 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
         }
         memcpy(buf, v->via.str.ptr, len);
         buf[len] = '\0';
+
+        /*
+         * strtoull() itself accepts a leading '+'/'-' and skips leading
+         * whitespace, which would let a value like "-5" silently wrap
+         * around into a huge positive number instead of being rejected.
+         * Kubernetes resourceVersion (the only caller) is always a plain,
+         * unsigned, digits-only decimal string, so require that directly
+         * before parsing.
+         */
+        if (!isdigit((unsigned char) buf[0])) {
+            return -1;
+        }
 
         errno = 0;
         *val = strtoull(buf, &end, 10);

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -226,6 +226,7 @@ static int record_get_field_sds(msgpack_object *obj, const char *fieldname, flb_
 
 static int record_get_field_time(msgpack_object *obj, const char *fieldname, struct flb_time *val)
 {
+    char *end;
     msgpack_object *v;
     struct flb_tm tm = { 0 };
     char buf[64];
@@ -250,13 +251,9 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
     memcpy(buf, v->via.str.ptr, v->via.str.size);
     buf[v->via.str.size] = '\0';
 
-    {
-        char *end;
-
-        end = flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm);
-        if (end == NULL || *end != '\0') {
-            return -2;
-        }
+    end = flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm);
+    if (end == NULL || *end != '\0') {
+        return -2;
     }
 
     val->tm.tv_sec = flb_parser_tm2time(&tm, FLB_FALSE);
@@ -565,7 +562,6 @@ static int process_event_list(struct k8s_events *ctx, char *in_data, size_t in_s
     size_t off = 0;
     msgpack_unpacked result;
     msgpack_object root;
-    msgpack_object k;
     msgpack_object *items = NULL;
     msgpack_object *item = NULL;
     msgpack_object *metadata = NULL;
@@ -594,27 +590,16 @@ static int process_event_list(struct k8s_events *ctx, char *in_data, size_t in_s
     /* Traverse the EventList for the metadata (for the continue token) and the items.
      * https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/#EventList
      */
-    for (i = 0; i < root.via.map.size; i++) {
-        k = root.via.map.ptr[i].key;
-        if (k.type != MSGPACK_OBJECT_STR) {
-            continue;
-        }
+    items = record_get_field_ptr(&root, "items");
+    if (items != NULL && items->type != MSGPACK_OBJECT_ARRAY) {
+        flb_plg_error(ctx->ins, "Cannot unpack items");
+        goto msg_error;
+    }
 
-        if (strncmp(k.via.str.ptr, "items", 5) == 0) {
-            items = &root.via.map.ptr[i].val;
-            if (items->type != MSGPACK_OBJECT_ARRAY) {
-                flb_plg_error(ctx->ins, "Cannot unpack items");
-                goto msg_error;
-            }
-        }
-
-        if (strncmp(k.via.str.ptr, "metadata", 8) == 0) {
-            metadata = &root.via.map.ptr[i].val;
-            if (metadata->type != MSGPACK_OBJECT_MAP) {
-                flb_plg_error(ctx->ins, "Cannot unpack metadata");
-                goto msg_error;
-            }
-        }
+    metadata = record_get_field_ptr(&root, "metadata");
+    if (metadata != NULL && metadata->type != MSGPACK_OBJECT_MAP) {
+        flb_plg_error(ctx->ins, "Cannot unpack metadata");
+        goto msg_error;
     }
 
     if (items == NULL) {
@@ -751,7 +736,7 @@ static int k8s_events_sql_insert_event(struct k8s_events *ctx, msgpack_object *i
     flb_sds_t uid;
 
 
-    meta = record_get_field_ptr(item, "meta");
+    meta = record_get_field_ptr(item, "metadata");
     if (meta == NULL) {
         flb_plg_error(ctx->ins, "unable to find metadata to save event");
         return -1;

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -174,6 +174,7 @@ static int refresh_token_if_needed(struct k8s_events *ctx)
 static msgpack_object *record_get_field_ptr(msgpack_object *obj, const char *fieldname)
 {
     int i;
+    size_t fieldname_len;
     msgpack_object *k;
     msgpack_object *v;
 
@@ -181,13 +182,23 @@ static msgpack_object *record_get_field_ptr(msgpack_object *obj, const char *fie
         return NULL;
     }
 
+    fieldname_len = strlen(fieldname);
+
     for (i = 0; i < obj->via.map.size; i++) {
         k = &obj->via.map.ptr[i].key;
         if (k->type != MSGPACK_OBJECT_STR) {
             continue;
         }
 
-        if (strncmp(k->via.str.ptr, fieldname, strlen(fieldname)) == 0) {
+        /*
+         * msgpack strings are not NUL terminated: k->via.str.ptr points
+         * directly into the decode buffer for exactly k->via.str.size
+         * bytes. Require an exact length match before comparing so we
+         * never read past that boundary, and so a key that merely shares
+         * a prefix with fieldname cannot match.
+         */
+        if ((size_t) k->via.str.size == fieldname_len &&
+            strncmp(k->via.str.ptr, fieldname, fieldname_len) == 0) {
             v = &obj->via.map.ptr[i].val;
             return v;
         }
@@ -215,6 +226,7 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
 {
     msgpack_object *v;
     struct flb_tm tm = { 0 };
+    char buf[64];
 
     v = record_get_field_ptr(obj, fieldname);
     if (v == NULL) {
@@ -224,7 +236,19 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
         return -1;
     }
 
-    if (flb_strptime(v->via.str.ptr, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL) {
+    /*
+     * msgpack strings are not NUL terminated: v->via.str.ptr points
+     * directly into the decode buffer for exactly v->via.str.size bytes.
+     * Copy it into a bounded, NUL-terminated stack buffer before handing
+     * it to flb_strptime(), instead of scanning the raw buffer directly.
+     */
+    if (v->via.str.size == 0 || v->via.str.size >= sizeof(buf)) {
+        return -2;
+    }
+    memcpy(buf, v->via.str.ptr, v->via.str.size);
+    buf[v->via.str.size] = '\0';
+
+    if (flb_strptime(buf, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL) {
         return -2;
     }
 
@@ -237,7 +261,9 @@ static int record_get_field_time(msgpack_object *obj, const char *fieldname, str
 static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, uint64_t *val)
 {
     msgpack_object *v;
+    char buf[32];
     char *end;
+    size_t len;
 
     v = record_get_field_ptr(obj, fieldname);
     if (v == NULL) {
@@ -246,8 +272,22 @@ static int record_get_field_uint64(msgpack_object *obj, const char *fieldname, u
 
     /* attempt to parse string as number... */
     if (v->type == MSGPACK_OBJECT_STR) {
-        *val = strtoul(v->via.str.ptr, &end, 10);
-        if (end == NULL || (end < v->via.str.ptr + v->via.str.size)) {
+        /*
+         * msgpack strings are not NUL terminated: v->via.str.ptr points
+         * directly into the decode buffer for exactly v->via.str.size
+         * bytes. Copy it into a bounded, NUL-terminated stack buffer
+         * before calling strtoul() on it, instead of scanning the raw
+         * buffer directly (no valid uint64 needs more than 20 digits).
+         */
+        len = v->via.str.size;
+        if (len == 0 || len > sizeof(buf) - 1) {
+            return -1;
+        }
+        memcpy(buf, v->via.str.ptr, len);
+        buf[len] = '\0';
+
+        *val = strtoul(buf, &end, 10);
+        if (end == NULL || end == buf || *end != '\0') {
             return -1;
         }
         return 0;

--- a/plugins/in_kubernetes_events/kubernetes_events.c
+++ b/plugins/in_kubernetes_events/kubernetes_events.c
@@ -447,7 +447,9 @@ static int process_watched_event(struct k8s_events *ctx, char *buf_data, size_t 
     msgpack_unpacked result;
     msgpack_object root;
     msgpack_object *item = NULL;
+    msgpack_object *metadata;
     flb_sds_t event_type = NULL;
+    uint64_t resource_version;
 
     /* unpack */
     msgpack_unpacked_init(&result);
@@ -476,6 +478,15 @@ static int process_watched_event(struct k8s_events *ctx, char *buf_data, size_t 
     }
 
     ret = process_event_object(ctx, event_type, item);
+    if (ret == 0) {
+        metadata = record_get_field_ptr(item, "metadata");
+        if (metadata != NULL &&
+            record_get_field_uint64(metadata, "resourceVersion", &resource_version) == 0 &&
+            resource_version > ctx->last_resource_version) {
+            flb_plg_debug(ctx->ins, "set last resourceVersion=%" PRIu64, resource_version);
+            ctx->last_resource_version = resource_version;
+        }
+    }
 
 msg_error:
     flb_sds_destroy(event_type);
@@ -602,6 +613,9 @@ static struct flb_http_client *make_event_watch_api_request(struct k8s_events *c
     }
 
     flb_sds_printf(&url, "?watch=1&resourceVersion=%" PRIu64, max_resource_version);
+    if (ctx->watch_timeout > 0) {
+        flb_sds_printf(&url, "&timeoutSeconds=%d", ctx->watch_timeout);
+    }
     flb_plg_info(ctx->ins, "Requesting %s", url);
     c = flb_http_client(ctx->current_connection, FLB_HTTP_GET, url,
                         NULL, 0, ctx->api_host, ctx->api_port, NULL, 0);
@@ -864,6 +878,9 @@ static int check_and_init_stream(struct k8s_events *ctx)
         goto failure;
     }
     initialize_http_client(ctx->streaming_client, ctx);
+    if (ctx->watch_timeout > 0) {
+        flb_http_set_read_idle_timeout(ctx->streaming_client, ctx->watch_timeout);
+    }
 
     /* Watch will stream chunked json data, so we only send
      * the http request, then use flb_http_get_response_data
@@ -1005,6 +1022,13 @@ static struct flb_config_map config_map[] = {
       FLB_CONFIG_MAP_INT, "interval_nsec", DEFAULT_INTERVAL_NSEC,
       0, FLB_TRUE, offsetof(struct k8s_events, interval_nsec),
       "Set the polling interval for each channel (sub seconds)"
+    },
+
+    {
+      FLB_CONFIG_MAP_TIME, "kube_watch_timeout", DEFAULT_WATCH_TIMEOUT,
+      0, FLB_TRUE, offsetof(struct k8s_events, watch_timeout),
+      "Set the maximum Kubernetes watch duration and client read idle timeout. "
+      "Set to 0 to disable the timeout"
     },
 
     /* TLS: set debug 'level' */

--- a/plugins/in_kubernetes_events/kubernetes_events.h
+++ b/plugins/in_kubernetes_events/kubernetes_events.h
@@ -28,6 +28,7 @@
 
 #define DEFAULT_INTERVAL_SEC "0"
 #define DEFAULT_INTERVAL_NSEC "500000000"
+#define DEFAULT_WATCH_TIMEOUT "10m"
 
 /* Filter context */
 struct k8s_events {
@@ -36,6 +37,7 @@ struct k8s_events {
     int interval_sec;             /* interval collection time (Second)     */
     int interval_nsec;            /* interval collection time (Nanosecond) */
     int retention_time;           /* retention time limit, default 1 hour */
+    int watch_timeout;            /* watch request timeout */
 
     /* Configuration parameters */
     char *api_host;

--- a/plugins/in_node_exporter_metrics/ne_diskstats_darwin.c
+++ b/plugins/in_node_exporter_metrics/ne_diskstats_darwin.c
@@ -62,15 +62,13 @@ struct dt_metric {
 static void metric_cache_set(struct flb_ne *ctx, void *metric, double factor, int *offset)
 {
     int id;
-    struct dt_metric *m;
-    struct dt_metric **cache;
+    struct dt_metric *cache;
 
     id = *offset;
 
-    cache = (struct dt_metric **) ctx->dt_metrics;
-    m = (struct dt_metric *) &cache[id];
-    m->metric = metric;
-    m->factor = factor;
+    cache = (struct dt_metric *) ctx->dt_metrics;
+    cache[id].metric = metric;
+    cache[id].factor = factor;
     (*offset)++;
 }
 
@@ -80,11 +78,11 @@ static void metric_cache_update(struct flb_ne *ctx, int id, flb_sds_t device,
     int ret = -1;
     uint64_t ts;
     struct dt_metric *m;
-    struct dt_metric **cache;
+    struct dt_metric *cache;
     struct cmt_counter *c;
 
-    cache = (struct dt_metric **) ctx->dt_metrics;
-    m = (struct dt_metric *) &cache[id];
+    cache = (struct dt_metric *) ctx->dt_metrics;
+    m = &cache[id];
 
     ts = cfl_time_now();
 

--- a/plugins/in_node_exporter_metrics/ne_diskstats_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_diskstats_linux.c
@@ -72,6 +72,7 @@
 
 #define KNOWN_FIELDS     17
 #define SECTOR_SIZE      512
+#define MS_TO_SECONDS    .001
 
 struct dt_metric {
     void *metric;
@@ -81,15 +82,13 @@ struct dt_metric {
 static void metric_cache_set(struct flb_ne *ctx, void *metric, double factor, int *offset)
 {
     int id;
-    struct dt_metric *m;
-    struct dt_metric **cache;
+    struct dt_metric *cache;
 
     id = *offset;
 
-    cache = (struct dt_metric **) ctx->dt_metrics;
-    m = (struct dt_metric *) &cache[id];
-    m->metric = metric;
-    m->factor = factor;
+    cache = (struct dt_metric *) ctx->dt_metrics;
+    cache[id].metric = metric;
+    cache[id].factor = factor;
     (*offset)++;
 }
 
@@ -100,12 +99,12 @@ static void metric_cache_update(struct flb_ne *ctx, int id, flb_sds_t device,
     uint64_t ts;
     double val;
     struct dt_metric *m;
-    struct dt_metric **cache;
+    struct dt_metric *cache;
     struct cmt_gauge *g;
     struct cmt_counter *c;
 
-    cache = (struct dt_metric **) ctx->dt_metrics;
-    m = (struct dt_metric *) &cache[id];
+    cache = (struct dt_metric *) ctx->dt_metrics;
+    m = &cache[id];
 
     ret = ne_utils_str_to_double(str_val, &val);
     if (ret == -1) {
@@ -197,7 +196,7 @@ static int ne_diskstats_configure(struct flb_ne *ctx)
     if (!c) {
         return -1;
     }
-    metric_cache_set(ctx, c, .001, &offset);
+    metric_cache_set(ctx, c, MS_TO_SECONDS, &offset);
 
     /* node_disk_writes_completed_total */
     c = cmt_counter_create(ctx->cmt, "node", "disk", "writes_completed_total",
@@ -233,7 +232,7 @@ static int ne_diskstats_configure(struct flb_ne *ctx)
     if (!c) {
         return -1;
     }
-    metric_cache_set(ctx, c, .001, &offset);
+    metric_cache_set(ctx, c, MS_TO_SECONDS, &offset);
 
     /* node_disk_io_now */
     g = cmt_gauge_create(ctx->cmt, "node", "disk", "io_now",
@@ -251,7 +250,7 @@ static int ne_diskstats_configure(struct flb_ne *ctx)
     if (!c) {
         return -1;
     }
-    metric_cache_set(ctx, c, .001, &offset);
+    metric_cache_set(ctx, c, MS_TO_SECONDS, &offset);
 
     /* node_disk_io_time_weighted_seconds */
     c = cmt_counter_create(ctx->cmt, "node", "disk", "io_time_weighted_seconds_total",
@@ -260,7 +259,7 @@ static int ne_diskstats_configure(struct flb_ne *ctx)
     if (!c) {
         return -1;
     }
-    metric_cache_set(ctx, c, .001, &offset);
+    metric_cache_set(ctx, c, MS_TO_SECONDS, &offset);
 
     /*
      * Linux Kernel >= 4.18
@@ -301,7 +300,7 @@ static int ne_diskstats_configure(struct flb_ne *ctx)
     if (!c) {
         return -1;
     }
-    metric_cache_set(ctx, c, .001, &offset);
+    metric_cache_set(ctx, c, MS_TO_SECONDS, &offset);
 
     /*
      * Linux Kernel >= 5.5
@@ -325,7 +324,7 @@ static int ne_diskstats_configure(struct flb_ne *ctx)
     if (!c) {
         return -1;
     }
-    metric_cache_set(ctx, c, .001, &offset);
+    metric_cache_set(ctx, c, MS_TO_SECONDS, &offset);
 
     return 0;
 }

--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -252,6 +252,9 @@ static int send_response_ng(struct flb_http_response *response,
     else if (http_status == 400) {
         flb_http_response_set_message(response, "Bad Request");
     }
+    else if (http_status == 404) {
+        flb_http_response_set_message(response, "Not Found");
+    }
 
     if (message != NULL) {
         flb_http_response_set_body(response,
@@ -828,7 +831,7 @@ int opentelemetry_prot_handle_ng(struct flb_http_request *request,
         grpc_request = FLB_TRUE;
     }
     else {
-        send_response_ng(response, 400, "error: invalid endpoint\n");
+        send_response_ng(response, 404, "error: invalid endpoint\n");
         return -1;
     }
 

--- a/plugins/in_storage_backlog/sb.c
+++ b/plugins/in_storage_backlog/sb.c
@@ -312,8 +312,11 @@ static int sb_append_chunk_to_segregated_backlogs(struct cio_chunk  *target_chun
         return -2;
     }
 
-    flb_routes_mask_set_by_tag(dummy_input_chunk.routes_mask, tag_buf, tag_len,
-                               context->ins);
+    result = flb_routes_mask_set_by_tag(dummy_input_chunk.routes_mask, tag_buf, tag_len,
+                                        context->ins);
+    if (result == 0) {
+        return -4;
+    }
 
     mk_list_foreach_safe(head, tmp, &context->backlogs) {
         backlog = mk_list_entry(head, struct sb_out_queue, _head);
@@ -412,6 +415,20 @@ int sb_segregate_chunks(struct flb_config *config)
             /* try to segregate a chunk */
             ret = sb_append_chunk_to_segregated_backlogs(chunk, stream, context);
             if (ret) {
+                /*
+                 * Leave chunks without a route on disk so a future configuration
+                 * can reconsider them. Closing the ChunkIO handle removes them
+                 * from this context's active chunk accounting without deleting
+                 * the underlying files.
+                 */
+                if (ret == -4) {
+                    flb_plg_info(context->ins,
+                                 "no matching route for %s/%s, keeping it on disk",
+                                 stream->name, chunk->name);
+                    cio_chunk_close(chunk, CIO_FALSE);
+                    continue;
+                }
+
                 /*
                  * if the chunk could not be segregated, just remove it from the
                  * queue, delete it and continue.

--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -33,6 +33,8 @@
 #include "remote_write.h"
 #include "remote_write_conf.h"
 
+#define FLB_PROMETHEUS_REMOTE_WRITE_METRIC_MAX_AGE_SECONDS 3600
+
 static int http_post(struct prometheus_remote_write_context *ctx,
                      const void *body, size_t body_len,
                      const char *tag, int tag_len)
@@ -296,6 +298,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     flb_sds_t buf = NULL;
     size_t diff = 0;
     size_t off = 0;
+    uint64_t expiration;
     struct cmt *cmt;
     struct prometheus_remote_write_context *ctx = out_context;
 
@@ -303,6 +306,9 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     ctx = out_context;
     ok = CMT_DECODE_MSGPACK_SUCCESS;
     result = FLB_OK;
+    expiration = cfl_time_now() -
+                 (FLB_PROMETHEUS_REMOTE_WRITE_METRIC_MAX_AGE_SECONDS *
+                  FLB_NSEC_IN_SEC);
 
     /* Buffer to concatenate multiple metrics contexts */
     buf = flb_sds_create_size(event_chunk->size);
@@ -319,6 +325,9 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     while ((ret = cmt_decode_msgpack_create(&cmt,
                                             (char *) event_chunk->data,
                                             event_chunk->size, &off)) == ok) {
+        /* Exclude samples that remote write backends consider stale. */
+        cmt_expire(cmt, expiration);
+
         /* append labels set by config */
         append_labels(ctx, cmt);
 

--- a/plugins/out_prometheus_remote_write/remote_write.c
+++ b/plugins/out_prometheus_remote_write/remote_write.c
@@ -23,6 +23,14 @@
 #include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_kv.h>
 
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_exp_histogram.h>
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_histogram.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_untyped.h>
+
 #ifdef FLB_HAVE_SIGNV4
 #ifdef FLB_HAVE_AWS
 #include <fluent-bit/flb_aws_credentials.h>
@@ -34,6 +42,87 @@
 #include "remote_write_conf.h"
 
 #define FLB_PROMETHEUS_REMOTE_WRITE_METRIC_MAX_AGE_SECONDS 3600
+#define FLB_PROMETHEUS_REMOTE_WRITE_NSEC_PER_SEC           1000000000ULL
+
+static void metric_storage_clear(struct cmt_metric *metric)
+{
+    if (metric->hist_buckets != NULL) {
+        flb_free(metric->hist_buckets);
+    }
+    if (metric->exp_hist_positive_buckets != NULL) {
+        flb_free(metric->exp_hist_positive_buckets);
+    }
+    if (metric->exp_hist_negative_buckets != NULL) {
+        flb_free(metric->exp_hist_negative_buckets);
+    }
+    if (metric->sum_quantiles != NULL) {
+        flb_free(metric->sum_quantiles);
+    }
+
+    memset(metric, 0, sizeof(struct cmt_metric));
+    cfl_list_init(&metric->labels);
+}
+
+static void map_metrics_expire(struct cmt_map *map, uint64_t expiration)
+{
+    struct cfl_list *tmp;
+    struct cfl_list *head;
+    struct cmt_metric *metric;
+
+    if (map->metric_static_set == CMT_TRUE &&
+        map->metric.timestamp < expiration) {
+        metric_storage_clear(&map->metric);
+        map->metric_static_set = CMT_FALSE;
+    }
+
+    cfl_list_foreach_safe(head, tmp, &map->metrics) {
+        metric = cfl_list_entry(head, struct cmt_metric, _head);
+        if (metric->timestamp < expiration) {
+            cmt_map_metric_destroy(metric);
+        }
+    }
+}
+
+static void metrics_expire(struct cmt *cmt, uint64_t expiration)
+{
+    struct cfl_list *head;
+    struct cmt_counter *counter;
+    struct cmt_gauge *gauge;
+    struct cmt_summary *summary;
+    struct cmt_histogram *histogram;
+    struct cmt_untyped *untyped;
+    struct cmt_exp_histogram *exp_histogram;
+
+    cfl_list_foreach(head, &cmt->counters) {
+        counter = cfl_list_entry(head, struct cmt_counter, _head);
+        map_metrics_expire(counter->map, expiration);
+    }
+
+    cfl_list_foreach(head, &cmt->gauges) {
+        gauge = cfl_list_entry(head, struct cmt_gauge, _head);
+        map_metrics_expire(gauge->map, expiration);
+    }
+
+    cfl_list_foreach(head, &cmt->summaries) {
+        summary = cfl_list_entry(head, struct cmt_summary, _head);
+        map_metrics_expire(summary->map, expiration);
+    }
+
+    cfl_list_foreach(head, &cmt->histograms) {
+        histogram = cfl_list_entry(head, struct cmt_histogram, _head);
+        map_metrics_expire(histogram->map, expiration);
+    }
+
+    cfl_list_foreach(head, &cmt->untypeds) {
+        untyped = cfl_list_entry(head, struct cmt_untyped, _head);
+        map_metrics_expire(untyped->map, expiration);
+    }
+
+    cfl_list_foreach(head, &cmt->exp_histograms) {
+        exp_histogram = cfl_list_entry(head, struct cmt_exp_histogram, _head);
+        map_metrics_expire(exp_histogram->map, expiration);
+    }
+}
 
 static int http_post(struct prometheus_remote_write_context *ctx,
                      const void *body, size_t body_len,
@@ -308,7 +397,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
     result = FLB_OK;
     expiration = cfl_time_now() -
                  (FLB_PROMETHEUS_REMOTE_WRITE_METRIC_MAX_AGE_SECONDS *
-                  FLB_NSEC_IN_SEC);
+                  FLB_PROMETHEUS_REMOTE_WRITE_NSEC_PER_SEC);
 
     /* Buffer to concatenate multiple metrics contexts */
     buf = flb_sds_create_size(event_chunk->size);
@@ -326,7 +415,7 @@ static void cb_prom_flush(struct flb_event_chunk *event_chunk,
                                             (char *) event_chunk->data,
                                             event_chunk->size, &off)) == ok) {
         /* Exclude samples that remote write backends consider stale. */
-        cmt_expire(cmt, expiration);
+        metrics_expire(cmt, expiration);
 
         /* append labels set by config */
         append_labels(ctx, cmt);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1075,7 +1075,16 @@ int flb_engine_start(struct flb_config *config)
     if (config->http_server == FLB_TRUE) {
         config->http_ctx = flb_hs_create(config->http_listen, config->http_port,
                                          config);
-        flb_hs_start(config->http_ctx);
+        if (!config->http_ctx) {
+            flb_error("[engine] could not initialize HTTP server");
+            return -1;
+        }
+
+        ret = flb_hs_start(config->http_ctx);
+        if (ret != 0) {
+            flb_error("[engine] could not start HTTP server");
+            return -1;
+        }
     }
 #endif
 

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -29,8 +29,58 @@
 #include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_task.h>
 #include <fluent-bit/flb_event.h>
+#include <fluent-bit/flb_metrics.h>
 #include <chunkio/chunkio.h>
+#include <cfl/cfl_time.h>
 
+
+static void record_retry_failure_metrics(struct flb_task *task,
+                                         struct flb_output_instance *output,
+                                         struct flb_config *config)
+{
+    int effective_records;
+    size_t effective_bytes;
+    uint64_t timestamp;
+    char *input_name;
+    char *output_name;
+
+    effective_records = 0;
+    effective_bytes = 0;
+    timestamp = cfl_time_now();
+    input_name = (char *) flb_input_name(task->i_ins);
+    output_name = (char *) flb_output_name(output);
+
+    flb_task_acquire_lock(task);
+    if (flb_task_get_route_data(task, output,
+                                &effective_records,
+                                &effective_bytes) != 0 &&
+        task->event_chunk != NULL) {
+        effective_records = task->event_chunk->total_events;
+        effective_bytes = task->event_chunk->size;
+    }
+    flb_task_release_lock(task);
+
+    cmt_counter_inc(output->cmt_retries_failed, timestamp,
+                    1, (char *[]) {output_name});
+    cmt_counter_add(output->cmt_dropped_records, timestamp, effective_records,
+                    1, (char *[]) {output_name});
+
+    if (config->router && task->event_chunk &&
+        task->event_chunk->type == FLB_EVENT_TYPE_LOGS) {
+        cmt_counter_add(config->router->logs_drop_records_total, timestamp,
+                        effective_records,
+                        2, (char *[]) {input_name, output_name});
+        cmt_counter_add(config->router->logs_drop_bytes_total, timestamp,
+                        effective_bytes,
+                        2, (char *[]) {input_name, output_name});
+    }
+
+#ifdef FLB_HAVE_METRICS
+    flb_metrics_sum(FLB_METRIC_OUT_RETRY_FAILED, 1, output->metrics);
+    flb_metrics_sum(FLB_METRIC_OUT_DROPPED_RECORDS,
+                    effective_records, output->metrics);
+#endif
+}
 
 /* It creates a new output thread using a 'Retry' context */
 int flb_engine_dispatch_retry(struct flb_task_retry *retry,
@@ -68,6 +118,7 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
     if (!buf_data) {
         /* Could not retrieve chunk content */
         flb_error("[engine_dispatch] could not retrieve chunk content, removing retry");
+        record_retry_failure_metrics(task, retry->o_ins, config);
         flb_task_retry_destroy(retry);
         flb_task_users_release(task);
         return -1;

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -69,6 +69,7 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
         /* Could not retrieve chunk content */
         flb_error("[engine_dispatch] could not retrieve chunk content, removing retry");
         flb_task_retry_destroy(retry);
+        flb_task_users_release(task);
         return -1;
     }
 

--- a/src/flb_engine_dispatch.c
+++ b/src/flb_engine_dispatch.c
@@ -90,6 +90,7 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
     char *buf_data;
     size_t buf_size;
     struct flb_task *task;
+    struct flb_output_instance *ins;
 
     task = retry->parent;
 
@@ -116,12 +117,38 @@ int flb_engine_dispatch_retry(struct flb_task_retry *retry,
     /* There is a match, get the buffer */
     buf_data = (char *) flb_input_chunk_flush(task->ic, &buf_size);
     if (!buf_data) {
-        /* Could not retrieve chunk content */
-        flb_error("[engine_dispatch] could not retrieve chunk content, removing retry");
-        record_retry_failure_metrics(task, retry->o_ins, config);
-        flb_task_retry_destroy(retry);
-        flb_task_users_release(task);
-        return -1;
+        /*
+         * The chunk is up but its content could not be read. That is usually
+         * transient, so spend a delivery attempt on it instead of discarding
+         * records a later attempt could still deliver.
+         *
+         * Destroying the retry without releasing the task would leave the task
+         * with no users and no retries, a state nothing reaps.
+         */
+        ins = retry->o_ins;
+
+        if (retry->attempts >= ins->retry_limit && ins->retry_limit >= 0) {
+            flb_error("[engine_dispatch] could not retrieve chunk content, "
+                      "task_id=%i reached retry-attempts limit %i/%i, dropping",
+                      task->id, retry->attempts, ins->retry_limit);
+            record_retry_failure_metrics(task, ins, config);
+            flb_task_retry_destroy(retry);
+            flb_task_users_release(task);
+            return -1;
+        }
+
+        retry->attempts++;
+        flb_warn("[engine_dispatch] could not retrieve chunk content, "
+                 "re-scheduling task_id=%i attempts=%i",
+                 task->id, retry->attempts);
+
+        ret = flb_task_retry_reschedule(retry, config);
+        if (ret == -1) {
+            return -1;
+        }
+
+        /* Just return because it has been re-scheduled */
+        return 0;
     }
 
     /* Update the buffer reference */

--- a/src/flb_input_thread.c
+++ b/src/flb_input_thread.c
@@ -581,6 +581,10 @@ int flb_input_thread_instance_exit(struct flb_input_instance *ins)
 
     memcpy(&tid, &thi->th->tid, sizeof(pthread_t));
 
+    if (ins->p->cb_pre_exit && ins->context) {
+        ins->p->cb_pre_exit(ins->context, ins->config);
+    }
+
     /* compose message to pause the thread */
     val = FLB_BITS_U64_SET(FLB_INPUT_THREAD_TO_THREAD,
                            FLB_INPUT_THREAD_EXIT);

--- a/src/flb_output.c
+++ b/src/flb_output.c
@@ -821,8 +821,16 @@ struct flb_output_instance *flb_output_new(struct flb_config *config,
     if (plugin->flags & FLB_OUTPUT_NET) {
         ret = flb_net_host_set(plugin->name, &instance->host, output);
         if (ret != 0) {
-            if (instance->flags & FLB_OUTPUT_SYNCHRONOUS) {
+            if ((instance->flags & FLB_OUTPUT_SYNCHRONOUS) &&
+                instance->singleplex_queue != NULL) {
                 flb_task_queue_destroy(instance->singleplex_queue);
+            }
+            if (instance->callback != NULL) {
+                flb_callback_destroy(instance->callback);
+            }
+            if (plugin->type != FLB_OUTPUT_PLUGIN_CORE &&
+                instance->context != NULL) {
+                flb_free(instance->context);
             }
             flb_free(instance->http_server_config);
             flb_free(instance);

--- a/src/flb_utils.c
+++ b/src/flb_utils.c
@@ -878,7 +878,7 @@ static int flb_utils_write_str_escaped(char *buf, int *off, size_t size, const c
 {
     int i, b, ret, len, hex_bytes, utf_sequence_length, utf_sequence_number;
     int processed_bytes = 0;
-    int is_valid, copypos = 0, vlen;
+    int is_valid, copypos = 0;
     uint32_t c;
     uint32_t codepoint = 0;
     uint32_t state = 0;
@@ -902,11 +902,9 @@ static int flb_utils_write_str_escaped(char *buf, int *off, size_t size, const c
 
     p = buf + *off;
 
-    /* align length to the nearest multiple of the vector size for safe SIMD processing */
-    vlen = str_len & ~(inst_len - 1);
     for (i = 0;;) {
         /* SIMD optimization: Process chunk of input string */
-        for (; i < vlen; i += inst_len) {
+        for (; i + inst_len <= str_len; i += inst_len) {
             flb_vector8 chunk;
             flb_vector8_load(&chunk, (const uint8_t *)&str[i]);
 
@@ -1247,7 +1245,7 @@ static inline int flb_utf8_validate_char(const unsigned char *str, int max_len)
 static int flb_utils_write_str_raw(char *buf, int *off, size_t size,
                                    const char *str, size_t str_len)
 {
-    int i, b, vlen, len, utf_len, copypos = 0;
+    int i, b, len, utf_len, copypos = 0;
     size_t available;
     char *p;
     off_t offset = 0;
@@ -1258,15 +1256,12 @@ static int flb_utils_write_str_raw(char *buf, int *off, size_t size,
     available = size - *off;
     p = buf + *off;
 
-    /* align length to the nearest multiple of the vector size for safe SIMD processing */
-    vlen = str_len & ~(inst_len - 1);
-
     for (i = 0;;) {
         /*
          * Process chunks of the input string using SIMD instructions.
          * This loop continues as long as it finds "safe" ASCII characters.
          */
-        for (; i < vlen; i += inst_len) {
+        for (; i + inst_len <= str_len; i += inst_len) {
             flb_vector8 chunk;
             flb_vector8_load(&chunk, (const uint8_t *)&str[i]);
 

--- a/src/opentelemetry/flb_opentelemetry_utils.c
+++ b/src/opentelemetry/flb_opentelemetry_utils.c
@@ -164,10 +164,6 @@ int flb_otel_utils_json_payload_get_wrapped_value(msgpack_object *wrapper,
             *type  = internal_type;
         }
 
-        if (value != NULL) {
-            *value = kv_value;
-        }
-
         if (kv_value->type == MSGPACK_OBJECT_MAP) {
             map = &kv_value->via.map;
 
@@ -175,15 +171,19 @@ int flb_otel_utils_json_payload_get_wrapped_value(msgpack_object *wrapper,
                 kv_value = &map->ptr[0].val;
                 kv_key = &map->ptr[0].key.via.str;
 
-                if (strncasecmp(kv_key->ptr, "values", kv_key->size) == 0) {
-                    if (value != NULL) {
-                        *value = kv_value;
-                    }
-                }
-                else {
+                if (strncasecmp(kv_key->ptr, "values", kv_key->size) != 0) {
                     return -3;
                 }
             }
+        }
+
+        if (internal_type == MSGPACK_OBJECT_ARRAY &&
+            kv_value->type != MSGPACK_OBJECT_ARRAY) {
+            return -2;
+        }
+
+        if (value != NULL) {
+            *value = kv_value;
         }
     }
     else {

--- a/src/opentelemetry/flb_opentelemetry_utils.c
+++ b/src/opentelemetry/flb_opentelemetry_utils.c
@@ -167,18 +167,35 @@ int flb_otel_utils_json_payload_get_wrapped_value(msgpack_object *wrapper,
         if (kv_value->type == MSGPACK_OBJECT_MAP) {
             map = &kv_value->via.map;
 
-            if (map->size == 1) {
+            if (map->size == 1)
+            {
+                if (map->ptr[0].key.type != MSGPACK_OBJECT_STR)
+                {
+                    return -3;
+                }
+
                 kv_value = &map->ptr[0].val;
                 kv_key = &map->ptr[0].key.via.str;
 
-                if (strncasecmp(kv_key->ptr, "values", kv_key->size) != 0) {
+                if (kv_key->size != 6 ||
+                    strncasecmp(kv_key->ptr, "values", 6) != 0)
+                {
                     return -3;
                 }
             }
         }
 
         if (internal_type == MSGPACK_OBJECT_ARRAY &&
-            kv_value->type != MSGPACK_OBJECT_ARRAY) {
+            kv_value->type != MSGPACK_OBJECT_ARRAY &&
+            (kv_value->type != MSGPACK_OBJECT_MAP ||
+             kv_value->via.map.size != 0))
+        {
+            return -2;
+        }
+        else if (internal_type == MSGPACK_OBJECT_MAP &&
+                 kv_value->type != MSGPACK_OBJECT_ARRAY &&
+                 kv_value->type != MSGPACK_OBJECT_MAP)
+        {
             return -2;
         }
 
@@ -187,7 +204,7 @@ int flb_otel_utils_json_payload_get_wrapped_value(msgpack_object *wrapper,
         }
     }
     else {
-        return -2;
+        return -1;
     }
 
     return 0;
@@ -329,17 +346,53 @@ int flb_otel_utils_json_payload_append_unwrapped_value(
         else if (type == MSGPACK_OBJECT_BIN) {
             unwrap_value = FLB_TRUE;
         }
-        else if (type == MSGPACK_OBJECT_ARRAY) {
-            result = flb_otel_utils_json_payload_append_converted_array(encoder,
-                                                         target_field,
-                                                         value);
+        else if (type == MSGPACK_OBJECT_ARRAY)
+        {
+            if (value->type == MSGPACK_OBJECT_ARRAY)
+            {
+                result = flb_otel_utils_json_payload_append_converted_array(
+                            encoder,
+                            target_field,
+                            value);
+            }
+            else if (value->type == MSGPACK_OBJECT_MAP &&
+                     value->via.map.size == 0)
+            {
+                result = flb_log_event_encoder_begin_array(encoder, target_field);
+
+                if (result == FLB_EVENT_ENCODER_SUCCESS)
+                {
+                    result = flb_log_event_encoder_commit_array(encoder, target_field);
+                }
+            }
+            else
+            {
+                return -2;
+            }
         }
-        else if (type == MSGPACK_OBJECT_MAP) {
-            result = flb_otel_utils_json_payload_append_converted_kvlist(encoder,
-                                                          target_field,
-                                                          value);
+        else if (type == MSGPACK_OBJECT_MAP)
+        {
+            if (value->type == MSGPACK_OBJECT_ARRAY)
+            {
+                result = flb_otel_utils_json_payload_append_converted_kvlist(
+                            encoder,
+                            target_field,
+                            value);
+            }
+            else if (value->type == MSGPACK_OBJECT_MAP)
+            {
+                result = flb_otel_utils_json_payload_append_converted_map(
+                            encoder,
+                            target_field,
+                            value);
+            }
+            else
+            {
+                return -2;
+            }
         }
-        else {
+        else
+        {
             return -2;
         }
 
@@ -353,11 +406,7 @@ int flb_otel_utils_json_payload_append_unwrapped_value(
 
         return 0;
     }
-    else {
-        return -1;
-    }
-
-    return -1;
+    return result;
 }
 
 int flb_otel_utils_json_payload_append_converted_map(
@@ -370,6 +419,11 @@ int flb_otel_utils_json_payload_append_converted_map(
     size_t              index;
     msgpack_object_map *map;
 
+    if (encoder == NULL || object == NULL ||
+        object->type != MSGPACK_OBJECT_MAP) {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
+    }
+
     map = &object->via.map;
 
     result = flb_otel_utils_json_payload_append_unwrapped_value(
@@ -378,8 +432,13 @@ int flb_otel_utils_json_payload_append_converted_map(
                 object,
                 &encoder_result);
 
-    if (result == 0) {
+    if (result == 0)
+    {
         return encoder_result;
+    }
+    else if (result != -1)
+    {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_VALUE_TYPE;
     }
 
     result = flb_log_event_encoder_begin_map(encoder, target_field);
@@ -419,6 +478,12 @@ int flb_otel_utils_json_payload_append_converted_array(struct flb_log_event_enco
     size_t                index;
     msgpack_object_array *array;
 
+    if (encoder == NULL || object == NULL ||
+        object->type != MSGPACK_OBJECT_ARRAY)
+    {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
+    }
+
     array = &object->via.array;
 
     result = flb_log_event_encoder_begin_array(encoder, target_field);
@@ -457,6 +522,12 @@ int flb_otel_utils_json_payload_append_converted_kvlist(
     size_t                index;
     msgpack_object_array *array;
     msgpack_object_map   *entry;
+
+    if (encoder == NULL || object == NULL ||
+        object->type != MSGPACK_OBJECT_ARRAY)
+    {
+        return FLB_EVENT_ENCODER_ERROR_INVALID_ARGUMENT;
+    }
 
     array = &object->via.array;
 
@@ -842,26 +913,42 @@ static struct cfl_variant *convert_otlp_anyvalue_wrapper_to_cfl_variant(
                                              value_object->via.bin.size,
                                              CFL_FALSE);
     }
-    else if (value_type == MSGPACK_OBJECT_ARRAY) {
-        if (value_object->type != MSGPACK_OBJECT_ARRAY) {
+    else if (value_type == MSGPACK_OBJECT_ARRAY)
+    {
+        if (value_object->type == MSGPACK_OBJECT_MAP &&
+            value_object->via.map.size == 0)
+        {
+            value_array = NULL;
+            array_instance = cfl_array_create(0);
+        }
+        else if (value_object->type == MSGPACK_OBJECT_ARRAY)
+        {
+            value_array = &value_object->via.array;
+            array_instance = cfl_array_create(value_array->size);
+        }
+        else
+        {
             return NULL;
         }
 
-        value_array = &value_object->via.array;
-        array_instance = cfl_array_create(value_array->size);
-        if (array_instance == NULL) {
+        if (array_instance == NULL)
+        {
             return NULL;
         }
 
-        for (index = 0 ; index < value_array->size ; index++) {
+        for (index = 0 ;
+             value_array != NULL && index < value_array->size ;
+             index++) {
             child_variant = flb_otel_utils_msgpack_object_to_cfl_variant(
                               &value_array->ptr[index]);
-            if (child_variant == NULL) {
+            if (child_variant == NULL)
+            {
                 cfl_array_destroy(array_instance);
                 return NULL;
             }
 
-            if (cfl_array_append(array_instance, child_variant) != 0) {
+            if (cfl_array_append(array_instance, child_variant) != 0)
+            {
                 cfl_variant_destroy(child_variant);
                 cfl_array_destroy(array_instance);
                 return NULL;

--- a/tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py
+++ b/tests/integration/scenarios/filter_kubernetes/tests/test_filter_kubernetes_001.py
@@ -2,6 +2,7 @@ import contextlib
 import http.server
 import os
 import shlex
+import ssl
 import sys
 import threading
 
@@ -33,6 +34,47 @@ def _run_kube_api_server():
 
     try:
         yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+class _PodAssociationServer(http.server.ThreadingHTTPServer):
+    def __init__(self, server_address, handler_class):
+        super().__init__(server_address, handler_class)
+        self.request_count = 0
+        self.request_count_lock = threading.Lock()
+
+
+class _PodAssociationHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        payload = b"{}"
+
+        with self.server.request_count_lock:
+            self.server.request_count += 1
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, fmt, *args):
+        return
+
+
+@contextlib.contextmanager
+def _run_pod_association_server(cert_file, key_file):
+    server = _PodAssociationServer(("127.0.0.1", 0), _PodAssociationHandler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_file, key_file)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield server
     finally:
         server.shutdown()
         server.server_close()
@@ -114,6 +156,59 @@ def _write_config(tmp_path, name, script_file, kube_api_port):
     return config_file
 
 
+def _write_pod_association_config(tmp_path, servers, cert_file, key_file):
+    config_lines = [
+        "[SERVICE]",
+        "    Flush 1",
+        "    Grace 1",
+        "    Log_Level info",
+        "    HTTP_Server On",
+        "    HTTP_Port ${FLUENT_BIT_HTTP_MONITORING_PORT}",
+        "",
+        "[INPUT]",
+        "    Name dummy",
+        "    Tag application.test",
+        "    Samples 1",
+        "",
+        "[INPUT]",
+        "    Name dummy",
+        "    Tag dataplane.test",
+        "    Samples 1",
+        "",
+    ]
+
+    for match, server in zip(("application.*", "dataplane.*"), servers):
+        config_lines.extend(
+            [
+                "[FILTER]",
+                "    Name kubernetes",
+                f"    Match {match}",
+                "    Dummy_Meta On",
+                "    Use_Pod_Association On",
+                "    AWS_Pod_Association_Host 127.0.0.1",
+                f"    AWS_Pod_Association_Port {server.server_address[1]}",
+                "    AWS_Pod_Service_Map_Refresh_Interval 1",
+                "    AWS_Pod_Association_Host_TLS_Verify Off",
+                f"    AWS_Pod_Association_Host_Server_CA_File {cert_file}",
+                f"    AWS_Pod_Association_Host_Client_Cert_File {cert_file}",
+                f"    AWS_Pod_Association_Host_Client_Key_File {key_file}",
+                "",
+            ]
+        )
+
+    config_lines.extend(
+        [
+            "[OUTPUT]",
+            "    Name null",
+            "    Match *",
+        ]
+    )
+
+    config_file = tmp_path / "pod_association_multiple_filters.conf"
+    config_file.write_text("\n".join(config_lines), encoding="utf-8")
+    return config_file
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="Kube_Token_Command test is Linux-only")
 def test_filter_kubernetes_token_command_accepts_multiline_output_over_8kb(tmp_path):
     script_file = _write_script(tmp_path, "token_large.py", 3000)
@@ -146,3 +241,31 @@ def test_filter_kubernetes_token_command_rejects_multiline_output_over_limit(tmp
 
     assert "failed to run command" in log_text
     assert "kube token command test" in log_text
+
+
+def test_filter_kubernetes_pod_association_is_independent_per_instance(tmp_path):
+    cert_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate")
+    )
+    cert_file = os.path.join(cert_dir, "certificate.pem")
+    key_file = os.path.join(cert_dir, "private_key.pem")
+
+    with _run_pod_association_server(cert_file, key_file) as application_server, \
+            _run_pod_association_server(cert_file, key_file) as dataplane_server:
+        servers = (application_server, dataplane_server)
+        config_file = _write_pod_association_config(
+            tmp_path, servers, cert_file, key_file
+        )
+        service = Service(str(config_file))
+        service.start()
+        try:
+            service.service.wait_for_condition(
+                lambda: all(server.request_count >= 2 for server in servers),
+                timeout=20,
+                interval=0.25,
+                description="two refreshes from each pod association filter",
+            )
+        finally:
+            service.stop()
+
+    assert all(server.request_count >= 2 for server in servers)

--- a/tests/integration/scenarios/in_exec/config/threaded_hot_reload.yaml
+++ b/tests/integration/scenarios/in_exec/config/threaded_hot_reload.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  hot_reload: on
+  hot_reload.timeout: 30
+
+pipeline:
+  inputs:
+    - name: exec
+      command: 'echo $$ > "${EXEC_CHILD_PID_FILE}"; exec tail -f /dev/null'
+      interval_sec: 1
+      threaded: on
+      tag: exec
+
+  outputs:
+    - name: null
+      match: "*"

--- a/tests/integration/scenarios/in_exec/tests/test_in_exec_001.py
+++ b/tests/integration/scenarios/in_exec/tests/test_in_exec_001.py
@@ -1,0 +1,105 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+from pathlib import Path
+import signal
+import sys
+import tempfile
+import time
+
+import pytest
+
+from utils.fluent_bit_manager import FluentBitManager
+
+
+def wait_for_child_pid(pid_file, previous_pid=None, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        try:
+            child_pid = int(pid_file.read_text(encoding="utf-8").strip())
+            if child_pid > 0 and child_pid != previous_pid:
+                return child_pid
+        except (FileNotFoundError, ValueError):
+            pass
+
+        time.sleep(0.1)
+
+    raise TimeoutError("Timed out waiting for the exec child PID")
+
+
+def process_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+
+    return True
+
+
+def wait_for_process_exit(pid, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not process_exists(pid):
+            return True
+        time.sleep(0.1)
+
+    return False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX signals and tail")
+def test_threaded_exec_hot_reload_stops_blocking_child():
+    test_path = Path(__file__).resolve().parent
+    config_path = test_path.parent / "config" / "threaded_hot_reload.yaml"
+    child_pids = []
+    new_child_pid = None
+    shutdown_child_exited = False
+
+    with tempfile.TemporaryDirectory(prefix="flb-in-exec-") as runtime_dir:
+        pid_file = Path(runtime_dir) / "child.pid"
+        previous_pid_file = os.environ.get("EXEC_CHILD_PID_FILE")
+        os.environ["EXEC_CHILD_PID_FILE"] = str(pid_file)
+        manager = FluentBitManager(str(config_path))
+
+        try:
+            manager.start()
+            old_child_pid = wait_for_child_pid(pid_file)
+            child_pids.append(old_child_pid)
+
+            manager.send_sighup()
+            manager.wait_for_hot_reload_count(1, timeout=30)
+
+            new_child_pid = wait_for_child_pid(pid_file, old_child_pid)
+            child_pids.append(new_child_pid)
+            assert wait_for_process_exit(old_child_pid)
+        finally:
+            try:
+                manager.stop()
+                if new_child_pid is not None:
+                    shutdown_child_exited = wait_for_process_exit(new_child_pid)
+            finally:
+                if previous_pid_file is None:
+                    os.environ.pop("EXEC_CHILD_PID_FILE", None)
+                else:
+                    os.environ["EXEC_CHILD_PID_FILE"] = previous_pid_file
+
+                for child_pid in child_pids:
+                    if process_exists(child_pid):
+                        os.kill(child_pid, signal.SIGKILL)
+
+        assert shutdown_child_exited

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -860,6 +860,27 @@ def test_in_forward_message_mode_partial_tcp_writes():
     assert records[0]["message"] == "partial"
 
 
+def test_in_forward_multiple_message_mode_frames_in_one_write():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        payload = b"".join(
+            _message_mode_payload(TEST_TAG, {"message": message})
+            for message in ["coalesced-one", "coalesced-two", "coalesced-three"]
+        )
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(3)
+    finally:
+        service.stop()
+
+    assert [record["message"] for record in records] == [
+        "coalesced-one",
+        "coalesced-two",
+        "coalesced-three",
+    ]
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="process resource limits are Linux-only")
 def test_in_forward_repro_payload_allocation_failure_closes_connection(tmp_path):
     if os.environ.get("VALGRIND"):

--- a/tests/integration/scenarios/in_kubernetes_events/tests/test_in_kubernetes_events_001.py
+++ b/tests/integration/scenarios/in_kubernetes_events/tests/test_in_kubernetes_events_001.py
@@ -1,0 +1,177 @@
+import contextlib
+import http.server
+import json
+import os
+import threading
+import time
+
+from utils.data_utils import read_file
+from utils.test_service import FluentBitTestService
+
+
+EVENT_UID = "watch-event-uid"
+RECOVERED_EVENT_UID = "post-recovery-event-uid"
+
+
+def _event(resource_version, uid):
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return {
+        "metadata": {
+            "creationTimestamp": timestamp,
+            "resourceVersion": str(resource_version),
+            "uid": uid,
+        }
+    }
+
+
+class _KubeApiServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, server_address, handler_class):
+        super().__init__(server_address, handler_class)
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.list_requests = 0
+        self.watch_requests = 0
+        self.watch_paths = []
+        self.event = _event(2, EVENT_UID)
+        self.recovered_event = _event(3, RECOVERED_EVENT_UID)
+
+
+class _KubeApiHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        if "watch=1" in self.path:
+            with self.server.lock:
+                self.server.watch_requests += 1
+                self.server.watch_paths.append(self.path)
+                watch_request = self.server.watch_requests
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            if watch_request <= 2:
+                event = self.server.event
+                if watch_request == 2:
+                    event = self.server.recovered_event
+                payload = (
+                    json.dumps({"type": "ADDED", "object": event}) + "\n"
+                ).encode("utf-8")
+                self.wfile.write(f"{len(payload):x}\r\n".encode("ascii"))
+                self.wfile.write(payload)
+                self.wfile.write(b"\r\n")
+            self.wfile.flush()
+            if watch_request == 2:
+                time.sleep(0.5)
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+                return
+            self.server.stop_event.wait(timeout=30)
+            try:
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+
+        with self.server.lock:
+            self.server.list_requests += 1
+            list_request = self.server.list_requests
+
+        payload = json.dumps(
+            {
+                "kind": "EventList",
+                "apiVersion": "v1",
+                "metadata": {"resourceVersion": str(min(list_request, 2))},
+                "items": [self.server.event] if list_request > 1 else [],
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+        self.wfile.flush()
+
+    def log_message(self, fmt, *args):
+        return
+
+
+@contextlib.contextmanager
+def _run_kube_api_server():
+    server = _KubeApiServer(("127.0.0.1", 0), _KubeApiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield server
+    finally:
+        server.stop_event.set()
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def _write_config(tmp_path, kube_api_port):
+    token_file = tmp_path / "token"
+    token_file.write_text("test-token", encoding="utf-8")
+    config_file = tmp_path / "kubernetes_events_watch_timeout.conf"
+    config_file.write_text(
+        "\n".join(
+            [
+                "[SERVICE]",
+                "    Flush 1",
+                "    Grace 1",
+                "    Log_Level info",
+                "    HTTP_Server On",
+                "    HTTP_Port ${FLUENT_BIT_HTTP_MONITORING_PORT}",
+                "",
+                "[INPUT]",
+                "    Name kubernetes_events",
+                f"    Kube_URL http://127.0.0.1:{kube_api_port}",
+                f"    Kube_Token_File {token_file}",
+                "    tls Off",
+                "    Interval_Sec 5",
+                "    Interval_NSec 0",
+                "    Kube_Watch_Timeout 1s",
+                "",
+                "[OUTPUT]",
+                "    Name stdout",
+                "    Match *",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_file
+
+
+def test_kubernetes_events_reconnects_stalled_watch(tmp_path):
+    with _run_kube_api_server() as kube_api_server:
+        config_file = _write_config(tmp_path, kube_api_server.server_address[1])
+        service = FluentBitTestService(os.fspath(config_file))
+        service.start()
+        log_file = service.flb.log_file
+
+        try:
+            service.wait_for_condition(
+                lambda: RECOVERED_EVENT_UID
+                if kube_api_server.watch_requests >= 2
+                and RECOVERED_EVENT_UID in read_file(log_file)
+                and read_file(log_file).count("kubernetes stream disconnected") >= 2
+                else None,
+                timeout=20,
+                interval=0.25,
+                description="an event from the reconnected Kubernetes watch",
+            )
+        finally:
+            service.stop()
+
+        with open(log_file, encoding="utf-8") as log:
+            log_text = log.read()
+        assert kube_api_server.list_requests >= 2
+        assert kube_api_server.watch_requests >= 2
+        assert all("timeoutSeconds=1" in path for path in kube_api_server.watch_paths)
+        assert log_text.count(EVENT_UID) == 1
+        assert log_text.count(RECOVERED_EVENT_UID) == 1

--- a/tests/integration/scenarios/in_kubernetes_events/tests/test_in_kubernetes_events_001.py
+++ b/tests/integration/scenarios/in_kubernetes_events/tests/test_in_kubernetes_events_001.py
@@ -11,6 +11,7 @@ from utils.test_service import FluentBitTestService
 
 EVENT_UID = "watch-event-uid"
 RECOVERED_EVENT_UID = "post-recovery-event-uid"
+PREFIX_COLLISION_EVENT_UID = "prefix-collision-event-uid"
 
 
 def _event(resource_version, uid):
@@ -27,14 +28,14 @@ def _event(resource_version, uid):
 class _KubeApiServer(http.server.ThreadingHTTPServer):
     daemon_threads = True
 
-    def __init__(self, server_address, handler_class):
+    def __init__(self, server_address, handler_class, event=None):
         super().__init__(server_address, handler_class)
         self.lock = threading.Lock()
         self.stop_event = threading.Event()
         self.list_requests = 0
         self.watch_requests = 0
         self.watch_paths = []
-        self.event = _event(2, EVENT_UID)
+        self.event = event or _event(2, EVENT_UID)
         self.recovered_event = _event(3, RECOVERED_EVENT_UID)
 
 
@@ -100,8 +101,8 @@ class _KubeApiHandler(http.server.BaseHTTPRequestHandler):
 
 
 @contextlib.contextmanager
-def _run_kube_api_server():
-    server = _KubeApiServer(("127.0.0.1", 0), _KubeApiHandler)
+def _run_kube_api_server(event=None):
+    server = _KubeApiServer(("127.0.0.1", 0), _KubeApiHandler, event)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
 
@@ -175,3 +176,44 @@ def test_kubernetes_events_reconnects_stalled_watch(tmp_path):
         assert all("timeoutSeconds=1" in path for path in kube_api_server.watch_paths)
         assert log_text.count(EVENT_UID) == 1
         assert log_text.count(RECOVERED_EVENT_UID) == 1
+
+
+def test_kubernetes_events_requires_exact_field_names(tmp_path):
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    event = {
+        "metadataExtra": {
+            "creationTimestamp": "invalid",
+            "resourceVersion": "-1",
+            "uid": "wrong-metadata",
+        },
+        "metadata": {
+            "creationTimestampExtra": "invalid",
+            "resourceVersionExtra": "18446744073709551616",
+            "uidExtra": "wrong-uid",
+            "creationTimestamp": timestamp,
+            "resourceVersion": "2",
+            "uid": PREFIX_COLLISION_EVENT_UID,
+        },
+    }
+
+    with _run_kube_api_server(event) as kube_api_server:
+        config_file = _write_config(tmp_path, kube_api_server.server_address[1])
+        service = FluentBitTestService(os.fspath(config_file))
+        service.start()
+        log_file = service.flb.log_file
+
+        try:
+            service.wait_for_condition(
+                lambda: PREFIX_COLLISION_EVENT_UID
+                if PREFIX_COLLISION_EVENT_UID in read_file(log_file)
+                else None,
+                timeout=15,
+                interval=0.25,
+                description="a Kubernetes event with prefix-collision fields",
+            )
+        finally:
+            service.stop()
+
+        with open(log_file, encoding="utf-8") as log:
+            log_text = log.read()
+        assert log_text.count(PREFIX_COLLISION_EVENT_UID) == 1

--- a/tests/integration/scenarios/in_node_exporter_metrics/config/in_node_exporter_metrics_diskstats.yaml
+++ b/tests/integration/scenarios/in_node_exporter_metrics/config/in_node_exporter_metrics_diskstats.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: node_exporter_metrics
+      tag: node_metrics
+      scrape_interval: 1
+      metrics: diskstats
+      path.procfs: ${NODE_EXPORTER_PROCFS}
+      diskstats.ignore_device_regex: "^$"
+
+  outputs:
+    - name: prometheus_exporter
+      match: node_metrics
+      host: 127.0.0.1
+      port: ${NODE_EXPORTER_EXPORTER_PORT}

--- a/tests/integration/scenarios/in_node_exporter_metrics/tests/test_in_node_exporter_metrics_001.py
+++ b/tests/integration/scenarios/in_node_exporter_metrics/tests/test_in_node_exporter_metrics_001.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+import pytest
+
+from utils.http_matrix import run_curl_request
+from utils.test_service import FluentBitTestService
+
+
+EXPECTED_METRICS = {
+    "node_disk_reads_completed_total": 1.0,
+    "node_disk_reads_merged_total": 2.0,
+    "node_disk_read_bytes_total": 1536.0,
+    "node_disk_read_time_seconds_total": 4.0,
+    "node_disk_writes_completed_total": 5.0,
+    "node_disk_writes_merged_total": 6.0,
+    "node_disk_written_bytes_total": 3584.0,
+    "node_disk_write_time_seconds_total": 8.0,
+    "node_disk_io_now": 9.0,
+    "node_disk_io_time_seconds_total": 10.0,
+    "node_disk_io_time_weighted_seconds_total": 11.0,
+}
+
+
+def _metric_value(metrics_text, metric_name):
+    prefix = f'{metric_name}{{device="sda"}} '
+    for line in metrics_text.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix):].split()[0])
+    return None
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="procfs diskstats are Linux-only")
+def test_node_exporter_diskstats_metric_cache(tmp_path):
+    procfs_path = tmp_path / "proc"
+    procfs_path.mkdir()
+    (procfs_path / "diskstats").write_text(
+        "8 0 sda 1 2 3 4000 5 6 7 8000 9 10000 11000 "
+        "12 13 14 15000 16 17000\n",
+        encoding="utf-8",
+    )
+
+    config_file = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../config/in_node_exporter_metrics_diskstats.yaml",
+        )
+    )
+
+    def pre_start(service):
+        service.allocate_port_env("NODE_EXPORTER_EXPORTER_PORT")
+
+    service = FluentBitTestService(
+        config_file,
+        extra_env={"NODE_EXPORTER_PROCFS": procfs_path},
+        pre_start=pre_start,
+    )
+    service.start()
+    exporter_port = os.environ["NODE_EXPORTER_EXPORTER_PORT"]
+
+    try:
+        response = service.wait_for_condition(
+            lambda: (
+                result
+                if result["status_code"] == 200
+                and all(
+                    _metric_value(result["body"], name) == value
+                    for name, value in EXPECTED_METRICS.items()
+                )
+                else None
+            )
+            if (
+                result := run_curl_request(
+                    f"http://127.0.0.1:{exporter_port}/metrics",
+                    method="GET",
+                    http_mode="http1.1",
+                )
+            )
+            else None,
+            timeout=15,
+            interval=1,
+            description="diskstats metrics with correct cache values",
+        )
+    finally:
+        service.stop()
+
+    for metric_name, expected_value in EXPECTED_METRICS.items():
+        assert _metric_value(response["body"], metric_name) == expected_value

--- a/tests/integration/scenarios/in_opentelemetry/config/expect_batch.yaml
+++ b/tests/integration/scenarios/in_opentelemetry/config/expect_batch.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 0.2
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  filters:
+    - name: expect
+      match: "*"
+      key_exists:
+        - field1
+        - field2
+        - field3
+        - field4
+      action: warn
+
+  outputs:
+    - name: null
+      match: "*"

--- a/tests/integration/scenarios/in_opentelemetry/config/expect_group_result_key.yaml
+++ b/tests/integration/scenarios/in_opentelemetry/config/expect_group_result_key.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 0.2
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  filters:
+    - name: expect
+      match: "*"
+      key_exists:
+        - field1
+        - field2
+        - field3
+        - field4
+      action: result_key
+      result_key: matched
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      logs_uri: /v1/logs

--- a/tests/integration/scenarios/in_opentelemetry/tests/data_files/test_logs_expect_batch.in.json
+++ b/tests/integration/scenarios/in_opentelemetry/tests/data_files/test_logs_expect_batch.in.json
@@ -1,0 +1,131 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my-service"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field1",
+                      "value": {
+                        "stringValue": "1"
+                      }
+                    },
+                    {
+                      "key": "field2",
+                      "value": {
+                        "stringValue": "2"
+                      }
+                    },
+                    {
+                      "key": "field3",
+                      "value": {
+                        "stringValue": "3"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field1",
+                      "value": {
+                        "stringValue": "1"
+                      }
+                    },
+                    {
+                      "key": "field2",
+                      "value": {
+                        "stringValue": "2"
+                      }
+                    },
+                    {
+                      "key": "field4",
+                      "value": {
+                        "stringValue": "4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field1",
+                      "value": {
+                        "stringValue": "1"
+                      }
+                    },
+                    {
+                      "key": "field3",
+                      "value": {
+                        "stringValue": "3"
+                      }
+                    },
+                    {
+                      "key": "field4",
+                      "value": {
+                        "stringValue": "4"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "timeUnixNano": "1784797967000450100",
+              "body": {
+                "kvlistValue": {
+                  "values": [
+                    {
+                      "key": "field2",
+                      "value": {
+                        "stringValue": "2"
+                      }
+                    },
+                    {
+                      "key": "field3",
+                      "value": {
+                        "stringValue": "3"
+                      }
+                    },
+                    {
+                      "key": "field4",
+                      "value": {
+                        "stringValue": "4"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -1258,6 +1258,27 @@ def test_in_opentelemetry_protocol_matrix(case, signal_type, json_input, endpoin
     assert len(response_payload) > 0
 
 
+def test_in_opentelemetry_http2_invalid_endpoint_returns_404():
+    service = Service(IN_OPENTELEMETRY_PROTOCOL_CONFIGS["http2_cleartext"])
+    service.start()
+
+    result = run_curl_request(
+        f"http://localhost:{service.flb_listener_port}/v1/invalid",
+        b"invalid payload",
+        headers=["Content-Type: application/x-protobuf"],
+        http_mode="http2-prior-knowledge",
+    )
+
+    service.stop()
+
+    assert result["status_code"] == 404
+    assert result["http_version"] == "2"
+    assert result["body"] == "error: invalid endpoint\n"
+    assert len(data_storage["logs"]) == 0
+    assert len(data_storage["metrics"]) == 0
+    assert len(data_storage["traces"]) == 0
+
+
 # This test is branch-specific coverage for the generic HTTP listener worker mode.
 # It does three things:
 # 1. enables http_server.workers on the in_opentelemetry listener,

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -804,7 +804,44 @@ def test_in_opentelemetry_rejects_invalid_logs_payload():
     assert len(data_storage["logs"]) == 0
 
 
-def test_in_opentelemetry_handles_json_logs_with_non_array_array_value():
+@pytest.mark.parametrize(
+    ("body", "expected_status", "expected_body"),
+    [
+        pytest.param(
+            {"arrayValue": {"values": "not-an-array"}},
+            400,
+            None,
+            id="array-value",
+        ),
+        pytest.param(
+            {"arrayValue": {"value": []}},
+            400,
+            None,
+            id="array-value-invalid-values-key",
+        ),
+        pytest.param(
+            {"kvlistValue": {"values": "not-a-kvlist"}},
+            400,
+            None,
+            id="kvlist-value",
+        ),
+        pytest.param(
+            {"kvlistValue": {}},
+            201,
+            {"kvlistValue": {"values": []}},
+            id="map-form-kvlist-value",
+        ),
+        pytest.param(
+            {"arrayValue": {}},
+            201,
+            {"arrayValue": {"values": []}},
+            id="empty-array-value",
+        ),
+    ],
+)
+def test_in_opentelemetry_handles_json_logs_with_invalid_any_value_container(
+    body, expected_status, expected_body
+):
     payload = {
         "resourceLogs": [
             {
@@ -812,11 +849,7 @@ def test_in_opentelemetry_handles_json_logs_with_non_array_array_value():
                     {
                         "logRecords": [
                             {
-                                "body": {
-                                    "arrayValue": {
-                                        "values": "not-an-array",
-                                    },
-                                },
+                                "body": body,
                             }
                         ],
                     }
@@ -835,9 +868,19 @@ def test_in_opentelemetry_handles_json_logs_with_non_array_array_value():
             content_type="application/json",
         )
 
-        assert response.status_code == 201
+        assert response.status_code == expected_status
         assert service.flb.process is not None
         assert service.flb.process.poll() is None
+
+        if expected_body is None:
+            with pytest.raises(TimeoutError):
+                read_stdout_otlp_json(service, "resourceLogs", timeout=2)
+        else:
+            output = read_stdout_otlp_json(service, "resourceLogs")
+            records = list(iter_log_records(output))
+
+            assert len(records) == 1
+            assert records[0]["record"]["body"] == expected_body
     finally:
         service.stop()
 

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -230,6 +230,14 @@ def read_stdout_otlp_json_text(service, root_key, timeout=10, interval=0.25):
     raise TimeoutError(f"Timed out waiting for stdout OTLP JSON payload with root key {root_key}")
 
 
+def read_fluent_bit_log(service):
+    if not service.flb or not service.flb.log_file or not os.path.exists(service.flb.log_file):
+        return ""
+
+    with open(service.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+        return log_file.read()
+
+
 def read_prometheus_metric_value(metrics_text, metric_name, input_name):
     label = f'name="{input_name}"'
 
@@ -1599,3 +1607,98 @@ def test_in_opentelemetry_http_workers_respect_ingress_queue_byte_limit():
         "fluentbit_input_http_server_ingress_queue_pending_bytes",
         "opentelemetry.0",
     ) == 0
+def test_expect_warn_validates_each_otlp_log_record_in_batch():
+    service = Service("expect_batch.yaml")
+    payload = read_json_file(
+        os.path.join(
+            os.path.dirname(__file__),
+            "data_files",
+            "test_logs_expect_batch.in.json",
+        )
+    )
+
+    service.start()
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/v1/logs",
+            json=payload,
+            timeout=5,
+        )
+        assert response.status_code == 201
+
+        log_text = service.service.wait_for_condition(
+            lambda: (
+                content
+                if content.count("expect check failed") >= 4
+                else None
+            ) if (content := read_fluent_bit_log(service)) else None,
+            timeout=10,
+            interval=0.25,
+            description="one expect warning per invalid OTLP log record",
+        )
+    finally:
+        service.stop()
+
+    assert log_text.count("expect check failed") == 4
+    for field_name in ("field1", "field2", "field3", "field4"):
+        assert log_text.count(f"key '{field_name}' not found") == 1
+
+
+def test_expect_result_key_preserves_otlp_log_groups():
+    service = Service("expect_group_result_key.yaml")
+    payload = read_json_file(
+        os.path.join(
+            os.path.dirname(__file__),
+            "data_files",
+            "test_logs_expect_batch.in.json",
+        )
+    )
+    scope_logs = payload["resourceLogs"][0]["scopeLogs"][0]
+    scope_logs["scope"] = {"name": "issue.scope"}
+    scope_logs["logRecords"].append(
+        {
+            "timeUnixNano": "1784797967000450100",
+            "body": {
+                "kvlistValue": {
+                    "values": [
+                        {
+                            "key": f"field{index}",
+                            "value": {"stringValue": str(index)},
+                        }
+                        for index in range(1, 5)
+                    ]
+                }
+            },
+        }
+    )
+
+    service.start()
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/v1/logs",
+            json=payload,
+            timeout=5,
+        )
+        assert response.status_code == 201
+        output = service.read_response("logs")
+    finally:
+        service.stop()
+
+    records = list(iter_log_records(output))
+    assert len(records) == 5
+
+    matched_values = []
+    for record in records:
+        assert record["resource_attributes"] == {"service.name": "my-service"}
+        assert record["scope_name"] == "issue.scope"
+
+        values = record["record"]["body"]["kvlistValue"]["values"]
+        fields = {
+            item["key"]: next(iter(item["value"].values()))
+            for item in values
+        }
+        matched_values.append(fields["matched"])
+
+    assert matched_values == [False, False, False, False, True]

--- a/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/tests/integration/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -804,6 +804,44 @@ def test_in_opentelemetry_rejects_invalid_logs_payload():
     assert len(data_storage["logs"]) == 0
 
 
+def test_in_opentelemetry_handles_json_logs_with_non_array_array_value():
+    payload = {
+        "resourceLogs": [
+            {
+                "scopeLogs": [
+                    {
+                        "logRecords": [
+                            {
+                                "body": {
+                                    "arrayValue": {
+                                        "values": "not-an-array",
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    service = Service("003-stdout-otlp-json.yaml")
+    service.start()
+
+    try:
+        response = service.send_raw_request(
+            "/v1/logs",
+            json.dumps(payload).encode("utf-8"),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        assert service.flb.process is not None
+        assert service.flb.process.poll() is None
+    finally:
+        service.stop()
+
+
 def test_in_opentelemetry_rejects_invalid_metrics_payload():
     service = Service("001-fluent-bit.yaml")
     service.start()

--- a/tests/integration/scenarios/in_prometheus_remote_write/config/sender_stale_metrics.yaml
+++ b/tests/integration/scenarios/in_prometheus_remote_write/config/sender_stale_metrics.yaml
@@ -1,0 +1,23 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: prometheus_scrape
+      tag: stale_metrics
+      host: 127.0.0.1
+      port: ${PROM_SCRAPE_SOURCE_PORT}
+      metrics_path: /metrics
+      scrape_interval: 1
+
+  outputs:
+    - name: prometheus_remote_write
+      match: stale_metrics
+      host: 127.0.0.1
+      port: ${PROM_RW_RECEIVER_PORT}
+      uri: /write
+      compression: snappy

--- a/tests/integration/scenarios/in_prometheus_remote_write/tests/test_in_prometheus_remote_write_001.py
+++ b/tests/integration/scenarios/in_prometheus_remote_write/tests/test_in_prometheus_remote_write_001.py
@@ -1,4 +1,7 @@
+import contextlib
+import http.server
 import os
+import threading
 import time
 
 import pytest
@@ -41,6 +44,9 @@ PROM_RW_CASES = [
         "sender_config": "sender_tls.yaml",
     },
 ]
+
+FRESH_METRIC = "backport_fresh_metric"
+STALE_METRIC = "backport_stale_metric"
 
 
 def _read_file(path):
@@ -104,6 +110,38 @@ class Service:
         raise TimeoutError(f"Timed out waiting for {pattern} in {path}")
 
 
+class _PrometheusSourceHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        now_ms = int(time.time() * 1000)
+        body = (
+            f"# TYPE {FRESH_METRIC} gauge\n"
+            f"{FRESH_METRIC} 2 {now_ms}\n"
+            f"# TYPE {STALE_METRIC} gauge\n"
+            f"{STALE_METRIC} 1 {now_ms - 7200000}\n"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        return
+
+
+@contextlib.contextmanager
+def _run_prometheus_source():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _PrometheusSourceHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
 @pytest.mark.parametrize("workers_enabled", [False, True], ids=["single_listener", "workers_4"])
 @pytest.mark.parametrize("case", PROM_RW_CASES, ids=[case["id"] for case in PROM_RW_CASES])
 def test_in_prometheus_remote_write_matrix(case, workers_enabled):
@@ -128,3 +166,26 @@ def test_in_prometheus_remote_write_matrix(case, workers_enabled):
         assert "fluentbit_input_metrics_scrapes_total" in receiver_log
     finally:
         service.stop()
+
+
+def test_prometheus_remote_write_expires_stale_metrics():
+    with _run_prometheus_source() as source_port:
+        previous_source_port = os.environ.get("PROM_SCRAPE_SOURCE_PORT")
+        os.environ["PROM_SCRAPE_SOURCE_PORT"] = str(source_port)
+        service = Service("receiver_http1_cleartext.yaml", "sender_stale_metrics.yaml")
+
+        try:
+            service.start()
+            receiver_log = service.wait_for_log(
+                service.receiver.log_file,
+                FRESH_METRIC,
+                timeout=30,
+                interval=1,
+            )
+            assert STALE_METRIC not in receiver_log
+        finally:
+            service.stop()
+            if previous_source_port is None:
+                os.environ.pop("PROM_SCRAPE_SOURCE_PORT", None)
+            else:
+                os.environ["PROM_SCRAPE_SOURCE_PORT"] = previous_source_port

--- a/tests/integration/scenarios/in_storage_backlog/config/reload_with_stale_route.yaml
+++ b/tests/integration/scenarios/in_storage_backlog/config/reload_with_stale_route.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  hot_reload: on
+  hot_reload.timeout: 10
+  storage.path: ${STORAGE_BACKLOG_PATH}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: live
+      path: ${STORAGE_BACKLOG_MISSING_PATH}
+      storage.type: filesystem
+
+  outputs:
+    - name: null
+      match: "*"

--- a/tests/integration/scenarios/in_storage_backlog/config/reload_without_stale_route.yaml
+++ b/tests/integration/scenarios/in_storage_backlog/config/reload_without_stale_route.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  hot_reload: on
+  hot_reload.timeout: 10
+  storage.path: ${STORAGE_BACKLOG_PATH}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: live
+      path: ${STORAGE_BACKLOG_MISSING_PATH}
+      storage.type: filesystem
+
+  outputs:
+    - name: null
+      match: live

--- a/tests/integration/scenarios/in_storage_backlog/config/seed_unroutable_chunk.yaml
+++ b/tests/integration/scenarios/in_storage_backlog/config/seed_unroutable_chunk.yaml
@@ -1,0 +1,18 @@
+service:
+  flush: 1
+  grace: 0
+  storage.path: ${STORAGE_BACKLOG_PATH}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: stale
+      samples: 1
+      storage.type: filesystem
+
+  outputs:
+    - name: http
+      match: stale
+      host: 127.0.0.1
+      port: 9
+      retry_limit: no_limits

--- a/tests/integration/scenarios/in_storage_backlog/tests/test_in_storage_backlog_001.py
+++ b/tests/integration/scenarios/in_storage_backlog/tests/test_in_storage_backlog_001.py
@@ -1,0 +1,174 @@
+import os
+from pathlib import Path
+import signal
+import shutil
+import subprocess
+import time
+
+import pytest
+
+from utils.fluent_bit_manager import FluentBitManager
+
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+SEED_CONFIG = CONFIG_DIR / "seed_unroutable_chunk.yaml"
+RELOAD_WITHOUT_ROUTE = CONFIG_DIR / "reload_without_stale_route.yaml"
+RELOAD_WITH_ROUTE = CONFIG_DIR / "reload_with_stale_route.yaml"
+KEEP_ON_DISK_MESSAGE = "no matching route for dummy.0/"
+REGISTER_MESSAGE = "register dummy.0/"
+QUEUE_MESSAGE = "queueing dummy.0:"
+
+
+def wait_for_persisted_chunk(storage_path, process, log_path, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        chunks = list(storage_path.glob("*/*.flb"))
+        if chunks and chunks[0].stat().st_size > 0:
+            return chunks[0]
+
+        return_code = process.poll()
+        if return_code is not None:
+            if log_path.exists():
+                log = log_path.read_text(encoding="utf-8", errors="replace")
+            else:
+                log = "seed log was not created"
+            raise RuntimeError(
+                f"seed Fluent Bit exited with code {return_code} before persisting a chunk:\n{log}"
+            )
+
+        time.sleep(0.1)
+
+    raise TimeoutError("timed out waiting for the seed filesystem chunk")
+
+
+def wait_for_log_occurrences(log_path, text, expected, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if log_path.exists():
+            log = log_path.read_text(encoding="utf-8", errors="replace")
+            if log.count(text) >= expected:
+                return
+
+        time.sleep(0.1)
+
+    raise TimeoutError(f"timed out waiting for {expected} occurrences of {text!r}")
+
+
+def wait_for_path_removal(path, timeout=10):
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not path.exists():
+            return
+
+        time.sleep(0.1)
+
+    raise TimeoutError(f"timed out waiting for {path} to be removed")
+
+
+def seed_persisted_chunk(storage_path, seed_log_path):
+    binary_path = FluentBitManager(str(SEED_CONFIG)).binary_absolute_path
+    seed_process = subprocess.Popen(
+        [binary_path, "-c", str(SEED_CONFIG), "-l", str(seed_log_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+    )
+
+    try:
+        return wait_for_persisted_chunk(storage_path, seed_process, seed_log_path)
+    finally:
+        if seed_process.poll() is None:
+            seed_process.kill()
+        seed_process.wait(timeout=10)
+
+
+@pytest.fixture
+def seeded_chunk(tmp_path, monkeypatch):
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+    seed_log_path = tmp_path / "seed.log"
+    missing_path = tmp_path / "does-not-exist.log"
+
+    monkeypatch.setenv("STORAGE_BACKLOG_PATH", str(storage_path))
+    monkeypatch.setenv("STORAGE_BACKLOG_MISSING_PATH", str(missing_path))
+
+    persisted_chunk = seed_persisted_chunk(storage_path, seed_log_path)
+    assert persisted_chunk.exists()
+
+    return persisted_chunk
+
+
+def test_routable_persisted_chunk_is_replayed_on_startup(seeded_chunk):
+    manager = FluentBitManager(str(RELOAD_WITH_ROUTE))
+
+    try:
+        manager.start()
+        wait_for_log_occurrences(
+            Path(manager.log_file), REGISTER_MESSAGE, expected=1
+        )
+        wait_for_log_occurrences(
+            Path(manager.log_file), QUEUE_MESSAGE, expected=1
+        )
+        wait_for_path_removal(seeded_chunk)
+    finally:
+        manager.stop()
+
+    assert not seeded_chunk.exists()
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP is unavailable")
+def test_unroutable_chunk_stays_on_disk_across_hot_reload(seeded_chunk):
+    manager = FluentBitManager(str(RELOAD_WITHOUT_ROUTE))
+
+    try:
+        manager.start()
+        wait_for_log_occurrences(
+            Path(manager.log_file), KEEP_ON_DISK_MESSAGE, expected=1
+        )
+        assert seeded_chunk.exists()
+
+        manager.send_sighup()
+        manager.wait_for_hot_reload_count(1, timeout=20)
+        wait_for_log_occurrences(
+            Path(manager.log_file), KEEP_ON_DISK_MESSAGE, expected=2, timeout=20
+        )
+        assert seeded_chunk.exists()
+    finally:
+        manager.stop()
+
+    assert seeded_chunk.exists()
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP is unavailable")
+def test_restored_route_recovers_chunk_during_hot_reload(tmp_path, seeded_chunk):
+    runtime_config = tmp_path / "fluent-bit.yaml"
+    shutil.copyfile(RELOAD_WITHOUT_ROUTE, runtime_config)
+    manager = FluentBitManager(str(runtime_config))
+
+    try:
+        manager.start()
+        wait_for_log_occurrences(
+            Path(manager.log_file), KEEP_ON_DISK_MESSAGE, expected=1
+        )
+        assert seeded_chunk.exists()
+
+        pending_config = tmp_path / "fluent-bit.yaml.tmp"
+        shutil.copyfile(RELOAD_WITH_ROUTE, pending_config)
+        os.replace(pending_config, runtime_config)
+
+        manager.send_sighup()
+        manager.wait_for_hot_reload_count(1, timeout=20)
+        wait_for_log_occurrences(
+            Path(manager.log_file), REGISTER_MESSAGE, expected=1, timeout=20
+        )
+        wait_for_log_occurrences(
+            Path(manager.log_file), QUEUE_MESSAGE, expected=1, timeout=20
+        )
+        wait_for_path_removal(seeded_chunk, timeout=20)
+    finally:
+        manager.stop()
+
+    assert not seeded_chunk.exists()

--- a/tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_001.py
+++ b/tests/integration/scenarios/internal_http_server/tests/test_internal_http_server_001.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import os
+import socket
 import subprocess
 
 import pytest
+from utils.fluent_bit_manager import FluentBitManager, FluentBitStartupError
 from utils.http_matrix import curl_supports_http2, run_curl_request
 from utils.test_service import FluentBitTestService
 
@@ -146,3 +148,28 @@ def test_internal_http_server_http2_subset():
             assert result["http_version"] == "2"
     finally:
         service.stop()
+
+
+def test_internal_http_server_bind_failure_fails_startup(monkeypatch):
+    config_file = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../config/internal_http_server.yaml")
+    )
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.bind(("127.0.0.1", 0))
+    port = holder.getsockname()[1]
+    fluent_bit = FluentBitManager(config_file)
+
+    monkeypatch.setenv("FLUENT_BIT_HTTP_MONITORING_PORT", str(port))
+
+    def use_occupied_monitoring_port(_env_var_name, starting_port=0):
+        fluent_bit.http_monitoring_port = str(port)
+
+    fluent_bit.set_http_monitoring_port = use_occupied_monitoring_port
+
+    try:
+        with pytest.raises(FluentBitStartupError, match="exited early with code"):
+            fluent_bit.start()
+        assert fluent_bit.process.returncode != 0
+    finally:
+        holder.close()
+        fluent_bit.stop()

--- a/tests/integration/scenarios/out_loki/config/out_loki_long_unicode.yaml
+++ b/tests/integration/scenarios/out_loki/config/out_loki_long_unicode.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  parsers_file: ${LOKI_PARSERS_FILE}
+
+pipeline:
+  inputs:
+    - name: tail
+      tag: loki.integration
+      path: ${LOKI_INPUT_PATH}
+      parser: loki-integration-json
+      read_from_head: true
+      refresh_interval: 1
+      buffer_chunk_size: 256k
+      buffer_max_size: 20m
+      mem_buf_limit: 512m
+
+  outputs:
+    - name: loki
+      match: loki.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      line_format: json
+      labels: job=integration-test
+      remove_keys: seq
+      retry_limit: no_limits

--- a/tests/integration/scenarios/out_loki/config/parsers.conf
+++ b/tests/integration/scenarios/out_loki/config/parsers.conf
@@ -1,0 +1,3 @@
+[PARSER]
+    Name        loki-integration-json
+    Format      json

--- a/tests/integration/scenarios/out_loki/tests/test_out_loki_001.py
+++ b/tests/integration/scenarios/out_loki/tests/test_out_loki_001.py
@@ -1,0 +1,133 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+
+import requests
+
+from server.http_server import data_storage, http_server_run
+from utils.memory_check import memory_check_enabled
+from utils.test_service import FluentBitTestService
+
+
+MESSAGE_SIZE = 40 * 1024
+RECORD_COUNT = 200
+
+
+def create_message(sequence):
+    prefix = f"<TEST {'®' * ((sequence % 15) + 1)}>"
+    suffix = "</TEST>"
+    token = f"{sequence},"
+    remaining = MESSAGE_SIZE - len(prefix.encode("utf-8")) - len(suffix)
+    repetitions = remaining // len(token)
+    padding = remaining - repetitions * len(token)
+
+    return prefix + token * repetitions + "-" * padding + suffix
+
+
+def write_input(path):
+    expected_messages = []
+
+    with path.open("w", encoding="utf-8") as input_file:
+        for sequence in range(RECORD_COUNT):
+            message = create_message(sequence)
+            expected_messages.append(message)
+            json.dump({"seq": sequence, "msg": message}, input_file, ensure_ascii=False)
+            input_file.write("\n")
+
+    return expected_messages
+
+
+def count_loki_values():
+    count = 0
+
+    for payload in data_storage["payloads"]:
+        if not isinstance(payload, dict):
+            continue
+
+        for stream in payload.get("streams", []):
+            count += len(stream.get("values", []))
+
+    return count
+
+
+def collect_loki_records():
+    records = []
+
+    for payload in data_storage["payloads"]:
+        assert isinstance(payload, dict)
+
+        for stream in payload.get("streams", []):
+            for value in stream.get("values", []):
+                records.append(json.loads(value[1]))
+
+    return records
+
+
+class Service:
+    def __init__(self, input_path):
+        test_directory = Path(__file__).resolve().parent
+        config_directory = test_directory.parent / "config"
+        self.service = FluentBitTestService(
+            str(config_directory / "out_loki_long_unicode.yaml"),
+            data_storage=data_storage,
+            data_keys=["payloads", "requests"],
+            extra_env={
+                "LOKI_INPUT_PATH": str(input_path),
+                "LOKI_PARSERS_FILE": str(config_directory / "parsers.conf"),
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(
+                f"http://127.0.0.1:{service.test_suite_http_port}/shutdown",
+                timeout=2,
+            )
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_records(self):
+        timeout = 60 if memory_check_enabled() else 20
+
+        self.service.wait_for_condition(
+            lambda: count_loki_values() >= RECORD_COUNT,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{RECORD_COUNT} Loki values",
+        )
+
+
+def test_out_loki_preserves_long_unicode_json_strings():
+    with tempfile.TemporaryDirectory(prefix="flb-out-loki-it-") as temp_directory:
+        input_path = Path(temp_directory) / "input.log"
+        expected_messages = write_input(input_path)
+        service = Service(input_path)
+
+        try:
+            service.start()
+            service.wait_for_records()
+        finally:
+            service.stop()
+
+        records = collect_loki_records()
+
+    assert len(records) == RECORD_COUNT
+    assert all(set(record) == {"msg"} for record in records)
+    assert sorted(record["msg"] for record in records) == sorted(expected_messages)

--- a/tests/integration/scenarios/out_loki/tests/test_out_loki_001.py
+++ b/tests/integration/scenarios/out_loki/tests/test_out_loki_001.py
@@ -6,7 +6,6 @@ import tempfile
 import requests
 
 from server.http_server import data_storage, http_server_run
-from utils.memory_check import memory_check_enabled
 from utils.test_service import FluentBitTestService
 
 
@@ -104,7 +103,7 @@ class Service:
         self.service.stop()
 
     def wait_for_records(self):
-        timeout = 60 if memory_check_enabled() else 20
+        timeout = 60 if os.environ.get("VALGRIND") or os.environ.get("LEAKS") else 20
 
         self.service.wait_for_condition(
             lambda: count_loki_values() >= RECORD_COUNT,

--- a/tests/integration/src/server/http_server.py
+++ b/tests/integration/src/server/http_server.py
@@ -256,6 +256,7 @@ def _decode_json_payload(decoded_payload):
 @app.route('/data', methods=['POST'])
 @app.route('/shared', methods=['POST'])
 @app.route('/solo', methods=['POST'])
+@app.route('/loki/api/v1/push', methods=['POST'])
 @app.route('/dataCollectionRules/<path:subpath>', methods=['POST'])
 def receive_data(subpath=None):
     _record_request()

--- a/tests/integration/src/utils/fluent_bit_manager.py
+++ b/tests/integration/src/utils/fluent_bit_manager.py
@@ -18,6 +18,7 @@ import datetime
 import logging
 import os
 from pathlib import Path
+import signal
 import shutil
 import subprocess
 import time
@@ -150,6 +151,32 @@ class FluentBitManager:
             assert_valgrind_clean(self.valgrind_log_file)
 
         logger.info(f"Fluent Bit stopped (pid: {pid})")
+
+    def send_sighup(self):
+        if not self.process:
+            raise RuntimeError("Fluent Bit is not running")
+
+        self.process.send_signal(signal.SIGHUP)
+
+    def get_reload_status(self):
+        url = f"http://127.0.0.1:{self.http_monitoring_port}/api/v2/reload"
+        response = requests.get(url, timeout=0.5)
+        response.raise_for_status()
+        return response.json()
+
+    def wait_for_hot_reload_count(self, expected_count, timeout=10):
+        deadline = time.time() + timeout
+
+        while time.time() < deadline:
+            try:
+                payload = self.get_reload_status()
+                if payload.get("hot_reload_count", 0) >= expected_count:
+                    return payload
+            except requests.RequestException:
+                pass
+            time.sleep(0.1)
+
+        raise TimeoutError(f"Timed out waiting for hot reload count {expected_count}")
 
     def get_version_info(self):
         try:

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -59,6 +59,7 @@ set(UNIT_TESTS_FILES
   opentelemetry.c
   storage_dlq.c
   engine_dispatch.c
+  output.c
 )
 
 if(FLB_OUT_AZURE_BLOB)

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -58,6 +58,7 @@ set(UNIT_TESTS_FILES
   unicode.c
   opentelemetry.c
   storage_dlq.c
+  engine_dispatch.c
 )
 
 if(FLB_OUT_AZURE_BLOB)
@@ -268,6 +269,10 @@ endfunction(prepare_unit_tests)
 
 prepare_unit_tests(flb-it- "${UNIT_TESTS_FILES}")
 
+if(TARGET flb-it-engine_dispatch)
+  target_include_directories(flb-it-engine_dispatch PRIVATE
+    ${PROJECT_SOURCE_DIR}/lib/chunkio/deps)
+endif()
 if(FLB_METRICS AND FLB_PROCESSOR_CUMULATIVE_TO_DELTA)
   set(CUMULATIVE_TO_DELTA_PLUGIN_DIR
     ${PROJECT_SOURCE_DIR}/plugins/processor_cumulative_to_delta)

--- a/tests/internal/engine_dispatch.c
+++ b/tests/internal/engine_dispatch.c
@@ -1,0 +1,354 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_engine_dispatch.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_chunk.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_scheduler.h>
+#include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_storage.h>
+#include <fluent-bit/flb_task.h>
+
+#include <chunkio/chunkio.h>
+#include <chunkio/cio_memfs.h>
+
+#include "flb_tests_internal.h"
+
+struct test_ctx {
+    struct flb_config *config;
+    struct cio_ctx *cio;
+    struct flb_input_instance *input;
+};
+
+static void test_ctx_destroy(struct test_ctx *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    if (ctx->config != NULL) {
+        flb_input_exit_all(ctx->config);
+    }
+
+    if (ctx->cio != NULL) {
+        cio_destroy(ctx->cio);
+        ctx->config->cio = NULL;
+    }
+
+    if (ctx->config != NULL) {
+        flb_config_exit(ctx->config);
+    }
+
+    flb_free(ctx);
+}
+
+static struct test_ctx *test_ctx_create(void)
+{
+    int ret;
+    struct test_ctx *ctx;
+    struct cio_options options;
+#ifdef _WIN32
+    WSADATA wsa_data;
+#endif
+
+    ctx = flb_calloc(1, sizeof(struct test_ctx));
+    if (ctx == NULL) {
+        flb_errno();
+        return NULL;
+    }
+
+    ctx->config = flb_config_init();
+    if (ctx->config == NULL) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+
+#ifdef _WIN32
+    WSAStartup(0x0201, &wsa_data);
+#endif
+
+    ctx->config->evl = mk_event_loop_create(8);
+    if (ctx->config->evl == NULL) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+
+    ctx->config->sched = flb_sched_create(ctx->config, ctx->config->evl);
+    if (ctx->config->sched == NULL) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+
+    cio_options_init(&options);
+    options.flags = CIO_OPEN;
+    ctx->cio = cio_create(&options);
+    if (ctx->cio == NULL) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+    ctx->config->cio = ctx->cio;
+
+    ctx->input = flb_input_new(ctx->config, "dummy", NULL, FLB_FALSE);
+    if (ctx->input == NULL) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+
+    ret = flb_storage_input_create(ctx->cio, ctx->input);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+static struct flb_task_retry *create_retry_dispatch_task(
+                                        struct test_ctx *ctx,
+                                        struct flb_output_instance *output,
+                                        int *task_id,
+                                        char **chunk_buffer)
+{
+    struct cio_memfs *memfs;
+    struct flb_input_chunk *chunk;
+    struct flb_task *task;
+    struct flb_task_route *route;
+    struct flb_task_retry *retry;
+
+    chunk = flb_input_chunk_create(ctx->input, FLB_INPUT_LOGS, "test", 4);
+    if (chunk == NULL) {
+        return NULL;
+    }
+
+    task = task_alloc(ctx->config);
+    if (task == NULL) {
+        flb_input_chunk_destroy(chunk, FLB_TRUE);
+        return NULL;
+    }
+
+    task->i_ins = ctx->input;
+    task->ic = chunk;
+    chunk->task = task;
+    chunk->busy = FLB_TRUE;
+    mk_list_add(&task->_head, &ctx->input->tasks);
+
+    route = flb_calloc(1, sizeof(struct flb_task_route));
+    if (route == NULL) {
+        flb_task_destroy(task, FLB_TRUE);
+        return NULL;
+    }
+    route->out = output;
+    route->status = FLB_TASK_ROUTE_INACTIVE;
+    mk_list_add(&route->_head, &task->routes);
+
+    retry = flb_calloc(1, sizeof(struct flb_task_retry));
+    if (retry == NULL) {
+        flb_task_destroy(task, FLB_TRUE);
+        return NULL;
+    }
+    retry->attempts = 1;
+    retry->o_ins = output;
+    retry->parent = task;
+    mk_list_add(&retry->_head, &task->retries);
+
+    /* Force flb_input_chunk_flush() to return NULL without altering production code. */
+    memfs = ((struct cio_chunk *) chunk->chunk)->backend;
+    *chunk_buffer = memfs->buf_data;
+    memfs->buf_data = NULL;
+    *task_id = task->id;
+
+    return retry;
+}
+
+static void test_retry_flush_failure_releases_last_task_owner(void)
+{
+    int ret;
+    int task_id;
+    char *chunk_buffer;
+    struct test_ctx *ctx;
+    struct flb_task *replacement;
+    struct flb_task_retry *retry;
+    struct flb_output_instance output;
+
+    ctx = test_ctx_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    memset(&output, 0, sizeof(output));
+    retry = create_retry_dispatch_task(ctx, &output, &task_id, &chunk_buffer);
+    TEST_CHECK(retry != NULL);
+    if (retry == NULL) {
+        test_ctx_destroy(ctx);
+        return;
+    }
+
+    ret = flb_engine_dispatch_retry(retry, ctx->config);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(ctx->config->task_map[task_id].task == NULL);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 0);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 0);
+
+    free(chunk_buffer);
+
+    replacement = task_alloc(ctx->config);
+    TEST_CHECK(replacement != NULL);
+    if (replacement != NULL) {
+        TEST_CHECK(replacement->id == task_id);
+        flb_task_destroy(replacement, FLB_TRUE);
+    }
+
+    test_ctx_destroy(ctx);
+}
+
+static void test_retry_flush_failure_preserves_active_task_owner(void)
+{
+    int ret;
+    int task_id;
+    char *chunk_buffer;
+    struct cio_memfs *memfs;
+    struct test_ctx *ctx;
+    struct flb_input_chunk *chunk;
+    struct flb_task *task;
+    struct flb_task_retry *retry;
+    struct flb_output_instance output;
+
+    ctx = test_ctx_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    memset(&output, 0, sizeof(output));
+    retry = create_retry_dispatch_task(ctx, &output, &task_id, &chunk_buffer);
+    TEST_CHECK(retry != NULL);
+    if (retry == NULL) {
+        test_ctx_destroy(ctx);
+        return;
+    }
+
+    task = retry->parent;
+    task->users = 1;
+
+    ret = flb_engine_dispatch_retry(retry, ctx->config);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(ctx->config->task_map[task_id].task == task);
+    TEST_CHECK(task->users == 1);
+    TEST_CHECK(mk_list_size(&task->retries) == 0);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 1);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 1);
+
+    if (ctx->config->task_map[task_id].task == task) {
+        chunk = task->ic;
+        memfs = ((struct cio_chunk *) chunk->chunk)->backend;
+        memfs->buf_data = chunk_buffer;
+        task->users = 0;
+        flb_task_users_release(task);
+    }
+    else {
+        free(chunk_buffer);
+    }
+
+    TEST_CHECK(ctx->config->task_map[task_id].task == NULL);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 0);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 0);
+
+    test_ctx_destroy(ctx);
+}
+
+static void test_retry_flush_failure_preserves_pending_retry(void)
+{
+    int ret;
+    int task_id;
+    char *chunk_buffer;
+    struct cio_memfs *memfs;
+    struct test_ctx *ctx;
+    struct flb_input_chunk *chunk;
+    struct flb_task *task;
+    struct flb_task_route *route;
+    struct flb_task_retry *remaining_retry;
+    struct flb_task_retry *retry;
+    struct flb_output_instance output_a;
+    struct flb_output_instance output_b;
+
+    ctx = test_ctx_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    memset(&output_a, 0, sizeof(output_a));
+    memset(&output_b, 0, sizeof(output_b));
+    retry = create_retry_dispatch_task(ctx, &output_a, &task_id, &chunk_buffer);
+    TEST_CHECK(retry != NULL);
+    if (retry == NULL) {
+        test_ctx_destroy(ctx);
+        return;
+    }
+    task = retry->parent;
+
+    route = flb_calloc(1, sizeof(struct flb_task_route));
+    remaining_retry = flb_calloc(1, sizeof(struct flb_task_retry));
+    TEST_CHECK(route != NULL);
+    TEST_CHECK(remaining_retry != NULL);
+    if (route == NULL || remaining_retry == NULL) {
+        flb_free(route);
+        flb_free(remaining_retry);
+        chunk = task->ic;
+        memfs = ((struct cio_chunk *) chunk->chunk)->backend;
+        memfs->buf_data = chunk_buffer;
+        flb_task_destroy(task, FLB_TRUE);
+        test_ctx_destroy(ctx);
+        return;
+    }
+
+    route->out = &output_b;
+    route->status = FLB_TASK_ROUTE_INACTIVE;
+    mk_list_add(&route->_head, &task->routes);
+
+    remaining_retry->attempts = 1;
+    remaining_retry->o_ins = &output_b;
+    remaining_retry->parent = task;
+    mk_list_add(&remaining_retry->_head, &task->retries);
+
+    ret = flb_engine_dispatch_retry(retry, ctx->config);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(ctx->config->task_map[task_id].task == task);
+    TEST_CHECK(task->users == 0);
+    TEST_CHECK(mk_list_size(&task->retries) == 1);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 1);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 1);
+
+    if (ctx->config->task_map[task_id].task == task) {
+        chunk = task->ic;
+        memfs = ((struct cio_chunk *) chunk->chunk)->backend;
+        memfs->buf_data = chunk_buffer;
+        flb_task_retry_destroy(remaining_retry);
+        flb_task_users_release(task);
+    }
+    else {
+        free(chunk_buffer);
+    }
+
+    TEST_CHECK(ctx->config->task_map[task_id].task == NULL);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 0);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 0);
+
+    test_ctx_destroy(ctx);
+}
+
+TEST_LIST = {
+    { "retry_flush_failure_releases_last_task_owner",
+      test_retry_flush_failure_releases_last_task_owner },
+    { "retry_flush_failure_preserves_active_task_owner",
+      test_retry_flush_failure_preserves_active_task_owner },
+    { "retry_flush_failure_preserves_pending_retry",
+      test_retry_flush_failure_preserves_pending_retry },
+    { 0 }
+};

--- a/tests/internal/engine_dispatch.c
+++ b/tests/internal/engine_dispatch.c
@@ -518,9 +518,83 @@ static void test_retry_flush_failure_preserves_pending_retry(void)
     test_ctx_destroy(ctx);
 }
 
+/*
+ * With retry budget left the chunk must be kept and the attempt re-scheduled,
+ * otherwise a transient read failure would delete records a later attempt
+ * could still deliver.
+ */
+static void test_retry_flush_failure_reschedules_within_retry_limit(void)
+{
+    int ret;
+    int task_id;
+    double value;
+    char *chunk_buffer;
+    char *output_name;
+    struct test_ctx *ctx;
+    struct flb_task *task;
+    struct flb_task_retry *retry;
+    struct flb_output_instance output;
+
+    ctx = test_ctx_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    ret = test_output_init(&output, "output_a");
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return;
+    }
+
+    /* the retry starts with attempts=1, so this leaves budget available */
+    output.retry_limit = 5;
+
+    retry = create_retry_dispatch_task(ctx, &output, &task_id, &chunk_buffer);
+    TEST_CHECK(retry != NULL);
+    if (retry == NULL) {
+        test_output_destroy(&output);
+        test_ctx_destroy(ctx);
+        return;
+    }
+    task = retry->parent;
+
+    ret = flb_engine_dispatch_retry(retry, ctx->config);
+    TEST_CHECK(ret == 0);
+
+    /* the task keeps its slot, its chunk and a pending retry */
+    TEST_CHECK(ctx->config->task_map[task_id].task == task);
+    TEST_CHECK(mk_list_size(&ctx->input->tasks) == 1);
+    TEST_CHECK(mk_list_size(&ctx->input->chunks) == 1);
+    TEST_CHECK(mk_list_size(&task->retries) == 1);
+    TEST_CHECK(retry->attempts == 2);
+
+    /*
+     * Nothing was dropped, so no drop accounting must be recorded. An untouched
+     * counter has no series yet, so cmt_counter_get_val() reports a failure.
+     */
+    output_name = (char *) flb_output_name(&output);
+    ret = cmt_counter_get_val(output.cmt_retries_failed,
+                              1, (char *[]) {output_name}, &value);
+    TEST_CHECK(ret != 0 || value == 0);
+
+    ret = cmt_counter_get_val(output.cmt_dropped_records,
+                              1, (char *[]) {output_name}, &value);
+    TEST_CHECK(ret != 0 || value == 0);
+
+    flb_task_destroy(task, FLB_TRUE);
+    free(chunk_buffer);
+
+    test_output_destroy(&output);
+    test_ctx_destroy(ctx);
+}
+
 TEST_LIST = {
     { "retry_flush_failure_releases_last_task_owner",
       test_retry_flush_failure_releases_last_task_owner },
+    { "retry_flush_failure_reschedules_within_retry_limit",
+      test_retry_flush_failure_reschedules_within_retry_limit },
     { "retry_flush_failure_preserves_active_task_owner",
       test_retry_flush_failure_preserves_active_task_owner },
     { "retry_flush_failure_preserves_pending_retry",

--- a/tests/internal/engine_dispatch.c
+++ b/tests/internal/engine_dispatch.c
@@ -5,10 +5,13 @@
 
 #include <fluent-bit/flb_config.h>
 #include <fluent-bit/flb_engine_dispatch.h>
+#include <fluent-bit/flb_event.h>
 #include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_input_chunk.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_metrics.h>
 #include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_socket.h>
 #include <fluent-bit/flb_storage.h>
@@ -19,10 +22,17 @@
 
 #include "flb_tests_internal.h"
 
+#define TEST_ROUTE_RECORDS 7
+#define TEST_ROUTE_BYTES   29
+#define TEST_CHUNK_RECORDS 13
+
 struct test_ctx {
     struct flb_config *config;
     struct cio_ctx *cio;
     struct flb_input_instance *input;
+#ifdef _WIN32
+    int winsock_initialized;
+#endif
 };
 
 static void test_ctx_destroy(struct test_ctx *ctx)
@@ -43,6 +53,13 @@ static void test_ctx_destroy(struct test_ctx *ctx)
     if (ctx->config != NULL) {
         flb_config_exit(ctx->config);
     }
+
+#ifdef _WIN32
+    if (ctx->winsock_initialized == FLB_TRUE) {
+        WSACleanup();
+        ctx->winsock_initialized = FLB_FALSE;
+    }
+#endif
 
     flb_free(ctx);
 }
@@ -69,7 +86,12 @@ static struct test_ctx *test_ctx_create(void)
     }
 
 #ifdef _WIN32
-    WSAStartup(0x0201, &wsa_data);
+    ret = WSAStartup(0x0201, &wsa_data);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return NULL;
+    }
+    ctx->winsock_initialized = FLB_TRUE;
 #endif
 
     ctx->config->evl = mk_event_loop_create(8);
@@ -108,6 +130,121 @@ static struct test_ctx *test_ctx_create(void)
     return ctx;
 }
 
+static int test_output_init(struct flb_output_instance *output, const char *name)
+{
+    memset(output, 0, sizeof(struct flb_output_instance));
+    strncpy(output->name, name, sizeof(output->name) - 1);
+
+    output->cmt = cmt_create();
+    if (output->cmt == NULL) {
+        return -1;
+    }
+
+    output->cmt_retries_failed = cmt_counter_create(output->cmt,
+                                                     "fluentbit",
+                                                     "output",
+                                                     "retries_failed_total",
+                                                     "Failed retries",
+                                                     1,
+                                                     (char *[]) {"name"});
+    output->cmt_dropped_records = cmt_counter_create(output->cmt,
+                                                      "fluentbit",
+                                                      "output",
+                                                      "dropped_records_total",
+                                                      "Dropped records",
+                                                      1,
+                                                      (char *[]) {"name"});
+    if (output->cmt_retries_failed == NULL ||
+        output->cmt_dropped_records == NULL) {
+        cmt_destroy(output->cmt);
+        output->cmt = NULL;
+        return -1;
+    }
+
+#ifdef FLB_HAVE_METRICS
+    output->metrics = flb_metrics_create(name);
+    if (output->metrics == NULL ||
+        flb_metrics_add(FLB_METRIC_OUT_RETRY_FAILED,
+                        "retries_failed", output->metrics) == -1 ||
+        flb_metrics_add(FLB_METRIC_OUT_DROPPED_RECORDS,
+                        "dropped_records", output->metrics) == -1) {
+        if (output->metrics != NULL) {
+            flb_metrics_destroy(output->metrics);
+            output->metrics = NULL;
+        }
+        cmt_destroy(output->cmt);
+        output->cmt = NULL;
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+static void test_output_destroy(struct flb_output_instance *output)
+{
+#ifdef FLB_HAVE_METRICS
+    if (output->metrics != NULL) {
+        flb_metrics_destroy(output->metrics);
+        output->metrics = NULL;
+    }
+#endif
+
+    if (output->cmt != NULL) {
+        cmt_destroy(output->cmt);
+        output->cmt = NULL;
+    }
+}
+
+static void check_retry_failure_metrics(struct test_ctx *ctx,
+                                        struct flb_output_instance *output)
+{
+    int ret;
+    double value;
+    char *input_name;
+    char *output_name;
+#ifdef FLB_HAVE_METRICS
+    struct flb_metric *metric;
+#endif
+
+    input_name = (char *) flb_input_name(ctx->input);
+    output_name = (char *) flb_output_name(output);
+
+    ret = cmt_counter_get_val(output->cmt_retries_failed,
+                              1, (char *[]) {output_name}, &value);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(value == 1);
+
+    ret = cmt_counter_get_val(output->cmt_dropped_records,
+                              1, (char *[]) {output_name}, &value);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(value == TEST_ROUTE_RECORDS);
+
+    ret = cmt_counter_get_val(ctx->config->router->logs_drop_records_total,
+                              2, (char *[]) {input_name, output_name}, &value);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(value == TEST_ROUTE_RECORDS);
+
+    ret = cmt_counter_get_val(ctx->config->router->logs_drop_bytes_total,
+                              2, (char *[]) {input_name, output_name}, &value);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(value == TEST_ROUTE_BYTES);
+
+#ifdef FLB_HAVE_METRICS
+    metric = flb_metrics_get_id(FLB_METRIC_OUT_RETRY_FAILED, output->metrics);
+    TEST_CHECK(metric != NULL);
+    if (metric != NULL) {
+        TEST_CHECK(metric->val == 1);
+    }
+
+    metric = flb_metrics_get_id(FLB_METRIC_OUT_DROPPED_RECORDS, output->metrics);
+    TEST_CHECK(metric != NULL);
+    if (metric != NULL) {
+        TEST_CHECK(metric->val == TEST_ROUTE_RECORDS);
+    }
+#endif
+}
+
 static struct flb_task_retry *create_retry_dispatch_task(
                                         struct test_ctx *ctx,
                                         struct flb_output_instance *output,
@@ -137,6 +274,17 @@ static struct flb_task_retry *create_retry_dispatch_task(
     chunk->busy = FLB_TRUE;
     mk_list_add(&task->_head, &ctx->input->tasks);
 
+    memfs = ((struct cio_chunk *) chunk->chunk)->backend;
+    task->event_chunk = flb_event_chunk_create(FLB_EVENT_TYPE_LOGS,
+                                               TEST_CHUNK_RECORDS,
+                                               "test", 4,
+                                               memfs->buf_data,
+                                               memfs->buf_len);
+    if (task->event_chunk == NULL) {
+        flb_task_destroy(task, FLB_TRUE);
+        return NULL;
+    }
+
     route = flb_calloc(1, sizeof(struct flb_task_route));
     if (route == NULL) {
         flb_task_destroy(task, FLB_TRUE);
@@ -144,6 +292,8 @@ static struct flb_task_retry *create_retry_dispatch_task(
     }
     route->out = output;
     route->status = FLB_TASK_ROUTE_INACTIVE;
+    route->records = TEST_ROUTE_RECORDS;
+    route->bytes = TEST_ROUTE_BYTES;
     mk_list_add(&route->_head, &task->routes);
 
     retry = flb_calloc(1, sizeof(struct flb_task_retry));
@@ -157,7 +307,6 @@ static struct flb_task_retry *create_retry_dispatch_task(
     mk_list_add(&retry->_head, &task->retries);
 
     /* Force flb_input_chunk_flush() to return NULL without altering production code. */
-    memfs = ((struct cio_chunk *) chunk->chunk)->backend;
     *chunk_buffer = memfs->buf_data;
     memfs->buf_data = NULL;
     *task_id = task->id;
@@ -181,10 +330,16 @@ static void test_retry_flush_failure_releases_last_task_owner(void)
         return;
     }
 
-    memset(&output, 0, sizeof(output));
+    ret = test_output_init(&output, "output_a");
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return;
+    }
     retry = create_retry_dispatch_task(ctx, &output, &task_id, &chunk_buffer);
     TEST_CHECK(retry != NULL);
     if (retry == NULL) {
+        test_output_destroy(&output);
         test_ctx_destroy(ctx);
         return;
     }
@@ -194,6 +349,7 @@ static void test_retry_flush_failure_releases_last_task_owner(void)
     TEST_CHECK(ctx->config->task_map[task_id].task == NULL);
     TEST_CHECK(mk_list_size(&ctx->input->tasks) == 0);
     TEST_CHECK(mk_list_size(&ctx->input->chunks) == 0);
+    check_retry_failure_metrics(ctx, &output);
 
     free(chunk_buffer);
 
@@ -204,6 +360,7 @@ static void test_retry_flush_failure_releases_last_task_owner(void)
         flb_task_destroy(replacement, FLB_TRUE);
     }
 
+    test_output_destroy(&output);
     test_ctx_destroy(ctx);
 }
 
@@ -225,10 +382,16 @@ static void test_retry_flush_failure_preserves_active_task_owner(void)
         return;
     }
 
-    memset(&output, 0, sizeof(output));
+    ret = test_output_init(&output, "output_a");
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return;
+    }
     retry = create_retry_dispatch_task(ctx, &output, &task_id, &chunk_buffer);
     TEST_CHECK(retry != NULL);
     if (retry == NULL) {
+        test_output_destroy(&output);
         test_ctx_destroy(ctx);
         return;
     }
@@ -243,6 +406,7 @@ static void test_retry_flush_failure_preserves_active_task_owner(void)
     TEST_CHECK(mk_list_size(&task->retries) == 0);
     TEST_CHECK(mk_list_size(&ctx->input->tasks) == 1);
     TEST_CHECK(mk_list_size(&ctx->input->chunks) == 1);
+    check_retry_failure_metrics(ctx, &output);
 
     if (ctx->config->task_map[task_id].task == task) {
         chunk = task->ic;
@@ -259,6 +423,7 @@ static void test_retry_flush_failure_preserves_active_task_owner(void)
     TEST_CHECK(mk_list_size(&ctx->input->tasks) == 0);
     TEST_CHECK(mk_list_size(&ctx->input->chunks) == 0);
 
+    test_output_destroy(&output);
     test_ctx_destroy(ctx);
 }
 
@@ -283,11 +448,18 @@ static void test_retry_flush_failure_preserves_pending_retry(void)
         return;
     }
 
-    memset(&output_a, 0, sizeof(output_a));
+    ret = test_output_init(&output_a, "output_a");
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        test_ctx_destroy(ctx);
+        return;
+    }
     memset(&output_b, 0, sizeof(output_b));
+    strncpy(output_b.name, "output_b", sizeof(output_b.name) - 1);
     retry = create_retry_dispatch_task(ctx, &output_a, &task_id, &chunk_buffer);
     TEST_CHECK(retry != NULL);
     if (retry == NULL) {
+        test_output_destroy(&output_a);
         test_ctx_destroy(ctx);
         return;
     }
@@ -304,6 +476,7 @@ static void test_retry_flush_failure_preserves_pending_retry(void)
         memfs = ((struct cio_chunk *) chunk->chunk)->backend;
         memfs->buf_data = chunk_buffer;
         flb_task_destroy(task, FLB_TRUE);
+        test_output_destroy(&output_a);
         test_ctx_destroy(ctx);
         return;
     }
@@ -324,6 +497,7 @@ static void test_retry_flush_failure_preserves_pending_retry(void)
     TEST_CHECK(mk_list_size(&task->retries) == 1);
     TEST_CHECK(mk_list_size(&ctx->input->tasks) == 1);
     TEST_CHECK(mk_list_size(&ctx->input->chunks) == 1);
+    check_retry_failure_metrics(ctx, &output_a);
 
     if (ctx->config->task_map[task_id].task == task) {
         chunk = task->ic;
@@ -340,6 +514,7 @@ static void test_retry_flush_failure_preserves_pending_retry(void)
     TEST_CHECK(mk_list_size(&ctx->input->tasks) == 0);
     TEST_CHECK(mk_list_size(&ctx->input->chunks) == 0);
 
+    test_output_destroy(&output_a);
     test_ctx_destroy(ctx);
 }
 

--- a/tests/internal/output.c
+++ b/tests/internal/output.c
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+
+#include "flb_tests_internal.h"
+
+static void test_invalid_network_address_cleanup(void)
+{
+    int output_id;
+    flb_ctx_t *ctx;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+    if (ctx == NULL) {
+        return;
+    }
+
+    output_id = flb_output(ctx, "http://[", NULL);
+    TEST_CHECK(output_id == -1);
+
+    flb_destroy(ctx);
+}
+
+TEST_LIST = {
+    {"invalid_network_address_cleanup", test_invalid_network_address_cleanup},
+    {NULL, NULL}
+};

--- a/tests/internal/utils.c
+++ b/tests/internal/utils.c
@@ -2,6 +2,7 @@
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_simd.h>
 #include <fluent-bit/flb_utils.h>
 #include <stdarg.h>
 #include "flb_tests_internal.h"
@@ -337,6 +338,67 @@ void test_write_str()
     off = 0;
     ret = flb_utils_write_str(buf, &off, size, "aaaaaaaaaaa", 11, FLB_TRUE);
     TEST_CHECK(ret == FLB_FALSE);
+}
+
+static void check_write_str_simd_boundary(size_t input_len)
+{
+    int off;
+    int ret;
+    size_t output_size;
+    char *input;
+    char *output;
+
+    output_size = input_len + FLB_SIMD_VEC8_INST_LEN + 8;
+
+    input = flb_malloc(input_len + FLB_SIMD_VEC8_INST_LEN);
+    output = flb_calloc(output_size, sizeof(char));
+    if (!TEST_CHECK(input != NULL && output != NULL)) {
+        flb_free(input);
+        flb_free(output);
+        return;
+    }
+
+    /*
+     * A multibyte character moves the input cursor off its original SIMD
+     * alignment. Poison the bytes beyond the declared string length to catch
+     * a subsequent vector copy that crosses that boundary.
+     */
+    memset(input, 'x', input_len + FLB_SIMD_VEC8_INST_LEN);
+    input[0] = '\xc2';
+    input[1] = '\xae';
+
+    off = 0;
+    ret = flb_utils_write_str(output, &off, output_size, input, input_len, FLB_TRUE);
+    TEST_CHECK(ret == FLB_TRUE);
+    TEST_CHECK_(off == input_len + 4, "expected %zu escaped bytes, got %d",
+                input_len + 4, off);
+    TEST_CHECK(memcmp(output, "\\u00ae", 6) == 0);
+    TEST_CHECK(memcmp(output + 6, input + 2, input_len - 2) == 0);
+
+    memset(output, 0, output_size);
+    off = 0;
+    ret = flb_utils_write_str(output, &off, output_size, input, input_len, FLB_FALSE);
+    TEST_CHECK(ret == FLB_TRUE);
+    TEST_CHECK_(off == input_len, "expected %zu raw bytes, got %d", input_len, off);
+    TEST_CHECK(memcmp(output, input, input_len) == 0);
+
+    flb_free(input);
+    flb_free(output);
+}
+
+void test_write_str_simd_boundary()
+{
+    size_t i;
+    size_t input_lengths[] = {
+        FLB_SIMD_VEC8_INST_LEN * 2,
+        /* Historical x86_64 and arm64 macOS coroutine stack sizes. */
+        24 * 1024,
+        36 * 1024
+    };
+
+    for (i = 0; i < sizeof(input_lengths) / sizeof(input_lengths[0]); i++) {
+        check_write_str_simd_boundary(input_lengths[i]);
+    }
 }
 
 void test_write_str_invalid_trailing_bytes()
@@ -1005,6 +1067,7 @@ TEST_LIST = {
     { "url_split", test_url_split },
     { "url_split_sds", test_url_split_sds },
     { "write_str", test_write_str },
+    { "write_str_simd_boundary", test_write_str_simd_boundary },
     { "write_str_special_bytes", test_write_str_special_bytes },
     { "write_raw_str_special_bytes", test_write_raw_str_special_bytes },
     { "write_raw_str_invalid_bytes", test_write_raw_str_invalid_sequences},

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -108,6 +108,10 @@ if (FLB_CUSTOM_CALYPTIA)
     endforeach()
 endif()
 
+if(FLB_IN_LIB AND FLB_OUT_HTTP AND FLB_OUT_NULL AND FLB_IN_STORAGE_BACKLOG)
+  FLB_RT_TEST(FLB_IN_STORAGE_BACKLOG "in_storage_backlog.c")
+endif()
+
 if(FLB_IN_EBPF)
     # Define common variables
     set(EBPF_TEST_INCLUDE_DIRS

--- a/tests/runtime/in_storage_backlog.c
+++ b/tests/runtime/in_storage_backlog.c
@@ -1,0 +1,212 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_chunk.h>
+#include <fluent-bit/flb_storage.h>
+#include <fluent-bit/flb_time.h>
+
+#include <chunkio/cio_utils.h>
+
+#include <string.h>
+#include <sys/stat.h>
+
+#include "flb_tests_runtime.h"
+#include "../include/flb_tests_tmpdir.h"
+
+#define TEST_RECORD "[0, {\"message\":\"persisted\"}]"
+
+static flb_ctx_t *start_context(const char *storage_path,
+                                const char *input_tag,
+                                const char *output_match,
+                                const char *output_name,
+                                int *input_id)
+{
+    int output_id;
+    int ret;
+    flb_ctx_t *ctx;
+
+    ctx = flb_create();
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    if (flb_service_set(ctx,
+                        "flush", "60",
+                        "grace", "0",
+                        "storage.path", storage_path,
+                        NULL) != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    *input_id = flb_input(ctx, (char *) "lib", NULL);
+    if (*input_id < 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    if (flb_input_set(ctx, *input_id,
+                      "tag", input_tag,
+                      "storage.type", "filesystem",
+                      NULL) != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    output_id = flb_output(ctx, output_name, NULL);
+    if (output_id < 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    if (strcmp(output_name, "http") == 0) {
+        ret = flb_output_set(ctx, output_id,
+                             "match", output_match,
+                             "host", "127.0.0.1",
+                             "port", "9",
+                             "retry_limit", "no_limits",
+                             NULL);
+    }
+    else {
+        ret = flb_output_set(ctx, output_id, "match", output_match, NULL);
+    }
+
+    if (ret != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    if (flb_start(ctx) != 0) {
+        flb_destroy(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+static int wait_for_chunk_content(struct flb_input_instance *input_instance)
+{
+    int attempts;
+    struct flb_input_chunk *input_chunk;
+
+    for (attempts = 0; attempts < 50; attempts++) {
+        if (mk_list_is_empty(&input_instance->chunks) != 0) {
+            input_chunk = mk_list_entry_first(&input_instance->chunks,
+                                              struct flb_input_chunk,
+                                              _head);
+            if (flb_input_chunk_get_size(input_chunk) > 0) {
+                return 0;
+            }
+        }
+
+        flb_time_msleep(100);
+    }
+
+    return -1;
+}
+
+static int wait_for_filesystem_chunk_count(flb_ctx_t *ctx, int expected)
+{
+    int attempts;
+    int fs_chunks;
+    int mem_chunks;
+
+    for (attempts = 0; attempts < 50; attempts++) {
+        flb_storage_chunk_count(ctx->config, &mem_chunks, &fs_chunks);
+        if (fs_chunks == expected) {
+            return 0;
+        }
+
+        flb_time_msleep(100);
+    }
+
+    return -1;
+}
+
+static void test_unroutable_chunk_is_detached_and_preserved(void)
+{
+    int input_id;
+    int ret;
+    struct stat file_status;
+    struct flb_input_chunk *input_chunk;
+    struct flb_input_instance *input_instance;
+    struct flb_storage_input *storage_input;
+    flb_ctx_t *ctx;
+    char chunk_path[4096];
+    char *storage_path;
+
+    storage_path = flb_test_tmpdir_cat("/flb-storage-backlog-no-route-XXXXXX");
+    TEST_ASSERT(storage_path != NULL);
+    TEST_ASSERT(mkdtemp(storage_path) != NULL);
+
+    /* Seed one routed filesystem chunk whose output cannot deliver it. */
+    ctx = start_context(storage_path, "stale", "stale", "http", &input_id);
+    TEST_ASSERT(ctx != NULL);
+
+    ret = flb_lib_push(ctx, input_id, TEST_RECORD, sizeof(TEST_RECORD) - 1);
+    TEST_ASSERT(ret >= 0);
+    TEST_ASSERT(wait_for_filesystem_chunk_count(ctx, 1) == 0);
+
+    input_instance = flb_input_get_instance(ctx->config, input_id);
+    TEST_ASSERT(input_instance != NULL);
+    TEST_ASSERT(wait_for_chunk_content(input_instance) == 0);
+    TEST_ASSERT(mk_list_is_empty(&input_instance->chunks) != 0);
+
+    input_chunk = mk_list_entry_first(&input_instance->chunks,
+                                      struct flb_input_chunk,
+                                      _head);
+    storage_input = (struct flb_storage_input *) input_instance->storage;
+    TEST_ASSERT(storage_input != NULL);
+
+    ret = snprintf(chunk_path, sizeof(chunk_path), "%s/%s/%s",
+                   storage_path, storage_input->stream->name,
+                   ((struct cio_chunk *) input_chunk->chunk)->name);
+    TEST_ASSERT(ret > 0 && (size_t) ret < sizeof(chunk_path));
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    TEST_ASSERT(stat(chunk_path, &file_status) == 0);
+
+    /* Restore with a configuration whose only route does not match the chunk. */
+    ctx = start_context(storage_path, "live", "live", "null", &input_id);
+    TEST_ASSERT(ctx != NULL);
+
+    TEST_CHECK_(wait_for_filesystem_chunk_count(ctx, 0) == 0,
+                "unroutable restored chunk remained in active filesystem accounting");
+    TEST_CHECK_(stat(chunk_path, &file_status) == 0,
+                "unroutable restored chunk was deleted");
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+
+    TEST_CHECK_(stat(chunk_path, &file_status) == 0,
+                "unroutable restored chunk was not preserved across shutdown");
+
+    cio_utils_recursive_delete(storage_path);
+    flb_free(storage_path);
+}
+
+TEST_LIST = {
+    {"unroutable_chunk_is_detached_and_preserved",
+     test_unroutable_chunk_is_detached_and_preserved},
+    {NULL, NULL}
+};

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -1188,6 +1188,155 @@ void flb_test_tenant_id_key_partial_error()
                                        FLB_TRUE);
 }
 
+static char *create_long_unicode_input(size_t message_size, size_t *input_size)
+{
+    size_t json_prefix_len;
+    size_t message_prefix_len;
+    size_t message_suffix_len;
+    size_t json_suffix_len;
+    char *input;
+    char *message;
+    const char json_prefix[] = "[12345678,{\"seq\":0,\"msg\":\"";
+    const char message_prefix[] = "<TEST \xc2\xae>";
+    const char message_suffix[] = "</TEST>";
+    const char json_suffix[] = "\"}]";
+
+    json_prefix_len = sizeof(json_prefix) - 1;
+    message_prefix_len = sizeof(message_prefix) - 1;
+    message_suffix_len = sizeof(message_suffix) - 1;
+    json_suffix_len = sizeof(json_suffix) - 1;
+
+    if (message_size < message_prefix_len + message_suffix_len) {
+        return NULL;
+    }
+
+    *input_size = json_prefix_len + message_size + json_suffix_len;
+    input = flb_malloc(*input_size + 1);
+    if (input == NULL) {
+        return NULL;
+    }
+
+    memcpy(input, json_prefix, json_prefix_len);
+    message = input + json_prefix_len;
+    memset(message, '1', message_size);
+    memcpy(message, message_prefix, message_prefix_len);
+    memcpy(message + message_size - message_suffix_len,
+           message_suffix, message_suffix_len);
+    memcpy(message + message_size, json_suffix, json_suffix_len);
+    input[*input_size] = '\0';
+
+    return input;
+}
+
+struct long_unicode_test_result {
+    size_t message_size;
+    int callback_called;
+};
+
+static void cb_check_long_unicode_payload(void *ctx, int ffd,
+                                          int res_ret, void *res_data,
+                                          size_t res_size, void *data)
+{
+    char *ending;
+    char *removed_key;
+    flb_sds_t out_js;
+    struct long_unicode_test_result *result;
+
+    out_js = res_data;
+    result = data;
+    result->callback_called = FLB_TRUE;
+
+    TEST_CHECK(res_ret == 0);
+    if (!TEST_CHECK(out_js != NULL)) {
+        return;
+    }
+
+    ending = strstr(out_js, "</TEST>\\\"}");
+    if (!TEST_CHECK(ending != NULL)) {
+        TEST_MSG("%zu-byte message did not end at </TEST>", result->message_size);
+    }
+
+    removed_key = strstr(out_js, "\\\"seq\\\":");
+    TEST_CHECK(removed_key == NULL);
+
+    flb_sds_destroy(out_js);
+}
+
+static void run_long_unicode_payload_boundary(size_t message_size)
+{
+    int ret;
+    int in_ffd;
+    int out_ffd;
+    size_t input_size;
+    char *input;
+    flb_ctx_t *ctx;
+    struct long_unicode_test_result result;
+
+    input = create_long_unicode_input(message_size, &input_size);
+    if (!TEST_CHECK(input != NULL)) {
+        return;
+    }
+
+    ctx = flb_create();
+    if (!TEST_CHECK(ctx != NULL)) {
+        flb_free(input);
+        return;
+    }
+
+    ret = flb_service_set(ctx,
+                          "flush", "1",
+                          "grace", "1",
+                          "log_level", "error",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "test",
+                         "line_format", "json",
+                         "labels", "job=mwe",
+                         "remove_keys", "seq",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    result.message_size = message_size;
+    result.callback_called = FLB_FALSE;
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_long_unicode_payload,
+                              &result, NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    if (!TEST_CHECK(ret == 0)) {
+        flb_destroy(ctx);
+        flb_free(input);
+        return;
+    }
+
+    ret = flb_lib_push(ctx, in_ffd, input, input_size);
+    TEST_CHECK(ret >= 0);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    flb_free(input);
+
+    if (!TEST_CHECK(result.callback_called == FLB_TRUE)) {
+        TEST_MSG("formatter was not called for %zu-byte message", message_size);
+    }
+}
+
+void flb_test_long_unicode_payload_boundaries()
+{
+    run_long_unicode_payload_boundary(24 * 1024);
+    run_long_unicode_payload_boundary(36 * 1024);
+}
+
 static void cb_check_label_map_path(void *ctx, int ffd,
                                     int res_ret, void *res_data, size_t res_size,
                                     void *data)
@@ -1520,6 +1669,7 @@ TEST_LIST = {
     {"tenant_id_key_splits_requests", flb_test_tenant_id_key_splits_requests },
     {"tenant_id_key_partial_success", flb_test_tenant_id_key_partial_success },
     {"tenant_id_key_partial_error", flb_test_tenant_id_key_partial_error },
+    {"long_unicode_payload_boundaries", flb_test_long_unicode_payload_boundaries },
     {"basic"                  , flb_test_basic },
     {"labels"                 , flb_test_labels },
     {"label_keys"             , flb_test_label_keys },


### PR DESCRIPTION
## Summary

Backport selected correctness, lifecycle, parsing, and memory-safety fixes from
`master` to the supported `5.0` series.

This branch contains 47 signed commits: 39 source backports and 8 focused
compatibility or integration-test commits. Each exact source backport retains
its upstream commit reference, followed by a contiguous DCO trailer block.

## Backport groups

| Area | Commits | Change and rationale | Validation |
|---|---:|---|---|
| OpenTelemetry input and JSON decoding | 6 | Return 404 for invalid OTLP endpoints and reject malformed array/container values instead of accepting invalid payload shapes. | Focused Python integration tests passed normally and with strict Valgrind; runtime and integration CTest coverage passed. |
| Forward input accounting | 2 | Refresh the consumed-byte count for every coalesced MessagePack frame, preventing stale offsets and buffer desynchronization. | New coalesced-frame Python regression passed normally and with strict Valgrind. The fixed-port runtime test was blocked by another listener on port 24224. |
| Kubernetes filter | 3 | Prevent pod-association crashes and clean exception-path allocations while preserving isolation between filter instances. | Focused Python integration test passed normally and with strict Valgrind; runtime CTest passed. |
| Kubernetes Events input | 7 | Bound stalled watch connections and replace unsafe parsing of non-NUL-terminated MessagePack fields with bounded, strict conversions. | Watch and bounded-field Python regressions passed normally and with strict Valgrind; runtime CTest passed. |
| HTTP server startup | 2 | Fail engine startup when the internal HTTP server cannot bind instead of continuing in a partially initialized state. | Python bind-failure regression passed normally and with strict Valgrind. |
| Expect filter | 2 | Validate every record in a batch and preserve grouped OTLP log results. | Two focused Python integration tests passed normally and with strict Valgrind; runtime CTest passed. |
| Threaded input and Exec shutdown | 4 | Add a pre-exit callback and stop blocking child processes during shutdown and hot reload. Includes 5.0-compatible hot-reload test helpers. | Exec hot-reload regression passed normally and with strict Valgrind. |
| Storage backlog | 3 | Preserve unroutable filesystem chunks, release stale registrations, and recover the chunks when a route returns after hot reload. | Three Python scenarios passed normally and with strict Valgrind; runtime CTest and full-suite storage coverage passed. |
| Engine dispatch | 6 | Clean stale tasks, account retry failures, and reschedule retries when chunk content cannot be read. | Comprehensive internal engine-dispatch tests passed. The corrupt-ChunkIO failure has no safe external control surface for a meaningful Python test. |
| Output creation cleanup | 2 | Release callback and proxy contexts when parsing a malformed network-output address fails. This narrowly adapts the cleanup from `e9d2e8606` without its plugin-alias feature. | New internal test passed; full Valgrind reported zero leaks/errors; the exact CI fuzz artifact passed under AddressSanitizer/libFuzzer. |
| Node Exporter diskstats | 2 | Fix stale metric-cache pointers across diskstats collection changes. | Focused Python regression passed normally and with strict Valgrind. |
| SIMD boundary and Loki long payloads | 5 | Correct the SIMD offload boundary and cover long Unicode Loki payloads. Includes a 5.0-compatible memory-check timeout adaptation. | Internal, runtime, and Python coverage passed; Python passed with strict Valgrind. |
| Prometheus Remote Write | 3 | Expire metrics that remain stale for one hour. The backport uses plugin-local 5.0 cmetrics structures because 5.0 does not provide master's `cmt_expire()` API. | Focused Python regression passed normally and with strict Valgrind. |

## Compatibility and scope

| Check | Result |
|---|---|
| Target branch | `5.0` |
| Public configuration or defaults | No changes |
| Bundled libraries under `lib/` | No changes |
| S3 implementation or tests | Explicitly excluded; no S3 paths changed |
| Diff hygiene | `git diff --check origin/5.0...HEAD` passed |
| DCO | All 47 commits contain `Signed-off-by` trailers |
| Commit-prefix lint | HEAD and full PR range passed |

## Test results

| Suite | Result |
|---|---|
| Configure with runtime and internal tests | Passed |
| Full build (`cmake --build build -j8`) | Passed |
| Focused Python integration coverage | 20 passed |
| Focused Python integration coverage with `VALGRIND=1 VALGRIND_STRICT=1` | 20 passed |
| Targeted CTest selection | 10/11 passed |
| Full CTest suite | 192/195 passed (98%) |
| Output cleanup internal test (`ctest -R '^flb-it-output$'`) | Passed |
| Output cleanup internal test under full Valgrind | Passed, 0 bytes in use and 0 errors |
| Saved CI fuzz reproducer under AddressSanitizer/libFuzzer | Passed, no leak report |

The remaining CTest failures are environment or fixture blockers rather than
observed regressions:

| Test | Blocker |
|---|---|
| `flb-rt-in_forward` | Port 24224 was already occupied by an external listener. Its focused Python regression passed normally and under strict Valgrind. |
| `flb-rt-out_http` | Port 8888 was already occupied. |
| `flb-rt-out_td` | The unrelated `/tmp/td.conf` API-key fixture was absent. |

The final history-only trailer rewrite did not change the previously tested
Git tree. The later output-cleanup addition was validated separately with its
focused internal test, Valgrind, and the exact artifact from the failed CIFuzz
job.
