### PR TITLE
tests: integration: Adjust allocation patterns for Ubuntu 26.04

### DIFF
--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -487,9 +487,9 @@ def _zstd_bytes(data):
 
 
 def _forward_allocation_repro_payload():
-    entry_count = 170
+    entry_count = 8
     declared_entries = entry_count * 2
-    body = "R" * 200
+    body = "R" * 100000
     payload = bytearray()
 
     payload += _pack_array_header(2)
@@ -499,7 +499,7 @@ def _forward_allocation_repro_payload():
     for i in range(entry_count):
         payload += _pack_obj([TEST_TS + i, {"log": body}])
 
-    return bytes(payload[:29229]).ljust(29229, b"\x00")
+    return bytes(payload[:800000]).ljust(800000, b"\x00")
 
 
 def _process_status_kb(pid, key):
@@ -650,6 +650,9 @@ def _run_forward_repro_attempt(tmp_path, data_limit_kb):
 
             if "fw_conn.c" in log_text and "Cannot allocate memory" in log_text:
                 return False, "connection allocation failed"
+
+            if "could not register new connection" in log_text:
+                return False, "connection registration failed"
 
             if process.poll() is not None:
                 return False, f"process exited with {process.returncode}"
@@ -936,10 +939,7 @@ def test_in_forward_repro_payload_allocation_failure_closes_connection(tmp_path)
     baseline_kb = _measure_forward_vmdata_kb(tmp_path)
     attempts = []
 
-    for delta_kb in [
-        512, 640, 768, 896, 960, 992, 1008, 1016, 1024, 1040, 1088, 1152, 1280,
-        1536, 2048,
-    ]:
+    for delta_kb in [1152, 1408, 1664, 1920, 2176, 2688, 3200]:
         data_limit_kb = baseline_kb + delta_kb
         matched, status = _run_forward_repro_attempt(tmp_path, data_limit_kb)
         attempts.append(f"{data_limit_kb} KiB: {status}")


### PR DESCRIPTION
This PR is leveraged with Fable5 investigation and plan and orchestrated Opus-5 agent(s).

## Investigation

The test works by sandwiching fluent-bit's heap with `RLIMIT_DATA`: it measures baseline `VmData`, then restarts fluent-bit with `limit = baseline + delta` and sends a truncated ~29 KiB forward payload. The payload keeps a msgpack object incomplete, forcing `msgpack_unpacker_reserve_buffer` in `receiver_to_unpacker` fw_prot.c:1233 to repeatedly grow its buffer (doubling from 1 KiB up to ~32–64 KiB). The test needs a limit where **connection setup succeeds but that buffer growth malloc fails**, producing "could not allocate msgpack unpacker buffer".

The failure log shows the two regimes are separated by at most **16 KiB** (27496 KiB → "connection allocation failed", 27512 KiB → "nothing failed"), and no probed delta lands in a working window. This machine runs Ubuntu 26.04.1 with **glibc 2.43**; on older glibc the heap-growth granularity left a gap where the ~32–64 KiB unpacker expansion was the first allocation to hit the limit. With glibc 2.43's malloc (different top-chunk padding/arena behavior), once the connection-setup allocations succeed, the arena already has enough slack to serve the unpacker growth too — the target window is narrower than the test's step size, or doesn't exist at all. The test's tiny 29 KiB payload makes it inherently fragile: the allocation it wants to fail is the same order of magnitude as malloc's growth granularity.

## Plan

1. **Investigate empirically** (Opus agent): confirm on this machine whether any window exists (1 KiB sweep across the boundary), and find a deterministic configuration — glibc tunables for the child process (`MALLOC_ARENA_MAX`, `MALLOC_TOP_PAD_`, `MALLOC_MMAP_THRESHOLD_`) and/or a much larger truncated payload (hundreds of KiB–MiB) so the unpacker's expansion allocation dwarfs malloc granularity and a wide limit window opens.
2. **Fix the test** (Opus agent): apply the winning approach to `test_in_forward_001.py`, keeping the test's intent (allocation failure closes connection, then recovery), then verify with the single test and the full in_forward scenario file.

## Root cause

On Ubuntu 26.04 (glibc 2.43) the test's target failure was **structurally unreachable, not just flaky**. The old 29229-byte payload only ever forced the msgpack unpacker to grow to 32–64 KiB, and glibc serves allocations that small from the ~128 KiB of arena top slack that already exists at startup — the kernel is never asked for memory, so `RLIMIT_DATA` is never consulted. Meanwhile `fw_conn_add()` does a single 1000 KiB `flb_malloc` for the connection buffer (`buffer_chunk_size`), which pinned the too-tight/too-loose boundary at exactly baseline+1000 KiB. A 1 KiB-step sweep confirmed the window between the two regimes was empty: no limit value could ever make the unpacker allocation fail first. glibc tunables (`MALLOC_ARENA_MAX` etc.) moved the boundary by only 1 KiB and were rejected.

## Fix (test file only, test_in_forward_001.py)

- **Payload**: now 8 entries of `{"log": "R"*100000}` with declared length 16, truncated/zero-padded to 800000 bytes. Peak unpacker allocation becomes ~1 MiB — roughly 8× any plausible glibc arena slack — while staying under `buffer_chunk_size` (1024000) so `conn->buf` is never realloc'd. This opens a measured ~1 MiB-wide trigger window (delta ∈ [1096, ~2160] KiB), which is granularity-independent across glibc 2.35/2.39/2.43.
- **Delta list**: trimmed to `[1152, 1408, 1664, 1920, 2176, 2688, 3200]`; the first four all land inside the window.
- **Honest classification**: a previously undetected third regime (`could not register new connection`, the coroutine-stack allocation failing) is now reported as its own too-tight status instead of masquerading as "allocation failure was not triggered".

## Verification

- Single test passed 3/3 runs, each in ~2.6 s (first delta triggers immediately; the old version took the full sweep and failed).
- Full `test_in_forward_001.py` file: **72 passed**, no regressions.
- One unrelated pre-existing flake surfaced during verification: `test_in_opentelemetry_non_matching_route_drops_all_signals[profiles-...]` failed once mid-run but passes standalone and in the final clean run — worth keeping an eye on separately.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forward allocation failure testing for larger payloads.
  * Added clearer handling for connection-registration allocation failures.
  * Updated memory-limit scenarios to better reflect high-volume allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->