### PR TITLE
bulk_search: es: opensearch: Acknowledge reasons of bulk failures

### DIFF
--- a/include/fluent-bit/flb_output.h
+++ b/include/fluent-bit/flb_output.h
@@ -597,8 +597,29 @@ struct flb_output_flush {
      */
     struct flb_event_chunk *processed_event_chunk;
 
+    /* Route-effective totals reported by an output on successful completion. */
+    int successful_route_data_set;
+    int successful_records;
+    size_t successful_bytes;
+
     struct mk_list _head;              /* Link to flb_task->threads */
 };
+
+static FLB_INLINE int flb_output_set_successful_route_data(
+                        struct flb_output_flush *out_flush,
+                        int records,
+                        size_t bytes)
+{
+    if (out_flush == NULL || records < 0) {
+        return -1;
+    }
+
+    out_flush->successful_records = records;
+    out_flush->successful_bytes = bytes;
+    out_flush->successful_route_data_set = FLB_TRUE;
+
+    return 0;
+}
 
 static FLB_INLINE void *flb_output_get_retry_context(
                         struct flb_output_flush *out_flush,
@@ -1313,7 +1334,11 @@ static inline void flb_output_return(int ret, struct flb_coro *co) {
     bytes = counted_event_chunk->size;
 
     flb_task_acquire_lock(task);
-    if (ret != FLB_OK &&
+    if (ret == FLB_OK && out_flush->successful_route_data_set == FLB_TRUE) {
+        records = out_flush->successful_records;
+        bytes = out_flush->successful_bytes;
+    }
+    else if (ret != FLB_OK &&
         flb_task_get_route_retry_context(task, o_ins,
                                          &records, &bytes) == NULL) {
         records = counted_event_chunk->total_events;

--- a/include/fluent-bit/flb_search_bulk.h
+++ b/include/fluent-bit/flb_search_bulk.h
@@ -23,6 +23,21 @@
 #define FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS  0
 #define FLB_SEARCH_BULK_ACK_ALL_CONFLICTS     1
 
+#define FLB_SEARCH_BULK_REASON_SIZE 256
+
+struct flb_search_bulk_stats {
+    size_t total_items;
+    size_t successful_items;
+    size_t successful_bytes;
+    size_t failed_items;
+    size_t retryable_items;
+    size_t unrecoverable_items;
+    size_t unrecoverable_bytes;
+    int first_error_status;
+    char first_error_type[FLB_SEARCH_BULK_REASON_SIZE];
+    char first_error_reason[FLB_SEARCH_BULK_REASON_SIZE];
+};
+
 struct flb_search_bulk_retry {
     char *payload;
     size_t size;
@@ -34,6 +49,8 @@ int flb_search_bulk_process_response(const char *response,
                                      const char *payload,
                                      size_t payload_size,
                                      int acknowledge_all_conflicts,
+                                     int drop_unrecoverable_records,
+                                     struct flb_search_bulk_stats *stats,
                                      struct flb_search_bulk_retry **retry);
 void flb_search_bulk_retry_destroy(void *data);
 

--- a/include/fluent-bit/flb_search_bulk.h
+++ b/include/fluent-bit/flb_search_bulk.h
@@ -44,6 +44,17 @@ struct flb_search_bulk_retry {
     int records;
 };
 
+/*
+ * Process a Search bulk API response and build a payload containing records
+ * that remain eligible for retry.
+ *
+ * drop_unrecoverable_records should default to FLB_FALSE. When FLB_TRUE,
+ * failed items with 4xx statuses other than 408 and 429 are classified as
+ * unrecoverable and omitted from the retry payload. Status 409 continues to
+ * follow acknowledge_all_conflicts, while 408, 429, and 5xx statuses remain
+ * retryable. Enabling this option can discard rejected records and cause data
+ * loss, so callers must expose it as an explicit opt-in behavior.
+ */
 int flb_search_bulk_process_response(const char *response,
                                      size_t response_size,
                                      const char *payload,

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_http_client.h>
@@ -41,11 +42,108 @@
 #include "es_bulk.h"
 #include "murmur3.h"
 
+#define FLB_ES_TRACE_CHUNK_SIZE 3000
+#define FLB_ES_RESPONSE_PREVIEW_SIZE 512
+
 struct flb_output_plugin out_es_plugin;
 
 static int es_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
                                  int replace_dots);
+
+static void log_payload_chunks(struct flb_elasticsearch *ctx,
+                               const char *label,
+                               const char *payload, size_t payload_size)
+{
+    size_t offset;
+    size_t part;
+    size_t part_count;
+    size_t part_size;
+
+    part_count = (payload_size + FLB_ES_TRACE_CHUNK_SIZE - 1) /
+                 FLB_ES_TRACE_CHUNK_SIZE;
+    for (offset = 0, part = 1; offset < payload_size; part++) {
+        part_size = payload_size - offset;
+        if (part_size > FLB_ES_TRACE_CHUNK_SIZE) {
+            part_size = FLB_ES_TRACE_CHUNK_SIZE;
+        }
+
+        flb_plg_error(ctx->ins, "%s part %zu/%zu: %.*s",
+                      label, part, part_count, (int) part_size,
+                      payload + offset);
+        offset += part_size;
+    }
+}
+
+static void log_invalid_bulk_response(struct flb_elasticsearch *ctx,
+                                      const char *payload,
+                                      size_t payload_size)
+{
+    char character;
+    char preview[(FLB_ES_RESPONSE_PREVIEW_SIZE * 2) + 1];
+    size_t input_index;
+    size_t input_size;
+    size_t output_index;
+
+    input_size = payload_size;
+    if (input_size > FLB_ES_RESPONSE_PREVIEW_SIZE) {
+        input_size = FLB_ES_RESPONSE_PREVIEW_SIZE;
+    }
+
+    output_index = 0;
+    for (input_index = 0; input_index < input_size; input_index++) {
+        character = payload[input_index];
+        if (character == '\n' || character == '\r' || character == '\t') {
+            preview[output_index++] = '\\';
+            if (character == '\n') {
+                preview[output_index++] = 'n';
+            }
+            else if (character == '\r') {
+                preview[output_index++] = 'r';
+            }
+            else {
+                preview[output_index++] = 't';
+            }
+        }
+        else if ((unsigned char) character < 0x20 || character == 0x7f) {
+            preview[output_index++] = '.';
+        }
+        else {
+            preview[output_index++] = character;
+        }
+    }
+    preview[output_index] = '\0';
+
+    flb_plg_error(ctx->ins,
+                  "invalid Elasticsearch bulk response (first %zu/%zu bytes): %s",
+                  input_size, payload_size, preview);
+}
+
+static void log_bulk_failure_summary(struct flb_elasticsearch *ctx,
+                                     struct flb_search_bulk_stats *stats,
+                                     size_t retry_records,
+                                     size_t dropped_records)
+{
+    if (dropped_records > 0) {
+        flb_plg_error(ctx->ins,
+                      "bulk response reported errors: %zu/%zu items failed, "
+                      "first error: status=%d type='%s' reason='%s'; "
+                      "retrying %zu record(s), dropped %zu unrecoverable record(s)",
+                      stats->failed_items, stats->total_items,
+                      stats->first_error_status, stats->first_error_type,
+                      stats->first_error_reason, retry_records,
+                      dropped_records);
+    }
+    else {
+        flb_plg_error(ctx->ins,
+                      "bulk response reported errors: %zu/%zu items failed, "
+                      "first error: status=%d type='%s' reason='%s'; "
+                      "retrying %zu record(s)",
+                      stats->failed_items, stats->total_items,
+                      stats->first_error_status, stats->first_error_type,
+                      stats->first_error_reason, retry_records);
+    }
+}
 
 static const char *es_get_property(const char *property,
                                    struct flb_upstream_node *node,
@@ -1228,6 +1326,13 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
     const char *http_user;
     const char *http_passwd;
     const char *http_api_key;
+    struct flb_search_bulk_stats bulk_stats;
+    size_t retry_records;
+    size_t dropped_records;
+    size_t dropped_bytes;
+    size_t successful_bytes;
+    int successful_records;
+    int retry_context_result;
 #ifdef FLB_HAVE_AWS
     struct flb_aws_provider *aws_provider;
     const char *aws_region;
@@ -1444,52 +1549,106 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
                                                    c->resp.payload_size,
                                                    pack, pack_size,
                                                    FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                                   ctx->drop_unrecoverable_records,
+                                                   &bulk_stats,
                                                    &next_retry_payload);
+            retry_records = 0;
+            if (next_retry_payload != NULL) {
+                retry_records = next_retry_payload->records;
+            }
+            dropped_records = 0;
+            dropped_bytes = 0;
+
+            if (ret == FLB_SEARCH_BULK_RETRY) {
+                retry_context_result = flb_output_set_retry_context(
+                                           out_flush, next_retry_payload,
+                                           flb_search_bulk_retry_destroy,
+                                           next_retry_payload->records,
+                                           next_retry_payload->size);
+                if (retry_context_result != 0) {
+                    flb_search_bulk_retry_destroy(next_retry_payload);
+                    next_retry_payload = NULL;
+                    retry_records = bulk_stats.total_items;
+                    flb_plg_error(ctx->ins,
+                                  "could not preserve filtered bulk retry payload; "
+                                  "retrying the full batch");
+                }
+                else {
+                    next_retry_payload = NULL;
+                    if (ctx->drop_unrecoverable_records == FLB_TRUE) {
+                        dropped_records = bulk_stats.unrecoverable_items;
+                        dropped_bytes = bulk_stats.unrecoverable_bytes;
+                    }
+                }
+            }
+            else if (ret == FLB_SEARCH_BULK_COMPLETE &&
+                     ctx->drop_unrecoverable_records == FLB_TRUE) {
+                dropped_records = bulk_stats.unrecoverable_items;
+                dropped_bytes = bulk_stats.unrecoverable_bytes;
+            }
+
+            if ((ret == FLB_SEARCH_BULK_COMPLETE ||
+                 ret == FLB_SEARCH_BULK_RETRY) &&
+                bulk_stats.failed_items > 0) {
+                log_bulk_failure_summary(ctx, &bulk_stats, retry_records,
+                                         dropped_records);
+#ifdef FLB_HAVE_METRICS
+                if (dropped_records > 0) {
+                    cmt_counter_add(ctx->ins->cmt_dropped_records,
+                                    cfl_time_now(),
+                                    dropped_records,
+                                    1, (char *[]) {
+                                        (char *) flb_output_name(ctx->ins)
+                                    });
+
+                    if (out_flush->config->router != NULL &&
+                        event_chunk->type == FLB_EVENT_TYPE_LOGS) {
+                        cmt_counter_add(out_flush->config->router->logs_drop_records_total,
+                                        cfl_time_now(), dropped_records,
+                                        2, (char *[]) {
+                                            (char *) flb_input_name(out_flush->task->i_ins),
+                                            (char *) flb_output_name(ctx->ins)
+                                        });
+                        cmt_counter_add(out_flush->config->router->logs_drop_bytes_total,
+                                        cfl_time_now(), dropped_bytes,
+                                        2, (char *[]) {
+                                            (char *) flb_input_name(out_flush->task->i_ins),
+                                            (char *) flb_output_name(ctx->ins)
+                                        });
+                    }
+                }
+#endif
+            }
+
+            if (ctx->trace_error == FLB_TRUE &&
+                (ret != FLB_SEARCH_BULK_COMPLETE || bulk_stats.failed_items > 0)) {
+                log_payload_chunks(ctx, "error caused by: Input", pack, pack_size);
+                log_payload_chunks(ctx, "error: Output", c->resp.payload,
+                                   c->resp.payload_size);
+            }
+
             if (ret == FLB_SEARCH_BULK_COMPLETE) {
+                if (bulk_stats.total_items > 0 &&
+                    (dropped_records > 0 || retry_payload != NULL)) {
+                    successful_records = (int) bulk_stats.successful_items;
+                    successful_bytes = bulk_stats.successful_bytes;
+                    flb_output_set_successful_route_data(out_flush,
+                                                         successful_records,
+                                                         successful_bytes);
+                }
+                else if (retry_payload != NULL) {
+                    flb_output_set_successful_route_data(out_flush,
+                                                         retry_payload->records,
+                                                         retry_payload->size);
+                }
                 flb_output_clear_retry_context(out_flush);
                 flb_plg_debug(ctx->ins, "Elasticsearch response\n%s",
                               c->resp.payload);
             }
             else {
-                if (ret == FLB_SEARCH_BULK_RETRY) {
-                    ret = flb_output_set_retry_context(
-                              out_flush, next_retry_payload,
-                              flb_search_bulk_retry_destroy,
-                              next_retry_payload->records,
-                              next_retry_payload->size);
-                    if (ret != 0) {
-                        flb_search_bulk_retry_destroy(next_retry_payload);
-                    }
-                    else {
-                        next_retry_payload = NULL;
-                    }
-                }
-                else {
-                    flb_plg_error(ctx->ins,
-                                  "invalid Elasticsearch bulk response");
-                }
-
-                if (ctx->trace_error) {
-                    /*
-                     * If trace_error is set, trace the actual
-                     * response from Elasticsearch explaining the problem.
-                     * Trace_Output can be used to see the request.
-                     */
-                    if (pack_size < 4000) {
-                        flb_plg_debug(ctx->ins, "error caused by: Input\n%.*s\n",
-                                      (int) pack_size, pack);
-                    }
-                    if (c->resp.payload_size < 4000) {
-                        flb_plg_error(ctx->ins, "error: Output\n%s",
-                                      c->resp.payload);
-                    } else {
-                        /*
-                        * We must use fwrite since the flb_log functions
-                        * will truncate data at 4KB
-                        */
-                        fwrite(c->resp.payload, 1, c->resp.payload_size, stderr);
-                        fflush(stderr);
-                    }
+                if (ret != FLB_SEARCH_BULK_RETRY) {
+                    log_invalid_bulk_response(ctx, c->resp.payload,
+                                              c->resp.payload_size);
                 }
                 goto retry;
             }
@@ -1812,6 +1971,11 @@ static struct flb_config_map config_map[] = {
      "Operation to use to write in bulk requests"
     },
     {
+     FLB_CONFIG_MAP_BOOL, "drop_unrecoverable_records", "false",
+     0, FLB_TRUE, offsetof(struct flb_elasticsearch, drop_unrecoverable_records),
+     "Drop records rejected by the bulk API with unrecoverable 4xx errors"
+    },
+    {
      FLB_CONFIG_MAP_STR, "id_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, id_key),
      "If set, _id will be the value of the key from incoming record."
@@ -1838,7 +2002,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, trace_error),
-     "When enabled print the Elasticsearch exception to stderr (for diag only)"
+     "When enabled log the Elasticsearch exception through the normal logging stream"
     },
     /* EOF */
     {0}

--- a/plugins/out_es/es.c
+++ b/plugins/out_es/es.c
@@ -53,7 +53,8 @@ static int es_pack_array_content(msgpack_packer *tmp_pck,
 
 static void log_payload_chunks(struct flb_elasticsearch *ctx,
                                const char *label,
-                               const char *payload, size_t payload_size)
+                               const char *payload, size_t payload_size,
+                               int log_level)
 {
     size_t offset;
     size_t part;
@@ -68,9 +69,36 @@ static void log_payload_chunks(struct flb_elasticsearch *ctx,
             part_size = FLB_ES_TRACE_CHUNK_SIZE;
         }
 
-        flb_plg_error(ctx->ins, "%s part %zu/%zu: %.*s",
-                      label, part, part_count, (int) part_size,
-                      payload + offset);
+        switch (log_level) {
+        case FLB_LOG_ERROR:
+            flb_plg_error(ctx->ins, "%s part %zu/%zu: %.*s",
+                          label, part, part_count, (int) part_size,
+                          payload + offset);
+            break;
+        case FLB_LOG_WARN:
+            flb_plg_warn(ctx->ins, "%s part %zu/%zu: %.*s",
+                         label, part, part_count, (int) part_size,
+                         payload + offset);
+            break;
+        case FLB_LOG_INFO:
+            flb_plg_info(ctx->ins, "%s part %zu/%zu: %.*s",
+                         label, part, part_count, (int) part_size,
+                         payload + offset);
+            break;
+        case FLB_LOG_DEBUG:
+            flb_plg_debug(ctx->ins, "%s part %zu/%zu: %.*s",
+                          label, part, part_count, (int) part_size,
+                          payload + offset);
+            break;
+        case FLB_LOG_TRACE:
+            flb_plg_trace(ctx->ins, "%s part %zu/%zu: %.*s",
+                          label, part, part_count, (int) part_size,
+                          payload + offset);
+            break;
+        case FLB_LOG_OFF:
+        default:
+            break;
+        }
         offset += part_size;
     }
 }
@@ -1622,9 +1650,10 @@ static void cb_es_flush(struct flb_event_chunk *event_chunk,
 
             if (ctx->trace_error == FLB_TRUE &&
                 (ret != FLB_SEARCH_BULK_COMPLETE || bulk_stats.failed_items > 0)) {
-                log_payload_chunks(ctx, "error caused by: Input", pack, pack_size);
+                log_payload_chunks(ctx, "error caused by: Input", pack, pack_size,
+                                   FLB_LOG_DEBUG);
                 log_payload_chunks(ctx, "error: Output", c->resp.payload,
-                                   c->resp.payload_size);
+                                   c->resp.payload_size, FLB_LOG_ERROR);
             }
 
             if (ret == FLB_SEARCH_BULK_COMPLETE) {
@@ -1973,7 +2002,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "drop_unrecoverable_records", "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, drop_unrecoverable_records),
-     "Drop records rejected by the bulk API with unrecoverable 4xx errors"
+     "Drop records rejected by non-retryable bulk 4xx errors; may cause data loss"
     },
     {
      FLB_CONFIG_MAP_STR, "id_key", NULL,
@@ -2002,7 +2031,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
      0, FLB_TRUE, offsetof(struct flb_elasticsearch, trace_error),
-     "When enabled log the Elasticsearch exception through the normal logging stream"
+     "Log failed requests at debug and Elasticsearch responses at error level"
     },
     /* EOF */
     {0}

--- a/plugins/out_es/es.h
+++ b/plugins/out_es/es.h
@@ -115,6 +115,7 @@ struct flb_elasticsearch {
 
     int trace_output;
     int trace_error;
+    int drop_unrecoverable_records;
 
     /*
      * Logstash compatibility options

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -47,7 +47,8 @@ static int os_pack_array_content(msgpack_packer *tmp_pck,
 
 static void log_payload_chunks(struct flb_opensearch *ctx,
                                const char *label,
-                               const char *payload, size_t payload_size)
+                               const char *payload, size_t payload_size,
+                               int log_level)
 {
     size_t offset;
     size_t part;
@@ -62,9 +63,36 @@ static void log_payload_chunks(struct flb_opensearch *ctx,
             part_size = FLB_OS_TRACE_CHUNK_SIZE;
         }
 
-        flb_plg_error(ctx->ins, "%s part %zu/%zu: %.*s",
-                      label, part, part_count, (int) part_size,
-                      payload + offset);
+        switch (log_level) {
+        case FLB_LOG_ERROR:
+            flb_plg_error(ctx->ins, "%s part %zu/%zu: %.*s",
+                          label, part, part_count, (int) part_size,
+                          payload + offset);
+            break;
+        case FLB_LOG_WARN:
+            flb_plg_warn(ctx->ins, "%s part %zu/%zu: %.*s",
+                         label, part, part_count, (int) part_size,
+                         payload + offset);
+            break;
+        case FLB_LOG_INFO:
+            flb_plg_info(ctx->ins, "%s part %zu/%zu: %.*s",
+                         label, part, part_count, (int) part_size,
+                         payload + offset);
+            break;
+        case FLB_LOG_DEBUG:
+            flb_plg_debug(ctx->ins, "%s part %zu/%zu: %.*s",
+                          label, part, part_count, (int) part_size,
+                          payload + offset);
+            break;
+        case FLB_LOG_TRACE:
+            flb_plg_trace(ctx->ins, "%s part %zu/%zu: %.*s",
+                          label, part, part_count, (int) part_size,
+                          payload + offset);
+            break;
+        case FLB_LOG_OFF:
+        default:
+            break;
+        }
         offset += part_size;
     }
 }
@@ -1281,9 +1309,10 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
 
             if (ctx->trace_error == FLB_TRUE &&
                 (ret != FLB_SEARCH_BULK_COMPLETE || bulk_stats.failed_items > 0)) {
-                log_payload_chunks(ctx, "error caused by: Input", pack, pack_size);
+                log_payload_chunks(ctx, "error caused by: Input", pack, pack_size,
+                                   FLB_LOG_DEBUG);
                 log_payload_chunks(ctx, "error: Output", c->resp.payload,
-                                   c->resp.payload_size);
+                                   c->resp.payload_size, FLB_LOG_ERROR);
             }
 
             if (ret != FLB_SEARCH_BULK_COMPLETE) {
@@ -1537,7 +1566,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "drop_unrecoverable_records", "false",
      0, FLB_TRUE, offsetof(struct flb_opensearch, drop_unrecoverable_records),
-     "Drop records rejected by the bulk API with unrecoverable 4xx errors"
+     "Drop records rejected by non-retryable bulk 4xx errors; may cause data loss"
     },
     {
      FLB_CONFIG_MAP_STR, "id_key", NULL,
@@ -1565,7 +1594,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
      0, FLB_TRUE, offsetof(struct flb_opensearch, trace_error),
-     "When enabled log the OpenSearch exception through the normal logging stream"
+     "Log failed requests at debug and OpenSearch responses at error level"
     },
 
     /* HTTP Compression */

--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -18,6 +18,7 @@
  */
 
 #include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_router.h>
 #include <fluent-bit/flb_utils.h>
 #include <fluent-bit/flb_network.h>
 #include <fluent-bit/flb_http_client.h>
@@ -37,9 +38,106 @@
 #include "opensearch.h"
 #include "os_conf.h"
 
+#define FLB_OS_TRACE_CHUNK_SIZE 3000
+#define FLB_OS_RESPONSE_PREVIEW_SIZE 512
+
 static int os_pack_array_content(msgpack_packer *tmp_pck,
                                  msgpack_object array,
                                  struct flb_opensearch *ctx);
+
+static void log_payload_chunks(struct flb_opensearch *ctx,
+                               const char *label,
+                               const char *payload, size_t payload_size)
+{
+    size_t offset;
+    size_t part;
+    size_t part_count;
+    size_t part_size;
+
+    part_count = (payload_size + FLB_OS_TRACE_CHUNK_SIZE - 1) /
+                 FLB_OS_TRACE_CHUNK_SIZE;
+    for (offset = 0, part = 1; offset < payload_size; part++) {
+        part_size = payload_size - offset;
+        if (part_size > FLB_OS_TRACE_CHUNK_SIZE) {
+            part_size = FLB_OS_TRACE_CHUNK_SIZE;
+        }
+
+        flb_plg_error(ctx->ins, "%s part %zu/%zu: %.*s",
+                      label, part, part_count, (int) part_size,
+                      payload + offset);
+        offset += part_size;
+    }
+}
+
+static void log_invalid_bulk_response(struct flb_opensearch *ctx,
+                                      const char *payload,
+                                      size_t payload_size)
+{
+    char character;
+    char preview[(FLB_OS_RESPONSE_PREVIEW_SIZE * 2) + 1];
+    size_t input_index;
+    size_t input_size;
+    size_t output_index;
+
+    input_size = payload_size;
+    if (input_size > FLB_OS_RESPONSE_PREVIEW_SIZE) {
+        input_size = FLB_OS_RESPONSE_PREVIEW_SIZE;
+    }
+
+    output_index = 0;
+    for (input_index = 0; input_index < input_size; input_index++) {
+        character = payload[input_index];
+        if (character == '\n' || character == '\r' || character == '\t') {
+            preview[output_index++] = '\\';
+            if (character == '\n') {
+                preview[output_index++] = 'n';
+            }
+            else if (character == '\r') {
+                preview[output_index++] = 'r';
+            }
+            else {
+                preview[output_index++] = 't';
+            }
+        }
+        else if ((unsigned char) character < 0x20 || character == 0x7f) {
+            preview[output_index++] = '.';
+        }
+        else {
+            preview[output_index++] = character;
+        }
+    }
+    preview[output_index] = '\0';
+
+    flb_plg_error(ctx->ins,
+                  "invalid OpenSearch bulk response (first %zu/%zu bytes): %s",
+                  input_size, payload_size, preview);
+}
+
+static void log_bulk_failure_summary(struct flb_opensearch *ctx,
+                                     struct flb_search_bulk_stats *stats,
+                                     size_t retry_records,
+                                     size_t dropped_records)
+{
+    if (dropped_records > 0) {
+        flb_plg_error(ctx->ins,
+                      "bulk response reported errors: %zu/%zu items failed, "
+                      "first error: status=%d type='%s' reason='%s'; "
+                      "retrying %zu record(s), dropped %zu unrecoverable record(s)",
+                      stats->failed_items, stats->total_items,
+                      stats->first_error_status, stats->first_error_type,
+                      stats->first_error_reason, retry_records,
+                      dropped_records);
+    }
+    else {
+        flb_plg_error(ctx->ins,
+                      "bulk response reported errors: %zu/%zu items failed, "
+                      "first error: status=%d type='%s' reason='%s'; "
+                      "retrying %zu record(s)",
+                      stats->failed_items, stats->total_items,
+                      stats->first_error_status, stats->first_error_type,
+                      stats->first_error_reason, retry_records);
+    }
+}
 
 #ifdef FLB_HAVE_AWS
 static flb_sds_t add_aws_auth(struct flb_http_client *c,
@@ -947,6 +1045,13 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     size_t final_payload_size = 0;
     struct flb_search_bulk_retry *retry_payload;
     struct flb_search_bulk_retry *next_retry_payload = NULL;
+    struct flb_search_bulk_stats bulk_stats;
+    size_t retry_records;
+    size_t dropped_records;
+    size_t dropped_bytes;
+    size_t successful_bytes;
+    int successful_records;
+    int retry_context_result;
 
     /* Get upstream connection */
     u_conn = flb_upstream_conn_get(ctx->u);
@@ -1089,12 +1194,15 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
         }
 
         if (c->resp.payload_size > 0) {
+            memset(&bulk_stats, 0, sizeof(struct flb_search_bulk_stats));
             if (event_chunk->type == FLB_EVENT_TYPE_LOGS) {
                 /* Preserve the existing behavior that acknowledges all conflicts. */
                 ret = flb_search_bulk_process_response(c->resp.payload,
                                                        c->resp.payload_size,
                                                        pack, pack_size,
                                                        FLB_SEARCH_BULK_ACK_ALL_CONFLICTS,
+                                                       ctx->drop_unrecoverable_records,
+                                                       &bulk_stats,
                                                        &next_retry_payload);
             }
             else if (opensearch_error_check(ctx, c) == FLB_TRUE) {
@@ -1103,46 +1211,85 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
             else {
                 ret = FLB_SEARCH_BULK_COMPLETE;
             }
-            if (ret != FLB_SEARCH_BULK_COMPLETE) {
-                if (ret == FLB_SEARCH_BULK_RETRY) {
-                    ret = flb_output_set_retry_context(
-                              out_flush, next_retry_payload,
-                              flb_search_bulk_retry_destroy,
-                              next_retry_payload->records,
-                              next_retry_payload->size);
-                    if (ret != 0) {
-                        flb_search_bulk_retry_destroy(next_retry_payload);
-                    }
-                    else {
-                        next_retry_payload = NULL;
-                    }
+            retry_records = 0;
+            if (next_retry_payload != NULL) {
+                retry_records = next_retry_payload->records;
+            }
+            dropped_records = 0;
+            dropped_bytes = 0;
+
+            if (ret == FLB_SEARCH_BULK_RETRY) {
+                retry_context_result = flb_output_set_retry_context(
+                                           out_flush, next_retry_payload,
+                                           flb_search_bulk_retry_destroy,
+                                           next_retry_payload->records,
+                                           next_retry_payload->size);
+                if (retry_context_result != 0) {
+                    flb_search_bulk_retry_destroy(next_retry_payload);
+                    next_retry_payload = NULL;
+                    retry_records = bulk_stats.total_items;
+                    flb_plg_error(ctx->ins,
+                                  "could not preserve filtered bulk retry payload; "
+                                  "retrying the full batch");
                 }
                 else {
-                    flb_plg_error(ctx->ins,
-                                  "invalid OpenSearch bulk response");
+                    next_retry_payload = NULL;
+                    if (ctx->drop_unrecoverable_records == FLB_TRUE) {
+                        dropped_records = bulk_stats.unrecoverable_items;
+                        dropped_bytes = bulk_stats.unrecoverable_bytes;
+                    }
                 }
+            }
+            else if (ret == FLB_SEARCH_BULK_COMPLETE &&
+                     ctx->drop_unrecoverable_records == FLB_TRUE) {
+                dropped_records = bulk_stats.unrecoverable_items;
+                dropped_bytes = bulk_stats.unrecoverable_bytes;
+            }
 
-                if (ctx->trace_error) {
-                    /*
-                     * If trace_error is set, trace the actual
-                     * response from Elasticsearch explaining the problem.
-                     * Trace_Output can be used to see the request.
-                     */
-                    if (pack_size < 4000) {
-                        flb_plg_debug(ctx->ins, "error caused by: Input\n%.*s\n",
-                                      (int) pack_size, pack);
+            if ((ret == FLB_SEARCH_BULK_COMPLETE ||
+                 ret == FLB_SEARCH_BULK_RETRY) &&
+                bulk_stats.failed_items > 0) {
+                log_bulk_failure_summary(ctx, &bulk_stats, retry_records,
+                                         dropped_records);
+#ifdef FLB_HAVE_METRICS
+                if (dropped_records > 0) {
+                    cmt_counter_add(ctx->ins->cmt_dropped_records,
+                                    cfl_time_now(),
+                                    dropped_records,
+                                    1, (char *[]) {
+                                        (char *) flb_output_name(ctx->ins)
+                                    });
+
+                    if (out_flush->config->router != NULL &&
+                        event_chunk->type == FLB_EVENT_TYPE_LOGS) {
+                        cmt_counter_add(out_flush->config->router->logs_drop_records_total,
+                                        cfl_time_now(), dropped_records,
+                                        2, (char *[]) {
+                                            (char *) flb_input_name(out_flush->task->i_ins),
+                                            (char *) flb_output_name(ctx->ins)
+                                        });
+                        cmt_counter_add(out_flush->config->router->logs_drop_bytes_total,
+                                        cfl_time_now(), dropped_bytes,
+                                        2, (char *[]) {
+                                            (char *) flb_input_name(out_flush->task->i_ins),
+                                            (char *) flb_output_name(ctx->ins)
+                                        });
                     }
-                    if (c->resp.payload_size < 4000) {
-                        flb_plg_error(ctx->ins, "error: Output\n%s",
-                                      c->resp.payload);
-                    } else {
-                        /*
-                        * We must use fwrite since the flb_log functions
-                        * will truncate data at 4KB
-                        */
-                        fwrite(c->resp.payload, 1, c->resp.payload_size, stderr);
-                        fflush(stderr);
-                    }
+                }
+#endif
+            }
+
+            if (ctx->trace_error == FLB_TRUE &&
+                (ret != FLB_SEARCH_BULK_COMPLETE || bulk_stats.failed_items > 0)) {
+                log_payload_chunks(ctx, "error caused by: Input", pack, pack_size);
+                log_payload_chunks(ctx, "error: Output", c->resp.payload,
+                                   c->resp.payload_size);
+            }
+
+            if (ret != FLB_SEARCH_BULK_COMPLETE) {
+                if (ret != FLB_SEARCH_BULK_RETRY) {
+                    log_invalid_bulk_response(ctx, c->resp.payload,
+                                              c->resp.payload_size);
                 }
                 if (signature) {
                     flb_sds_destroy(signature);
@@ -1151,6 +1298,19 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
                 goto retry;
             }
             else {
+                if (bulk_stats.total_items > 0 &&
+                    (dropped_records > 0 || retry_payload != NULL)) {
+                    successful_records = (int) bulk_stats.successful_items;
+                    successful_bytes = bulk_stats.successful_bytes;
+                    flb_output_set_successful_route_data(out_flush,
+                                                         successful_records,
+                                                         successful_bytes);
+                }
+                else if (retry_payload != NULL) {
+                    flb_output_set_successful_route_data(out_flush,
+                                                         retry_payload->records,
+                                                         retry_payload->size);
+                }
                 flb_output_clear_retry_context(out_flush);
                 flb_plg_debug(ctx->ins, "OpenSearch response\n%s",
                               c->resp.payload);
@@ -1375,6 +1535,11 @@ static struct flb_config_map config_map[] = {
      "Operation to use to write in bulk requests"
     },
     {
+     FLB_CONFIG_MAP_BOOL, "drop_unrecoverable_records", "false",
+     0, FLB_TRUE, offsetof(struct flb_opensearch, drop_unrecoverable_records),
+     "Drop records rejected by the bulk API with unrecoverable 4xx errors"
+    },
+    {
      FLB_CONFIG_MAP_STR, "id_key", NULL,
      0, FLB_TRUE, offsetof(struct flb_opensearch, id_key),
      "If set, _id will be the value of the key from incoming record."
@@ -1400,7 +1565,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "trace_error", "false",
      0, FLB_TRUE, offsetof(struct flb_opensearch, trace_error),
-     "When enabled print the OpenSearch exception to stderr (for diag only)"
+     "When enabled log the OpenSearch exception through the normal logging stream"
     },
 
     /* HTTP Compression */

--- a/plugins/out_opensearch/opensearch.h
+++ b/plugins/out_opensearch/opensearch.h
@@ -92,6 +92,7 @@ struct flb_opensearch {
 
     int trace_output;
     int trace_error;
+    int drop_unrecoverable_records;
 
     /*
      * Logstash compatibility options

--- a/src/flb_search_bulk.c
+++ b/src/flb_search_bulk.c
@@ -16,7 +16,13 @@
 #include <fluent-bit/flb_search_bulk.h>
 
 #include <msgpack.h>
+#include <limits.h>
 #include <string.h>
+
+#define FLB_SEARCH_BULK_ITEM_INVALID        -1
+#define FLB_SEARCH_BULK_ITEM_ACKNOWLEDGED    0
+#define FLB_SEARCH_BULK_ITEM_RETRYABLE       1
+#define FLB_SEARCH_BULK_ITEM_UNRECOVERABLE   2
 
 static int object_key_equals(msgpack_object key, const char *value, size_t length)
 {
@@ -318,8 +324,79 @@ static int top_level_errors_is_false(const char *json, size_t size)
     return FLB_FALSE;
 }
 
-static int item_is_acknowledged(msgpack_object item,
-                                int acknowledge_all_conflicts)
+static void copy_error_text(char *destination, size_t destination_size,
+                            msgpack_object value)
+{
+    unsigned char character;
+    size_t index;
+    size_t copy_size;
+
+    if (destination_size == 0 || value.type != MSGPACK_OBJECT_STR) {
+        return;
+    }
+
+    copy_size = value.via.str.size;
+    if (copy_size >= destination_size) {
+        copy_size = destination_size - 1;
+    }
+
+    for (index = 0; index < copy_size; index++) {
+        character = value.via.str.ptr[index];
+        if (character < 0x20 || character == 0x7f) {
+            destination[index] = ' ';
+        }
+        else {
+            destination[index] = character;
+        }
+    }
+    destination[copy_size] = '\0';
+}
+
+static void capture_first_error(struct flb_search_bulk_stats *stats,
+                                int status, msgpack_object operation)
+{
+    int index;
+    int error_index;
+    msgpack_object error;
+    msgpack_object value;
+
+    if (stats == NULL || stats->failed_items != 0) {
+        return;
+    }
+
+    stats->first_error_status = status;
+    for (index = 0; index < operation.via.map.size; index++) {
+        if (object_key_equals(operation.via.map.ptr[index].key,
+                              "error", 5) == FLB_FALSE) {
+            continue;
+        }
+
+        error = operation.via.map.ptr[index].val;
+        if (error.type != MSGPACK_OBJECT_MAP) {
+            return;
+        }
+
+        for (error_index = 0; error_index < error.via.map.size; error_index++) {
+            value = error.via.map.ptr[error_index].val;
+            if (object_key_equals(error.via.map.ptr[error_index].key,
+                                  "type", 4) == FLB_TRUE) {
+                copy_error_text(stats->first_error_type,
+                                sizeof(stats->first_error_type), value);
+            }
+            else if (object_key_equals(error.via.map.ptr[error_index].key,
+                                       "reason", 6) == FLB_TRUE) {
+                copy_error_text(stats->first_error_reason,
+                                sizeof(stats->first_error_reason), value);
+            }
+        }
+        return;
+    }
+}
+
+static int classify_item(msgpack_object item,
+                         int acknowledge_all_conflicts,
+                         int *out_status,
+                         msgpack_object *out_operation)
 {
     int index;
     int status;
@@ -328,13 +405,13 @@ static int item_is_acknowledged(msgpack_object item,
     msgpack_object value;
 
     if (item.type != MSGPACK_OBJECT_MAP || item.via.map.size != 1) {
-        return -1;
+        return FLB_SEARCH_BULK_ITEM_INVALID;
     }
 
     key = item.via.map.ptr[0].key;
     operation = item.via.map.ptr[0].val;
     if (key.type != MSGPACK_OBJECT_STR || operation.type != MSGPACK_OBJECT_MAP) {
-        return -1;
+        return FLB_SEARCH_BULK_ITEM_INVALID;
     }
 
     status = -1;
@@ -343,27 +420,39 @@ static int item_is_acknowledged(msgpack_object item,
         if (object_key_equals(operation.via.map.ptr[index].key,
                               "status", 6) == FLB_TRUE) {
             if (value.type != MSGPACK_OBJECT_POSITIVE_INTEGER) {
-                return -1;
+                return FLB_SEARCH_BULK_ITEM_INVALID;
             }
-            status = value.via.u64;
+            if (value.via.u64 > INT_MAX) {
+                return FLB_SEARCH_BULK_ITEM_INVALID;
+            }
+            status = (int) value.via.u64;
             break;
         }
     }
 
     if (status < 0) {
-        return -1;
+        return FLB_SEARCH_BULK_ITEM_INVALID;
     }
+
+    *out_status = status;
+    *out_operation = operation;
+
     if (status >= 200 && status < 300) {
-        return FLB_TRUE;
+        return FLB_SEARCH_BULK_ITEM_ACKNOWLEDGED;
     }
     if (status == 409) {
         if (acknowledge_all_conflicts == FLB_TRUE ||
             object_key_equals(key, "create", 6) == FLB_TRUE) {
-            return FLB_TRUE;
+            return FLB_SEARCH_BULK_ITEM_ACKNOWLEDGED;
         }
+
+        return FLB_SEARCH_BULK_ITEM_RETRYABLE;
+    }
+    if (status >= 400 && status < 500 && status != 408 && status != 429) {
+        return FLB_SEARCH_BULK_ITEM_UNRECOVERABLE;
     }
 
-    return FLB_FALSE;
+    return FLB_SEARCH_BULK_ITEM_RETRYABLE;
 }
 
 static int next_entry(const char *payload, size_t payload_size,
@@ -414,6 +503,8 @@ int flb_search_bulk_process_response(const char *response,
                                      const char *payload,
                                      size_t payload_size,
                                      int acknowledge_all_conflicts,
+                                     int drop_unrecoverable_records,
+                                     struct flb_search_bulk_stats *stats,
                                      struct flb_search_bulk_retry **out_retry)
 {
     int index;
@@ -421,7 +512,8 @@ int flb_search_bulk_process_response(const char *response,
     int root_type;
     int errors_found;
     int has_errors;
-    int acknowledged;
+    int item_result;
+    int status;
     char *packed_response;
     size_t packed_size;
     size_t unpack_offset;
@@ -433,9 +525,13 @@ int flb_search_bulk_process_response(const char *response,
     msgpack_object items;
     msgpack_object key;
     msgpack_object value;
+    msgpack_object operation;
     struct flb_search_bulk_retry *retry;
 
     *out_retry = NULL;
+    if (stats != NULL) {
+        memset(stats, 0, sizeof(struct flb_search_bulk_stats));
+    }
     packed_response = NULL;
     retry = NULL;
     items.type = MSGPACK_OBJECT_NIL;
@@ -525,13 +621,38 @@ int flb_search_bulk_process_response(const char *response,
             goto done;
         }
 
-        acknowledged = item_is_acknowledged(items.via.array.ptr[index],
-                                            acknowledge_all_conflicts);
-        if (acknowledged < 0) {
+        item_result = classify_item(items.via.array.ptr[index],
+                                    acknowledge_all_conflicts,
+                                    &status, &operation);
+        if (item_result == FLB_SEARCH_BULK_ITEM_INVALID) {
             result = FLB_SEARCH_BULK_INVALID;
             goto done;
         }
-        if (acknowledged == FLB_FALSE) {
+
+        if (stats != NULL) {
+            stats->total_items++;
+            if (item_result == FLB_SEARCH_BULK_ITEM_ACKNOWLEDGED) {
+                stats->successful_items++;
+                stats->successful_bytes += entry_size;
+            }
+        }
+        if (item_result != FLB_SEARCH_BULK_ITEM_ACKNOWLEDGED) {
+            capture_first_error(stats, status, operation);
+            if (stats != NULL) {
+                stats->failed_items++;
+                if (item_result == FLB_SEARCH_BULK_ITEM_UNRECOVERABLE) {
+                    stats->unrecoverable_items++;
+                    stats->unrecoverable_bytes += entry_size;
+                }
+                else {
+                    stats->retryable_items++;
+                }
+            }
+        }
+
+        if (item_result == FLB_SEARCH_BULK_ITEM_RETRYABLE ||
+            (item_result == FLB_SEARCH_BULK_ITEM_UNRECOVERABLE &&
+             drop_unrecoverable_records == FLB_FALSE)) {
             memcpy(retry->payload + retry->size,
                    payload + entry_start, entry_size);
             retry->size += entry_size;

--- a/tests/integration/scenarios/out_es/config/out_es_drop_unrecoverable_records.yaml
+++ b/tests/integration/scenarios/out_es/config/out_es_drop_unrecoverable_records.yaml
@@ -1,0 +1,26 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: error
+  scheduler.base: 1
+  scheduler.cap: 1
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_es_drop_unrecoverable_records
+      dummy: '{"message":"${BULK_TEST_MESSAGE}"}'
+      samples: 1
+
+  outputs:
+    - name: es
+      match: out_es_drop_unrecoverable_records
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      index: fluent-bit
+      suppress_type_name: on
+      trace_error: on
+      drop_unrecoverable_records: on
+      retry_limit: 2

--- a/tests/integration/scenarios/out_es/config/out_opensearch_drop_unrecoverable_records.yaml
+++ b/tests/integration/scenarios/out_es/config/out_opensearch_drop_unrecoverable_records.yaml
@@ -1,0 +1,26 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: error
+  scheduler.base: 1
+  scheduler.cap: 1
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_opensearch_drop_unrecoverable_records
+      dummy: '{"message":"${BULK_TEST_MESSAGE}"}'
+      samples: 1
+
+  outputs:
+    - name: opensearch
+      match: out_opensearch_drop_unrecoverable_records
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      index: fluent-bit
+      suppress_type_name: on
+      trace_error: on
+      drop_unrecoverable_records: on
+      retry_limit: 2

--- a/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
+++ b/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
@@ -371,7 +371,6 @@ def test_unrecoverable_bulk_errors_are_logged_and_not_retried(config_file):
         service.start()
         requests_seen = service.wait_for_requests(1)
         log_text = service.wait_for_log_text("dropped 1 unrecoverable record(s)")
-        log_text = service.wait_for_log_text("error caused by: Input part 2/2")
         log_text = service.wait_for_log_text("error: Output part 2/2")
         accounting = service.wait_for_bulk_accounting(output_name)
         time.sleep(3)
@@ -385,6 +384,11 @@ def test_unrecoverable_bulk_errors_are_logged_and_not_retried(config_file):
     assert "bulk response reported errors: 1/1 items failed" in log_text
     assert "status=400 type='mapper_parsing_exception'" in log_text
     assert "retrying 0 record(s), dropped 1 unrecoverable record(s)" in log_text
+    assert "error caused by: Input" not in log_text
+    assert any(
+        "[error]" in line and "error: Output part 2/2" in line
+        for line in log_text.splitlines()
+    )
     assert accounting["processed_records"] == 0.0
     assert accounting["processed_bytes"] == 0.0
     assert accounting["dropped_records"] == 1.0

--- a/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
+++ b/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
@@ -6,6 +6,7 @@ import threading
 import time
 
 import pytest
+import requests
 
 from utils.memory_check import memory_check_enabled
 from utils.test_service import FluentBitTestService
@@ -142,6 +143,63 @@ class Service:
             timeout=timeout,
             interval=0.5,
             description=f"Fluent Bit log text {text!r}",
+        )
+
+    def wait_for_bulk_accounting(self, output_name, timeout=10):
+        if memory_check_enabled():
+            timeout = max(timeout * 3, 30)
+
+        metrics_url = (
+            f"http://127.0.0.1:{self.service.flb.http_monitoring_port}"
+            "/api/v2/metrics/prometheus"
+        )
+
+        def metric_value(metrics, name, labels):
+            for line in metrics.splitlines():
+                if not line.startswith(f"{name}{{"):
+                    continue
+                if all(f'{key}="{value}"' in line for key, value in labels.items()):
+                    return float(line.rsplit(" ", 1)[-1])
+            return None
+
+        def accounting_snapshot():
+            response = requests.get(metrics_url, timeout=2)
+            response.raise_for_status()
+            metrics = response.text
+            output_labels = {"name": output_name}
+            route_labels = {"input": "dummy.0", "output": output_name}
+            snapshot = {
+                "processed_records": metric_value(
+                    metrics, "fluentbit_output_proc_records_total", output_labels
+                ),
+                "processed_bytes": metric_value(
+                    metrics, "fluentbit_output_proc_bytes_total", output_labels
+                ),
+                "dropped_records": metric_value(
+                    metrics, "fluentbit_output_dropped_records_total", output_labels
+                ),
+                "routed_records": metric_value(
+                    metrics, "fluentbit_routing_logs_records_total", route_labels
+                ),
+                "routed_bytes": metric_value(
+                    metrics, "fluentbit_routing_logs_bytes_total", route_labels
+                ),
+                "dropped_route_records": metric_value(
+                    metrics, "fluentbit_routing_logs_drop_records_total", route_labels
+                ),
+                "dropped_route_bytes": metric_value(
+                    metrics, "fluentbit_routing_logs_drop_bytes_total", route_labels
+                ),
+            }
+            if snapshot["dropped_records"] == 1.0:
+                return snapshot
+            return None
+
+        return self.service.wait_for_condition(
+            accounting_snapshot,
+            timeout=timeout,
+            interval=0.5,
+            description=f"successful and dropped route accounting for {output_name}",
         )
 
 
@@ -302,6 +360,7 @@ def test_partial_bulk_retry_sends_only_unresolved_records(config_file):
     ],
 )
 def test_unrecoverable_bulk_errors_are_logged_and_not_retried(config_file):
+    output_name = "opensearch.0" if "opensearch" in config_file else "es.0"
     service = Service(
         config_file,
         response_factory=_unrecoverable_bulk_response,
@@ -314,6 +373,7 @@ def test_unrecoverable_bulk_errors_are_logged_and_not_retried(config_file):
         log_text = service.wait_for_log_text("dropped 1 unrecoverable record(s)")
         log_text = service.wait_for_log_text("error caused by: Input part 2/2")
         log_text = service.wait_for_log_text("error: Output part 2/2")
+        accounting = service.wait_for_bulk_accounting(output_name)
         time.sleep(3)
         request_count = len(service.bulk_server.requests)
     finally:
@@ -325,3 +385,10 @@ def test_unrecoverable_bulk_errors_are_logged_and_not_retried(config_file):
     assert "bulk response reported errors: 1/1 items failed" in log_text
     assert "status=400 type='mapper_parsing_exception'" in log_text
     assert "retrying 0 record(s), dropped 1 unrecoverable record(s)" in log_text
+    assert accounting["processed_records"] == 0.0
+    assert accounting["processed_bytes"] == 0.0
+    assert accounting["dropped_records"] == 1.0
+    assert accounting["routed_records"] == 0.0
+    assert accounting["routed_bytes"] == 0.0
+    assert accounting["dropped_route_records"] == 1.0
+    assert accounting["dropped_route_bytes"] > 4000

--- a/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
+++ b/tests/integration/scenarios/out_es/tests/test_out_es_ndjson_action_line_001.py
@@ -1,7 +1,9 @@
 import json
 import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 import threading
+import time
 
 import pytest
 
@@ -55,7 +57,7 @@ class _BulkCaptureServer(ThreadingHTTPServer):
 
 
 class Service:
-    def __init__(self, config_file, response_factory=None):
+    def __init__(self, config_file, response_factory=None, extra_env=None):
         self.config_file = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../config", config_file)
         )
@@ -64,6 +66,7 @@ class Service:
         self.response_factory = response_factory
         self.service = FluentBitTestService(
             self.config_file,
+            extra_env=extra_env,
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
         )
@@ -122,6 +125,25 @@ class Service:
             description=f"{minimum_count} Elasticsearch bulk action lines",
         )
 
+    def wait_for_log_text(self, text, timeout=10):
+        if memory_check_enabled():
+            timeout = max(timeout * 3, 30)
+
+        def matching_log():
+            log_path = Path(self.service.flb.log_file)
+            if not log_path.exists():
+                return None
+
+            log_text = log_path.read_text(encoding="utf-8", errors="replace")
+            return log_text if text in log_text else None
+
+        return self.service.wait_for_condition(
+            matching_log,
+            timeout=timeout,
+            interval=0.5,
+            description=f"Fluent Bit log text {text!r}",
+        )
+
 
 def _bulk_action_lines(body):
     actions = []
@@ -172,12 +194,30 @@ def _partial_bulk_response(request_number, request):
         return (
             b'{"errors":true,"items":['
             b'{"create":{"status":201}},'
-            b'{"create":{"status":429}},'
+            b'{"create":{"status":429,"error":{'
+            b'"type":"es_rejected_execution_exception",'
+            b'"reason":"bulk queue is full"}}},'
             b'{"create":{"status":409}}]}'
         )
 
     assert action_count == 1
     return b'{"errors":false,"items":[{"create":{"status":201}}]}'
+
+
+def _unrecoverable_bulk_response(request_number, request):
+    action_count = len(_bulk_action_lines(request["body"]))
+    reason = "strict mapping conflict " + ("x" * 5000)
+    item = {
+        "create": {
+            "status": 400,
+            "error": {
+                "type": "mapper_parsing_exception",
+                "reason": reason,
+            },
+        }
+    }
+
+    return json.dumps({"errors": True, "items": [item] * action_count}).encode()
 
 
 @pytest.mark.parametrize(
@@ -241,8 +281,47 @@ def test_partial_bulk_retry_sends_only_unresolved_records(config_file):
     try:
         service.start()
         requests_seen = service.wait_for_requests(2)
+        log_text = service.wait_for_log_text(
+            "reason='bulk queue is full'; retrying 1 record(s)"
+        )
     finally:
         service.stop()
 
     assert len(_bulk_action_lines(requests_seen[0]["body"])) == 3
     assert len(_bulk_action_lines(requests_seen[1]["body"])) == 1
+    assert "bulk response reported errors: 1/3 items failed" in log_text
+    assert "status=429 type='es_rejected_execution_exception'" in log_text
+    assert "reason='bulk queue is full'; retrying 1 record(s)" in log_text
+
+
+@pytest.mark.parametrize(
+    "config_file",
+    [
+        "out_es_drop_unrecoverable_records.yaml",
+        "out_opensearch_drop_unrecoverable_records.yaml",
+    ],
+)
+def test_unrecoverable_bulk_errors_are_logged_and_not_retried(config_file):
+    service = Service(
+        config_file,
+        response_factory=_unrecoverable_bulk_response,
+        extra_env={"BULK_TEST_MESSAGE": "y" * 5000},
+    )
+
+    try:
+        service.start()
+        requests_seen = service.wait_for_requests(1)
+        log_text = service.wait_for_log_text("dropped 1 unrecoverable record(s)")
+        log_text = service.wait_for_log_text("error caused by: Input part 2/2")
+        log_text = service.wait_for_log_text("error: Output part 2/2")
+        time.sleep(3)
+        request_count = len(service.bulk_server.requests)
+    finally:
+        service.stop()
+
+    assert len(_bulk_action_lines(requests_seen[0]["body"])) == 1
+    assert len(requests_seen[0]["body"]) > 4000
+    assert request_count == 1
+    assert "bulk response reported errors: 1/1 items failed" in log_text
+    assert "status=400 type='mapper_parsing_exception'" in log_text
+    assert "retrying 0 record(s), dropped 1 unrecoverable record(s)" in log_text

--- a/tests/internal/search_bulk.c
+++ b/tests/internal/search_bulk.c
@@ -18,6 +18,21 @@
     "{\"create\":{\"_index\":\"logs\",\"_id\":\"two\"}}\n"       \
     "{\"message\":\"two\"}\n"
 
+#define FOUR_ENTRY_BULK_PAYLOAD                                         \
+    BULK_PAYLOAD                                                        \
+    "{\"create\":{\"_index\":\"logs\",\"_id\":\"four\"}}\n"      \
+    "{\"message\":\"four\"}\n"
+
+#define UPSERT_PAYLOAD                                                  \
+    "{\"update\":{\"_index\":\"logs\",\"_id\":\"one\"}}\n"       \
+    "{\"doc_as_upsert\":true,\"doc\":{\"message\":\"one\"}}\n"       \
+    "{\"update\":{\"_index\":\"logs\",\"_id\":\"two\"}}\n"       \
+    "{\"doc_as_upsert\":true,\"doc\":{\"message\":\"two\"}}\n"
+
+#define SECOND_UPSERT_ENTRY                                             \
+    "{\"update\":{\"_index\":\"logs\",\"_id\":\"two\"}}\n"       \
+    "{\"doc_as_upsert\":true,\"doc\":{\"message\":\"two\"}}\n"
+
 static void test_mixed_response_keeps_only_unresolved(void)
 {
     int result;
@@ -33,6 +48,7 @@ static void test_mixed_response_keeps_only_unresolved(void)
                                               BULK_PAYLOAD,
                                               strlen(BULK_PAYLOAD),
                                               FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_RETRY);
     TEST_CHECK(retry != NULL);
@@ -57,6 +73,7 @@ static void test_create_conflicts_are_complete(void)
                                               BULK_PAYLOAD,
                                               strlen(BULK_PAYLOAD),
                                               FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_COMPLETE);
     TEST_CHECK(retry == NULL);
@@ -77,6 +94,7 @@ static void test_update_conflict_is_retried(void)
     result = flb_search_bulk_process_response(response, strlen(response),
                                               payload, strlen(payload),
                                               FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_RETRY);
     TEST_CHECK(retry != NULL);
@@ -100,6 +118,7 @@ static void test_update_conflict_is_complete_when_all_conflicts_are_acknowledged
     result = flb_search_bulk_process_response(response, strlen(response),
                                               payload, strlen(payload),
                                               FLB_SEARCH_BULK_ACK_ALL_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_COMPLETE);
     TEST_CHECK(retry == NULL);
@@ -118,6 +137,7 @@ static void test_truncated_success_response_is_complete(void)
                                               BULK_PAYLOAD,
                                               strlen(BULK_PAYLOAD),
                                               FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_COMPLETE);
     TEST_CHECK(retry == NULL);
@@ -136,6 +156,7 @@ static void test_nested_success_marker_with_top_level_errors_is_invalid(void)
                                               BULK_PAYLOAD,
                                               strlen(BULK_PAYLOAD),
                                               FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_INVALID);
     TEST_CHECK(retry == NULL);
@@ -154,9 +175,114 @@ static void test_item_count_mismatch_is_invalid(void)
                                               BULK_PAYLOAD,
                                               strlen(BULK_PAYLOAD),
                                               FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, NULL,
                                               &retry);
     TEST_CHECK(result == FLB_SEARCH_BULK_INVALID);
     TEST_CHECK(retry == NULL);
+}
+
+static void test_mixed_response_populates_stats(void)
+{
+    int result;
+    const char *response;
+    struct flb_search_bulk_retry *retry;
+    struct flb_search_bulk_stats stats;
+
+    response = "{\"errors\":true,\"items\":["
+               "{\"create\":{\"status\":201}},"
+               "{\"create\":{\"status\":200}},"
+               "{\"create\":{\"status\":400,\"error\":{"
+               "\"type\":\"mapper_parsing_exception\","
+               "\"reason\":\"strict mapping conflict\"}}},"
+               "{\"create\":{\"status\":429,\"error\":{"
+               "\"type\":\"es_rejected_execution_exception\","
+               "\"reason\":\"queue is full\"}}}]}";
+
+    result = flb_search_bulk_process_response(response, strlen(response),
+                                              FOUR_ENTRY_BULK_PAYLOAD,
+                                              strlen(FOUR_ENTRY_BULK_PAYLOAD),
+                                              FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, &stats, &retry);
+    TEST_CHECK(result == FLB_SEARCH_BULK_RETRY);
+    TEST_CHECK(retry != NULL);
+    TEST_CHECK(retry->records == 2);
+    TEST_CHECK(stats.total_items == 4);
+    TEST_CHECK(stats.successful_items == 2);
+    TEST_CHECK(stats.successful_bytes < strlen(FOUR_ENTRY_BULK_PAYLOAD));
+    TEST_CHECK(stats.failed_items == 2);
+    TEST_CHECK(stats.retryable_items == 1);
+    TEST_CHECK(stats.unrecoverable_items == 1);
+    TEST_CHECK(stats.unrecoverable_bytes > 0);
+    TEST_CHECK(stats.first_error_status == 400);
+    TEST_CHECK(strcmp(stats.first_error_type, "mapper_parsing_exception") == 0);
+    TEST_CHECK(strcmp(stats.first_error_reason, "strict mapping conflict") == 0);
+    flb_search_bulk_retry_destroy(retry);
+}
+
+static void test_drop_unrecoverable_upsert_records(void)
+{
+    int result;
+    const char *response;
+    struct flb_search_bulk_retry *retry;
+    struct flb_search_bulk_stats stats;
+
+    response = "{\"errors\":true,\"items\":["
+               "{\"update\":{\"status\":400,\"error\":{"
+               "\"type\":\"illegal_argument_exception\","
+               "\"reason\":\"invalid field\"}}},"
+               "{\"update\":{\"status\":429}}]}";
+
+    result = flb_search_bulk_process_response(response, strlen(response),
+                                              UPSERT_PAYLOAD,
+                                              strlen(UPSERT_PAYLOAD),
+                                              FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_TRUE, &stats, &retry);
+    TEST_CHECK(result == FLB_SEARCH_BULK_RETRY);
+    TEST_CHECK(retry != NULL);
+    TEST_CHECK(retry->records == 1);
+    TEST_CHECK(retry->size == strlen(SECOND_UPSERT_ENTRY));
+    TEST_CHECK(memcmp(retry->payload, SECOND_UPSERT_ENTRY, retry->size) == 0);
+    TEST_CHECK(stats.retryable_items == 1);
+    TEST_CHECK(stats.unrecoverable_items == 1);
+    flb_search_bulk_retry_destroy(retry);
+
+    result = flb_search_bulk_process_response(response, strlen(response),
+                                              UPSERT_PAYLOAD,
+                                              strlen(UPSERT_PAYLOAD),
+                                              FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_FALSE, &stats, &retry);
+    TEST_CHECK(result == FLB_SEARCH_BULK_RETRY);
+    TEST_CHECK(retry != NULL);
+    TEST_CHECK(retry->records == 2);
+    TEST_CHECK(retry->size == strlen(UPSERT_PAYLOAD));
+    TEST_CHECK(memcmp(retry->payload, UPSERT_PAYLOAD, retry->size) == 0);
+    flb_search_bulk_retry_destroy(retry);
+}
+
+static void test_only_unrecoverable_records_complete_when_dropped(void)
+{
+    int result;
+    const char *response;
+    struct flb_search_bulk_retry *retry;
+    struct flb_search_bulk_stats stats;
+
+    response = "{\"errors\":true,\"items\":["
+               "{\"update\":{\"status\":400}},"
+               "{\"update\":{\"status\":422}}]}";
+
+    result = flb_search_bulk_process_response(response, strlen(response),
+                                              UPSERT_PAYLOAD,
+                                              strlen(UPSERT_PAYLOAD),
+                                              FLB_SEARCH_BULK_ACK_CREATE_CONFLICTS,
+                                              FLB_TRUE, &stats, &retry);
+    TEST_CHECK(result == FLB_SEARCH_BULK_COMPLETE);
+    TEST_CHECK(retry == NULL);
+    TEST_CHECK(stats.failed_items == 2);
+    TEST_CHECK(stats.successful_items == 0);
+    TEST_CHECK(stats.successful_bytes == 0);
+    TEST_CHECK(stats.retryable_items == 0);
+    TEST_CHECK(stats.unrecoverable_items == 2);
+    TEST_CHECK(stats.unrecoverable_bytes == strlen(UPSERT_PAYLOAD));
 }
 
 TEST_LIST = {
@@ -170,5 +296,9 @@ TEST_LIST = {
     {"nested_success_marker_with_top_level_errors_is_invalid",
      test_nested_success_marker_with_top_level_errors_is_invalid},
     {"item_count_mismatch_is_invalid", test_item_count_mismatch_is_invalid},
+    {"mixed_response_populates_stats", test_mixed_response_populates_stats},
+    {"drop_unrecoverable_upsert_records", test_drop_unrecoverable_upsert_records},
+    {"only_unrecoverable_records_complete_when_dropped",
+     test_only_unrecoverable_records_complete_when_dropped},
     {NULL, NULL}
 };

--- a/tests/runtime/out_elasticsearch.c
+++ b/tests/runtime/out_elasticsearch.c
@@ -11,6 +11,19 @@
 #include "data/es/json_es.h" /* JSON_ES */
 #include "../../plugins/out_es/es.h"
 
+static void *cb_check_drop_unrecoverable_records(
+                        struct flb_config *config,
+                        struct flb_input_instance *ins,
+                        void *plugin_context, void *flush_ctx)
+{
+    struct flb_elasticsearch *ctx = plugin_context;
+
+    (void) config;
+    (void) ins;
+
+    TEST_CHECK(ctx->drop_unrecoverable_records == FLB_TRUE);
+    return flush_ctx;
+}
 
 static void cb_check_http_api_key(void *ctx, int ffd,
                                 int res_ret, void *res_data,
@@ -1513,6 +1526,40 @@ void flb_test_upstream_id_key()
     unlink(upstream_file);
 }
 
+void flb_test_drop_unrecoverable_records_config()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "es", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "drop_unrecoverable_records", "on",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(
+              ctx, out_ffd, "formatter", cb_check_write_op_create,
+              NULL, NULL, cb_check_drop_unrecoverable_records);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"long_index"            , flb_test_long_index },
@@ -1539,5 +1586,7 @@ TEST_LIST = {
     {"upstream_logstash_format"  , flb_test_upstream_logstash_format },
     {"upstream_replace_dots"     , flb_test_upstream_replace_dots },
     {"upstream_id_key"           , flb_test_upstream_id_key },
+    {"drop_unrecoverable_records_config",
+     flb_test_drop_unrecoverable_records_config},
     {NULL, NULL}
 };

--- a/tests/runtime/out_opensearch.c
+++ b/tests/runtime/out_opensearch.c
@@ -5,6 +5,21 @@
 
 /* Test data */
 #include "data/es/json_es.h" /* JSON_ES */
+#include "../../plugins/out_opensearch/opensearch.h"
+
+static void *cb_check_drop_unrecoverable_records(
+                        struct flb_config *config,
+                        struct flb_input_instance *ins,
+                        void *plugin_context, void *flush_ctx)
+{
+    struct flb_opensearch *ctx = plugin_context;
+
+    (void) config;
+    (void) ins;
+
+    TEST_CHECK(ctx->drop_unrecoverable_records == FLB_TRUE);
+    return flush_ctx;
+}
 
 static void cb_check_write_op_index(void *ctx, int ffd,
                                     int res_ret, void *res_data,
@@ -1096,6 +1111,40 @@ void flb_test_logstash_prefix_separator()
     flb_destroy(ctx);
 }
 
+void flb_test_drop_unrecoverable_records_config()
+{
+    int ret;
+    int size = sizeof(JSON_ES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "opensearch", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "drop_unrecoverable_records", "on",
+                   NULL);
+
+    ret = flb_output_set_test_with_ctx_callback(
+              ctx, out_ffd, "formatter", cb_check_write_op_create,
+              NULL, NULL, cb_check_drop_unrecoverable_records);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+    flb_lib_push(ctx, in_ffd, (char *) JSON_ES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"long_index"            , flb_test_long_index },
@@ -1115,5 +1164,7 @@ TEST_LIST = {
     {"replace_dots"          , flb_test_replace_dots },
     {"id_key"                , flb_test_id_key },
     {"logstash_prefix_separator" , flb_test_logstash_prefix_separator },
+    {"drop_unrecoverable_records_config",
+     flb_test_drop_unrecoverable_records_config},
     {NULL, NULL}
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add bulk search traces for out_es and out_opensearch.

Implemented the bulk-failure mitigation for Elasticsearch and OpenSearch.

Implemented the Elasticsearch and OpenSearch bulk-failure mitigation and addressed route-accounting feedback.

Key changes:

- Added per-item bulk statistics, first-error extraction, and successful/unrecoverable byte accounting.
- Classified 408, 429, and 5xx responses as retryable; other 4xx responses as unrecoverable. Existing 409 handling remains unchanged.
- Added opt-in `drop_unrecoverable_records`, defaulting to `false`.
- Added bounded failure summaries, escaped invalid-response previews, and chunked `Trace_Error` output through the normal logging stream.
- Preserved route-effective record and byte totals through retries and successful completion.
- Excluded unrecoverable records and bytes from processed and router-success counters.
- Added dropped record and byte accounting through cmetrics for Prometheus observation.
- Added internal, runtime, and integration coverage for classification, partial retries, permanent drops, accounting, diagnostics, and payloads larger than 4 KB.

Verification passed:

- Focused build completed successfully.
- CTest: 3/3 passed.
- Functional integration: 4 passed.
- Strict Linux Valgrind integration: 4 passed.
- `git diff --check` passed.
- No generated integration artifacts or commits were added.
Addressed the accounting review comment.

Closes https://github.com/fluent/fluent-bit/issues/12302.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added `drop_unrecoverable_records` configuration for Elasticsearch and OpenSearch outputs.
- Unrecoverable bulk failures can be dropped instead of retried, with potential data loss.
- Added detailed accounting for successful, retried, failed, and dropped records and bytes.
- Improved bulk failure summaries and request/response tracing.

## Bug Fixes
- Prevented unrecoverable records from being unnecessarily retried when enabled.
- Improved handling and reporting of invalid bulk responses.

## Tests
- Added coverage for configuration, retry filtering, dropped records, and bulk accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->