### PR TITLE
in_node_exporter_metrics: expire metrics for networking

### DIFF
--- a/plugins/in_node_exporter_metrics/ne_netdev_darwin.c
+++ b/plugins/in_node_exporter_metrics/ne_netdev_darwin.c
@@ -21,6 +21,9 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_input_plugin.h>
 
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_map.h>
+
 #include "ne.h"
 #include "ne_utils.h"
 
@@ -128,6 +131,7 @@ static int netdev_update(struct flb_ne *ctx)
     int ret;
     int i;
     int if_count;
+    size_t metric_index;
     size_t clen = sizeof(if_count);
     int cmib[] = { CTL_NET, PF_LINK, NETLINK_GENERIC, IFMIB_SYSTEM, IFMIB_IFCOUNT };
     int mib[6];
@@ -135,6 +139,19 @@ static int netdev_update(struct flb_ne *ctx)
     size_t ifmd_len = sizeof(ifmd);
     char ifname[IF_NAMESIZE];
     uint64_t ts;
+    struct cmt_gauge *metrics[] = {
+        ctx->darwin_receive_packets,
+        ctx->darwin_transmit_packets,
+        ctx->darwin_receive_bytes,
+        ctx->darwin_transmit_bytes,
+        ctx->darwin_receive_errors,
+        ctx->darwin_transmit_errors,
+        ctx->darwin_receive_dropped,
+        ctx->darwin_receive_multicast,
+        ctx->darwin_transmit_multicast,
+        ctx->darwin_collisions,
+        ctx->darwin_noproto
+    };
 
     ts = cfl_time_now();
 
@@ -198,6 +215,13 @@ static int netdev_update(struct flb_ne *ctx)
         cmt_gauge_set(ctx->darwin_noproto, ts,
                       (double)ifmd.ifmd_data.ifi_noproto, 1, (char *[]) { ifname });
 
+    }
+
+    /* Remove label sets for network devices not observed during this scan. */
+    for (metric_index = 0;
+         metric_index < sizeof(metrics) / sizeof(metrics[0]);
+         metric_index++) {
+        cmt_map_metrics_expire(metrics[metric_index]->map, ts);
     }
 
     return 0;

--- a/plugins/in_node_exporter_metrics/ne_netdev_linux.c
+++ b/plugins/in_node_exporter_metrics/ne_netdev_linux.c
@@ -21,6 +21,9 @@
 #include <fluent-bit/flb_sds.h>
 #include <fluent-bit/flb_input_plugin.h>
 
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_map.h>
+
 #include "ne.h"
 #include "ne_utils.h"
 
@@ -227,6 +230,7 @@ static int netdev_update(struct flb_ne *ctx)
     struct flb_slist_entry *tx_header;
     struct flb_slist_entry *prop;
     struct flb_slist_entry *prop_name;
+    struct flb_hash_table_entry *hash_entry;
 
     struct cmt_counter *c;
 
@@ -331,6 +335,13 @@ static int netdev_update(struct flb_ne *ctx)
             n++;
         }
         flb_slist_destroy(&split_list);
+    }
+
+    /* Remove label sets for network devices not observed during this scan. */
+    mk_list_foreach(head, &ctx->netdev_ht->entries) {
+        hash_entry = mk_list_entry(head, struct flb_hash_table_entry, _head_parent);
+        c = hash_entry->val;
+        cmt_map_metrics_expire(c->map, ts);
     }
 
     flb_slist_destroy(&head_list);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -41,6 +41,10 @@ FLB_RT_TEST(FLB_IN_EVENT_TEST   "in_event_test.c")
 FLB_RT_TEST(FLB_IN_WINEVTLOG    "in_winevtlog.c")
 
 if(FLB_OUT_LIB)
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    FLB_RT_TEST(FLB_IN_NODE_EXPORTER_METRICS "in_node_exporter_metrics.c")
+  endif()
+
   # These plugins works only on Linux
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     FLB_RT_TEST(FLB_IN_CPU            "in_cpu.c")

--- a/tests/runtime/in_node_exporter_metrics.c
+++ b/tests/runtime/in_node_exporter_metrics.c
@@ -1,0 +1,317 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit.h>
+#include <fluent-bit/flb_time.h>
+
+#include <cmetrics/cmt_decode_msgpack.h>
+#include <cmetrics/cmt_encode_text.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "flb_tests_runtime.h"
+
+static pthread_mutex_t result_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int output_count;
+
+static int cb_count_output(void *record, size_t size, void *data)
+{
+    (void) size;
+    (void) data;
+
+    pthread_mutex_lock(&result_mutex);
+    output_count++;
+    pthread_mutex_unlock(&result_mutex);
+
+    flb_free(record);
+
+    return 0;
+}
+
+static int get_output_count(void)
+{
+    int count;
+
+    pthread_mutex_lock(&result_mutex);
+    count = output_count;
+    pthread_mutex_unlock(&result_mutex);
+
+    return count;
+}
+
+static void test_diskstats(void)
+{
+    int ret;
+    int input_fd;
+    int output_fd;
+    int count;
+    uint64_t elapsed_ms;
+    flb_ctx_t *ctx;
+    struct flb_time start;
+    struct flb_time end;
+    struct flb_time diff;
+    struct flb_lib_out_cb callback;
+
+    output_count = 0;
+    elapsed_ms = 0;
+    callback.cb = cb_count_output;
+    callback.data = NULL;
+
+    ctx = flb_create();
+    TEST_CHECK(ctx != NULL);
+
+    ret = flb_service_set(ctx,
+                          "Flush", "0.2",
+                          "Grace", "1",
+                          "Log_Level", "error",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    input_fd = flb_input(ctx, (char *) "node_exporter_metrics", NULL);
+    TEST_CHECK(input_fd >= 0);
+
+    ret = flb_input_set(ctx, input_fd,
+                        "metrics", "diskstats",
+                        "scrape_interval", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    output_fd = flb_output(ctx, (char *) "lib", &callback);
+    TEST_CHECK(output_fd >= 0);
+
+    ret = flb_output_set(ctx, output_fd,
+                         "format", "json",
+                         NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_time_get(&start);
+    count = get_output_count();
+    while (count == 0 && elapsed_ms < 5000) {
+        flb_time_msleep(100);
+        count = get_output_count();
+        flb_time_get(&end);
+        flb_time_diff(&end, &start, &diff);
+        elapsed_ms = flb_time_to_nanosec(&diff) / 1000000;
+    }
+
+    TEST_CHECK(count > 0);
+
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+#ifdef FLB_SYSTEM_LINUX
+
+#define NETDEV_HEADER                                                        \
+    "Inter-|   Receive                                                |"     \
+    "  Transmit\n"                                                        \
+    " face |bytes    packets errs drop fifo frame compressed multicast|"   \
+    "bytes    packets errs drop fifo colls carrier compressed\n"
+
+static int stale_device_observed;
+static int stale_device_removed;
+static int clean_snapshot_observed;
+
+static int write_netdev_file(const char *path, int include_stale_device)
+{
+    int ret;
+    FILE *stream;
+
+    stream = fopen(path, "w");
+    if (stream == NULL) {
+        return -1;
+    }
+
+    ret = fprintf(stream,
+                  NETDEV_HEADER
+                  "  eth0: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16\n");
+    if (ret >= 0 && include_stale_device) {
+        ret = fprintf(stream,
+                      "  veth-stale: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16\n");
+    }
+
+    if (fclose(stream) != 0) {
+        return -1;
+    }
+
+    return ret < 0 ? -1 : 0;
+}
+
+static int cb_check_metrics(void *record, size_t size, void *data)
+{
+    int ret;
+    int removed;
+    size_t offset;
+    cfl_sds_t text;
+    struct cmt *cmt;
+
+    (void) data;
+
+    offset = 0;
+    cmt = NULL;
+    ret = cmt_decode_msgpack_create(&cmt, (char *) record, size, &offset);
+    if (ret == 0) {
+        text = cmt_encode_text_create(cmt);
+        if (text != NULL) {
+            pthread_mutex_lock(&result_mutex);
+            removed = stale_device_removed;
+            if (!removed && strstr(text, "device=\"veth-stale\"") != NULL) {
+                stale_device_observed = FLB_TRUE;
+            }
+            else if (removed && strstr(text, "device=\"eth0\"") != NULL &&
+                     strstr(text, "device=\"veth-stale\"") == NULL) {
+                clean_snapshot_observed = FLB_TRUE;
+            }
+            pthread_mutex_unlock(&result_mutex);
+            cmt_encode_text_destroy(text);
+        }
+        cmt_destroy(cmt);
+    }
+
+    flb_free(record);
+    return 0;
+}
+
+static int wait_for_flag(int *flag, int timeout_ms)
+{
+    int elapsed;
+    int value;
+
+    elapsed = 0;
+    while (elapsed < timeout_ms) {
+        pthread_mutex_lock(&result_mutex);
+        value = *flag;
+        pthread_mutex_unlock(&result_mutex);
+
+        if (value == FLB_TRUE) {
+            return 0;
+        }
+
+        flb_time_msleep(100);
+        elapsed += 100;
+    }
+
+    return -1;
+}
+
+static void test_netdev_removes_stale_devices(void)
+{
+    int ret;
+    int input_fd;
+    int output_fd;
+    char procfs_template[] = "/tmp/flb-node-exporter-XXXXXX";
+    char net_path[sizeof(procfs_template) + 5];
+    char netdev_path[sizeof(procfs_template) + 9];
+    char *procfs_path;
+    flb_ctx_t *flb;
+    struct flb_lib_out_cb callback;
+
+    procfs_path = mkdtemp(procfs_template);
+    TEST_CHECK(procfs_path != NULL);
+    if (procfs_path == NULL) {
+        return;
+    }
+
+    snprintf(net_path, sizeof(net_path), "%s/net", procfs_path);
+    snprintf(netdev_path, sizeof(netdev_path), "%s/net/dev", procfs_path);
+    ret = mkdir(net_path, 0700);
+    TEST_CHECK(ret == 0);
+    ret = write_netdev_file(netdev_path, FLB_TRUE);
+    TEST_CHECK(ret == 0);
+
+    pthread_mutex_lock(&result_mutex);
+    stale_device_observed = FLB_FALSE;
+    stale_device_removed = FLB_FALSE;
+    clean_snapshot_observed = FLB_FALSE;
+    pthread_mutex_unlock(&result_mutex);
+
+    memset(&callback, 0, sizeof(callback));
+    callback.cb = cb_check_metrics;
+
+    flb = flb_create();
+    TEST_CHECK(flb != NULL);
+    if (flb == NULL) {
+        goto cleanup;
+    }
+
+    ret = flb_service_set(flb,
+                          "Flush", "0.2",
+                          "Grace", "1",
+                          "Log_Level", "error",
+                          NULL);
+    TEST_CHECK(ret == 0);
+
+    input_fd = flb_input(flb, (char *) "node_exporter_metrics", NULL);
+    TEST_CHECK(input_fd >= 0);
+    ret = flb_input_set(flb, input_fd,
+                        "metrics", "netdev",
+                        "path.procfs", procfs_path,
+                        "scrape_interval", "1",
+                        NULL);
+    TEST_CHECK(ret == 0);
+
+    output_fd = flb_output(flb, (char *) "lib", &callback);
+    TEST_CHECK(output_fd >= 0);
+    ret = flb_output_set(flb, output_fd, "match", "*", NULL);
+    TEST_CHECK(ret == 0);
+
+    ret = flb_start(flb);
+    TEST_CHECK(ret == 0);
+    if (ret != 0) {
+        flb_destroy(flb);
+        goto cleanup;
+    }
+
+    ret = wait_for_flag(&stale_device_observed, 5000);
+    TEST_CHECK(ret == 0);
+
+    ret = write_netdev_file(netdev_path, FLB_FALSE);
+    TEST_CHECK(ret == 0);
+    pthread_mutex_lock(&result_mutex);
+    stale_device_removed = FLB_TRUE;
+    pthread_mutex_unlock(&result_mutex);
+
+    ret = wait_for_flag(&clean_snapshot_observed, 5000);
+    TEST_CHECK(ret == 0);
+
+    flb_stop(flb);
+    flb_destroy(flb);
+
+cleanup:
+    unlink(netdev_path);
+    rmdir(net_path);
+    rmdir(procfs_path);
+}
+
+#endif
+
+TEST_LIST = {
+    {"diskstats", test_diskstats},
+#ifdef FLB_SYSTEM_LINUX
+    {"netdev_removes_stale_devices", test_netdev_removes_stale_devices},
+#endif
+    {NULL, NULL}
+};


### PR DESCRIPTION
<!-- Provide summary of changes -->

This is because network interfaces sometimes absent after VM creation and exit.

The test is now implemented in the existing runtime binary at in_node_exporter_metrics.c and registered at line 314.

Summary:

- Creates a fake `/proc/net/dev` containing `eth0` and `veth-stale`.
- Confirms both are emitted.
- Rewrites the file without `veth-stale`.
- Confirms the next snapshot retains `eth0` but removes `veth-stale`.

The existing `diskstats` test was restored in the same binary. The netdev test is Linux-only, so macOS correctly reports one test; Linux will report two. The CMake registration now supports the binary on both platforms at CMakeLists.txt

Verification:

- `cmake --build build --target flb-rt-in_node_exporter_metrics -j8` — passed.
- `ctest --test-dir build -R '^flb-rt-in_node_exporter_metrics$' --output-on-failure` — passed on macOS (`diskstats`).
- Linux netdev execution and memory-checker pass — not run because this host is macOS; the Linux-only section passed a forced syntax compilation.


Closes https://github.com/fluent/fluent-bit/issues/9400.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network device metrics now remove stale label sets when devices are no longer detected, preventing outdated device metrics from persisting across scans.

* **Tests**
  * Added runtime coverage for disk statistics metric collection.
  * Added Linux coverage verifying that metrics for removed network devices disappear from subsequent snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->