### PR TITLE
emitter: ml: plug data losses during multiline processing on shutdown

### DIFF
--- a/include/fluent-bit/flb_emitter.h
+++ b/include/fluent-bit/flb_emitter.h
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_EMITTER_H
+#define FLB_EMITTER_H
+
+struct flb_config;
+
+typedef void (*flb_in_emitter_pause_cb)(void *data, struct flb_config *config);
+
+struct flb_emitter_callbacks {
+    flb_in_emitter_pause_cb pause;
+    void *data;
+};
+
+#endif

--- a/include/fluent-bit/flb_input.h
+++ b/include/fluent-bit/flb_input.h
@@ -74,6 +74,7 @@
                                      * private key and certificate are required.
                                      */
 #define FLB_INPUT_HTTP_SERVER 4096  /* input uses the generic HTTP server     */
+#define FLB_INPUT_SHUTDOWN_FLUSH         8192 /* allow publishing while shutdown flushes */
 
 /* Input status */
 #define FLB_INPUT_RUNNING     1

--- a/plugins/filter_multiline/ml.c
+++ b/plugins/filter_multiline/ml.c
@@ -32,15 +32,80 @@
 #include <fluent-bit/flb_log_event_decoder.h>
 #include <fluent-bit/flb_log_event_encoder.h>
 
+#include <cfl/cfl_atomic.h>
+
 #include "ml.h"
 #include "ml_concat.h"
 
 static struct ml_stream *get_by_id(struct ml_ctx *ctx, uint64_t stream_id);
+static void flush_pending_partial_messages(struct ml_ctx *ctx);
+
+static void active_callback_leave(struct ml_ctx *ctx)
+{
+    uint64_t active;
+
+    do {
+        active = cfl_atomic_load(&ctx->active_callbacks);
+    } while (cfl_atomic_compare_exchange(&ctx->active_callbacks,
+                                         active, active - 1) == 0);
+}
+
+static int active_callback_enter(struct ml_ctx *ctx)
+{
+    uint64_t active;
+
+    while (cfl_atomic_load(&ctx->shutdown_flush_requested) == FLB_FALSE) {
+        active = cfl_atomic_load(&ctx->active_callbacks);
+        if (cfl_atomic_compare_exchange(&ctx->active_callbacks,
+                                        active, active + 1) == 0) {
+            continue;
+        }
+
+        if (cfl_atomic_load(&ctx->shutdown_flush_requested) == FLB_FALSE) {
+            return FLB_TRUE;
+        }
+
+        active_callback_leave(ctx);
+        break;
+    }
+
+    return FLB_FALSE;
+}
+
+static void cb_emitter_pause(void *data, struct flb_config *config)
+{
+    struct ml_ctx *ctx = data;
+
+    if (ctx == NULL) {
+        return;
+    }
+
+    /*
+     * Close the parser path before flushing. Normal ingestion remains
+     * lock-free; only shutdown waits for callbacks already concatenating.
+     * A callback that arrives after the gate returns NOTOUCH and keeps its
+     * original record instead of racing the final multiline flush.
+     */
+    cfl_atomic_store(&ctx->shutdown_flush_requested, FLB_TRUE);
+    while (cfl_atomic_load(&ctx->active_callbacks) > 0) {
+        flb_time_msleep(1);
+    }
+
+    if (ctx->partial_mode == FLB_TRUE) {
+        flb_plg_debug(ctx->ins, "flushing pending partial-message records on shutdown");
+        flush_pending_partial_messages(ctx);
+    }
+    else if (ctx->m != NULL) {
+        flb_plg_debug(ctx->ins, "flushing pending multiline records on shutdown");
+        flb_ml_flush_pending_now(ctx->m);
+    }
+}
 
 /* Create an emitter input instance */
 static int emitter_create(struct ml_ctx *ctx)
 {
     int ret;
+    void *emitter_data;
     struct flb_input_instance *ins;
 
     ret = flb_input_name_exists(ctx->emitter_name, ctx->config);
@@ -50,7 +115,11 @@ static int emitter_create(struct ml_ctx *ctx)
         return -1;
     }
 
-    ins = flb_input_new(ctx->config, "emitter", NULL, FLB_FALSE);
+    ctx->emitter_callbacks.pause = cb_emitter_pause;
+    ctx->emitter_callbacks.data = ctx;
+    emitter_data = &ctx->emitter_callbacks;
+
+    ins = flb_input_new(ctx->config, "emitter", emitter_data, FLB_FALSE);
     if (!ins) {
         flb_plg_error(ctx->ins, "cannot create emitter instance");
         return -1;
@@ -179,6 +248,59 @@ static int ingest_inline(struct ml_ctx *ctx,
     }
 
     return FLB_FALSE;
+}
+
+static void flush_split_message_packer(struct ml_ctx *ctx,
+                                       struct split_message_packer *packer)
+{
+    int ret;
+
+    mk_list_del(&packer->_head);
+    ml_split_message_packer_complete(packer);
+
+    /* Re-emit the completed record with its original tag. */
+    if (packer->log_encoder.output_buffer != NULL &&
+        packer->log_encoder.output_length > 0) {
+        flb_plg_trace(ctx->ins, "emitting from %s to %s",
+                      packer->input_name, packer->tag);
+
+        ret = ingest_inline(ctx, packer->tag,
+                            packer->log_encoder.output_buffer,
+                            packer->log_encoder.output_length);
+        if (ret == FLB_FALSE) {
+            ret = in_emitter_add_record(packer->tag,
+                                        flb_sds_len(packer->tag),
+                                        packer->log_encoder.output_buffer,
+                                        packer->log_encoder.output_length,
+                                        ctx->ins_emitter,
+                                        ctx->i_ins);
+        }
+        else {
+            ret = 0;
+        }
+
+        if (ret < 0) {
+            flb_plg_warn(ctx->ins,
+                         "could not send concatenated record of size %zu "
+                         "bytes to in_emitter %s",
+                         packer->log_encoder.output_length,
+                         ctx->ins_emitter->name);
+        }
+    }
+
+    ml_split_message_packer_destroy(packer);
+}
+
+static void flush_pending_partial_messages(struct ml_ctx *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct split_message_packer *packer;
+
+    mk_list_foreach_safe(head, tmp, &ctx->split_message_packers) {
+        packer = mk_list_entry(head, struct split_message_packer, _head);
+        flush_split_message_packer(ctx, packer);
+    }
 }
 
 static int flush_callback(struct flb_ml_parser *parser,
@@ -356,13 +478,6 @@ static int cb_ml_init(struct flb_filter_instance *ins,
             return -1;
         }
 
-        /* Create the emitter context */
-        ret = emitter_create(ctx);
-        if (ret == -1) {
-            flb_free(ctx);
-            return -1;
-        }
-
         /* Register a metric to count the number of emitted records */
 #ifdef FLB_HAVE_METRICS
         ctx->cmt_emitted = cmt_counter_create(ins->cmt,
@@ -439,6 +554,17 @@ static int cb_ml_init(struct flb_filter_instance *ins,
                 return -1;
             }
             ctx->stream_id = stream_id;
+        }
+    }
+
+    /*
+     * Create the emitter only after the owner context is fully initialized.
+     * The emitter keeps a callback reference to this context in parser mode.
+     */
+    if (ctx->use_buffer == FLB_TRUE) {
+        ret = emitter_create(ctx);
+        if (ret == -1) {
+            return -1;
         }
     }
 
@@ -569,7 +695,6 @@ static void partial_timer_cb(struct flb_config *config, void *data)
     struct split_message_packer *packer;
     unsigned long long now;
     unsigned long long diff;
-    int ret;
 
     now = ml_current_timestamp();
 
@@ -581,36 +706,7 @@ static void partial_timer_cb(struct flb_config *config, void *data)
             continue;
         }
 
-        mk_list_del(&packer->_head);
-        ml_split_message_packer_complete(packer);
-        /* re-emit record with original tag */
-        if (packer->log_encoder.output_buffer != NULL &&
-            packer->log_encoder.output_length > 0) {
-
-            flb_plg_trace(ctx->ins, "emitting from %s to %s", packer->input_name, packer->tag);
-
-            ret = ingest_inline(ctx, packer->tag, packer->log_encoder.output_buffer,
-                            packer->log_encoder.output_length);
-            if (!ret) {
-                ret = in_emitter_add_record(packer->tag, flb_sds_len(packer->tag),
-                                        packer->log_encoder.output_buffer,
-                                        packer->log_encoder.output_length,
-                                        ctx->ins_emitter,
-                                        ctx->i_ins);
-            }
-            else {
-                ret = 0;
-            }
-            if (ret < 0) {
-                /* this shouldn't happen in normal execution */
-                flb_plg_warn(ctx->ins,
-                             "Couldn't send concatenated record of size %zu "
-                             "bytes to in_emitter %s",
-                             packer->log_encoder.output_length,
-                             ctx->ins_emitter->name);
-            }
-        }
-        ml_split_message_packer_destroy(packer);
+        flush_split_message_packer(ctx, packer);
     }
 }
 
@@ -803,6 +899,7 @@ static int cb_ml_filter(const void *data, size_t bytes,
     struct ml_stream            *stream;
     struct flb_log_event         event;
     int                          ret;
+    int                          callback_active;
     struct ml_ctx               *ctx;
 #ifdef FLB_HAVE_METRICS
     uint64_t ts;
@@ -813,10 +910,18 @@ static int cb_ml_filter(const void *data, size_t bytes,
     (void) config;
 
     ctx = (struct ml_ctx *) filter_context;
+    callback_active = FLB_FALSE;
 
     if (i_ins == ctx->ins_emitter) {
         flb_plg_trace(ctx->ins, "not processing records from the emitter");
         return FLB_FILTER_NOTOUCH;
+    }
+
+    if (ctx->use_buffer == FLB_TRUE) {
+        callback_active = active_callback_enter(ctx);
+        if (callback_active == FLB_FALSE) {
+            return FLB_FILTER_NOTOUCH;
+        }
     }
 
     if (ctx->i_ins == NULL){
@@ -830,10 +935,14 @@ static int cb_ml_filter(const void *data, size_t bytes,
 
     /* 'partial_message' mode */
     if (ctx->partial_mode == FLB_TRUE) {
-        return ml_filter_partial(data, bytes, tag, tag_len,
-                                 out_buf, out_bytes,
-                                 f_ins, i_ins,
-                                 filter_context, config);
+        ret = ml_filter_partial(data, bytes, tag, tag_len,
+                                out_buf, out_bytes,
+                                f_ins, i_ins,
+                                filter_context, config);
+        if (callback_active == FLB_TRUE) {
+            active_callback_leave(ctx);
+        }
+        return ret;
     }
 
     /* 'parser' mode */
@@ -913,6 +1022,7 @@ static int cb_ml_filter(const void *data, size_t bytes,
 
         if (!stream) {
             flb_plg_error(ctx->ins, "Could not find or create ML stream for %s", tag);
+            active_callback_leave(ctx);
             return FLB_FILTER_NOTOUCH;
         }
 
@@ -953,6 +1063,8 @@ static int cb_ml_filter(const void *data, size_t bytes,
 
         flb_log_event_decoder_destroy(&decoder);
 
+        active_callback_leave(ctx);
+
         /*
          * always returned modified, which will be 0 records, since the emitter takes
          * all records.
@@ -974,6 +1086,10 @@ static int cb_ml_exit(void *data, struct flb_config *config)
 
     if (ctx->m) {
         flb_ml_destroy(ctx->m);
+    }
+
+    if (ctx->partial_mode == FLB_TRUE) {
+        flush_pending_partial_messages(ctx);
     }
 
     mk_list_foreach_safe(head, tmp, &ctx->ml_streams) {

--- a/plugins/filter_multiline/ml.h
+++ b/plugins/filter_multiline/ml.h
@@ -21,6 +21,7 @@
 #define FLB_FILTER_MULTILINE_H
 
 #include <fluent-bit/flb_filter_plugin.h>
+#include <fluent-bit/flb_emitter.h>
 #include "ml_concat.h"
 
 #define FLB_MULTILINE_MEM_BUF_LIMIT_DEFAULT  "10M"
@@ -67,6 +68,12 @@ struct ml_ctx {
     struct mk_list split_message_packers;
 
     struct flb_filter_instance *ins;
+
+    struct flb_emitter_callbacks emitter_callbacks;
+
+    /* Shutdown-only gate for concurrent buffered parser callbacks. */
+    uint64_t active_callbacks;
+    uint64_t shutdown_flush_requested;
 
     /* emitter */
     flb_sds_t emitter_name;                 /* emitter input plugin name */

--- a/plugins/in_emitter/emitter.c
+++ b/plugins/in_emitter/emitter.c
@@ -18,8 +18,10 @@
  */
 
 #include <fluent-bit/flb_compat.h>
+#include <fluent-bit/flb_emitter.h>
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_input_chunk.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_sds.h>
@@ -57,7 +59,20 @@ struct flb_emitter {
     struct mk_list i_ins_list;          /* instance list of linked/sending inputs */
     int cycle_reported;                 /* self-emission cycle already logged ? */
     int propagating;                    /* pause/resume propagation in progress */
+    int owner_flush_enabled;             /* owner supports lossless shutdown flush */
+    int shutdown_flush_done;            /* owner shutdown hook already invoked */
+    int shutdown_flush_active;          /* owner shutdown hook is emitting */
 };
+
+static inline int shutdown_flush_enabled(struct flb_emitter *ctx)
+{
+    if (ctx->ins->config->is_shutting_down == FLB_TRUE &&
+        ctx->owner_flush_enabled == FLB_TRUE) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
 
 struct em_chunk *em_chunk_create(const char *tag, int tag_len,
                                  struct flb_emitter *ctx)
@@ -114,13 +129,34 @@ static int is_queue_overlimit(struct flb_emitter *ctx, size_t append_size)
     return FLB_FALSE;
 }
 
+static int is_owner_queue_overlimit(struct flb_emitter *ctx, size_t append_size)
+{
+    size_t limit;
+
+    if (ctx->ins->mem_buf_limit == 0) {
+        return FLB_FALSE;
+    }
+
+    limit = ctx->ins->mem_buf_limit;
+    if (limit < FLB_INPUT_CHUNK_SIZE) {
+        limit = FLB_INPUT_CHUNK_SIZE;
+    }
+
+    if (ctx->pending_bytes + append_size > limit) {
+        return FLB_TRUE;
+    }
+
+    return FLB_FALSE;
+}
+
 int static do_in_emitter_add_record(struct em_chunk *ec,
                                     struct flb_input_instance *in)
 {
     struct flb_emitter *ctx = (struct flb_emitter *) in->context;
     int ret;
 
-    if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
+    if (flb_input_buf_paused(ctx->ins) == FLB_TRUE &&
+        shutdown_flush_enabled(ctx) == FLB_FALSE) {
         flb_plg_debug(ctx->ins, "_emitter %s paused. Not processing records.",
                          ctx->ins->name);
         return FLB_EMITTER_BUSY;
@@ -210,9 +246,10 @@ int in_emitter_add_record(const char *tag, int tag_len,
 
 
     /* Use the ring buffer first if it exists */
-    if (ctx->msgs) {
+    if (ctx->msgs && ctx->shutdown_flush_active == FLB_FALSE) {
         /* Restricted by mem_buf_limit */
-        if (flb_input_buf_paused(ctx->ins) == FLB_TRUE) {
+        if (flb_input_buf_paused(ctx->ins) == FLB_TRUE &&
+            shutdown_flush_enabled(ctx) == FLB_FALSE) {
             flb_plg_debug(ctx->ins,
                           "emitter memory buffer limit reached. Not accepting record.");
             return FLB_EMITTER_BUSY;
@@ -237,7 +274,15 @@ int in_emitter_add_record(const char *tag, int tag_len,
                                      sizeof(struct em_chunk));
     }
 
-    if (is_queue_overlimit(ctx, buf_size) == FLB_TRUE) {
+    /*
+     * A callback-owning filter cannot retry its in-flight batch. Allow one
+     * input-chunk-sized pending batch while normal chunk accounting pauses
+     * the emitter, but retain a hard bound under sustained backpressure.
+     */
+    if (shutdown_flush_enabled(ctx) == FLB_FALSE &&
+        is_queue_overlimit(ctx, buf_size) == FLB_TRUE &&
+        (ctx->owner_flush_enabled == FLB_FALSE ||
+         is_owner_queue_overlimit(ctx, buf_size) == FLB_TRUE)) {
         flb_plg_debug(ctx->ins,
                       "emitter memory buffer limit reached. Not accepting record.");
         return FLB_EMITTER_BUSY;
@@ -366,6 +411,7 @@ static int cb_emitter_init(struct flb_input_instance *in,
 {
     struct flb_sched *scheduler;
     struct flb_emitter *ctx;
+    struct flb_emitter_callbacks *callbacks;
     char *pause_prop = NULL;
     int ret;
 
@@ -380,6 +426,12 @@ static int cb_emitter_init(struct flb_input_instance *in,
     mk_list_init(&ctx->chunks);
 
     mk_list_init(&ctx->i_ins_list);
+
+    callbacks = (struct flb_emitter_callbacks *) in->data;
+    if (callbacks != NULL && callbacks->pause != NULL) {
+        ctx->owner_flush_enabled = FLB_TRUE;
+        in->flags |= FLB_INPUT_SHUTDOWN_FLUSH;
+    }
 
 
     ret = flb_input_config_map_set(in, (void *) ctx);
@@ -439,6 +491,7 @@ static int cb_emitter_init(struct flb_input_instance *in,
 
 static void cb_emitter_pause(void *data, struct flb_config *config)
 {
+    struct flb_emitter_callbacks *callbacks;
     struct flb_emitter *ctx = data;
     struct mk_list *tmp;
     struct mk_list *head;
@@ -452,6 +505,27 @@ static void cb_emitter_pause(void *data, struct flb_config *config)
         return;
     }
     ctx->propagating = FLB_TRUE;
+
+    if (shutdown_flush_enabled(ctx) == FLB_TRUE &&
+        ctx->shutdown_flush_done == FLB_FALSE &&
+        ctx->ins->data != NULL) {
+        callbacks = (struct flb_emitter_callbacks *) ctx->ins->data;
+        ctx->shutdown_flush_done = FLB_TRUE;
+
+        if (callbacks->pause != NULL) {
+            /* Publish any records already waiting in a threaded emitter. */
+            if (ctx->msgs != NULL) {
+                in_emitter_ingest_ring_buffer(ctx->ins, config, ctx);
+            }
+
+            ctx->shutdown_flush_active = FLB_TRUE;
+            callbacks->pause(callbacks->data, config);
+            ctx->shutdown_flush_active = FLB_FALSE;
+
+            /* Convert owner-emitted records into input chunks before pausing. */
+            cb_queue_chunks(ctx->ins, config, ctx);
+        }
+    }
 
     /* Pause all known senders */
     flb_input_collector_pause(ctx->coll_fd, ctx->ins);

--- a/src/flb_input.c
+++ b/src/flb_input.c
@@ -3056,7 +3056,9 @@ int flb_input_plugin_resume(struct flb_input_instance *ins)
 int flb_input_pause(struct flb_input_instance *ins)
 {
     /* if the instance is already paused, just return */
-    if (flb_input_buf_paused(ins)) {
+    if (flb_input_buf_paused(ins) &&
+        (ins->config == NULL || ins->config->is_shutting_down == FLB_FALSE ||
+         (ins->flags & FLB_INPUT_SHUTDOWN_FLUSH) == 0)) {
         return -1;
     }
 

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -3215,7 +3215,9 @@ static int input_chunk_append_raw(struct flb_input_instance *in,
     }
 
     /* Check if the input plugin has been paused */
-    if (flb_input_paused(in) == FLB_TRUE) {
+    if (flb_input_paused(in) == FLB_TRUE &&
+        (in->config->is_shutting_down == FLB_FALSE ||
+         (in->flags & FLB_INPUT_SHUTDOWN_FLUSH) == 0)) {
         flb_debug("[input chunk] %s is paused, cannot append records",
                   flb_input_name(in));
         return -1;

--- a/tests/integration/scenarios/filter_multiline/README.md
+++ b/tests/integration/scenarios/filter_multiline/README.md
@@ -1,0 +1,7 @@
+# `filter_multiline` Integration Scenario
+
+This scenario exercises buffered multiline processing through a real Fluent Bit
+process. It verifies that a pending multiline group is emitted during graceful
+shutdown, including when the multiline emitter was already paused by its memory
+buffer limit. Both operation patterns must preserve the completed group and the
+pending group exactly once.

--- a/tests/integration/scenarios/filter_multiline/config/filter_multiline_partial_shutdown.yaml
+++ b/tests/integration/scenarios/filter_multiline/config/filter_multiline_partial_shutdown.yaml
@@ -1,0 +1,31 @@
+service:
+  flush: 0.2
+  grace: 10
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: http
+      tag: multiline.integration
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  filters:
+    - name: multiline
+      match: multiline.integration
+      multiline.key_content: log
+      mode: partial_message
+      buffer: on
+      flush_ms: 60000
+      emitter_mem_buf_limit: 10M
+
+  outputs:
+    - name: http
+      match: multiline.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/filter_multiline/config/filter_multiline_shutdown.yaml
+++ b/tests/integration/scenarios/filter_multiline/config/filter_multiline_shutdown.yaml
@@ -1,0 +1,31 @@
+service:
+  flush: ${MULTILINE_SERVICE_FLUSH}
+  grace: 10
+  log_level: debug
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: http
+      tag: multiline.integration
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  filters:
+    - name: multiline
+      match: multiline.integration
+      multiline.key_content: log
+      multiline.parser: java
+      buffer: on
+      flush_ms: 60000
+      emitter_mem_buf_limit: ${MULTILINE_EMITTER_MEM_BUF_LIMIT}
+
+  outputs:
+    - name: http
+      match: multiline.integration
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json
+      json_date_key: false

--- a/tests/integration/scenarios/filter_multiline/tests/test_filter_multiline_001.py
+++ b/tests/integration/scenarios/filter_multiline/tests/test_filter_multiline_001.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+
+import pytest
+import requests
+
+from server.http_server import data_storage, http_server_run
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, *, config_name="filter_multiline_shutdown.yaml",
+                 service_flush="0.2", emitter_mem_buf_limit="10M"):
+        config_file = (
+            Path(__file__).resolve().parents[1]
+            / "config"
+            / config_name
+        )
+        self.service = FluentBitTestService(
+            str(config_file),
+            data_storage=data_storage,
+            data_keys=["payloads", "requests"],
+            extra_env={
+                "MULTILINE_SERVICE_FLUSH": service_flush,
+                "MULTILINE_EMITTER_MEM_BUF_LIMIT": emitter_mem_buf_limit,
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+        self.flb = None
+        self.listener_port = None
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(
+                f"http://127.0.0.1:{service.test_suite_http_port}/shutdown",
+                timeout=2,
+            )
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+        self.listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def send(self, log, **fields):
+        payload = {"log": log}
+        payload.update(fields)
+        response = requests.post(
+            f"http://127.0.0.1:{self.listener_port}/",
+            json=payload,
+            timeout=10,
+        )
+        assert response.status_code == 201
+
+    def wait_for_records(self, minimum_count, timeout=20):
+        return self.service.wait_for_condition(
+            lambda: flattened_records()
+            if len(flattened_records()) >= minimum_count
+            else None,
+            timeout=timeout,
+            interval=0.2,
+            description=f"{minimum_count} multiline records",
+        )
+
+    def wait_for_log(self, text, timeout=20):
+        def log_contains_text():
+            if not self.flb or not self.flb.log_file:
+                return None
+
+            try:
+                log_text = Path(self.flb.log_file).read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            except OSError:
+                return None
+
+            return log_text if text in log_text else None
+
+        return self.service.wait_for_condition(
+            log_contains_text,
+            timeout=timeout,
+            interval=0.2,
+            description=f"log text {text!r}",
+        )
+
+
+def flattened_records():
+    records = []
+
+    for payload in data_storage["payloads"]:
+        if isinstance(payload, list):
+            records.extend(payload)
+        elif payload is not None:
+            records.append(payload)
+
+    return records
+
+
+@pytest.mark.parametrize(
+    "pause_before_shutdown",
+    [False, True],
+    ids=["pending", "emitter-prepaused"],
+)
+def test_filter_multiline_flushes_pending_group_on_shutdown(pause_before_shutdown):
+    padding = "x" * 2048 if pause_before_shutdown else ""
+    service = Service(
+        service_flush="60" if pause_before_shutdown else "0.2",
+        emitter_mem_buf_limit="1K" if pause_before_shutdown else "10M",
+    )
+
+    try:
+        service.start()
+        service.send(
+            "Exception in thread main java.lang.IllegalStateException: "
+            f"first-complete-marker{padding}"
+        )
+        service.send("    at com.example.first-stack-frame(First.java:1)")
+        service.send(
+            "Exception in thread main java.lang.RuntimeException: "
+            "dangling-shutdown-marker"
+        )
+
+        if pause_before_shutdown:
+            service.wait_for_log("emitter_for_multiline.0 paused (mem buf overlimit")
+        else:
+            service.wait_for_records(1)
+    finally:
+        service.stop()
+
+    records = flattened_records()
+    matching_logs = [
+        record["log"]
+        for record in records
+        if "first-complete-marker" in record.get("log", "")
+        or "dangling-shutdown-marker" in record.get("log", "")
+    ]
+
+    assert len(matching_logs) == 2
+
+    complete = next(log for log in matching_logs if "first-complete-marker" in log)
+    dangling = next(log for log in matching_logs if "dangling-shutdown-marker" in log)
+
+    assert "first-stack-frame" in complete
+    assert "dangling-shutdown-marker" not in complete
+    assert "first-complete-marker" not in dangling
+    assert "first-stack-frame" not in dangling
+
+
+def test_filter_multiline_flushes_pending_partial_message_on_shutdown():
+    service = Service(config_name="filter_multiline_partial_shutdown.yaml")
+
+    try:
+        service.start()
+        service.send(
+            "partial-shutdown-one..",
+            partial_message="true",
+            partial_id="shutdown",
+            partial_ordinal="1",
+            partial_last="false",
+        )
+        service.send(
+            "two",
+            partial_message="true",
+            partial_id="shutdown",
+            partial_ordinal="2",
+            partial_last="false",
+        )
+        service.send("partial-shutdown-barrier")
+
+        records = service.wait_for_records(1)
+        assert len(records) == 1
+        assert records[0]["log"] == "partial-shutdown-barrier"
+    finally:
+        service.stop()
+
+    records = flattened_records()
+    matching_logs = [
+        record["log"]
+        for record in records
+        if record.get("log", "").startswith("partial-shutdown-")
+    ]
+
+    assert sorted(matching_logs) == [
+        "partial-shutdown-barrier",
+        "partial-shutdown-one..two",
+    ]

--- a/tests/internal/input_pause.c
+++ b/tests/internal/input_pause.c
@@ -185,10 +185,43 @@ static void test_threaded_dispatch_failure_preserves_state()
     input_pause_test_metrics_destroy(&instance);
 }
 
+static void test_shutdown_pause_notification_is_opt_in()
+{
+    int ret;
+    struct flb_config config;
+    struct flb_input_plugin plugin;
+    struct flb_input_instance instance;
+    struct input_pause_test_context context;
+
+    memset(&config, 0, sizeof(config));
+    memset(&plugin, 0, sizeof(plugin));
+    memset(&instance, 0, sizeof(instance));
+    memset(&context, 0, sizeof(context));
+
+    config.is_shutting_down = FLB_TRUE;
+    plugin.cb_pause_checked = checked_pause;
+    instance.p = &plugin;
+    instance.context = &context;
+    instance.config = &config;
+    instance.mem_buf_status = FLB_INPUT_PAUSED;
+    context.result = 0;
+
+    ret = flb_input_pause(&instance);
+    TEST_CHECK(ret == -1);
+    TEST_CHECK(context.pause_calls == 0);
+
+    instance.flags = FLB_INPUT_SHUTDOWN_FLUSH;
+    ret = flb_input_pause(&instance);
+    TEST_CHECK(ret == 0);
+    TEST_CHECK(context.pause_calls == 1);
+}
+
 TEST_LIST = {
     { "checked_pause_resume_result_and_metric",
       test_checked_pause_resume_result_and_metric },
     { "threaded_dispatch_failure_preserves_state",
       test_threaded_dispatch_failure_preserves_state },
+    { "shutdown_pause_notification_is_opt_in",
+      test_shutdown_pause_notification_is_opt_in },
     { 0 }
 };

--- a/tests/internal/multiline.c
+++ b/tests/internal/multiline.c
@@ -785,6 +785,10 @@ static void test_parser_java()
         msgpack_sbuffer_destroy(&mp_sbuf);
     }
 
+    flb_ml_flush_pending_now(ml);
+    flb_ml_flush_pending_now(ml);
+    TEST_CHECK(res.current_record == 2);
+
     if (ml) {
         flb_ml_destroy(ml);
     }

--- a/tests/runtime/filter_multiline.c
+++ b/tests/runtime/filter_multiline.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_engine.h>
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_time.h>
 #include "flb_tests_runtime.h"
@@ -17,6 +18,30 @@ struct filter_test_result {
     int expected_records;       /* expected number of outputted records */
     int actual_records;         /* actual number of outputted records */
 };
+
+struct shutdown_flush_result {
+    int records;
+    int complete_records;
+    int dangling_records;
+    int invalid_records;
+};
+
+struct backpressure_result {
+    int initial_records;
+    int resumed_records;
+    int premature_records;
+    int invalid_records;
+};
+
+struct partial_shutdown_result {
+    int records;
+    int pending_records;
+    int barrier_records;
+    int invalid_records;
+};
+
+pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+int num_output = 0;
 
 /* Callback to check expected results */
 static int cb_check_result(void *record, size_t size, void *data)
@@ -49,9 +74,115 @@ static int cb_check_result(void *record, size_t size, void *data)
     return 0;
 }
 
+static int cb_check_shutdown_flush(void *record, size_t size, void *data)
+{
+    char *result;
+    int has_complete;
+    int has_dangling;
+    int has_stack_frame;
+    struct shutdown_flush_result *expected;
 
-pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
-int num_output = 0;
+    result = record;
+    expected = data;
+    has_complete = strstr(result, "first-complete-marker") != NULL;
+    has_dangling = strstr(result, "dangling-shutdown-marker") != NULL;
+    has_stack_frame = strstr(result, "first-stack-frame") != NULL;
+
+    pthread_mutex_lock(&result_mutex);
+    expected->records++;
+    if (has_complete && has_stack_frame && !has_dangling) {
+        expected->complete_records++;
+    }
+    else if (has_dangling && !has_complete && !has_stack_frame) {
+        expected->dangling_records++;
+    }
+    else {
+        expected->invalid_records++;
+    }
+    num_output++;
+    pthread_mutex_unlock(&result_mutex);
+
+    flb_free(record);
+    return 0;
+}
+
+static int cb_check_backpressure(void *record, size_t size, void *data)
+{
+    char *result;
+    int has_initial;
+    int has_pending;
+    int has_continuation;
+    struct backpressure_result *expected;
+
+    result = record;
+    expected = data;
+    has_initial = strstr(result, "backpressure-initial-marker") != NULL;
+    has_pending = strstr(result, "backpressure-pending-marker") != NULL;
+    has_continuation = strstr(result, "backpressure-resume-frame") != NULL;
+
+    pthread_mutex_lock(&result_mutex);
+    if (has_initial && !has_pending) {
+        expected->initial_records++;
+    }
+    else if (has_pending && has_continuation && !has_initial) {
+        expected->resumed_records++;
+    }
+    else if (has_pending) {
+        expected->premature_records++;
+    }
+    else {
+        expected->invalid_records++;
+    }
+    num_output++;
+    pthread_mutex_unlock(&result_mutex);
+
+    flb_free(record);
+    return 0;
+}
+
+static int cb_check_partial_shutdown(void *record, size_t size, void *data)
+{
+    char *result;
+    int has_pending;
+    int has_barrier;
+    struct partial_shutdown_result *expected;
+
+    result = record;
+    expected = data;
+    has_pending = strstr(result, "partial-shutdown-one..two") != NULL;
+    has_barrier = strstr(result, "partial-shutdown-barrier") != NULL;
+
+    pthread_mutex_lock(&result_mutex);
+    expected->records++;
+    if (has_pending && !has_barrier) {
+        expected->pending_records++;
+    }
+    else if (has_barrier && !has_pending) {
+        expected->barrier_records++;
+    }
+    else {
+        expected->invalid_records++;
+    }
+    num_output++;
+    pthread_mutex_unlock(&result_mutex);
+
+    flb_free(record);
+    return 0;
+}
+
+static struct backpressure_result get_backpressure_result(
+    struct backpressure_result *expected)
+{
+    struct backpressure_result result;
+
+    pthread_mutex_lock(&result_mutex);
+    result = *expected;
+    pthread_mutex_unlock(&result_mutex);
+
+    return result;
+}
+
+
 static int get_output_num()
 {
     int ret;
@@ -145,6 +276,35 @@ void wait_with_timeout(uint32_t timeout_ms, int *output_num, int expected)
         if (elapsed_time_flb > timeout_ms) {
             flb_warn("[timeout] elapsed_time: %ld", elapsed_time_flb);
             // Reached timeout.
+            break;
+        }
+    }
+}
+
+static void wait_with_timeout_at_least(uint32_t timeout_ms, int *output_num,
+                                       int expected)
+{
+    struct flb_time start_time;
+    struct flb_time end_time;
+    struct flb_time diff_time;
+    uint64_t elapsed_time_flb = 0;
+
+    flb_time_get(&start_time);
+
+    while (true) {
+        *output_num = get_output_num();
+
+        if (*output_num >= expected) {
+            break;
+        }
+
+        flb_time_msleep(100);
+        flb_time_get(&end_time);
+        flb_time_diff(&end_time, &start_time, &diff_time);
+        elapsed_time_flb = flb_time_to_nanosec(&diff_time) / 1000000;
+
+        if (elapsed_time_flb > timeout_ms) {
+            flb_warn("[timeout] elapsed_time: %ld", elapsed_time_flb);
             break;
         }
     }
@@ -342,6 +502,121 @@ static void flb_test_multiline_buffered_one_output_record()
     filter_test_destroy(ctx);
 }
 
+static void run_multiline_flush_pending_on_shutdown(int emitter_prepaused)
+{
+    int len;
+    int ret;
+    int bytes;
+    int num;
+    char *record;
+    struct mk_list *head;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct flb_input_instance *emitter;
+    struct flb_input_instance *instance;
+    struct shutdown_flush_result expected = {0};
+
+    clear_output_num();
+
+    cb_data.cb = cb_check_shutdown_flush;
+    cb_data.data = &expected;
+
+    ctx = filter_test_create(&cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_service_set(ctx->flb,
+                          "Flush", "0.100000000",
+                          "Grace", "2",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "java",
+                         "buffer", "on",
+                         "flush_ms", "60000",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    record = "[0, {\"log\":\"Exception in thread main "
+             "java.lang.IllegalStateException: first-complete-marker\"}]";
+    len = strlen(record);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, record, len);
+    TEST_CHECK(bytes == len);
+
+    record = "[1, {\"log\":\"     at com.example.first-stack-frame\"}]";
+    len = strlen(record);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, record, len);
+    TEST_CHECK(bytes == len);
+
+    record = "[2, {\"log\":\"Exception in thread main "
+             "java.lang.RuntimeException: dangling-shutdown-marker\"}]";
+    len = strlen(record);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, record, len);
+    TEST_CHECK(bytes == len);
+
+    /* The second start line proves that all three source records were processed. */
+    wait_with_timeout(5000, &num, 1);
+    TEST_CHECK(num == 1);
+
+    if (emitter_prepaused == FLB_TRUE) {
+        emitter = NULL;
+        mk_list_foreach(head, &ctx->flb->config->inputs) {
+            instance = mk_list_entry(head, struct flb_input_instance, _head);
+            if (strcmp(instance->p->name, "emitter") == 0) {
+                emitter = instance;
+                break;
+            }
+        }
+
+        TEST_CHECK(emitter != NULL);
+        if (emitter != NULL) {
+            /* Simulate an emitter already paused by flb_input_chunk_protect(). */
+            emitter->mem_buf_status = FLB_INPUT_PAUSED;
+        }
+    }
+
+    /*
+     * Send the shutdown notification separately so the test can observe the
+     * shutdown flush before flb_stop() performs platform-specific cleanup.
+     * On macOS flb_stop() cancels the engine worker immediately after sending
+     * this notification, which can preempt the shutdown pause callback.
+     */
+    ret = flb_engine_exit(ctx->flb->config);
+    TEST_CHECK(ret >= 0);
+
+    wait_with_timeout(5000, &num, 2);
+    TEST_CHECK(num == 2);
+
+    ret = flb_stop(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* The pending group is emitted once by the shutdown pause hook. */
+    TEST_CHECK(get_output_num() == 2);
+    TEST_CHECK(expected.records == 2);
+    TEST_CHECK(expected.complete_records == 1);
+    TEST_CHECK(expected.dangling_records == 1);
+    TEST_CHECK(expected.invalid_records == 0);
+
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
+}
+
+static void flb_test_multiline_flush_pending_on_shutdown()
+{
+    run_multiline_flush_pending_on_shutdown(FLB_FALSE);
+}
+
+static void flb_test_multiline_flush_pending_on_shutdown_when_prepaused()
+{
+    run_multiline_flush_pending_on_shutdown(FLB_TRUE);
+}
+
 static void flb_test_multiline_unbuffered()
 {
     int len;
@@ -465,6 +740,80 @@ static void flb_test_multiline_partial_message_concat()
     sleep(2);
     TEST_CHECK(expected.actual_records == expected.expected_records);
     filter_test_destroy(ctx);
+}
+
+static void flb_test_multiline_partial_message_flush_pending_on_shutdown()
+{
+    int len;
+    int ret;
+    int bytes;
+    int num;
+    char *p;
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct partial_shutdown_result expected = {0};
+
+    clear_output_num();
+    cb_data.cb = cb_check_partial_shutdown;
+    cb_data.data = &expected;
+
+    ctx = filter_test_create(&cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "mode", "partial_message",
+                         "buffer", "on",
+                         "flush_ms", "60000",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    p = "[0, {\"log\":\"partial-shutdown-one..\", "
+        "\"partial_message\":\"true\", \"partial_id\":\"shutdown\", "
+        "\"partial_ordinal\":\"1\", \"partial_last\":\"false\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    p = "[0, {\"log\":\"two\", \"partial_message\":\"true\", "
+        "\"partial_id\":\"shutdown\", \"partial_ordinal\":\"2\", "
+        "\"partial_last\":\"false\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    /* This output proves the preceding partial fragments were processed. */
+    p = "[0, {\"log\":\"partial-shutdown-barrier\"}]";
+    len = strlen(p);
+    bytes = flb_lib_push(ctx->flb, ctx->i_ffd, p, len);
+    TEST_CHECK(bytes == len);
+
+    wait_with_timeout(5000, &num, 1);
+    TEST_CHECK(num == 1);
+    TEST_CHECK(expected.barrier_records == 1);
+    TEST_CHECK(expected.pending_records == 0);
+
+    ret = flb_engine_exit(ctx->flb->config);
+    TEST_CHECK(ret >= 0);
+
+    wait_with_timeout(5000, &num, 2);
+    TEST_CHECK(num == 2);
+
+    ret = flb_stop(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    TEST_CHECK(expected.records == 2);
+    TEST_CHECK(expected.pending_records == 1);
+    TEST_CHECK(expected.barrier_records == 1);
+    TEST_CHECK(expected.invalid_records == 0);
+
+    flb_destroy(ctx->flb);
+    flb_free(ctx);
 }
 
 static void flb_test_multiline_partial_message_concat_two_ids()
@@ -710,6 +1059,135 @@ static void flb_test_ml_buffered_16_streams()
     filter_test_destroy(ctx);
 }
 
+/*
+ * Exercise a regular emitter memory-limit pause. The second Java exception
+ * remains pending while the emitter drains the first one. It must not be
+ * flushed by the shutdown-only pause hook, and it must concatenate normally
+ * once the emitter has resumed.
+ */
+static void flb_test_multiline_buffered_backpressure_does_not_flush()
+{
+    struct flb_lib_out_cb cb_data;
+    struct filter_test *ctx;
+    struct backpressure_result expected = {0};
+    struct backpressure_result result;
+    int i_ffds[16] = {0};
+    int ffd_num = sizeof(i_ffds) / sizeof(int);
+    int bytes;
+    int i;
+    int len;
+    int num;
+    int ret;
+    char padding[257];
+    char record[1024];
+    char tag[32];
+
+    clear_output_num();
+    cb_data.cb = cb_check_backpressure;
+    cb_data.data = &expected;
+
+    ctx = filter_test_create(&cb_data);
+    if (!ctx) {
+        exit(EXIT_FAILURE);
+    }
+
+    ret = flb_service_set(ctx->flb,
+                          "Flush", "0.100000000",
+                          "Grace", "2",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    i_ffds[0] = ctx->i_ffd;
+    for (i = 1; i < ffd_num; i++) {
+        i_ffds[i] = flb_input(ctx->flb, (char *) "lib", NULL);
+        TEST_CHECK(i_ffds[i] >= 0);
+        snprintf(tag, sizeof(tag), "testbackpressure%d", i);
+        flb_input_set(ctx->flb, i_ffds[i], "tag", tag, NULL);
+    }
+
+    ret = flb_filter_set(ctx->flb, ctx->f_ffd,
+                         "multiline.key_content", "log",
+                         "multiline.parser", "java",
+                         "buffer", "on",
+                         "flush_ms", "60000",
+                         "emitter_mem_buf_limit", "1k",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    memset(padding, 'x', sizeof(padding) - 1);
+    padding[sizeof(padding) - 1] = '\0';
+
+    for (i = 0; i < ffd_num; i++) {
+        snprintf(record, sizeof(record),
+                 "[%d, {\"log\":\"Exception in thread main "
+                 "java.lang.IllegalStateException: "
+                 "backpressure-initial-marker-%d-%s\"}]",
+                 i, i, padding);
+        len = strlen(record);
+        bytes = flb_lib_push(ctx->flb, i_ffds[i], record, len);
+        TEST_CHECK(bytes == len);
+
+        snprintf(record, sizeof(record),
+                 "[%d, {\"log\":\"     at "
+                 "com.example.initial.Frame%d\"}]",
+                 i, i);
+        len = strlen(record);
+        bytes = flb_lib_push(ctx->flb, i_ffds[i], record, len);
+        TEST_CHECK(bytes == len);
+
+        snprintf(record, sizeof(record),
+                 "[%d, {\"log\":\"Exception in thread main "
+                 "java.lang.RuntimeException: backpressure-pending-marker-%d\"}]",
+                 i, i);
+        len = strlen(record);
+        bytes = flb_lib_push(ctx->flb, i_ffds[i], record, len);
+        TEST_CHECK(bytes == len);
+    }
+
+    /* The 16 emitted first groups exceed the 1 KiB emitter limit and pause it. */
+    wait_with_timeout_at_least(10000, &num, ffd_num);
+    TEST_CHECK(num >= ffd_num);
+
+    /* Allow the successful output flush to resume the emitter and its senders. */
+    flb_time_msleep(500);
+    result = get_backpressure_result(&expected);
+    TEST_CHECK(result.initial_records == ffd_num);
+    TEST_CHECK(result.premature_records == 0);
+    TEST_CHECK(result.invalid_records == 0);
+
+    for (i = 0; i < ffd_num; i++) {
+        snprintf(record, sizeof(record),
+                 "[%d, {\"log\":\"     at "
+                 "com.example.backpressure-resume-frame%d\"}]",
+                 i, i);
+        len = strlen(record);
+        bytes = flb_lib_push(ctx->flb, i_ffds[i], record, len);
+        TEST_CHECK(bytes == len);
+
+        snprintf(record, sizeof(record),
+                 "[%d, {\"log\":\"Exception in thread main "
+                 "java.lang.RuntimeException: backpressure-next-marker-%d\"}]",
+                 i, i);
+        len = strlen(record);
+        bytes = flb_lib_push(ctx->flb, i_ffds[i], record, len);
+        TEST_CHECK(bytes == len);
+    }
+
+    wait_with_timeout_at_least(10000, &num, ffd_num * 2);
+    TEST_CHECK(num >= ffd_num * 2);
+
+    result = get_backpressure_result(&expected);
+    TEST_CHECK(result.initial_records == ffd_num);
+    TEST_CHECK(result.resumed_records == ffd_num);
+    TEST_CHECK(result.premature_records == 0);
+    TEST_CHECK(result.invalid_records == 0);
+
+    filter_test_destroy(ctx);
+}
+
 /* This test will test the pausing of in_emitter */
 static void flb_test_ml_buffered_16_streams_pausing()
 {
@@ -813,11 +1291,18 @@ TEST_LIST = {
 
     {"multiline_buffered_one_record"                      , flb_test_multiline_buffered_one_output_record },
     {"multiline_buffered_two_record"                      , flb_test_multiline_buffered_two_output_record },
+    {"multiline_flush_pending_on_shutdown"                , flb_test_multiline_flush_pending_on_shutdown },
+    {"multiline_flush_pending_on_shutdown_when_prepaused",
+     flb_test_multiline_flush_pending_on_shutdown_when_prepaused},
     {"flb_test_multiline_unbuffered"                      , flb_test_multiline_unbuffered },
 
     {"flb_test_multiline_partial_message_concat"          , flb_test_multiline_partial_message_concat },
+    {"multiline_partial_message_flush_pending_on_shutdown",
+     flb_test_multiline_partial_message_flush_pending_on_shutdown},
     {"flb_test_multiline_partial_message_concat_two_ids"  , flb_test_multiline_partial_message_concat_two_ids },
 
+    {"multiline_buffered_backpressure_does_not_flush",
+     flb_test_multiline_buffered_backpressure_does_not_flush},
     {"ml_buffered_16_streams_pausing" , flb_test_ml_buffered_16_streams_pausing },
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

The branch prevents buffered multiline records from being lost during graceful shutdown, including when the emitter is already paused by backpressure.

Implementation:

- Adds an opt-in emitter-owner pause callback interface.
- Uses a shutdown-only atomic gate in `filter_multiline` to block new callbacks, wait for active concatenations, and flush pending groups exactly once.
- Drains threaded emitter records and queues shutdown-flushed records before pausing collectors.
- Allows opted-in, already-paused emitters to receive the shutdown notification and append final records.
- Keeps ordinary backpressure behavior separate and bounded to Fluent Bit’s 256 KiB chunk hint.

Coverage includes:

- Normal and pre-paused shutdown flushing.
- Exact-once preservation of complete and dangling multiline groups.
- Ordinary pause/resume without premature multiline flushing.
- Shutdown opt-in behavior and repeated flush idempotency.
- A real HTTP → multiline filter → HTTP integration scenario for both shutdown patterns.

Verification:

- Focused CTest: 4/4 passed.
- Shutdown soak: 50/50 passed.
- Python integration scenario: 2/2 passed.
- Strict Valgrind integration run: 2/2 passed with no memory errors.
- Additional focused Valgrind runs: zero errors and no definite, indirect, or possible leaks.
- ThreadSanitizer product paths passed; reported races were limited to existing test-harness state.
- Commit-prefix lint and full `master` range passed.
- Strict Sol audit found no P0/P1 issues.
- Worktree is clean.

Known limitation: normal backpressure still cannot guarantee lossless handling for a single batch larger than the 256 KiB allowance without a separate retry or reservation design. Shutdown flushing bypasses that limit.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending multiline log groups and partial messages are now flushed during graceful shutdown.
  * Improved reliability when the emitter is paused or under memory pressure.
  * Prevented incomplete or duplicated multiline records during shutdown.

* **Tests**
  * Added coverage for shutdown flushing, paused emitters, backpressure, and pending Java stack traces.
  * Added documentation for multiline shutdown scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->