### PR TITLE
out_kafka: preserve infinite shutdown grace

### DIFF
--- a/plugins/out_kafka/kafka.c
+++ b/plugins/out_kafka/kafka.c
@@ -1392,13 +1392,21 @@ static void kafka_flush_force(struct flb_out_kafka *ctx,
                               struct flb_config *config)
 {
     int ret;
+    int timeout;
 
     if (!ctx) {
         return;
     }
 
     if (ctx->kafka.rk) {
-        ret = rd_kafka_flush(ctx->kafka.rk, config->grace * 1000);
+        timeout = config->grace;
+
+        /* Preserve the no-wait and infinite timeout (-1) sentinels. */
+        if (timeout > 0) {
+            timeout *= 1000;
+        }
+
+        ret = rd_kafka_flush(ctx->kafka.rk, timeout);
         if (ret != RD_KAFKA_RESP_ERR_NO_ERROR) {
             flb_plg_warn(ctx->ins, "Failed to force flush: %s",
                          rd_kafka_err2str(ret));

--- a/tests/integration/scenarios/out_kafka/config/out_kafka_shutdown_grace.yaml
+++ b/tests/integration/scenarios/out_kafka/config/out_kafka_shutdown_grace.yaml
@@ -1,0 +1,27 @@
+service:
+  flush: 0.1
+  grace: 2
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+  hot_reload: on
+  hot_reload.ensure_thread_safety: ${TEST_HOT_RELOAD_ENSURE_THREAD_SAFETY}
+  hot_reload.timeout: 30
+
+pipeline:
+  inputs:
+    - name: http
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      tag: out_kafka
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: json
+      queue_full_retries: 1
+      rdkafka.message.timeout.ms: 5000
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -625,6 +625,7 @@ def test_out_kafka_hot_reload_times_out_pending_delivery_with_finite_grace():
     try:
         _send_shutdown_grace_record(service)
         _wait_for_log_text(service.flb.log_file, "enqueued message")
+        reload_started_at = time.monotonic()
         service.flb.trigger_http_reload()
         service.flb.wait_for_hot_reload_count(
             1,
@@ -635,8 +636,12 @@ def test_out_kafka_hot_reload_times_out_pending_delivery_with_finite_grace():
             "Failed to force flush: Local: Timed out",
         )
 
+        reload_elapsed_seconds = time.monotonic() - reload_started_at
         force_flush_failure = "Failed to force flush: Local: Timed out"
         reload_start = "[reload] start everything"
+
+        # Allow scheduling margin around the configured two-second grace.
+        assert reload_elapsed_seconds >= 1.5
         assert reload_start in log_text
         assert log_text.index(force_flush_failure) < log_text.index(reload_start)
     finally:

--- a/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/tests/integration/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -543,6 +543,35 @@ def test_decode_avro_long_rejects_out_of_range_terminal_bits():
         _decode_avro_long(payload)
 
 
+def _create_shutdown_grace_service(ensure_thread_safe_reload):
+    config_file = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../config",
+            "out_kafka_shutdown_grace.yaml",
+        )
+    )
+    service = FluentBitTestService(
+        config_file,
+        extra_env={
+            "TEST_HOT_RELOAD_ENSURE_THREAD_SAFETY": (
+                "on" if ensure_thread_safe_reload else "off"
+            ),
+        },
+    )
+    service.allocate_port_env("TEST_SUITE_KAFKA_PORT")
+    return service
+
+
+def _send_shutdown_grace_record(service):
+    response = requests.post(
+        f"http://127.0.0.1:{service.flb_listener_port}/",
+        json={"message": "pending during reload"},
+        timeout=5,
+    )
+    response.raise_for_status()
+
+
 def test_out_kafka_sends_json_payload():
     service = Service("out_kafka_basic.yaml")
     service.start()
@@ -560,6 +589,58 @@ def test_out_kafka_sends_json_payload():
     assert payload["source"] == "dummy"
     assert any(request["api_key"] == 3 for request in data_storage["requests"])
     assert any(request["api_key"] == 0 for request in data_storage["requests"])
+
+
+def test_out_kafka_hot_reload_waits_for_pending_delivery_with_infinite_grace():
+    service = _create_shutdown_grace_service(ensure_thread_safe_reload=True)
+    service.start()
+
+    try:
+        _send_shutdown_grace_record(service)
+        _wait_for_log_text(service.flb.log_file, "enqueued message")
+        service.flb.trigger_http_reload()
+        service.flb.wait_for_hot_reload_count(
+            1,
+            timeout=30 if memory_check_enabled() else 10,
+        )
+        log_text = _wait_for_log_text(
+            service.flb.log_file,
+            "[reload] start everything",
+            timeout=30 if memory_check_enabled() else 10,
+        )
+
+        delivery_failure = "message delivery failed: Local: Message timed out"
+        reload_start = "[reload] start everything"
+        assert delivery_failure in log_text
+        assert "Failed to force flush" not in log_text
+        assert log_text.index(delivery_failure) < log_text.index(reload_start)
+    finally:
+        service.stop()
+
+
+def test_out_kafka_hot_reload_times_out_pending_delivery_with_finite_grace():
+    service = _create_shutdown_grace_service(ensure_thread_safe_reload=False)
+    service.start()
+
+    try:
+        _send_shutdown_grace_record(service)
+        _wait_for_log_text(service.flb.log_file, "enqueued message")
+        service.flb.trigger_http_reload()
+        service.flb.wait_for_hot_reload_count(
+            1,
+            timeout=30 if memory_check_enabled() else 10,
+        )
+        log_text = _wait_for_log_text(
+            service.flb.log_file,
+            "Failed to force flush: Local: Timed out",
+        )
+
+        force_flush_failure = "Failed to force flush: Local: Timed out"
+        reload_start = "[reload] start everything"
+        assert reload_start in log_text
+        assert log_text.index(force_flush_failure) < log_text.index(reload_start)
+    finally:
+        service.stop()
 
 
 def test_out_kafka_raw_format_uses_selected_field():


### PR DESCRIPTION
Preserve Fluent Bit's no-wait and infinite grace values when converting the Kafka shutdown timeout from seconds to milliseconds. Positive grace values continue to be converted before calling `rd_kafka_flush()`.

Thread-safe hot reload sets the old context's grace to `-1`. The Kafka output previously multiplied that sentinel by 1000 and passed `-1000` to librdkafka, which treated it as an expired timeout and returned before outstanding messages reached a delivery result.

The integration coverage keeps a Kafka message pending with an unavailable broker and exercises both infinite and finite grace behavior during hot reload.

This patch was developed with AI assistance.

Fixes #12343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kafka shutdown handling for zero-wait and unlimited-wait grace settings.
  - Applied positive shutdown grace periods consistently when flushing pending messages.
  - Improved hot reload reliability while Kafka deliveries are in progress.

- **Tests**
  - Added integration coverage for Kafka delivery during hot reload with finite and unlimited shutdown grace periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->