### PR TITLE
out_opentelemetry: support metrics max datapoints

### DIFF
--- a/include/fluent-bit/flb_input_chunk.h
+++ b/include/fluent-bit/flb_input_chunk.h
@@ -179,6 +179,10 @@ int flb_input_chunk_set_up_down(struct flb_input_chunk *ic);
 int flb_input_chunk_set_up(struct flb_input_chunk *ic);
 int flb_input_chunk_down(struct flb_input_chunk *ic);
 int flb_input_chunk_is_up(struct flb_input_chunk *ic);
+int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
+                                        size_t chunk_size);
+int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
+                                         size_t chunk_size);
 void flb_input_chunk_update_output_instances(struct flb_input_chunk *ic,
                                              ssize_t chunk_size);
 

--- a/plugins/out_opentelemetry/opentelemetry.c
+++ b/plugins/out_opentelemetry/opentelemetry.c
@@ -25,6 +25,7 @@
 #include <fluent-bit/flb_kv.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_log_event_decoder.h>
+#include <fluent-bit/flb_opentelemetry.h>
 #include <fluent-bit/flb_ra_key.h>
 
 #include <cfl/cfl.h>
@@ -48,9 +49,6 @@
 #include <fluent-bit/flb_signv4.h>
 #endif
 #endif
-
-extern cfl_sds_t cmt_encode_opentelemetry_create(struct cmt *cmt);
-extern void cmt_encode_opentelemetry_destroy(cfl_sds_t text);
 
 #include "opentelemetry.h"
 #include "opentelemetry_conf.h"
@@ -730,6 +728,67 @@ static int opentelemetry_format_test(struct flb_config *config,
     return 0;
 }
 
+static int post_metrics_payload(struct opentelemetry_context *ctx,
+                                struct flb_event_chunk *event_chunk,
+                                flb_sds_t payload)
+{
+    int result;
+    int split_result;
+    size_t index;
+    struct cmt_opentelemetry_batches *batches;
+
+    if (ctx->metrics_max_datapoints == 0) {
+        return opentelemetry_post(ctx,
+                                  payload,
+                                  flb_sds_len(payload),
+                                  event_chunk->tag,
+                                  flb_sds_len(event_chunk->tag),
+                                  ctx->metrics_uri_sanitized,
+                                  ctx->grpc_metrics_uri);
+    }
+
+    batches = cmt_encode_opentelemetry_split_payload(
+                  payload,
+                  flb_sds_len(payload),
+                  (size_t) ctx->metrics_max_datapoints,
+                  &split_result);
+    if (batches == NULL) {
+        flb_plg_error(ctx->ins,
+                      "could not split metric payload into batches: %i",
+                      split_result);
+        if (split_result == CMT_ENCODE_OPENTELEMETRY_ALLOCATION_ERROR) {
+            return FLB_RETRY;
+        }
+        return FLB_ERROR;
+    }
+
+    result = FLB_OK;
+    for (index = 0; index < batches->count; index++) {
+        result = opentelemetry_post(ctx,
+                                    batches->entries[index].payload,
+                                    cfl_sds_len(batches->entries[index].payload),
+                                    event_chunk->tag,
+                                    flb_sds_len(event_chunk->tag),
+                                    ctx->metrics_uri_sanitized,
+                                    ctx->grpc_metrics_uri);
+        if (result != FLB_OK) {
+            if (result == FLB_RETRY && index > 0) {
+                flb_plg_warn(ctx->ins,
+                             "metric payload partially succeeded (%zu/%zu batches); "
+                             "skipping retry to avoid resending accepted data",
+                             index,
+                             batches->count);
+                result = FLB_OK;
+            }
+            break;
+        }
+    }
+
+    cmt_encode_opentelemetry_destroy_batches(batches);
+
+    return result;
+}
+
 static int process_metrics(struct flb_event_chunk *event_chunk,
                            struct flb_output_flush *out1_flush,
                            struct flb_input_instance *ins, void *out_context,
@@ -796,11 +855,7 @@ static int process_metrics(struct flb_event_chunk *event_chunk,
         flb_plg_debug(ctx->ins, "final payload size: %lu", flb_sds_len(buf));
         if (buf && flb_sds_len(buf) > 0) {
             /* Send HTTP request */
-            result = opentelemetry_post(ctx, buf, flb_sds_len(buf),
-                                        event_chunk->tag,
-                                        flb_sds_len(event_chunk->tag),
-                                        ctx->metrics_uri_sanitized,
-                                        ctx->grpc_metrics_uri);
+            result = post_metrics_payload(ctx, event_chunk, buf);
 
             /* Debug http_post() result statuses */
             if (result == FLB_OK) {
@@ -1020,6 +1075,12 @@ static int cb_opentelemetry_init(struct flb_output_instance *ins,
         ctx->batch_size = atoi(DEFAULT_LOG_RECORD_BATCH_SIZE);
     }
 
+    if (ctx->metrics_max_datapoints < 0) {
+        flb_plg_error(ins, "metrics_max_datapoints must be zero or greater");
+        flb_opentelemetry_context_destroy(ctx);
+        return -1;
+    }
+
     flb_output_set_context(ins, ctx);
 
     /*
@@ -1116,6 +1177,12 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_STR, "grpc_metrics_uri", "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export",
      0, FLB_TRUE, offsetof(struct opentelemetry_context, grpc_metrics_uri),
      "Specify an optional gRPC URI for the target OTel endpoint."
+    },
+    {
+     FLB_CONFIG_MAP_INT, "metrics_max_datapoints", DEFAULT_METRICS_MAX_DATAPOINTS,
+     0, FLB_TRUE, offsetof(struct opentelemetry_context, metrics_max_datapoints),
+     "Set the maximum number of metric data points per OTLP export request "
+     "(0 disables the limit; default: 0)"
     },
 
     {

--- a/plugins/out_opentelemetry/opentelemetry.h
+++ b/plugins/out_opentelemetry/opentelemetry.h
@@ -44,6 +44,7 @@
 #define DEFAULT_LOG_RECORD_BATCH_SIZE "1000"
 #define DEFAULT_MAX_RESOURCE_EXPORT   "0"    /* no resource limits */
 #define DEFAULT_MAX_SCOPE_EXPORT      "0"    /* no scope limits */
+#define DEFAULT_METRICS_MAX_DATAPOINTS "0"    /* no data point limit */
 
 struct opentelemetry_body_key {
     flb_sds_t key;
@@ -144,6 +145,9 @@ struct opentelemetry_context {
 
     /* Number of logs to flush at a time */
     int batch_size;
+
+    /* Maximum number of metric data points per OTLP export request */
+    int metrics_max_datapoints;
 
     /* Maximum number of resources per OTLP export */
     int max_resources;

--- a/src/flb_http_client.c
+++ b/src/flb_http_client.c
@@ -2560,6 +2560,7 @@ struct flb_http_client_session *flb_http_client_session_begin(struct flb_http_cl
 
     if (protocol_version == HTTP_PROTOCOL_VERSION_20) {
         flb_stream_disable_keepalive(&upstream->base);
+        flb_upstream_conn_recycle(connection, FLB_FALSE);
     }
 
     session = flb_http_client_session_create(client, protocol_version, connection);

--- a/src/flb_input_chunk.c
+++ b/src/flb_input_chunk.c
@@ -1170,6 +1170,35 @@ int flb_input_chunk_release_space_compound(
     return 0;
 }
 
+static int flb_input_chunk_output_would_exceed_limit(
+                struct flb_output_instance *o_ins,
+                size_t chunk_size,
+                size_t *available_space)
+{
+    size_t remaining_space;
+
+    remaining_space = 0;
+
+    if (o_ins->fs_chunks_size <= o_ins->total_limit_size) {
+        remaining_space = o_ins->total_limit_size - o_ins->fs_chunks_size;
+        if (o_ins->fs_backlog_chunks_size <= remaining_space) {
+            remaining_space -= o_ins->fs_backlog_chunks_size;
+
+            if (available_space != NULL) {
+                *available_space = remaining_space;
+            }
+
+            return chunk_size > remaining_space;
+        }
+    }
+
+    if (available_space != NULL) {
+        *available_space = 0;
+    }
+
+    return FLB_TRUE;
+}
+
 /*
  * Find a slot in the output instance to append the new data with size chunk_size, it
  * will drop the the oldest chunks when the limitation on local disk is reached.
@@ -1198,9 +1227,8 @@ int flb_input_chunk_find_space_new_data(struct flb_input_chunk *ic,
             (flb_routes_mask_get_bit(ic->routes_mask,
                                      o_ins->id,
                                      o_ins->config->router) == 0) ||
-            (o_ins->fs_chunks_size +
-             o_ins->fs_backlog_chunks_size +
-             chunk_size) <= o_ins->total_limit_size) {
+            flb_input_chunk_output_would_exceed_limit(o_ins, chunk_size,
+                                                      NULL) == FLB_FALSE) {
             continue;
         }
 
@@ -1234,6 +1262,8 @@ int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
                                          size_t chunk_size)
 {
     int overlimit = 0;
+    int route_overlimit;
+    size_t available_space;
     struct mk_list *head;
     struct flb_output_instance *o_ins;
 
@@ -1248,16 +1278,14 @@ int flb_input_chunk_has_overlimit_routes(struct flb_input_chunk *ic,
         }
 
         FS_CHUNK_SIZE_DEBUG(o_ins);
+        route_overlimit = flb_input_chunk_output_would_exceed_limit(
+                              o_ins, chunk_size, &available_space);
         flb_trace("[input chunk] chunk %s required %ld bytes and %ld bytes left "
                   "in plugin %s", flb_input_chunk_get_name(ic), chunk_size,
-                  o_ins->total_limit_size -
-                  o_ins->fs_backlog_chunks_size -
-                  o_ins->fs_chunks_size,
+                  available_space,
                   o_ins->name);
 
-        if ((o_ins->fs_chunks_size +
-             o_ins->fs_backlog_chunks_size +
-             chunk_size) > o_ins->total_limit_size) {
+        if (route_overlimit == FLB_TRUE) {
             overlimit = FLB_TRUE;
         }
     }

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -490,6 +490,7 @@ Covers:
 - metadata and message key mapping
 - `add_label`
 - `batch_size`
+- `metrics_max_datapoints`
 - `logs_max_resources`
 - `logs_max_scopes`
 

--- a/tests/integration/scenarios/out_opentelemetry/config/out_otel_grpc_metrics_max_datapoints.conf
+++ b/tests/integration/scenarios/out_opentelemetry/config/out_otel_grpc_metrics_max_datapoints.conf
@@ -1,0 +1,19 @@
+[SERVICE]
+    flush        1
+    log_level    info
+    http_server  on
+    http_port    ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+[INPUT]
+    name  opentelemetry
+    port  ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+[OUTPUT]
+    name                    opentelemetry
+    match                   *
+    host                    127.0.0.1
+    port                    ${TEST_SUITE_HTTP_PORT}
+    http2                   on
+    grpc                    on
+    grpc_metrics_uri        /batched.metrics.v1.Metrics/Export
+    metrics_max_datapoints  4

--- a/tests/integration/scenarios/out_opentelemetry/config/out_otel_http_metrics_max_datapoints.conf
+++ b/tests/integration/scenarios/out_opentelemetry/config/out_otel_http_metrics_max_datapoints.conf
@@ -1,0 +1,17 @@
+[SERVICE]
+    flush        1
+    log_level    info
+    http_server  on
+    http_port    ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+[INPUT]
+    name  opentelemetry
+    port  ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+[OUTPUT]
+    name                    opentelemetry
+    match                   *
+    host                    127.0.0.1
+    port                    ${TEST_SUITE_HTTP_PORT}
+    metrics_uri             /batched/metrics
+    metrics_max_datapoints  4

--- a/tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
+++ b/tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import os
+import shutil
 import socket
 import threading
 
@@ -22,6 +23,7 @@ from server.http_server import (
 )
 from server.otlp_server import (
     configure_otlp_grpc_methods,
+    configure_otlp_response,
     data_storage,
     otlp_server_run,
     stop_otlp_server,
@@ -523,6 +525,111 @@ def _build_conditional_grouped_logs_payload():
     return {"resource_logs": resource_logs}
 
 
+def _build_batched_metrics_payload():
+    def attributes(series_id):
+        return [
+            {
+                "key": "series.id",
+                "value": {
+                    "string_value": str(series_id),
+                },
+            }
+        ]
+
+    def resource(service_name, metric):
+        return {
+            "schema_url": f"https://example.com/resource/{service_name}/1.0.0",
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "string_value": service_name,
+                        },
+                    }
+                ],
+            },
+            "scope_metrics": [
+                {
+                    "scope": {
+                        "name": f"batch-test-{service_name}",
+                        "version": "1.0.0",
+                    },
+                    "schema_url": f"https://example.com/scope/{service_name}/1.0.0",
+                    "metrics": [metric],
+                }
+            ],
+        }
+
+    gauge_points = [
+        {
+            "attributes": attributes(series_id),
+            "time_unix_nano": str(1704067200000000000 + series_id),
+            "as_int": series_id,
+        }
+        for series_id in range(7)
+    ]
+    sum_points = [
+        {
+            "attributes": attributes(series_id),
+            "start_time_unix_nano": "1704067200000000000",
+            "time_unix_nano": str(1704067200000000000 + series_id),
+            "as_int": series_id,
+        }
+        for series_id in range(7, 11)
+    ]
+
+    return {
+        "resource_metrics": [
+            resource(
+                "service-a",
+                {
+                    "name": "batch.gauge",
+                    "gauge": {
+                        "data_points": gauge_points,
+                    },
+                },
+            ),
+            resource(
+                "service-b",
+                {
+                    "name": "batch.sum",
+                    "sum": {
+                        "data_points": sum_points,
+                        "aggregation_temporality": 2,
+                        "is_monotonic": True,
+                    },
+                },
+            ),
+        ]
+    }
+
+
+def iter_metric_points_with_resource(output):
+    data_keys = ("gauge", "sum", "histogram", "exponentialHistogram", "summary")
+
+    for resource_metric in output.get("resourceMetrics", []):
+        resource_attributes = _attributes_to_dict(
+            resource_metric.get("resource", {}).get("attributes", [])
+        )
+        resource_schema_url = resource_metric.get("schemaUrl")
+        for scope_metric in resource_metric.get("scopeMetrics", []):
+            scope = scope_metric.get("scope", {})
+            scope_schema_url = scope_metric.get("schemaUrl")
+            for metric in scope_metric.get("metrics", []):
+                for data_key in data_keys:
+                    if data_key in metric:
+                        for point in metric[data_key].get("dataPoints", []):
+                            yield (
+                                point,
+                                resource_attributes,
+                                resource_schema_url,
+                                scope,
+                                scope_schema_url,
+                            )
+                        break
+
+
 def _assert_log_resource_attribution(logs_seen):
     output = json.loads(json_format.MessageToJson(logs_seen[0]))
     records = list(iter_log_records(output))
@@ -717,6 +824,10 @@ def test_out_opentelemetry_gzip_and_logs_body_key_attributes():
     assert "message" not in attributes
 
 
+@pytest.mark.skipif(
+    shutil.which("zstd") is None,
+    reason="zstd executable is required to decode the test payload",
+)
 def test_out_opentelemetry_zstd_and_logs_body_key_attributes():
     service = Service("out_otel_http_logs_zstd.yaml")
     service.start()
@@ -849,6 +960,118 @@ def test_out_opentelemetry_grpc_metrics_uri():
     assert request_seen["path"] == "/custom.metrics.v1.Metrics/Push"
     assert request_seen["headers"]["x-metrics"] == "grpc"
     assert output["resourceMetrics"]
+
+
+@pytest.mark.parametrize(
+    "config_file,receiver_mode,request_path",
+    [
+        ("out_otel_http_metrics_max_datapoints.conf", "http", "/batched/metrics"),
+        (
+            "out_otel_grpc_metrics_max_datapoints.conf",
+            "grpc",
+            "/batched.metrics.v1.Metrics/Export",
+        ),
+    ],
+    ids=["http", "grpc"],
+)
+def test_out_opentelemetry_metrics_max_datapoints(
+    config_file,
+    receiver_mode,
+    request_path,
+):
+    grpc_methods = {"metrics": request_path} if receiver_mode == "grpc" else None
+    service = Service(
+        config_file,
+        receiver_mode=receiver_mode,
+        grpc_methods=grpc_methods,
+    )
+    service.start()
+    service.send_payload_dict(_build_batched_metrics_payload(), "metrics")
+    metrics_seen = service.wait_for_signal("metrics", minimum_count=3, timeout=15)
+    requests_seen = service.wait_for_requests(3, timeout=15)
+    service.stop()
+
+    assert len(metrics_seen) == 3
+    assert len(requests_seen) == 3
+    assert {request["path"] for request in requests_seen} == {request_path}
+
+    batch_sizes = []
+    observed_series = {}
+    for export_request in metrics_seen:
+        output = json.loads(json_format.MessageToJson(export_request))
+        points = list(iter_metric_points_with_resource(output))
+        batch_sizes.append(len(points))
+        assert len(points) <= 4
+
+        for (
+            point,
+            resource_attributes,
+            resource_schema_url,
+            scope,
+            scope_schema_url,
+        ) in points:
+            point_attributes = _attributes_to_dict(point.get("attributes", []))
+            series_id = int(point_attributes["series.id"])
+            assert series_id not in observed_series
+            service_name = "service-a" if series_id < 7 else "service-b"
+            assert resource_attributes["service.name"] == service_name
+            assert resource_schema_url == (
+                f"https://example.com/resource/{service_name}/1.0.0"
+            )
+            assert scope == {
+                "name": f"batch-test-{service_name}",
+                "version": "1.0.0",
+            }
+            assert scope_schema_url == (
+                f"https://example.com/scope/{service_name}/1.0.0"
+            )
+            observed_series[series_id] = service_name
+
+    assert sorted(batch_sizes) == [3, 4, 4]
+    assert observed_series == {
+        **{series_id: "service-a" for series_id in range(7)},
+        **{series_id: "service-b" for series_id in range(7, 11)},
+    }
+
+
+def test_out_opentelemetry_metrics_partial_success_is_not_retried():
+    payload = _build_batched_metrics_payload()
+    resource_metrics = payload["resource_metrics"]
+    gauge_points = resource_metrics[0]["scope_metrics"][0]["metrics"][0]["gauge"]
+    gauge_points["data_points"].extend(
+        resource_metrics[1]["scope_metrics"][0]["metrics"][0]["sum"]["data_points"]
+    )
+    payload["resource_metrics"] = [resource_metrics[0]]
+
+    service = Service("out_otel_http_metrics_max_datapoints.conf")
+    service.start()
+    try:
+        configure_otlp_response(status_codes=[200, 503, 200])
+        service.send_payload_dict(payload, "metrics")
+        metrics_seen = service.wait_for_signal("metrics", minimum_count=2, timeout=15)
+        _wait_for_log_message(service, "metric payload partially succeeded")
+        requests_seen = list(data_storage["requests"])
+    finally:
+        service.stop()
+
+    assert len(metrics_seen) == 2
+    assert len(requests_seen) == 2
+
+    batch_series = []
+    for export_request in metrics_seen:
+        output = json.loads(json_format.MessageToJson(export_request))
+        points = list(iter_metric_points_with_resource(output))
+        assert len(points) == 4
+        batch_series.append(
+            {
+                int(_attributes_to_dict(point.get("attributes", []))["series.id"])
+                for point, _, _, _, _ in points
+            }
+        )
+
+    assert batch_series[0] == {0, 1, 2, 3}
+    assert batch_series[1] == {4, 5, 6, 7}
+    assert {8, 9, 10}.isdisjoint(set().union(*batch_series))
 
 
 def test_out_opentelemetry_traces_uri():

--- a/tests/integration/src/server/otlp_server.py
+++ b/tests/integration/src/server/otlp_server.py
@@ -42,6 +42,7 @@ app = Flask(__name__)
 data_storage = {"traces": [], "metrics": [], "logs": [], "requests": []}
 response_config = {
     "status_code": 200,
+    "status_codes": [],
     "body": {"status": "received"},
     "content_type": "application/json",
     "delay_seconds": 0,
@@ -65,6 +66,7 @@ def reset_otlp_server_state():
     response_config.update(
         {
             "status_code": 200,
+            "status_codes": [],
             "body": {"status": "received"},
             "content_type": "application/json",
             "delay_seconds": 0,
@@ -80,9 +82,18 @@ def reset_otlp_server_state():
     shutdown_flag.clear()
 
 
-def configure_otlp_response(*, status_code=None, body=None, content_type=None, delay_seconds=None):
+def configure_otlp_response(
+    *,
+    status_code=None,
+    status_codes=None,
+    body=None,
+    content_type=None,
+    delay_seconds=None,
+):
     if status_code is not None:
         response_config["status_code"] = status_code
+    if status_codes is not None:
+        response_config["status_codes"] = list(status_codes)
     if body is not None:
         response_config["body"] = body
     if content_type is not None:
@@ -101,16 +112,21 @@ def configure_otlp_grpc_methods(*, logs=None, metrics=None, traces=None):
 
 
 def _build_response():
+    status_code = response_config["status_code"]
+
     if response_config["delay_seconds"]:
         time.sleep(response_config["delay_seconds"])
 
+    if response_config["status_codes"]:
+        status_code = response_config["status_codes"].pop(0)
+
     body = response_config["body"]
     if isinstance(body, (dict, list)):
-        return jsonify(body), response_config["status_code"]
+        return jsonify(body), status_code
 
     return Response(
         body,
-        status=response_config["status_code"],
+        status=status_code,
         content_type=response_config["content_type"],
     )
 

--- a/tests/internal/input_chunk_routes.c
+++ b/tests/internal/input_chunk_routes.c
@@ -752,6 +752,21 @@ static void test_chunk_restore_alias_plugin_match_multiple()
                                        http_out.id,
                                        config.router) == 0);
 
+    /* A saturated counter must remain over the configured storage limit. */
+    stdout_one.total_limit_size = 1024;
+    stdout_one.fs_chunks_size = SIZE_MAX - 1;
+    stdout_two.total_limit_size = (size_t) -1;
+    http_out.total_limit_size = (size_t) -1;
+
+    flb_input_chunk_update_output_instances(ic, 2);
+
+    TEST_CHECK(stdout_one.fs_chunks_size == SIZE_MAX);
+    TEST_CHECK(flb_input_chunk_has_overlimit_routes(ic, 1) == FLB_TRUE);
+    TEST_CHECK(flb_input_chunk_find_space_new_data(ic, 1) == 1);
+
+    stdout_one.fs_chunks_size = 0;
+    ic->fs_counted = FLB_FALSE;
+
 cleanup:
     cleanup_test_routing_scenario(ic, &stdout_one, &stdout_two, &http_out,
                                   &in, &config, chunk, ctx, config_ready,

--- a/tests/internal/opentelemetry.c
+++ b/tests/internal/opentelemetry.c
@@ -2706,6 +2706,667 @@ void test_opentelemetry_metrics_msgpack_otlp_proto_merges_contexts()
     destroy_metrics_context_list(&contexts);
 }
 
+void test_opentelemetry_metrics_otlp_proto_data_point_batches()
+{
+    int index;
+    int result;
+    int ret;
+    int seen[11];
+    size_t batch_index;
+    size_t resource_index;
+    size_t scope_index;
+    size_t metric_index;
+    size_t point_index;
+    size_t total_data_points;
+    uint64_t timestamp;
+    char *label_keys[] = {"series"};
+    char *label_values[1];
+    char *series[] = {
+        "series-0", "series-1", "series-2", "series-3", "series-4", "series-5",
+        "series-6", "series-7", "series-8", "series-9", "series-10"
+    };
+    struct cmt *context;
+    struct cmt_gauge *gauge;
+    struct cmt_opentelemetry_batches *batches;
+    Opentelemetry__Proto__Metrics__V1__Metric *metric;
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics *scope;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics *resource;
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *point;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *decoded;
+
+    memset(seen, 0, sizeof(seen));
+    context = cmt_create();
+    TEST_CHECK(context != NULL);
+    if (context == NULL) {
+        return;
+    }
+
+    gauge = cmt_gauge_create(context,
+                             "test",
+                             "batch",
+                             "value",
+                             "batching test",
+                             1,
+                             label_keys);
+    TEST_CHECK(gauge != NULL);
+    if (gauge == NULL) {
+        cmt_destroy(context);
+        return;
+    }
+
+    for (index = 0; index < 11; index++) {
+        label_values[0] = series[index];
+        ret = cmt_gauge_set(gauge,
+                            (uint64_t) index + 1,
+                            (double) index,
+                            1,
+                            label_values);
+        TEST_CHECK(ret == 0);
+    }
+
+    batches = cmt_encode_opentelemetry_create_batches(context, 4, &result);
+    TEST_CHECK(result == CMT_ENCODE_OPENTELEMETRY_SUCCESS);
+    TEST_CHECK(batches != NULL);
+    if (batches == NULL) {
+        cmt_destroy(context);
+        return;
+    }
+
+    TEST_CHECK(batches->count == 3);
+    TEST_CHECK(batches->entries[0].data_point_count == 4);
+    TEST_CHECK(batches->entries[1].data_point_count == 4);
+    TEST_CHECK(batches->entries[2].data_point_count == 3);
+
+    total_data_points = 0;
+    for (batch_index = 0; batch_index < batches->count; batch_index++) {
+        decoded =
+            opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__unpack(
+                NULL,
+                cfl_sds_len(batches->entries[batch_index].payload),
+                (uint8_t *) batches->entries[batch_index].payload);
+        TEST_CHECK(decoded != NULL);
+        if (decoded == NULL) {
+            continue;
+        }
+
+        for (resource_index = 0;
+             resource_index < decoded->n_resource_metrics;
+             resource_index++) {
+            resource = decoded->resource_metrics[resource_index];
+            for (scope_index = 0; scope_index < resource->n_scope_metrics; scope_index++) {
+                scope = resource->scope_metrics[scope_index];
+                for (metric_index = 0; metric_index < scope->n_metrics; metric_index++) {
+                    metric = scope->metrics[metric_index];
+                    TEST_CHECK(metric->data_case ==
+                               OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE);
+                    if (metric->data_case !=
+                        OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
+                        continue;
+                    }
+
+                    for (point_index = 0;
+                         point_index < metric->gauge->n_data_points;
+                         point_index++) {
+                        point = metric->gauge->data_points[point_index];
+                        timestamp = point->time_unix_nano;
+                        TEST_CHECK(timestamp >= 1 && timestamp <= 11);
+                        if (timestamp >= 1 && timestamp <= 11) {
+                            seen[timestamp - 1]++;
+                        }
+                        total_data_points++;
+                    }
+                }
+            }
+        }
+
+        opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__free_unpacked(
+            decoded,
+            NULL);
+    }
+
+    TEST_CHECK(total_data_points == 11);
+    for (index = 0; index < 11; index++) {
+        TEST_CHECK(seen[index] == 1);
+    }
+
+    cmt_encode_opentelemetry_destroy_batches(batches);
+
+    batches = cmt_encode_opentelemetry_create_batches(context, 11, &result);
+    TEST_CHECK(result == CMT_ENCODE_OPENTELEMETRY_SUCCESS);
+    TEST_CHECK(batches != NULL);
+    if (batches != NULL) {
+        TEST_CHECK(batches->count == 1);
+        TEST_CHECK(batches->entries[0].data_point_count == 11);
+        cmt_encode_opentelemetry_destroy_batches(batches);
+    }
+
+    batches = cmt_encode_opentelemetry_create_batches(context, 0, &result);
+    TEST_CHECK(result == CMT_ENCODE_OPENTELEMETRY_SUCCESS);
+    TEST_CHECK(batches != NULL);
+    if (batches != NULL) {
+        TEST_CHECK(batches->count == 1);
+        TEST_CHECK(batches->entries[0].data_point_count == 11);
+        cmt_encode_opentelemetry_destroy_batches(batches);
+    }
+
+    cmt_destroy(context);
+
+    batches = cmt_encode_opentelemetry_split_payload("invalid", 7, 4, &result);
+    TEST_CHECK(batches == NULL);
+    TEST_CHECK(result == CMT_ENCODE_OPENTELEMETRY_INVALID_ARGUMENT_ERROR);
+}
+
+void test_opentelemetry_metrics_otlp_proto_batches_all_metric_types()
+{
+    int result;
+    int gauge_seen;
+    int sum_seen;
+    int histogram_seen;
+    int exp_histogram_seen;
+    int summary_seen;
+    int gauge_points_seen[3] = {0};
+    int sum_points_seen[3] = {0};
+    int histogram_points_seen[3] = {0};
+    int exp_histogram_points_seen[3] = {0};
+    int summary_points_seen[3] = {0};
+    size_t payload_size;
+    size_t batch_index;
+    size_t resource_index;
+    size_t scope_index;
+    size_t metric_index;
+    size_t point_index;
+    size_t data_point_index;
+    size_t total_data_points;
+    flb_sds_t payload;
+    Opentelemetry__Proto__Metrics__V1__Metric *metric;
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *number_point;
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *histogram_point;
+    Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint
+        *exp_histogram_point;
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *summary_point;
+    Opentelemetry__Proto__Metrics__V1__Metric metrics[5];
+    Opentelemetry__Proto__Metrics__V1__Metric *metric_entries[5];
+    Opentelemetry__Proto__Metrics__V1__Gauge gauge;
+    Opentelemetry__Proto__Metrics__V1__Sum sum;
+    Opentelemetry__Proto__Metrics__V1__Histogram histogram;
+    Opentelemetry__Proto__Metrics__V1__ExponentialHistogram exp_histogram;
+    Opentelemetry__Proto__Metrics__V1__Summary summary;
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint gauge_point_values[3];
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint sum_point_values[3];
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *gauge_points[3];
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *sum_points[3];
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint histogram_point_values[3];
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *histogram_points[3];
+    Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint
+        exp_histogram_point_values[3];
+    Opentelemetry__Proto__Metrics__V1__ExponentialHistogramDataPoint
+        *exp_histogram_points[3];
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint summary_point_values[3];
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *summary_points[3];
+    Opentelemetry__Proto__Resource__V1__Resource resource_metadata;
+    Opentelemetry__Proto__Common__V1__InstrumentationScope scope_metadata;
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics scope;
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics *scopes[1];
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics resource;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics *resources[1];
+    Opentelemetry__Proto__Metrics__V1__ScopeMetrics *decoded_scope;
+    Opentelemetry__Proto__Metrics__V1__ResourceMetrics *decoded_resource;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest request;
+    Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *decoded;
+    struct cmt_opentelemetry_batches *batches;
+
+    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__init(
+        &request);
+    opentelemetry__proto__metrics__v1__resource_metrics__init(&resource);
+    opentelemetry__proto__metrics__v1__scope_metrics__init(&scope);
+    opentelemetry__proto__metrics__v1__gauge__init(&gauge);
+    opentelemetry__proto__metrics__v1__sum__init(&sum);
+    opentelemetry__proto__metrics__v1__histogram__init(&histogram);
+    opentelemetry__proto__metrics__v1__exponential_histogram__init(&exp_histogram);
+    opentelemetry__proto__metrics__v1__summary__init(&summary);
+    opentelemetry__proto__resource__v1__resource__init(&resource_metadata);
+    opentelemetry__proto__common__v1__instrumentation_scope__init(&scope_metadata);
+
+    for (metric_index = 0; metric_index < 5; metric_index++) {
+        opentelemetry__proto__metrics__v1__metric__init(&metrics[metric_index]);
+        metric_entries[metric_index] = &metrics[metric_index];
+    }
+
+    for (point_index = 0; point_index < 3; point_index++) {
+        opentelemetry__proto__metrics__v1__number_data_point__init(
+            &gauge_point_values[point_index]);
+        opentelemetry__proto__metrics__v1__number_data_point__init(
+            &sum_point_values[point_index]);
+        opentelemetry__proto__metrics__v1__histogram_data_point__init(
+            &histogram_point_values[point_index]);
+        opentelemetry__proto__metrics__v1__exponential_histogram_data_point__init(
+            &exp_histogram_point_values[point_index]);
+        opentelemetry__proto__metrics__v1__summary_data_point__init(
+            &summary_point_values[point_index]);
+
+        gauge_points[point_index] = &gauge_point_values[point_index];
+        gauge_point_values[point_index].start_time_unix_nano = 100 + point_index;
+        gauge_point_values[point_index].time_unix_nano = 1000 + point_index;
+        gauge_point_values[point_index].flags = 1 + point_index;
+        gauge_point_values[point_index].value_case =
+            OPENTELEMETRY__PROTO__METRICS__V1__NUMBER_DATA_POINT__VALUE_AS_INT;
+        gauge_point_values[point_index].as_int = 10 + point_index;
+
+        sum_points[point_index] = &sum_point_values[point_index];
+        sum_point_values[point_index].start_time_unix_nano = 200 + point_index;
+        sum_point_values[point_index].time_unix_nano = 2000 + point_index;
+        sum_point_values[point_index].flags = 11 + point_index;
+        sum_point_values[point_index].value_case =
+            OPENTELEMETRY__PROTO__METRICS__V1__NUMBER_DATA_POINT__VALUE_AS_DOUBLE;
+        sum_point_values[point_index].as_double = 20.5 + point_index;
+
+        histogram_points[point_index] = &histogram_point_values[point_index];
+        histogram_point_values[point_index].start_time_unix_nano = 300 + point_index;
+        histogram_point_values[point_index].time_unix_nano = 3000 + point_index;
+        histogram_point_values[point_index].count = 30 + point_index;
+        histogram_point_values[point_index].has_sum = FLB_TRUE;
+        histogram_point_values[point_index].sum = 30.5 + point_index;
+        histogram_point_values[point_index].flags = 21 + point_index;
+        histogram_point_values[point_index].has_min = FLB_TRUE;
+        histogram_point_values[point_index].min = 3.5 + point_index;
+        histogram_point_values[point_index].has_max = FLB_TRUE;
+        histogram_point_values[point_index].max = 35.5 + point_index;
+
+        exp_histogram_points[point_index] = &exp_histogram_point_values[point_index];
+        exp_histogram_point_values[point_index].start_time_unix_nano = 400 + point_index;
+        exp_histogram_point_values[point_index].time_unix_nano = 4000 + point_index;
+        exp_histogram_point_values[point_index].count = 40 + point_index;
+        exp_histogram_point_values[point_index].has_sum = FLB_TRUE;
+        exp_histogram_point_values[point_index].sum = 40.5 + point_index;
+        exp_histogram_point_values[point_index].scale = 4 + point_index;
+        exp_histogram_point_values[point_index].zero_count = 40 + point_index;
+        exp_histogram_point_values[point_index].flags = 31 + point_index;
+        exp_histogram_point_values[point_index].has_min = FLB_TRUE;
+        exp_histogram_point_values[point_index].min = 4.5 + point_index;
+        exp_histogram_point_values[point_index].has_max = FLB_TRUE;
+        exp_histogram_point_values[point_index].max = 45.5 + point_index;
+        exp_histogram_point_values[point_index].zero_threshold = 0.5 + point_index;
+
+        summary_points[point_index] = &summary_point_values[point_index];
+        summary_point_values[point_index].start_time_unix_nano = 500 + point_index;
+        summary_point_values[point_index].time_unix_nano = 5000 + point_index;
+        summary_point_values[point_index].count = 50 + point_index;
+        summary_point_values[point_index].sum = 50.5 + point_index;
+        summary_point_values[point_index].flags = 41 + point_index;
+    }
+
+    gauge.n_data_points = 3;
+    gauge.data_points = gauge_points;
+    metrics[0].name = "gauge";
+    metrics[0].description = "gauge description";
+    metrics[0].unit = "gauge unit";
+    metrics[0].data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE;
+    metrics[0].gauge = &gauge;
+
+    sum.n_data_points = 3;
+    sum.data_points = sum_points;
+    sum.aggregation_temporality =
+        OPENTELEMETRY__PROTO__METRICS__V1__AGGREGATION_TEMPORALITY__AGGREGATION_TEMPORALITY_DELTA;
+    sum.is_monotonic = FLB_TRUE;
+    metrics[1].name = "sum";
+    metrics[1].description = "sum description";
+    metrics[1].unit = "sum unit";
+    metrics[1].data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM;
+    metrics[1].sum = &sum;
+
+    histogram.n_data_points = 3;
+    histogram.data_points = histogram_points;
+    histogram.aggregation_temporality =
+        OPENTELEMETRY__PROTO__METRICS__V1__AGGREGATION_TEMPORALITY__AGGREGATION_TEMPORALITY_CUMULATIVE;
+    metrics[2].name = "histogram";
+    metrics[2].description = "histogram description";
+    metrics[2].unit = "histogram unit";
+    metrics[2].data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_HISTOGRAM;
+    metrics[2].histogram = &histogram;
+
+    exp_histogram.n_data_points = 3;
+    exp_histogram.data_points = exp_histogram_points;
+    exp_histogram.aggregation_temporality =
+        OPENTELEMETRY__PROTO__METRICS__V1__AGGREGATION_TEMPORALITY__AGGREGATION_TEMPORALITY_DELTA;
+    metrics[3].name = "exponential_histogram";
+    metrics[3].description = "exponential histogram description";
+    metrics[3].unit = "exponential histogram unit";
+    metrics[3].data_case =
+        OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_EXPONENTIAL_HISTOGRAM;
+    metrics[3].exponential_histogram = &exp_histogram;
+
+    summary.n_data_points = 3;
+    summary.data_points = summary_points;
+    metrics[4].name = "summary";
+    metrics[4].description = "summary description";
+    metrics[4].unit = "summary unit";
+    metrics[4].data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUMMARY;
+    metrics[4].summary = &summary;
+
+    scope_metadata.name = "splitter scope";
+    scope_metadata.version = "2.0.0";
+    scope_metadata.dropped_attributes_count = 9;
+    scope.scope = &scope_metadata;
+    scope.schema_url = "https://example.com/scope/2.0.0";
+    scope.n_metrics = 5;
+    scope.metrics = metric_entries;
+    scopes[0] = &scope;
+    resource_metadata.dropped_attributes_count = 7;
+    resource.resource = &resource_metadata;
+    resource.schema_url = "https://example.com/resource/1.0.0";
+    resource.n_scope_metrics = 1;
+    resource.scope_metrics = scopes;
+    resources[0] = &resource;
+    request.n_resource_metrics = 1;
+    request.resource_metrics = resources;
+
+    payload_size =
+        opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__get_packed_size(
+            &request);
+    payload = flb_sds_create_size(payload_size);
+    TEST_CHECK(payload != NULL);
+    if (payload == NULL) {
+        return;
+    }
+
+    opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__pack(
+        &request,
+        (uint8_t *) payload);
+    flb_sds_len_set(payload, payload_size);
+
+    batches = cmt_encode_opentelemetry_split_payload(payload,
+                                                     payload_size,
+                                                     2,
+                                                     &result);
+    flb_sds_destroy(payload);
+    TEST_CHECK(result == CMT_ENCODE_OPENTELEMETRY_SUCCESS);
+    TEST_CHECK(batches != NULL);
+    if (batches == NULL) {
+        return;
+    }
+
+    TEST_CHECK(batches->count == 8);
+    for (batch_index = 0; batch_index < batches->count; batch_index++) {
+        if (batch_index < 7) {
+            TEST_CHECK(batches->entries[batch_index].data_point_count == 2);
+        }
+        else {
+            TEST_CHECK(batches->entries[batch_index].data_point_count == 1);
+        }
+    }
+
+    gauge_seen = 0;
+    sum_seen = 0;
+    histogram_seen = 0;
+    exp_histogram_seen = 0;
+    summary_seen = 0;
+    total_data_points = 0;
+
+    for (batch_index = 0; batch_index < batches->count; batch_index++) {
+        decoded =
+            opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__unpack(
+                NULL,
+                cfl_sds_len(batches->entries[batch_index].payload),
+                (uint8_t *) batches->entries[batch_index].payload);
+        TEST_CHECK(decoded != NULL);
+        if (decoded == NULL) {
+            continue;
+        }
+
+        TEST_CHECK(decoded->n_resource_metrics == 1);
+        for (resource_index = 0;
+             resource_index < decoded->n_resource_metrics;
+             resource_index++) {
+            decoded_resource = decoded->resource_metrics[resource_index];
+            TEST_CHECK(decoded_resource->resource != NULL);
+            TEST_CHECK(strcmp(decoded_resource->schema_url,
+                              "https://example.com/resource/1.0.0") == 0);
+            if (decoded_resource->resource != NULL) {
+                TEST_CHECK(decoded_resource->resource->dropped_attributes_count == 7);
+            }
+            TEST_CHECK(decoded_resource->n_scope_metrics == 1);
+
+            for (scope_index = 0;
+                 scope_index < decoded_resource->n_scope_metrics;
+                 scope_index++) {
+                decoded_scope = decoded_resource->scope_metrics[scope_index];
+                TEST_CHECK(decoded_scope->scope != NULL);
+                TEST_CHECK(strcmp(decoded_scope->schema_url,
+                                  "https://example.com/scope/2.0.0") == 0);
+                if (decoded_scope->scope != NULL) {
+                    TEST_CHECK(strcmp(decoded_scope->scope->name, "splitter scope") == 0);
+                    TEST_CHECK(strcmp(decoded_scope->scope->version, "2.0.0") == 0);
+                    TEST_CHECK(decoded_scope->scope->dropped_attributes_count == 9);
+                }
+
+                for (metric_index = 0;
+                     metric_index < decoded_scope->n_metrics;
+                     metric_index++) {
+                    metric = decoded_scope->metrics[metric_index];
+                    if (metric->data_case ==
+                        OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
+                        gauge_seen++;
+                        TEST_CHECK(strcmp(metric->name, "gauge") == 0);
+                        TEST_CHECK(strcmp(metric->description, "gauge description") == 0);
+                        TEST_CHECK(strcmp(metric->unit, "gauge unit") == 0);
+                        TEST_CHECK(metric->gauge->n_data_points > 0);
+                        TEST_CHECK(metric->gauge->n_data_points <= 2);
+                        total_data_points += metric->gauge->n_data_points;
+
+                        for (point_index = 0;
+                             point_index < metric->gauge->n_data_points;
+                             point_index++) {
+                            number_point = metric->gauge->data_points[point_index];
+                            TEST_CHECK(number_point->time_unix_nano >= 1000);
+                            TEST_CHECK(number_point->time_unix_nano < 1003);
+                            if (number_point->time_unix_nano < 1000 ||
+                                number_point->time_unix_nano >= 1003) {
+                                continue;
+                            }
+                            data_point_index = number_point->time_unix_nano - 1000;
+                            gauge_points_seen[data_point_index]++;
+                            TEST_CHECK(number_point->start_time_unix_nano ==
+                                       100 + data_point_index);
+                            TEST_CHECK(number_point->flags == 1 + data_point_index);
+                            TEST_CHECK(number_point->value_case ==
+                                OPENTELEMETRY__PROTO__METRICS__V1__NUMBER_DATA_POINT__VALUE_AS_INT);
+                            TEST_CHECK(number_point->as_int == 10 + data_point_index);
+                        }
+                    }
+                    else if (metric->data_case ==
+                             OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM) {
+                        sum_seen++;
+                        TEST_CHECK(strcmp(metric->name, "sum") == 0);
+                        TEST_CHECK(strcmp(metric->description, "sum description") == 0);
+                        TEST_CHECK(strcmp(metric->unit, "sum unit") == 0);
+                        TEST_CHECK(metric->sum->aggregation_temporality ==
+                                   sum.aggregation_temporality);
+                        TEST_CHECK(metric->sum->is_monotonic == sum.is_monotonic);
+                        TEST_CHECK(metric->sum->n_data_points > 0);
+                        TEST_CHECK(metric->sum->n_data_points <= 2);
+                        total_data_points += metric->sum->n_data_points;
+
+                        for (point_index = 0;
+                             point_index < metric->sum->n_data_points;
+                             point_index++) {
+                            number_point = metric->sum->data_points[point_index];
+                            TEST_CHECK(number_point->time_unix_nano >= 2000);
+                            TEST_CHECK(number_point->time_unix_nano < 2003);
+                            if (number_point->time_unix_nano < 2000 ||
+                                number_point->time_unix_nano >= 2003) {
+                                continue;
+                            }
+                            data_point_index = number_point->time_unix_nano - 2000;
+                            sum_points_seen[data_point_index]++;
+                            TEST_CHECK(number_point->start_time_unix_nano ==
+                                       200 + data_point_index);
+                            TEST_CHECK(number_point->flags == 11 + data_point_index);
+                            TEST_CHECK(number_point->value_case ==
+                                OPENTELEMETRY__PROTO__METRICS__V1__NUMBER_DATA_POINT__VALUE_AS_DOUBLE);
+                            TEST_CHECK(number_point->as_double == 20.5 + data_point_index);
+                        }
+                    }
+                    else if (metric->data_case ==
+                             OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_HISTOGRAM) {
+                        histogram_seen++;
+                        TEST_CHECK(strcmp(metric->name, "histogram") == 0);
+                        TEST_CHECK(strcmp(metric->description, "histogram description") == 0);
+                        TEST_CHECK(strcmp(metric->unit, "histogram unit") == 0);
+                        TEST_CHECK(metric->histogram->aggregation_temporality ==
+                                   histogram.aggregation_temporality);
+                        TEST_CHECK(metric->histogram->n_data_points > 0);
+                        TEST_CHECK(metric->histogram->n_data_points <= 2);
+                        total_data_points += metric->histogram->n_data_points;
+
+                        for (point_index = 0;
+                             point_index < metric->histogram->n_data_points;
+                             point_index++) {
+                            histogram_point = metric->histogram->data_points[point_index];
+                            TEST_CHECK(histogram_point->time_unix_nano >= 3000);
+                            TEST_CHECK(histogram_point->time_unix_nano < 3003);
+                            if (histogram_point->time_unix_nano < 3000 ||
+                                histogram_point->time_unix_nano >= 3003) {
+                                continue;
+                            }
+                            data_point_index = histogram_point->time_unix_nano - 3000;
+                            histogram_points_seen[data_point_index]++;
+                            TEST_CHECK(histogram_point->start_time_unix_nano ==
+                                       300 + data_point_index);
+                            TEST_CHECK(histogram_point->count == 30 + data_point_index);
+                            TEST_CHECK(histogram_point->has_sum == FLB_TRUE);
+                            TEST_CHECK(histogram_point->sum == 30.5 + data_point_index);
+                            TEST_CHECK(histogram_point->flags == 21 + data_point_index);
+                            TEST_CHECK(histogram_point->has_min == FLB_TRUE);
+                            TEST_CHECK(histogram_point->min == 3.5 + data_point_index);
+                            TEST_CHECK(histogram_point->has_max == FLB_TRUE);
+                            TEST_CHECK(histogram_point->max == 35.5 + data_point_index);
+                        }
+                    }
+                    else if (metric->data_case ==
+                             OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_EXPONENTIAL_HISTOGRAM) {
+                        exp_histogram_seen++;
+                        TEST_CHECK(strcmp(metric->name, "exponential_histogram") == 0);
+                        TEST_CHECK(strcmp(metric->description,
+                                          "exponential histogram description") == 0);
+                        TEST_CHECK(strcmp(metric->unit,
+                                          "exponential histogram unit") == 0);
+                        TEST_CHECK(metric->exponential_histogram->aggregation_temporality ==
+                                   exp_histogram.aggregation_temporality);
+                        TEST_CHECK(metric->exponential_histogram->n_data_points > 0);
+                        TEST_CHECK(metric->exponential_histogram->n_data_points <= 2);
+                        total_data_points += metric->exponential_histogram->n_data_points;
+
+                        for (point_index = 0;
+                             point_index < metric->exponential_histogram->n_data_points;
+                             point_index++) {
+                            exp_histogram_point =
+                                metric->exponential_histogram->data_points[point_index];
+                            TEST_CHECK(exp_histogram_point->time_unix_nano >= 4000);
+                            TEST_CHECK(exp_histogram_point->time_unix_nano < 4003);
+                            if (exp_histogram_point->time_unix_nano < 4000 ||
+                                exp_histogram_point->time_unix_nano >= 4003) {
+                                continue;
+                            }
+                            data_point_index = exp_histogram_point->time_unix_nano - 4000;
+                            exp_histogram_points_seen[data_point_index]++;
+                            TEST_CHECK(exp_histogram_point->start_time_unix_nano ==
+                                       400 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->count == 40 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->has_sum == FLB_TRUE);
+                            TEST_CHECK(exp_histogram_point->sum == 40.5 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->scale == 4 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->zero_count ==
+                                       40 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->flags == 31 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->has_min == FLB_TRUE);
+                            TEST_CHECK(exp_histogram_point->min == 4.5 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->has_max == FLB_TRUE);
+                            TEST_CHECK(exp_histogram_point->max == 45.5 + data_point_index);
+                            TEST_CHECK(exp_histogram_point->zero_threshold ==
+                                       0.5 + data_point_index);
+                        }
+                    }
+                    else if (metric->data_case ==
+                             OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUMMARY) {
+                        summary_seen++;
+                        TEST_CHECK(strcmp(metric->name, "summary") == 0);
+                        TEST_CHECK(strcmp(metric->description, "summary description") == 0);
+                        TEST_CHECK(strcmp(metric->unit, "summary unit") == 0);
+                        TEST_CHECK(metric->summary->n_data_points > 0);
+                        TEST_CHECK(metric->summary->n_data_points <= 2);
+                        total_data_points += metric->summary->n_data_points;
+
+                        for (point_index = 0;
+                             point_index < metric->summary->n_data_points;
+                             point_index++) {
+                            summary_point = metric->summary->data_points[point_index];
+                            TEST_CHECK(summary_point->time_unix_nano >= 5000);
+                            TEST_CHECK(summary_point->time_unix_nano < 5003);
+                            if (summary_point->time_unix_nano < 5000 ||
+                                summary_point->time_unix_nano >= 5003) {
+                                continue;
+                            }
+                            data_point_index = summary_point->time_unix_nano - 5000;
+                            summary_points_seen[data_point_index]++;
+                            TEST_CHECK(summary_point->start_time_unix_nano ==
+                                       500 + data_point_index);
+                            TEST_CHECK(summary_point->count == 50 + data_point_index);
+                            TEST_CHECK(summary_point->sum == 50.5 + data_point_index);
+                            TEST_CHECK(summary_point->flags == 41 + data_point_index);
+                        }
+                    }
+                }
+            }
+        }
+
+        opentelemetry__proto__collector__metrics__v1__export_metrics_service_request__free_unpacked(
+            decoded,
+            NULL);
+    }
+
+    TEST_CHECK(total_data_points == 15);
+    TEST_CHECK(gauge_seen == 2);
+    TEST_CHECK(sum_seen == 2);
+    TEST_CHECK(histogram_seen == 2);
+    TEST_CHECK(exp_histogram_seen == 2);
+    TEST_CHECK(summary_seen == 2);
+    for (point_index = 0; point_index < 3; point_index++) {
+        TEST_CHECK(gauge_points_seen[point_index] == 1);
+        TEST_CHECK(sum_points_seen[point_index] == 1);
+        TEST_CHECK(histogram_points_seen[point_index] == 1);
+        TEST_CHECK(exp_histogram_points_seen[point_index] == 1);
+        TEST_CHECK(summary_points_seen[point_index] == 1);
+    }
+
+    cmt_encode_opentelemetry_destroy_batches(batches);
+}
+
+void test_opentelemetry_metrics_otlp_proto_batches_empty_context()
+{
+    int result;
+    struct cmt *context;
+    struct cmt_opentelemetry_batches *batches;
+
+    context = cmt_create();
+    TEST_CHECK(context != NULL);
+    if (context == NULL) {
+        return;
+    }
+
+    batches = cmt_encode_opentelemetry_create_batches(context, 4, &result);
+    TEST_CHECK(result == CMT_ENCODE_OPENTELEMETRY_SUCCESS);
+    TEST_CHECK(batches != NULL);
+    if (batches != NULL) {
+        TEST_CHECK(batches->count <= 1);
+        if (batches->count == 1) {
+            TEST_CHECK(batches->entries[0].data_point_count == 0);
+        }
+        cmt_encode_opentelemetry_destroy_batches(batches);
+    }
+
+    cmt_destroy(context);
+}
+
 void test_opentelemetry_traces_otlp_proto_roundtrip()
 {
     int result;
@@ -2780,5 +3441,11 @@ TEST_LIST = {
       test_opentelemetry_metrics_otlp_proto_roundtrip },
     { "opentelemetry_metrics_msgpack_otlp_proto_merges_contexts",
       test_opentelemetry_metrics_msgpack_otlp_proto_merges_contexts },
+    { "opentelemetry_metrics_otlp_proto_data_point_batches",
+      test_opentelemetry_metrics_otlp_proto_data_point_batches },
+    { "opentelemetry_metrics_otlp_proto_batches_all_metric_types",
+      test_opentelemetry_metrics_otlp_proto_batches_all_metric_types },
+    { "opentelemetry_metrics_otlp_proto_batches_empty_context",
+      test_opentelemetry_metrics_otlp_proto_batches_empty_context },
     { 0 }
 };


### PR DESCRIPTION
Supersedes #12251.

This replays Hiroshi Hatake's original commits on current `master`, preserving
their author metadata, author dates, commit messages, and DCO trailers. The
original `lib: cmetrics: Implement batch operations for Otel` commit is omitted
because the required batching API is already present in the bundled cmetrics
v2.2.2 update on `master`.

There are no `lib/cmetrics` changes in this PR.

Summary:

- Add `metrics_max_datapoints` to the OpenTelemetry output.
- Split OTLP metrics into bounded batches for HTTP and gRPC export.
- Correct HTTP client connection recycling for multiple gRPC requests.
- Add overflow-safe storage-limit checks for input chunks.
- Add internal and end-to-end coverage.

Verification:

- `cmake -S . -B build -DFLB_TESTS_RUNTIME=On -DFLB_TESTS_INTERNAL=On`
- `cmake --build build -j8`
- `ctest --test-dir build -R 'flb-it-(opentelemetry|input_chunk_routes)' --output-on-failure` — 2 passed
- `FLUENT_BIT_BINARY=build/bin/fluent-bit tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py -k metrics_max_datapoints -q` — 2 passed
- `VALGRIND=1 VALGRIND_STRICT=1 FLUENT_BIT_BINARY=build/bin/fluent-bit tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py -k metrics_max_datapoints -q` — 2 passed
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master python .github/scripts/commit_prefix_check.py` — passed
- `git diff --check origin/master...HEAD` — passed

Closes #12247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the OpenTelemetry output option `metrics_max_datapoints` to limit the number of metric data points per export request.
  * Oversized metric payloads are now split into sequential batches for HTTP and gRPC exports. Set the option to `0` to keep batching disabled.
  * Partial successes are no longer retried, preventing duplicate metric delivery.

* **Bug Fixes**
  * Improved storage-limit handling when input chunks exceed configured limits, including protection against size calculation overflow.
  * Improved HTTP/2 connection handling for more reliable sessions.

* **Documentation**
  * Added integration coverage for metric batching and maximum datapoint limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->