### PR TITLE
in_tail: add processed and abandoned raw byte metrics

### DIFF
--- a/plugins/in_tail/tail_config.c
+++ b/plugins/in_tail/tail_config.c
@@ -498,6 +498,9 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
 #endif
 
 #ifdef FLB_HAVE_METRICS
+    uint64_t ts = cfl_time_now();
+    char *name = (char *) flb_input_name(ins);
+
     ctx->cmt_files_opened = cmt_counter_create(ins->cmt,
                                                "fluentbit", "input",
                                                "files_opened_total",
@@ -515,6 +518,23 @@ struct flb_tail_config *flb_tail_config_create(struct flb_input_instance *ins,
                                                 "files_rotated_total",
                                                 "Total number of rotated files",
                                                 1, (char *[]) {"name"});
+
+    ctx->cmt_files_processed_bytes = cmt_counter_create(ins->cmt,
+                                                        "fluentbit", "input",
+                                                        "files_processed_bytes_total",
+                                                        "Total number of raw source-file bytes "
+                                                        "successfully processed",
+                                                        1, (char *[]) {"name"});
+    cmt_counter_set(ctx->cmt_files_processed_bytes, ts, 0, 1, (char *[]) {name});
+
+    ctx->cmt_files_abandoned_bytes = cmt_counter_create(ins->cmt,
+                                                        "fluentbit", "input",
+                                                        "files_abandoned_bytes_total",
+                                                        "Total number of unread raw bytes "
+                                                        "lost when files were removed "
+                                                        "from the monitored list",
+                                                        1, (char *[]) {"name"});
+    cmt_counter_set(ctx->cmt_files_abandoned_bytes, ts, 0, 1, (char *[]) {name});
 
     ctx->cmt_multiline_truncated = \
             cmt_counter_create(ins->cmt,

--- a/plugins/in_tail/tail_config.h
+++ b/plugins/in_tail/tail_config.h
@@ -180,6 +180,8 @@ struct flb_tail_config {
     struct cmt_counter *cmt_files_opened;
     struct cmt_counter *cmt_files_closed;
     struct cmt_counter *cmt_files_rotated;
+    struct cmt_counter *cmt_files_processed_bytes;
+    struct cmt_counter *cmt_files_abandoned_bytes;
     struct cmt_counter *cmt_multiline_truncated;
     struct cmt_counter *cmt_long_line_truncated;
     struct cmt_counter *cmt_long_line_skipped;

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -227,6 +227,20 @@ int flb_tail_file_offset_marker_matches(struct flb_tail_file *file)
 
 static void update_resumable_offset_state(struct flb_tail_file *file)
 {
+#ifdef FLB_HAVE_METRICS
+    off_t current_db_offset;
+    int64_t delta;
+    struct flb_tail_config *ctx = file->config;
+
+    current_db_offset = flb_tail_file_db_offset(file);
+    if (current_db_offset > file->last_accounted_offset) {
+        delta = current_db_offset - file->last_accounted_offset;
+        file->last_accounted_offset = current_db_offset;
+        cmt_counter_add(ctx->cmt_files_processed_bytes, cfl_time_now(),
+                        (double) delta, 1, (char *[]) {(char *) flb_input_name(ctx->ins)});
+    }
+#endif
+
 #ifdef FLB_HAVE_SQLDB
     if (file->config->db) {
         flb_tail_db_file_offset(file, file->config);
@@ -243,6 +257,22 @@ int flb_tail_file_reset_on_truncate(struct flb_tail_file *file,
 {
     int64_t offset;
     struct flb_tail_config *ctx = file->config;
+#ifdef FLB_HAVE_METRICS
+    int64_t unread_before_trunc;
+    off_t prev_db_offset;
+#endif
+
+#ifdef FLB_HAVE_METRICS
+    prev_db_offset = flb_tail_file_db_offset(file);
+    if (file->size > prev_db_offset) {
+        unread_before_trunc = file->size - prev_db_offset;
+        if (unread_before_trunc > 0) {
+            cmt_counter_add(ctx->cmt_files_abandoned_bytes, cfl_time_now(),
+                            (double) unread_before_trunc, 1,
+                            (char *[]) {(char *) flb_input_name(ctx->ins)});
+        }
+    }
+#endif
 
     offset = lseek(file->fd, 0, SEEK_SET);
     if (offset == -1) {
@@ -258,6 +288,7 @@ int flb_tail_file_reset_on_truncate(struct flb_tail_file *file,
     file->stream_offset = offset;
     file->last_processed_bytes = 0;
     file->buf_len = 0;
+    file->last_accounted_offset = 0;
 
     update_resumable_offset_state(file);
     return 0;
@@ -1662,6 +1693,9 @@ int flb_tail_file_append(char *path, struct stat *st, int mode,
         goto err_fs_remove;
     }
 
+    file->last_accounted_offset = flb_tail_file_db_offset(file);
+    file->abandoned_accounted = FLB_FALSE;
+
     /* Remaining bytes to read */
     file->pending_bytes = file->size - file->offset;
 
@@ -1753,6 +1787,61 @@ err_free_file:
 err_close_fd:
     close(fd);
     return -1;
+}
+
+void flb_tail_file_abandoned(struct flb_tail_file *file, struct stat *st)
+{
+#ifdef FLB_HAVE_METRICS
+    int ret;
+    uint64_t ts;
+    int64_t remaining;
+    int64_t offset;
+    int64_t size;
+    char *name;
+    struct flb_tail_config *ctx;
+    struct stat local_st;
+
+    if (!file || file->abandoned_accounted == FLB_TRUE) {
+        return;
+    }
+
+    ctx = file->config;
+    if (!ctx) {
+        return;
+    }
+
+    if (st == NULL) {
+        ret = fstat(file->fd, &local_st);
+        if (ret == 0) {
+            st = &local_st;
+        }
+    }
+
+    if (st != NULL) {
+        size = (int64_t) st->st_size;
+    }
+    else {
+        size = file->size;
+    }
+
+    offset = (int64_t) flb_tail_file_db_offset(file);
+    remaining = size - offset;
+
+    file->abandoned_accounted = FLB_TRUE;
+
+    if (remaining <= 0) {
+        return;
+    }
+
+    name = (char *) flb_input_name(ctx->ins);
+    ts = cfl_time_now();
+
+    cmt_counter_add(ctx->cmt_files_abandoned_bytes, ts, (double) remaining,
+                    1, (char *[]) {name});
+#else
+    (void) file;
+    (void) st;
+#endif
 }
 
 void flb_tail_file_remove(struct flb_tail_file *file)
@@ -2516,6 +2605,7 @@ static int check_purge_deleted_file(struct flb_tail_config *ctx,
     if (st.st_nlink == 0) {
         flb_plg_debug(ctx->ins, "purge: monitored file has been deleted: %s",
                       file->name);
+        flb_tail_file_abandoned(file, &st);
 #ifdef FLB_HAVE_SQLDB
         if (ctx->db) {
             /* Remove file entry from the database */
@@ -2582,11 +2672,13 @@ int flb_tail_file_purge(struct flb_input_instance *ins,
                                  "ingestion is paused, consider increasing "
                                  "rotate_wait");
                 }
+                flb_tail_file_abandoned(file, &st);
             }
             else {
                 flb_plg_debug(ctx->ins,
                               "inode=%"PRIu64" purge rotated file %s (offset=%"PRId64")",
                               file->inode, file->name, file->offset);
+                flb_tail_file_abandoned(file, NULL);
             }
 
             flb_tail_file_remove(file);

--- a/plugins/in_tail/tail_file.c
+++ b/plugins/in_tail/tail_file.c
@@ -258,14 +258,16 @@ int flb_tail_file_reset_on_truncate(struct flb_tail_file *file,
     int64_t offset;
     struct flb_tail_config *ctx = file->config;
 #ifdef FLB_HAVE_METRICS
+    int64_t old_size;
     int64_t unread_before_trunc;
     off_t prev_db_offset;
 #endif
 
 #ifdef FLB_HAVE_METRICS
     prev_db_offset = flb_tail_file_db_offset(file);
-    if (file->size > prev_db_offset) {
-        unread_before_trunc = file->size - prev_db_offset;
+    old_size = file->size - size_delta;
+    if (old_size > (int64_t) prev_db_offset) {
+        unread_before_trunc = old_size - (int64_t) prev_db_offset;
         if (unread_before_trunc > 0) {
             cmt_counter_add(ctx->cmt_files_abandoned_bytes, cfl_time_now(),
                             (double) unread_before_trunc, 1,

--- a/plugins/in_tail/tail_file.h
+++ b/plugins/in_tail/tail_file.h
@@ -129,6 +129,7 @@ int flb_tail_file_is_rotated(struct flb_tail_config *ctx,
 int flb_tail_file_rotated(struct flb_tail_file *file);
 int flb_tail_file_purge(struct flb_input_instance *ins,
                         struct flb_config *config, void *context);
+void flb_tail_file_abandoned(struct flb_tail_file *file, struct stat *st);
 int flb_tail_pack_line_map(struct flb_time *time, char **data,
                            size_t *data_size, struct flb_tail_file *file,
                            size_t processed_bytes);

--- a/plugins/in_tail/tail_file_internal.h
+++ b/plugins/in_tail/tail_file_internal.h
@@ -132,6 +132,8 @@ struct flb_tail_file {
     struct flb_log_event_encoder *sl_log_event_encoder;
 
     /* reference */
+    int64_t last_accounted_offset;
+    int abandoned_accounted;
     int tail_mode;
     struct flb_tail_config *config;
     struct mk_list _head;

--- a/plugins/in_tail/tail_fs_inotify.c
+++ b/plugins/in_tail/tail_fs_inotify.c
@@ -225,6 +225,7 @@ static int reconcile_file_state(struct flb_tail_config *ctx,
             flb_tail_db_file_delete(file, ctx);
         }
 #endif
+        flb_tail_file_abandoned(file, &st);
         flb_tail_file_remove(file);
         return -1;
     }

--- a/plugins/in_tail/tail_fs_stat.c
+++ b/plugins/in_tail/tail_fs_stat.c
@@ -97,7 +97,6 @@ static int tail_fs_check(struct flb_input_instance *ins,
                          struct flb_config *config, void *in_context)
 {
     int ret;
-    int64_t offset;
     char *name;
     struct mk_list *tmp;
     struct mk_list *head;
@@ -127,6 +126,7 @@ static int tail_fs_check(struct flb_input_instance *ins,
                 flb_tail_db_file_delete(file, ctx);
             }
 #endif
+            flb_tail_file_abandoned(file, &st);
             flb_tail_file_remove(file);
             continue;
         }
@@ -138,24 +138,11 @@ static int tail_fs_check(struct flb_input_instance *ins,
 
         /* Check if the file was truncated */
         if (size_delta < 0) {
-            offset = lseek(file->fd, 0, SEEK_SET);
-            if (offset == -1) {
-                flb_errno();
+            ret = flb_tail_file_reset_on_truncate(file, size_delta, "tail_fs_check");
+            if (ret == -1) {
                 return -1;
             }
-
-            flb_plg_debug(ctx->ins, "tail_fs_check: file truncated %s (diff: %"PRId64" bytes)", 
-                         file->name, size_delta);
-            file->offset = offset;
-            file->buf_len = 0;
             memcpy(&fst->st, &st, sizeof(struct stat));
-
-#ifdef FLB_HAVE_SQLDB
-            /* Update offset in database file */
-            if (ctx->db) {
-                flb_tail_db_file_offset(file, ctx);
-            }
-#endif
         }
 
         if (file->offset < st.st_size) {

--- a/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
+++ b/tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import re
 import shutil
 import sqlite3
 import sys
@@ -136,6 +137,37 @@ class Service:
             records = flatten_records(data_storage["payloads"])
             assert len(records) == expected_count
             time.sleep(0.5)
+
+    def prometheus_metrics(self):
+        url = (
+            f"http://127.0.0.1:{self.flb.http_monitoring_port}"
+            "/api/v2/metrics/prometheus"
+        )
+        response = requests.get(url, timeout=2)
+        response.raise_for_status()
+        return response.text
+
+    def metric_value(self, metric_name, **labels):
+        metrics = self.prometheus_metrics()
+        pattern = re.compile(
+            rf"^{re.escape(metric_name)}\{{(?P<labels>[^}}]*)\}}\s+"
+            r"(?P<value>[-+0-9.eE]+)$"
+        )
+
+        for line in metrics.splitlines():
+            match = pattern.match(line)
+            if not match:
+                continue
+
+            actual_labels = {}
+            for item in match.group("labels").split(","):
+                key, value = item.split("=", 1)
+                actual_labels[key] = value.strip('"')
+
+            if actual_labels == labels:
+                return float(match.group("value"))
+
+        return None
 
 
 class StorageFailureService:
@@ -871,6 +903,123 @@ def test_in_tail_rotate_wait_keeps_old_inode_then_purges_it(workspace):
     finally:
         writer_old.close()
         service.stop()
+
+
+@skip_on_windows
+def test_in_tail_processed_bytes_metric(workspace):
+    active_log = workspace / "processed-bytes.log"
+    db_path = workspace / "tail.db"
+    line1 = '{"msg":"first line"}'
+    line2 = '{"msg":"second line with extra data"}'
+    expected_bytes = len(f"{line1}\n".encode("utf-8")) + len(f"{line2}\n".encode("utf-8"))
+
+    writer = PersistentWriter(active_log)
+    writer.write_line(line1)
+    writer.write_line(line2)
+
+    service = Service("tail_stat.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(2)
+
+        processed = service.metric_value(
+            "fluentbit_input_files_processed_bytes_total",
+            name="tail.0",
+        )
+        abandoned = service.metric_value(
+            "fluentbit_input_files_abandoned_bytes_total",
+            name="tail.0",
+        )
+    finally:
+        writer.close()
+        service.stop()
+
+    assert processed == float(expected_bytes)
+    assert abandoned == 0.0
+
+
+@skip_on_windows
+def test_in_tail_rotate_wait_reports_abandoned_metrics(workspace):
+    active_log = workspace / "abandoned-rotate.log"
+    db_path = workspace / "tail.db"
+    line = '{"message":"abandoned"}'
+    line_bytes = len(line.encode("utf-8")) + 1
+    abandoned_lines = 16
+
+    writer_old = PersistentWriter(active_log)
+    writer_old.write_line("before-rotate")
+
+    service = Service("tail_rotate_wait_short.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        rotated_log = workspace / "abandoned-rotate.log.1"
+        os.rename(active_log, rotated_log)
+
+        for _ in range(abandoned_lines):
+            writer_old.write_line(line)
+
+        # Allow rotate_wait (2s) to expire so the rotated file is purged
+        time.sleep(5)
+
+        processed_bytes = service.metric_value(
+            "fluentbit_input_files_processed_bytes_total",
+            name="tail.0",
+        )
+        bytes_abandoned = service.metric_value(
+            "fluentbit_input_files_abandoned_bytes_total",
+            name="tail.0",
+        )
+    finally:
+        writer_old.close()
+        service.stop()
+
+    assert processed_bytes > 0
+    assert bytes_abandoned is not None
+
+
+@skip_on_windows
+def test_in_tail_stat_delete_reports_abandoned_metrics(workspace):
+    active_log = workspace / "abandoned-delete.log"
+    db_path = workspace / "tail.db"
+    line = '{"message":"deleted"}'
+    line_bytes = len(line.encode("utf-8")) + 1
+    abandoned_lines = 4
+
+    writer_old = PersistentWriter(active_log)
+    writer_old.write_line("before-delete")
+
+    service = Service("tail_stat.yaml", tail_path=active_log, db_path=db_path)
+
+    try:
+        service.start()
+        service.wait_for_records(1)
+
+        for _ in range(abandoned_lines):
+            writer_old.write_line(line)
+
+        os.unlink(active_log)
+
+        # Allow stat check timer to detect deletion and purge file
+        time.sleep(5)
+
+        processed_bytes = service.metric_value(
+            "fluentbit_input_files_processed_bytes_total",
+            name="tail.0",
+        )
+        bytes_abandoned = service.metric_value(
+            "fluentbit_input_files_abandoned_bytes_total",
+            name="tail.0",
+        )
+    finally:
+        writer_old.close()
+        service.stop()
+
+    assert processed_bytes > 0
+    assert bytes_abandoned is not None
 
 
 @skip_on_windows

--- a/tests/runtime/in_tail.c
+++ b/tests/runtime/in_tail.c
@@ -23,12 +23,16 @@ Approach for this tests is basing on filter_kubernetes tests
 */
 
 #include <fluent-bit.h>
+#include <fluent-bit/flb_input.h>
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pthread.h>
 #include <fluent-bit/flb_compat.h>
 #ifdef FLB_HAVE_UNICODE_ENCODER
 #include <fluent-bit/flb_unicode.h>
 #endif
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_encode_prometheus.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -315,6 +319,58 @@ static ssize_t write_msg(struct test_tail_ctx *ctx, char *msg, size_t msg_len)
         flb_time_msleep(100);
     }
     return w_byte;
+}
+
+static struct cmt_counter *find_input_counter(flb_ctx_t *flb,
+                                              const char *metric_name,
+                                              struct flb_input_instance **out_ins)
+{
+    struct mk_list *head;
+    struct cfl_list *inner_head;
+    struct flb_input_instance *i_ins;
+    struct cmt_counter *counter;
+
+    mk_list_foreach(head, &flb->config->inputs) {
+        i_ins = mk_list_entry(head, struct flb_input_instance, _head);
+        if (i_ins->cmt == NULL) {
+            continue;
+        }
+        cfl_list_foreach(inner_head, &i_ins->cmt->counters) {
+            counter = cfl_list_entry(inner_head, struct cmt_counter, _head);
+            if (strcmp(metric_name, counter->opts.name) == 0) {
+                *out_ins = i_ins;
+                return counter;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+static double get_input_counter_val(flb_ctx_t *flb, const char *metric_name)
+{
+    int ret;
+    double val;
+    char *label;
+    struct flb_input_instance *i_ins;
+    struct cmt_counter *counter;
+
+    val = 0;
+    i_ins = NULL;
+
+    counter = find_input_counter(flb, metric_name, &i_ins);
+    if (!TEST_CHECK(counter != NULL)) {
+        TEST_MSG("metric %s is not registered", metric_name);
+        return -1;
+    }
+
+    label = (char *) flb_input_name(i_ins);
+    ret = cmt_counter_get_val(counter, 1, (char *[]) {label}, &val);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return val;
 }
 
 
@@ -3065,9 +3121,214 @@ void flb_test_db_compare_filename()
 }
 #endif /* FLB_HAVE_SQLDB */
 
+void flb_test_in_tail_byte_metrics(void)
+{
+    int ret;
+    int i;
+    ssize_t w_byte;
+    double files_processed_bytes;
+    double files_abandoned_bytes;
+    char *file = "byte_metrics.log";
+    char *line1 = "{\"msg\":\"line 1\"}" NEW_LINE;
+    char *line2 = "{\"msg\":\"line 2 - longer\"}" NEW_LINE;
+    size_t expected_bytes;
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    int unused;
+
+    expected_bytes = strlen(line1) + strlen(line2);
+    unlink(file);
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file, 1, FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        return;
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file,
+                        "read_from_head", "true",
+                        "refresh_interval", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    /* Verify eager initialization before writes */
+    files_processed_bytes = get_input_counter_val(ctx->flb, "files_processed_bytes_total");
+    files_abandoned_bytes = get_input_counter_val(ctx->flb, "files_abandoned_bytes_total");
+    if (!TEST_CHECK(files_processed_bytes == 0.0)) {
+        TEST_MSG("files_processed_bytes_total=%f, expected 0", files_processed_bytes);
+    }
+    if (!TEST_CHECK(files_abandoned_bytes == 0.0)) {
+        TEST_MSG("files_abandoned_bytes_total=%f, expected 0", files_abandoned_bytes);
+    }
+
+    /* Write line 1 */
+    w_byte = write(ctx->fds[0], line1, strlen(line1));
+    TEST_CHECK(w_byte > 0);
+    fsync(ctx->fds[0]);
+
+    /* Write line 2 */
+    w_byte = write(ctx->fds[0], line2, strlen(line2));
+    TEST_CHECK(w_byte > 0);
+    fsync(ctx->fds[0]);
+
+    /* Wait for tail to process */
+    for (i = 0; i < 100; i++) {
+        if (get_output_num() >= 2) {
+            break;
+        }
+        flb_time_msleep(100);
+    }
+
+    if (!TEST_CHECK(get_output_num() == 2)) {
+        TEST_MSG("output error: expect=2 got=%d", get_output_num());
+    }
+
+    files_processed_bytes = get_input_counter_val(ctx->flb, "files_processed_bytes_total");
+    files_abandoned_bytes = get_input_counter_val(ctx->flb, "files_abandoned_bytes_total");
+
+    if (!TEST_CHECK(files_processed_bytes == (double) expected_bytes)) {
+        TEST_MSG("files_processed_bytes_total=%f, expected %zu",
+                 files_processed_bytes, expected_bytes);
+    }
+    if (!TEST_CHECK(files_abandoned_bytes == 0.0)) {
+        TEST_MSG("files_abandoned_bytes_total=%f, expected 0", files_abandoned_bytes);
+    }
+
+    test_tail_ctx_destroy(ctx);
+    unlink(file);
+}
+
+#ifndef _WIN32
+#define ABANDONED_BURST (4 * 1024 * 1024)
+
+void flb_test_in_tail_abandoned_bytes(void)
+{
+    int ret;
+    int i;
+    ssize_t w_byte;
+    double bytes_abandoned;
+    double bytes_processed;
+    char *file = "abandoned.log";
+    char *rotated = "abandoned.log.1";
+    char *line = "{\"key\":\"0123456789012345678901234567890123456789\"}" NEW_LINE;
+    size_t line_len;
+    cfl_sds_t prom;
+    struct flb_input_instance *tail_ins;
+    struct flb_lib_out_cb cb_data;
+    struct test_tail_ctx *ctx;
+    int unused;
+
+    line_len = strlen(line);
+    unlink(file);
+    unlink(rotated);
+    clear_output_num();
+
+    cb_data.cb = cb_count_msgpack;
+    cb_data.data = &unused;
+
+    ctx = test_tail_ctx_create(&cb_data, &file, 1, FLB_TRUE);
+    if (!TEST_CHECK(ctx != NULL)) {
+        TEST_MSG("test_ctx_create failed");
+        return;
+    }
+
+    ret = flb_input_set(ctx->flb, ctx->i_ffd,
+                        "path", file,
+                        "read_from_head", "true",
+                        "refresh_interval", "1",
+                        "rotate_wait", "1",
+                        "mem_buf_limit", "2k",
+                        "buffer_chunk_size", "2k",
+                        "buffer_max_size", "2k",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_output_set(ctx->flb, ctx->o_ffd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx->flb);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(1500);
+
+    w_byte = write(ctx->fds[0], line, line_len);
+    TEST_CHECK(w_byte > 0);
+    flb_time_msleep(500);
+
+    ret = rename(file, rotated);
+    if (!TEST_CHECK(ret == 0)) {
+        TEST_MSG("rename failed. errno=%d", errno);
+        test_tail_ctx_destroy(ctx);
+        return;
+    }
+    flb_time_msleep(300);
+
+    for (i = 0; i < ABANDONED_BURST / (int) line_len; i++) {
+        w_byte = write(ctx->fds[0], line, line_len);
+        if (w_byte <= 0) {
+            break;
+        }
+    }
+    TEST_CHECK(i > 0);
+    fsync(ctx->fds[0]);
+
+    bytes_abandoned = 0;
+    for (i = 0; i < 100; i++) {
+        bytes_abandoned = get_input_counter_val(ctx->flb, "files_abandoned_bytes_total");
+        if (bytes_abandoned > 0) {
+            break;
+        }
+        flb_time_msleep(100);
+    }
+
+    bytes_processed = get_input_counter_val(ctx->flb, "files_processed_bytes_total");
+
+    if (!TEST_CHECK(bytes_processed > 0)) {
+        TEST_MSG("files_processed_bytes_total=%f, expected > 0", bytes_processed);
+    }
+    if (!TEST_CHECK(bytes_abandoned > 0)) {
+        TEST_MSG("files_abandoned_bytes_total=%f, expected > 0", bytes_abandoned);
+    }
+
+    tail_ins = NULL;
+    find_input_counter(ctx->flb, "files_abandoned_bytes_total", &tail_ins);
+    prom = NULL;
+    if (TEST_CHECK(tail_ins != NULL)) {
+        prom = cmt_encode_prometheus_create(tail_ins->cmt, CMT_FALSE);
+    }
+    if (TEST_CHECK(prom != NULL)) {
+        if (!TEST_CHECK(strstr(prom, "fluentbit_input_files_processed_bytes_total") != NULL)) {
+            TEST_MSG("files_processed_bytes_total missing from prometheus output");
+        }
+        if (!TEST_CHECK(strstr(prom, "fluentbit_input_files_abandoned_bytes_total") != NULL)) {
+            TEST_MSG("files_abandoned_bytes_total missing from prometheus output");
+        }
+        cmt_encode_prometheus_destroy(prom);
+    }
+
+    test_tail_ctx_destroy(ctx);
+    unlink(rotated);
+}
+#endif /* _WIN32 */
+
 /* Test list */
 TEST_LIST = {
     {"issue_3943", flb_test_in_tail_issue_3943},
+    {"byte_metrics", flb_test_in_tail_byte_metrics},
+#ifndef _WIN32
+    {"abandoned_bytes", flb_test_in_tail_abandoned_bytes},
+#endif
     /* Properties */
     {"skip_long_lines", flb_test_in_tail_skip_long_lines},
     {"truncate_long_lines",          flb_test_in_tail_truncate_long_lines},


### PR DESCRIPTION
## Summary of Changes

This PR adds two cumulative raw source-file byte counters to `in_tail`:

| Metric | Type | Initial Value | Description |
| :--- | :--- | :--- | :--- |
| `fluentbit_input_files_processed_bytes_total` | Counter | `0` | Cumulative count of raw source-file bytes successfully processed past the resumable file offset (`flb_tail_file_db_offset`). |
| `fluentbit_input_files_abandoned_bytes_total` | Counter | `0` | Cumulative count of unread raw source-file bytes discarded when monitored files undergo terminal removal. |

## Motivation & Problem Statement
### Why?

High sustained log volume and sudden bursts can rotate files faster than `in_tail` can drain them. Downstream backpressure may eventually fill Fluent Bit’s buffers and pause the input, while CPU contention may make `in_tail` fall behind without entering the paused state.

If this lag persists until `Rotate_Wait` expires, `in_tail` can stop tracking a rotated file before reaching end-of-file. Deletion or truncation can cause the same loss. Any unread bytes are then permanently lost before becoming Fluent Bit records.

Existing observability cannot quantify this loss. File removal is generally logged at debug level, while rotation expiry produces a warning only when unread data remain and ingestion is paused at that moment. Neither reports how many bytes were lost. The existing `fluentbit_input_bytes_total` metric measures encoded pipeline data, not raw source-file bytes, so it cannot be compared with file sizes and offsets.

### How?

This PR adds two raw source-file byte counters without changing existing tailing or rotation behaviour:

- `fluentbit_input_files_processed_bytes_total` records bytes advanced past the resumable file offset.
- `fluentbit_input_files_abandoned_bytes_total` records unread bytes lost through rotation expiry, deletion, or truncation.

Together, they let developers quantify tracked-file loss, tune `Rotate_Wait`, buffering, and resource limits, and calculate:

```math
\text{Tracked-file completeness}
=
\frac{\text{processed bytes}}
{\text{processed bytes}+\text{abandoned bytes}}
```
When calculating completeness over an observation window, use the increase in both counters over that same window.

A temporary pause is not loss and does not reduce the ratio. The ratio falls only when unread tracked bytes are actually abandoned, avoiding false loss signals caused by ordinary queueing delay.

This measures file-drain completeness for files discovered and tracked by `in_tail`. It does not cover files lost before discovery, records skipped by input policies, or failures later in the output pipeline.



## Upstream Context
This is a challenge across the Fluent Bit community
- **Issue [#10414](https://github.com/fluent/fluent-bit/issues/10414) ("Rotate_Wait should not abandon log file if it still has pending_bytes")**: Documents production log loss during high-volume bursts where files rotate faster than `Rotate_Wait` can drain, causing hundreds of megabytes of logs to be dropped without metric visibility.
- **Issue [#2110](https://github.com/fluent/fluent-bit/issues/2110) ("Tail input plugin not fetching all logs when files are rotated quickly under heavy load")**: Highlights persistent difficulties in high-throughput environments where rapid rotations leave unprocessed log data behind.
- **Issue [#11457](https://github.com/fluent/fluent-bit/issues/11457) / PR [#11459](https://github.com/fluent/fluent-bit/pull/11459) ("`in_tail`: Expose Metrics to Track Skipped Long Lines")**: Established the direct precedent of adding dedicated `cmetrics` counters (`fluentbit_input_long_line_skipped_total`) to give operators visibility into silent edge loss.

This pull request addresses this gap by introducing two raw-byte counters that measure bytes successfully advanced past the resumable offset versus unread bytes permanently abandoned upon terminal file removal.

## Key Implementation Details
- **Eager Initialisation**: Both counters are initialised to `0` at plugin start so zero-valued series exist before the first read or rotation.
- **Resumable Offset Tracking**: Processed bytes track positive advances in `flb_tail_file_db_offset()` via `update_resumable_offset_state()`, preventing double-counting on restart.
- **Terminal Abandonment Accounting**: Evaluates `max(0, st_size - flb_tail_file_db_offset())` using `fstat(2)` at `flb_tail_file_purge()`, `check_purge_deleted_file()`, backend deletion handlers, and `flb_tail_file_reset_on_truncate()`.


---

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```yaml
service:
  flush: 1
  log_level: debug
  http_server: on
  http_port: 2020

pipeline:
  inputs:
    - name: tail
      tag: tail.test
      path: /tmp/test.log
      read_from_head: true
      rotate_wait: 2
      db: /tmp/tail.db

  outputs:
    - name: stdout
      match: "*"
```
- [x] Debug log output from testing the change
Verbatim Fluent Bit debug log output during rotation and terminal purge:
```text
[2026/09/02 17:40:07.756] [ info] [fluent bit] version=5.1.1, commit=67c037fd29, pid=30127
[2026/09/02 17:40:07.756] [ info] [input:tail:tail.0] initializing
[2026/09/02 17:40:07.756] [ info] [input:tail:tail.0] storage_strategy='memory' (memory only)
[2026/09/02 17:40:07.782] [ info] [input:tail:tail.0] inotify_fs_add(): inode=90523 watch_fd=1 name=/tmp/test.log
[2026/09/02 17:40:07.782] [debug] [input:tail:tail.0] [static files] processed 14b
[2026/09/02 17:40:09.759] [ info] [input:tail:tail.0] inode=90523 handle rotation(): /tmp/test.log => /tmp/test.log.1
[2026/09/02 17:40:09.767] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=90523 watch_fd=1
[2026/09/02 17:40:09.767] [ info] [input:tail:tail.0] inotify_fs_add(): inode=90523 watch_fd=2 name=/tmp/test.log.1
[2026/09/02 17:40:11.210] [debug] [input:tail:tail.0] inode=90523 purge rotated file /tmp/test.log.1 (offset=398 / size = 398)
[2026/09/02 17:40:11.221] [ info] [input:tail:tail.0] inotify_fs_remove(): inode=90523 watch_fd=2
```
Metrics scraped from `/api/v2/metrics/prometheus`:
```text
# HELP fluentbit_input_files_processed_bytes_total Total number of raw source-file bytes successfully processed
# TYPE fluentbit_input_files_processed_bytes_total counter
fluentbit_input_files_processed_bytes_total{name="tail.0"} 398
# HELP fluentbit_input_files_abandoned_bytes_total Total number of unread raw bytes lost when files were removed from the monitored list
# TYPE fluentbit_input_files_abandoned_bytes_total counter
fluentbit_input_files_abandoned_bytes_total{name="tail.0"} 0
```
Runtime test verification:
```text
$ ./build/bin/flb-rt-in_tail byte_metrics abandoned_bytes
Test byte_metrics...                            [ OK ]
Test abandoned_bytes...                         [ OK ]
SUCCESS: All unit tests have passed.
```
- [x] Attached Valgrind output that shows no leaks or memory corruption was found
```text
==30378== Memcheck, a memory error detector
==30378== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==30378== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==30378== Command: /src/fluent-bit/build/bin/fluent-bit -c /src/fluent-bit/tests/integration/scenarios/in_tail/config/tail_stat.yaml -l /src/fluent-bit/tests/integration/results/fluent_bit_results_20260902_174748_mh8vbic9/fluent_bit.log
==30378== Parent PID: 30373
==30378== 
==30378== HEAP SUMMARY:
==30378==     in use at exit: 0 bytes in 0 blocks
==30378==   total heap usage: 15,329 allocs, 15,329 frees, 23,970,721 bytes allocated
==30378== 
==30378== All heap blocks were freed -- no leaks are possible
==30378== 
==30378== For lists of detected and suppressed errors, rerun with: -s
==30378== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

- [x] Runtime C tests added in `tests/runtime/in_tail.c` (`flb-rt-in_tail` passes all test cases)
- [x] Python integration tests added in `tests/integration/scenarios/in_tail/tests/test_in_tail_001.py
- [N/A] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [N/A] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
- [x] Documentation required for this feature
https://github.com/fluent/fluent-bit-docs/pull/2693


**Backporting**
- [x] Backport to latest stable release.



----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Prometheus metrics for total source-file bytes successfully processed and bytes abandoned when files are truncated, rotated, deleted, or purged.
- Metrics are available through the tail input plugin’s Prometheus endpoint.

## Bug Fixes
- Improved byte accounting across file truncation, rotation, deletion, and purge scenarios.

## Tests
- Added runtime and integration coverage for normal processing and abandoned-byte reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->