### PR TITLE
out_loki: scope remove_mpa thread-local cache per instance

### DIFF
--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -24,7 +24,7 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_http_client.h>
 #include <fluent-bit/flb_ra_key.h>
-#include <fluent-bit/flb_thread_storage.h>
+#include <fluent-bit/flb_pthread.h>
 #include <fluent-bit/record_accessor/flb_ra_parser.h>
 #include <fluent-bit/flb_mp.h>
 #include <fluent-bit/flb_log_event_decoder.h>
@@ -45,18 +45,10 @@ struct flb_loki_tenant_group {
 #define FLB_LOKI_TENANT_GROUP_FLUSH_ERROR   (((uint64_t) 1) << 1)
 #define FLB_LOKI_TENANT_GROUP_FLUSH_RETRY   (((uint64_t) 1) << 2)
 
-pthread_once_t initialization_guard = PTHREAD_ONCE_INIT;
-
 struct flb_loki_remove_mpa_entry {
     struct flb_mp_accessor *mpa;
     struct cfl_list _head;
 };
-FLB_TLS_DEFINE(struct flb_loki_remove_mpa_entry, thread_local_remove_mpa);
-
-void initialize_thread_local_storage()
-{
-    FLB_TLS_INIT(thread_local_remove_mpa);
-}
 
 static struct flb_loki_remove_mpa_entry *remove_mpa_entry_create(struct flb_loki *ctx)
 {
@@ -1590,19 +1582,6 @@ static int cb_loki_init(struct flb_output_instance *ins,
         return -1;
     }
 
-    result = pthread_once(&initialization_guard,
-                          initialize_thread_local_storage);
-
-    if (result != 0) {
-        flb_errno();
-
-        flb_plg_error(ins, "cannot initialize thread local storage");
-
-        loki_config_destroy(ctx);
-
-        return -1;
-    }
-
     result = pthread_mutex_init(&ctx->remove_mpa_list_lock, NULL);
     if (result != 0) {
         flb_errno();
@@ -1612,6 +1591,21 @@ static int cb_loki_init(struct flb_output_instance *ins,
     }
 
     cfl_list_init(&ctx->remove_mpa_list);
+
+    /*
+     * Per-instance TLS key for the remove_mpa cache. Using a global TLS
+     * symbol here would let two loki outputs running on the same worker
+     * thread share the first instance's mpa and silently skip remove_keys
+     * for the second one.
+     */
+    result = pthread_key_create(&ctx->remove_mpa_key, NULL);
+    if (result != 0) {
+        flb_errno();
+        flb_plg_error(ins, "cannot create remove_mpa thread-local key");
+        loki_config_destroy(ctx);
+        return -1;
+    }
+    ctx->remove_mpa_key_initialized = FLB_TRUE;
 
     /*
      * This plugin instance uses the HTTP client interface, let's register
@@ -2142,7 +2136,7 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
     struct mk_list *head;
     struct flb_loki_tenant_group *group;
 
-    remove_mpa_entry = FLB_TLS_GET(thread_local_remove_mpa);
+    remove_mpa_entry = pthread_getspecific(ctx->remove_mpa_key);
 
     if (remove_mpa_entry == NULL) {
         remove_mpa_entry = remove_mpa_entry_create(ctx);
@@ -2151,7 +2145,7 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
 
-        FLB_TLS_SET(thread_local_remove_mpa, remove_mpa_entry);
+        pthread_setspecific(ctx->remove_mpa_key, remove_mpa_entry);
 
         pthread_mutex_lock(&ctx->remove_mpa_list_lock);
         cfl_list_add(&remove_mpa_entry->_head, &ctx->remove_mpa_list);
@@ -2247,6 +2241,11 @@ static int cb_loki_exit(void *data, struct flb_config *config)
     release_remove_mpa_entries(&ctx->remove_mpa_list);
 
     pthread_mutex_unlock(&ctx->remove_mpa_list_lock);
+
+    if (ctx->remove_mpa_key_initialized == FLB_TRUE) {
+        pthread_key_delete(ctx->remove_mpa_key);
+        ctx->remove_mpa_key_initialized = FLB_FALSE;
+    }
 
     loki_config_destroy(ctx);
 

--- a/plugins/out_loki/loki.c
+++ b/plugins/out_loki/loki.c
@@ -2145,7 +2145,19 @@ static void cb_loki_flush(struct flb_event_chunk *event_chunk,
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
 
-        pthread_setspecific(ctx->remove_mpa_key, remove_mpa_entry);
+        /*
+         * Publish the entry before linking it: if the key cannot be set the
+         * entry stays unreachable from this thread, and linking it anyway
+         * would leak one accessor per flush until the instance is destroyed.
+         */
+        ret = pthread_setspecific(ctx->remove_mpa_key, remove_mpa_entry);
+        if (ret != 0) {
+            flb_plg_error(ctx->ins,
+                          "cannot store remove_mpa entry in thread-local "
+                          "storage: %d", ret);
+            remove_mpa_entry_destroy(remove_mpa_entry);
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
 
         pthread_mutex_lock(&ctx->remove_mpa_list_lock);
         cfl_list_add(&remove_mpa_entry->_head, &ctx->remove_mpa_list);

--- a/plugins/out_loki/loki.h
+++ b/plugins/out_loki/loki.h
@@ -24,6 +24,7 @@
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_upstream.h>
 #include <fluent-bit/flb_hash_table.h>
+#include <fluent-bit/flb_pthread.h>
 #include <cfl/cfl_list.h>
 
 #define FLB_LOKI_CT              "Content-Type"
@@ -105,6 +106,16 @@ struct flb_loki {
 
     struct cfl_list remove_mpa_list;
     pthread_mutex_t remove_mpa_list_lock;
+
+    /*
+     * Per-instance TLS key for the thread-local remove_mpa cache. Each loki
+     * output instance owns its own key so multiple loki outputs running on
+     * the same worker thread do not share each other's mpa, which would
+     * cause one instance to silently skip remove_keys against records that
+     * do not match the other instance's patterns.
+     */
+    pthread_key_t remove_mpa_key;
+    int remove_mpa_key_initialized;
 
     /* Upstream Context */
     struct flb_upstream *u;

--- a/tests/runtime/out_loki.c
+++ b/tests/runtime/out_loki.c
@@ -34,6 +34,7 @@
 #define LOKI_TENANT_SPLIT_PORT "18083"
 #define LOKI_TENANT_POLICY_SUCCESS_PORT "18084"
 #define LOKI_TENANT_POLICY_ERROR_PORT "18085"
+#define LOKI_MULTI_INSTANCE_PORT "18086"
 
 pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
 int num_output = 0;
@@ -992,6 +993,120 @@ void flb_test_remove_keys_workers()
     flb_destroy(ctx);
 }
 
+/*
+ * Two 'loki' instances flushing the same records must each apply their own
+ * remove_keys set. Without a per-instance removal context they share the one
+ * created by whichever instance flushes first.
+ */
+#define JSON_MULTI_INSTANCE \
+    "[12345678, {\"msg\":\"hello\",\"alpha\":\"a\",\"beta\":\"b\"}]"
+
+static int check_instance_payload(char *marker, char *present, char *absent)
+{
+    int i;
+
+    for (i = 0; i < tenant_request_count; i++) {
+        if (tenant_payloads[i] == NULL) {
+            continue;
+        }
+
+        if (strstr(tenant_payloads[i], marker) == NULL) {
+            continue;
+        }
+
+        if (!TEST_CHECK(strstr(tenant_payloads[i], present) != NULL)) {
+            TEST_MSG("payload for %s did not contain %s: %s",
+                     marker, present, tenant_payloads[i]);
+            return -1;
+        }
+
+        if (!TEST_CHECK(strstr(tenant_payloads[i], absent) == NULL)) {
+            TEST_MSG("payload for %s contained %s: %s",
+                     marker, absent, tenant_payloads[i]);
+            return -1;
+        }
+
+        return 0;
+    }
+
+    TEST_CHECK(0);
+    TEST_MSG("no request found for %s", marker);
+
+    return -1;
+}
+
+void flb_test_remove_keys_multiple_instances()
+{
+    int ret;
+    int tries;
+    int in_ffd;
+    int out_ffd;
+    flb_ctx_t *ctx;
+    struct tenant_policy_server mock_server;
+
+    clear_tenant_requests();
+    clear_tenant_policy_requests();
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1",
+                    "log_level", "error",
+                    NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* First instance: drops 'alpha', keeps 'beta' */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "test",
+                         "host", LOKI_TENANT_POLICY_HOST,
+                         "port", LOKI_MULTI_INSTANCE_PORT,
+                         "labels", "instance=first",
+                         "remove_keys", "alpha",
+                         "net.keepalive", "off",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    /* Second instance: drops 'beta', keeps 'alpha' */
+    out_ffd = flb_output(ctx, (char *) "loki", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    ret = flb_output_set(ctx, out_ffd,
+                         "match", "test",
+                         "host", LOKI_TENANT_POLICY_HOST,
+                         "port", LOKI_MULTI_INSTANCE_PORT,
+                         "labels", "instance=second",
+                         "remove_keys", "beta",
+                         "net.keepalive", "off",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    ret = start_tenant_policy_server(&mock_server, LOKI_MULTI_INSTANCE_PORT);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_lib_push(ctx, in_ffd, (char *) JSON_MULTI_INSTANCE,
+                       sizeof(JSON_MULTI_INSTANCE) - 1);
+    TEST_CHECK(ret >= 0);
+
+    for (tries = 0; tries < 20 && get_tenant_request_count() < 2; tries++) {
+        sleep(1);
+    }
+
+    TEST_CHECK(get_tenant_request_count() >= 2);
+
+    check_instance_payload("first", "beta", "alpha");
+    check_instance_payload("second", "alpha", "beta");
+
+    stop_tenant_policy_server(&mock_server);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+    clear_tenant_requests();
+}
+
 static int check_tenant_request(char *tenant, char *present, char *absent)
 {
     int i;
@@ -1694,6 +1809,7 @@ TEST_LIST = {
     {"labels_ra"              , flb_test_labels_ra },
     {"remove_keys"            , flb_test_remove_keys },
     {"remove_keys_workers"    , flb_test_remove_keys_workers },
+    {"remove_keys_multiple_instances", flb_test_remove_keys_multiple_instances },
     {"tenant_id_key_splits_requests", flb_test_tenant_id_key_splits_requests },
     {"tenant_id_key_partial_success", flb_test_tenant_id_key_partial_success },
     {"tenant_id_key_partial_error", flb_test_tenant_id_key_partial_error },


### PR DESCRIPTION
`out_loki` keeps one key-removal context (`struct flb_mp_accessor`) per thread so that
concurrent flushes do not share the mutable match state inside
`flb_mp_accessor_keys_remove()`. Since #10563 those contexts are cached in thread local
storage declared with `FLB_TLS_DEFINE`, which creates one key for the whole plugin
rather than one per plugin instance.

With no `workers` configured every output flushes as a coroutine on the same engine
thread, so with two or more `loki` outputs the first instance to flush populates the
shared slot and every other instance then finds it non-NULL and reuses it. Those
instances end up filtering against another instance's `remove_keys` set, so none of
their own keys are removed and `drop_single_key` never triggers.

The first commit is @dbeneker's fix from
c338a323a3ecfd6eb4ac7ea3b875d018ccb42a24, which he posted in #10704 but never opened as
a PR. It moves the TLS slot into the per-instance context as a dedicated
`pthread_key_t`. I have rebased it onto master with his authorship and sign-off intact;
the only adaptation is that `thread_local_remove_mpa` was by then the only remaining
user of the TLS helpers in this plugin, so `initialize_thread_local_storage()` and its
`pthread_once` guard are removed rather than left empty.

@dbeneker — you are kept as the author of that commit and your sign-off is untouched. I
am opening this only because the issue has been open for a year and stale-flagged twice;
if you would rather submit it yourself, say so and I will close this in favour of yours.

The second commit adds a runtime test with two `loki` instances removing different keys.
It drives `cb_loki_flush()` through the mock HTTP server already used by the
`tenant_id_key` tests, because the accessor is selected while flushing and the
`formatter` test hook does not reach that code.

Fixes #10704

Reporters in that thread have confirmed it on 4.0.6, 4.1.0, 4.2.2 and 5.0.6. I
reproduced it on the 5.0.9 and 5.1.1 release images and on a build of current master.
The `workers` workaround mentioned in that thread works because it gives each instance
its own thread. Grepping `plugins/out_loki/loki.c` across tags puts the first affected
release at v4.0.4.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
- [x] Debug log output from testing the change
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [N/A] Documentation required for this feature

**Backporting**
- [ ] Backport to latest stable release.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Loki outputs with multiple instances running on the same worker so each instance applies its own `remove_keys` configuration correctly.
  * Prevented fields from being incorrectly retained or removed when records are sent through multiple Loki outputs.

* **Tests**
  * Added runtime coverage validating independent field filtering and payload contents across multiple Loki instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->