### PR TITLE
input_chunk: bring new chunks up before projected size calculation

### DIFF
--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -2832,6 +2832,30 @@ static struct flb_input_chunk *input_chunk_get(struct flb_input_instance *in,
     }
 
     /*
+     * A new filesystem chunk can be returned DOWN after the maximum number
+     * of UP chunks is reached. Bring it UP before calculating the projected
+     * size, which reads metadata from the mapped file.
+     */
+    if (cio_chunk_is_up(ic->chunk) == CIO_FALSE) {
+        ret = cio_chunk_up_force(ic->chunk);
+        if (ret != CIO_OK) {
+            if (new_chunk == FLB_TRUE) {
+                /*
+                 * flb_input_chunk_create() has already indexed the chunk.
+                 * Since the tag cannot be read from an unavailable DOWN
+                 * chunk, remove it using the caller-provided tag before
+                 * freeing the chunk.
+                 */
+                flb_input_chunk_destroy_corrupted(ic,
+                                                  tag, tag_len,
+                                                  FLB_TRUE);
+            }
+            return NULL;
+        }
+        *set_down = FLB_TRUE;
+    }
+
+    /*
      * If buffering this block of data will exceed one of the limit among all output instances
      * that the chunk will flush to, we need to modify the routes_mask of the oldest chunks
      * (based in creation time) to get enough space for the incoming chunk.

--- a/tests/internal/input_chunk.c
+++ b/tests/internal/input_chunk.c
@@ -20,6 +20,8 @@
 #define MAX_LINES        32
 
 int64_t result_time;
+static int mmap_read_error_count;
+
 struct tail_test_result {
     const char *target;
     int   nMatched;
@@ -487,6 +489,10 @@ static int log_cb(struct cio_ctx *data, int level, const char *file, int line,
                   char *str)
 {
     if (level == CIO_LOG_ERROR) {
+        if (strstr(str, "cannot mmap/read chunk") != NULL) {
+            mmap_read_error_count++;
+        }
+
         flb_error("[fstore] %s", str);
     }
     else if (level == CIO_LOG_WARN) {
@@ -500,6 +506,148 @@ static int log_cb(struct cio_ctx *data, int level, const char *file, int line,
     }
 
     return 0;
+}
+
+/*
+ * Verify that calculating the projected size of a newly created DOWN chunk
+ * does not try to map the chunk before it is brought UP.
+ */
+void flb_test_input_chunk_projected_size_for_down_chunk(void)
+{
+    int ret;
+    char *payload;
+    char *root_path;
+    char temp_path[128];
+    size_t payload_size;
+    struct flb_config *cfg;
+    struct cio_ctx *cio;
+    struct mk_event_loop *evl;
+    struct flb_input_chunk *ic;
+    struct flb_input_instance *i_ins;
+    struct flb_output_instance *o_ins;
+    struct flb_task *task;
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct cio_options opts = {0};
+
+    payload = NULL;
+    payload_size = 0;
+
+    snprintf(temp_path, sizeof(temp_path) - 1,
+             "/input-chunk-down-projected-size-%i/", getpid());
+    temp_path[sizeof(temp_path) - 1] = '\0';
+
+    root_path = flb_test_tmpdir_cat(temp_path);
+    TEST_CHECK(root_path != NULL);
+    if (root_path == NULL) {
+        return;
+    }
+
+    ret = build_grouped_log_payload(&payload, &payload_size);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_free(root_path);
+        return;
+    }
+
+    flb_init_env();
+    cfg = flb_config_init();
+    evl = mk_event_loop_create(256);
+
+    TEST_CHECK(evl != NULL);
+    if (evl == NULL) {
+        flb_config_exit(cfg);
+        flb_free(payload);
+        flb_free(root_path);
+        return;
+    }
+
+    cfg->evl = evl;
+    flb_log_create(cfg, FLB_LOG_STDERR, FLB_LOG_DEBUG, NULL);
+
+    i_ins = flb_input_new(cfg, "dummy", NULL, FLB_TRUE);
+    TEST_CHECK(i_ins != NULL);
+    if (i_ins == NULL) {
+        flb_config_exit(cfg);
+        flb_free(payload);
+        flb_free(root_path);
+        return;
+    }
+    i_ins->storage_type = CIO_STORE_FS;
+
+    cio_options_init(&opts);
+    opts.root_path = root_path;
+    opts.log_cb = log_cb;
+    opts.log_level = CIO_LOG_DEBUG;
+    opts.flags = CIO_OPEN;
+
+    cio = cio_create(&opts);
+    TEST_CHECK(cio != NULL);
+    if (cio == NULL) {
+        flb_input_exit_all(cfg);
+        flb_output_exit(cfg);
+        flb_config_exit(cfg);
+        flb_free(payload);
+        flb_free(root_path);
+        return;
+    }
+
+    cio_set_max_chunks_up(cio, 1);
+    flb_storage_input_create(cio, i_ins);
+    flb_input_init_all(cfg);
+
+    o_ins = flb_output_new(cfg, "http", NULL, FLB_TRUE);
+    TEST_CHECK(o_ins != NULL);
+    if (o_ins == NULL) {
+        cio_destroy(cio);
+        flb_input_exit_all(cfg);
+        flb_output_exit(cfg);
+        flb_config_exit(cfg);
+        flb_free(payload);
+        flb_free(root_path);
+        return;
+    }
+
+    flb_output_set_property(o_ins, "match", "down.*");
+    flb_output_set_property(o_ins, "storage.total_limit_size", "10M");
+
+    TEST_CHECK_(flb_router_io_set(cfg) != -1, "unable to router");
+
+    mmap_read_error_count = 0;
+
+    ret = flb_input_chunk_append_raw(i_ins, FLB_INPUT_LOGS, 0,
+                                     "down.one", 8,
+                                     payload, payload_size);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(cio->total_chunks_up == 1);
+
+    ret = flb_input_chunk_append_raw(i_ins, FLB_INPUT_LOGS, 0,
+                                     "down.two", 8,
+                                     payload, payload_size);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(mk_list_size(&i_ins->chunks) == 2);
+
+    ic = mk_list_entry_last(&i_ins->chunks, struct flb_input_chunk, _head);
+    TEST_CHECK(cio_chunk_is_up(ic->chunk) == CIO_FALSE);
+    TEST_CHECK(mmap_read_error_count == 0);
+
+    mk_list_foreach_safe(head, tmp, &i_ins->tasks) {
+        task = mk_list_entry(head, struct flb_task, _head);
+        flb_task_destroy(task, FLB_TRUE);
+    }
+
+    mk_list_foreach_safe(head, tmp, &i_ins->chunks) {
+        ic = mk_list_entry(head, struct flb_input_chunk, _head);
+        flb_input_chunk_destroy(ic, FLB_TRUE);
+    }
+
+    cio_destroy(cio);
+    flb_router_exit(cfg);
+    flb_input_exit_all(cfg);
+    flb_output_exit(cfg);
+    flb_config_exit(cfg);
+    flb_free(payload);
+    flb_free(root_path);
 }
 
 static int get_counter_value_1(struct cmt_counter *counter,
@@ -1305,5 +1453,7 @@ TEST_LIST = {
      flb_test_input_chunk_prefers_deletable_files_on_limit},
     {"input_chunk_limit_with_many_outputs",
      flb_test_input_chunk_limit_with_many_outputs},
+    {"input_chunk_projected_size_for_down_chunk",
+     flb_test_input_chunk_projected_size_for_down_chunk},
     {NULL, NULL}
 };


### PR DESCRIPTION
## Summary

Ensure that a newly created filesystem chunk is UP before calculating its
projected write size.

The reproduced failure is specific to filesystem buffering; memory-backed
chunks do not use the DOWN file-descriptor and mapping path involved here.

This prevents ChunkIO from attempting to read metadata from a DOWN chunk with
a closed file descriptor and emitting a misleading `cannot mmap/read chunk`
error.

No issue has been filed for this specific reproducer.

## Background and root cause

I initially observed frequent errors like this on Fluent Bit 5.0.9 with
filesystem buffering under high ingestion:

```text
[error] [storage] cannot mmap/read chunk '/var/log/flb-storage/tail.0/...flb'
```

The frequency dropped sharply after increasing `storage.max_chunks_up` from
128 to 256. That suggested that the error was related to the transition from
UP to DOWN chunks rather than to the lifetime of the source log file.

I reduced the case to `storage.max_chunks_up 1` and two chunks with different
tags. The same behavior is reproducible on v5.1.1 and current `master`.

The sequence is:

1. `cio_chunk_open()` can return a new filesystem chunk DOWN after the maximum
   number of UP chunks is reached.
2. `flb_input_chunk_create()` temporarily brings the chunk UP, writes the
   header, and restores it to DOWN before returning.
3. `input_chunk_get()` immediately calls
   `flb_input_chunk_get_projected_write_size()`.
4. The projected size calculation calls `cio_meta_size()`, which reaches
   `cio_file_read_prepare()` and `cio_file_native_map()`.
5. `cio_file_native_map()` detects that the file descriptor is not open and
   returns `CIO_ERROR` before the `mmap()` system call is made. ChunkIO then
   emits the generic `cannot mmap/read chunk` message.
6. The append path subsequently brings the same chunk UP and can continue
   writing it, which is why this specific message does not necessarily mean
   that the chunk append failed.

On the metadata read failure,
`flb_input_chunk_get_projected_write_size()` returns `SIZE_MAX`. That value is
then passed to the output storage-limit placement checks. Therefore this is
not only a logging change: the fix also ensures that those checks receive a
real projected chunk size.

## Change

After selecting or creating the input chunk, check whether it is DOWN before
calculating the projected size. If so, bring it UP and set the existing
`set_down` flag. The normal append path then restores the chunk to DOWN.

If a newly created chunk cannot be brought UP, destroy it and return the
failure instead of continuing with an unavailable chunk.

This does not change the chunk format or suppress real operating-system mmap
errors. It makes the chunk state valid before the metadata read.

## Reproducer

Create several files so the tail input creates chunks with distinct expanded
tags:

```shell
mkdir -p /tmp/flb-mmap-input /tmp/flb-mmap-storage
for n in 1 2 3 4 5 6 7 8; do
    printf '{"message":"test-%s"}\n' "$n" > "/tmp/flb-mmap-input/$n.log"
done
```

Configuration:

```text
[SERVICE]
    Flush                 60
    Log_Level             debug
    storage.path          /tmp/flb-mmap-storage
    storage.sync          normal
    storage.max_chunks_up 1

[INPUT]
    Name                  tail
    Tag                   mmap.*
    Path                  /tmp/flb-mmap-input/*.log
    Read_from_Head        On
    Inotify_Watcher       Off
    Refresh_Interval      1
    storage.type          filesystem

[OUTPUT]
    Name                  null
    Match                 *
    storage.total_limit_size 16M
```

Before this change, the new internal test fails with:

```text
[error] [fstore] cannot mmap/read chunk '.../dummy.0/...flb'
input_chunk.c:632: Check mmap_read_error_count == 0... failed
FAILED: 1 of 1 unit tests has failed.
```

After this change:

```text
Test input_chunk_projected_size_for_down_chunk... [ OK ]
SUCCESS: All unit tests have passed.
```

## Testing

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Valgrind output that shows no leaks or memory corruption

Focused regression test:

```shell
./build/bin/flb-it-input_chunk input_chunk_projected_size_for_down_chunk
```

The test fails on unmodified `master` and passes with this change.

Full component suite:

```shell
./build/bin/flb-it-input_chunk
```

Result:

```text
SUCCESS: All unit tests have passed.
```

Valgrind command:

```shell
valgrind --leak-check=full \
    --show-leak-kinds=all \
    --errors-for-leak-kinds=definite,indirect \
    --error-exitcode=99 \
    ./build/bin/flb-it-input_chunk \
    input_chunk_projected_size_for_down_chunk
```

Valgrind result:

```text
HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
  total heap usage: 3,958 allocs, 3,958 frees, 739,273 bytes allocated
All heap blocks were freed -- no leaks are possible
ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

The change is not related to packaging or container build definitions.

- [N/A] Run local packaging test showing all targets build
- [N/A] Set `ok-package-test` label

## Documentation

- [N/A] Documentation required for this bug fix

The change corrects an internal chunk-state transition and introduces no new
configuration or user-facing behavior.

## Backporting

- [x] Backport to latest stable release

The issue is reproducible on v5.1.1. I can submit a separate backport after
the change is accepted in `master`.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I
understand that this code will be released under the terms of that license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of newly created storage chunks in the DOWN state.
  * Prevented projected-size calculations from failing when chunk metadata is temporarily unavailable.
  * Ensured failed chunk initialization is cleaned up safely.
  * Improved reliability when appending data to newly created chunks.

* **Tests**
  * Added coverage validating projected-size calculations for DOWN chunks.
  * Added checks to confirm no chunk mapping or read errors occur during this process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->