### PR TITLE
log: clamp the suppression length to what was written

### DIFF
--- a/include/fluent-bit/flb_log.h
+++ b/include/fluent-bit/flb_log.h
@@ -198,6 +198,7 @@ int flb_log_cache_check_suppress(struct flb_log_cache *cache, char *msg_buf, siz
 static inline int flb_log_suppress_check(int log_suppress_interval, const char *fmt, ...)
 {
     int ret;
+    int written;
     size_t size;
     va_list args;
     char buf[4096];
@@ -208,11 +209,23 @@ static inline int flb_log_suppress_check(int log_suppress_interval, const char *
     }
 
     va_start(args, fmt);
-    size = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
+    written = vsnprintf(buf, sizeof(buf) - 1, fmt, args);
     va_end(args);
 
-    if (size == -1) {
+    if (written < 0) {
         return FLB_FALSE;
+    }
+
+    /*
+     * vsnprintf() returns the length the message would have had, not what it
+     * wrote, so a message longer than the buffer is truncated while the return
+     * value is not. Passing that length on makes the suppression cache read
+     * past the end of this stack frame. Clamp to what actually landed in buf:
+     * vsnprintf() writes at most (sizeof(buf) - 1) - 1 characters plus a NUL.
+     */
+    size = (size_t) written;
+    if (size > sizeof(buf) - 2) {
+        size = sizeof(buf) - 2;
     }
 
     w = flb_worker_get();


### PR DESCRIPTION
Fixes #12342.

`vsnprintf()` returns the length the message *would* have had, so past 4096 bytes `buf` is truncated while the length passed on is not, and `flb_log_cache_check_suppress()` copies that many bytes back out of the stack frame.

This clamps to what actually landed in the buffer. `vsnprintf()` is called with `sizeof(buf) - 1`, so the most it writes is `sizeof(buf) - 2` characters plus the terminator:

```
vsnprintf returned 8999, strlen(buf)=4094, sizeof(buf)-2=4094
vsnprintf returned 5,    strlen(buf)=5
```

## A second thing in the same lines

`size` was declared `size_t` and the guard was `size == -1`. That happens to work for exactly `-1`, because the constant converts to `SIZE_MAX` and matches, but `vsnprintf()` is only specified to return "a negative value" on an encoding error. Any other negative return would have wrapped to a very large `size_t` and sailed past the check into the same copy. The return now goes into an `int` and is tested for `< 0` before the conversion.

## Verification

I did not build the whole of Fluent Bit under ASan; your trace already covers the real binary. What I did instead was extract the function body into a harness with a stub cache doing the same `memcpy()`, and compile it both ways at `-O0`:

```
BEFORE
==28823==ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 8299 at 0x00016cebe760 thread T0
    [64, 4160) 'buf' (line 18) <== Memory access at offset 4160 overflows this variable

AFTER
copied 4094 bytes
```

Same class and the same `[64, 4160) 'buf'` frame layout as the report. Worth noting it needs `-O0` to show: at `-O1` the copy ran to completion without ASan flagging it, which is the sort of thing that makes this easy to miss in a release build.

I also checked the rest of the file. `flb_log_cache_check_suppress()` has one production caller, this one. The other `vsnprintf()` in `src/flb_log.c:1158` already compares its return against the buffer size and reports the overflow, so it is not affected.

Since this is a header, everything that includes `flb_log.h` recompiles; no callers change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of logging messages that exceed the available buffer size.
  * Prevented truncated messages from being processed with an invalid length.
  * Added safeguards for formatting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->