### PR TITLE
[Canary] lib: monkey: proceed oversized fired events on windows

### DIFF
--- a/lib/monkey/mk_core/mk_event_libevent.c
+++ b/lib/monkey/mk_core/mk_event_libevent.c
@@ -39,6 +39,9 @@ struct ev_map {
 
     struct event *event;
     struct mk_event_ctx *ctx;
+
+    /* libevent timer that feeds pipe[1] (timeouts only, NULL otherwise) */
+    struct event *timer;
 };
 
 static int mk_event_libevent_socketpair(evutil_socket_t fd[2])
@@ -118,16 +121,54 @@ static inline void _mk_event_loop_destroy(struct mk_event_ctx *ctx)
     mk_mem_free(ctx);
 }
 
+/*
+ * Append an entry to the 'fired' array. The array is allocated once with
+ * 'queue_size' entries but the number of events registered in libevent is
+ * unbounded, so more than 'queue_size' events can become ready in a single
+ * event_base_loop() pass. Grow the array on demand instead of writing past
+ * its end.
+ *
+ * Growing here is safe: nothing keeps a pointer into ctx->fired across
+ * callbacks, libevent never references it, and consumers index it through
+ * ctx->fired only after event_base_loop() returns.
+ */
+static inline int mk_event_fired_push(struct mk_event_ctx *ctx,
+                                      int fd, uint32_t mask,
+                                      struct mk_event *event)
+{
+    size_t new_size;
+    struct mk_event *fired;
+
+    if ((size_t) ctx->fired_count >= ctx->queue_size) {
+        new_size = (ctx->queue_size > 0) ? ctx->queue_size * 2 : 256;
+        fired = mk_mem_realloc(ctx->fired, sizeof(struct mk_event) * new_size);
+        if (fired == NULL) {
+            /*
+             * Out of memory: drop this notification rather than overflow.
+             * Registered events are level triggered and persistent, so a
+             * still-ready descriptor is reported again on the next pass.
+             */
+            return -1;
+        }
+        ctx->fired = fired;
+        ctx->queue_size = new_size;
+    }
+
+    fired = &ctx->fired[ctx->fired_count];
+    fired->fd   = fd;
+    fired->mask = mask;
+    fired->data = event;
+
+    ctx->fired_count++;
+
+    return 0;
+}
+
 static void cb_event(evutil_socket_t fd, short flags, void *data)
 {
-    int i;
-    int mask = 0;
+    uint32_t mask = 0;
     struct mk_event *event = data;
-    struct mk_event *fired;
-    struct mk_event_ctx *ctx;
     struct ev_map *map = event->data;
-
-    ctx = map->ctx;
 
     /* Compose mask */
     if (flags & EV_READ) {
@@ -138,13 +179,7 @@ static void cb_event(evutil_socket_t fd, short flags, void *data)
     }
 
     /* Register the event in the fired array */
-    i = ctx->fired_count;
-    fired = &ctx->fired[i];
-    fired->fd   = event->fd;
-    fired->mask = mask;
-    fired->data = event;
-
-    ctx->fired_count++;
+    mk_event_fired_push(map->ctx, event->fd, mask, event);
 }
 
 /*
@@ -278,6 +313,20 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 
     mk_bug(ev_map == NULL);
 
+    /* Stop the timer first so cb_timeout() can never run against a freed map */
+    if (ev_map->timer != NULL) {
+        event_del(ev_map->timer);
+        event_free(ev_map->timer);
+        ev_map->timer = NULL;
+    }
+
+    /*
+     * Unregister from libevent before closing the descriptors: on Windows a
+     * closed socket handle can be reused by another thread right away.
+     */
+    ret = event_del(ev_map->event);
+    event_free(ev_map->event);
+
     if (ev_map->pipe[0] > 0) {
         evutil_closesocket(ev_map->pipe[0]);
         ev_map->pipe[0] = -1;
@@ -287,8 +336,6 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
         ev_map->pipe[1] = -1;
     }
 
-    ret = event_del(ev_map->event);
-    event_free(ev_map->event);
     mk_mem_free(ev_map);
 
     event->data = NULL;
@@ -304,8 +351,9 @@ static inline int _mk_event_del(struct mk_event_ctx *ctx, struct mk_event *event
 }
 
 /*
- * Timeout worker, it writes a byte every certain amount of seconds, it finish
- * once the other end of the pipe closes the fd[0].
+ * Timeout worker, it writes a byte every certain amount of seconds. It only
+ * signals: the lifetime of the timer, the socket pair and the ev_map is owned
+ * by _mk_event_del(), which stops this timer before releasing any of them.
  */
 static void cb_timeout(evutil_socket_t fd, short flags, void *data)
 {
@@ -314,15 +362,10 @@ static void cb_timeout(evutil_socket_t fd, short flags, void *data)
     struct ev_map *ev_map = data;
 
     ret = send(ev_map->pipe[1], (char *) &val, sizeof(uint64_t), 0);
-
     if (ret == -1) {
-        if (evutil_socket_geterror(fd) != ERR(ECONNABORTED)) {
+        if (evutil_socket_geterror(ev_map->pipe[1]) != ERR(ECONNABORTED)) {
             perror("write");
         }
-        evutil_closesocket(ev_map->pipe[1]);
-        event_del(ev_map->event);
-        event_free(ev_map->event);
-        mk_mem_free(ev_map);
     }
 }
 
@@ -351,52 +394,57 @@ static inline int _mk_event_timeout_create(struct mk_event_ctx *ctx,
 
     event = (struct mk_event *) data;
 
-    ev_map = mk_mem_alloc_z(sizeof(struct ev_map));
-    if (!ev_map) {
-        perror("malloc");
-        return -1;
-    }
-
-    ev_map->pipe[0] = fd[0];
-    ev_map->pipe[1] = fd[1];
-    ev_map->ctx = ctx;
-
-    libev = event_new(ctx->base, -1,
-                      EV_TIMEOUT | EV_PERSIST,
-                      cb_timeout, ev_map);
-    ev_map->event = libev;
-
-    event_add(libev, &timev);
-
     event->fd = fd[0];
     event->type = MK_EVENT_NOTIFICATION;
     event->mask = MK_EVENT_EMPTY;
 
-    _mk_event_add(ctx, fd[0], MK_EVENT_NOTIFICATION, MK_EVENT_READ, data);
+    /* Register the read end; this allocates the ev_map stored in event->data */
+    ret = _mk_event_add(ctx, fd[0], MK_EVENT_NOTIFICATION, MK_EVENT_READ, data);
+    if (ret != 0) {
+        evutil_closesocket(fd[0]);
+        evutil_closesocket(fd[1]);
+        return -1;
+    }
     event->mask = MK_EVENT_READ;
+
+    /*
+     * The same ev_map owns the socket pair and the timer, so _mk_event_del()
+     * releases everything in one place.
+     */
+    ev_map = event->data;
+    ev_map->pipe[0] = fd[0];
+    ev_map->pipe[1] = fd[1];
+
+    libev = event_new(ctx->base, -1,
+                      EV_TIMEOUT | EV_PERSIST,
+                      cb_timeout, ev_map);
+    if (libev == NULL) {
+        _mk_event_del(ctx, event);
+        return -1;
+    }
+    ev_map->timer = libev;
+
+    ret = event_add(libev, &timev);
+    if (ret != 0) {
+        _mk_event_del(ctx, event);
+        return -1;
+    }
 
     return fd[0];
 }
 
 static inline int _mk_event_timeout_destroy(struct mk_event_ctx *ctx, void *data)
 {
-    struct mk_event *event;
-
     if (data == NULL) {
         return 0;
     }
 
-    /* In the case that the timeout is being destroyed manually, we need to close the
-     * read end of the socket to ensure that cb_timeout will eventually fail to send
-     * data and clean itself up (including the write end of the socket and the event's
-     * data).
+    /*
+     * _mk_event_del() is the single owner of the timer, the socket pair and
+     * the ev_map: it stops the timer, unregisters the reader and closes both
+     * ends exactly once. Do not close event->fd here, it aliases pipe[0].
      */
-    event = (struct mk_event*)data; 
-    if (event->fd > 0) {
-        evutil_closesocket(event->fd);
-    }
-
-    return _mk_event_del(ctx, data);
+    return _mk_event_del(ctx, (struct mk_event *) data);
 }
 
 static inline int _mk_event_channel_create(struct mk_event_ctx *ctx,
@@ -475,11 +523,9 @@ static inline int _mk_event_inject(struct mk_event_loop *loop,
 
     event->mask = mask;
 
-    ctx->fired[ctx->fired_count].fd = event->fd;
-    ctx->fired[ctx->fired_count].mask = mask;
-    ctx->fired[ctx->fired_count].data = event;
-
-    ctx->fired_count++;
+    if (mk_event_fired_push(ctx, event->fd, mask, event) != 0) {
+        return -1;
+    }
     loop->n_events++;
 
     return 0;

--- a/tests/internal/flb_event_loop.c
+++ b/tests/internal/flb_event_loop.c
@@ -583,10 +583,102 @@ void event_loop_stress_priority_add_delete()
 #endif
 }
 
+/*
+ * Regression test: more events become ready in a single wait than the loop
+ * was created for. The libevent backend collected fired events in an array
+ * sized once at loop creation and wrote past its end in this situation
+ * (heap corruption / crash on Windows under heavy retry load).
+ */
+#define EVENT_LOOP_OVERFLOW_EVENTS (EVENT_LOOP_MAX_EVENTS * 4)
+
+void test_more_ready_events_than_loop_size()
+{
+    int i;
+    int ret;
+    int seen;
+    int passes;
+    uint64_t val = 1;
+    struct mk_event *event;
+    struct mk_event *events;
+    struct mk_event_loop *evl;
+    flb_pipefd_t (*fds)[2];
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+    WSAStartup(0x0201, &wsa_data);
+#endif
+
+    evl = mk_event_loop_create(EVENT_LOOP_MAX_EVENTS);
+    TEST_CHECK(evl != NULL);
+
+    events = flb_calloc(EVENT_LOOP_OVERFLOW_EVENTS, sizeof(struct mk_event));
+    fds = flb_calloc(EVENT_LOOP_OVERFLOW_EVENTS, sizeof(*fds));
+    TEST_CHECK(events != NULL && fds != NULL);
+
+    /* Register every read end and make all of them readable at once */
+    for (i = 0; i < EVENT_LOOP_OVERFLOW_EVENTS; i++) {
+        ret = flb_pipe_create(fds[i]);
+        TEST_CHECK(ret == 0);
+
+        MK_EVENT_NEW(&events[i]);
+        ret = mk_event_add(evl, fds[i][0], MK_EVENT_NOTIFICATION,
+                           MK_EVENT_READ, &events[i]);
+        TEST_CHECK(ret == 0);
+
+        ret = flb_pipe_w(fds[i][1], &val, sizeof(val));
+        TEST_CHECK(ret == sizeof(val));
+    }
+
+    /*
+     * Drain the loop. Backends with a kernel side cap (epoll) report at most
+     * the loop size per pass; the libevent backend reports everything in one
+     * pass, which is the overflowing case. Each event must be reported once.
+     */
+    seen = 0;
+    passes = 0;
+    while (seen < EVENT_LOOP_OVERFLOW_EVENTS &&
+           passes < EVENT_LOOP_OVERFLOW_EVENTS) {
+        ret = mk_event_wait_2(evl, 1000);
+        TEST_CHECK(ret > 0);
+        if (ret <= 0) {
+            break;
+        }
+        passes++;
+
+        mk_event_foreach(event, evl) {
+            i = (int) (event - events);
+            TEST_CHECK(i >= 0 && i < EVENT_LOOP_OVERFLOW_EVENTS);
+
+            ret = flb_pipe_r(event->fd, &val, sizeof(val));
+            TEST_CHECK(ret == sizeof(val));
+
+            mk_event_del(evl, event);
+            seen++;
+        }
+    }
+
+    TEST_CHECK(seen == EVENT_LOOP_OVERFLOW_EVENTS);
+    TEST_MSG("expected %d events, got %d in %d passes",
+             EVENT_LOOP_OVERFLOW_EVENTS, seen, passes);
+
+    for (i = 0; i < EVENT_LOOP_OVERFLOW_EVENTS; i++) {
+        flb_pipe_close(fds[i][0]);
+        flb_pipe_close(fds[i][1]);
+    }
+    flb_free(fds);
+    flb_free(events);
+    mk_event_loop_destroy(evl);
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
+}
+
 TEST_LIST = {
     {"test_simple_timeout_1000ms", test_simple_timeout_1000ms},
     {"test_non_blocking_and_blocking_timeout", test_non_blocking_and_blocking_timeout},
     {"test_infinite_wait", test_infinite_wait},
     {"event_loop_stress_priority_add_delete", event_loop_stress_priority_add_delete},
+    {"test_more_ready_events_than_loop_size", test_more_ready_events_than_loop_size},
     { 0 }
 };


### PR DESCRIPTION
<!-- Provide summary of changes -->

# This is a Canary PR. DO NOT MERGE THIS.

Currently, monkey core does not have a bound of firing events.
This PR adds a capability for proceeding out-of-bounds sized events on monkey core.


<html>
<body>
<!--StartFragment--><p dir="ltr"><strong>What is wrong.</strong> The libevent backend allocates <code>ctx-&gt;fired</code> once, at loop creation, with 256 entries for the engine loop, and never grows it. <code>cb_event</code> and <code>_mk_event_inject</code> append to it with no bounds check, so the 257th event that becomes ready in a single <code>event_base_loop</code> pass writes past the heap block. The reporter's stack trace, page-heap fault, and the fired_count of 546 in the 5.0.7 dump all match this. Only Windows is affected in practice, since the epoll and kqueue backends pass <code>queue_size</code> to the kernel and cannot overrun.</p><p dir="ltr"><strong>The fix, in <span role="button" tabindex="0">mk_event_libevent.c</span>:</strong></p><ul dir="ltr"><li><strong>Grow the fired array on demand.</strong> A new helper, <code>mk_event_fired_push</code>, doubles the array with <code>mk_mem_realloc</code> when it is full, and both append sites go through it. If the realloc fails, the notification is dropped instead of overflowing. That is safe because the events are level triggered and persistent, so a still-ready descriptor fires again on the next pass. Growing inside the callback is safe: I checked every consumer, and all of them re-read <code>ctx-&gt;fired</code> through the context pointer rather than caching a pointer into it.</li><li><strong>Deterministic timer teardown.</strong> The reporter's secondary claim of a double close and double free does not actually occur, because the timer and the read-side registration used two separate <code>ev_map</code> structs. What was real is that the timer's <code>ev_map</code>, its write socket, and its libevent timer lived on until <code>cb_timeout</code> noticed the peer was closed, and leaked entirely if the event was removed via plain <code>mk_event_del</code> or the loop was destroyed. Now one <code>ev_map</code> owns the socket pair and the timer, <code>_mk_event_del</code> stops the timer, unregisters, and closes both ends in one place, and <code>cb_timeout</code> only signals. <code>_mk_event_del</code> also now unregisters from libevent before closing sockets, since on Windows a closed handle can be reused by another thread immediately.</li></ul><p dir="ltr"><strong>Regression test</strong> in <span role="button" tabindex="0">flb_event_loop.c</span>: it creates a loop of size 64, registers 256 pipes that are all readable at once, and drains them. It is backend-neutral, since epoll simply needs more passes.</p><p dir="ltr">Verification with the NMake Debug tree in <code>build/</code>:</p><div dir="ltr">


Run | Result
-- | --
New test, old backend | crashes with access violation 0xc0000005
New test, fixed backend | passes
Full flb-it-flb_event_loop suite | passes
flb-it-scheduler suite (real timer create/destroy path) | passes

<p dir="ltr"><strong>Mitigation for users until a release ships</strong> is to keep the number of simultaneously ready events under 256: a finite <code>Retry_Limit</code> on the forward output, <code>storage.max_chunks_up</code> below 256, and <code>storage.total_limit_size</code> to bound the backlog. These reduce the odds but do not remove the bug.</p><!--EndFragment-->
</body>
</html>

Related to https://github.com/fluent/fluent-bit/issues/11905.

This patch is fully included in https://github.com/monkey/monkey/pull/446.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
