### PR TITLE
in_kubernetes_events: add sqlite indexes

### DIFF
--- a/plugins/in_kubernetes_events/kubernetes_events_conf.c
+++ b/plugins/in_kubernetes_events/kubernetes_events_conf.c
@@ -78,6 +78,13 @@ static struct flb_sqldb *flb_kubernetes_event_db_open(const char *path,
         }
     }
 
+    ret = flb_sqldb_query(db, SQL_CREATE_KUBERNETES_EVENTS_INDEXES, NULL, NULL);
+    if (ret != FLB_OK) {
+        flb_plg_error(ctx->ins, "db: could not create 'in_kubernetes_events' indexes");
+        flb_sqldb_close(db);
+        return NULL;
+    }
+
     return db;
 }
 

--- a/plugins/in_kubernetes_events/kubernetes_events_sql.h
+++ b/plugins/in_kubernetes_events/kubernetes_events_sql.h
@@ -36,6 +36,12 @@
     "  created         INTEGER NOT NULL"                                \
     ");"
 
+#define SQL_CREATE_KUBERNETES_EVENTS_INDEXES                            \
+    "CREATE INDEX IF NOT EXISTS idx_in_kubernetes_events_uid "          \
+    "    ON in_kubernetes_events(uid);"                                 \
+    "CREATE INDEX IF NOT EXISTS idx_in_kubernetes_events_created "      \
+    "    ON in_kubernetes_events(created);"
+
 #define SQL_KUBERNETES_EVENT_EXISTS_BY_UID                              \
     "SELECT COUNT(id) "                                                 \
     "    FROM in_kubernetes_events "                                    \

--- a/tests/runtime/in_kubernetes_events.c
+++ b/tests/runtime/in_kubernetes_events.c
@@ -24,10 +24,14 @@
 #include <fluent-bit/flb_time.h>
 #include <fluent-bit/flb_pack.h>
 #include <fluent-bit/flb_downstream.h>
+#ifdef FLB_HAVE_SQLDB
+#include <fluent-bit/flb_sqldb.h>
+#endif
 #include <monkey/mk_core.h>
 #include <monkey/mk_lib.h>
 
 #include "flb_tests_runtime.h"
+#include "../include/flb_tests_tmpdir.h"
 
 #define JSON_CONTENT_TYPE "application/json"
 
@@ -312,7 +316,8 @@ static struct test_ctx *test_ctx_create(struct flb_lib_out_cb *data)
 static struct test_ctx *test_ctx_create_with_config(struct flb_lib_out_cb *data,
                                                     const char *db_sync,
                                                     const char *db_locking,
-                                                    const char *db_journal_mode)
+                                                    const char *db_journal_mode,
+                                                    const char *db_path)
 {
     int i_ffd;
     int o_ffd;
@@ -362,6 +367,10 @@ static struct test_ctx *test_ctx_create_with_config(struct flb_lib_out_cb *data,
     }
     if (db_journal_mode) {
         ret = flb_input_set(ctx->flb, i_ffd, "db.journal_mode", db_journal_mode, NULL);
+        TEST_CHECK(ret == 0);
+    }
+    if (db_path) {
+        ret = flb_input_set(ctx->flb, i_ffd, "db", db_path, NULL);
         TEST_CHECK(ret == 0);
     }
 
@@ -520,6 +529,168 @@ void flb_test_events_with_chunkedrecv()
 }
 
 #ifdef FLB_HAVE_SQLDB
+static int database_contains_index(sqlite3 *database, const char *index_name)
+{
+    int ret;
+    int result;
+    sqlite3_stmt *statement;
+    const char *query;
+
+    result = FLB_FALSE;
+    statement = NULL;
+    query = "SELECT 1 FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='in_kubernetes_events' AND name=?1;";
+
+    ret = sqlite3_prepare_v2(database, query, -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        TEST_MSG("could not prepare index lookup: %s", sqlite3_errmsg(database));
+        return FLB_FALSE;
+    }
+
+    ret = sqlite3_bind_text(statement, 1, index_name, -1, SQLITE_STATIC);
+    if (ret == SQLITE_OK && sqlite3_step(statement) == SQLITE_ROW) {
+        result = FLB_TRUE;
+    }
+
+    sqlite3_finalize(statement);
+    return result;
+}
+
+static int create_legacy_database(const char *path)
+{
+    int ret;
+    char *error_message;
+    sqlite3 *database;
+    const char *schema;
+
+    database = NULL;
+    error_message = NULL;
+    schema = "CREATE TABLE in_kubernetes_events ("
+             "id INTEGER PRIMARY KEY,"
+             "uid TEXT NOT NULL,"
+             "resourceVersion INTEGER NOT NULL,"
+             "created INTEGER NOT NULL);"
+             "INSERT INTO in_kubernetes_events (uid, resourceVersion, created) "
+             "VALUES ('duplicate', 1, 1), ('duplicate', 2, 2);";
+
+    ret = sqlite3_open(path, &database);
+    if (ret != SQLITE_OK) {
+        if (database != NULL) {
+            TEST_MSG("could not create legacy database: %s", sqlite3_errmsg(database));
+        }
+        else {
+            TEST_MSG("could not create legacy database");
+        }
+        sqlite3_close(database);
+        return -1;
+    }
+
+    ret = sqlite3_exec(database, schema, NULL, NULL, &error_message);
+    if (ret != SQLITE_OK) {
+        TEST_MSG("could not create legacy schema: %s", error_message);
+        sqlite3_free(error_message);
+        sqlite3_close(database);
+        return -1;
+    }
+
+    sqlite3_close(database);
+    return 0;
+}
+
+static void test_database_indexes(int legacy_database)
+{
+    int ret;
+    int path_length;
+    char db_path[PATH_MAX];
+    char *temp_directory;
+    sqlite3 *database;
+    struct flb_lib_out_cb cb_data;
+    struct test_ctx *ctx;
+
+    database = NULL;
+    ctx = NULL;
+    temp_directory = flb_test_tmpdir_cat("/flb-kubernetes-events-XXXXXX");
+    if (!TEST_CHECK(temp_directory != NULL)) {
+        return;
+    }
+
+    if (!TEST_CHECK(mkdtemp(temp_directory) != NULL)) {
+        flb_free(temp_directory);
+        return;
+    }
+
+    path_length = snprintf(db_path, sizeof(db_path), "%s/events.db", temp_directory);
+    if (!TEST_CHECK(path_length > 0 && (size_t) path_length < sizeof(db_path))) {
+        flb_test_rmdir(temp_directory);
+        flb_free(temp_directory);
+        return;
+    }
+
+    if (legacy_database == FLB_TRUE && !TEST_CHECK(create_legacy_database(db_path) == 0)) {
+        remove(db_path);
+        flb_test_rmdir(temp_directory);
+        flb_free(temp_directory);
+        return;
+    }
+
+    cb_data.cb = NULL;
+    cb_data.data = NULL;
+    ctx = test_ctx_create_with_config(&cb_data,
+                                      NULL,      /* db.sync */
+                                      NULL,      /* db.locking */
+                                      "DELETE",  /* db.journal_mode */
+                                      db_path);  /* db */
+    if (!TEST_CHECK(ctx != NULL)) {
+        remove(db_path);
+        flb_test_rmdir(temp_directory);
+        flb_free(temp_directory);
+        return;
+    }
+
+    ret = flb_start(ctx->flb);
+    if (!TEST_CHECK(ret == 0)) {
+        flb_destroy(ctx->flb);
+        flb_free(ctx);
+        remove(db_path);
+        flb_test_rmdir(temp_directory);
+        flb_free(temp_directory);
+        return;
+    }
+    test_ctx_destroy(ctx);
+
+    ret = sqlite3_open_v2(db_path, &database, SQLITE_OPEN_READONLY, NULL);
+    if (ret != SQLITE_OK) {
+        if (database != NULL) {
+            TEST_CHECK_(ret == SQLITE_OK, "could not open database: %s",
+                        sqlite3_errmsg(database));
+        }
+        else {
+            TEST_CHECK_(ret == SQLITE_OK, "could not open database");
+        }
+    }
+    else {
+        TEST_CHECK(database_contains_index(database,
+                                           "idx_in_kubernetes_events_uid") == FLB_TRUE);
+        TEST_CHECK(database_contains_index(database,
+                                           "idx_in_kubernetes_events_created") == FLB_TRUE);
+    }
+
+    sqlite3_close(database);
+    remove(db_path);
+    flb_test_rmdir(temp_directory);
+    flb_free(temp_directory);
+}
+
+void flb_test_database_indexes_created()
+{
+    test_database_indexes(FLB_FALSE);
+}
+
+void flb_test_database_indexes_migrated()
+{
+    test_database_indexes(FLB_TRUE);
+}
+
 /* Test valid db.sync values */
 void flb_test_config_db_sync_values()
 {
@@ -536,7 +707,8 @@ void flb_test_config_db_sync_values()
         ctx = test_ctx_create_with_config(&cb_data,
                                           sync_values[i],  /* db.sync */
                                           NULL,            /* db.locking */
-                                          NULL);           /* db.journal_mode */
+                                          NULL,            /* db.journal_mode */
+                                          NULL);           /* db */
         if (!TEST_CHECK(ctx != NULL)) {
             TEST_MSG("test_ctx_create_with_config failed for db.sync=%s", sync_values[i]);
             continue;
@@ -570,7 +742,8 @@ void flb_test_config_db_journal_mode_values()
         ctx = test_ctx_create_with_config(&cb_data,
                                           NULL,              /* db.sync */
                                           NULL,              /* db.locking */
-                                          journal_modes[i]); /* db.journal_mode */
+                                          journal_modes[i],  /* db.journal_mode */
+                                          NULL);             /* db */
         if (!TEST_CHECK(ctx != NULL)) {
             TEST_MSG("test_ctx_create_with_config failed for db.journal_mode=%s", journal_modes[i]);
             continue;
@@ -604,7 +777,8 @@ void flb_test_config_db_locking_values()
         ctx = test_ctx_create_with_config(&cb_data,
                                           NULL,              /* db.sync */
                                           locking_values[i], /* db.locking */
-                                          NULL);             /* db.journal_mode */
+                                          NULL,              /* db.journal_mode */
+                                          NULL);             /* db */
         if (!TEST_CHECK(ctx != NULL)) {
             TEST_MSG("test_ctx_create_with_config failed for db.locking=%s", locking_values[i]);
             continue;
@@ -628,10 +802,11 @@ TEST_LIST = {
     {"events_v1_with_creationTimestamp", flb_test_events_v1_with_creationTimestamp},
     //{"events_v1_with_chunkedrecv", flb_test_events_with_chunkedrecv},
 #ifdef FLB_HAVE_SQLDB
+    {"database_indexes_created", flb_test_database_indexes_created},
+    {"database_indexes_migrated", flb_test_database_indexes_migrated},
     {"config_db_sync_values", flb_test_config_db_sync_values},
     {"config_db_journal_mode_values", flb_test_config_db_journal_mode_values},
     {"config_db_locking_values", flb_test_config_db_locking_values},
 #endif
     {NULL, NULL}
 };
-


### PR DESCRIPTION
<!-- Provide summary of changes -->

Implemented SQLite indexes for `in_kubernetes_events`.

- Added idempotent indexes for `uid` and `created` in kubernetes_events_sql.h.
- Indexes are created after configured SQLite pragmas; failures are fatal in kubernetes_events_conf.c.
- Added fresh-database and legacy migration coverage in in_kubernetes_events.c. The legacy fixture includes duplicate UIDs, confirming the indexes remain non-unique.

Verification passed:

- `cmake --build build -j8 --target flb-rt-in_kubernetes_events`
- Focused fresh/migration tests: passed.
- `ctest --test-dir build -R '^flb-rt-in_kubernetes_events$' --output-on-failure`: all 7 tests passed.
- Valgrind focused tests: 0 errors, 0 definitely/possibly lost bytes.
- `git diff --check`: passed.

Closes https://github.com/fluent/fluent-bit/issues/12327.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved Kubernetes event database lookup performance by adding indexes for event IDs and creation timestamps.

- **Reliability**
  - Database initialization now verifies that required indexes are created and reports failures cleanly if setup cannot be completed.

- **Testing**
  - Added coverage for index creation on both new and existing Kubernetes event databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->