### PR TITLE
engine: Plug a race on starting engine

### DIFF
--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -623,7 +623,8 @@ void flb_config_exit(struct flb_config *config)
     /* Channel notifications */
     if (config->ch_notif[0] > 0) {
         mk_event_closesocket(config->ch_notif[0]);
-        if (config->ch_notif[0] != config->ch_notif[1]) {
+        if (config->ch_notif[1] > 0 &&
+            config->ch_notif[0] != config->ch_notif[1]) {
             mk_event_closesocket(config->ch_notif[1]);
         }
     }

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1038,6 +1038,16 @@ int flb_engine_failed(struct flb_config *config)
     ret = flb_pipe_w(config->ch_notif[1], &val, sizeof(uint64_t));
     if (ret == -1) {
         flb_error("[engine] fail to dispatch FAILED message");
+
+        /*
+         * A library mode caller may be blocked on the notification
+         * channel waiting for this message: close the write end so the
+         * reader wakes up with EOF instead of waiting forever.
+         */
+        if (config->ch_notif[1] != config->ch_notif[0]) {
+            mk_event_closesocket(config->ch_notif[1]);
+            config->ch_notif[1] = -1;
+        }
     }
 
     /* Waiting flushing log */
@@ -1379,16 +1389,23 @@ int flb_engine_start(struct flb_config *config)
         return -1;
     }
 
-    /* Signal that we have started */
-    flb_engine_started(config);
-
+    /*
+     * Segregate the backlog chunks before notifying the library mode
+     * caller: segregation closes chunks that cannot be routed, so it must
+     * not run concurrently with callers inspecting storage right after
+     * flb_start() returns.
+     */
     ret = sb_segregate_chunks(config);
 
     if (ret < 0)
     {
         flb_error("[engine] could not segregate backlog chunks");
+        flb_engine_failed(config);
         return -2;
     }
+
+    /* Signal that we have started */
+    flb_engine_started(config);
 
     config->grace_input  = config->grace / 2;
     flb_info("[engine] Shutdown Grace Period=%d, Shutdown Input Grace Period=%d", config->grace, config->grace_input);

--- a/src/flb_engine.c
+++ b/src/flb_engine.c
@@ -1401,6 +1401,7 @@ int flb_engine_start(struct flb_config *config)
     {
         flb_error("[engine] could not segregate backlog chunks");
         flb_engine_failed(config);
+        flb_engine_shutdown(config);
         return -2;
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR is investigated by Fable 5.

**Root cause:** In flb_engine.c, the engine signaled `FLB_ENGINE_STARTED` — which unblocks `flb_start()` in the caller's thread — *before* running `sb_segregate_chunks()`. In the test's second phase, the test thread immediately starts polling `flb_storage_chunk_count()` → `cio_stats_get()`, which iterates every `stream->chunks` list without locking. Meanwhile the engine thread was still segregating the restored backlog, and the new unroutable-chunk path (`no matching route ... keeping it on disk`) calls `cio_chunk_close()`, which unlinks and frees the chunk from the very list the test thread is walking. When the timing overlapped, the test dereferenced a freed list node — hence the intermittent SegFault right after the second startup.

**Fix** in flb_engine.c:1385: run `sb_segregate_chunks()` *before* `flb_engine_started()`, so `flb_start()` doesn't return until segregation (and any chunk closing it does) is complete. I also added `flb_engine_failed(config)` on the segregation-failure path — previously, with the signal moved, a failure there would have left `flb_start()` blocked forever waiting for a notification that never comes. Service (non-lib) mode is unaffected since `flb_engine_started()` is a no-op without the notification channel.

**Verification:** rebuilt and ran `flb-rt-in_storage_backlog` 30 times in a row — all passed (it previously segfaulted intermittently). Also ran `flb-rt-core_engine`, `flb-rt-core_routes`, and `flb-rt-core_shutdown_spin` to confirm the startup reordering didn't disturb engine start/stop behavior — all pass.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine startup reliability by processing pending work before signaling that startup is complete.
  * Startup failures are now reported correctly when pending work cannot be prepared.
  * Prevented library-mode callers from waiting indefinitely when engine failure notifications cannot be delivered.
  * Improved shutdown cleanup by avoiding attempts to close invalid notification channels.
  * Ensured failed startup attempts complete cleanup before returning an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->