### PR TITLE
in_winevtlog: fix crash when all channels are missing and ignore_missing_channels is enabled [Backport to 5.0]

### DIFF
--- a/plugins/in_winevtlog/in_winevtlog.c
+++ b/plugins/in_winevtlog/in_winevtlog.c
@@ -444,6 +444,10 @@ static int in_winevtlog_collect(struct flb_input_instance *ins,
     struct mk_list *head;
     struct winevtlog_channel *ch;
 
+    if (!ctx->active_channel) {
+        return 0;
+    }
+
     mk_list_foreach(head, ctx->active_channel) {
         ch = mk_list_entry(head, struct winevtlog_channel, _head);
         in_winevtlog_read_channel(ins, ctx, ch);

--- a/plugins/in_winevtlog/winevtlog.c
+++ b/plugins/in_winevtlog/winevtlog.c
@@ -2222,6 +2222,13 @@ struct mk_list *winevtlog_open_all(const char *channels, struct winevtlog_config
 
     if (mk_list_size(list) == 0) {
         flb_free(tmp);
+        if (ctx->ignore_missing_channels) {
+            /*
+             * All channels are missing but tolerated: return the empty
+             * list so the caller can iterate it safely on collect/exit.
+             */
+            return list;
+        }
         winevtlog_close_all(list);
         return NULL;
     }
@@ -2235,6 +2242,10 @@ void winevtlog_close_all(struct mk_list *list)
     struct winevtlog_channel *ch;
     struct mk_list *head;
     struct mk_list *tmp;
+
+    if (!list) {
+        return;
+    }
 
     mk_list_foreach_safe(head, tmp, list) {
         ch = mk_list_entry(head, struct winevtlog_channel, _head);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -37,6 +37,8 @@ FLB_RT_TEST(FLB_CHUNK_TRACE "core_chunk_trace.c")
 
 # Input Plugins
 FLB_RT_TEST(FLB_IN_EVENT_TEST   "in_event_test.c")
+# FLB_IN_WINEVTLOG is only enabled on Windows builds
+FLB_RT_TEST(FLB_IN_WINEVTLOG    "in_winevtlog.c")
 
 if(FLB_OUT_LIB)
   # These plugins works only on Linux

--- a/tests/runtime/in_winevtlog.c
+++ b/tests/runtime/in_winevtlog.c
@@ -1,0 +1,184 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+#include "flb_tests_runtime.h"
+
+/*
+ * Channels that must not exist on the host. The names are deliberately
+ * implausible; the tests rely on subscription to them failing with
+ * ERROR_EVT_CHANNEL_NOT_FOUND.
+ */
+#define MISSING_CHANNEL_A "FlbTestMissingChannelA"
+#define MISSING_CHANNEL_B "FlbTestMissingChannelB"
+
+/*
+ * All channels of the instance are missing and tolerated: the engine must
+ * start, survive collection cycles and stop cleanly. Before the fix,
+ * ctx->active_channel was NULL and the first collection cycle crashed the
+ * process (NULL dereference in mk_list_foreach).
+ */
+void flb_test_winevtlog_all_channels_missing_ignored(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", MISSING_CHANNEL_A,
+                        "ignore_missing_channels", "true",
+                        "interval_sec", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Let at least two collection cycles run (interval_sec=1) */
+    flb_time_msleep(2500);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/* Same as above but with several missing channels in one instance */
+void flb_test_winevtlog_multiple_missing_channels_ignored(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", MISSING_CHANNEL_A "," MISSING_CHANNEL_B,
+                        "ignore_missing_channels", "true",
+                        "interval_sec", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2500);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * A mix of one existing channel ('Application' always exists on Windows)
+ * and one missing channel: the missing one is skipped, the instance keeps
+ * working. This was already the behavior before the fix and must not
+ * regress.
+ */
+void flb_test_winevtlog_mixed_channels_ignored(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", "Application," MISSING_CHANNEL_A,
+                        "ignore_missing_channels", "true",
+                        "interval_sec", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_msleep(2500);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+/*
+ * Without ignore_missing_channels, a missing channel must keep failing
+ * initialization (documented behavior: "Subscribe at least one").
+ */
+void flb_test_winevtlog_missing_channel_fails_without_ignore(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    in_ffd = flb_input(ctx, (char *) "winevtlog", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    ret = flb_input_set(ctx, in_ffd,
+                        "channels", MISSING_CHANNEL_A,
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    out_ffd = flb_output(ctx, (char *) "null", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd, "match", "*", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret != 0);
+
+    flb_destroy(ctx);
+}
+
+/* Test list */
+TEST_LIST = {
+    {"all_channels_missing_ignored",
+     flb_test_winevtlog_all_channels_missing_ignored},
+    {"multiple_missing_channels_ignored",
+     flb_test_winevtlog_multiple_missing_channels_ignored},
+    {"mixed_channels_ignored",
+     flb_test_winevtlog_mixed_channels_ignored},
+    {"missing_channel_fails_without_ignore",
+     flb_test_winevtlog_missing_channel_fails_without_ignore},
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->
Backporting of https://github.com/fluent/fluent-bit/pull/12318.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
