### PR TITLE
out_azure_logs_ingestion: add payload size metrics

### DIFF
--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -260,6 +260,10 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
     int is_compressed = FLB_FALSE;
     flb_sds_t json_payload = NULL;
     struct flb_az_li *ctx = out_context;
+#ifdef FLB_HAVE_METRICS
+    uint64_t metrics_timestamp;
+    char *output_name;
+#endif
     (void) i_ins;
     (void) config;
 
@@ -320,6 +324,19 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
     }
     flb_http_add_header(c, "Authorization", 13, token, flb_sds_len(token));
     flb_http_buffer_size(c, FLB_HTTP_DATA_SIZE_MAX);
+
+#ifdef FLB_HAVE_METRICS
+    metrics_timestamp = cfl_time_now();
+    output_name = (char *) flb_output_name(ctx->ins);
+    cmt_histogram_observe(ctx->cmt_uncompressed_payload_size,
+                          metrics_timestamp,
+                          (double) json_payload_size,
+                          1, (char *[]) {output_name});
+    cmt_histogram_observe(ctx->cmt_http_payload_size,
+                          metrics_timestamp,
+                          (double) final_payload_size,
+                          1, (char *[]) {output_name});
+#endif
 
     /* Execute rest call */
     ret = flb_http_do(c, &b_sent);

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -38,6 +38,10 @@
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_sds.h>
 
+#ifdef FLB_HAVE_METRICS
+#include <cmetrics/cmt_histogram.h>
+#endif
+
 /* Context structure for Azure Logs Ingestion API */
 struct flb_az_li {
     /* log ingestion account setup */
@@ -66,6 +70,11 @@ struct flb_az_li {
     /* upstream connection to the data collection endpoint */
     struct flb_upstream *u_dce;
     flb_sds_t dce_u_url;
+
+#ifdef FLB_HAVE_METRICS
+    struct cmt_histogram *cmt_uncompressed_payload_size;
+    struct cmt_histogram *cmt_http_payload_size;
+#endif
 
     /* plugin output and config instance reference */
     struct flb_output_instance *ins;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -26,6 +26,68 @@
 #include "azure_logs_ingestion.h"
 #include "azure_logs_ingestion_conf.h"
 
+#ifdef FLB_HAVE_METRICS
+static const double payload_size_buckets[] = {
+    262144.0,
+    524288.0,
+    786432.0,
+    1048576.0,
+    1310720.0,
+    1572864.0,
+    1835008.0,
+    2097152.0
+};
+
+static int initialize_payload_size_metrics(struct flb_az_li *ctx)
+{
+    struct cmt_histogram_buckets *buckets;
+
+    buckets = cmt_histogram_buckets_create_size(
+                    (double *) payload_size_buckets,
+                    sizeof(payload_size_buckets) / sizeof(payload_size_buckets[0]));
+    if (!buckets) {
+        flb_plg_error(ctx->ins, "could not create uncompressed payload size buckets");
+        return -1;
+    }
+
+    ctx->cmt_uncompressed_payload_size = cmt_histogram_create(
+                    ctx->ins->cmt,
+                    "fluentbit",
+                    "azure_logs_ingestion",
+                    "uncompressed_payload_size_bytes",
+                    "Uncompressed request payload size in bytes.",
+                    buckets,
+                    1, (char *[]) {"name"});
+    if (!ctx->cmt_uncompressed_payload_size) {
+        flb_plg_error(ctx->ins, "could not create uncompressed payload size histogram");
+        return -1;
+    }
+
+    buckets = cmt_histogram_buckets_create_size(
+                    (double *) payload_size_buckets,
+                    sizeof(payload_size_buckets) / sizeof(payload_size_buckets[0]));
+    if (!buckets) {
+        flb_plg_error(ctx->ins, "could not create HTTP payload size buckets");
+        return -1;
+    }
+
+    ctx->cmt_http_payload_size = cmt_histogram_create(
+                    ctx->ins->cmt,
+                    "fluentbit",
+                    "azure_logs_ingestion",
+                    "http_payload_size_bytes",
+                    "HTTP request payload size in bytes.",
+                    buckets,
+                    1, (char *[]) {"name"});
+    if (!ctx->cmt_http_payload_size) {
+        flb_plg_error(ctx->ins, "could not create HTTP payload size histogram");
+        return -1;
+    }
+
+    return 0;
+}
+#endif
+
 static int validate_auth_url_override(struct flb_output_instance *ins,
                                       flb_sds_t auth_url_override)
 {
@@ -185,6 +247,14 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     flb_sds_snprintf(&ctx->dce_u_url, flb_sds_alloc(ctx->dce_u_url),
                     FLB_AZ_LI_DCE_URL_TMPLT, ctx->dce_url, 
                     ctx->dcr_id, ctx->table_name);
+
+#ifdef FLB_HAVE_METRICS
+    ret = initialize_payload_size_metrics(ctx);
+    if (ret == -1) {
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+#endif
 
     /* Initialize the auth mutex */
     pthread_mutex_init(&ctx->token_mutex, NULL);

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 import requests
 
@@ -13,14 +14,62 @@ from utils.test_service import FluentBitTestService
 
 logger = logging.getLogger(__name__)
 
+METRIC_RE = re.compile(
+    r'^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)\{(?P<labels>[^}]*)\}\s+(?P<value>[-+0-9.eE]+)$'
+)
+UNCOMPRESSED_PAYLOAD_SIZE_METRIC = (
+    "fluentbit_azure_logs_ingestion_uncompressed_payload_size_bytes"
+)
+HTTP_PAYLOAD_SIZE_METRIC = "fluentbit_azure_logs_ingestion_http_payload_size_bytes"
+PAYLOAD_SIZE_BUCKETS = [
+    262144,
+    524288,
+    786432,
+    1048576,
+    1310720,
+    1572864,
+    1835008,
+    2097152,
+]
+
+
+def _labels_to_dict(labels):
+    result = {}
+    for item in labels.split(","):
+        key, value = item.split("=", 1)
+        result[key] = value.strip('"')
+    return result
+
+
+def _metric_value(metrics, metric_name, **labels):
+    for line in metrics.splitlines():
+        match = METRIC_RE.match(line)
+        if not match or match.group("name") != metric_name:
+            continue
+        if _labels_to_dict(match.group("labels")) == labels:
+            return float(match.group("value"))
+    return None
+
+
+def _metric_series(metrics, metric_name):
+    series = []
+    for line in metrics.splitlines():
+        match = METRIC_RE.match(line)
+        if match and match.group("name") == metric_name:
+            series.append(
+                (_labels_to_dict(match.group("labels")), float(match.group("value")))
+            )
+    return series
+
 
 class Service:
-    def __init__(self, config_file):
+    def __init__(self, config_file, initial_http_status=200):
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
         cert_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate"))
         self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
         self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
         self.oauth_server_port = None
+        self.initial_http_status = initial_http_status
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
@@ -43,6 +92,7 @@ class Service:
             tls_key_file=self.tls_key_file,
             reset_state=False,
         )
+        configure_http_response(status_code=self.initial_http_status)
 
         def _http_ready():
             try:
@@ -115,25 +165,72 @@ class Service:
             description=f"{minimum_count} azure logs ingestion requests",
         )
 
+    def wait_for_data_responses(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: requests_seen
+            if len(
+                requests_seen := [
+                    request
+                    for request in data_storage["requests"]
+                    if request.get("response_completed")
+                ]
+            )
+            >= minimum_count
+            else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} completed azure logs ingestion responses",
+        )
+
+    def metrics(self, expected, timeout=10):
+        url = (
+            f"http://127.0.0.1:{self.flb.http_monitoring_port}"
+            "/api/v2/metrics/prometheus"
+        )
+        return self.service.wait_for_condition(
+            lambda: response.text
+            if (
+                (response := requests.get(url, timeout=2)).status_code == 200
+                and expected in response.text
+            )
+            else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"prometheus metric {expected}",
+        )
+
 
 def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
-    service = Service("out_azure_logs_ingestion_oauth2.yaml")
+    service = Service("out_azure_logs_ingestion_oauth2.yaml", initial_http_status=500)
     service.start()
-    configure_http_response(status_code=200, body={"status": "received"})
-    configure_oauth_token_response(
-        status_code=200,
-        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
-    )
+    try:
+        configure_oauth_token_response(
+            status_code=200,
+            body={
+                "access_token": "oauth-access-token",
+                "token_type": "Bearer",
+                "expires_in": 300,
+            },
+        )
 
-    requests_seen = service.wait_for_requests(2, timeout=15)
-    service.stop()
+        requests_seen = service.wait_for_requests(2, timeout=15)
+        configure_http_response(status_code=200, body={"status": "received"})
+        requests_seen = service.wait_for_requests(3, timeout=15)
+        service.wait_for_data_responses(2, timeout=15)
+        metrics = service.metrics(
+            f'{HTTP_PAYLOAD_SIZE_METRIC}_count{{name="azure_logs_ingestion.0"}} 2'
+        )
+    finally:
+        service.stop()
 
     token_request = next(request for request in requests_seen if request["path"] == "/oauth/token")
-    data_request = next(
+    data_requests = [
         request
         for request in requests_seen
         if request["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
-    )
+    ]
+    data_request = data_requests[-1]
+    assert [request["response_status"] for request in data_requests] == [500, 200]
 
     assert token_request["method"] == "POST"
     assert "grant_type=client_credentials" in token_request["raw_data"]
@@ -154,3 +251,29 @@ def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
     assert payload[0]["source"] == "dummy"
     assert payload[0]["level"] == "info"
     assert isinstance(payload[0]["@timestamp"], (int, float))
+
+    output_name = "azure_logs_ingestion.0"
+    expected_uncompressed_size = sum(
+        len(request["decoded_data"].encode("utf-8")) for request in data_requests
+    )
+    expected_http_size = sum(
+        int(request["headers"]["Content-Length"]) for request in data_requests
+    )
+
+    for metric_name, expected_size in [
+        (UNCOMPRESSED_PAYLOAD_SIZE_METRIC, expected_uncompressed_size),
+        (HTTP_PAYLOAD_SIZE_METRIC, expected_http_size),
+    ]:
+        assert f"# TYPE {metric_name} histogram" in metrics
+        assert _metric_value(metrics, f"{metric_name}_count", name=output_name) == 2
+        assert _metric_value(metrics, f"{metric_name}_sum", name=output_name) == expected_size
+
+        bucket_series = [
+            (labels["le"], value)
+            for labels, value in _metric_series(metrics, f"{metric_name}_bucket")
+            if labels.get("name") == output_name
+        ]
+        assert bucket_series == [
+            *[(f"{bucket}.0", 2) for bucket in PAYLOAD_SIZE_BUCKETS],
+            ("+Inf", 2),
+        ]

--- a/tests/integration/src/server/http_server.py
+++ b/tests/integration/src/server/http_server.py
@@ -193,47 +193,50 @@ def _build_streaming_response(config):
     )
 
 
-def _build_response():
-    if response_config["delay_seconds"]:
-        _sleep_interruptible(response_config["delay_seconds"])
+def _build_response(config):
+    if config["delay_seconds"]:
+        _sleep_interruptible(config["delay_seconds"])
 
-    if response_config["hang_before_response"]:
+    if config["hang_before_response"]:
         _wait_for_shutdown()
         return Response(status=503)
 
-    if response_config["stream_fragments"] is not None:
-        return _build_streaming_response(response_config)
+    if config["stream_fragments"] is not None:
+        return _build_streaming_response(config)
 
-    body = response_config["body"]
+    body = config["body"]
     if isinstance(body, (dict, list)):
-        return jsonify(body), response_config["status_code"]
+        return jsonify(body), config["status_code"]
 
     return Response(
         body,
-        status=response_config["status_code"],
-        content_type=response_config["content_type"],
+        status=config["status_code"],
+        content_type=config["content_type"],
     )
 
 
-def _record_request():
+def _record_request(response_status=None):
     raw_payload = request.get_data(cache=True)
     decoded_payload = _decode_payload(raw_payload)
     data = _decode_json_payload(decoded_payload)
     raw_data = raw_payload.decode("utf-8", errors="replace")
     decoded_data = decoded_payload.decode("utf-8", errors="replace")
+    request_data = {
+        "path": request.path,
+        "query_string": request.query_string.decode("utf-8", errors="replace"),
+        "method": request.method,
+        "headers": dict(request.headers),
+        "raw_data": raw_data,
+        "decoded_data": decoded_data,
+        "json": data,
+    }
+
+    if response_status is not None:
+        request_data["response_status"] = response_status
 
     data_storage["payloads"].append(data)
-    data_storage["requests"].append(
-        {
-            "path": request.path,
-            "query_string": request.query_string.decode("utf-8", errors="replace"),
-            "method": request.method,
-            "headers": dict(request.headers),
-            "raw_data": raw_data,
-            "decoded_data": decoded_data,
-            "json": data,
-        }
-    )
+    data_storage["requests"].append(request_data)
+    return request_data
 
 
 def _decode_payload(raw_payload):
@@ -259,16 +262,22 @@ def _decode_json_payload(decoded_payload):
 @app.route('/loki/api/v1/push', methods=['POST'])
 @app.route('/dataCollectionRules/<path:subpath>', methods=['POST'])
 def receive_data(subpath=None):
-    _record_request()
-    return _build_response()
+    response_snapshot = response_config.copy()
+    request_data = _record_request(response_status=response_snapshot["status_code"])
+    response = _build_response(response_snapshot)
+    request_data["response_completed"] = True
+    return response
 
 
 @app.route('/services/collector', methods=['POST'])
 @app.route('/services/collector/event', methods=['POST'])
 @app.route('/services/collector/raw', methods=['POST'])
 def receive_splunk_hec():
-    _record_request()
-    return _build_response()
+    response_snapshot = response_config.copy()
+    request_data = _record_request(response_status=response_snapshot["status_code"])
+    response = _build_response(response_snapshot)
+    request_data["response_completed"] = True
+    return response
 
 
 @app.route('/jwks', methods=['GET'])


### PR DESCRIPTION
## Problem

The Azure Logs Ingestion output does not expose the size of its formatted JSON payload or the final HTTP request body, making it difficult to monitor request-size distributions and compression effectiveness.

## Changes

- add `fluentbit_azure_logs_ingestion_uncompressed_payload_size_bytes`
- add `fluentbit_azure_logs_ingestion_http_payload_size_bytes`
- expose both as histograms labeled by output instance
- use eight 256 KiB buckets from 256 KiB through 2 MiB
- record every HTTP send attempt, including failed attempts and retries
- make the integration receiver snapshot and report the response selected for each request so retry coverage is deterministic

## Testing

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8 --target fluent-bit-bin`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py tests/integration/scenarios/out_splunk/tests/test_out_splunk_001.py -q`
- `LEAKS=1 LEAKS_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py -q`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`

## Compatibility

This is an additive metrics-only change. Existing configuration and request behavior are unchanged.

This pull request was created with AI assistance.