### PR TITLE
out_azure_logs_ingestion: add durable request batching

### DIFF
--- a/plugins/out_azure_logs_ingestion/CMakeLists.txt
+++ b/plugins/out_azure_logs_ingestion/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(src
   azure_logs_ingestion.c
+  azure_logs_ingestion_batch.c
   azure_logs_ingestion_conf.c
   )
 

--- a/plugins/out_azure_logs_ingestion/CMakeLists.txt
+++ b/plugins/out_azure_logs_ingestion/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(src
   azure_logs_ingestion.c
-  azure_logs_ingestion_batch.c
   azure_logs_ingestion_conf.c
   )
+
+if(FLB_SQLDB)
+  list(APPEND src azure_logs_ingestion_batch.c)
+endif()
 
 FLB_PLUGIN(out_azure_logs_ingestion "${src}" "")

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -33,14 +33,24 @@
 
 #include "azure_logs_ingestion.h"
 #include "azure_logs_ingestion_conf.h"
+#include "azure_logs_ingestion_batch.h"
 
 static int cb_azure_logs_ingestion_init(struct flb_output_instance *ins,
                           struct flb_config *config, void *data)
 {
+    const char *buffering;
     struct flb_az_li *ctx;
     (void) config;
-    (void) ins;
     (void) data;
+
+    buffering = flb_output_get_property("buffering_enabled", ins);
+    if (buffering != NULL && flb_utils_bool(buffering) == FLB_TRUE) {
+        if (ins->tp_workers > 1) {
+            flb_plg_error(ins, "buffering supports exactly one output worker");
+            return -1;
+        }
+        ins->tp_workers = 1;
+    }
 
     /* Allocate and initialize a context from configuration */
     ctx = flb_az_li_ctx_create(ins, config);
@@ -49,6 +59,35 @@ static int cb_azure_logs_ingestion_init(struct flb_output_instance *ins,
         return -1;
     }
 
+    if (ctx->buffering_enabled == FLB_TRUE) {
+        /* OAuth creates its upstream independently of the output helper. Add
+         * it to the single output worker's upstream map explicitly. */
+        flb_upstream_thread_safe(ctx->u_auth->u);
+        mk_list_add(&ctx->u_auth->u->base._head, &ins->upstreams);
+
+        if (az_li_batch_init(ctx) == -1) {
+            flb_plg_error(ins, "could not initialize disk-backed batching");
+            flb_az_li_ctx_destroy(ctx);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int cb_azure_logs_ingestion_worker_init(void *data,
+                                                struct flb_config *config)
+{
+    struct flb_az_li *ctx = data;
+
+    (void) config;
+    if (ctx->buffering_enabled == FLB_FALSE) {
+        return 0;
+    }
+    if (az_li_batch_start_uploader(ctx) == -1) {
+        flb_plg_error(ctx->ins, "could not start disk-backed batching uploader");
+        return -1;
+    }
     return 0;
 }
 
@@ -163,6 +202,113 @@ static int az_li_format(const void *in_buf, size_t in_bytes,
     return 0;
 }
 
+static int az_li_format_records(const void *in_buf, size_t in_bytes,
+                                flb_sds_t **out_records, size_t *out_count,
+                                struct flb_az_li *ctx,
+                                struct flb_config *config)
+{
+    int i;
+    int ret;
+    int map_size;
+    int expected;
+    int len;
+    double timestamp;
+    size_t count;
+    size_t formatted_size;
+    struct tm time_parts;
+    struct flb_time event_time;
+    struct flb_log_event_decoder decoder;
+    struct flb_log_event event;
+    msgpack_object map;
+    msgpack_sbuffer buffer;
+    msgpack_packer packer;
+    flb_sds_t record;
+    flb_sds_t *records;
+    char formatted_time[32];
+
+    expected = flb_mp_count_log_records(in_buf, in_bytes);
+    if (expected <= 0) {
+        *out_records = NULL;
+        *out_count = 0;
+        return 0;
+    }
+
+    records = flb_calloc(expected, sizeof(flb_sds_t));
+    if (records == NULL) {
+        return -1;
+    }
+
+    ret = flb_log_event_decoder_init(&decoder, (char *) in_buf, in_bytes);
+    if (ret != FLB_EVENT_DECODER_SUCCESS) {
+        flb_free(records);
+        return -1;
+    }
+
+    count = 0;
+    while ((ret = flb_log_event_decoder_next(&decoder, &event)) ==
+           FLB_EVENT_DECODER_SUCCESS) {
+        flb_time_copy(&event_time, &event.timestamp);
+        map = *event.body;
+        map_size = map.via.map.size;
+
+        msgpack_sbuffer_init(&buffer);
+        msgpack_packer_init(&packer, &buffer, msgpack_sbuffer_write);
+        msgpack_pack_map(&packer, map_size + 1);
+        msgpack_pack_str(&packer, flb_sds_len(ctx->time_key));
+        msgpack_pack_str_body(&packer, ctx->time_key, flb_sds_len(ctx->time_key));
+
+        if (ctx->time_generated == FLB_TRUE) {
+            gmtime_r(&event_time.tm.tv_sec, &time_parts);
+            formatted_size = strftime(formatted_time, sizeof(formatted_time) - 1,
+                                      FLB_PACK_JSON_DATE_ISO8601_FMT, &time_parts);
+            len = snprintf(formatted_time + formatted_size,
+                           sizeof(formatted_time) - 1 - formatted_size,
+                           ".%03" PRIu64 "Z",
+                           (uint64_t) event_time.tm.tv_nsec / 1000000);
+            formatted_size += len;
+            msgpack_pack_str(&packer, formatted_size);
+            msgpack_pack_str_body(&packer, formatted_time, formatted_size);
+        }
+        else {
+            timestamp = flb_time_to_double(&event_time);
+            msgpack_pack_double(&packer, timestamp);
+        }
+
+        for (i = 0; i < map_size; i++) {
+            msgpack_pack_object(&packer, map.via.map.ptr[i].key);
+            msgpack_pack_object(&packer, map.via.map.ptr[i].val);
+        }
+
+        record = flb_msgpack_raw_to_json_sds(buffer.data, buffer.size,
+                                             config->json_escape_unicode);
+        msgpack_sbuffer_destroy(&buffer);
+        if (record == NULL) {
+            for (i = 0; i < count; i++) {
+                flb_sds_destroy(records[i]);
+            }
+            flb_free(records);
+            flb_log_event_decoder_destroy(&decoder);
+            return -1;
+        }
+        records[count++] = record;
+    }
+
+    flb_log_event_decoder_destroy(&decoder);
+    *out_records = records;
+    *out_count = count;
+    return 0;
+}
+
+static void az_li_records_destroy(flb_sds_t *records, size_t count)
+{
+    size_t index;
+
+    for (index = 0; index < count; index++) {
+        flb_sds_destroy(records[index]);
+    }
+    flb_free(records);
+}
+
 /* Gets OAuth token; (allocates sds string everytime, must deallocate) */
 flb_sds_t get_az_li_token(struct flb_az_li *ctx)
 {
@@ -242,6 +388,96 @@ token_cleanup:
     return token_return;
 }
 
+int az_li_send_payload(struct flb_az_li *ctx, const void *payload,
+                       size_t payload_size, size_t uncompressed_size,
+                       int compressed, int *http_status)
+{
+    int ret;
+    size_t bytes_sent;
+    flb_sds_t token;
+#ifdef FLB_HAVE_METRICS
+    uint64_t metrics_timestamp;
+    char *output_name;
+#endif
+    struct flb_connection *connection;
+    struct flb_http_client *client;
+
+    token = NULL;
+    client = NULL;
+    connection = flb_upstream_conn_get(ctx->u_dce);
+    if (connection == NULL) {
+        return -1;
+    }
+
+    token = get_az_li_token(ctx);
+    if (token == NULL) {
+        flb_upstream_conn_release(connection);
+        return -1;
+    }
+
+    client = flb_http_client(connection, FLB_HTTP_POST, ctx->dce_u_url,
+                             payload, payload_size, NULL, 0, NULL, 0);
+    if (client == NULL) {
+        flb_sds_destroy(token);
+        flb_upstream_conn_release(connection);
+        return -1;
+    }
+
+    flb_http_add_header(client, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(client, "Content-Type", 12, "application/json", 16);
+    if (compressed == FLB_TRUE) {
+        flb_http_add_header(client, "Content-Encoding", 16, "gzip", 4);
+    }
+    flb_http_add_header(client, "Authorization", 13, token, flb_sds_len(token));
+    flb_http_buffer_size(client, FLB_HTTP_DATA_SIZE_MAX);
+    flb_http_set_response_timeout(client, ctx->http_timeout);
+    flb_http_set_read_idle_timeout(client, ctx->http_timeout);
+
+#ifdef FLB_HAVE_METRICS
+    metrics_timestamp = cfl_time_now();
+    output_name = (char *) flb_output_name(ctx->ins);
+    pthread_mutex_lock(&ctx->payload_metrics_mutex);
+    cmt_histogram_observe(ctx->cmt_uncompressed_payload_size,
+                          metrics_timestamp,
+                          (double) uncompressed_size,
+                          2, (char *[]) {output_name, ctx->dcr_id});
+    cmt_histogram_observe(ctx->cmt_http_payload_size,
+                          metrics_timestamp,
+                          (double) payload_size,
+                          2, (char *[]) {output_name, ctx->dcr_id});
+    if (payload_size < ctx->http_payload_size_min) {
+        ctx->http_payload_size_min = payload_size;
+        cmt_gauge_set(ctx->cmt_http_payload_size_min,
+                      metrics_timestamp,
+                      (double) payload_size,
+                      2, (char *[]) {output_name, ctx->dcr_id});
+    }
+    pthread_mutex_unlock(&ctx->payload_metrics_mutex);
+#endif
+
+    ret = flb_http_do(client, &bytes_sent);
+    if (ret == 0) {
+        *http_status = client->resp.status;
+        if (client->resp.status < 200 || client->resp.status > 299) {
+            if (client->resp.payload_size > 0) {
+                flb_plg_warn(ctx->ins, "http_status=%i: %s",
+                             client->resp.status, client->resp.payload);
+            }
+            else {
+                flb_plg_warn(ctx->ins, "http_status=%i", client->resp.status);
+            }
+        }
+    }
+    else {
+        flb_plg_warn(ctx->ins, "http_do=%i", ret);
+    }
+
+    flb_http_client_destroy(client);
+    flb_sds_destroy(token);
+    flb_upstream_conn_release(connection);
+    return ret;
+}
+
 static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
                            struct flb_output_flush *out_flush,
                            struct flb_input_instance *i_ins,
@@ -249,129 +485,82 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
                            struct flb_config *config)
 {
     int ret;
-    int flush_status;
-    size_t b_sent;
+    int status;
     size_t json_payload_size;
-    void* final_payload;
+    size_t record_count;
+    void *final_payload;
     size_t final_payload_size;
-    flb_sds_t token;
-    struct flb_connection *u_conn;
-    struct flb_http_client *c = NULL;
-    int is_compressed = FLB_FALSE;
-    flb_sds_t json_payload = NULL;
-    struct flb_az_li *ctx = out_context;
-    (void) i_ins;
-    (void) config;
+    int is_compressed;
+    flb_sds_t json_payload;
+    flb_sds_t *records;
+    struct flb_az_li *ctx;
 
-    /* Get upstream connection */
-    u_conn = flb_upstream_conn_get(ctx->u_dce);
-    if (!u_conn) {
-        FLB_OUTPUT_RETURN(FLB_RETRY);
+    (void) i_ins;
+    ctx = out_context;
+    json_payload = NULL;
+    records = NULL;
+    record_count = 0;
+    final_payload = NULL;
+    is_compressed = FLB_FALSE;
+
+    if (ctx->buffering_enabled == FLB_TRUE) {
+        /* cb_worker_init failures are not propagated by the output thread
+         * framework. Retry timer creation here and never accept durable
+         * ownership unless the uploader is active. */
+        if (az_li_batch_start_uploader(ctx) == -1) {
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+        ret = az_li_format_records(event_chunk->data, event_chunk->size,
+                                   &records, &record_count, ctx, config);
+        if (ret == -1) {
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+        ret = az_li_batch_admit_chunk(ctx, out_flush, event_chunk,
+                                      records, record_count);
+        az_li_records_destroy(records, record_count);
+        if (ret == -1) {
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
+        FLB_OUTPUT_RETURN(FLB_OK);
     }
 
-    /* Convert binary logs into a JSON payload */
     ret = az_li_format(event_chunk->data, event_chunk->size,
-                       &json_payload, &json_payload_size, ctx,
-                       config);
+                       &json_payload, &json_payload_size, ctx, config);
     if (ret == -1) {
-        flb_upstream_conn_release(u_conn);
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
 
-    /* Get OAuth2 token */
-    token = get_az_li_token(ctx);
-    if (!token) {
-        flush_status = FLB_RETRY;
-        goto cleanup;
-    }
-
-    /* Map buffer */
     final_payload = json_payload;
     final_payload_size = json_payload_size;
     if (ctx->compress_enabled == FLB_TRUE) {
-        ret = flb_gzip_compress((void *) json_payload, json_payload_size,
+        ret = flb_gzip_compress(json_payload, json_payload_size,
                                 &final_payload, &final_payload_size);
         if (ret == -1) {
-            flb_plg_error(ctx->ins,
-                          "cannot gzip payload, disabling compression");
+            flb_plg_error(ctx->ins, "cannot gzip payload, disabling compression");
+            final_payload = json_payload;
+            final_payload_size = json_payload_size;
         }
         else {
             is_compressed = FLB_TRUE;
-            flb_plg_debug(ctx->ins, "enabled payload gzip compression");
-            /* JSON buffer will be cleared at cleanup: */
         }
     }
 
-    /* Compose HTTP Client request */
-    c = flb_http_client(u_conn, FLB_HTTP_POST, ctx->dce_u_url,
-                        final_payload, final_payload_size, NULL, 0, NULL, 0);
-
-    if (!c) {
-        flb_plg_warn(ctx->ins, "retrying payload bytes=%lu", final_payload_size);
-        flush_status = FLB_RETRY;
-        goto cleanup;
-    }
-
-    /* Append headers */
-    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
-    flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
-    if (is_compressed) {
-        flb_http_add_header(c, "Content-Encoding", 16, "gzip", 4);
-    }
-    flb_http_add_header(c, "Authorization", 13, token, flb_sds_len(token));
-    flb_http_buffer_size(c, FLB_HTTP_DATA_SIZE_MAX);
-
-    /* Execute rest call */
-    ret = flb_http_do(c, &b_sent);
-    if (ret != 0) {
-        flb_plg_warn(ctx->ins, "http_do=%i", ret);
-        flush_status = FLB_RETRY;
-        goto cleanup;
-    }
-    else {
-        if (c->resp.status >= 200 && c->resp.status <= 299) {
-            flb_plg_info(ctx->ins, "http_status=%i, dcr_id=%s, table=%s",
-                         c->resp.status, ctx->dcr_id, ctx->table_name);
-            flush_status = FLB_OK;
-            goto cleanup;
-        }
-        else {
-            if (c->resp.payload_size > 0) {
-                flb_plg_warn(ctx->ins, "http_status=%i:\n%s",
-                             c->resp.status, c->resp.payload);
-            }
-            else {
-                flb_plg_warn(ctx->ins, "http_status=%i", c->resp.status);
-            }
-            flb_plg_debug(ctx->ins, "retrying payload bytes=%lu", final_payload_size);
-            flush_status = FLB_RETRY;
-            goto cleanup;
-        }
-    }
-
-cleanup:
-    /* cleanup */
-    if (json_payload) {
-        flb_sds_destroy(json_payload);
-    }
-
-    /* release compressed payload */
+    status = 0;
+    ret = az_li_send_payload(ctx, final_payload, final_payload_size,
+                             json_payload_size, is_compressed, &status);
     if (is_compressed == FLB_TRUE) {
         flb_free(final_payload);
     }
+    flb_sds_destroy(json_payload);
 
-    if (c) {
-        flb_http_client_destroy(c);
-    }
-    if (u_conn) {
-        flb_upstream_conn_release(u_conn);
+    if (ret != 0 || status < 200 || status > 299) {
+        FLB_OUTPUT_RETURN(FLB_RETRY);
     }
 
-    /* destory token at last after HTTP call has finished */
-    if (token) {
-        flb_sds_destroy(token);
-    }
-    FLB_OUTPUT_RETURN(flush_status);
+    flb_plg_info(ctx->ins,
+                 "http_status=%i, dcr_id=%s, table=%s, request_bytes=%zu",
+                 status, ctx->dcr_id, ctx->table_name, final_payload_size);
+    FLB_OUTPUT_RETURN(FLB_OK);
 }
 
 static int cb_azure_logs_ingestion_exit(void *data, struct flb_config *config)
@@ -442,6 +631,61 @@ static struct flb_config_map config_map[] = {
      0, FLB_TRUE,  offsetof(struct flb_az_li, compress_enabled),
      "Enable HTTP payload compression (gzip)."
     },
+    {
+     FLB_CONFIG_MAP_BOOL, "buffering_enabled", "false",
+     0, FLB_TRUE, offsetof(struct flb_az_li, buffering_enabled),
+     "Persist and batch records locally before ingestion."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "buffer_dir", "/tmp/fluent-bit/azure-logs-ingestion",
+     0, FLB_TRUE, offsetof(struct flb_az_li, buffer_dir),
+     "Directory for local request batches."
+    },
+    {
+     FLB_CONFIG_MAP_STR, "buffer_key", (char *) NULL,
+     0, FLB_TRUE, offsetof(struct flb_az_li, buffer_key),
+     "Stable storage key for this output instance."
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "batch_target_size", "900000",
+     0, FLB_TRUE, offsetof(struct flb_az_li, batch_target_size),
+     "Preferred compressed request size in bytes."
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "batch_timeout", "5s",
+     0, FLB_TRUE, offsetof(struct flb_az_li, batch_timeout),
+     "Maximum age of an active local batch."
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "batch_max_uncompressed_size", "16M",
+     0, FLB_TRUE, offsetof(struct flb_az_li, batch_max_uncompressed_size),
+     "Maximum uncompressed JSON batch size."
+    },
+    {
+     FLB_CONFIG_MAP_SIZE, "buffer_dir_limit_size", "0",
+     0, FLB_TRUE, offsetof(struct flb_az_li, buffer_dir_limit_size),
+     "Aggregate bytes owned by outputs sharing buffer_dir."
+    },
+    {
+     FLB_CONFIG_MAP_INT, "upload_retry_limit", "0",
+     0, FLB_TRUE, offsetof(struct flb_az_li, upload_retry_limit),
+     "Maximum transient retries before quarantine; zero retries indefinitely."
+    },
+    {
+     FLB_CONFIG_MAP_INT, "upload_retry_base", "1",
+     0, FLB_TRUE, offsetof(struct flb_az_li, upload_retry_base),
+     "Base retry delay in seconds."
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "buffer_receipt_ttl", "24h",
+     0, FLB_TRUE, offsetof(struct flb_az_li, buffer_receipt_ttl),
+     "Retention for completed chunk receipts; zero retains them indefinitely."
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "http_timeout", "30s",
+     0, FLB_TRUE, offsetof(struct flb_az_li, http_timeout),
+     "Maximum response and read-idle time for an ingestion request."
+    },
     /* EOF */
     {0}
 };
@@ -450,8 +694,9 @@ struct flb_output_plugin out_azure_logs_ingestion_plugin = {
     .name         = "azure_logs_ingestion",
     .description  = "Send logs to Log Analytics with Log Ingestion API",
     .cb_init      = cb_azure_logs_ingestion_init,
-    .cb_flush     = cb_azure_logs_ingestion_flush,
-    .cb_exit      = cb_azure_logs_ingestion_exit,
+    .cb_flush       = cb_azure_logs_ingestion_flush,
+    .cb_exit        = cb_azure_logs_ingestion_exit,
+    .cb_worker_init = cb_azure_logs_ingestion_worker_init,
 
     /* Configuration */
     .config_map     = config_map,

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -59,6 +59,7 @@ static int cb_azure_logs_ingestion_init(struct flb_output_instance *ins,
         return -1;
     }
 
+#ifdef FLB_HAVE_SQLDB
     if (ctx->buffering_enabled == FLB_TRUE) {
         /* OAuth creates its upstream independently of the output helper. Add
          * it to the single output worker's upstream map explicitly. */
@@ -71,6 +72,7 @@ static int cb_azure_logs_ingestion_init(struct flb_output_instance *ins,
             return -1;
         }
     }
+#endif
 
     return 0;
 }
@@ -84,10 +86,29 @@ static int cb_azure_logs_ingestion_worker_init(void *data,
     if (ctx->buffering_enabled == FLB_FALSE) {
         return 0;
     }
+#ifdef FLB_HAVE_SQLDB
     if (az_li_batch_start_uploader(ctx) == -1) {
         flb_plg_error(ctx->ins, "could not start disk-backed batching uploader");
         return -1;
     }
+    return 0;
+#else
+    return -1;
+#endif
+}
+
+static int cb_azure_logs_ingestion_worker_exit(void *data,
+                                                struct flb_config *config)
+{
+    struct flb_az_li *ctx = data;
+
+    (void) config;
+    (void) ctx;
+#ifdef FLB_HAVE_SQLDB
+    if (ctx->buffering_enabled == FLB_TRUE) {
+        az_li_batch_stop_uploader(ctx);
+    }
+#endif
     return 0;
 }
 
@@ -95,6 +116,7 @@ static int cb_azure_logs_ingestion_worker_init(void *data,
     allocates sds string */
 static int az_li_format(const void *in_buf, size_t in_bytes,
                         char **out_buf, size_t *out_size,
+                        size_t *out_record_count,
                         struct flb_az_li *ctx,
                         struct flb_config *config)
 {
@@ -198,115 +220,9 @@ static int az_li_format(const void *in_buf, size_t in_bytes,
 
     *out_buf = record;
     *out_size = flb_sds_len(record);
+    *out_record_count = (size_t) array_size;
 
     return 0;
-}
-
-static int az_li_format_records(const void *in_buf, size_t in_bytes,
-                                flb_sds_t **out_records, size_t *out_count,
-                                struct flb_az_li *ctx,
-                                struct flb_config *config)
-{
-    int i;
-    int ret;
-    int map_size;
-    int expected;
-    int len;
-    double timestamp;
-    size_t count;
-    size_t formatted_size;
-    struct tm time_parts;
-    struct flb_time event_time;
-    struct flb_log_event_decoder decoder;
-    struct flb_log_event event;
-    msgpack_object map;
-    msgpack_sbuffer buffer;
-    msgpack_packer packer;
-    flb_sds_t record;
-    flb_sds_t *records;
-    char formatted_time[32];
-
-    expected = flb_mp_count_log_records(in_buf, in_bytes);
-    if (expected <= 0) {
-        *out_records = NULL;
-        *out_count = 0;
-        return 0;
-    }
-
-    records = flb_calloc(expected, sizeof(flb_sds_t));
-    if (records == NULL) {
-        return -1;
-    }
-
-    ret = flb_log_event_decoder_init(&decoder, (char *) in_buf, in_bytes);
-    if (ret != FLB_EVENT_DECODER_SUCCESS) {
-        flb_free(records);
-        return -1;
-    }
-
-    count = 0;
-    while ((ret = flb_log_event_decoder_next(&decoder, &event)) ==
-           FLB_EVENT_DECODER_SUCCESS) {
-        flb_time_copy(&event_time, &event.timestamp);
-        map = *event.body;
-        map_size = map.via.map.size;
-
-        msgpack_sbuffer_init(&buffer);
-        msgpack_packer_init(&packer, &buffer, msgpack_sbuffer_write);
-        msgpack_pack_map(&packer, map_size + 1);
-        msgpack_pack_str(&packer, flb_sds_len(ctx->time_key));
-        msgpack_pack_str_body(&packer, ctx->time_key, flb_sds_len(ctx->time_key));
-
-        if (ctx->time_generated == FLB_TRUE) {
-            gmtime_r(&event_time.tm.tv_sec, &time_parts);
-            formatted_size = strftime(formatted_time, sizeof(formatted_time) - 1,
-                                      FLB_PACK_JSON_DATE_ISO8601_FMT, &time_parts);
-            len = snprintf(formatted_time + formatted_size,
-                           sizeof(formatted_time) - 1 - formatted_size,
-                           ".%03" PRIu64 "Z",
-                           (uint64_t) event_time.tm.tv_nsec / 1000000);
-            formatted_size += len;
-            msgpack_pack_str(&packer, formatted_size);
-            msgpack_pack_str_body(&packer, formatted_time, formatted_size);
-        }
-        else {
-            timestamp = flb_time_to_double(&event_time);
-            msgpack_pack_double(&packer, timestamp);
-        }
-
-        for (i = 0; i < map_size; i++) {
-            msgpack_pack_object(&packer, map.via.map.ptr[i].key);
-            msgpack_pack_object(&packer, map.via.map.ptr[i].val);
-        }
-
-        record = flb_msgpack_raw_to_json_sds(buffer.data, buffer.size,
-                                             config->json_escape_unicode);
-        msgpack_sbuffer_destroy(&buffer);
-        if (record == NULL) {
-            for (i = 0; i < count; i++) {
-                flb_sds_destroy(records[i]);
-            }
-            flb_free(records);
-            flb_log_event_decoder_destroy(&decoder);
-            return -1;
-        }
-        records[count++] = record;
-    }
-
-    flb_log_event_decoder_destroy(&decoder);
-    *out_records = records;
-    *out_count = count;
-    return 0;
-}
-
-static void az_li_records_destroy(flb_sds_t *records, size_t count)
-{
-    size_t index;
-
-    for (index = 0; index < count; index++) {
-        flb_sds_destroy(records[index]);
-    }
-    flb_free(records);
 }
 
 /* Gets OAuth token; (allocates sds string everytime, must deallocate) */
@@ -430,29 +346,30 @@ int az_li_send_payload(struct flb_az_li *ctx, const void *payload,
     }
     flb_http_add_header(client, "Authorization", 13, token, flb_sds_len(token));
     flb_http_buffer_size(client, FLB_HTTP_DATA_SIZE_MAX);
-    flb_http_set_response_timeout(client, ctx->http_timeout);
-    flb_http_set_read_idle_timeout(client, ctx->http_timeout);
+    if (ctx->buffering_enabled == FLB_TRUE) {
+        flb_http_set_response_timeout(client, ctx->http_timeout);
+        flb_http_set_read_idle_timeout(client, ctx->http_timeout);
+    }
 
 #ifdef FLB_HAVE_METRICS
-    metrics_timestamp = cfl_time_now();
-    output_name = (char *) flb_output_name(ctx->ins);
-    pthread_mutex_lock(&ctx->payload_metrics_mutex);
-    cmt_histogram_observe(ctx->cmt_uncompressed_payload_size,
-                          metrics_timestamp,
-                          (double) uncompressed_size,
-                          2, (char *[]) {output_name, ctx->dcr_id});
-    cmt_histogram_observe(ctx->cmt_http_payload_size,
-                          metrics_timestamp,
-                          (double) payload_size,
-                          2, (char *[]) {output_name, ctx->dcr_id});
-    if (payload_size < ctx->http_payload_size_min) {
-        ctx->http_payload_size_min = payload_size;
-        cmt_gauge_set(ctx->cmt_http_payload_size_min,
-                      metrics_timestamp,
-                      (double) payload_size,
-                      2, (char *[]) {output_name, ctx->dcr_id});
+    if (ctx->payload_metrics_mutex_initialized == FLB_TRUE) {
+        metrics_timestamp = cfl_time_now();
+        output_name = (char *) flb_output_name(ctx->ins);
+        pthread_mutex_lock(&ctx->payload_metrics_mutex);
+        if (ctx->cmt_uncompressed_payload_size != NULL) {
+            cmt_histogram_observe(ctx->cmt_uncompressed_payload_size,
+                                  metrics_timestamp,
+                                  (double) uncompressed_size,
+                                  2, (char *[]) {output_name, ctx->dcr_id});
+        }
+        if (ctx->cmt_http_payload_size != NULL) {
+            cmt_histogram_observe(ctx->cmt_http_payload_size,
+                                  metrics_timestamp,
+                                  (double) payload_size,
+                                  2, (char *[]) {output_name, ctx->dcr_id});
+        }
+        pthread_mutex_unlock(&ctx->payload_metrics_mutex);
     }
-    pthread_mutex_unlock(&ctx->payload_metrics_mutex);
 #endif
 
     ret = flb_http_do(client, &bytes_sent);
@@ -492,40 +409,47 @@ static void cb_azure_logs_ingestion_flush(struct flb_event_chunk *event_chunk,
     size_t final_payload_size;
     int is_compressed;
     flb_sds_t json_payload;
-    flb_sds_t *records;
     struct flb_az_li *ctx;
 
     (void) i_ins;
     ctx = out_context;
     json_payload = NULL;
-    records = NULL;
     record_count = 0;
     final_payload = NULL;
     is_compressed = FLB_FALSE;
 
     if (ctx->buffering_enabled == FLB_TRUE) {
+#ifdef FLB_HAVE_SQLDB
         /* cb_worker_init failures are not propagated by the output thread
          * framework. Retry timer creation here and never accept durable
          * ownership unless the uploader is active. */
         if (az_li_batch_start_uploader(ctx) == -1) {
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
-        ret = az_li_format_records(event_chunk->data, event_chunk->size,
-                                   &records, &record_count, ctx, config);
+        ret = az_li_format(event_chunk->data, event_chunk->size,
+                           &json_payload, &json_payload_size, &record_count,
+                           ctx, config);
         if (ret == -1) {
-            FLB_OUTPUT_RETURN(FLB_ERROR);
+            /* The plugin has not taken ownership yet. Preserve the engine chunk
+             * for retry on transient decoder, allocation, or formatting errors. */
+            FLB_OUTPUT_RETURN(FLB_RETRY);
         }
-        ret = az_li_batch_admit_chunk(ctx, out_flush, event_chunk,
-                                      records, record_count);
-        az_li_records_destroy(records, record_count);
-        if (ret == -1) {
+        ret = az_li_batch_admit_chunk(ctx, out_flush,
+                                      json_payload, json_payload_size,
+                                      record_count);
+        flb_sds_destroy(json_payload);
+        if (ret != 0) {
             FLB_OUTPUT_RETURN(FLB_RETRY);
         }
         FLB_OUTPUT_RETURN(FLB_OK);
+#else
+        FLB_OUTPUT_RETURN(FLB_ERROR);
+#endif
     }
 
     ret = az_li_format(event_chunk->data, event_chunk->size,
-                       &json_payload, &json_payload_size, ctx, config);
+                       &json_payload, &json_payload_size, &record_count,
+                       ctx, config);
     if (ret == -1) {
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
@@ -634,12 +558,15 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_BOOL, "buffering_enabled", "false",
      0, FLB_TRUE, offsetof(struct flb_az_li, buffering_enabled),
-     "Persist and batch records locally before ingestion."
+     "Persist and batch complete engine chunks locally before ingestion. In this "
+     "mode retry_limit must be no_limits, and generic output processed and latency "
+     "metrics end at durable local admission; use plugin delivery and queue metrics "
+     "for Azure delivery health."
     },
     {
      FLB_CONFIG_MAP_STR, "buffer_dir", "/tmp/fluent-bit/azure-logs-ingestion",
      0, FLB_TRUE, offsetof(struct flb_az_li, buffer_dir),
-     "Directory for local request batches."
+     "Dedicated directory for the SQLite spool and its sidecars."
     },
     {
      FLB_CONFIG_MAP_STR, "buffer_key", (char *) NULL,
@@ -649,7 +576,7 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "batch_target_size", "900000",
      0, FLB_TRUE, offsetof(struct flb_az_li, batch_target_size),
-     "Preferred compressed request size in bytes."
+     "Soft compressed-size trigger for requests of complete source chunks."
     },
     {
      FLB_CONFIG_MAP_TIME, "batch_timeout", "5s",
@@ -659,17 +586,23 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_SIZE, "batch_max_uncompressed_size", "16M",
      0, FLB_TRUE, offsetof(struct flb_az_li, batch_max_uncompressed_size),
-     "Maximum uncompressed JSON batch size."
+     "Hard uncompressed JSON limit for a source chunk or combined request. The "
+     "planner snapshots at most this many source bytes and may temporarily hold "
+     "source copies, assembled JSON and gzip workspace (roughly three times the limit)."
     },
     {
      FLB_CONFIG_MAP_SIZE, "buffer_dir_limit_size", "0",
      0, FLB_TRUE, offsetof(struct flb_az_li, buffer_dir_limit_size),
-     "Aggregate bytes owned by outputs sharing buffer_dir."
+     "Aggregate logical owned-data limit with SQLite main-database and WAL "
+     "headroom for outputs sharing buffer_dir. Use a dedicated filesystem quota or "
+     "ephemeral-storage limit as the physical hard bound."
     },
     {
      FLB_CONFIG_MAP_INT, "upload_retry_limit", "0",
      0, FLB_TRUE, offsetof(struct flb_az_li, upload_retry_limit),
-     "Maximum transient retries before quarantine; zero retries indefinitely."
+     "Maximum transient retries before quarantine. Zero preserves strict FIFO and "
+     "retries outage data indefinitely; alert on queue age, uploader health and "
+     "quarantine usage."
     },
     {
      FLB_CONFIG_MAP_INT, "upload_retry_base", "1",
@@ -679,12 +612,12 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_TIME, "buffer_receipt_ttl", "24h",
      0, FLB_TRUE, offsetof(struct flb_az_li, buffer_receipt_ttl),
-     "Retention for completed chunk receipts; zero retains them indefinitely."
+     "Positive retention window for completed chunk deduplication receipts."
     },
     {
      FLB_CONFIG_MAP_TIME, "http_timeout", "30s",
      0, FLB_TRUE, offsetof(struct flb_az_li, http_timeout),
-     "Maximum response and read-idle time for an ingestion request."
+     "Maximum connect, response and read-idle time for buffered OAuth and ingestion requests."
     },
     /* EOF */
     {0}
@@ -697,6 +630,7 @@ struct flb_output_plugin out_azure_logs_ingestion_plugin = {
     .cb_flush       = cb_azure_logs_ingestion_flush,
     .cb_exit        = cb_azure_logs_ingestion_exit,
     .cb_worker_init = cb_azure_logs_ingestion_worker_init,
+    .cb_worker_exit = cb_azure_logs_ingestion_worker_exit,
 
     /* Configuration */
     .config_map     = config_map,

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c
@@ -83,6 +83,9 @@ static int cb_azure_logs_ingestion_worker_init(void *data,
     struct flb_az_li *ctx = data;
 
     (void) config;
+    if (ctx == NULL) {
+        return 0;
+    }
     if (ctx->buffering_enabled == FLB_FALSE) {
         return 0;
     }
@@ -103,7 +106,9 @@ static int cb_azure_logs_ingestion_worker_exit(void *data,
     struct flb_az_li *ctx = data;
 
     (void) config;
-    (void) ctx;
+    if (ctx == NULL) {
+        return 0;
+    }
 #ifdef FLB_HAVE_SQLDB
     if (ctx->buffering_enabled == FLB_TRUE) {
         az_li_batch_stop_uploader(ctx);

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -33,10 +33,25 @@
 #define FLB_AZ_LI_TLS_MODE          FLB_IO_TLS
 /* refresh token every 60 minutes */
 #define FLB_AZ_LI_TOKEN_TIMEOUT 3600
+/* Azure Logs Ingestion API maximum HTTP body size. With Content-Encoding:
+ * gzip this applies to the compressed wire representation. */
+#define FLB_AZ_LI_MAX_REQUEST_SIZE (1024 * 1024)
+/* One maximum-size request artifact, SQLite rows for 256 source spans, and
+ * filesystem metadata must remain constructible when admission is full. */
+#define FLB_AZ_LI_MIN_BUFFER_SIZE (FLB_AZ_LI_MAX_REQUEST_SIZE + 73728)
+
+#include <time.h>
 
 #include <fluent-bit/flb_info.h>
 #include <fluent-bit/flb_output.h>
 #include <fluent-bit/flb_sds.h>
+
+#ifdef FLB_HAVE_METRICS
+#include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_histogram.h>
+#endif
+
+struct flb_az_li_batch;
 
 /* Context structure for Azure Logs Ingestion API */
 struct flb_az_li {
@@ -56,20 +71,49 @@ struct flb_az_li {
     /* compress payload */
     int compress_enabled;
 
+    /* optional disk-backed request batching */
+    int buffering_enabled;
+    flb_sds_t buffer_dir;
+    flb_sds_t buffer_key;
+    int buffer_key_owned;
+    size_t batch_target_size;
+    time_t batch_timeout;
+    size_t batch_max_uncompressed_size;
+    size_t buffer_dir_limit_size;
+    int upload_retry_limit;
+    int upload_retry_base;
+    time_t buffer_receipt_ttl;
+    time_t http_timeout;
+    struct flb_az_li_batch *batch;
+
     /* mangement auth */
     flb_sds_t auth_url_override;
     flb_sds_t auth_url;
     struct flb_oauth2 *u_auth;
     /* mutex for acquiring tokens */
     pthread_mutex_t token_mutex;
+    int token_mutex_initialized;
 
     /* upstream connection to the data collection endpoint */
     struct flb_upstream *u_dce;
     flb_sds_t dce_u_url;
 
+#ifdef FLB_HAVE_METRICS
+    struct cmt_histogram *cmt_uncompressed_payload_size;
+    struct cmt_histogram *cmt_http_payload_size;
+    struct cmt_gauge *cmt_http_payload_size_min;
+    pthread_mutex_t payload_metrics_mutex;
+    size_t http_payload_size_min;
+    int payload_metrics_mutex_initialized;
+#endif
+
     /* plugin output and config instance reference */
     struct flb_output_instance *ins;
     struct flb_config *config;
 };
+
+int az_li_send_payload(struct flb_az_li *ctx, const void *payload,
+                       size_t payload_size, size_t uncompressed_size,
+                       int compressed, int *http_status);
 
 #endif

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion.h
@@ -36,8 +36,8 @@
 /* Azure Logs Ingestion API maximum HTTP body size. With Content-Encoding:
  * gzip this applies to the compressed wire representation. */
 #define FLB_AZ_LI_MAX_REQUEST_SIZE (1024 * 1024)
-/* One maximum-size request artifact, SQLite rows for 256 source spans, and
- * filesystem metadata must remain constructible when admission is full. */
+/* One maximum-size request BLOB, SQLite membership for eight complete
+ * source chunks, and transition metadata must remain constructible. */
 #define FLB_AZ_LI_MIN_BUFFER_SIZE (FLB_AZ_LI_MAX_REQUEST_SIZE + 73728)
 
 #include <time.h>
@@ -47,6 +47,7 @@
 #include <fluent-bit/flb_sds.h>
 
 #ifdef FLB_HAVE_METRICS
+#include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_histogram.h>
 #endif
@@ -77,13 +78,13 @@ struct flb_az_li {
     flb_sds_t buffer_key;
     int buffer_key_owned;
     size_t batch_target_size;
-    time_t batch_timeout;
+    int batch_timeout;
     size_t batch_max_uncompressed_size;
     size_t buffer_dir_limit_size;
     int upload_retry_limit;
     int upload_retry_base;
-    time_t buffer_receipt_ttl;
-    time_t http_timeout;
+    int buffer_receipt_ttl;
+    int http_timeout;
     struct flb_az_li_batch *batch;
 
     /* mangement auth */
@@ -101,9 +102,29 @@ struct flb_az_li {
 #ifdef FLB_HAVE_METRICS
     struct cmt_histogram *cmt_uncompressed_payload_size;
     struct cmt_histogram *cmt_http_payload_size;
-    struct cmt_gauge *cmt_http_payload_size_min;
+    struct cmt_counter *cmt_admitted_chunks;
+    struct cmt_counter *cmt_admitted_records;
+    struct cmt_counter *cmt_admitted_bytes;
+    struct cmt_counter *cmt_delivered_chunks;
+    struct cmt_counter *cmt_delivered_records;
+    struct cmt_counter *cmt_delivered_bytes;
+    struct cmt_counter *cmt_quarantined_chunks;
+    struct cmt_counter *cmt_quarantined_records;
+    struct cmt_counter *cmt_quota_rejections;
+    struct cmt_counter *cmt_persistence_failures;
+    struct cmt_counter *cmt_degraded_recoveries;
+    struct cmt_gauge *cmt_queued_chunks;
+    struct cmt_gauge *cmt_queued_records;
+    struct cmt_gauge *cmt_queued_bytes;
+    struct cmt_gauge *cmt_quarantined_chunks_current;
+    struct cmt_gauge *cmt_quarantined_bytes;
+    struct cmt_gauge *cmt_quota_used_bytes;
+    struct cmt_gauge *cmt_quota_limit_bytes;
+    struct cmt_gauge *cmt_oldest_queued_age;
+    struct cmt_gauge *cmt_uploader_up;
+    struct cmt_gauge *cmt_uploader_consecutive_failures;
+    struct cmt_gauge *cmt_uploader_last_success;
     pthread_mutex_t payload_metrics_mutex;
-    size_t http_payload_size_min;
     int payload_metrics_mutex_initialized;
 #endif
 

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
@@ -1,0 +1,2367 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <sys/stat.h>
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+#endif
+
+#include <fluent-bit/flb_event.h>
+#include <fluent-bit/flb_fstore.h>
+#include <fluent-bit/flb_gzip.h>
+#include <fluent-bit/flb_hash.h>
+#include <fluent-bit/flb_input_chunk.h>
+#include <fluent-bit/flb_mem.h>
+#include <fluent-bit/flb_oauth2.h>
+#include <fluent-bit/flb_output.h>
+#include <fluent-bit/flb_output_plugin.h>
+#include <fluent-bit/flb_random.h>
+#include <fluent-bit/flb_scheduler.h>
+#include <fluent-bit/flb_sqldb.h>
+#include <fluent-bit/flb_task.h>
+#include <fluent-bit/flb_time.h>
+#include <chunkio/cio_chunk.h>
+
+#include "azure_logs_ingestion.h"
+#include "azure_logs_ingestion_batch.h"
+#include "azure_logs_ingestion_conf.h"
+
+#define AZLI_SOURCE_STREAM       "sources"
+#define AZLI_REQUEST_STREAM      "requests"
+#define AZLI_TIMER_MS            1000
+#define AZLI_RATIO_ALPHA         0.25
+#define AZLI_FILE_OVERHEAD       4096
+/* Conservative reservations are charged in addition to actual SQLite files. */
+#define AZLI_SOURCE_DB_RESERVE   4096
+#define AZLI_REQUEST_DB_RESERVE  4096
+#define AZLI_SPAN_DB_RESERVE     256
+#define AZLI_MAX_REQUEST_SPANS   256
+#define AZLI_MAX_SOURCE_FILES    10000
+#define AZLI_SOURCE_READY        1
+#define AZLI_SOURCE_DRAINED      2
+#define AZLI_SOURCE_QUARANTINED  3
+#define AZLI_REQUEST_READY       1
+#define AZLI_REQUEST_INFLIGHT    2
+#define AZLI_REQUEST_RETRY       3
+#define AZLI_REQUEST_ACKED       4
+#define AZLI_REQUEST_QUARANTINED 5
+#define AZLI_DIGEST_SIZE         32
+#define AZLI_HEX_SIZE            (AZLI_DIGEST_SIZE * 2)
+
+struct azli_root_manager {
+    flb_sds_t path;
+    size_t limit;
+    size_t used;
+    size_t files;
+    int references;
+    int lock_fd;
+    struct flb_sqldb *db;
+    pthread_mutex_t mutex;
+    struct mk_list _head;
+};
+
+struct azli_candidate_record {
+    int64_t source_pk;
+    int64_t record_index;
+    size_t json_end;
+};
+
+struct azli_source_buffer {
+    void *data;
+    struct mk_list _head;
+};
+
+struct azli_span {
+    int64_t source_pk;
+    int64_t first_record;
+    int64_t record_count;
+};
+
+struct azli_request {
+    int64_t request_pk;
+    int state;
+    int attempts;
+    int64_t next_retry;
+    int64_t json_bytes;
+    int64_t gzip_bytes;
+    flb_sds_t name;
+    unsigned char digest[AZLI_DIGEST_SIZE];
+};
+
+static int request_commit_spans(struct flb_az_li *ctx,
+                                struct azli_request *request,
+                                int quarantine, int status,
+                                const char *reason);
+
+struct flb_az_li_batch {
+    flb_sds_t root_path;
+    struct flb_fstore *fs;
+    struct flb_fstore_stream *sources;
+    struct flb_fstore_stream *requests;
+    struct azli_root_manager *manager;
+    pthread_mutex_t lifecycle_mutex;
+    int lifecycle_initialized;
+    int lock_fd;
+    int upload_in_progress;
+    int uploader_started;
+    int shutting_down;
+    int fatal_error;
+    uint64_t request_sequence;
+    uint64_t probe_count;
+    double compression_ratio;
+    int compression_ratio_initialized;
+};
+
+static pthread_mutex_t manager_registry_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_once_t manager_registry_once = PTHREAD_ONCE_INIT;
+static struct mk_list manager_registry;
+
+static void manager_registry_init(void)
+{
+    mk_list_init(&manager_registry);
+}
+
+static int64_t now_seconds(void)
+{
+    return (int64_t) time(NULL);
+}
+
+static int sync_directory(const char *path)
+{
+#ifdef _WIN32
+    (void) path;
+    return 0;
+#else
+    int descriptor;
+    int result;
+
+    descriptor = open(path, O_RDONLY);
+    if (descriptor == -1) {
+        return -1;
+    }
+    result = fsync(descriptor);
+    close(descriptor);
+    return result;
+#endif
+}
+
+static int lock_spool_root(struct flb_az_li_batch *batch)
+{
+#ifdef _WIN32
+    batch->lock_fd = -1;
+    return 0;
+#else
+    char path[PATH_MAX];
+
+    snprintf(path, sizeof(path), "%s/.owner.lock", batch->root_path);
+    batch->lock_fd = open(path, O_CREAT | O_RDWR, 0600);
+    if (batch->lock_fd == -1 || flock(batch->lock_fd, LOCK_EX | LOCK_NB) == -1) {
+        if (batch->lock_fd != -1) {
+            close(batch->lock_fd);
+            batch->lock_fd = -1;
+        }
+        return -1;
+    }
+    return sync_directory(batch->root_path);
+#endif
+}
+
+static void unlock_spool_root(struct flb_az_li_batch *batch)
+{
+#ifndef _WIN32
+    if (batch->lock_fd != -1) {
+        flock(batch->lock_fd, LOCK_UN);
+        close(batch->lock_fd);
+        batch->lock_fd = -1;
+    }
+#else
+    (void) batch;
+#endif
+}
+
+static int lock_manager_root(struct azli_root_manager *manager)
+{
+#ifndef _WIN32
+    char path[PATH_MAX];
+
+    snprintf(path, sizeof(path), "%s/.azure_logs_ingestion.owner.lock",
+             manager->path);
+    manager->lock_fd = open(path, O_CREAT | O_RDWR, 0600);
+    if (manager->lock_fd == -1 ||
+        flock(manager->lock_fd, LOCK_EX | LOCK_NB) == -1) {
+        if (manager->lock_fd != -1) {
+            close(manager->lock_fd);
+            manager->lock_fd = -1;
+        }
+        return -1;
+    }
+    return sync_directory(manager->path);
+#else
+    (void) manager;
+    return -1;
+#endif
+}
+
+static void unlock_manager_root(struct azli_root_manager *manager)
+{
+#ifndef _WIN32
+    if (manager->lock_fd != -1) {
+        flock(manager->lock_fd, LOCK_UN);
+        close(manager->lock_fd);
+        manager->lock_fd = -1;
+    }
+#else
+    (void) manager;
+#endif
+}
+
+static int sql_exec(struct azli_root_manager *manager, const char *sql)
+{
+    char *error;
+    int ret;
+
+    error = NULL;
+    ret = sqlite3_exec(manager->db->handler, sql, NULL, NULL, &error);
+    if (ret != SQLITE_OK) {
+        if (error != NULL) {
+            flb_error("[azure_logs_ingestion] sqlite: %s", error);
+            sqlite3_free(error);
+        }
+        return -1;
+    }
+    return 0;
+}
+
+static void sql_rollback_if_active(struct azli_root_manager *manager)
+{
+    if (sqlite3_get_autocommit(manager->db->handler) == 0) {
+        sql_exec(manager, "ROLLBACK");
+    }
+}
+
+static int sql_commit(struct azli_root_manager *manager)
+{
+    if (sql_exec(manager, "COMMIT") == 0) {
+        return 0;
+    }
+
+    sql_rollback_if_active(manager);
+    return -1;
+}
+
+static int hash_bytes(const void *data, size_t size,
+                      unsigned char digest[AZLI_DIGEST_SIZE])
+{
+    return flb_hash_simple(FLB_HASH_SHA256, (unsigned char *) data, size,
+                           digest, AZLI_DIGEST_SIZE);
+}
+
+static void digest_hex(const unsigned char digest[AZLI_DIGEST_SIZE],
+                       char output[AZLI_HEX_SIZE + 1])
+{
+    static const char digits[] = "0123456789abcdef";
+    int index;
+
+    for (index = 0; index < AZLI_DIGEST_SIZE; index++) {
+        output[index * 2] = digits[digest[index] >> 4];
+        output[index * 2 + 1] = digits[digest[index] & 0x0f];
+    }
+    output[AZLI_HEX_SIZE] = '\0';
+}
+
+static int digest_from_hex(const char *input,
+                           unsigned char digest[AZLI_DIGEST_SIZE])
+{
+    int index;
+    unsigned int value;
+
+    if (input == NULL || strlen(input) != AZLI_HEX_SIZE) {
+        return -1;
+    }
+    for (index = 0; index < AZLI_DIGEST_SIZE; index++) {
+        if (sscanf(input + index * 2, "%2x", &value) != 1) {
+            return -1;
+        }
+        digest[index] = (unsigned char) value;
+    }
+    return 0;
+}
+
+static int manager_recount(struct azli_root_manager *manager)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(manager->db->handler,
+            "SELECT COALESCE((SELECT SUM(bytes) FROM azli_sources),0) + "
+            "COALESCE((SELECT SUM(bytes) FROM azli_requests),0), "
+            "(SELECT COUNT(*) FROM azli_sources) + "
+            "(SELECT COUNT(*) FROM azli_requests)", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    ret = sqlite3_step(statement);
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    manager->used = (size_t) sqlite3_column_int64(statement, 0);
+    manager->files = (size_t) sqlite3_column_int64(statement, 1);
+    sqlite3_finalize(statement);
+
+    if (manager->db->path != NULL) {
+        struct stat file_info;
+        char path[PATH_MAX];
+        const char *suffixes[] = {"", "-wal", "-shm"};
+        size_t index;
+
+        for (index = 0; index < sizeof(suffixes) / sizeof(suffixes[0]); index++) {
+            snprintf(path, sizeof(path), "%s%s", manager->db->path, suffixes[index]);
+            if (stat(path, &file_info) == 0 && file_info.st_size > 0) {
+                manager->used += (size_t) file_info.st_size;
+            }
+        }
+    }
+    return 0;
+}
+
+static int manager_schema(struct azli_root_manager *manager)
+{
+    const char *schema =
+        "PRAGMA journal_mode=WAL;"
+        "PRAGMA synchronous=FULL;"
+        "PRAGMA foreign_keys=ON;"
+        "CREATE TABLE IF NOT EXISTS azli_settings("
+        " root TEXT PRIMARY KEY, disk_limit INTEGER NOT NULL);"
+        "CREATE TABLE IF NOT EXISTS azli_instances("
+        " instance_key TEXT PRIMARY KEY, destination BLOB NOT NULL);"
+        "CREATE TABLE IF NOT EXISTS azli_sources("
+        " source_pk INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " instance_key TEXT NOT NULL, source_id TEXT NOT NULL,"
+        " name TEXT NOT NULL, digest BLOB NOT NULL,"
+        " record_count INTEGER NOT NULL, next_record INTEGER NOT NULL DEFAULT 0,"
+        " bytes INTEGER NOT NULL, created INTEGER NOT NULL, state INTEGER NOT NULL,"
+        " has_quarantine INTEGER NOT NULL DEFAULT 0,"
+        " UNIQUE(instance_key,source_id));"
+        "CREATE INDEX IF NOT EXISTS azli_sources_order "
+        " ON azli_sources(instance_key,source_pk);"
+        "CREATE TABLE IF NOT EXISTS azli_requests("
+        " request_pk INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " instance_key TEXT NOT NULL, name TEXT NOT NULL UNIQUE,"
+        " state INTEGER NOT NULL, attempts INTEGER NOT NULL DEFAULT 0,"
+        " next_retry INTEGER NOT NULL DEFAULT 0, json_bytes INTEGER NOT NULL,"
+        " gzip_bytes INTEGER NOT NULL, body_digest BLOB NOT NULL,"
+        " bytes INTEGER NOT NULL, created INTEGER NOT NULL,"
+        " status INTEGER NOT NULL DEFAULT 0,"
+        " reason TEXT);"
+        "CREATE INDEX IF NOT EXISTS azli_requests_order "
+        " ON azli_requests(instance_key,request_pk);"
+        "CREATE UNIQUE INDEX IF NOT EXISTS azli_one_active_request "
+        " ON azli_requests(instance_key) WHERE state IN (1,2,3,4);"
+        "CREATE TABLE IF NOT EXISTS azli_spans("
+        " request_pk INTEGER NOT NULL REFERENCES azli_requests(request_pk) ON DELETE CASCADE,"
+        " ordinal INTEGER NOT NULL, source_pk INTEGER NOT NULL "
+        " REFERENCES azli_sources(source_pk),"
+        " first_record INTEGER NOT NULL, record_count INTEGER NOT NULL,"
+        " PRIMARY KEY(request_pk,ordinal));"
+        "CREATE TABLE IF NOT EXISTS azli_receipts("
+        " instance_key TEXT NOT NULL, source_id TEXT NOT NULL,"
+        " digest BLOB NOT NULL, completed INTEGER NOT NULL,"
+        " PRIMARY KEY(instance_key,source_id));";
+
+    return sql_exec(manager, schema);
+}
+
+static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
+{
+    char db_path[PATH_MAX];
+    char canonical_path[PATH_MAX];
+    const char *root_path;
+    struct mk_list *head;
+    struct azli_root_manager *manager;
+    sqlite3_stmt *statement;
+    int ret;
+    int64_t stored_limit;
+
+    pthread_once(&manager_registry_once, manager_registry_init);
+#ifdef _WIN32
+    root_path = ctx->buffer_dir;
+#else
+    root_path = realpath(ctx->buffer_dir, canonical_path);
+    if (root_path == NULL) {
+        root_path = ctx->buffer_dir;
+    }
+#endif
+    pthread_mutex_lock(&manager_registry_mutex);
+    mk_list_foreach(head, &manager_registry) {
+        manager = mk_list_entry(head, struct azli_root_manager, _head);
+        if (strcmp(manager->path, root_path) == 0) {
+            if (manager->limit != ctx->buffer_dir_limit_size) {
+                pthread_mutex_unlock(&manager_registry_mutex);
+                flb_plg_error(ctx->ins, "buffer root has conflicting aggregate limits");
+                return NULL;
+            }
+            manager->references++;
+            pthread_mutex_unlock(&manager_registry_mutex);
+            return manager;
+        }
+    }
+
+    manager = flb_calloc(1, sizeof(*manager));
+    if (manager == NULL) {
+        pthread_mutex_unlock(&manager_registry_mutex);
+        return NULL;
+    }
+    manager->path = flb_sds_create(root_path);
+    manager->limit = ctx->buffer_dir_limit_size;
+    manager->references = 1;
+    manager->lock_fd = -1;
+    pthread_mutex_init(&manager->mutex, NULL);
+    snprintf(db_path, sizeof(db_path), "%s/.azure_logs_ingestion.db", root_path);
+    if (manager->path == NULL || lock_manager_root(manager) == -1) {
+        flb_plg_error(ctx->ins, "buffer_dir is already owned by another process");
+        manager->db = NULL;
+    }
+    else {
+        manager->db = flb_sqldb_open(db_path, "azure logs ingestion spool", ctx->config);
+    }
+    if (manager->path == NULL || manager->db == NULL || manager_schema(manager) == -1) {
+        if (manager->db != NULL) {
+            flb_sqldb_close(manager->db);
+        }
+        unlock_manager_root(manager);
+        if (manager->path != NULL) {
+            flb_sds_destroy(manager->path);
+        }
+        pthread_mutex_destroy(&manager->mutex);
+        flb_free(manager);
+        pthread_mutex_unlock(&manager_registry_mutex);
+        return NULL;
+    }
+
+    ret = sqlite3_prepare_v2(manager->db->handler,
+            "SELECT disk_limit FROM azli_settings WHERE root=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto error;
+    }
+    sqlite3_bind_text(statement, 1, manager->path, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        stored_limit = sqlite3_column_int64(statement, 0);
+        sqlite3_finalize(statement);
+        if (stored_limit != (int64_t) manager->limit) {
+            ret = sqlite3_prepare_v2(manager->db->handler,
+                    "UPDATE azli_settings SET disk_limit=? WHERE root=?", -1,
+                    &statement, NULL);
+            if (ret != SQLITE_OK) {
+                goto error;
+            }
+            sqlite3_bind_int64(statement, 1, manager->limit);
+            sqlite3_bind_text(statement, 2, manager->path, -1, SQLITE_TRANSIENT);
+            if (sqlite3_step(statement) != SQLITE_DONE) {
+                goto error;
+            }
+            sqlite3_finalize(statement);
+        }
+    }
+    else {
+        sqlite3_finalize(statement);
+        ret = sqlite3_prepare_v2(manager->db->handler,
+                "INSERT INTO azli_settings(root,disk_limit) VALUES(?,?)", -1,
+                &statement, NULL);
+        if (ret != SQLITE_OK) {
+            goto error;
+        }
+        sqlite3_bind_text(statement, 1, manager->path, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(statement, 2, manager->limit);
+        if (sqlite3_step(statement) != SQLITE_DONE) {
+            goto error;
+        }
+        sqlite3_finalize(statement);
+    }
+    if (manager_recount(manager) == -1) {
+        goto error_no_statement;
+    }
+    mk_list_add(&manager->_head, &manager_registry);
+    pthread_mutex_unlock(&manager_registry_mutex);
+    return manager;
+
+error:
+    sqlite3_finalize(statement);
+error_no_statement:
+    flb_sqldb_close(manager->db);
+    unlock_manager_root(manager);
+    flb_sds_destroy(manager->path);
+    pthread_mutex_destroy(&manager->mutex);
+    flb_free(manager);
+    pthread_mutex_unlock(&manager_registry_mutex);
+    return NULL;
+}
+
+static void manager_release(struct azli_root_manager *manager)
+{
+    pthread_mutex_lock(&manager_registry_mutex);
+    manager->references--;
+    if (manager->references > 0) {
+        pthread_mutex_unlock(&manager_registry_mutex);
+        return;
+    }
+    mk_list_del(&manager->_head);
+    flb_sqldb_close(manager->db);
+    unlock_manager_root(manager);
+    flb_sds_destroy(manager->path);
+    pthread_mutex_destroy(&manager->mutex);
+    flb_free(manager);
+    pthread_mutex_unlock(&manager_registry_mutex);
+}
+
+static int instance_attach(struct flb_az_li *ctx)
+{
+    flb_sds_t value;
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    int ret;
+
+    value = flb_sds_create_size(strlen(ctx->dce_url) + strlen(ctx->dcr_id) +
+                                strlen(ctx->table_name) + strlen(ctx->time_key) + 64);
+    if (value == NULL) {
+        return -1;
+    }
+    value = flb_sds_printf(&value, "%s\n%s\n%s\n%s\n%d", ctx->dce_url,
+                           ctx->dcr_id, ctx->table_name, ctx->time_key,
+                           ctx->time_generated);
+    if (value == NULL || hash_bytes(value, flb_sds_len(value), digest) != 0) {
+        flb_sds_destroy(value);
+        return -1;
+    }
+    flb_sds_destroy(value);
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT destination FROM azli_instances WHERE instance_key=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
+              memcmp(sqlite3_column_blob(statement, 0), digest,
+                     AZLI_DIGEST_SIZE) == 0 ? 0 : -1;
+        sqlite3_finalize(statement);
+        if (ret == -1) {
+            flb_plg_error(ctx->ins, "buffer_key belongs to a different destination");
+        }
+        return ret;
+    }
+    sqlite3_finalize(statement);
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "INSERT INTO azli_instances(instance_key,destination) VALUES(?,?)", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_blob(statement, 2, digest, AZLI_DIGEST_SIZE, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int cleanup_expired_receipts(struct flb_az_li *ctx)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    if (ctx->buffer_receipt_ttl == 0) {
+        return 0;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "DELETE FROM azli_receipts WHERE instance_key=? AND completed<? "
+            "AND NOT EXISTS (SELECT 1 FROM azli_sources s "
+            "WHERE s.instance_key=azli_receipts.instance_key "
+            "AND s.source_id=azli_receipts.source_id)", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(statement, 2,
+                       now_seconds() - (int64_t) ctx->buffer_receipt_ttl);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int source_content_validate(const void *data, size_t size,
+                                   int64_t expected_records)
+{
+    const char *bytes;
+    size_t offset;
+    size_t start;
+    int64_t records;
+
+    bytes = data;
+    start = 0;
+    records = 0;
+    for (offset = 0; offset < size; offset++) {
+        if (bytes[offset] != '\n') {
+            continue;
+        }
+        if (offset == start || bytes[start] != '{' || bytes[offset - 1] != '}') {
+            return -1;
+        }
+        records++;
+        start = offset + 1;
+    }
+    if (start != size || records != expected_records) {
+        return -1;
+    }
+    return 0;
+}
+
+static int source_meta_parse(struct flb_fstore_file *file, char source_id[65],
+                             unsigned char digest[32], int64_t *record_count,
+                             int64_t *created)
+{
+    char magic[8];
+    char digest_text[65];
+    long long records;
+    long long timestamp;
+
+    if (file->meta_buf == NULL || file->meta_size < 1 ||
+        sscanf(file->meta_buf, "%7[^|]|%64[^|]|%64[^|]|%lld|%lld",
+               magic, source_id, digest_text, &records, &timestamp) != 5 ||
+        strcmp(magic, "AZLIS1") != 0 || digest_from_hex(digest_text, digest) == -1) {
+        return -1;
+    }
+    *record_count = records;
+    *created = timestamp;
+    return 0;
+}
+
+static int recover_sources(struct flb_az_li *ctx)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct flb_fstore_file *file;
+    sqlite3_stmt *statement;
+    unsigned char digest[32];
+    unsigned char actual_digest[32];
+    char source_id[65];
+    int64_t record_count;
+    int64_t created;
+    ssize_t real_size;
+    void *content;
+    size_t size;
+    int ret;
+
+    mk_list_foreach_safe(head, tmp, &ctx->batch->sources->files) {
+        file = mk_list_entry(head, struct flb_fstore_file, _head);
+        if (flb_fstore_file_meta_get(ctx->batch->fs, file) == -1 ||
+            source_meta_parse(file, source_id, digest, &record_count, &created) == -1) {
+            flb_plg_error(ctx->ins, "invalid immutable source metadata file=%s", file->name);
+            return -1;
+        }
+        content = NULL;
+        if (flb_fstore_file_content_copy(NULL, file, &content, &size) == -1 ||
+            hash_bytes(content, size, actual_digest) != 0 ||
+            memcmp(digest, actual_digest, sizeof(digest)) != 0 ||
+            source_content_validate(content, size, record_count) == -1) {
+            flb_free(content);
+            flb_plg_error(ctx->ins, "invalid immutable source content file=%s", file->name);
+            return -1;
+        }
+        flb_free(content);
+        real_size = cio_chunk_get_real_size(file->chunk);
+        if (real_size < 0) {
+            return -1;
+        }
+
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "SELECT digest FROM azli_sources WHERE instance_key=? AND source_id=?", -1,
+                &statement, NULL);
+        if (ret != SQLITE_OK) {
+            return -1;
+        }
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
+        ret = sqlite3_step(statement);
+        if (ret == SQLITE_ROW) {
+            ret = sqlite3_column_bytes(statement, 0) == 32 &&
+                  memcmp(sqlite3_column_blob(statement, 0), digest, 32) == 0 ? 0 : -1;
+            sqlite3_finalize(statement);
+            if (ret == -1) {
+                return -1;
+            }
+            continue;
+        }
+        sqlite3_finalize(statement);
+
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "SELECT digest FROM azli_receipts WHERE instance_key=? AND source_id=?", -1,
+                &statement, NULL);
+        if (ret != SQLITE_OK) {
+            return -1;
+        }
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
+        ret = sqlite3_step(statement);
+        if (ret == SQLITE_ROW) {
+            ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
+                  memcmp(sqlite3_column_blob(statement, 0), digest,
+                         AZLI_DIGEST_SIZE) == 0 ? 0 : -1;
+            sqlite3_finalize(statement);
+            if (ret == -1) {
+                return -1;
+            }
+            flb_fstore_file_delete(ctx->batch->fs, file);
+            if (sync_directory(ctx->batch->sources->path) == -1) {
+                return -1;
+            }
+            continue;
+        }
+        sqlite3_finalize(statement);
+
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "INSERT INTO azli_sources(instance_key,source_id,name,digest,record_count,"
+                "next_record,bytes,created,state) VALUES(?,?,?,?,?,0,?,?,?)", -1,
+                &statement, NULL);
+        if (ret != SQLITE_OK) {
+            return -1;
+        }
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, 3, file->name, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_blob(statement, 4, digest, 32, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(statement, 5, record_count);
+        if ((size_t) real_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE) {
+            sqlite3_finalize(statement);
+            return -1;
+        }
+        sqlite3_bind_int64(statement, 6,
+                           (size_t) real_size + AZLI_SOURCE_DB_RESERVE);
+        sqlite3_bind_int64(statement, 7, created);
+        sqlite3_bind_int(statement, 8, AZLI_SOURCE_READY);
+        ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+        sqlite3_finalize(statement);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int cleanup_acked_request(struct flb_az_li *ctx, int64_t request_pk,
+                                 const char *request_name)
+{
+    sqlite3_stmt *statement;
+    struct flb_fstore_file *file;
+    int ret;
+
+    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->requests,
+                               (char *) request_name, strlen(request_name));
+    if (file != NULL) {
+        flb_fstore_file_delete(ctx->batch->fs, file);
+        if (sync_directory(ctx->batch->requests->path) == -1) {
+            return -1;
+        }
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "DELETE FROM azli_requests WHERE request_pk=? AND state=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int64(statement, 1, request_pk);
+    sqlite3_bind_int(statement, 2, AZLI_REQUEST_ACKED);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    manager_recount(ctx->batch->manager);
+    return ret;
+}
+
+static int cleanup_drained_sources(struct flb_az_li *ctx)
+{
+    sqlite3_stmt *query;
+    sqlite3_stmt *remove;
+    struct flb_fstore_file *file;
+    const char *name;
+    int64_t source_pk;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT source_pk,name FROM azli_sources WHERE instance_key=? AND state=?", -1,
+            &query, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(query, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(query, 2, AZLI_SOURCE_DRAINED);
+    while (sqlite3_step(query) == SQLITE_ROW) {
+        source_pk = sqlite3_column_int64(query, 0);
+        name = (const char *) sqlite3_column_text(query, 1);
+        file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->sources,
+                                   (char *) name, strlen(name));
+        if (file != NULL) {
+            flb_fstore_file_delete(ctx->batch->fs, file);
+            if (sync_directory(ctx->batch->sources->path) == -1) {
+                sqlite3_finalize(query);
+                return -1;
+            }
+        }
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "DELETE FROM azli_sources WHERE source_pk=?", -1, &remove, NULL);
+        if (ret != SQLITE_OK) {
+            sqlite3_finalize(query);
+            return -1;
+        }
+        sqlite3_bind_int64(remove, 1, source_pk);
+        if (sqlite3_step(remove) != SQLITE_DONE) {
+            sqlite3_finalize(remove);
+            sqlite3_finalize(query);
+            return -1;
+        }
+        sqlite3_finalize(remove);
+    }
+    sqlite3_finalize(query);
+    manager_recount(ctx->batch->manager);
+    return 0;
+}
+
+static int recover_requests(struct flb_az_li *ctx)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct flb_fstore_file *file;
+    sqlite3_stmt *statement;
+    const char *name;
+    int64_t request_pk;
+    int64_t gzip_bytes;
+    int state;
+    int ret;
+    void *body;
+    size_t body_size;
+    unsigned char digest[AZLI_DIGEST_SIZE];
+
+    /* A request file without a manifest never owned source spans and is safe to remove. */
+    mk_list_foreach_safe(head, tmp, &ctx->batch->requests->files) {
+        file = mk_list_entry(head, struct flb_fstore_file, _head);
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "SELECT 1 FROM azli_requests WHERE name=?", -1, &statement, NULL);
+        if (ret != SQLITE_OK) {
+            return -1;
+        }
+        sqlite3_bind_text(statement, 1, file->name, -1, SQLITE_TRANSIENT);
+        ret = sqlite3_step(statement);
+        sqlite3_finalize(statement);
+        if (ret != SQLITE_ROW) {
+            flb_fstore_file_delete(ctx->batch->fs, file);
+            if (sync_directory(ctx->batch->requests->path) == -1) {
+                return -1;
+            }
+        }
+    }
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT request_pk,name,state,gzip_bytes,body_digest FROM azli_requests "
+            "WHERE instance_key=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    while (sqlite3_step(statement) == SQLITE_ROW) {
+        request_pk = sqlite3_column_int64(statement, 0);
+        name = (const char *) sqlite3_column_text(statement, 1);
+        state = sqlite3_column_int(statement, 2);
+        gzip_bytes = sqlite3_column_int64(statement, 3);
+        if (state == AZLI_REQUEST_ACKED) {
+            cleanup_acked_request(ctx, request_pk, name);
+            continue;
+        }
+        if (state == AZLI_REQUEST_QUARANTINED) {
+            continue;
+        }
+        file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->requests,
+                                   (char *) name, strlen(name));
+        body = NULL;
+        if (file == NULL || sqlite3_column_bytes(statement, 4) != AZLI_DIGEST_SIZE ||
+            flb_fstore_file_content_copy(NULL, file, &body, &body_size) == -1 ||
+            body_size != (size_t) gzip_bytes ||
+            hash_bytes(body, body_size, digest) != 0 ||
+            memcmp(digest, sqlite3_column_blob(statement, 4),
+                   AZLI_DIGEST_SIZE) != 0) {
+            struct azli_request corrupt_request;
+
+            flb_free(body);
+            memset(&corrupt_request, 0, sizeof(corrupt_request));
+            corrupt_request.request_pk = request_pk;
+            corrupt_request.name = flb_sds_create(name);
+            flb_plg_error(ctx->ins,
+                          "request manifest/artifact mismatch name=%s; quarantining spans",
+                          name);
+            sqlite3_finalize(statement);
+            if (corrupt_request.name == NULL ||
+                request_commit_spans(ctx, &corrupt_request, FLB_TRUE, 0,
+                                     "artifact_corrupt") == -1) {
+                flb_sds_destroy(corrupt_request.name);
+                return -1;
+            }
+            flb_sds_destroy(corrupt_request.name);
+            return recover_requests(ctx);
+        }
+        flb_free(body);
+    }
+    sqlite3_finalize(statement);
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_requests SET state=?,next_retry=? "
+            "WHERE instance_key=? AND state=?", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int(statement, 1, AZLI_REQUEST_RETRY);
+    sqlite3_bind_int64(statement, 2, now_seconds());
+    sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 4, AZLI_REQUEST_INFLIGHT);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    cleanup_drained_sources(ctx);
+    return ret;
+}
+
+static int source_identity(struct flb_az_li *ctx,
+                           struct flb_output_flush *out_flush,
+                           char output[AZLI_HEX_SIZE + 1])
+{
+    flb_sds_t chunk_name;
+    flb_sds_t key;
+    const char *input_name;
+    unsigned char digest[AZLI_DIGEST_SIZE];
+
+    if (out_flush == NULL || out_flush->task == NULL ||
+        out_flush->task->ic == NULL || out_flush->task->i_ins == NULL ||
+        out_flush->task->i_ins->name[0] == '\0') {
+        flb_plg_error(ctx->ins, "input chunk has no durable name");
+        return -1;
+    }
+    chunk_name = flb_input_chunk_get_name(
+                    (struct flb_input_chunk *) out_flush->task->ic);
+    if (chunk_name == NULL || strlen(chunk_name) == 0) {
+        flb_plg_error(ctx->ins, "input chunk has no durable name");
+        return -1;
+    }
+    input_name = out_flush->task->i_ins->name;
+    key = flb_sds_create_size(strlen(ctx->buffer_key) + strlen(input_name) +
+                              strlen(chunk_name) + 64);
+    if (key == NULL) {
+        return -1;
+    }
+    key = flb_sds_printf(&key, "%s\n%s\n%s", ctx->buffer_key,
+                         input_name, chunk_name);
+    if (key == NULL) {
+        flb_plg_error(ctx->ins, "cannot allocate input chunk identity");
+        return -1;
+    }
+    if (hash_bytes(key, flb_sds_len(key), digest) != 0) {
+        flb_plg_error(ctx->ins, "cannot hash input chunk identity");
+        flb_sds_destroy(key);
+        return -1;
+    }
+    flb_sds_destroy(key);
+    digest_hex(digest, output);
+    return 0;
+}
+
+static flb_sds_t records_to_ndjson(flb_sds_t *records, size_t record_count)
+{
+    flb_sds_t output;
+    flb_sds_t tmp;
+    size_t size;
+    size_t index;
+
+    size = 0;
+    for (index = 0; index < record_count; index++) {
+        size += flb_sds_len(records[index]) + 1;
+    }
+    output = flb_sds_create_size(size);
+    if (output == NULL) {
+        return NULL;
+    }
+    for (index = 0; index < record_count; index++) {
+        tmp = flb_sds_cat(output, records[index], flb_sds_len(records[index]));
+        if (tmp == NULL) {
+            flb_sds_destroy(output);
+            return NULL;
+        }
+        output = tmp;
+        tmp = flb_sds_cat(output, "\n", 1);
+        if (tmp == NULL) {
+            flb_sds_destroy(output);
+            return NULL;
+        }
+        output = tmp;
+    }
+    return output;
+}
+
+static int receipt_or_source_exists(struct flb_az_li *ctx, const char *source_id,
+                                    const unsigned char digest[32])
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT digest FROM azli_sources WHERE instance_key=? AND source_id=? "
+            "UNION ALL SELECT digest FROM azli_receipts WHERE instance_key=? AND source_id=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 4, source_id, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        ret = sqlite3_column_bytes(statement, 0) == 32 &&
+              memcmp(sqlite3_column_blob(statement, 0), digest, 32) == 0 ? 1 : -1;
+    }
+    else {
+        ret = 0;
+    }
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+int az_li_batch_admit_chunk(struct flb_az_li *ctx,
+                            struct flb_output_flush *out_flush,
+                            struct flb_event_chunk *event_chunk,
+                            flb_sds_t *records, size_t record_count)
+{
+    char source_id[65];
+    char digest_text[65];
+    char name[80];
+    char metadata[256];
+    unsigned char digest[32];
+    flb_sds_t ndjson;
+    struct flb_fstore_file *file;
+    sqlite3_stmt *statement;
+    size_t charged_bytes;
+    size_t construction_headroom;
+    ssize_t real_size;
+    int exists;
+    int file_created;
+    int ret;
+
+    (void) event_chunk;
+    pthread_mutex_lock(&ctx->batch->lifecycle_mutex);
+    if (ctx->batch->shutting_down || ctx->batch->fatal_error) {
+        pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
+        return -1;
+    }
+    pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
+    if (record_count == 0) {
+        return 0;
+    }
+    if (source_identity(ctx, out_flush, source_id) == -1) {
+        flb_plg_error(ctx->ins, "cannot resolve durable input chunk identity");
+        return -1;
+    }
+    ndjson = records_to_ndjson(records, record_count);
+    if (ndjson == NULL || hash_bytes(ndjson, flb_sds_len(ndjson), digest) != 0) {
+        flb_sds_destroy(ndjson);
+        return -1;
+    }
+    digest_hex(digest, digest_text);
+    charged_bytes = flb_sds_len(ndjson) + AZLI_FILE_OVERHEAD +
+                    AZLI_SOURCE_DB_RESERVE;
+
+    pthread_mutex_lock(&ctx->batch->manager->mutex);
+    if (manager_recount(ctx->batch->manager) == -1) {
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(ndjson);
+        return -1;
+    }
+    exists = receipt_or_source_exists(ctx, source_id, digest);
+    if (exists != 0) {
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(ndjson);
+        if (exists < 0) {
+            flb_plg_error(ctx->ins, "input chunk identity collision id=%s", source_id);
+            return -1;
+        }
+        flb_plg_debug(ctx->ins, "input chunk already durably owned id=%s", source_id);
+        return 0;
+    }
+    construction_headroom = FLB_AZ_LI_MAX_REQUEST_SIZE +
+                            AZLI_FILE_OVERHEAD + AZLI_REQUEST_DB_RESERVE +
+                            AZLI_MAX_REQUEST_SPANS * AZLI_SPAN_DB_RESERVE;
+    if (ctx->batch->manager->files >= AZLI_MAX_SOURCE_FILES ||
+        construction_headroom > ctx->batch->manager->limit ||
+        charged_bytes > ctx->batch->manager->limit - construction_headroom ||
+        ctx->batch->manager->used >
+        ctx->batch->manager->limit - construction_headroom - charged_bytes) {
+        flb_plg_error(ctx->ins, "batch buffer full current=%zu incoming=%zu limit=%zu",
+                      ctx->batch->manager->used, charged_bytes,
+                      ctx->batch->manager->limit);
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(ndjson);
+        return -1;
+    }
+
+    snprintf(name, sizeof(name), "%s.source", source_id);
+    file_created = FLB_FALSE;
+    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->sources,
+                               name, strlen(name));
+    if (file == NULL) {
+        file_created = FLB_TRUE;
+        file = flb_fstore_file_create(ctx->batch->fs, ctx->batch->sources, name, 0);
+        if (file == NULL || cio_chunk_tx_begin(file->chunk) != CIO_OK ||
+            flb_fstore_file_append(file, ndjson, flb_sds_len(ndjson)) != 0) {
+            if (file != NULL) {
+                cio_chunk_tx_rollback(file->chunk);
+                flb_fstore_file_delete(ctx->batch->fs, file);
+            }
+            pthread_mutex_unlock(&ctx->batch->manager->mutex);
+            flb_sds_destroy(ndjson);
+            return -1;
+        }
+        snprintf(metadata, sizeof(metadata), "AZLIS1|%s|%s|%zu|%" PRId64,
+                 source_id, digest_text, record_count, now_seconds());
+        if (flb_fstore_file_meta_set(ctx->batch->fs, file, metadata,
+                                    strlen(metadata) + 1) == -1 ||
+            cio_chunk_tx_commit(file->chunk) != CIO_OK ||
+            sync_directory(ctx->batch->sources->path) == -1) {
+            cio_chunk_tx_rollback(file->chunk);
+            flb_fstore_file_delete(ctx->batch->fs, file);
+            pthread_mutex_unlock(&ctx->batch->manager->mutex);
+            flb_sds_destroy(ndjson);
+            return -1;
+        }
+    }
+    else {
+        void *existing_content;
+        size_t existing_size;
+        unsigned char existing_digest[AZLI_DIGEST_SIZE];
+
+        existing_content = NULL;
+        if (flb_fstore_file_content_copy(NULL, file, &existing_content,
+                                         &existing_size) == -1 ||
+            hash_bytes(existing_content, existing_size, existing_digest) != 0 ||
+            existing_size != flb_sds_len(ndjson) ||
+            memcmp(existing_digest, digest, AZLI_DIGEST_SIZE) != 0) {
+            flb_free(existing_content);
+            pthread_mutex_unlock(&ctx->batch->manager->mutex);
+            flb_sds_destroy(ndjson);
+            return -1;
+        }
+        flb_free(existing_content);
+    }
+    real_size = cio_chunk_get_real_size(file->chunk);
+    if (real_size < 0 || (size_t) real_size >
+        ctx->batch->manager->limit - construction_headroom ||
+        (size_t) real_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE ||
+        (size_t) real_size + AZLI_SOURCE_DB_RESERVE >
+        ctx->batch->manager->limit - construction_headroom ||
+        ctx->batch->manager->used > ctx->batch->manager->limit -
+        construction_headroom - ((size_t) real_size + AZLI_SOURCE_DB_RESERVE)) {
+        if (file_created) {
+            flb_fstore_file_delete(ctx->batch->fs, file);
+        }
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(ndjson);
+        return -1;
+    }
+    if ((size_t) real_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE) {
+        if (file_created) {
+            flb_fstore_file_delete(ctx->batch->fs, file);
+        }
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(ndjson);
+        return -1;
+    }
+    charged_bytes = (size_t) real_size + AZLI_SOURCE_DB_RESERVE;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "INSERT INTO azli_sources(instance_key,source_id,name,digest,record_count,"
+            "next_record,bytes,created,state) VALUES(?,?,?,?,?,0,?,?,?)", -1,
+            &statement, NULL);
+    if (ret == SQLITE_OK) {
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement, 3, name, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_blob(statement, 4, digest, 32, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(statement, 5, record_count);
+        sqlite3_bind_int64(statement, 6, charged_bytes);
+        sqlite3_bind_int64(statement, 7, now_seconds());
+        sqlite3_bind_int(statement, 8, AZLI_SOURCE_READY);
+        ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+        sqlite3_finalize(statement);
+    }
+    if (ret == 0 && manager_recount(ctx->batch->manager) == -1) {
+        ret = -1;
+    }
+    pthread_mutex_unlock(&ctx->batch->manager->mutex);
+    flb_plg_debug(ctx->ins,
+                  "buffered callback records=%zu probes=0 ratio=%.6f source=%s",
+                  record_count,
+                  ctx->batch->compression_ratio_initialized ?
+                  ctx->batch->compression_ratio : 1.0, source_id);
+    flb_sds_destroy(ndjson);
+    return ret;
+}
+
+static int candidate_add_record(flb_sds_t *json, const char *record,
+                                size_t length, size_t count)
+{
+    flb_sds_t tmp;
+
+    if (count > 0) {
+        tmp = flb_sds_cat(*json, ",", 1);
+        if (tmp == NULL) {
+            return -1;
+        }
+        *json = tmp;
+    }
+    tmp = flb_sds_cat(*json, record, length);
+    if (tmp == NULL) {
+        return -1;
+    }
+    *json = tmp;
+    return 0;
+}
+
+static int collect_source_records(struct flb_az_li *ctx, int64_t source_pk,
+                                  const char *name, int64_t first_record,
+                                  flb_sds_t *json,
+                                  struct azli_candidate_record **records,
+                                  size_t *count, size_t *capacity,
+                                  struct mk_list *buffers)
+{
+    struct flb_fstore_file *file;
+    struct azli_source_buffer *holder;
+    struct azli_candidate_record *tmp_records;
+    const char *bytes;
+    void *data;
+    size_t size;
+    size_t offset;
+    size_t start;
+    int64_t index;
+    int size_limited;
+
+    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->sources,
+                               (char *) name, strlen(name));
+    if (file == NULL || flb_fstore_file_content_copy(NULL, file, &data, &size) == -1) {
+        return -1;
+    }
+    holder = flb_calloc(1, sizeof(*holder));
+    if (holder == NULL) {
+        flb_free(data);
+        return -1;
+    }
+    holder->data = data;
+    mk_list_add(&holder->_head, buffers);
+    bytes = data;
+    start = 0;
+    index = 0;
+    size_limited = FLB_FALSE;
+    for (offset = 0; offset < size; offset++) {
+        if (bytes[offset] != '\n') {
+            continue;
+        }
+        if (index++ < first_record) {
+            start = offset + 1;
+            continue;
+        }
+        if (*count > 0 && flb_sds_len(*json) + (offset - start) + 2 >
+            ctx->batch_max_uncompressed_size) {
+            size_limited = FLB_TRUE;
+            break;
+        }
+        if (*count == *capacity) {
+            *capacity = *capacity == 0 ? 256 : *capacity * 2;
+            tmp_records = flb_realloc(*records,
+                                      *capacity * sizeof(**records));
+            if (tmp_records == NULL) {
+                return -1;
+            }
+            *records = tmp_records;
+        }
+        if (candidate_add_record(json, bytes + start, offset - start, *count) == -1) {
+            return -1;
+        }
+        (*records)[*count].source_pk = source_pk;
+        (*records)[*count].record_index = index - 1;
+        (*records)[*count].json_end = flb_sds_len(*json);
+        (*count)++;
+        start = offset + 1;
+    }
+    return size_limited;
+}
+
+static void candidate_buffers_destroy(struct mk_list *buffers)
+{
+    struct mk_list *head;
+    struct mk_list *tmp;
+    struct azli_source_buffer *holder;
+
+    mk_list_foreach_safe(head, tmp, buffers) {
+        holder = mk_list_entry(head, struct azli_source_buffer, _head);
+        mk_list_del(&holder->_head);
+        flb_free(holder->data);
+        flb_free(holder);
+    }
+}
+
+static int compress_prefix(flb_sds_t json,
+                           struct azli_candidate_record *records,
+                           size_t count, void **output, size_t *output_size,
+                           size_t *json_size)
+{
+    flb_sds_t candidate;
+    flb_sds_t tmp;
+    int ret;
+
+    candidate = flb_sds_create_len(json, records[count - 1].json_end);
+    if (candidate == NULL) {
+        return -1;
+    }
+    tmp = flb_sds_cat(candidate, "]", 1);
+    if (tmp == NULL) {
+        flb_sds_destroy(candidate);
+        return -1;
+    }
+    candidate = tmp;
+    *json_size = flb_sds_len(candidate);
+    ret = flb_gzip_compress(candidate, *json_size, output, output_size);
+    flb_sds_destroy(candidate);
+    return ret;
+}
+
+static int source_mark_singleton_quarantine(struct flb_az_li *ctx,
+                                             struct azli_candidate_record *record)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_sources SET next_record=?,has_quarantine=1,state="
+            "CASE WHEN record_count<=? THEN ? ELSE state END WHERE source_pk=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int64(statement, 1, record->record_index + 1);
+    sqlite3_bind_int64(statement, 2, record->record_index + 1);
+    sqlite3_bind_int(statement, 3, AZLI_SOURCE_QUARANTINED);
+    sqlite3_bind_int64(statement, 4, record->source_pk);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int request_manifest_matches(struct flb_az_li *ctx, const char *name,
+                                    const unsigned char digest[AZLI_DIGEST_SIZE])
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT body_digest FROM azli_requests WHERE name=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, name, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
+              memcmp(sqlite3_column_blob(statement, 0), digest,
+                     AZLI_DIGEST_SIZE) == 0 ? 1 : -1;
+    }
+    else {
+        ret = 0;
+    }
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int persist_request(struct flb_az_li *ctx, const void *gzip,
+                           size_t gzip_size, size_t json_size,
+                           struct azli_candidate_record *records,
+                           size_t record_count)
+{
+    unsigned char random[8];
+    unsigned char body_digest[AZLI_DIGEST_SIZE];
+    uint64_t random_value;
+    char name[96];
+    char digest_text[AZLI_HEX_SIZE + 1];
+    char metadata[192];
+    struct flb_fstore_file *file;
+    struct azli_span *spans;
+    sqlite3_stmt *statement;
+    int64_t request_pk;
+    ssize_t real_size;
+    size_t span_count;
+    size_t index;
+    int ret;
+    size_t reserved_bytes;
+
+    if (flb_random_bytes(random, sizeof(random)) != 0 ||
+        hash_bytes(gzip, gzip_size, body_digest) != 0) {
+        return -1;
+    }
+    spans = flb_calloc(record_count, sizeof(*spans));
+    if (spans == NULL) {
+        return -1;
+    }
+    span_count = 0;
+    for (index = 0; index < record_count; index++) {
+        if (span_count == 0 ||
+            spans[span_count - 1].source_pk != records[index].source_pk ||
+            spans[span_count - 1].first_record +
+            spans[span_count - 1].record_count != records[index].record_index) {
+            spans[span_count].source_pk = records[index].source_pk;
+            spans[span_count].first_record = records[index].record_index;
+            spans[span_count].record_count = 1;
+            span_count++;
+        }
+        else {
+            spans[span_count - 1].record_count++;
+        }
+    }
+    if (span_count > AZLI_MAX_REQUEST_SPANS ||
+        span_count > (SIZE_MAX - AZLI_REQUEST_DB_RESERVE) /
+                     AZLI_SPAN_DB_RESERVE ||
+        gzip_size > SIZE_MAX - AZLI_FILE_OVERHEAD - AZLI_REQUEST_DB_RESERVE -
+                    span_count * AZLI_SPAN_DB_RESERVE) {
+        flb_free(spans);
+        return -1;
+    }
+    reserved_bytes = gzip_size + AZLI_FILE_OVERHEAD +
+                     AZLI_REQUEST_DB_RESERVE +
+                     span_count * AZLI_SPAN_DB_RESERVE;
+    if (reserved_bytes > ctx->batch->manager->limit ||
+        ctx->batch->manager->used >
+        ctx->batch->manager->limit - reserved_bytes) {
+        flb_free(spans);
+        return -1;
+    }
+    memcpy(&random_value, random, sizeof(random_value));
+    digest_hex(body_digest, digest_text);
+    snprintf(name, sizeof(name), "request-%" PRIx64 "-%" PRIu64 ".gzip",
+             random_value, ctx->batch->request_sequence++);
+    snprintf(metadata, sizeof(metadata), "AZLIR1|%s|%zu|%zu",
+             digest_text, gzip_size, json_size);
+    file = flb_fstore_file_create(ctx->batch->fs, ctx->batch->requests, name, 0);
+    if (file == NULL || cio_chunk_tx_begin(file->chunk) != CIO_OK ||
+        flb_fstore_file_append(file, (void *) gzip, gzip_size) != 0 ||
+        flb_fstore_file_meta_set(ctx->batch->fs, file, metadata,
+                                strlen(metadata) + 1) == -1 ||
+        cio_chunk_tx_commit(file->chunk) != CIO_OK ||
+        sync_directory(ctx->batch->requests->path) == -1) {
+        if (file != NULL) {
+            cio_chunk_tx_rollback(file->chunk);
+            flb_fstore_file_delete(ctx->batch->fs, file);
+        }
+        flb_free(spans);
+        return -1;
+    }
+
+    real_size = cio_chunk_get_real_size(file->chunk);
+    if (real_size < 0 || (size_t) real_size > SIZE_MAX -
+        AZLI_REQUEST_DB_RESERVE - span_count * AZLI_SPAN_DB_RESERVE) {
+        flb_fstore_file_delete(ctx->batch->fs, file);
+        flb_free(spans);
+        return -1;
+    }
+    reserved_bytes = (size_t) real_size + AZLI_REQUEST_DB_RESERVE +
+                     span_count * AZLI_SPAN_DB_RESERVE;
+    if (reserved_bytes > ctx->batch->manager->limit ||
+        ctx->batch->manager->used >
+        ctx->batch->manager->limit - reserved_bytes) {
+        flb_fstore_file_delete(ctx->batch->fs, file);
+        flb_free(spans);
+        return -1;
+    }
+
+    if (sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
+        goto error;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "INSERT INTO azli_requests(instance_key,name,state,json_bytes,gzip_bytes,"
+            "body_digest,bytes,created) VALUES(?,?,?,?,?,?,?,?)", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 2, name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 3, AZLI_REQUEST_READY);
+    sqlite3_bind_int64(statement, 4, json_size);
+    sqlite3_bind_int64(statement, 5, gzip_size);
+    sqlite3_bind_blob(statement, 6, body_digest, AZLI_DIGEST_SIZE, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(statement, 7, reserved_bytes);
+    sqlite3_bind_int64(statement, 8, now_seconds());
+    if (sqlite3_step(statement) != SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        goto rollback;
+    }
+    sqlite3_finalize(statement);
+    request_pk = sqlite3_last_insert_rowid(ctx->batch->manager->db->handler);
+
+    for (index = 0; index < span_count; index++) {
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "INSERT INTO azli_spans(request_pk,ordinal,source_pk,first_record,record_count)"
+                " VALUES(?,?,?,?,?)", -1, &statement, NULL);
+        if (ret != SQLITE_OK) {
+            goto rollback;
+        }
+        sqlite3_bind_int64(statement, 1, request_pk);
+        sqlite3_bind_int64(statement, 2, index);
+        sqlite3_bind_int64(statement, 3, spans[index].source_pk);
+        sqlite3_bind_int64(statement, 4, spans[index].first_record);
+        sqlite3_bind_int64(statement, 5, spans[index].record_count);
+        if (sqlite3_step(statement) != SQLITE_DONE) {
+            sqlite3_finalize(statement);
+            goto rollback;
+        }
+        sqlite3_finalize(statement);
+    }
+    if (sql_commit(ctx->batch->manager) == -1) {
+        ret = request_manifest_matches(ctx, name, body_digest);
+        if (ret != 1) {
+            goto error;
+        }
+        flb_plg_warn(ctx->ins,
+                     "request COMMIT returned an error but durable manifest was reconciled name=%s",
+                     name);
+    }
+    if (manager_recount(ctx->batch->manager) == -1) {
+        flb_plg_error(ctx->ins, "could not reconcile shared spool quota after request commit");
+    }
+    flb_free(spans);
+    return 0;
+
+rollback:
+    sql_rollback_if_active(ctx->batch->manager);
+error:
+    flb_fstore_file_delete(ctx->batch->fs, file);
+    flb_free(spans);
+    return -1;
+}
+
+static int request_exists(struct flb_az_li *ctx)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT 1 FROM azli_requests WHERE instance_key=? AND state IN (1,2,3,4) LIMIT 1",
+            -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement) == SQLITE_ROW ? 1 : 0;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int plan_request(struct flb_az_li *ctx)
+{
+    struct mk_list buffers;
+    struct azli_candidate_record *records;
+    sqlite3_stmt *statement;
+    flb_sds_t json;
+    const char *name;
+    int64_t source_pk;
+    int64_t next_record;
+    int64_t oldest_created;
+    size_t capacity;
+    size_t count;
+    size_t source_count;
+    size_t chosen;
+    size_t low;
+    size_t high;
+    size_t middle;
+    size_t best;
+    size_t gzip_size;
+    size_t json_size;
+    size_t candidate_gzip_size;
+    size_t candidate_json_size;
+    uint64_t initial_probe_count;
+    void *gzip = NULL;
+    void *candidate_gzip;
+    int ret;
+
+    ret = request_exists(ctx);
+    if (ret != 0) {
+        return ret < 0 ? -1 : 0;
+    }
+    initial_probe_count = ctx->batch->probe_count;
+    records = NULL;
+    capacity = 0;
+    count = 0;
+    source_count = 0;
+    oldest_created = 0;
+    mk_list_init(&buffers);
+    json = flb_sds_create("[");
+    if (json == NULL) {
+        return -1;
+    }
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT source_pk,name,next_record,created FROM azli_sources "
+            "WHERE instance_key=? AND next_record<record_count AND state IN (1,3) "
+            "ORDER BY source_pk", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto error;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    while (sqlite3_step(statement) == SQLITE_ROW) {
+        source_pk = sqlite3_column_int64(statement, 0);
+        name = (const char *) sqlite3_column_text(statement, 1);
+        next_record = sqlite3_column_int64(statement, 2);
+        if (oldest_created == 0) {
+            oldest_created = sqlite3_column_int64(statement, 3);
+        }
+        if (source_count >= AZLI_MAX_REQUEST_SPANS) {
+            break;
+        }
+        source_count++;
+        ret = collect_source_records(ctx, source_pk, name, next_record, &json,
+                                     &records, &count, &capacity, &buffers);
+        if (ret == -1) {
+            sqlite3_finalize(statement);
+            goto error;
+        }
+        if (ret == 1 ||
+            flb_sds_len(json) + 2 >= ctx->batch_max_uncompressed_size) {
+            break;
+        }
+    }
+    sqlite3_finalize(statement);
+    if (count == 0) {
+        flb_sds_destroy(json);
+        candidate_buffers_destroy(&buffers);
+        flb_free(records);
+        return 0;
+    }
+
+    /* The EWMA only decides when to pay for an exact probe. It never
+     * authorizes persistence or transmission of a request. */
+    if (ctx->batch->compression_ratio_initialized &&
+        (double) (flb_sds_len(json) + 1) * ctx->batch->compression_ratio <
+        (double) ctx->batch_target_size &&
+        now_seconds() - oldest_created < ctx->batch_timeout &&
+        flb_sds_len(json) + 1 < ctx->batch_max_uncompressed_size) {
+        flb_plg_debug(ctx->ins,
+                      "deferred exact probe using compression ratio=%.6f records=%zu",
+                      ctx->batch->compression_ratio, count);
+        flb_sds_destroy(json);
+        candidate_buffers_destroy(&buffers);
+        flb_free(records);
+        return 0;
+    }
+
+    chosen = count;
+    if (ctx->batch->compression_ratio_initialized && count > 1 &&
+        (double) (records[count - 1].json_end + 1) *
+        ctx->batch->compression_ratio > (double) ctx->batch_target_size) {
+        size_t estimated_json_target;
+
+        estimated_json_target = (size_t) ((double) ctx->batch_target_size /
+                                          ctx->batch->compression_ratio);
+        low = 1;
+        high = count;
+        best = 0;
+        while (low <= high) {
+            middle = low + (high - low) / 2;
+            if (records[middle - 1].json_end + 1 <= estimated_json_target) {
+                best = middle;
+                low = middle + 1;
+            }
+            else {
+                high = middle - 1;
+            }
+        }
+        chosen = best < count ? best + 1 : best;
+        if (chosen == 0) {
+            chosen = 1;
+        }
+    }
+    if (compress_prefix(json, records, chosen, &gzip, &gzip_size, &json_size) == -1) {
+        goto error;
+    }
+    ctx->batch->probe_count++;
+    if (json_size > 0) {
+        double observed = (double) gzip_size / (double) json_size;
+        if (!ctx->batch->compression_ratio_initialized) {
+            ctx->batch->compression_ratio = observed;
+            ctx->batch->compression_ratio_initialized = FLB_TRUE;
+        }
+        else {
+            ctx->batch->compression_ratio = AZLI_RATIO_ALPHA * observed +
+                (1.0 - AZLI_RATIO_ALPHA) * ctx->batch->compression_ratio;
+        }
+    }
+
+    if (chosen == count && gzip_size < ctx->batch_target_size &&
+        now_seconds() - oldest_created < ctx->batch_timeout &&
+        json_size < ctx->batch_max_uncompressed_size) {
+        flb_free(gzip);
+        flb_sds_destroy(json);
+        candidate_buffers_destroy(&buffers);
+        flb_free(records);
+        return 0;
+    }
+
+    if (gzip_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
+        json_size > ctx->batch_max_uncompressed_size) {
+        flb_free(gzip);
+        gzip = NULL;
+        low = 1;
+        high = count;
+        best = 0;
+        while (low <= high) {
+            middle = low + (high - low) / 2;
+            candidate_gzip = NULL;
+            if (compress_prefix(json, records, middle, &candidate_gzip,
+                                &candidate_gzip_size, &candidate_json_size) == -1) {
+                goto error;
+            }
+            ctx->batch->probe_count++;
+            flb_free(candidate_gzip);
+            if (candidate_gzip_size <= FLB_AZ_LI_MAX_REQUEST_SIZE &&
+                candidate_json_size <= ctx->batch_max_uncompressed_size) {
+                best = middle;
+                low = middle + 1;
+            }
+            else {
+                if (middle == 1) {
+                    high = 0;
+                }
+                else {
+                    high = middle - 1;
+                }
+            }
+        }
+        chosen = best;
+        if (chosen == 0) {
+            chosen = 1;
+        }
+        if (compress_prefix(json, records, chosen, &gzip, &gzip_size, &json_size) == -1) {
+            goto error;
+        }
+        ctx->batch->probe_count++;
+        if (gzip_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
+            json_size > ctx->batch_max_uncompressed_size) {
+            flb_free(gzip);
+            gzip = NULL;
+            if (chosen == 1) {
+                ret = source_mark_singleton_quarantine(ctx, &records[0]);
+                if (ret == 0) {
+                    flb_plg_error(ctx->ins,
+                                  "quarantined record compressed_bytes=%zu json_bytes=%zu",
+                                  gzip_size, json_size);
+                }
+                flb_sds_destroy(json);
+                candidate_buffers_destroy(&buffers);
+                flb_free(records);
+                return ret;
+            }
+            chosen--;
+            if (compress_prefix(json, records, chosen, &gzip, &gzip_size,
+                                &json_size) == -1) {
+                goto error;
+            }
+            ctx->batch->probe_count++;
+        }
+    }
+
+    ret = persist_request(ctx, gzip, gzip_size, json_size, records, chosen);
+    if (ret == 0) {
+        flb_plg_debug(ctx->ins,
+                      "planned durable request records=%zu probes=%" PRIu64
+                      " ratio=%.6f gzip_bytes=%zu",
+                      chosen, ctx->batch->probe_count - initial_probe_count,
+                      ctx->batch->compression_ratio, gzip_size);
+    }
+    flb_free(gzip);
+    flb_sds_destroy(json);
+    candidate_buffers_destroy(&buffers);
+    flb_free(records);
+    return ret;
+
+error:
+    if (gzip != NULL) {
+        flb_free(gzip);
+    }
+    flb_sds_destroy(json);
+    candidate_buffers_destroy(&buffers);
+    flb_free(records);
+    return -1;
+}
+
+static int request_load_next(struct flb_az_li *ctx, struct azli_request *request)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    memset(request, 0, sizeof(*request));
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT request_pk,name,state,attempts,next_retry,json_bytes,gzip_bytes,body_digest "
+            "FROM azli_requests WHERE instance_key=? AND state IN (1,2,3) "
+            "AND next_retry<=? ORDER BY request_pk LIMIT 1", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(statement, 2, now_seconds());
+    if (sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return 0;
+    }
+    request->request_pk = sqlite3_column_int64(statement, 0);
+    request->name = flb_sds_create((const char *) sqlite3_column_text(statement, 1));
+    request->state = sqlite3_column_int(statement, 2);
+    request->attempts = sqlite3_column_int(statement, 3);
+    request->next_retry = sqlite3_column_int64(statement, 4);
+    request->json_bytes = sqlite3_column_int64(statement, 5);
+    request->gzip_bytes = sqlite3_column_int64(statement, 6);
+    if (sqlite3_column_bytes(statement, 7) != AZLI_DIGEST_SIZE) {
+        sqlite3_finalize(statement);
+        flb_sds_destroy(request->name);
+        request->name = NULL;
+        return -1;
+    }
+    memcpy(request->digest, sqlite3_column_blob(statement, 7), AZLI_DIGEST_SIZE);
+    sqlite3_finalize(statement);
+    return request->name == NULL ? -1 : 1;
+}
+
+static int request_mark_inflight(struct flb_az_li *ctx, struct azli_request *request)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_requests SET state=?,attempts=attempts+1 WHERE request_pk=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int(statement, 1, AZLI_REQUEST_INFLIGHT);
+    sqlite3_bind_int64(statement, 2, request->request_pk);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int request_state_is(struct flb_az_li *ctx, int64_t request_pk,
+                            int expected_state)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT state FROM azli_requests WHERE request_pk=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int64(statement, 1, request_pk);
+    ret = sqlite3_step(statement);
+    ret = ret == SQLITE_ROW && sqlite3_column_int(statement, 0) == expected_state;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int request_commit_spans(struct flb_az_li *ctx,
+                                struct azli_request *request,
+                                int quarantine, int status, const char *reason)
+{
+    sqlite3_stmt *query;
+    sqlite3_stmt *update;
+    sqlite3_stmt *receipt;
+    int64_t source_pk;
+    int64_t end_record;
+    int ret;
+
+    if (sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT source_pk,first_record+record_count FROM azli_spans "
+            "WHERE request_pk=? ORDER BY ordinal", -1, &query, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
+    }
+    sqlite3_bind_int64(query, 1, request->request_pk);
+    while (sqlite3_step(query) == SQLITE_ROW) {
+        source_pk = sqlite3_column_int64(query, 0);
+        end_record = sqlite3_column_int64(query, 1);
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "UPDATE azli_sources SET next_record=MAX(next_record,?),"
+                "has_quarantine=MAX(has_quarantine,?),state="
+                "CASE WHEN record_count<=? THEN CASE WHEN has_quarantine=1 OR ?=1 "
+                "THEN ? ELSE ? END ELSE state END WHERE source_pk=?", -1,
+                &update, NULL);
+        if (ret != SQLITE_OK) {
+            sqlite3_finalize(query);
+            goto rollback;
+        }
+        sqlite3_bind_int64(update, 1, end_record);
+        sqlite3_bind_int(update, 2, quarantine);
+        sqlite3_bind_int64(update, 3, end_record);
+        sqlite3_bind_int(update, 4, quarantine);
+        sqlite3_bind_int(update, 5, AZLI_SOURCE_QUARANTINED);
+        sqlite3_bind_int(update, 6, AZLI_SOURCE_DRAINED);
+        sqlite3_bind_int64(update, 7, source_pk);
+        if (sqlite3_step(update) != SQLITE_DONE) {
+            sqlite3_finalize(update);
+            sqlite3_finalize(query);
+            goto rollback;
+        }
+        sqlite3_finalize(update);
+
+        if (!quarantine) {
+            ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                    "INSERT OR IGNORE INTO azli_receipts(instance_key,source_id,digest,completed) "
+                    "SELECT instance_key,source_id,digest,? FROM azli_sources "
+                    "WHERE source_pk=? AND next_record>=record_count AND has_quarantine=0", -1,
+                    &receipt, NULL);
+            if (ret != SQLITE_OK) {
+                sqlite3_finalize(query);
+                goto rollback;
+            }
+            sqlite3_bind_int64(receipt, 1, now_seconds());
+            sqlite3_bind_int64(receipt, 2, source_pk);
+            sqlite3_step(receipt);
+            sqlite3_finalize(receipt);
+        }
+    }
+    sqlite3_finalize(query);
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_requests SET state=?,status=?,reason=? WHERE request_pk=?", -1,
+            &update, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
+    }
+    sqlite3_bind_int(update, 1, quarantine ? AZLI_REQUEST_QUARANTINED : AZLI_REQUEST_ACKED);
+    sqlite3_bind_int(update, 2, status);
+    if (reason != NULL) {
+        sqlite3_bind_text(update, 3, reason, -1, SQLITE_TRANSIENT);
+    }
+    else {
+        sqlite3_bind_null(update, 3);
+    }
+    sqlite3_bind_int64(update, 4, request->request_pk);
+    if (sqlite3_step(update) != SQLITE_DONE) {
+        sqlite3_finalize(update);
+        goto rollback;
+    }
+    sqlite3_finalize(update);
+    if (sql_commit(ctx->batch->manager) == -1) {
+        ret = request_state_is(ctx, request->request_pk,
+                               quarantine ? AZLI_REQUEST_QUARANTINED :
+                               AZLI_REQUEST_ACKED);
+        if (ret != 1) {
+            return -1;
+        }
+        flb_plg_warn(ctx->ins,
+                     "request outcome COMMIT returned an error but durable state was reconciled name=%s",
+                     request->name);
+    }
+    if (!quarantine &&
+        (cleanup_acked_request(ctx, request->request_pk, request->name) == -1 ||
+         cleanup_drained_sources(ctx) == -1)) {
+        return -1;
+    }
+    if (manager_recount(ctx->batch->manager) == -1) {
+        return -1;
+    }
+    return 0;
+
+rollback:
+    sql_rollback_if_active(ctx->batch->manager);
+    return -1;
+}
+
+static time_t retry_delay(struct flb_az_li *ctx, int attempts)
+{
+    time_t delay;
+    int index;
+
+    delay = ctx->upload_retry_base;
+    for (index = 1; index < attempts && delay < 60; index++) {
+        delay *= 2;
+    }
+    return delay > 60 ? 60 : delay;
+}
+
+static int request_schedule_retry(struct flb_az_li *ctx,
+                                  struct azli_request *request, int status)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    if (ctx->upload_retry_limit > 0 &&
+        request->attempts + 1 > ctx->upload_retry_limit) {
+        return request_commit_spans(ctx, request, FLB_TRUE, status,
+                                    "retry_exhausted");
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_requests SET state=?,next_retry=?,status=? WHERE request_pk=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int(statement, 1, AZLI_REQUEST_RETRY);
+    sqlite3_bind_int64(statement, 2,
+                       now_seconds() + retry_delay(ctx, request->attempts + 1));
+    sqlite3_bind_int(statement, 3, status);
+    sqlite3_bind_int64(statement, 4, request->request_pk);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int response_is_transient(int transport_result, int status)
+{
+    return transport_result != 0 || status == 401 || status == 408 ||
+           status == 429 || status >= 500;
+}
+
+static int upload_one(struct flb_az_li *ctx)
+{
+    struct azli_request request;
+    struct flb_fstore_file *file;
+    void *body;
+    size_t body_size;
+    unsigned char body_digest[AZLI_DIGEST_SIZE];
+    int status;
+    int ret;
+    int transition_ret;
+
+    body = NULL;
+    body_size = 0;
+    pthread_mutex_lock(&ctx->batch->manager->mutex);
+    ret = request_load_next(ctx, &request);
+    if (ret <= 0) {
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        return ret;
+    }
+    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->requests,
+                               request.name, flb_sds_len(request.name));
+    if (file == NULL ||
+        flb_fstore_file_content_copy(NULL, file, &body, &body_size) == -1 ||
+        body_size != (size_t) request.gzip_bytes ||
+        hash_bytes(body, body_size, body_digest) != 0 ||
+        memcmp(body_digest, request.digest, AZLI_DIGEST_SIZE) != 0 ||
+        body_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
+        request.json_bytes > (int64_t) ctx->batch_max_uncompressed_size) {
+        flb_plg_error(ctx->ins,
+                      "durable request artifact failed validation name=%s",
+                      request.name);
+        flb_free(body);
+        transition_ret = request_commit_spans(ctx, &request, FLB_TRUE, 0,
+                                              "artifact_corrupt");
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(request.name);
+        return transition_ret;
+    }
+    if (request_mark_inflight(ctx, &request) == -1) {
+        flb_plg_error(ctx->ins,
+                      "could not persist inflight request state name=%s",
+                      request.name);
+        flb_free(body);
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        flb_sds_destroy(request.name);
+        return -1;
+    }
+    pthread_mutex_unlock(&ctx->batch->manager->mutex);
+
+    status = 0;
+    ret = az_li_send_payload(ctx, body, body_size, request.json_bytes,
+                             FLB_TRUE, &status);
+    flb_free(body);
+    if (ret == 0 && status == 401) {
+        flb_oauth2_invalidate_token(ctx->u_auth);
+    }
+
+    pthread_mutex_lock(&ctx->batch->manager->mutex);
+    if (ret == 0 && status >= 200 && status <= 299) {
+        transition_ret = request_commit_spans(ctx, &request, FLB_FALSE,
+                                              status, NULL);
+    }
+    else if (response_is_transient(ret, status)) {
+        transition_ret = request_schedule_retry(ctx, &request, status);
+    }
+    else {
+        transition_ret = request_commit_spans(
+                            ctx, &request, FLB_TRUE, status,
+                            status == 413 ? "http_413" : "permanent");
+    }
+    if (transition_ret == -1) {
+        flb_plg_error(ctx->ins,
+                      "could not persist request outcome name=%s status=%d",
+                      request.name, status);
+    }
+    pthread_mutex_unlock(&ctx->batch->manager->mutex);
+    flb_sds_destroy(request.name);
+    return transition_ret;
+}
+
+static void batch_timer_return(struct flb_config *config)
+{
+    struct flb_coro *coro;
+    struct flb_sched *scheduler;
+    struct flb_sched_timer_coro *timer_coro;
+
+    if (config->hot_reloading == FLB_FALSE && config->is_running == FLB_TRUE) {
+        flb_sched_timer_cb_coro_return();
+        return;
+    }
+
+    /* The output worker exits as soon as its last upstream becomes idle. A
+     * timer coroutine completing during shutdown must therefore publish
+     * itself directly to the drop list instead of relying on a later pipe
+     * event that the worker might never process. The worker loop performs its
+     * normal scheduler drop-list cleanup before checking whether it can exit. */
+    coro = flb_coro_get();
+    scheduler = flb_sched_ctx_get();
+    timer_coro = coro == NULL ? NULL : coro->data;
+    if (coro == NULL || scheduler == NULL || timer_coro == NULL) {
+        flb_sched_timer_cb_coro_return();
+        return;
+    }
+
+    cfl_list_del(&timer_coro->_head);
+    cfl_list_add(&timer_coro->_head, &scheduler->timer_coro_list_drop);
+    flb_coro_yield(coro, FLB_TRUE);
+}
+
+static void batch_timer_callback(struct flb_config *config, void *data)
+{
+    struct flb_az_li *ctx;
+    struct flb_az_li_batch *batch;
+
+    ctx = data;
+    batch = ctx->batch;
+    if (batch == NULL) {
+        batch_timer_return(config);
+        return;
+    }
+
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    if (config->is_running == FLB_FALSE || config->hot_reloading == FLB_TRUE ||
+        batch->shutting_down || batch->upload_in_progress || batch->fatal_error) {
+        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        batch_timer_return(config);
+        return;
+    }
+    batch->upload_in_progress = FLB_TRUE;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+
+    pthread_mutex_lock(&batch->manager->mutex);
+    if (plan_request(ctx) == -1) {
+        flb_plg_error(ctx->ins, "could not plan durable buffered request");
+    }
+    pthread_mutex_unlock(&batch->manager->mutex);
+    if (upload_one(ctx) == -1) {
+        pthread_mutex_lock(&batch->lifecycle_mutex);
+        batch->fatal_error = FLB_TRUE;
+        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        flb_plg_error(ctx->ins,
+                      "durable uploader stopped after a state persistence failure");
+    }
+
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    batch->upload_in_progress = FLB_FALSE;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+    batch_timer_return(config);
+}
+
+int az_li_batch_init(struct flb_az_li *ctx)
+{
+    flb_sds_t root;
+    struct flb_az_li_batch *batch;
+    int ret;
+
+    batch = flb_calloc(1, sizeof(*batch));
+    if (batch == NULL) {
+        return -1;
+    }
+    batch->lock_fd = -1;
+    pthread_mutex_init(&batch->lifecycle_mutex, NULL);
+    batch->lifecycle_initialized = FLB_TRUE;
+    root = flb_sds_create_size(strlen(ctx->buffer_dir) + strlen(ctx->buffer_key) + 2);
+    if (root == NULL) {
+        goto error;
+    }
+    root = flb_sds_printf(&root, "%s/%s", ctx->buffer_dir, ctx->buffer_key);
+    if (root == NULL) {
+        goto error;
+    }
+    batch->root_path = root;
+    batch->fs = flb_fstore_create(root, FLB_FSTORE_FS);
+    if (batch->fs == NULL) {
+        goto error;
+    }
+    if (lock_spool_root(batch) == -1) {
+        flb_plg_error(ctx->ins, "buffer_key is already owned by another process");
+        goto error;
+    }
+    batch->sources = flb_fstore_stream_create(batch->fs, AZLI_SOURCE_STREAM);
+    batch->requests = flb_fstore_stream_create(batch->fs, AZLI_REQUEST_STREAM);
+    if (batch->sources == NULL || batch->requests == NULL) {
+        goto error;
+    }
+    ctx->batch = batch;
+    batch->manager = manager_acquire(ctx);
+    if (batch->manager == NULL) {
+        goto error;
+    }
+    pthread_mutex_lock(&batch->manager->mutex);
+    ret = instance_attach(ctx);
+    if (ret == 0) {
+        ret = recover_sources(ctx);
+    }
+    if (ret == 0) {
+        ret = recover_requests(ctx);
+    }
+    if (ret == 0) {
+        ret = cleanup_expired_receipts(ctx);
+    }
+    if (ret == 0) {
+        ret = manager_recount(batch->manager);
+    }
+    pthread_mutex_unlock(&batch->manager->mutex);
+    if (ret == -1) {
+        goto error;
+    }
+
+    flb_plg_info(ctx->ins,
+                 "chunk spool enabled path=%s target=%zu aggregate_limit=%zu used=%zu",
+                 root, ctx->batch_target_size, batch->manager->limit,
+                 batch->manager->used);
+    return 0;
+
+error:
+    if (batch->manager != NULL) {
+        manager_release(batch->manager);
+    }
+    unlock_spool_root(batch);
+    if (batch->fs != NULL) {
+        flb_fstore_destroy(batch->fs);
+    }
+    if (batch->root_path != NULL) {
+        flb_sds_destroy(batch->root_path);
+    }
+    if (batch->lifecycle_initialized) {
+        pthread_mutex_destroy(&batch->lifecycle_mutex);
+    }
+    flb_free(batch);
+    ctx->batch = NULL;
+    return -1;
+}
+
+int az_li_batch_start_uploader(struct flb_az_li *ctx)
+{
+    int ret;
+    struct flb_sched *scheduler;
+    struct flb_az_li_batch *batch;
+
+    batch = ctx->batch;
+    if (batch == NULL) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    if (batch->uploader_started == FLB_TRUE) {
+        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        return 0;
+    }
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+
+    scheduler = flb_sched_ctx_get();
+    if (scheduler == NULL) {
+        pthread_mutex_lock(&batch->lifecycle_mutex);
+        batch->fatal_error = FLB_TRUE;
+        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        return -1;
+    }
+
+    ret = flb_sched_timer_coro_cb_create(scheduler, FLB_SCHED_TIMER_CB_PERM,
+                                         AZLI_TIMER_MS, batch_timer_callback,
+                                         ctx, NULL);
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    if (ret == -1) {
+        batch->fatal_error = FLB_TRUE;
+        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        return -1;
+    }
+    batch->uploader_started = FLB_TRUE;
+    batch->fatal_error = FLB_FALSE;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+    return 0;
+}
+
+void az_li_batch_destroy(struct flb_az_li *ctx)
+{
+    struct flb_az_li_batch *batch;
+
+    batch = ctx->batch;
+    if (batch == NULL) {
+        return;
+    }
+
+    /* Buffered mode uses exactly one Fluent Bit output worker. The worker
+     * event loop drains an active upstream request before cb_worker_exit runs,
+     * and the worker pool is joined before this output exit callback. It is
+     * therefore safe to release the spool synchronously for the replacement
+     * hot-reload generation. */
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    batch->shutting_down = FLB_TRUE;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+
+    manager_release(batch->manager);
+    unlock_spool_root(batch);
+    flb_fstore_destroy(batch->fs);
+    flb_sds_destroy(batch->root_path);
+    pthread_mutex_destroy(&batch->lifecycle_mutex);
+    flb_free(batch);
+    ctx->batch = NULL;
+}

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.c
@@ -33,7 +33,6 @@
 #endif
 
 #include <fluent-bit/flb_event.h>
-#include <fluent-bit/flb_fstore.h>
 #include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_input_chunk.h>
@@ -45,24 +44,28 @@
 #include <fluent-bit/flb_scheduler.h>
 #include <fluent-bit/flb_sqldb.h>
 #include <fluent-bit/flb_task.h>
-#include <fluent-bit/flb_time.h>
-#include <chunkio/cio_chunk.h>
 
 #include "azure_logs_ingestion.h"
 #include "azure_logs_ingestion_batch.h"
 #include "azure_logs_ingestion_conf.h"
 
-#define AZLI_SOURCE_STREAM       "sources"
-#define AZLI_REQUEST_STREAM      "requests"
+#define AZLI_SCHEMA_VERSION      3
 #define AZLI_TIMER_MS            1000
-#define AZLI_RATIO_ALPHA         0.25
-#define AZLI_FILE_OVERHEAD       4096
-/* Conservative reservations are charged in addition to actual SQLite files. */
 #define AZLI_SOURCE_DB_RESERVE   4096
 #define AZLI_REQUEST_DB_RESERVE  4096
-#define AZLI_SPAN_DB_RESERVE     256
-#define AZLI_MAX_REQUEST_SPANS   256
+#define AZLI_MEMBER_DB_RESERVE   128
+#define AZLI_RECEIPT_DB_RESERVE  256
+#define AZLI_MAINTENANCE_SECONDS 60
+#define AZLI_WAL_AUTOCHECKPOINT  64
+#define AZLI_WAL_LIMIT_MAX       (4 * 1024 * 1024)
+#define AZLI_MAX_REQUEST_SOURCES 8
+#define AZLI_MAX_COMPRESSION_PROBES 8
+#define AZLI_MAX_UPLOADS_PER_TICK 4
 #define AZLI_MAX_SOURCE_FILES    10000
+#define AZLI_SOURCE_EXISTS_NONE       0
+#define AZLI_SOURCE_EXISTS_MATCH      1
+#define AZLI_SOURCE_EXISTS_ERROR     -1
+#define AZLI_SOURCE_EXISTS_COLLISION -2
 #define AZLI_SOURCE_READY        1
 #define AZLI_SOURCE_DRAINED      2
 #define AZLI_SOURCE_QUARANTINED  3
@@ -74,33 +77,42 @@
 #define AZLI_DIGEST_SIZE         32
 #define AZLI_HEX_SIZE            (AZLI_DIGEST_SIZE * 2)
 
+struct azli_instance_lease {
+    flb_sds_t instance_key;
+    struct mk_list _head;
+};
+
 struct azli_root_manager {
     flb_sds_t path;
     size_t limit;
     size_t used;
+    size_t logical_used;
+    size_t physical_used;
+    size_t database_bytes;
+    size_t wal_bytes;
+    size_t shm_bytes;
     size_t files;
+    size_t reserved_bytes;
+    int64_t last_maintenance;
+    size_t page_size;
+    size_t max_page_count;
+    size_t wal_headroom;
     int references;
     int lock_fd;
+    struct mk_list instance_leases;
     struct flb_sqldb *db;
     pthread_mutex_t mutex;
     struct mk_list _head;
 };
 
-struct azli_candidate_record {
+struct azli_candidate_source {
     int64_t source_pk;
-    int64_t record_index;
-    size_t json_end;
-};
-
-struct azli_source_buffer {
-    void *data;
-    struct mk_list _head;
-};
-
-struct azli_span {
-    int64_t source_pk;
-    int64_t first_record;
+    int64_t created;
     int64_t record_count;
+    int64_t json_bytes;
+    int64_t standalone_gzip_bytes;
+    void *content;
+    size_t content_size;
 };
 
 struct azli_request {
@@ -111,32 +123,33 @@ struct azli_request {
     int64_t json_bytes;
     int64_t gzip_bytes;
     flb_sds_t name;
+    unsigned char json_digest[AZLI_DIGEST_SIZE];
+    void *body;
+    size_t body_size;
     unsigned char digest[AZLI_DIGEST_SIZE];
 };
 
-static int request_commit_spans(struct flb_az_li *ctx,
-                                struct azli_request *request,
-                                int quarantine, int status,
-                                const char *reason);
-
 struct flb_az_li_batch {
-    flb_sds_t root_path;
-    struct flb_fstore *fs;
-    struct flb_fstore_stream *sources;
-    struct flb_fstore_stream *requests;
     struct azli_root_manager *manager;
     pthread_mutex_t lifecycle_mutex;
     int lifecycle_initialized;
     int lock_fd;
     int upload_in_progress;
     int uploader_started;
+    struct flb_sched_timer *uploader_retry_timer;
     int shutting_down;
     int fatal_error;
+    int persistence_degraded;
+    int consecutive_failures;
+    int64_t next_recovery;
     uint64_t request_sequence;
-    uint64_t probe_count;
-    double compression_ratio;
-    int compression_ratio_initialized;
+    struct azli_instance_lease *lease;
 };
+
+static int request_commit_sources(struct flb_az_li *ctx,
+                                  struct azli_request *request,
+                                  int quarantine, int status,
+                                  const char *reason);
 
 static pthread_mutex_t manager_registry_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_once_t manager_registry_once = PTHREAD_ONCE_INIT;
@@ -151,6 +164,41 @@ static int64_t now_seconds(void)
 {
     return (int64_t) time(NULL);
 }
+
+#ifdef FLB_HAVE_METRICS
+static void metric_counter_add(struct flb_az_li *ctx, struct cmt_counter *counter,
+                               double value)
+{
+    char *output_name;
+
+    if (counter == NULL || ctx->payload_metrics_mutex_initialized != FLB_TRUE) {
+        return;
+    }
+    output_name = (char *) flb_output_name(ctx->ins);
+    pthread_mutex_lock(&ctx->payload_metrics_mutex);
+    cmt_counter_add(counter, cfl_time_now(), value, 2,
+                    (char *[]) {output_name, ctx->dcr_id});
+    pthread_mutex_unlock(&ctx->payload_metrics_mutex);
+}
+
+static void metric_gauge_set(struct flb_az_li *ctx, struct cmt_gauge *gauge,
+                             double value)
+{
+    char *output_name;
+
+    if (gauge == NULL || ctx->payload_metrics_mutex_initialized != FLB_TRUE) {
+        return;
+    }
+    output_name = (char *) flb_output_name(ctx->ins);
+    pthread_mutex_lock(&ctx->payload_metrics_mutex);
+    cmt_gauge_set(gauge, cfl_time_now(), value, 2,
+                  (char *[]) {output_name, ctx->dcr_id});
+    pthread_mutex_unlock(&ctx->payload_metrics_mutex);
+}
+#else
+#define metric_counter_add(ctx, counter, value) do { } while (0)
+#define metric_gauge_set(ctx, gauge, value) do { } while (0)
+#endif
 
 static int sync_directory(const char *path)
 {
@@ -168,40 +216,6 @@ static int sync_directory(const char *path)
     result = fsync(descriptor);
     close(descriptor);
     return result;
-#endif
-}
-
-static int lock_spool_root(struct flb_az_li_batch *batch)
-{
-#ifdef _WIN32
-    batch->lock_fd = -1;
-    return 0;
-#else
-    char path[PATH_MAX];
-
-    snprintf(path, sizeof(path), "%s/.owner.lock", batch->root_path);
-    batch->lock_fd = open(path, O_CREAT | O_RDWR, 0600);
-    if (batch->lock_fd == -1 || flock(batch->lock_fd, LOCK_EX | LOCK_NB) == -1) {
-        if (batch->lock_fd != -1) {
-            close(batch->lock_fd);
-            batch->lock_fd = -1;
-        }
-        return -1;
-    }
-    return sync_directory(batch->root_path);
-#endif
-}
-
-static void unlock_spool_root(struct flb_az_li_batch *batch)
-{
-#ifndef _WIN32
-    if (batch->lock_fd != -1) {
-        flock(batch->lock_fd, LOCK_UN);
-        close(batch->lock_fd);
-        batch->lock_fd = -1;
-    }
-#else
-    (void) batch;
 #endif
 }
 
@@ -258,11 +272,12 @@ static int sql_exec(struct azli_root_manager *manager, const char *sql)
     return 0;
 }
 
-static void sql_rollback_if_active(struct azli_root_manager *manager)
+static int sql_rollback_if_active(struct azli_root_manager *manager)
 {
-    if (sqlite3_get_autocommit(manager->db->handler) == 0) {
-        sql_exec(manager, "ROLLBACK");
+    if (sqlite3_get_autocommit(manager->db->handler) != 0) {
+        return 0;
     }
+    return sql_exec(manager, "ROLLBACK");
 }
 
 static int sql_commit(struct azli_root_manager *manager)
@@ -271,8 +286,19 @@ static int sql_commit(struct azli_root_manager *manager)
         return 0;
     }
 
-    sql_rollback_if_active(manager);
-    return -1;
+    /*
+     * A failed COMMIT can still have completed. Only an autocommit connection
+     * may be queried to reconcile that outcome. Otherwise, make the rollback
+     * result explicit so callers never mistake an unresolved transaction for
+     * durable state.
+     */
+    if (sqlite3_get_autocommit(manager->db->handler) != 0) {
+        return 1;
+    }
+    if (sql_rollback_if_active(manager) == 0) {
+        return -1;
+    }
+    return -2;
 }
 
 static int hash_bytes(const void *data, size_t size,
@@ -295,32 +321,27 @@ static void digest_hex(const unsigned char digest[AZLI_DIGEST_SIZE],
     output[AZLI_HEX_SIZE] = '\0';
 }
 
-static int digest_from_hex(const char *input,
-                           unsigned char digest[AZLI_DIGEST_SIZE])
+static size_t file_size(const char *path)
 {
-    int index;
-    unsigned int value;
+    struct stat file_info;
 
-    if (input == NULL || strlen(input) != AZLI_HEX_SIZE) {
-        return -1;
+    if (stat(path, &file_info) == -1 || file_info.st_size < 0) {
+        return 0;
     }
-    for (index = 0; index < AZLI_DIGEST_SIZE; index++) {
-        if (sscanf(input + index * 2, "%2x", &value) != 1) {
-            return -1;
-        }
-        digest[index] = (unsigned char) value;
-    }
-    return 0;
+    return (size_t) file_info.st_size;
 }
 
 static int manager_recount(struct azli_root_manager *manager)
 {
     sqlite3_stmt *statement;
+    char path[PATH_MAX];
     int ret;
 
+    statement = NULL;
     ret = sqlite3_prepare_v2(manager->db->handler,
             "SELECT COALESCE((SELECT SUM(bytes) FROM azli_sources),0) + "
-            "COALESCE((SELECT SUM(bytes) FROM azli_requests),0), "
+            "COALESCE((SELECT SUM(bytes) FROM azli_requests),0) + "
+            "COALESCE((SELECT SUM(bytes) FROM azli_receipts),0), "
             "(SELECT COUNT(*) FROM azli_sources) + "
             "(SELECT COUNT(*) FROM azli_requests)", -1, &statement, NULL);
     if (ret != SQLITE_OK) {
@@ -331,71 +352,405 @@ static int manager_recount(struct azli_root_manager *manager)
         sqlite3_finalize(statement);
         return -1;
     }
-    manager->used = (size_t) sqlite3_column_int64(statement, 0);
+    manager->logical_used = (size_t) sqlite3_column_int64(statement, 0);
     manager->files = (size_t) sqlite3_column_int64(statement, 1);
+    ret = sqlite3_step(statement);
     sqlite3_finalize(statement);
-
-    if (manager->db->path != NULL) {
-        struct stat file_info;
-        char path[PATH_MAX];
-        const char *suffixes[] = {"", "-wal", "-shm"};
-        size_t index;
-
-        for (index = 0; index < sizeof(suffixes) / sizeof(suffixes[0]); index++) {
-            snprintf(path, sizeof(path), "%s%s", manager->db->path, suffixes[index]);
-            if (stat(path, &file_info) == 0 && file_info.st_size > 0) {
-                manager->used += (size_t) file_info.st_size;
-            }
-        }
+    if (ret != SQLITE_DONE) {
+        return -1;
     }
+
+    manager->database_bytes = file_size(manager->db->path);
+    snprintf(path, sizeof(path), "%s-wal", manager->db->path);
+    manager->wal_bytes = file_size(path);
+    snprintf(path, sizeof(path), "%s-shm", manager->db->path);
+    manager->shm_bytes = file_size(path);
+    manager->physical_used = manager->database_bytes + manager->wal_bytes +
+                             manager->shm_bytes;
+    manager->used = manager->logical_used;
     return 0;
+}
+
+static int manager_checkpoint(struct azli_root_manager *manager, int mode)
+{
+    int log_frames;
+    int checkpointed_frames;
+    int ret;
+
+    log_frames = 0;
+    checkpointed_frames = 0;
+    ret = sqlite3_wal_checkpoint_v2(manager->db->handler, NULL, mode,
+                                    &log_frames, &checkpointed_frames);
+    if (ret == SQLITE_BUSY) {
+        return 1;
+    }
+    return ret == SQLITE_OK ? 0 : -1;
+}
+
+static int manager_maintain(struct azli_root_manager *manager, int truncate)
+{
+    int ret;
+
+    if (sqlite3_get_autocommit(manager->db->handler) == 0) {
+        return 1;
+    }
+    ret = manager_checkpoint(manager, truncate ? SQLITE_CHECKPOINT_TRUNCATE :
+                                                 SQLITE_CHECKPOINT_PASSIVE);
+    if (ret < 0) {
+        return -1;
+    }
+    if (manager_recount(manager) == -1) {
+        return -1;
+    }
+    manager->last_maintenance = now_seconds();
+    return ret;
+}
+
+static int manager_has_physical_capacity(struct azli_root_manager *manager,
+                                         size_t transaction_bytes)
+{
+    size_t pages;
+    size_t reserve;
+
+    if (manager->page_size == 0 ||
+        transaction_bytes > SIZE_MAX - manager->reserved_bytes) {
+        return -1;
+    }
+    transaction_bytes += manager->reserved_bytes;
+    pages = transaction_bytes / manager->page_size + 2;
+    if (pages > SIZE_MAX / manager->page_size / 2) {
+        return 0;
+    }
+    reserve = pages * manager->page_size * 2;
+    if (manager->physical_used > manager->limit ||
+        reserve > manager->limit - manager->physical_used) {
+        return 0;
+    }
+    return 1;
+}
+
+static void metrics_refresh_locked(struct flb_az_li *ctx)
+{
+#ifdef FLB_HAVE_METRICS
+    sqlite3_stmt *statement;
+    int64_t oldest;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT COUNT(*),COALESCE(SUM(record_count),0),"
+            "COALESCE(SUM(json_bytes),0),COALESCE(MIN(created),0) "
+            "FROM azli_sources WHERE instance_key=? AND state=1", -1,
+            &statement, NULL);
+    if (ret == SQLITE_OK) {
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(statement) == SQLITE_ROW) {
+            metric_gauge_set(ctx, ctx->cmt_queued_chunks,
+                             sqlite3_column_double(statement, 0));
+            metric_gauge_set(ctx, ctx->cmt_queued_records,
+                             sqlite3_column_double(statement, 1));
+            metric_gauge_set(ctx, ctx->cmt_queued_bytes,
+                             sqlite3_column_double(statement, 2));
+            oldest = sqlite3_column_int64(statement, 3);
+            metric_gauge_set(ctx, ctx->cmt_oldest_queued_age,
+                             oldest > 0 ? (double) (now_seconds() - oldest) : 0.0);
+        }
+        sqlite3_finalize(statement);
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT COUNT(*),COALESCE(SUM(json_bytes),0) FROM azli_sources "
+            "WHERE instance_key=? AND state=3", -1, &statement, NULL);
+    if (ret == SQLITE_OK) {
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(statement) == SQLITE_ROW) {
+            metric_gauge_set(ctx, ctx->cmt_quarantined_chunks_current,
+                             sqlite3_column_double(statement, 0));
+            metric_gauge_set(ctx, ctx->cmt_quarantined_bytes,
+                             sqlite3_column_double(statement, 1));
+        }
+        sqlite3_finalize(statement);
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT last_success FROM azli_instances WHERE instance_key=?", -1,
+            &statement, NULL);
+    if (ret == SQLITE_OK) {
+        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(statement) == SQLITE_ROW) {
+            metric_gauge_set(ctx, ctx->cmt_uploader_last_success,
+                             sqlite3_column_double(statement, 0));
+        }
+        sqlite3_finalize(statement);
+    }
+    metric_gauge_set(ctx, ctx->cmt_quota_used_bytes,
+                     (double) ctx->batch->manager->logical_used);
+    metric_gauge_set(ctx, ctx->cmt_quota_limit_bytes,
+                     (double) ctx->batch->manager->limit);
+    metric_gauge_set(ctx, ctx->cmt_uploader_up,
+                     ctx->batch->fatal_error ? 0.0 : 1.0);
+    metric_gauge_set(ctx, ctx->cmt_uploader_consecutive_failures,
+                     (double) ctx->batch->consecutive_failures);
+#else
+    (void) ctx;
+#endif
+}
+
+static int database_has_legacy_schema(struct azli_root_manager *manager)
+{
+    sqlite3_stmt *statement;
+    int count;
+    int ret;
+
+    statement = NULL;
+    ret = sqlite3_prepare_v2(manager->db->handler,
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' "
+            "AND name LIKE 'azli_%'", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    ret = sqlite3_step(statement);
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    count = sqlite3_column_int(statement, 0);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE) {
+        return -1;
+    }
+    return count > 0;
 }
 
 static int manager_schema(struct azli_root_manager *manager)
 {
-    const char *schema =
-        "PRAGMA journal_mode=WAL;"
-        "PRAGMA synchronous=FULL;"
-        "PRAGMA foreign_keys=ON;"
-        "CREATE TABLE IF NOT EXISTS azli_settings("
-        " root TEXT PRIMARY KEY, disk_limit INTEGER NOT NULL);"
-        "CREATE TABLE IF NOT EXISTS azli_instances("
-        " instance_key TEXT PRIMARY KEY, destination BLOB NOT NULL);"
-        "CREATE TABLE IF NOT EXISTS azli_sources("
-        " source_pk INTEGER PRIMARY KEY AUTOINCREMENT,"
-        " instance_key TEXT NOT NULL, source_id TEXT NOT NULL,"
-        " name TEXT NOT NULL, digest BLOB NOT NULL,"
-        " record_count INTEGER NOT NULL, next_record INTEGER NOT NULL DEFAULT 0,"
-        " bytes INTEGER NOT NULL, created INTEGER NOT NULL, state INTEGER NOT NULL,"
-        " has_quarantine INTEGER NOT NULL DEFAULT 0,"
-        " UNIQUE(instance_key,source_id));"
-        "CREATE INDEX IF NOT EXISTS azli_sources_order "
-        " ON azli_sources(instance_key,source_pk);"
-        "CREATE TABLE IF NOT EXISTS azli_requests("
-        " request_pk INTEGER PRIMARY KEY AUTOINCREMENT,"
-        " instance_key TEXT NOT NULL, name TEXT NOT NULL UNIQUE,"
-        " state INTEGER NOT NULL, attempts INTEGER NOT NULL DEFAULT 0,"
-        " next_retry INTEGER NOT NULL DEFAULT 0, json_bytes INTEGER NOT NULL,"
-        " gzip_bytes INTEGER NOT NULL, body_digest BLOB NOT NULL,"
-        " bytes INTEGER NOT NULL, created INTEGER NOT NULL,"
-        " status INTEGER NOT NULL DEFAULT 0,"
-        " reason TEXT);"
-        "CREATE INDEX IF NOT EXISTS azli_requests_order "
-        " ON azli_requests(instance_key,request_pk);"
-        "CREATE UNIQUE INDEX IF NOT EXISTS azli_one_active_request "
-        " ON azli_requests(instance_key) WHERE state IN (1,2,3,4);"
-        "CREATE TABLE IF NOT EXISTS azli_spans("
-        " request_pk INTEGER NOT NULL REFERENCES azli_requests(request_pk) ON DELETE CASCADE,"
-        " ordinal INTEGER NOT NULL, source_pk INTEGER NOT NULL "
-        " REFERENCES azli_sources(source_pk),"
-        " first_record INTEGER NOT NULL, record_count INTEGER NOT NULL,"
-        " PRIMARY KEY(request_pk,ordinal));"
-        "CREATE TABLE IF NOT EXISTS azli_receipts("
-        " instance_key TEXT NOT NULL, source_id TEXT NOT NULL,"
-        " digest BLOB NOT NULL, completed INTEGER NOT NULL,"
-        " PRIMARY KEY(instance_key,source_id));";
+    sqlite3_stmt *statement;
+    int legacy;
+    int version;
+    int ret;
+    const char *schema;
 
-    return sql_exec(manager, schema);
+    statement = NULL;
+    ret = sqlite3_prepare_v2(manager->db->handler, "PRAGMA user_version", -1,
+                             &statement, NULL);
+    if (ret != SQLITE_OK || sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    version = sqlite3_column_int(statement, 0);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE) {
+        return -1;
+    }
+
+    if (version == 0) {
+        legacy = database_has_legacy_schema(manager);
+        if (legacy != 0) {
+            if (legacy > 0) {
+                flb_error("[azure_logs_ingestion] incompatible record-range spool schema; "
+                          "drain, archive, or reset it with the prototype build");
+            }
+            return -1;
+        }
+    }
+    else if (version != AZLI_SCHEMA_VERSION) {
+        flb_error("[azure_logs_ingestion] unsupported spool schema version=%d expected=%d",
+                  version, AZLI_SCHEMA_VERSION);
+        return -1;
+    }
+
+    if (sql_exec(manager, "PRAGMA journal_mode=WAL;PRAGMA synchronous=FULL;"
+                          "PRAGMA foreign_keys=ON;PRAGMA wal_autocheckpoint=64;") == -1) {
+        return -1;
+    }
+    if (version == AZLI_SCHEMA_VERSION) {
+        return 0;
+    }
+
+    schema =
+        "BEGIN IMMEDIATE;"
+        "CREATE TABLE azli_settings("
+        " root TEXT PRIMARY KEY, disk_limit INTEGER NOT NULL CHECK(disk_limit>0));"
+        "CREATE TABLE azli_instances("
+        " instance_key TEXT PRIMARY KEY,"
+        " destination BLOB NOT NULL CHECK(length(destination)=32),"
+        " last_success INTEGER NOT NULL DEFAULT 0 CHECK(last_success>=0));"
+        "CREATE TABLE azli_requests("
+        " request_pk INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " instance_key TEXT NOT NULL REFERENCES azli_instances(instance_key),"
+        " name TEXT NOT NULL UNIQUE,"
+        " state INTEGER NOT NULL CHECK(state IN (1,2,3,4,5)),"
+        " attempts INTEGER NOT NULL DEFAULT 0 CHECK(attempts>=0),"
+        " next_retry INTEGER NOT NULL DEFAULT 0 CHECK(next_retry>=0),"
+        " json_bytes INTEGER NOT NULL CHECK(json_bytes>=2),"
+        " gzip_bytes INTEGER NOT NULL CHECK(gzip_bytes>0 AND gzip_bytes<=1048576),"
+        " body BLOB NOT NULL CHECK(length(body)=gzip_bytes),"
+        " body_digest BLOB NOT NULL CHECK(length(body_digest)=32),"
+        " json_digest BLOB NOT NULL CHECK(length(json_digest)=32),"
+        " bytes INTEGER NOT NULL CHECK(bytes>=gzip_bytes),"
+        " created INTEGER NOT NULL CHECK(created>0),"
+        " status INTEGER NOT NULL DEFAULT 0 CHECK(status>=0), reason TEXT,"
+        " UNIQUE(instance_key,request_pk));"
+        "CREATE INDEX azli_requests_order "
+        " ON azli_requests(instance_key,request_pk);"
+        "CREATE UNIQUE INDEX azli_one_active_request "
+        " ON azli_requests(instance_key) WHERE state IN (1,2,3,4);"
+        "CREATE TABLE azli_sources("
+        " source_pk INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " instance_key TEXT NOT NULL REFERENCES azli_instances(instance_key),"
+        " source_id TEXT NOT NULL CHECK(length(source_id)=64),"
+        " name TEXT NOT NULL CHECK(length(name)>0),"
+        " digest BLOB NOT NULL CHECK(length(digest)=32),"
+        " content BLOB NOT NULL CHECK(length(content)=json_bytes),"
+        " record_count INTEGER NOT NULL CHECK(record_count>0),"
+        " json_bytes INTEGER NOT NULL CHECK(json_bytes>=2),"
+        " standalone_gzip_bytes INTEGER NOT NULL "
+        " CHECK(standalone_gzip_bytes>0 AND standalone_gzip_bytes<=1048576),"
+        " bytes INTEGER NOT NULL CHECK(bytes>=json_bytes),"
+        " created INTEGER NOT NULL CHECK(created>0),"
+        " state INTEGER NOT NULL CHECK(state IN (1,2,3)),"
+        " request_pk INTEGER, quarantine_reason TEXT,"
+        " UNIQUE(instance_key,source_id),"
+        " FOREIGN KEY(instance_key,request_pk)"
+        " REFERENCES azli_requests(instance_key,request_pk));"
+        "CREATE INDEX azli_sources_order "
+        " ON azli_sources(instance_key,state,source_pk);"
+        "CREATE INDEX azli_sources_request ON azli_sources(request_pk,source_pk);"
+        "CREATE TABLE azli_receipts("
+        " instance_key TEXT NOT NULL REFERENCES azli_instances(instance_key),"
+        " source_id TEXT NOT NULL CHECK(length(source_id)=64),"
+        " digest BLOB NOT NULL CHECK(length(digest)=32),"
+        " completed INTEGER NOT NULL CHECK(completed>0),"
+        " expires INTEGER NOT NULL CHECK(expires>completed),"
+        " bytes INTEGER NOT NULL CHECK(bytes>=256),"
+        " PRIMARY KEY(instance_key,source_id));"
+        "PRAGMA user_version=3;"
+        "COMMIT;";
+
+    if (sql_exec(manager, schema) == -1) {
+        sql_rollback_if_active(manager);
+        return -1;
+    }
+    return 0;
+}
+
+static int manager_validate_invariants(struct azli_root_manager *manager)
+{
+    sqlite3_stmt *statement;
+    int invalid;
+    int ret;
+    const char *query;
+
+    query =
+        "SELECT "
+        "(SELECT COUNT(*) FROM azli_instances i WHERE "
+        " length(i.destination)!=32 OR i.last_success<0) + "
+        "(SELECT COUNT(*) FROM azli_requests r WHERE "
+        " r.state NOT IN (1,2,3,4,5) OR r.attempts<0 OR r.next_retry<0 OR "
+        " r.json_bytes<2 OR r.gzip_bytes<1 OR r.gzip_bytes>1048576 OR "
+        " length(r.body)!=r.gzip_bytes OR length(r.body_digest)!=32 OR "
+        " length(r.json_digest)!=32 OR "
+        " r.bytes<r.gzip_bytes OR r.created<=0 OR r.status<0 OR "
+        " NOT EXISTS(SELECT 1 FROM azli_instances i "
+        " WHERE i.instance_key=r.instance_key) OR "
+        " NOT EXISTS(SELECT 1 FROM azli_sources s "
+        " WHERE s.request_pk=r.request_pk AND s.instance_key=r.instance_key)) + "
+        "(SELECT COUNT(*) FROM azli_sources s WHERE "
+        " s.state NOT IN (1,2,3) OR length(s.source_id)!=64 OR "
+        " length(s.name)=0 OR length(s.digest)!=32 OR "
+        " length(s.content)!=s.json_bytes OR s.record_count<=0 OR "
+        " s.json_bytes<2 OR s.standalone_gzip_bytes<1 OR "
+        " s.standalone_gzip_bytes>1048576 OR s.bytes<s.json_bytes OR "
+        " s.created<=0 OR "
+        " NOT EXISTS(SELECT 1 FROM azli_instances i "
+        " WHERE i.instance_key=s.instance_key) OR "
+        " (s.request_pk IS NOT NULL AND NOT EXISTS("
+        " SELECT 1 FROM azli_requests r WHERE r.request_pk=s.request_pk "
+        " AND r.instance_key=s.instance_key)) OR "
+        " (s.request_pk IS NULL AND s.state=2) OR "
+        " (s.request_pk IS NOT NULL AND NOT EXISTS("
+        " SELECT 1 FROM azli_requests r WHERE r.request_pk=s.request_pk AND "
+        " ((s.state=1 AND r.state IN (1,2,3)) OR "
+        " (s.state=2 AND r.state=4) OR (s.state=3 AND r.state=5))))) + "
+        "(SELECT COUNT(*) FROM azli_receipts p WHERE "
+        " length(p.source_id)!=64 OR length(p.digest)!=32 OR p.completed<=0 OR "
+        " p.expires<=p.completed OR p.bytes<256 OR "
+        " NOT EXISTS(SELECT 1 FROM azli_instances i "
+        " WHERE i.instance_key=p.instance_key) OR EXISTS("
+        " SELECT 1 FROM azli_sources s WHERE s.instance_key=p.instance_key "
+        " AND s.source_id=p.source_id AND (s.state!=2 OR s.digest!=p.digest)))";
+
+    ret = sqlite3_prepare_v2(manager->db->handler, query, -1, &statement, NULL);
+    if (ret != SQLITE_OK || sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    invalid = sqlite3_column_int(statement, 0);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE || invalid != 0) {
+        if (invalid != 0) {
+            flb_error("[azure_logs_ingestion] spool invariant violation rows=%d",
+                      invalid);
+        }
+        return -1;
+    }
+    return 0;
+}
+
+static int manager_configure_limits(struct azli_root_manager *manager)
+{
+    sqlite3_stmt *statement;
+    char sql[160];
+    size_t main_limit;
+    int64_t effective_pages;
+    int ret;
+
+    statement = NULL;
+    ret = sqlite3_prepare_v2(manager->db->handler, "PRAGMA page_size", -1,
+                             &statement, NULL);
+    if (ret != SQLITE_OK || sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    manager->page_size = (size_t) sqlite3_column_int(statement, 0);
+    sqlite3_finalize(statement);
+    if (manager->page_size == 0) {
+        return -1;
+    }
+    manager->wal_headroom = manager->limit / 4;
+    if (manager->wal_headroom > AZLI_WAL_LIMIT_MAX) {
+        manager->wal_headroom = AZLI_WAL_LIMIT_MAX;
+    }
+    if (manager->wal_headroom < manager->page_size * 16) {
+        manager->wal_headroom = manager->page_size * 16;
+    }
+    main_limit = manager->limit > manager->wal_headroom + manager->page_size * 16 ?
+                 manager->limit - manager->wal_headroom - manager->page_size * 16 :
+                 manager->page_size * 32;
+    manager->max_page_count = main_limit / manager->page_size;
+    snprintf(sql, sizeof(sql), "PRAGMA journal_size_limit=%zu;",
+             manager->wal_headroom);
+    if (sql_exec(manager, sql) == -1) {
+        return -1;
+    }
+    snprintf(sql, sizeof(sql), "PRAGMA max_page_count=%zu",
+             manager->max_page_count);
+    ret = sqlite3_prepare_v2(manager->db->handler, sql, -1, &statement, NULL);
+    if (ret != SQLITE_OK || sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    effective_pages = sqlite3_column_int64(statement, 0);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE || effective_pages <= 0 ||
+        (uint64_t) effective_pages != manager->max_page_count) {
+        flb_error("[azure_logs_ingestion] cannot enforce SQLite max_page_count "
+                  "requested=%zu effective=%" PRId64,
+                  manager->max_page_count, effective_pages);
+        return -1;
+    }
+    return 0;
 }
 
 static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
@@ -409,6 +764,7 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
     int ret;
     int64_t stored_limit;
 
+    statement = NULL;
     pthread_once(&manager_registry_once, manager_registry_init);
 #ifdef _WIN32
     root_path = ctx->buffer_dir;
@@ -442,6 +798,7 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
     manager->limit = ctx->buffer_dir_limit_size;
     manager->references = 1;
     manager->lock_fd = -1;
+    mk_list_init(&manager->instance_leases);
     pthread_mutex_init(&manager->mutex, NULL);
     snprintf(db_path, sizeof(db_path), "%s/.azure_logs_ingestion.db", root_path);
     if (manager->path == NULL || lock_manager_root(manager) == -1) {
@@ -456,9 +813,7 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
             flb_sqldb_close(manager->db);
         }
         unlock_manager_root(manager);
-        if (manager->path != NULL) {
-            flb_sds_destroy(manager->path);
-        }
+        flb_sds_destroy(manager->path);
         pthread_mutex_destroy(&manager->mutex);
         flb_free(manager);
         pthread_mutex_unlock(&manager_registry_mutex);
@@ -475,7 +830,12 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
     ret = sqlite3_step(statement);
     if (ret == SQLITE_ROW) {
         stored_limit = sqlite3_column_int64(statement, 0);
+        ret = sqlite3_step(statement);
         sqlite3_finalize(statement);
+        statement = NULL;
+        if (ret != SQLITE_DONE) {
+            goto error;
+        }
         if (stored_limit != (int64_t) manager->limit) {
             ret = sqlite3_prepare_v2(manager->db->handler,
                     "UPDATE azli_settings SET disk_limit=? WHERE root=?", -1,
@@ -489,10 +849,12 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
                 goto error;
             }
             sqlite3_finalize(statement);
+            statement = NULL;
         }
     }
-    else {
+    else if (ret == SQLITE_DONE) {
         sqlite3_finalize(statement);
+        statement = NULL;
         ret = sqlite3_prepare_v2(manager->db->handler,
                 "INSERT INTO azli_settings(root,disk_limit) VALUES(?,?)", -1,
                 &statement, NULL);
@@ -505,9 +867,21 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
             goto error;
         }
         sqlite3_finalize(statement);
+        statement = NULL;
     }
-    if (manager_recount(manager) == -1) {
-        goto error_no_statement;
+    else {
+        goto error;
+    }
+    if (manager_validate_invariants(manager) == -1 ||
+        manager_configure_limits(manager) == -1 ||
+        manager_maintain(manager, FLB_TRUE) < 0) {
+        goto error;
+    }
+    if (manager->physical_used > manager->limit) {
+        flb_plg_error(ctx->ins,
+                      "SQLite spool exceeds physical limit used=%zu limit=%zu",
+                      manager->physical_used, manager->limit);
+        goto error;
     }
     mk_list_add(&manager->_head, &manager_registry);
     pthread_mutex_unlock(&manager_registry_mutex);
@@ -515,7 +889,6 @@ static struct azli_root_manager *manager_acquire(struct flb_az_li *ctx)
 
 error:
     sqlite3_finalize(statement);
-error_no_statement:
     flb_sqldb_close(manager->db);
     unlock_manager_root(manager);
     flb_sds_destroy(manager->path);
@@ -542,6 +915,45 @@ static void manager_release(struct azli_root_manager *manager)
     pthread_mutex_unlock(&manager_registry_mutex);
 }
 
+static int manager_claim_instance(struct flb_az_li *ctx)
+{
+    struct azli_instance_lease *lease;
+    struct mk_list *head;
+
+    mk_list_foreach(head, &ctx->batch->manager->instance_leases) {
+        lease = mk_list_entry(head, struct azli_instance_lease, _head);
+        if (strcmp(lease->instance_key, ctx->buffer_key) == 0) {
+            flb_plg_error(ctx->ins,
+                          "buffer_key is already active in this process key=%s",
+                          ctx->buffer_key);
+            return -1;
+        }
+    }
+    lease = flb_calloc(1, sizeof(*lease));
+    if (lease == NULL) {
+        return -1;
+    }
+    lease->instance_key = flb_sds_create(ctx->buffer_key);
+    if (lease->instance_key == NULL) {
+        flb_free(lease);
+        return -1;
+    }
+    mk_list_add(&lease->_head, &ctx->batch->manager->instance_leases);
+    ctx->batch->lease = lease;
+    return 0;
+}
+
+static void manager_release_instance(struct flb_az_li_batch *batch)
+{
+    if (batch->lease == NULL) {
+        return;
+    }
+    mk_list_del(&batch->lease->_head);
+    flb_sds_destroy(batch->lease->instance_key);
+    flb_free(batch->lease);
+    batch->lease = NULL;
+}
+
 static int instance_attach(struct flb_az_li *ctx)
 {
     flb_sds_t value;
@@ -563,6 +975,7 @@ static int instance_attach(struct flb_az_li *ctx)
     }
     flb_sds_destroy(value);
 
+    statement = NULL;
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
             "SELECT destination FROM azli_instances WHERE instance_key=?", -1,
             &statement, NULL);
@@ -575,11 +988,18 @@ static int instance_attach(struct flb_az_li *ctx)
         ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
               memcmp(sqlite3_column_blob(statement, 0), digest,
                      AZLI_DIGEST_SIZE) == 0 ? 0 : -1;
+        if (sqlite3_step(statement) != SQLITE_DONE) {
+            ret = -1;
+        }
         sqlite3_finalize(statement);
         if (ret == -1) {
             flb_plg_error(ctx->ins, "buffer_key belongs to a different destination");
         }
         return ret;
+    }
+    if (ret != SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        return -1;
     }
     sqlite3_finalize(statement);
 
@@ -596,16 +1016,13 @@ static int instance_attach(struct flb_az_li *ctx)
     return ret;
 }
 
-static int cleanup_expired_receipts(struct flb_az_li *ctx)
+static int cleanup_expired_receipts(struct azli_root_manager *manager)
 {
     sqlite3_stmt *statement;
     int ret;
 
-    if (ctx->buffer_receipt_ttl == 0) {
-        return 0;
-    }
-    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "DELETE FROM azli_receipts WHERE instance_key=? AND completed<? "
+    ret = sqlite3_prepare_v2(manager->db->handler,
+            "DELETE FROM azli_receipts WHERE expires<=? "
             "AND NOT EXISTS (SELECT 1 FROM azli_sources s "
             "WHERE s.instance_key=azli_receipts.instance_key "
             "AND s.source_id=azli_receipts.source_id)", -1,
@@ -613,348 +1030,103 @@ static int cleanup_expired_receipts(struct flb_az_li *ctx)
     if (ret != SQLITE_OK) {
         return -1;
     }
-    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int64(statement, 2,
-                       now_seconds() - (int64_t) ctx->buffer_receipt_ttl);
+    sqlite3_bind_int64(statement, 1, now_seconds());
     ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
     sqlite3_finalize(statement);
     return ret;
 }
 
-static int source_content_validate(const void *data, size_t size,
-                                   int64_t expected_records)
+static int source_content_validate(const void *data, size_t size)
 {
     const char *bytes;
-    size_t offset;
-    size_t start;
-    int64_t records;
 
+    if (data == NULL || size < 2) {
+        return -1;
+    }
     bytes = data;
-    start = 0;
-    records = 0;
-    for (offset = 0; offset < size; offset++) {
-        if (bytes[offset] != '\n') {
-            continue;
-        }
-        if (offset == start || bytes[start] != '{' || bytes[offset - 1] != '}') {
-            return -1;
-        }
-        records++;
-        start = offset + 1;
-    }
-    if (start != size || records != expected_records) {
+    if (bytes[0] != '[' || bytes[size - 1] != ']') {
         return -1;
     }
     return 0;
 }
 
-static int source_meta_parse(struct flb_fstore_file *file, char source_id[65],
-                             unsigned char digest[32], int64_t *record_count,
-                             int64_t *created)
+static int source_quarantine(struct flb_az_li *ctx, int64_t source_pk,
+                             const char *reason)
 {
-    char magic[8];
-    char digest_text[65];
-    long long records;
-    long long timestamp;
-
-    if (file->meta_buf == NULL || file->meta_size < 1 ||
-        sscanf(file->meta_buf, "%7[^|]|%64[^|]|%64[^|]|%lld|%lld",
-               magic, source_id, digest_text, &records, &timestamp) != 5 ||
-        strcmp(magic, "AZLIS1") != 0 || digest_from_hex(digest_text, digest) == -1) {
-        return -1;
-    }
-    *record_count = records;
-    *created = timestamp;
-    return 0;
-}
-
-static int recover_sources(struct flb_az_li *ctx)
-{
-    struct mk_list *head;
-    struct mk_list *tmp;
-    struct flb_fstore_file *file;
     sqlite3_stmt *statement;
-    unsigned char digest[32];
-    unsigned char actual_digest[32];
-    char source_id[65];
     int64_t record_count;
-    int64_t created;
-    ssize_t real_size;
-    void *content;
-    size_t size;
     int ret;
 
-    mk_list_foreach_safe(head, tmp, &ctx->batch->sources->files) {
-        file = mk_list_entry(head, struct flb_fstore_file, _head);
-        if (flb_fstore_file_meta_get(ctx->batch->fs, file) == -1 ||
-            source_meta_parse(file, source_id, digest, &record_count, &created) == -1) {
-            flb_plg_error(ctx->ins, "invalid immutable source metadata file=%s", file->name);
-            return -1;
-        }
-        content = NULL;
-        if (flb_fstore_file_content_copy(NULL, file, &content, &size) == -1 ||
-            hash_bytes(content, size, actual_digest) != 0 ||
-            memcmp(digest, actual_digest, sizeof(digest)) != 0 ||
-            source_content_validate(content, size, record_count) == -1) {
-            flb_free(content);
-            flb_plg_error(ctx->ins, "invalid immutable source content file=%s", file->name);
-            return -1;
-        }
-        flb_free(content);
-        real_size = cio_chunk_get_real_size(file->chunk);
-        if (real_size < 0) {
-            return -1;
-        }
-
-        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "SELECT digest FROM azli_sources WHERE instance_key=? AND source_id=?", -1,
-                &statement, NULL);
-        if (ret != SQLITE_OK) {
-            return -1;
-        }
-        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
-        ret = sqlite3_step(statement);
-        if (ret == SQLITE_ROW) {
-            ret = sqlite3_column_bytes(statement, 0) == 32 &&
-                  memcmp(sqlite3_column_blob(statement, 0), digest, 32) == 0 ? 0 : -1;
-            sqlite3_finalize(statement);
-            if (ret == -1) {
-                return -1;
-            }
-            continue;
-        }
-        sqlite3_finalize(statement);
-
-        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "SELECT digest FROM azli_receipts WHERE instance_key=? AND source_id=?", -1,
-                &statement, NULL);
-        if (ret != SQLITE_OK) {
-            return -1;
-        }
-        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
-        ret = sqlite3_step(statement);
-        if (ret == SQLITE_ROW) {
-            ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
-                  memcmp(sqlite3_column_blob(statement, 0), digest,
-                         AZLI_DIGEST_SIZE) == 0 ? 0 : -1;
-            sqlite3_finalize(statement);
-            if (ret == -1) {
-                return -1;
-            }
-            flb_fstore_file_delete(ctx->batch->fs, file);
-            if (sync_directory(ctx->batch->sources->path) == -1) {
-                return -1;
-            }
-            continue;
-        }
-        sqlite3_finalize(statement);
-
-        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "INSERT INTO azli_sources(instance_key,source_id,name,digest,record_count,"
-                "next_record,bytes,created,state) VALUES(?,?,?,?,?,0,?,?,?)", -1,
-                &statement, NULL);
-        if (ret != SQLITE_OK) {
-            return -1;
-        }
-        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, 3, file->name, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_blob(statement, 4, digest, 32, SQLITE_TRANSIENT);
-        sqlite3_bind_int64(statement, 5, record_count);
-        if ((size_t) real_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE) {
-            sqlite3_finalize(statement);
-            return -1;
-        }
-        sqlite3_bind_int64(statement, 6,
-                           (size_t) real_size + AZLI_SOURCE_DB_RESERVE);
-        sqlite3_bind_int64(statement, 7, created);
-        sqlite3_bind_int(statement, 8, AZLI_SOURCE_READY);
-        ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
-        sqlite3_finalize(statement);
-        if (ret == -1) {
-            return -1;
-        }
-    }
-    return 0;
-}
-
-static int cleanup_acked_request(struct flb_az_li *ctx, int64_t request_pk,
-                                 const char *request_name)
-{
-    sqlite3_stmt *statement;
-    struct flb_fstore_file *file;
-    int ret;
-
-    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->requests,
-                               (char *) request_name, strlen(request_name));
-    if (file != NULL) {
-        flb_fstore_file_delete(ctx->batch->fs, file);
-        if (sync_directory(ctx->batch->requests->path) == -1) {
-            return -1;
-        }
-    }
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "DELETE FROM azli_requests WHERE request_pk=? AND state=?", -1,
+            "SELECT record_count FROM azli_sources WHERE source_pk=? "
+            "AND instance_key=? AND state=? AND request_pk IS NULL", -1,
             &statement, NULL);
     if (ret != SQLITE_OK) {
         return -1;
     }
-    sqlite3_bind_int64(statement, 1, request_pk);
-    sqlite3_bind_int(statement, 2, AZLI_REQUEST_ACKED);
-    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_bind_int64(statement, 1, source_pk);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 3, AZLI_SOURCE_READY);
+    if (sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    record_count = sqlite3_column_int64(statement, 0);
     sqlite3_finalize(statement);
-    manager_recount(ctx->batch->manager);
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_sources SET state=?,quarantine_reason=? "
+            "WHERE source_pk=? AND instance_key=? AND state=? "
+            "AND request_pk IS NULL", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int(statement, 1, AZLI_SOURCE_QUARANTINED);
+    sqlite3_bind_text(statement, 2, reason, -1, SQLITE_STATIC);
+    sqlite3_bind_int64(statement, 3, source_pk);
+    sqlite3_bind_text(statement, 4, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 5, AZLI_SOURCE_READY);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    if (ret == 0 && sqlite3_changes(ctx->batch->manager->db->handler) == 1) {
+        metric_counter_add(ctx, ctx->cmt_quarantined_chunks, 1.0);
+        metric_counter_add(ctx, ctx->cmt_quarantined_records,
+                           (double) record_count);
+    }
+    sqlite3_finalize(statement);
     return ret;
 }
 
-static int cleanup_drained_sources(struct flb_az_li *ctx)
+static int receipt_or_source_exists(struct flb_az_li *ctx, const char *source_id,
+                                    const unsigned char digest[32])
 {
-    sqlite3_stmt *query;
-    sqlite3_stmt *remove;
-    struct flb_fstore_file *file;
-    const char *name;
-    int64_t source_pk;
-    int ret;
-
-    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT source_pk,name FROM azli_sources WHERE instance_key=? AND state=?", -1,
-            &query, NULL);
-    if (ret != SQLITE_OK) {
-        return -1;
-    }
-    sqlite3_bind_text(query, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(query, 2, AZLI_SOURCE_DRAINED);
-    while (sqlite3_step(query) == SQLITE_ROW) {
-        source_pk = sqlite3_column_int64(query, 0);
-        name = (const char *) sqlite3_column_text(query, 1);
-        file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->sources,
-                                   (char *) name, strlen(name));
-        if (file != NULL) {
-            flb_fstore_file_delete(ctx->batch->fs, file);
-            if (sync_directory(ctx->batch->sources->path) == -1) {
-                sqlite3_finalize(query);
-                return -1;
-            }
-        }
-        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "DELETE FROM azli_sources WHERE source_pk=?", -1, &remove, NULL);
-        if (ret != SQLITE_OK) {
-            sqlite3_finalize(query);
-            return -1;
-        }
-        sqlite3_bind_int64(remove, 1, source_pk);
-        if (sqlite3_step(remove) != SQLITE_DONE) {
-            sqlite3_finalize(remove);
-            sqlite3_finalize(query);
-            return -1;
-        }
-        sqlite3_finalize(remove);
-    }
-    sqlite3_finalize(query);
-    manager_recount(ctx->batch->manager);
-    return 0;
-}
-
-static int recover_requests(struct flb_az_li *ctx)
-{
-    struct mk_list *head;
-    struct mk_list *tmp;
-    struct flb_fstore_file *file;
     sqlite3_stmt *statement;
-    const char *name;
-    int64_t request_pk;
-    int64_t gzip_bytes;
-    int state;
     int ret;
-    void *body;
-    size_t body_size;
-    unsigned char digest[AZLI_DIGEST_SIZE];
-
-    /* A request file without a manifest never owned source spans and is safe to remove. */
-    mk_list_foreach_safe(head, tmp, &ctx->batch->requests->files) {
-        file = mk_list_entry(head, struct flb_fstore_file, _head);
-        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "SELECT 1 FROM azli_requests WHERE name=?", -1, &statement, NULL);
-        if (ret != SQLITE_OK) {
-            return -1;
-        }
-        sqlite3_bind_text(statement, 1, file->name, -1, SQLITE_TRANSIENT);
-        ret = sqlite3_step(statement);
-        sqlite3_finalize(statement);
-        if (ret != SQLITE_ROW) {
-            flb_fstore_file_delete(ctx->batch->fs, file);
-            if (sync_directory(ctx->batch->requests->path) == -1) {
-                return -1;
-            }
-        }
-    }
 
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT request_pk,name,state,gzip_bytes,body_digest FROM azli_requests "
-            "WHERE instance_key=?", -1,
-            &statement, NULL);
+            "SELECT digest FROM azli_sources WHERE instance_key=? AND source_id=? "
+            "UNION ALL SELECT digest FROM azli_receipts "
+            "WHERE instance_key=? AND source_id=?", -1, &statement, NULL);
     if (ret != SQLITE_OK) {
-        return -1;
+        return AZLI_SOURCE_EXISTS_ERROR;
     }
     sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    while (sqlite3_step(statement) == SQLITE_ROW) {
-        request_pk = sqlite3_column_int64(statement, 0);
-        name = (const char *) sqlite3_column_text(statement, 1);
-        state = sqlite3_column_int(statement, 2);
-        gzip_bytes = sqlite3_column_int64(statement, 3);
-        if (state == AZLI_REQUEST_ACKED) {
-            cleanup_acked_request(ctx, request_pk, name);
-            continue;
-        }
-        if (state == AZLI_REQUEST_QUARANTINED) {
-            continue;
-        }
-        file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->requests,
-                                   (char *) name, strlen(name));
-        body = NULL;
-        if (file == NULL || sqlite3_column_bytes(statement, 4) != AZLI_DIGEST_SIZE ||
-            flb_fstore_file_content_copy(NULL, file, &body, &body_size) == -1 ||
-            body_size != (size_t) gzip_bytes ||
-            hash_bytes(body, body_size, digest) != 0 ||
-            memcmp(digest, sqlite3_column_blob(statement, 4),
-                   AZLI_DIGEST_SIZE) != 0) {
-            struct azli_request corrupt_request;
-
-            flb_free(body);
-            memset(&corrupt_request, 0, sizeof(corrupt_request));
-            corrupt_request.request_pk = request_pk;
-            corrupt_request.name = flb_sds_create(name);
-            flb_plg_error(ctx->ins,
-                          "request manifest/artifact mismatch name=%s; quarantining spans",
-                          name);
-            sqlite3_finalize(statement);
-            if (corrupt_request.name == NULL ||
-                request_commit_spans(ctx, &corrupt_request, FLB_TRUE, 0,
-                                     "artifact_corrupt") == -1) {
-                flb_sds_destroy(corrupt_request.name);
-                return -1;
-            }
-            flb_sds_destroy(corrupt_request.name);
-            return recover_requests(ctx);
-        }
-        flb_free(body);
-    }
-    sqlite3_finalize(statement);
-    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "UPDATE azli_requests SET state=?,next_retry=? "
-            "WHERE instance_key=? AND state=?", -1, &statement, NULL);
-    if (ret != SQLITE_OK) {
-        return -1;
-    }
-    sqlite3_bind_int(statement, 1, AZLI_REQUEST_RETRY);
-    sqlite3_bind_int64(statement, 2, now_seconds());
+    sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(statement, 4, AZLI_REQUEST_INFLIGHT);
-    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_bind_text(statement, 4, source_id, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
+              memcmp(sqlite3_column_blob(statement, 0), digest,
+                     AZLI_DIGEST_SIZE) == 0 ? AZLI_SOURCE_EXISTS_MATCH :
+                                             AZLI_SOURCE_EXISTS_COLLISION;
+    }
+    else if (ret == SQLITE_DONE) {
+        ret = AZLI_SOURCE_EXISTS_NONE;
+    }
+    else {
+        ret = AZLI_SOURCE_EXISTS_ERROR;
+    }
     sqlite3_finalize(statement);
-    cleanup_drained_sources(ctx);
     return ret;
 }
 
@@ -1001,88 +1173,742 @@ static int source_identity(struct flb_az_li *ctx,
     return 0;
 }
 
-static flb_sds_t records_to_ndjson(flb_sds_t *records, size_t record_count)
-{
-    flb_sds_t output;
-    flb_sds_t tmp;
-    size_t size;
-    size_t index;
 
-    size = 0;
-    for (index = 0; index < record_count; index++) {
-        size += flb_sds_len(records[index]) + 1;
+static int validate_source_blob(struct flb_az_li *ctx, int64_t source_pk)
+{
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    const void *content;
+    const void *stored_digest;
+    int content_size;
+    int digest_size;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT content,digest,json_bytes,record_count,bytes,created,source_id,name "
+            "FROM azli_sources WHERE source_pk=? AND instance_key=? AND state=? "
+            "AND request_pk IS NULL", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
     }
-    output = flb_sds_create_size(size);
-    if (output == NULL) {
-        return NULL;
+    sqlite3_bind_int64(statement, 1, source_pk);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 3, AZLI_SOURCE_READY);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        return 0;
     }
-    for (index = 0; index < record_count; index++) {
-        tmp = flb_sds_cat(output, records[index], flb_sds_len(records[index]));
-        if (tmp == NULL) {
-            flb_sds_destroy(output);
-            return NULL;
-        }
-        output = tmp;
-        tmp = flb_sds_cat(output, "\n", 1);
-        if (tmp == NULL) {
-            flb_sds_destroy(output);
-            return NULL;
-        }
-        output = tmp;
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
     }
-    return output;
+    content = sqlite3_column_blob(statement, 0);
+    content_size = sqlite3_column_bytes(statement, 0);
+    stored_digest = sqlite3_column_blob(statement, 1);
+    digest_size = sqlite3_column_bytes(statement, 1);
+    if (content_size < 2 || sqlite3_column_int64(statement, 2) != content_size ||
+        sqlite3_column_int64(statement, 3) <= 0 ||
+        sqlite3_column_int64(statement, 4) < content_size ||
+        sqlite3_column_int64(statement, 5) <= 0 ||
+        sqlite3_column_text(statement, 6) == NULL ||
+        strlen((const char *) sqlite3_column_text(statement, 6)) != AZLI_HEX_SIZE ||
+        sqlite3_column_text(statement, 7) == NULL ||
+        sqlite3_column_bytes(statement, 7) == 0 ||
+        digest_size != AZLI_DIGEST_SIZE ||
+        source_content_validate(content, (size_t) content_size) == -1 ||
+        hash_bytes(content, (size_t) content_size, digest) != 0 ||
+        memcmp(digest, stored_digest, AZLI_DIGEST_SIZE) != 0) {
+        sqlite3_finalize(statement);
+        flb_plg_error(ctx->ins, "quarantining corrupt source row=%" PRId64,
+                      source_pk);
+        return source_quarantine(ctx, source_pk, "content_corrupt");
+    }
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    return ret == SQLITE_DONE ? 0 : -1;
 }
 
-static int receipt_or_source_exists(struct flb_az_li *ctx, const char *source_id,
-                                    const unsigned char digest[32])
+static int validate_source_rows(struct flb_az_li *ctx)
+{
+    int64_t *source_pks;
+    sqlite3_stmt *statement;
+    size_t count;
+    size_t index;
+    int ret;
+
+    source_pks = flb_calloc(AZLI_MAX_SOURCE_FILES, sizeof(*source_pks));
+    if (source_pks == NULL) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT source_pk FROM azli_sources WHERE instance_key=? "
+            "AND state=? AND request_pk IS NULL ORDER BY source_pk", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        flb_free(source_pks);
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_READY);
+    count = 0;
+    while ((ret = sqlite3_step(statement)) == SQLITE_ROW) {
+        if (count >= AZLI_MAX_SOURCE_FILES) {
+            sqlite3_finalize(statement);
+            flb_free(source_pks);
+            return -1;
+        }
+        source_pks[count++] = sqlite3_column_int64(statement, 0);
+    }
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE) {
+        flb_free(source_pks);
+        return -1;
+    }
+    for (index = 0; index < count; index++) {
+        if (validate_source_blob(ctx, source_pks[index]) == -1) {
+            flb_free(source_pks);
+            return -1;
+        }
+    }
+    flb_free(source_pks);
+    return 0;
+}
+
+static int repair_acked_receipts(struct flb_az_li *ctx)
+{
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    const void *content;
+    const void *stored_digest;
+    int64_t completed;
+    int content_size;
+    int missing;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT s.content,s.digest,s.json_bytes,s.record_count,s.source_id "
+            "FROM azli_sources s JOIN azli_requests r "
+            "ON r.request_pk=s.request_pk AND r.instance_key=s.instance_key "
+            "WHERE s.instance_key=? AND s.state=? AND r.state=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_DRAINED);
+    sqlite3_bind_int(statement, 3, AZLI_REQUEST_ACKED);
+    while ((ret = sqlite3_step(statement)) == SQLITE_ROW) {
+        content = sqlite3_column_blob(statement, 0);
+        content_size = sqlite3_column_bytes(statement, 0);
+        stored_digest = sqlite3_column_blob(statement, 1);
+        if (content_size < 2 || sqlite3_column_bytes(statement, 1) != AZLI_DIGEST_SIZE ||
+            sqlite3_column_int64(statement, 2) != content_size ||
+            sqlite3_column_int64(statement, 3) <= 0 ||
+            sqlite3_column_text(statement, 4) == NULL ||
+            strlen((const char *) sqlite3_column_text(statement, 4)) != AZLI_HEX_SIZE ||
+            source_content_validate(content, (size_t) content_size) == -1 ||
+            hash_bytes(content, (size_t) content_size, digest) != 0 ||
+            memcmp(digest, stored_digest, AZLI_DIGEST_SIZE) != 0) {
+            sqlite3_finalize(statement);
+            return -1;
+        }
+    }
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE ||
+        sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
+        return -1;
+    }
+    completed = now_seconds();
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT COUNT(*) FROM azli_sources s JOIN azli_requests r "
+            "ON r.request_pk=s.request_pk AND r.instance_key=s.instance_key "
+            "JOIN azli_receipts p ON p.instance_key=s.instance_key "
+            "AND p.source_id=s.source_id WHERE s.instance_key=? AND s.state=? "
+            "AND r.state=? AND p.digest!=s.digest", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto repair_rollback;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_DRAINED);
+    sqlite3_bind_int(statement, 3, AZLI_REQUEST_ACKED);
+    if (sqlite3_step(statement) != SQLITE_ROW || sqlite3_column_int(statement, 0) != 0 ||
+        sqlite3_step(statement) != SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        goto repair_rollback;
+    }
+    sqlite3_finalize(statement);
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "INSERT OR IGNORE INTO azli_receipts(instance_key,source_id,digest,"
+            "completed,expires,bytes) SELECT s.instance_key,s.source_id,s.digest,?,?,? "
+            "FROM azli_sources s JOIN azli_requests r "
+            "ON r.request_pk=s.request_pk AND r.instance_key=s.instance_key "
+            "WHERE s.instance_key=? AND s.state=? AND r.state=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto repair_rollback;
+    }
+    sqlite3_bind_int64(statement, 1, completed);
+    sqlite3_bind_int64(statement, 2,
+                       completed + (int64_t) ctx->buffer_receipt_ttl);
+    sqlite3_bind_int64(statement, 3, AZLI_RECEIPT_DB_RESERVE);
+    sqlite3_bind_text(statement, 4, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 5, AZLI_SOURCE_DRAINED);
+    sqlite3_bind_int(statement, 6, AZLI_REQUEST_ACKED);
+    if (sqlite3_step(statement) != SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        goto repair_rollback;
+    }
+    sqlite3_finalize(statement);
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT COUNT(*) FROM azli_sources s JOIN azli_requests r "
+            "ON r.request_pk=s.request_pk AND r.instance_key=s.instance_key "
+            "LEFT JOIN azli_receipts p ON p.instance_key=s.instance_key "
+            "AND p.source_id=s.source_id AND p.digest=s.digest "
+            "WHERE s.instance_key=? AND s.state=? AND r.state=? "
+            "AND p.source_id IS NULL", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto repair_rollback;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_DRAINED);
+    sqlite3_bind_int(statement, 3, AZLI_REQUEST_ACKED);
+    if (sqlite3_step(statement) != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        goto repair_rollback;
+    }
+    missing = sqlite3_column_int(statement, 0);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE || missing != 0) {
+        goto repair_rollback;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_instances SET last_success=MAX(last_success,COALESCE(("
+            "SELECT MAX(completed) FROM azli_receipts WHERE instance_key=?),0)) "
+            "WHERE instance_key=?", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto repair_rollback;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(statement) != SQLITE_DONE ||
+        sqlite3_changes(ctx->batch->manager->db->handler) != 1) {
+        sqlite3_finalize(statement);
+        goto repair_rollback;
+    }
+    sqlite3_finalize(statement);
+    ret = sql_commit(ctx->batch->manager);
+    if (ret == 0) {
+        return 0;
+    }
+    if (ret == 1 && sqlite3_get_autocommit(ctx->batch->manager->db->handler) != 0) {
+        return repair_acked_receipts(ctx);
+    }
+    return -1;
+
+repair_rollback:
+    sql_rollback_if_active(ctx->batch->manager);
+    return -1;
+}
+
+static int acknowledged_cleanup_complete(struct flb_az_li *ctx)
+{
+    sqlite3_stmt *statement;
+    int count;
+    int ret;
+
+    if (sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT (SELECT COUNT(*) FROM azli_sources WHERE instance_key=? "
+            "AND state=?) + (SELECT COUNT(*) FROM azli_requests "
+            "WHERE instance_key=? AND state=?)", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_DRAINED);
+    sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 4, AZLI_REQUEST_ACKED);
+    ret = sqlite3_step(statement);
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    count = sqlite3_column_int(statement, 0);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    return ret == SQLITE_DONE && count == 0 ? 1 : 0;
+}
+
+static int cleanup_acknowledged(struct flb_az_li *ctx)
 {
     sqlite3_stmt *statement;
     int ret;
 
+    if (repair_acked_receipts(ctx) == -1 ||
+        sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
+        return -1;
+    }
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT digest FROM azli_sources WHERE instance_key=? AND source_id=? "
-            "UNION ALL SELECT digest FROM azli_receipts WHERE instance_key=? AND source_id=?", -1,
+            "DELETE FROM azli_sources WHERE instance_key=? AND state=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_DRAINED);
+    if (sqlite3_step(statement) != SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        goto rollback;
+    }
+    sqlite3_finalize(statement);
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "DELETE FROM azli_requests WHERE instance_key=? AND state=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_REQUEST_ACKED);
+    if (sqlite3_step(statement) != SQLITE_DONE) {
+        sqlite3_finalize(statement);
+        goto rollback;
+    }
+    sqlite3_finalize(statement);
+    ret = sql_commit(ctx->batch->manager);
+    if (ret != 0 &&
+        (ret != 1 || acknowledged_cleanup_complete(ctx) != 1)) {
+        return -1;
+    }
+    return manager_recount(ctx->batch->manager);
+
+rollback:
+    sql_rollback_if_active(ctx->batch->manager);
+    return -1;
+}
+
+static int request_outcome_matches(struct flb_az_li *ctx, int64_t request_pk,
+                                   int quarantine)
+{
+    sqlite3_stmt *statement;
+    int expected_request_state;
+    int expected_source_state;
+    int64_t member_count;
+    int64_t state_count;
+    int64_t receipt_count;
+    int64_t last_success;
+    int64_t latest_receipt;
+    int ret;
+
+    if (sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT r.state,"
+            "(SELECT COUNT(*) FROM azli_sources s WHERE s.request_pk=r.request_pk "
+            " AND s.instance_key=r.instance_key),"
+            "(SELECT COUNT(*) FROM azli_sources s WHERE s.request_pk=r.request_pk "
+            " AND s.instance_key=r.instance_key AND s.state=?),"
+            "(SELECT COUNT(*) FROM azli_sources s JOIN azli_receipts p "
+            " ON p.instance_key=s.instance_key AND p.source_id=s.source_id "
+            " AND p.digest=s.digest WHERE s.request_pk=r.request_pk "
+            " AND s.instance_key=r.instance_key),"
+            "(SELECT i.last_success FROM azli_instances i "
+            " WHERE i.instance_key=r.instance_key),"
+            "(SELECT COALESCE(MAX(p.completed),0) FROM azli_sources s "
+            " JOIN azli_receipts p ON p.instance_key=s.instance_key "
+            " AND p.source_id=s.source_id AND p.digest=s.digest "
+            " WHERE s.request_pk=r.request_pk AND s.instance_key=r.instance_key) "
+            "FROM azli_requests r WHERE r.request_pk=? AND r.instance_key=?",
+            -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    expected_request_state = quarantine ? AZLI_REQUEST_QUARANTINED :
+                                          AZLI_REQUEST_ACKED;
+    expected_source_state = quarantine ? AZLI_SOURCE_QUARANTINED :
+                                         AZLI_SOURCE_DRAINED;
+    sqlite3_bind_int(statement, 1, expected_source_state);
+    sqlite3_bind_int64(statement, 2, request_pk);
+    sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        member_count = sqlite3_column_int64(statement, 1);
+        state_count = sqlite3_column_int64(statement, 2);
+        receipt_count = sqlite3_column_int64(statement, 3);
+        last_success = sqlite3_column_int64(statement, 4);
+        latest_receipt = sqlite3_column_int64(statement, 5);
+        ret = sqlite3_column_int(statement, 0) == expected_request_state &&
+              member_count > 0 && state_count == member_count &&
+              (quarantine || (receipt_count == member_count &&
+                              latest_receipt > 0 &&
+                              last_success >= latest_receipt)) ? 1 : 0;
+    }
+    else if (ret == SQLITE_DONE) {
+        ret = 0;
+    }
+    else {
+        ret = -1;
+    }
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int validate_request_members(struct flb_az_li *ctx, int64_t request_pk,
+                                    unsigned char json_digest[AZLI_DIGEST_SIZE])
+{
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    const void *content;
+    const void *stored_digest;
+    const unsigned char *source_id;
+    const unsigned char *name;
+    flb_sds_t json;
+    flb_sds_t tmp;
+    int content_size;
+    int count;
+    int ret;
+
+    json = flb_sds_create("[");
+    if (json == NULL) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT source_id,name,digest,content,record_count,json_bytes,bytes,"
+            "created,state,EXISTS(SELECT 1 FROM azli_receipts p WHERE "
+            "p.instance_key=azli_sources.instance_key AND "
+            "p.source_id=azli_sources.source_id) "
+            "FROM azli_sources WHERE request_pk=? AND instance_key=? "
+            "ORDER BY source_pk", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        flb_sds_destroy(json);
+        return -1;
+    }
+    sqlite3_bind_int64(statement, 1, request_pk);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    count = 0;
+    while ((ret = sqlite3_step(statement)) == SQLITE_ROW) {
+        source_id = sqlite3_column_text(statement, 0);
+        name = sqlite3_column_text(statement, 1);
+        stored_digest = sqlite3_column_blob(statement, 2);
+        content = sqlite3_column_blob(statement, 3);
+        content_size = sqlite3_column_bytes(statement, 3);
+        if (sqlite3_column_int(statement, 9) != 0) {
+            sqlite3_finalize(statement);
+            flb_sds_destroy(json);
+            return 2;
+        }
+        if (source_id == NULL || strlen((const char *) source_id) != AZLI_HEX_SIZE ||
+            name == NULL || name[0] == '\0' ||
+            sqlite3_column_bytes(statement, 2) != AZLI_DIGEST_SIZE ||
+            content_size < 2 || sqlite3_column_int64(statement, 4) <= 0 ||
+            sqlite3_column_int64(statement, 5) != content_size ||
+            sqlite3_column_int64(statement, 6) < content_size ||
+            sqlite3_column_int64(statement, 7) <= 0 ||
+            sqlite3_column_int(statement, 8) != AZLI_SOURCE_READY ||
+            source_content_validate(content, (size_t) content_size) == -1 ||
+            hash_bytes(content, (size_t) content_size, digest) != 0 ||
+            memcmp(digest, stored_digest, AZLI_DIGEST_SIZE) != 0) {
+            sqlite3_finalize(statement);
+            flb_sds_destroy(json);
+            return 1;
+        }
+        if (count > 0) {
+            tmp = flb_sds_cat(json, ",", 1);
+            if (tmp == NULL) {
+                sqlite3_finalize(statement);
+                flb_sds_destroy(json);
+                return -1;
+            }
+            json = tmp;
+        }
+        tmp = flb_sds_cat(json, (const char *) content + 1,
+                          (size_t) content_size - 2);
+        if (tmp == NULL) {
+            sqlite3_finalize(statement);
+            flb_sds_destroy(json);
+            return -1;
+        }
+        json = tmp;
+        count++;
+    }
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE || count == 0) {
+        flb_sds_destroy(json);
+        return ret == SQLITE_DONE ? 1 : -1;
+    }
+    tmp = flb_sds_cat(json, "]", 1);
+    if (tmp == NULL) {
+        flb_sds_destroy(json);
+        return -1;
+    }
+    json = tmp;
+    ret = hash_bytes(json, flb_sds_len(json), json_digest);
+    flb_sds_destroy(json);
+    return ret == 0 ? 0 : -1;
+}
+
+static int validate_request_blob(struct flb_az_li *ctx, int64_t request_pk)
+{
+    struct azli_request request;
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    unsigned char member_digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    const void *body;
+    const void *stored_digest;
+    const void *stored_json_digest;
+    void *uncompressed;
+    size_t uncompressed_size;
+    int body_size;
+    int ret;
+
+    memset(&request, 0, sizeof(request));
+    uncompressed = NULL;
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT name,state,gzip_bytes,body,body_digest,json_digest,json_bytes "
+            "FROM azli_requests WHERE request_pk=? AND instance_key=?", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int64(statement, 1, request_pk);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    ret = sqlite3_step(statement);
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return ret == SQLITE_DONE ? 0 : -1;
+    }
+    request.request_pk = request_pk;
+    request.state = sqlite3_column_int(statement, 1);
+    request.name = flb_sds_create((const char *) sqlite3_column_text(statement, 0));
+    body_size = sqlite3_column_bytes(statement, 3);
+    body = sqlite3_column_blob(statement, 3);
+    stored_digest = sqlite3_column_blob(statement, 4);
+    stored_json_digest = sqlite3_column_blob(statement, 5);
+    if (request.name == NULL || body_size < 0 ||
+        sqlite3_column_int64(statement, 2) != body_size ||
+        sqlite3_column_bytes(statement, 4) != AZLI_DIGEST_SIZE ||
+        sqlite3_column_bytes(statement, 5) != AZLI_DIGEST_SIZE ||
+        sqlite3_column_int64(statement, 6) < 2 ||
+        (size_t) body_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
+        hash_bytes(body, (size_t) body_size, digest) != 0 ||
+        memcmp(digest, stored_digest, AZLI_DIGEST_SIZE) != 0 ||
+        flb_gzip_uncompress((void *) body, (size_t) body_size,
+                            &uncompressed, &uncompressed_size) != 0 ||
+        uncompressed_size != (size_t) sqlite3_column_int64(statement, 6) ||
+        hash_bytes(uncompressed, uncompressed_size, digest) != 0 ||
+        memcmp(digest, stored_json_digest, AZLI_DIGEST_SIZE) != 0) {
+        flb_free(uncompressed);
+        sqlite3_finalize(statement);
+        if (request.name == NULL) {
+            return -1;
+        }
+        flb_plg_error(ctx->ins, "quarantining corrupt request name=%s",
+                      request.name);
+        ret = request_commit_sources(ctx, &request, FLB_TRUE, 0,
+                                     "artifact_corrupt");
+        flb_sds_destroy(request.name);
+        return ret;
+    }
+    memcpy(request.json_digest, stored_json_digest, AZLI_DIGEST_SIZE);
+    flb_free(uncompressed);
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE) {
+        flb_sds_destroy(request.name);
+        return -1;
+    }
+    ret = validate_request_members(ctx, request_pk, member_digest);
+    if (ret == 0 && memcmp(member_digest, request.json_digest,
+                           AZLI_DIGEST_SIZE) != 0) {
+        ret = 1;
+    }
+    if (ret == 1) {
+        flb_plg_error(ctx->ins,
+                      "quarantining request with mismatched source membership name=%s",
+                      request.name);
+        ret = request_commit_sources(ctx, &request, FLB_TRUE, 0,
+                                     "source_membership_mismatch");
+    }
+    flb_sds_destroy(request.name);
+    return ret;
+}
+
+static int validate_request_rows(struct flb_az_li *ctx)
+{
+    int64_t *request_pks;
+    sqlite3_stmt *statement;
+    size_t count;
+    size_t index;
+    int ret;
+
+    request_pks = flb_calloc(AZLI_MAX_SOURCE_FILES, sizeof(*request_pks));
+    if (request_pks == NULL) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT request_pk FROM azli_requests WHERE instance_key=? "
+            "AND state IN (1,2,3) ORDER BY request_pk", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        flb_free(request_pks);
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    count = 0;
+    while ((ret = sqlite3_step(statement)) == SQLITE_ROW) {
+        if (count >= AZLI_MAX_SOURCE_FILES) {
+            sqlite3_finalize(statement);
+            flb_free(request_pks);
+            return -1;
+        }
+        request_pks[count++] = sqlite3_column_int64(statement, 0);
+    }
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE) {
+        flb_free(request_pks);
+        return -1;
+    }
+    for (index = 0; index < count; index++) {
+        if (validate_request_blob(ctx, request_pks[index]) != 0) {
+            flb_free(request_pks);
+            return -1;
+        }
+    }
+    flb_free(request_pks);
+    return 0;
+}
+
+static int recover_requests(struct flb_az_li *ctx)
+{
+    sqlite3_stmt *statement;
+    int ret;
+
+    if (cleanup_acknowledged(ctx) == -1 || validate_request_rows(ctx) == -1) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_requests SET state=?,next_retry=0 WHERE instance_key=? "
+            "AND state=?", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int(statement, 1, AZLI_REQUEST_RETRY);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 3, AZLI_REQUEST_INFLIGHT);
+    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
+    sqlite3_finalize(statement);
+    return ret;
+}
+
+static int source_manifest_matches(struct flb_az_li *ctx,
+                                   const char *source_id, const char *name,
+                                   const unsigned char digest[AZLI_DIGEST_SIZE],
+                                   size_t record_count, size_t json_size,
+                                   size_t gzip_size, int64_t created)
+{
+    unsigned char actual_digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    const void *content;
+    int content_size;
+    int ret;
+
+    if (sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT name,digest,content,record_count,json_bytes,standalone_gzip_bytes,"
+            "created,state,request_pk "
+            "FROM azli_sources WHERE instance_key=? AND source_id=?", -1,
             &statement, NULL);
     if (ret != SQLITE_OK) {
         return -1;
     }
     sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(statement, 4, source_id, -1, SQLITE_TRANSIENT);
     ret = sqlite3_step(statement);
     if (ret == SQLITE_ROW) {
-        ret = sqlite3_column_bytes(statement, 0) == 32 &&
-              memcmp(sqlite3_column_blob(statement, 0), digest, 32) == 0 ? 1 : -1;
+        content = sqlite3_column_blob(statement, 2);
+        content_size = sqlite3_column_bytes(statement, 2);
+        ret = content_size == (int) json_size &&
+              hash_bytes(content, json_size, actual_digest) == 0 &&
+              strcmp((const char *) sqlite3_column_text(statement, 0), name) == 0 &&
+              sqlite3_column_bytes(statement, 1) == AZLI_DIGEST_SIZE &&
+              memcmp(sqlite3_column_blob(statement, 1), digest,
+                     AZLI_DIGEST_SIZE) == 0 &&
+              memcmp(actual_digest, digest, AZLI_DIGEST_SIZE) == 0 &&
+              sqlite3_column_int64(statement, 3) == (int64_t) record_count &&
+              sqlite3_column_int64(statement, 4) == (int64_t) json_size &&
+              sqlite3_column_int64(statement, 5) == (int64_t) gzip_size &&
+              sqlite3_column_int64(statement, 6) == created &&
+              sqlite3_column_int(statement, 7) == AZLI_SOURCE_READY &&
+              sqlite3_column_type(statement, 8) == SQLITE_NULL ? 1 : -1;
+    }
+    else if (ret == SQLITE_DONE) {
+        ret = 0;
     }
     else {
-        ret = 0;
+        ret = -1;
     }
     sqlite3_finalize(statement);
     return ret;
 }
 
+static int admission_has_capacity(struct flb_az_li *ctx, size_t incoming)
+{
+    struct azli_root_manager *manager;
+    size_t headroom;
+
+    manager = ctx->batch->manager;
+    headroom = FLB_AZ_LI_MAX_REQUEST_SIZE + AZLI_REQUEST_DB_RESERVE +
+               AZLI_MAX_REQUEST_SOURCES * AZLI_MEMBER_DB_RESERVE;
+    if (manager_recount(manager) == -1) {
+        return -1;
+    }
+    if (headroom <= manager->limit && incoming <= manager->limit - headroom &&
+        manager->reserved_bytes <= manager->limit - headroom - incoming &&
+        manager->logical_used <= manager->limit - headroom - incoming -
+                                 manager->reserved_bytes &&
+        manager_has_physical_capacity(manager, incoming) == 1) {
+        return 1;
+    }
+    if (cleanup_expired_receipts(ctx->batch->manager) == -1 ||
+        manager_maintain(manager, FLB_TRUE) < 0) {
+        return -1;
+    }
+    if (headroom > manager->limit || incoming > manager->limit - headroom ||
+        manager->reserved_bytes > manager->limit - headroom - incoming ||
+        manager->logical_used > manager->limit - headroom - incoming -
+                                manager->reserved_bytes ||
+        manager_has_physical_capacity(manager, incoming) != 1) {
+        return 0;
+    }
+    return 1;
+}
+
 int az_li_batch_admit_chunk(struct flb_az_li *ctx,
                             struct flb_output_flush *out_flush,
-                            struct flb_event_chunk *event_chunk,
-                            flb_sds_t *records, size_t record_count)
+                            const void *json, size_t json_size,
+                            size_t record_count)
 {
-    char source_id[65];
-    char digest_text[65];
+    char source_id[AZLI_HEX_SIZE + 1];
     char name[80];
-    char metadata[256];
-    unsigned char digest[32];
-    flb_sds_t ndjson;
-    struct flb_fstore_file *file;
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    void *gzip;
+    size_t gzip_size;
     sqlite3_stmt *statement;
     size_t charged_bytes;
-    size_t construction_headroom;
-    ssize_t real_size;
+    int64_t created;
+    int capacity;
     int exists;
-    int file_created;
+    int rollback_ret;
+    int recount_failed;
     int ret;
 
-    (void) event_chunk;
+    gzip = NULL;
+    recount_failed = FLB_FALSE;
     pthread_mutex_lock(&ctx->batch->lifecycle_mutex);
     if (ctx->batch->shutting_down || ctx->batch->fatal_error) {
         pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
@@ -1092,167 +1918,308 @@ int az_li_batch_admit_chunk(struct flb_az_li *ctx,
     if (record_count == 0) {
         return 0;
     }
-    if (source_identity(ctx, out_flush, source_id) == -1) {
-        flb_plg_error(ctx->ins, "cannot resolve durable input chunk identity");
+    if (source_identity(ctx, out_flush, source_id) == -1 ||
+        source_content_validate(json, json_size) == -1 ||
+        hash_bytes(json, json_size, digest) != 0) {
         return -1;
     }
-    ndjson = records_to_ndjson(records, record_count);
-    if (ndjson == NULL || hash_bytes(ndjson, flb_sds_len(ndjson), digest) != 0) {
-        flb_sds_destroy(ndjson);
+    if (json_size > ctx->batch_max_uncompressed_size) {
+        flb_plg_error(ctx->ins,
+                      "input chunk exceeds uncompressed request limit id=%s bytes=%zu limit=%zu",
+                      source_id, json_size, ctx->batch_max_uncompressed_size);
         return -1;
     }
-    digest_hex(digest, digest_text);
-    charged_bytes = flb_sds_len(ndjson) + AZLI_FILE_OVERHEAD +
-                    AZLI_SOURCE_DB_RESERVE;
+    if (flb_gzip_compress((void *) json, json_size, &gzip, &gzip_size) == -1) {
+        return -1;
+    }
+    flb_free(gzip);
+    if (gzip_size > FLB_AZ_LI_MAX_REQUEST_SIZE) {
+        flb_plg_error(ctx->ins,
+                      "input chunk exceeds compressed request limit id=%s bytes=%zu limit=%d",
+                      source_id, gzip_size, FLB_AZ_LI_MAX_REQUEST_SIZE);
+        return -1;
+    }
+    if (json_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE -
+                    AZLI_RECEIPT_DB_RESERVE) {
+        return -1;
+    }
+    charged_bytes = json_size + AZLI_SOURCE_DB_RESERVE +
+                    AZLI_RECEIPT_DB_RESERVE;
+    created = now_seconds();
+    snprintf(name, sizeof(name), "%s.source", source_id);
 
     pthread_mutex_lock(&ctx->batch->manager->mutex);
-    if (manager_recount(ctx->batch->manager) == -1) {
-        pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(ndjson);
-        return -1;
-    }
     exists = receipt_or_source_exists(ctx, source_id, digest);
-    if (exists != 0) {
+    if (exists != AZLI_SOURCE_EXISTS_NONE) {
         pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(ndjson);
-        if (exists < 0) {
+        if (exists == AZLI_SOURCE_EXISTS_ERROR) {
+            flb_plg_error(ctx->ins,
+                          "could not query durable input chunk identity id=%s",
+                          source_id);
+            metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+            return -1;
+        }
+        if (exists == AZLI_SOURCE_EXISTS_COLLISION) {
             flb_plg_error(ctx->ins, "input chunk identity collision id=%s", source_id);
             return -1;
         }
         flb_plg_debug(ctx->ins, "input chunk already durably owned id=%s", source_id);
         return 0;
     }
-    construction_headroom = FLB_AZ_LI_MAX_REQUEST_SIZE +
-                            AZLI_FILE_OVERHEAD + AZLI_REQUEST_DB_RESERVE +
-                            AZLI_MAX_REQUEST_SPANS * AZLI_SPAN_DB_RESERVE;
-    if (ctx->batch->manager->files >= AZLI_MAX_SOURCE_FILES ||
-        construction_headroom > ctx->batch->manager->limit ||
-        charged_bytes > ctx->batch->manager->limit - construction_headroom ||
-        ctx->batch->manager->used >
-        ctx->batch->manager->limit - construction_headroom - charged_bytes) {
-        flb_plg_error(ctx->ins, "batch buffer full current=%zu incoming=%zu limit=%zu",
-                      ctx->batch->manager->used, charged_bytes,
-                      ctx->batch->manager->limit);
+    capacity = admission_has_capacity(ctx, charged_bytes);
+    if (capacity <= 0 || ctx->batch->manager->files >= AZLI_MAX_SOURCE_FILES) {
+        if (capacity == 0) {
+            flb_plg_error(ctx->ins,
+                          "batch buffer full logical=%zu physical=%zu incoming=%zu limit=%zu",
+                          ctx->batch->manager->logical_used,
+                          ctx->batch->manager->physical_used, charged_bytes,
+                          ctx->batch->manager->limit);
+            metric_counter_add(ctx, ctx->cmt_quota_rejections, 1.0);
+        }
         pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(ndjson);
+        if (capacity < 0) {
+            metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+        }
         return -1;
     }
 
-    snprintf(name, sizeof(name), "%s.source", source_id);
-    file_created = FLB_FALSE;
-    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->sources,
-                               name, strlen(name));
-    if (file == NULL) {
-        file_created = FLB_TRUE;
-        file = flb_fstore_file_create(ctx->batch->fs, ctx->batch->sources, name, 0);
-        if (file == NULL || cio_chunk_tx_begin(file->chunk) != CIO_OK ||
-            flb_fstore_file_append(file, ndjson, flb_sds_len(ndjson)) != 0) {
-            if (file != NULL) {
-                cio_chunk_tx_rollback(file->chunk);
-                flb_fstore_file_delete(ctx->batch->fs, file);
-            }
-            pthread_mutex_unlock(&ctx->batch->manager->mutex);
-            flb_sds_destroy(ndjson);
-            return -1;
-        }
-        snprintf(metadata, sizeof(metadata), "AZLIS1|%s|%s|%zu|%" PRId64,
-                 source_id, digest_text, record_count, now_seconds());
-        if (flb_fstore_file_meta_set(ctx->batch->fs, file, metadata,
-                                    strlen(metadata) + 1) == -1 ||
-            cio_chunk_tx_commit(file->chunk) != CIO_OK ||
-            sync_directory(ctx->batch->sources->path) == -1) {
-            cio_chunk_tx_rollback(file->chunk);
-            flb_fstore_file_delete(ctx->batch->fs, file);
-            pthread_mutex_unlock(&ctx->batch->manager->mutex);
-            flb_sds_destroy(ndjson);
-            return -1;
-        }
-    }
-    else {
-        void *existing_content;
-        size_t existing_size;
-        unsigned char existing_digest[AZLI_DIGEST_SIZE];
-
-        existing_content = NULL;
-        if (flb_fstore_file_content_copy(NULL, file, &existing_content,
-                                         &existing_size) == -1 ||
-            hash_bytes(existing_content, existing_size, existing_digest) != 0 ||
-            existing_size != flb_sds_len(ndjson) ||
-            memcmp(existing_digest, digest, AZLI_DIGEST_SIZE) != 0) {
-            flb_free(existing_content);
-            pthread_mutex_unlock(&ctx->batch->manager->mutex);
-            flb_sds_destroy(ndjson);
-            return -1;
-        }
-        flb_free(existing_content);
-    }
-    real_size = cio_chunk_get_real_size(file->chunk);
-    if (real_size < 0 || (size_t) real_size >
-        ctx->batch->manager->limit - construction_headroom ||
-        (size_t) real_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE ||
-        (size_t) real_size + AZLI_SOURCE_DB_RESERVE >
-        ctx->batch->manager->limit - construction_headroom ||
-        ctx->batch->manager->used > ctx->batch->manager->limit -
-        construction_headroom - ((size_t) real_size + AZLI_SOURCE_DB_RESERVE)) {
-        if (file_created) {
-            flb_fstore_file_delete(ctx->batch->fs, file);
-        }
+    statement = NULL;
+    if (sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
         pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(ndjson);
+        metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
         return -1;
     }
-    if ((size_t) real_size > SIZE_MAX - AZLI_SOURCE_DB_RESERVE) {
-        if (file_created) {
-            flb_fstore_file_delete(ctx->batch->fs, file);
-        }
-        pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(ndjson);
-        return -1;
-    }
-    charged_bytes = (size_t) real_size + AZLI_SOURCE_DB_RESERVE;
-
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "INSERT INTO azli_sources(instance_key,source_id,name,digest,record_count,"
-            "next_record,bytes,created,state) VALUES(?,?,?,?,?,0,?,?,?)", -1,
-            &statement, NULL);
-    if (ret == SQLITE_OK) {
-        sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement, 3, name, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_blob(statement, 4, digest, 32, SQLITE_TRANSIENT);
-        sqlite3_bind_int64(statement, 5, record_count);
-        sqlite3_bind_int64(statement, 6, charged_bytes);
-        sqlite3_bind_int64(statement, 7, now_seconds());
-        sqlite3_bind_int(statement, 8, AZLI_SOURCE_READY);
-        ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
-        sqlite3_finalize(statement);
+            "INSERT INTO azli_sources(instance_key,source_id,name,digest,content,"
+            "record_count,json_bytes,standalone_gzip_bytes,bytes,created,state,request_pk) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?,NULL)", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
     }
-    if (ret == 0 && manager_recount(ctx->batch->manager) == -1) {
-        ret = -1;
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 2, source_id, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 3, name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_blob64(statement, 4, digest, AZLI_DIGEST_SIZE, SQLITE_TRANSIENT);
+    sqlite3_bind_blob64(statement, 5, json, json_size, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(statement, 6, record_count);
+    sqlite3_bind_int64(statement, 7, json_size);
+    sqlite3_bind_int64(statement, 8, gzip_size);
+    sqlite3_bind_int64(statement, 9, charged_bytes);
+    sqlite3_bind_int64(statement, 10, created);
+    sqlite3_bind_int(statement, 11, AZLI_SOURCE_READY);
+    if (sqlite3_step(statement) != SQLITE_DONE) {
+        goto rollback;
+    }
+    sqlite3_finalize(statement);
+    statement = NULL;
+    ret = sql_commit(ctx->batch->manager);
+    if (ret != 0) {
+        if (ret != 1 ||
+            sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+            pthread_mutex_lock(&ctx->batch->lifecycle_mutex);
+            ctx->batch->fatal_error = FLB_TRUE;
+            ctx->batch->persistence_degraded = FLB_TRUE;
+            ctx->batch->next_recovery = now_seconds() + 1;
+            pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
+            pthread_mutex_unlock(&ctx->batch->manager->mutex);
+            metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+            return -1;
+        }
+        ret = source_manifest_matches(ctx, source_id, name, digest,
+                                      record_count, json_size, gzip_size, created);
+        if (ret != 1) {
+            pthread_mutex_lock(&ctx->batch->lifecycle_mutex);
+            ctx->batch->fatal_error = FLB_TRUE;
+            ctx->batch->persistence_degraded = FLB_TRUE;
+            ctx->batch->next_recovery = now_seconds() + 1;
+            pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
+            pthread_mutex_unlock(&ctx->batch->manager->mutex);
+            metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+            return -1;
+        }
+        flb_plg_warn(ctx->ins,
+                     "source COMMIT returned an error but durable row was reconciled id=%s",
+                     source_id);
+    }
+    if (manager_recount(ctx->batch->manager) == -1) {
+        pthread_mutex_lock(&ctx->batch->lifecycle_mutex);
+        ctx->batch->fatal_error = FLB_TRUE;
+        ctx->batch->persistence_degraded = FLB_TRUE;
+        ctx->batch->next_recovery = now_seconds() + 1;
+        pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
+        recount_failed = FLB_TRUE;
+    }
+    metrics_refresh_locked(ctx);
+    pthread_mutex_unlock(&ctx->batch->manager->mutex);
+    if (recount_failed) {
+        metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+    }
+    metric_counter_add(ctx, ctx->cmt_admitted_chunks, 1.0);
+    metric_counter_add(ctx, ctx->cmt_admitted_records, (double) record_count);
+    metric_counter_add(ctx, ctx->cmt_admitted_bytes, (double) json_size);
+    flb_plg_debug(ctx->ins,
+                  "buffered whole chunk records=%zu json_bytes=%zu gzip_bytes=%zu source=%s",
+                  record_count, json_size, gzip_size, source_id);
+    return 0;
+
+rollback:
+    sqlite3_finalize(statement);
+    rollback_ret = sql_rollback_if_active(ctx->batch->manager);
+    if (rollback_ret == -1) {
+        pthread_mutex_lock(&ctx->batch->lifecycle_mutex);
+        ctx->batch->fatal_error = FLB_TRUE;
+        ctx->batch->persistence_degraded = FLB_TRUE;
+        ctx->batch->next_recovery = now_seconds() + 1;
+        pthread_mutex_unlock(&ctx->batch->lifecycle_mutex);
     }
     pthread_mutex_unlock(&ctx->batch->manager->mutex);
-    flb_plg_debug(ctx->ins,
-                  "buffered callback records=%zu probes=0 ratio=%.6f source=%s",
-                  record_count,
-                  ctx->batch->compression_ratio_initialized ?
-                  ctx->batch->compression_ratio : 1.0, source_id);
-    flb_sds_destroy(ndjson);
-    return ret;
+    metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+    return -1;
 }
 
-static int candidate_add_record(flb_sds_t *json, const char *record,
-                                size_t length, size_t count)
+static void candidate_sources_destroy(struct azli_candidate_source *sources,
+                                      size_t count)
+{
+    size_t index;
+
+    for (index = 0; index < count; index++) {
+        flb_free(sources[index].content);
+    }
+    flb_free(sources);
+}
+
+static int load_candidate_sources(struct flb_az_li *ctx,
+                                  struct azli_candidate_source **out_sources,
+                                  size_t *out_count, int *more_sources)
+{
+    struct azli_candidate_source *sources;
+    sqlite3_stmt *statement;
+    size_t count;
+    int ret;
+
+    sources = flb_calloc(AZLI_MAX_REQUEST_SOURCES + 1, sizeof(*sources));
+    if (sources == NULL) {
+        return -1;
+    }
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT source_pk,created,record_count,json_bytes,standalone_gzip_bytes "
+            "FROM azli_sources WHERE instance_key=? AND state=? AND request_pk IS NULL "
+            "ORDER BY source_pk LIMIT ?", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        flb_free(sources);
+        return -1;
+    }
+    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 2, AZLI_SOURCE_READY);
+    sqlite3_bind_int(statement, 3, AZLI_MAX_REQUEST_SOURCES + 1);
+    count = 0;
+    while ((ret = sqlite3_step(statement)) == SQLITE_ROW) {
+        sources[count].source_pk = sqlite3_column_int64(statement, 0);
+        sources[count].created = sqlite3_column_int64(statement, 1);
+        sources[count].record_count = sqlite3_column_int64(statement, 2);
+        sources[count].json_bytes = sqlite3_column_int64(statement, 3);
+        sources[count].standalone_gzip_bytes = sqlite3_column_int64(statement, 4);
+        if (sources[count].source_pk <= 0 || sources[count].created <= 0 ||
+            sources[count].record_count <= 0 || sources[count].json_bytes < 2 ||
+            sources[count].standalone_gzip_bytes <= 0 ||
+            sources[count].standalone_gzip_bytes > FLB_AZ_LI_MAX_REQUEST_SIZE) {
+            sqlite3_finalize(statement);
+            flb_free(sources);
+            return -1;
+        }
+        count++;
+    }
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE) {
+        flb_free(sources);
+        return -1;
+    }
+    *more_sources = count > AZLI_MAX_REQUEST_SOURCES;
+    if (*more_sources) {
+        count = AZLI_MAX_REQUEST_SOURCES;
+    }
+    *out_sources = sources;
+    *out_count = count;
+    return 0;
+}
+
+static int load_candidate_content(struct flb_az_li *ctx,
+                                  struct azli_candidate_source *source)
+{
+    unsigned char digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    const void *content;
+    const void *stored_digest;
+    int content_size;
+    int ret;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "SELECT content,digest,json_bytes,record_count,created,bytes,"
+            "standalone_gzip_bytes FROM azli_sources WHERE source_pk=? "
+            "AND instance_key=? AND state=? AND request_pk IS NULL", -1,
+            &statement, NULL);
+    if (ret != SQLITE_OK) {
+        return -1;
+    }
+    sqlite3_bind_int64(statement, 1, source->source_pk);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(statement, 3, AZLI_SOURCE_READY);
+    ret = sqlite3_step(statement);
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    content = sqlite3_column_blob(statement, 0);
+    content_size = sqlite3_column_bytes(statement, 0);
+    stored_digest = sqlite3_column_blob(statement, 1);
+    if (content_size < 2 || sqlite3_column_bytes(statement, 1) != AZLI_DIGEST_SIZE ||
+        sqlite3_column_int64(statement, 2) != content_size ||
+        sqlite3_column_int64(statement, 2) != source->json_bytes ||
+        sqlite3_column_int64(statement, 3) != source->record_count ||
+        sqlite3_column_int64(statement, 4) != source->created ||
+        sqlite3_column_int64(statement, 5) < content_size ||
+        sqlite3_column_int64(statement, 6) != source->standalone_gzip_bytes ||
+        source_content_validate(content, (size_t) content_size) == -1 ||
+        hash_bytes(content, (size_t) content_size, digest) != 0 ||
+        memcmp(digest, stored_digest, AZLI_DIGEST_SIZE) != 0) {
+        sqlite3_finalize(statement);
+        if (source_quarantine(ctx, source->source_pk, "content_corrupt") == -1) {
+            return -1;
+        }
+        return -2;
+    }
+    source->content = flb_malloc((size_t) content_size);
+    if (source->content != NULL) {
+        memcpy(source->content, content, (size_t) content_size);
+        source->content_size = (size_t) content_size;
+    }
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (source->content == NULL || ret != SQLITE_DONE) {
+        flb_free(source->content);
+        source->content = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+static int append_source_json(struct azli_candidate_source *source,
+                              flb_sds_t *json, size_t included_sources)
 {
     flb_sds_t tmp;
 
-    if (count > 0) {
+    if (source->content == NULL || source->content_size < 2) {
+        return -1;
+    }
+    if (included_sources > 0) {
         tmp = flb_sds_cat(*json, ",", 1);
         if (tmp == NULL) {
             return -1;
         }
         *json = tmp;
     }
-    tmp = flb_sds_cat(*json, record, length);
+    tmp = flb_sds_cat(*json, (const char *) source->content + 1,
+                      source->content_size - 2);
     if (tmp == NULL) {
         return -1;
     }
@@ -1260,266 +2227,102 @@ static int candidate_add_record(flb_sds_t *json, const char *record,
     return 0;
 }
 
-static int collect_source_records(struct flb_az_li *ctx, int64_t source_pk,
-                                  const char *name, int64_t first_record,
-                                  flb_sds_t *json,
-                                  struct azli_candidate_record **records,
-                                  size_t *count, size_t *capacity,
-                                  struct mk_list *buffers)
-{
-    struct flb_fstore_file *file;
-    struct azli_source_buffer *holder;
-    struct azli_candidate_record *tmp_records;
-    const char *bytes;
-    void *data;
-    size_t size;
-    size_t offset;
-    size_t start;
-    int64_t index;
-    int size_limited;
-
-    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->sources,
-                               (char *) name, strlen(name));
-    if (file == NULL || flb_fstore_file_content_copy(NULL, file, &data, &size) == -1) {
-        return -1;
-    }
-    holder = flb_calloc(1, sizeof(*holder));
-    if (holder == NULL) {
-        flb_free(data);
-        return -1;
-    }
-    holder->data = data;
-    mk_list_add(&holder->_head, buffers);
-    bytes = data;
-    start = 0;
-    index = 0;
-    size_limited = FLB_FALSE;
-    for (offset = 0; offset < size; offset++) {
-        if (bytes[offset] != '\n') {
-            continue;
-        }
-        if (index++ < first_record) {
-            start = offset + 1;
-            continue;
-        }
-        if (*count > 0 && flb_sds_len(*json) + (offset - start) + 2 >
-            ctx->batch_max_uncompressed_size) {
-            size_limited = FLB_TRUE;
-            break;
-        }
-        if (*count == *capacity) {
-            *capacity = *capacity == 0 ? 256 : *capacity * 2;
-            tmp_records = flb_realloc(*records,
-                                      *capacity * sizeof(**records));
-            if (tmp_records == NULL) {
-                return -1;
-            }
-            *records = tmp_records;
-        }
-        if (candidate_add_record(json, bytes + start, offset - start, *count) == -1) {
-            return -1;
-        }
-        (*records)[*count].source_pk = source_pk;
-        (*records)[*count].record_index = index - 1;
-        (*records)[*count].json_end = flb_sds_len(*json);
-        (*count)++;
-        start = offset + 1;
-    }
-    return size_limited;
-}
-
-static void candidate_buffers_destroy(struct mk_list *buffers)
-{
-    struct mk_list *head;
-    struct mk_list *tmp;
-    struct azli_source_buffer *holder;
-
-    mk_list_foreach_safe(head, tmp, buffers) {
-        holder = mk_list_entry(head, struct azli_source_buffer, _head);
-        mk_list_del(&holder->_head);
-        flb_free(holder->data);
-        flb_free(holder);
-    }
-}
-
-static int compress_prefix(flb_sds_t json,
-                           struct azli_candidate_record *records,
-                           size_t count, void **output, size_t *output_size,
-                           size_t *json_size)
-{
-    flb_sds_t candidate;
-    flb_sds_t tmp;
-    int ret;
-
-    candidate = flb_sds_create_len(json, records[count - 1].json_end);
-    if (candidate == NULL) {
-        return -1;
-    }
-    tmp = flb_sds_cat(candidate, "]", 1);
-    if (tmp == NULL) {
-        flb_sds_destroy(candidate);
-        return -1;
-    }
-    candidate = tmp;
-    *json_size = flb_sds_len(candidate);
-    ret = flb_gzip_compress(candidate, *json_size, output, output_size);
-    flb_sds_destroy(candidate);
-    return ret;
-}
-
-static int source_mark_singleton_quarantine(struct flb_az_li *ctx,
-                                             struct azli_candidate_record *record)
-{
-    sqlite3_stmt *statement;
-    int ret;
-
-    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "UPDATE azli_sources SET next_record=?,has_quarantine=1,state="
-            "CASE WHEN record_count<=? THEN ? ELSE state END WHERE source_pk=?", -1,
-            &statement, NULL);
-    if (ret != SQLITE_OK) {
-        return -1;
-    }
-    sqlite3_bind_int64(statement, 1, record->record_index + 1);
-    sqlite3_bind_int64(statement, 2, record->record_index + 1);
-    sqlite3_bind_int(statement, 3, AZLI_SOURCE_QUARANTINED);
-    sqlite3_bind_int64(statement, 4, record->source_pk);
-    ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
-    sqlite3_finalize(statement);
-    return ret;
-}
-
 static int request_manifest_matches(struct flb_az_li *ctx, const char *name,
-                                    const unsigned char digest[AZLI_DIGEST_SIZE])
+                                    const unsigned char digest[AZLI_DIGEST_SIZE],
+                                    const unsigned char json_digest[AZLI_DIGEST_SIZE],
+                                    size_t source_count)
 {
+    unsigned char actual_digest[AZLI_DIGEST_SIZE];
     sqlite3_stmt *statement;
+    const void *body;
+    int body_size;
     int ret;
 
+    if (sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+        return -1;
+    }
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT body_digest FROM azli_requests WHERE name=?", -1,
-            &statement, NULL);
+            "SELECT r.body_digest,r.body,r.gzip_bytes,r.state,r.json_digest,"
+            "(SELECT COUNT(*) FROM azli_sources s WHERE s.request_pk=r.request_pk "
+            " AND s.instance_key=r.instance_key),"
+            "(SELECT COUNT(*) FROM azli_sources s WHERE s.request_pk=r.request_pk "
+            " AND s.instance_key=r.instance_key AND s.state=1) "
+            "FROM azli_requests r WHERE r.name=? AND r.instance_key=?",
+            -1, &statement, NULL);
     if (ret != SQLITE_OK) {
         return -1;
     }
     sqlite3_bind_text(statement, 1, name, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
     ret = sqlite3_step(statement);
     if (ret == SQLITE_ROW) {
-        ret = sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
+        body = sqlite3_column_blob(statement, 1);
+        body_size = sqlite3_column_bytes(statement, 1);
+        ret = body_size >= 0 && sqlite3_column_int64(statement, 2) == body_size &&
+              sqlite3_column_bytes(statement, 0) == AZLI_DIGEST_SIZE &&
+              hash_bytes(body, (size_t) body_size, actual_digest) == 0 &&
               memcmp(sqlite3_column_blob(statement, 0), digest,
-                     AZLI_DIGEST_SIZE) == 0 ? 1 : -1;
+                     AZLI_DIGEST_SIZE) == 0 &&
+              memcmp(actual_digest, digest, AZLI_DIGEST_SIZE) == 0 &&
+              sqlite3_column_int(statement, 3) == AZLI_REQUEST_READY &&
+              sqlite3_column_bytes(statement, 4) == AZLI_DIGEST_SIZE &&
+              memcmp(sqlite3_column_blob(statement, 4), json_digest,
+                     AZLI_DIGEST_SIZE) == 0 &&
+              sqlite3_column_int64(statement, 5) == (int64_t) source_count &&
+              sqlite3_column_int64(statement, 6) == (int64_t) source_count ? 1 : -1;
+    }
+    else if (ret == SQLITE_DONE) {
+        ret = 0;
     }
     else {
-        ret = 0;
+        ret = -1;
     }
     sqlite3_finalize(statement);
     return ret;
 }
 
 static int persist_request(struct flb_az_li *ctx, const void *gzip,
-                           size_t gzip_size, size_t json_size,
-                           struct azli_candidate_record *records,
-                           size_t record_count)
+                           size_t gzip_size, const void *json, size_t json_size,
+                           struct azli_candidate_source *sources,
+                           size_t source_count, size_t record_count)
 {
     unsigned char random[8];
     unsigned char body_digest[AZLI_DIGEST_SIZE];
+    unsigned char json_digest[AZLI_DIGEST_SIZE];
     uint64_t random_value;
     char name[96];
-    char digest_text[AZLI_HEX_SIZE + 1];
-    char metadata[192];
-    struct flb_fstore_file *file;
-    struct azli_span *spans;
     sqlite3_stmt *statement;
     int64_t request_pk;
-    ssize_t real_size;
-    size_t span_count;
     size_t index;
-    int ret;
     size_t reserved_bytes;
+    int ret;
 
-    if (flb_random_bytes(random, sizeof(random)) != 0 ||
-        hash_bytes(gzip, gzip_size, body_digest) != 0) {
+    if (source_count == 0 || source_count > AZLI_MAX_REQUEST_SOURCES ||
+        flb_random_bytes(random, sizeof(random)) != 0 ||
+        hash_bytes(gzip, gzip_size, body_digest) != 0 ||
+        hash_bytes(json, json_size, json_digest) != 0 ||
+        source_count > (SIZE_MAX - AZLI_REQUEST_DB_RESERVE) /
+                       AZLI_MEMBER_DB_RESERVE ||
+        gzip_size > SIZE_MAX - AZLI_REQUEST_DB_RESERVE -
+                    source_count * AZLI_MEMBER_DB_RESERVE) {
         return -1;
     }
-    spans = flb_calloc(record_count, sizeof(*spans));
-    if (spans == NULL) {
+    reserved_bytes = gzip_size + AZLI_REQUEST_DB_RESERVE +
+                     source_count * AZLI_MEMBER_DB_RESERVE;
+    if (ctx->batch->manager->reserved_bytes < reserved_bytes) {
         return -1;
     }
-    span_count = 0;
-    for (index = 0; index < record_count; index++) {
-        if (span_count == 0 ||
-            spans[span_count - 1].source_pk != records[index].source_pk ||
-            spans[span_count - 1].first_record +
-            spans[span_count - 1].record_count != records[index].record_index) {
-            spans[span_count].source_pk = records[index].source_pk;
-            spans[span_count].first_record = records[index].record_index;
-            spans[span_count].record_count = 1;
-            span_count++;
-        }
-        else {
-            spans[span_count - 1].record_count++;
-        }
-    }
-    if (span_count > AZLI_MAX_REQUEST_SPANS ||
-        span_count > (SIZE_MAX - AZLI_REQUEST_DB_RESERVE) /
-                     AZLI_SPAN_DB_RESERVE ||
-        gzip_size > SIZE_MAX - AZLI_FILE_OVERHEAD - AZLI_REQUEST_DB_RESERVE -
-                    span_count * AZLI_SPAN_DB_RESERVE) {
-        flb_free(spans);
-        return -1;
-    }
-    reserved_bytes = gzip_size + AZLI_FILE_OVERHEAD +
-                     AZLI_REQUEST_DB_RESERVE +
-                     span_count * AZLI_SPAN_DB_RESERVE;
-    if (reserved_bytes > ctx->batch->manager->limit ||
-        ctx->batch->manager->used >
-        ctx->batch->manager->limit - reserved_bytes) {
-        flb_free(spans);
-        return -1;
-    }
+
     memcpy(&random_value, random, sizeof(random_value));
-    digest_hex(body_digest, digest_text);
     snprintf(name, sizeof(name), "request-%" PRIx64 "-%" PRIu64 ".gzip",
              random_value, ctx->batch->request_sequence++);
-    snprintf(metadata, sizeof(metadata), "AZLIR1|%s|%zu|%zu",
-             digest_text, gzip_size, json_size);
-    file = flb_fstore_file_create(ctx->batch->fs, ctx->batch->requests, name, 0);
-    if (file == NULL || cio_chunk_tx_begin(file->chunk) != CIO_OK ||
-        flb_fstore_file_append(file, (void *) gzip, gzip_size) != 0 ||
-        flb_fstore_file_meta_set(ctx->batch->fs, file, metadata,
-                                strlen(metadata) + 1) == -1 ||
-        cio_chunk_tx_commit(file->chunk) != CIO_OK ||
-        sync_directory(ctx->batch->requests->path) == -1) {
-        if (file != NULL) {
-            cio_chunk_tx_rollback(file->chunk);
-            flb_fstore_file_delete(ctx->batch->fs, file);
-        }
-        flb_free(spans);
-        return -1;
-    }
-
-    real_size = cio_chunk_get_real_size(file->chunk);
-    if (real_size < 0 || (size_t) real_size > SIZE_MAX -
-        AZLI_REQUEST_DB_RESERVE - span_count * AZLI_SPAN_DB_RESERVE) {
-        flb_fstore_file_delete(ctx->batch->fs, file);
-        flb_free(spans);
-        return -1;
-    }
-    reserved_bytes = (size_t) real_size + AZLI_REQUEST_DB_RESERVE +
-                     span_count * AZLI_SPAN_DB_RESERVE;
-    if (reserved_bytes > ctx->batch->manager->limit ||
-        ctx->batch->manager->used >
-        ctx->batch->manager->limit - reserved_bytes) {
-        flb_fstore_file_delete(ctx->batch->fs, file);
-        flb_free(spans);
-        return -1;
-    }
-
+    statement = NULL;
     if (sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
-        goto error;
+        return -1;
     }
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
             "INSERT INTO azli_requests(instance_key,name,state,json_bytes,gzip_bytes,"
-            "body_digest,bytes,created) VALUES(?,?,?,?,?,?,?,?)", -1,
+            "body,body_digest,json_digest,bytes,created) VALUES(?,?,?,?,?,?,?,?,?,?)", -1,
             &statement, NULL);
     if (ret != SQLITE_OK) {
         goto rollback;
@@ -1529,54 +2332,65 @@ static int persist_request(struct flb_az_li *ctx, const void *gzip,
     sqlite3_bind_int(statement, 3, AZLI_REQUEST_READY);
     sqlite3_bind_int64(statement, 4, json_size);
     sqlite3_bind_int64(statement, 5, gzip_size);
-    sqlite3_bind_blob(statement, 6, body_digest, AZLI_DIGEST_SIZE, SQLITE_TRANSIENT);
-    sqlite3_bind_int64(statement, 7, reserved_bytes);
-    sqlite3_bind_int64(statement, 8, now_seconds());
+    sqlite3_bind_blob64(statement, 6, gzip, gzip_size, SQLITE_TRANSIENT);
+    sqlite3_bind_blob64(statement, 7, body_digest, AZLI_DIGEST_SIZE,
+                        SQLITE_TRANSIENT);
+    sqlite3_bind_blob64(statement, 8, json_digest, AZLI_DIGEST_SIZE,
+                        SQLITE_TRANSIENT);
+    sqlite3_bind_int64(statement, 9, reserved_bytes);
+    sqlite3_bind_int64(statement, 10, now_seconds());
     if (sqlite3_step(statement) != SQLITE_DONE) {
-        sqlite3_finalize(statement);
         goto rollback;
     }
     sqlite3_finalize(statement);
+    statement = NULL;
     request_pk = sqlite3_last_insert_rowid(ctx->batch->manager->db->handler);
 
-    for (index = 0; index < span_count; index++) {
+    for (index = 0; index < source_count; index++) {
         ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "INSERT INTO azli_spans(request_pk,ordinal,source_pk,first_record,record_count)"
-                " VALUES(?,?,?,?,?)", -1, &statement, NULL);
+                "UPDATE azli_sources SET request_pk=? WHERE source_pk=? "
+                "AND instance_key=? AND state=? AND request_pk IS NULL", -1,
+                &statement, NULL);
         if (ret != SQLITE_OK) {
             goto rollback;
         }
         sqlite3_bind_int64(statement, 1, request_pk);
-        sqlite3_bind_int64(statement, 2, index);
-        sqlite3_bind_int64(statement, 3, spans[index].source_pk);
-        sqlite3_bind_int64(statement, 4, spans[index].first_record);
-        sqlite3_bind_int64(statement, 5, spans[index].record_count);
-        if (sqlite3_step(statement) != SQLITE_DONE) {
-            sqlite3_finalize(statement);
+        sqlite3_bind_int64(statement, 2, sources[index].source_pk);
+        sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(statement, 4, AZLI_SOURCE_READY);
+        if (sqlite3_step(statement) != SQLITE_DONE ||
+            sqlite3_changes(ctx->batch->manager->db->handler) != 1) {
             goto rollback;
         }
         sqlite3_finalize(statement);
+        statement = NULL;
     }
-    if (sql_commit(ctx->batch->manager) == -1) {
-        ret = request_manifest_matches(ctx, name, body_digest);
+    ret = sql_commit(ctx->batch->manager);
+    if (ret != 0) {
+        if (ret != 1 ||
+            sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+            return -1;
+        }
+        ret = request_manifest_matches(ctx, name, body_digest, json_digest,
+                                       source_count);
         if (ret != 1) {
-            goto error;
+            return -1;
         }
         flb_plg_warn(ctx->ins,
-                     "request COMMIT returned an error but durable manifest was reconciled name=%s",
+                     "request COMMIT returned an error but durable row was reconciled name=%s",
                      name);
     }
     if (manager_recount(ctx->batch->manager) == -1) {
-        flb_plg_error(ctx->ins, "could not reconcile shared spool quota after request commit");
+        return -1;
     }
-    flb_free(spans);
+    flb_plg_debug(ctx->ins,
+                  "planned durable request chunks=%zu records=%zu json_bytes=%zu gzip_bytes=%zu",
+                  source_count, record_count, json_size, gzip_size);
     return 0;
 
 rollback:
+    sqlite3_finalize(statement);
     sql_rollback_if_active(ctx->batch->manager);
-error:
-    flb_fstore_file_delete(ctx->batch->fs, file);
-    flb_free(spans);
     return -1;
 }
 
@@ -1586,271 +2400,304 @@ static int request_exists(struct flb_az_li *ctx)
     int ret;
 
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT 1 FROM azli_requests WHERE instance_key=? AND state IN (1,2,3,4) LIMIT 1",
-            -1, &statement, NULL);
+            "SELECT 1 FROM azli_requests WHERE instance_key=? "
+            "AND state IN (1,2,3,4) LIMIT 1", -1, &statement, NULL);
     if (ret != SQLITE_OK) {
         return -1;
     }
     sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    ret = sqlite3_step(statement) == SQLITE_ROW ? 1 : 0;
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_ROW) {
+        ret = 1;
+    }
+    else if (ret == SQLITE_DONE) {
+        ret = 0;
+    }
+    else {
+        ret = -1;
+    }
     sqlite3_finalize(statement);
     return ret;
 }
 
-static int plan_request(struct flb_az_li *ctx)
+static int reserve_request_locked(struct azli_root_manager *manager,
+                                  size_t reserved_bytes)
 {
-    struct mk_list buffers;
-    struct azli_candidate_record *records;
-    sqlite3_stmt *statement;
-    flb_sds_t json;
-    const char *name;
-    int64_t source_pk;
-    int64_t next_record;
-    int64_t oldest_created;
-    size_t capacity;
-    size_t count;
-    size_t source_count;
-    size_t chosen;
-    size_t low;
-    size_t high;
-    size_t middle;
-    size_t best;
-    size_t gzip_size;
-    size_t json_size;
-    size_t candidate_gzip_size;
-    size_t candidate_json_size;
-    uint64_t initial_probe_count;
-    void *gzip = NULL;
-    void *candidate_gzip;
-    int ret;
-
-    ret = request_exists(ctx);
-    if (ret != 0) {
-        return ret < 0 ? -1 : 0;
-    }
-    initial_probe_count = ctx->batch->probe_count;
-    records = NULL;
-    capacity = 0;
-    count = 0;
-    source_count = 0;
-    oldest_created = 0;
-    mk_list_init(&buffers);
-    json = flb_sds_create("[");
-    if (json == NULL) {
+    if (manager_recount(manager) == -1 || reserved_bytes > manager->limit ||
+        manager->reserved_bytes > manager->limit - reserved_bytes ||
+        manager->logical_used > manager->limit - reserved_bytes -
+                                manager->reserved_bytes ||
+        manager->physical_used > manager->limit - reserved_bytes -
+                                 manager->reserved_bytes) {
         return -1;
     }
+    manager->reserved_bytes += reserved_bytes;
+    return 0;
+}
 
-    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT source_pk,name,next_record,created FROM azli_sources "
-            "WHERE instance_key=? AND next_record<record_count AND state IN (1,3) "
-            "ORDER BY source_pk", -1, &statement, NULL);
-    if (ret != SQLITE_OK) {
-        goto error;
+static void release_request_reservation(struct azli_root_manager *manager,
+                                        size_t reserved_bytes)
+{
+    if (manager->reserved_bytes >= reserved_bytes) {
+        manager->reserved_bytes -= reserved_bytes;
     }
-    sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
-    while (sqlite3_step(statement) == SQLITE_ROW) {
-        source_pk = sqlite3_column_int64(statement, 0);
-        name = (const char *) sqlite3_column_text(statement, 1);
-        next_record = sqlite3_column_int64(statement, 2);
-        if (oldest_created == 0) {
-            oldest_created = sqlite3_column_int64(statement, 3);
+    else {
+        manager->reserved_bytes = 0;
+    }
+}
+
+static int plan_request(struct flb_az_li *ctx)
+{
+    struct azli_root_manager *manager;
+    struct azli_candidate_source *sources;
+    flb_sds_t json;
+    flb_sds_t tmp;
+    void *gzip;
+    void *candidate_gzip;
+    size_t gzip_size;
+    size_t candidate_gzip_size;
+    size_t candidate_json_size;
+    size_t prior_length;
+    size_t source_count;
+    size_t snapshot_count;
+    size_t included_count;
+    size_t record_count;
+    size_t addition;
+    size_t estimated_gzip_size;
+    size_t estimated_json_size;
+    size_t request_body_bound;
+    size_t reserved_bytes;
+    size_t index;
+    size_t probes;
+    int more_sources;
+    int uncompressed_boundary;
+    int boundary;
+    int ret;
+
+    manager = ctx->batch->manager;
+    sources = NULL;
+    source_count = 0;
+    more_sources = FLB_FALSE;
+    reserved_bytes = 0;
+
+    pthread_mutex_lock(&manager->mutex);
+    ret = request_exists(ctx);
+    if (ret != 0) {
+        pthread_mutex_unlock(&manager->mutex);
+        return ret < 0 ? -1 : 0;
+    }
+    if (load_candidate_sources(ctx, &sources, &source_count, &more_sources) == -1) {
+        pthread_mutex_unlock(&manager->mutex);
+        return -1;
+    }
+    if (source_count == 0) {
+        pthread_mutex_unlock(&manager->mutex);
+        candidate_sources_destroy(sources, source_count);
+        return 0;
+    }
+
+    estimated_gzip_size = 0;
+    estimated_json_size = 2;
+    snapshot_count = 0;
+    uncompressed_boundary = FLB_FALSE;
+    for (index = 0; index < source_count; index++) {
+        addition = (size_t) sources[index].json_bytes - 2;
+        if (snapshot_count > 0) {
+            if (addition == SIZE_MAX) {
+                pthread_mutex_unlock(&manager->mutex);
+                candidate_sources_destroy(sources, source_count);
+                return -1;
+            }
+            addition++;
         }
-        if (source_count >= AZLI_MAX_REQUEST_SPANS) {
+        if (estimated_json_size > ctx->batch_max_uncompressed_size ||
+            addition > ctx->batch_max_uncompressed_size - estimated_json_size) {
+            uncompressed_boundary = FLB_TRUE;
+            more_sources = FLB_TRUE;
             break;
         }
-        source_count++;
-        ret = collect_source_records(ctx, source_pk, name, next_record, &json,
-                                     &records, &count, &capacity, &buffers);
-        if (ret == -1) {
-            sqlite3_finalize(statement);
+        if ((uint64_t) sources[index].standalone_gzip_bytes >
+            SIZE_MAX - estimated_gzip_size) {
+            pthread_mutex_unlock(&manager->mutex);
+            candidate_sources_destroy(sources, source_count);
+            return -1;
+        }
+        estimated_json_size += addition;
+        estimated_gzip_size += (size_t) sources[index].standalone_gzip_bytes;
+        snapshot_count++;
+    }
+    if (snapshot_count == 0) {
+        pthread_mutex_unlock(&manager->mutex);
+        candidate_sources_destroy(sources, source_count);
+        return -1;
+    }
+    source_count = snapshot_count;
+    request_body_bound = estimated_json_size > FLB_AZ_LI_MAX_REQUEST_SIZE - 65536 ?
+                         FLB_AZ_LI_MAX_REQUEST_SIZE : estimated_json_size + 65536;
+    reserved_bytes = request_body_bound + AZLI_REQUEST_DB_RESERVE +
+                     source_count * AZLI_MEMBER_DB_RESERVE;
+    if (!more_sources && estimated_gzip_size < ctx->batch_target_size &&
+        now_seconds() - sources[0].created < ctx->batch_timeout) {
+        pthread_mutex_unlock(&manager->mutex);
+        candidate_sources_destroy(sources, source_count);
+        return 0;
+    }
+    if (reserve_request_locked(manager, reserved_bytes) == -1) {
+        pthread_mutex_unlock(&manager->mutex);
+        candidate_sources_destroy(sources, source_count);
+        return -1;
+    }
+    for (index = 0; index < source_count; index++) {
+        ret = load_candidate_content(ctx, &sources[index]);
+        if (ret != 0) {
+            release_request_reservation(manager, reserved_bytes);
+            pthread_mutex_unlock(&manager->mutex);
+            candidate_sources_destroy(sources, source_count);
+            return ret == -2 ? 0 : -1;
+        }
+    }
+    pthread_mutex_unlock(&manager->mutex);
+    flb_plg_debug(ctx->ins,
+                  "whole-chunk planner snapshot_bytes=%zu limit=%zu sources=%zu%s",
+                  estimated_json_size, ctx->batch_max_uncompressed_size,
+                  source_count, uncompressed_boundary ? " boundary" : "");
+
+    json = flb_sds_create("[");
+    gzip = NULL;
+    gzip_size = 0;
+    candidate_json_size = 0;
+    included_count = 0;
+    record_count = 0;
+    probes = 0;
+    boundary = FLB_FALSE;
+    if (json == NULL) {
+        goto error;
+    }
+
+    for (index = 0; index < source_count && probes < AZLI_MAX_COMPRESSION_PROBES;
+         index++) {
+        prior_length = flb_sds_len(json);
+        if (append_source_json(&sources[index], &json, included_count) == -1) {
             goto error;
         }
-        if (ret == 1 ||
-            flb_sds_len(json) + 2 >= ctx->batch_max_uncompressed_size) {
+        tmp = flb_sds_cat(json, "]", 1);
+        if (tmp == NULL) {
+            goto error;
+        }
+        json = tmp;
+        candidate_json_size = flb_sds_len(json);
+        if (candidate_json_size > ctx->batch_max_uncompressed_size) {
+            flb_sds_len_set(json, prior_length);
+            boundary = FLB_TRUE;
             break;
         }
-    }
-    sqlite3_finalize(statement);
-    if (count == 0) {
-        flb_sds_destroy(json);
-        candidate_buffers_destroy(&buffers);
-        flb_free(records);
-        return 0;
-    }
-
-    /* The EWMA only decides when to pay for an exact probe. It never
-     * authorizes persistence or transmission of a request. */
-    if (ctx->batch->compression_ratio_initialized &&
-        (double) (flb_sds_len(json) + 1) * ctx->batch->compression_ratio <
-        (double) ctx->batch_target_size &&
-        now_seconds() - oldest_created < ctx->batch_timeout &&
-        flb_sds_len(json) + 1 < ctx->batch_max_uncompressed_size) {
-        flb_plg_debug(ctx->ins,
-                      "deferred exact probe using compression ratio=%.6f records=%zu",
-                      ctx->batch->compression_ratio, count);
-        flb_sds_destroy(json);
-        candidate_buffers_destroy(&buffers);
-        flb_free(records);
-        return 0;
-    }
-
-    chosen = count;
-    if (ctx->batch->compression_ratio_initialized && count > 1 &&
-        (double) (records[count - 1].json_end + 1) *
-        ctx->batch->compression_ratio > (double) ctx->batch_target_size) {
-        size_t estimated_json_target;
-
-        estimated_json_target = (size_t) ((double) ctx->batch_target_size /
-                                          ctx->batch->compression_ratio);
-        low = 1;
-        high = count;
-        best = 0;
-        while (low <= high) {
-            middle = low + (high - low) / 2;
-            if (records[middle - 1].json_end + 1 <= estimated_json_target) {
-                best = middle;
-                low = middle + 1;
-            }
-            else {
-                high = middle - 1;
-            }
+        candidate_gzip = NULL;
+        if (flb_gzip_compress(json, candidate_json_size, &candidate_gzip,
+                              &candidate_gzip_size) == -1) {
+            goto error;
         }
-        chosen = best < count ? best + 1 : best;
-        if (chosen == 0) {
-            chosen = 1;
-        }
-    }
-    if (compress_prefix(json, records, chosen, &gzip, &gzip_size, &json_size) == -1) {
-        goto error;
-    }
-    ctx->batch->probe_count++;
-    if (json_size > 0) {
-        double observed = (double) gzip_size / (double) json_size;
-        if (!ctx->batch->compression_ratio_initialized) {
-            ctx->batch->compression_ratio = observed;
-            ctx->batch->compression_ratio_initialized = FLB_TRUE;
-        }
-        else {
-            ctx->batch->compression_ratio = AZLI_RATIO_ALPHA * observed +
-                (1.0 - AZLI_RATIO_ALPHA) * ctx->batch->compression_ratio;
-        }
-    }
-
-    if (chosen == count && gzip_size < ctx->batch_target_size &&
-        now_seconds() - oldest_created < ctx->batch_timeout &&
-        json_size < ctx->batch_max_uncompressed_size) {
-        flb_free(gzip);
-        flb_sds_destroy(json);
-        candidate_buffers_destroy(&buffers);
-        flb_free(records);
-        return 0;
-    }
-
-    if (gzip_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
-        json_size > ctx->batch_max_uncompressed_size) {
-        flb_free(gzip);
-        gzip = NULL;
-        low = 1;
-        high = count;
-        best = 0;
-        while (low <= high) {
-            middle = low + (high - low) / 2;
-            candidate_gzip = NULL;
-            if (compress_prefix(json, records, middle, &candidate_gzip,
-                                &candidate_gzip_size, &candidate_json_size) == -1) {
-                goto error;
-            }
-            ctx->batch->probe_count++;
+        probes++;
+        if (candidate_gzip_size > FLB_AZ_LI_MAX_REQUEST_SIZE) {
             flb_free(candidate_gzip);
-            if (candidate_gzip_size <= FLB_AZ_LI_MAX_REQUEST_SIZE &&
-                candidate_json_size <= ctx->batch_max_uncompressed_size) {
-                best = middle;
-                low = middle + 1;
-            }
-            else {
-                if (middle == 1) {
-                    high = 0;
-                }
-                else {
-                    high = middle - 1;
-                }
-            }
+            flb_sds_len_set(json, prior_length);
+            boundary = FLB_TRUE;
+            break;
         }
-        chosen = best;
-        if (chosen == 0) {
-            chosen = 1;
-        }
-        if (compress_prefix(json, records, chosen, &gzip, &gzip_size, &json_size) == -1) {
+        flb_free(gzip);
+        gzip = candidate_gzip;
+        gzip_size = candidate_gzip_size;
+        if ((uint64_t) sources[index].record_count > SIZE_MAX - record_count) {
             goto error;
         }
-        ctx->batch->probe_count++;
-        if (gzip_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
-            json_size > ctx->batch_max_uncompressed_size) {
-            flb_free(gzip);
-            gzip = NULL;
-            if (chosen == 1) {
-                ret = source_mark_singleton_quarantine(ctx, &records[0]);
-                if (ret == 0) {
-                    flb_plg_error(ctx->ins,
-                                  "quarantined record compressed_bytes=%zu json_bytes=%zu",
-                                  gzip_size, json_size);
-                }
-                flb_sds_destroy(json);
-                candidate_buffers_destroy(&buffers);
-                flb_free(records);
-                return ret;
-            }
-            chosen--;
-            if (compress_prefix(json, records, chosen, &gzip, &gzip_size,
-                                &json_size) == -1) {
-                goto error;
-            }
-            ctx->batch->probe_count++;
+        included_count++;
+        record_count += (size_t) sources[index].record_count;
+        if (gzip_size >= ctx->batch_target_size) {
+            boundary = FLB_TRUE;
+            break;
         }
+        flb_sds_len_set(json, flb_sds_len(json) - 1);
     }
 
-    ret = persist_request(ctx, gzip, gzip_size, json_size, records, chosen);
-    if (ret == 0) {
-        flb_plg_debug(ctx->ins,
-                      "planned durable request records=%zu probes=%" PRIu64
-                      " ratio=%.6f gzip_bytes=%zu",
-                      chosen, ctx->batch->probe_count - initial_probe_count,
-                      ctx->batch->compression_ratio, gzip_size);
+    if (included_count == 0) {
+        goto error;
     }
-    flb_free(gzip);
-    flb_sds_destroy(json);
-    candidate_buffers_destroy(&buffers);
-    flb_free(records);
-    return ret;
+    if (included_count == AZLI_MAX_REQUEST_SOURCES ||
+        probes == AZLI_MAX_COMPRESSION_PROBES) {
+        boundary = FLB_TRUE;
+    }
+    if (!boundary && included_count == source_count && !more_sources &&
+        now_seconds() - sources[0].created < ctx->batch_timeout) {
+        ret = 0;
+        goto done;
+    }
+    if (json[flb_sds_len(json) - 1] != ']') {
+        tmp = flb_sds_cat(json, "]", 1);
+        if (tmp == NULL) {
+            goto error;
+        }
+        json = tmp;
+    }
+    candidate_json_size = flb_sds_len(json);
+
+    pthread_mutex_lock(&manager->mutex);
+    ret = persist_request(ctx, gzip, gzip_size, json, candidate_json_size,
+                          sources, included_count, record_count);
+    release_request_reservation(manager, reserved_bytes);
+    metrics_refresh_locked(ctx);
+    pthread_mutex_unlock(&manager->mutex);
+    if (ret == 0) {
+        flb_plg_debug(ctx->ins, "whole-chunk planner probes=%zu limit=%d",
+                      probes, AZLI_MAX_COMPRESSION_PROBES);
+        ret = 1;
+    }
+    goto done_unreserved;
 
 error:
-    if (gzip != NULL) {
-        flb_free(gzip);
-    }
+    ret = -1;
+done:
+    pthread_mutex_lock(&manager->mutex);
+    release_request_reservation(manager, reserved_bytes);
+    metrics_refresh_locked(ctx);
+    pthread_mutex_unlock(&manager->mutex);
+done_unreserved:
+    flb_free(gzip);
     flb_sds_destroy(json);
-    candidate_buffers_destroy(&buffers);
-    flb_free(records);
-    return -1;
+    candidate_sources_destroy(sources, source_count);
+    return ret;
 }
 
 static int request_load_next(struct flb_az_li *ctx, struct azli_request *request)
 {
     sqlite3_stmt *statement;
+    const void *body;
+    int body_size;
     int ret;
 
     memset(request, 0, sizeof(*request));
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT request_pk,name,state,attempts,next_retry,json_bytes,gzip_bytes,body_digest "
-            "FROM azli_requests WHERE instance_key=? AND state IN (1,2,3) "
-            "AND next_retry<=? ORDER BY request_pk LIMIT 1", -1, &statement, NULL);
+            "SELECT request_pk,name,state,attempts,next_retry,json_bytes,gzip_bytes,"
+            "body_digest,json_digest,body FROM azli_requests WHERE instance_key=? "
+            "AND state IN (1,2,3) AND next_retry<=? ORDER BY request_pk LIMIT 1",
+            -1, &statement, NULL);
     if (ret != SQLITE_OK) {
         return -1;
     }
     sqlite3_bind_text(statement, 1, ctx->buffer_key, -1, SQLITE_TRANSIENT);
     sqlite3_bind_int64(statement, 2, now_seconds());
-    if (sqlite3_step(statement) != SQLITE_ROW) {
+    ret = sqlite3_step(statement);
+    if (ret == SQLITE_DONE) {
         sqlite3_finalize(statement);
         return 0;
+    }
+    if (ret != SQLITE_ROW) {
+        sqlite3_finalize(statement);
+        return -1;
+    }
+    body_size = sqlite3_column_bytes(statement, 9);
+    if (sqlite3_column_bytes(statement, 7) != AZLI_DIGEST_SIZE ||
+        sqlite3_column_bytes(statement, 8) != AZLI_DIGEST_SIZE || body_size < 0) {
+        sqlite3_finalize(statement);
+        return -1;
     }
     request->request_pk = sqlite3_column_int64(statement, 0);
     request->name = flb_sds_create((const char *) sqlite3_column_text(statement, 1));
@@ -1859,18 +2706,27 @@ static int request_load_next(struct flb_az_li *ctx, struct azli_request *request
     request->next_retry = sqlite3_column_int64(statement, 4);
     request->json_bytes = sqlite3_column_int64(statement, 5);
     request->gzip_bytes = sqlite3_column_int64(statement, 6);
-    if (sqlite3_column_bytes(statement, 7) != AZLI_DIGEST_SIZE) {
-        sqlite3_finalize(statement);
+    memcpy(request->digest, sqlite3_column_blob(statement, 7), AZLI_DIGEST_SIZE);
+    memcpy(request->json_digest, sqlite3_column_blob(statement, 8), AZLI_DIGEST_SIZE);
+    body = sqlite3_column_blob(statement, 9);
+    request->body = flb_malloc((size_t) body_size);
+    if (request->body != NULL && body_size > 0) {
+        memcpy(request->body, body, (size_t) body_size);
+    }
+    request->body_size = (size_t) body_size;
+    ret = sqlite3_step(statement);
+    sqlite3_finalize(statement);
+    if (ret != SQLITE_DONE || request->name == NULL || request->body == NULL) {
         flb_sds_destroy(request->name);
-        request->name = NULL;
+        flb_free(request->body);
+        memset(request, 0, sizeof(*request));
         return -1;
     }
-    memcpy(request->digest, sqlite3_column_blob(statement, 7), AZLI_DIGEST_SIZE);
-    sqlite3_finalize(statement);
-    return request->name == NULL ? -1 : 1;
+    return 1;
 }
 
-static int request_mark_inflight(struct flb_az_li *ctx, struct azli_request *request)
+static int request_mark_inflight(struct flb_az_li *ctx,
+                                 struct azli_request *request)
 {
     sqlite3_stmt *statement;
     int ret;
@@ -1884,137 +2740,187 @@ static int request_mark_inflight(struct flb_az_li *ctx, struct azli_request *req
     sqlite3_bind_int(statement, 1, AZLI_REQUEST_INFLIGHT);
     sqlite3_bind_int64(statement, 2, request->request_pk);
     ret = sqlite3_step(statement) == SQLITE_DONE ? 0 : -1;
-    sqlite3_finalize(statement);
-    return ret;
-}
-
-static int request_state_is(struct flb_az_li *ctx, int64_t request_pk,
-                            int expected_state)
-{
-    sqlite3_stmt *statement;
-    int ret;
-
-    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT state FROM azli_requests WHERE request_pk=?", -1,
-            &statement, NULL);
-    if (ret != SQLITE_OK) {
-        return -1;
+    if (ret == 0 && sqlite3_changes(ctx->batch->manager->db->handler) != 1) {
+        ret = -1;
     }
-    sqlite3_bind_int64(statement, 1, request_pk);
-    ret = sqlite3_step(statement);
-    ret = ret == SQLITE_ROW && sqlite3_column_int(statement, 0) == expected_state;
     sqlite3_finalize(statement);
     return ret;
 }
 
-static int request_commit_spans(struct flb_az_li *ctx,
-                                struct azli_request *request,
-                                int quarantine, int status, const char *reason)
+static int request_commit_sources(struct flb_az_li *ctx,
+                                  struct azli_request *request,
+                                  int quarantine, int status,
+                                  const char *reason)
 {
-    sqlite3_stmt *query;
-    sqlite3_stmt *update;
-    sqlite3_stmt *receipt;
-    int64_t source_pk;
-    int64_t end_record;
+    unsigned char member_digest[AZLI_DIGEST_SIZE];
+    sqlite3_stmt *statement;
+    int64_t member_count;
+    int64_t member_records;
+    int64_t member_bytes;
+    int64_t completed;
     int ret;
 
+    statement = NULL;
     if (sql_exec(ctx->batch->manager, "BEGIN IMMEDIATE") == -1) {
         return -1;
     }
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "SELECT source_pk,first_record+record_count FROM azli_spans "
-            "WHERE request_pk=? ORDER BY ordinal", -1, &query, NULL);
+            "SELECT COUNT(*),COALESCE(SUM(record_count),0),"
+            "COALESCE(SUM(json_bytes),0) FROM azli_sources "
+            "WHERE request_pk=? AND instance_key=?", -1,
+            &statement, NULL);
     if (ret != SQLITE_OK) {
         goto rollback;
     }
-    sqlite3_bind_int64(query, 1, request->request_pk);
-    while (sqlite3_step(query) == SQLITE_ROW) {
-        source_pk = sqlite3_column_int64(query, 0);
-        end_record = sqlite3_column_int64(query, 1);
-        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                "UPDATE azli_sources SET next_record=MAX(next_record,?),"
-                "has_quarantine=MAX(has_quarantine,?),state="
-                "CASE WHEN record_count<=? THEN CASE WHEN has_quarantine=1 OR ?=1 "
-                "THEN ? ELSE ? END ELSE state END WHERE source_pk=?", -1,
-                &update, NULL);
-        if (ret != SQLITE_OK) {
-            sqlite3_finalize(query);
-            goto rollback;
-        }
-        sqlite3_bind_int64(update, 1, end_record);
-        sqlite3_bind_int(update, 2, quarantine);
-        sqlite3_bind_int64(update, 3, end_record);
-        sqlite3_bind_int(update, 4, quarantine);
-        sqlite3_bind_int(update, 5, AZLI_SOURCE_QUARANTINED);
-        sqlite3_bind_int(update, 6, AZLI_SOURCE_DRAINED);
-        sqlite3_bind_int64(update, 7, source_pk);
-        if (sqlite3_step(update) != SQLITE_DONE) {
-            sqlite3_finalize(update);
-            sqlite3_finalize(query);
-            goto rollback;
-        }
-        sqlite3_finalize(update);
-
-        if (!quarantine) {
-            ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-                    "INSERT OR IGNORE INTO azli_receipts(instance_key,source_id,digest,completed) "
-                    "SELECT instance_key,source_id,digest,? FROM azli_sources "
-                    "WHERE source_pk=? AND next_record>=record_count AND has_quarantine=0", -1,
-                    &receipt, NULL);
-            if (ret != SQLITE_OK) {
-                sqlite3_finalize(query);
-                goto rollback;
-            }
-            sqlite3_bind_int64(receipt, 1, now_seconds());
-            sqlite3_bind_int64(receipt, 2, source_pk);
-            sqlite3_step(receipt);
-            sqlite3_finalize(receipt);
-        }
+    sqlite3_bind_int64(statement, 1, request->request_pk);
+    sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(statement) != SQLITE_ROW) {
+        goto rollback;
     }
-    sqlite3_finalize(query);
+    member_count = sqlite3_column_int64(statement, 0);
+    member_records = sqlite3_column_int64(statement, 1);
+    member_bytes = sqlite3_column_int64(statement, 2);
+    if (member_count < 1 || member_records < 1 || member_bytes < 2 ||
+        sqlite3_step(statement) != SQLITE_DONE) {
+        goto rollback;
+    }
+    sqlite3_finalize(statement);
+    statement = NULL;
+
+    if (!quarantine &&
+        (validate_request_members(ctx, request->request_pk, member_digest) != 0 ||
+         memcmp(member_digest, request->json_digest, AZLI_DIGEST_SIZE) != 0)) {
+        goto rollback;
+    }
+    if (!quarantine) {
+        completed = now_seconds();
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "INSERT INTO azli_receipts(instance_key,source_id,digest,completed,"
+                "expires,bytes) SELECT instance_key,source_id,digest,?,?,? "
+                "FROM azli_sources WHERE request_pk=? AND instance_key=?", -1,
+                &statement, NULL);
+        if (ret != SQLITE_OK) {
+            goto rollback;
+        }
+        sqlite3_bind_int64(statement, 1, completed);
+        sqlite3_bind_int64(statement, 2,
+                           completed + (int64_t) ctx->buffer_receipt_ttl);
+        sqlite3_bind_int64(statement, 3, AZLI_RECEIPT_DB_RESERVE);
+        sqlite3_bind_int64(statement, 4, request->request_pk);
+        sqlite3_bind_text(statement, 5, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(statement) != SQLITE_DONE ||
+            sqlite3_changes(ctx->batch->manager->db->handler) != member_count) {
+            goto rollback;
+        }
+        sqlite3_finalize(statement);
+        statement = NULL;
+
+        ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+                "UPDATE azli_instances SET last_success=MAX(last_success,?) "
+                "WHERE instance_key=?", -1, &statement, NULL);
+        if (ret != SQLITE_OK) {
+            goto rollback;
+        }
+        sqlite3_bind_int64(statement, 1, completed);
+        sqlite3_bind_text(statement, 2, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(statement) != SQLITE_DONE ||
+            sqlite3_changes(ctx->batch->manager->db->handler) != 1) {
+            goto rollback;
+        }
+        sqlite3_finalize(statement);
+        statement = NULL;
+    }
 
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
-            "UPDATE azli_requests SET state=?,status=?,reason=? WHERE request_pk=?", -1,
-            &update, NULL);
+            "UPDATE azli_sources SET state=? WHERE request_pk=? AND instance_key=?", -1,
+            &statement, NULL);
     if (ret != SQLITE_OK) {
         goto rollback;
     }
-    sqlite3_bind_int(update, 1, quarantine ? AZLI_REQUEST_QUARANTINED : AZLI_REQUEST_ACKED);
-    sqlite3_bind_int(update, 2, status);
-    if (reason != NULL) {
-        sqlite3_bind_text(update, 3, reason, -1, SQLITE_TRANSIENT);
-    }
-    else {
-        sqlite3_bind_null(update, 3);
-    }
-    sqlite3_bind_int64(update, 4, request->request_pk);
-    if (sqlite3_step(update) != SQLITE_DONE) {
-        sqlite3_finalize(update);
+    sqlite3_bind_int(statement, 1,
+                     quarantine ? AZLI_SOURCE_QUARANTINED : AZLI_SOURCE_DRAINED);
+    sqlite3_bind_int64(statement, 2, request->request_pk);
+    sqlite3_bind_text(statement, 3, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(statement) != SQLITE_DONE ||
+        sqlite3_changes(ctx->batch->manager->db->handler) != member_count) {
         goto rollback;
     }
-    sqlite3_finalize(update);
-    if (sql_commit(ctx->batch->manager) == -1) {
-        ret = request_state_is(ctx, request->request_pk,
-                               quarantine ? AZLI_REQUEST_QUARANTINED :
-                               AZLI_REQUEST_ACKED);
+    sqlite3_finalize(statement);
+    statement = NULL;
+
+    ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
+            "UPDATE azli_requests SET state=?,status=?,reason=? WHERE request_pk=? "
+            "AND instance_key=?", -1, &statement, NULL);
+    if (ret != SQLITE_OK) {
+        goto rollback;
+    }
+    sqlite3_bind_int(statement, 1,
+                     quarantine ? AZLI_REQUEST_QUARANTINED : AZLI_REQUEST_ACKED);
+    sqlite3_bind_int(statement, 2, status);
+    if (reason != NULL) {
+        sqlite3_bind_text(statement, 3, reason, -1, SQLITE_TRANSIENT);
+    }
+    else {
+        sqlite3_bind_null(statement, 3);
+    }
+    sqlite3_bind_int64(statement, 4, request->request_pk);
+    sqlite3_bind_text(statement, 5, ctx->buffer_key, -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(statement) != SQLITE_DONE ||
+        sqlite3_changes(ctx->batch->manager->db->handler) != 1) {
+        goto rollback;
+    }
+    sqlite3_finalize(statement);
+    statement = NULL;
+
+    ret = sql_commit(ctx->batch->manager);
+    if (ret != 0) {
+        if (ret != 1 ||
+            sqlite3_get_autocommit(ctx->batch->manager->db->handler) == 0) {
+            return -1;
+        }
+        ret = request_outcome_matches(ctx, request->request_pk, quarantine);
         if (ret != 1) {
             return -1;
         }
         flb_plg_warn(ctx->ins,
-                     "request outcome COMMIT returned an error but durable state was reconciled name=%s",
-                     request->name);
+                     "request outcome COMMIT returned an error but durable state was "
+                     "reconciled name=%s", request->name);
     }
-    if (!quarantine &&
-        (cleanup_acked_request(ctx, request->request_pk, request->name) == -1 ||
-         cleanup_drained_sources(ctx) == -1)) {
-        return -1;
+    if (quarantine) {
+        metric_counter_add(ctx, ctx->cmt_quarantined_chunks,
+                           (double) member_count);
+        metric_counter_add(ctx, ctx->cmt_quarantined_records,
+                           (double) member_records);
     }
-    if (manager_recount(ctx->batch->manager) == -1) {
-        return -1;
+    else {
+        metric_counter_add(ctx, ctx->cmt_delivered_chunks,
+                           (double) member_count);
+        metric_counter_add(ctx, ctx->cmt_delivered_records,
+                           (double) member_records);
+        metric_counter_add(ctx, ctx->cmt_delivered_bytes,
+                           (double) member_bytes);
     }
-    return 0;
+    if (!quarantine) {
+        metric_gauge_set(ctx, ctx->cmt_uploader_last_success,
+                         (double) completed);
+        if (cleanup_acknowledged(ctx) == -1 ||
+            manager_maintain(ctx->batch->manager,
+                             ctx->batch->manager->logical_used == 0 ||
+                             ctx->batch->manager->wal_bytes >
+                             ctx->batch->manager->limit / 4) < 0) {
+            return -1;
+        }
+        metrics_refresh_locked(ctx);
+        return 0;
+    }
+    ret = manager_recount(ctx->batch->manager);
+    if (ret == 0) {
+        metrics_refresh_locked(ctx);
+    }
+    return ret;
 
 rollback:
+    sqlite3_finalize(statement);
     sql_rollback_if_active(ctx->batch->manager);
     return -1;
 }
@@ -2039,8 +2945,8 @@ static int request_schedule_retry(struct flb_az_li *ctx,
 
     if (ctx->upload_retry_limit > 0 &&
         request->attempts + 1 > ctx->upload_retry_limit) {
-        return request_commit_spans(ctx, request, FLB_TRUE, status,
-                                    "retry_exhausted");
+        return request_commit_sources(ctx, request, FLB_TRUE, status,
+                                      "retry_exhausted");
     }
     ret = sqlite3_prepare_v2(ctx->batch->manager->db->handler,
             "UPDATE azli_requests SET state=?,next_retry=?,status=? WHERE request_pk=?", -1,
@@ -2064,73 +2970,84 @@ static int response_is_transient(int transport_result, int status)
            status == 429 || status >= 500;
 }
 
+static void request_destroy(struct azli_request *request)
+{
+    flb_sds_destroy(request->name);
+    flb_free(request->body);
+    memset(request, 0, sizeof(*request));
+}
+
 static int upload_one(struct flb_az_li *ctx)
 {
     struct azli_request request;
-    struct flb_fstore_file *file;
-    void *body;
-    size_t body_size;
     unsigned char body_digest[AZLI_DIGEST_SIZE];
+    unsigned char member_digest[AZLI_DIGEST_SIZE];
     int status;
     int ret;
     int transition_ret;
 
-    body = NULL;
-    body_size = 0;
     pthread_mutex_lock(&ctx->batch->manager->mutex);
     ret = request_load_next(ctx, &request);
     if (ret <= 0) {
         pthread_mutex_unlock(&ctx->batch->manager->mutex);
         return ret;
     }
-    file = flb_fstore_file_get(ctx->batch->fs, ctx->batch->requests,
-                               request.name, flb_sds_len(request.name));
-    if (file == NULL ||
-        flb_fstore_file_content_copy(NULL, file, &body, &body_size) == -1 ||
-        body_size != (size_t) request.gzip_bytes ||
-        hash_bytes(body, body_size, body_digest) != 0 ||
+    if (request.body_size != (size_t) request.gzip_bytes ||
+        hash_bytes(request.body, request.body_size, body_digest) != 0 ||
         memcmp(body_digest, request.digest, AZLI_DIGEST_SIZE) != 0 ||
-        body_size > FLB_AZ_LI_MAX_REQUEST_SIZE ||
-        request.json_bytes > (int64_t) ctx->batch_max_uncompressed_size) {
+        request.body_size > FLB_AZ_LI_MAX_REQUEST_SIZE) {
         flb_plg_error(ctx->ins,
-                      "durable request artifact failed validation name=%s",
-                      request.name);
-        flb_free(body);
-        transition_ret = request_commit_spans(ctx, &request, FLB_TRUE, 0,
-                                              "artifact_corrupt");
+                      "durable request BLOB failed validation name=%s", request.name);
+        transition_ret = request_commit_sources(ctx, &request, FLB_TRUE, 0,
+                                                "artifact_corrupt");
         pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(request.name);
-        return transition_ret;
+        request_destroy(&request);
+        return transition_ret == 0 ? 1 : -1;
+    }
+    ret = validate_request_members(ctx, request.request_pk, member_digest);
+    if (ret == 0 && memcmp(member_digest, request.json_digest,
+                           AZLI_DIGEST_SIZE) != 0) {
+        ret = 1;
+    }
+    if (ret != 0) {
+        if (ret > 0) {
+            flb_plg_error(ctx->ins,
+                          "durable request source member failed validation name=%s",
+                          request.name);
+            transition_ret = request_commit_sources(ctx, &request, FLB_TRUE, 0,
+                                                    "source_corrupt");
+        }
+        else {
+            transition_ret = -1;
+        }
+        pthread_mutex_unlock(&ctx->batch->manager->mutex);
+        request_destroy(&request);
+        return transition_ret == 0 ? 1 : -1;
     }
     if (request_mark_inflight(ctx, &request) == -1) {
-        flb_plg_error(ctx->ins,
-                      "could not persist inflight request state name=%s",
-                      request.name);
-        flb_free(body);
         pthread_mutex_unlock(&ctx->batch->manager->mutex);
-        flb_sds_destroy(request.name);
+        request_destroy(&request);
         return -1;
     }
     pthread_mutex_unlock(&ctx->batch->manager->mutex);
 
     status = 0;
-    ret = az_li_send_payload(ctx, body, body_size, request.json_bytes,
-                             FLB_TRUE, &status);
-    flb_free(body);
+    ret = az_li_send_payload(ctx, request.body, request.body_size,
+                             request.json_bytes, FLB_TRUE, &status);
     if (ret == 0 && status == 401) {
         flb_oauth2_invalidate_token(ctx->u_auth);
     }
 
     pthread_mutex_lock(&ctx->batch->manager->mutex);
     if (ret == 0 && status >= 200 && status <= 299) {
-        transition_ret = request_commit_spans(ctx, &request, FLB_FALSE,
-                                              status, NULL);
+        transition_ret = request_commit_sources(ctx, &request, FLB_FALSE,
+                                                status, NULL);
     }
     else if (response_is_transient(ret, status)) {
         transition_ret = request_schedule_retry(ctx, &request, status);
     }
     else {
-        transition_ret = request_commit_spans(
+        transition_ret = request_commit_sources(
                             ctx, &request, FLB_TRUE, status,
                             status == 413 ? "http_413" : "permanent");
     }
@@ -2140,8 +3057,8 @@ static int upload_one(struct flb_az_li *ctx)
                       request.name, status);
     }
     pthread_mutex_unlock(&ctx->batch->manager->mutex);
-    flb_sds_destroy(request.name);
-    return transition_ret;
+    request_destroy(&request);
+    return transition_ret == 0 ? 1 : -1;
 }
 
 static void batch_timer_return(struct flb_config *config)
@@ -2154,12 +3071,6 @@ static void batch_timer_return(struct flb_config *config)
         flb_sched_timer_cb_coro_return();
         return;
     }
-
-    /* The output worker exits as soon as its last upstream becomes idle. A
-     * timer coroutine completing during shutdown must therefore publish
-     * itself directly to the drop list instead of relying on a later pipe
-     * event that the worker might never process. The worker loop performs its
-     * normal scheduler drop-list cleanup before checking whether it can exit. */
     coro = flb_coro_get();
     scheduler = flb_sched_ctx_get();
     timer_coro = coro == NULL ? NULL : coro->data;
@@ -2167,16 +3078,45 @@ static void batch_timer_return(struct flb_config *config)
         flb_sched_timer_cb_coro_return();
         return;
     }
-
     cfl_list_del(&timer_coro->_head);
     cfl_list_add(&timer_coro->_head, &scheduler->timer_coro_list_drop);
     flb_coro_yield(coro, FLB_TRUE);
+}
+
+static int batch_run_maintenance(struct flb_az_li *ctx, int recovery)
+{
+    struct azli_root_manager *manager;
+    int interval;
+
+    manager = ctx->batch->manager;
+    if (recovery) {
+        if (sql_rollback_if_active(manager) == -1 ||
+            recover_requests(ctx) == -1 || validate_source_rows(ctx) == -1) {
+            return -1;
+        }
+    }
+    interval = AZLI_MAINTENANCE_SECONDS;
+    if (ctx->buffer_receipt_ttl > 0 && ctx->buffer_receipt_ttl < interval) {
+        interval = ctx->buffer_receipt_ttl;
+    }
+    if (recovery || now_seconds() - manager->last_maintenance >= interval) {
+        if (cleanup_expired_receipts(ctx->batch->manager) == -1 ||
+            manager_maintain(manager, FLB_FALSE) < 0) {
+            return -1;
+        }
+    }
+    return 0;
 }
 
 static void batch_timer_callback(struct flb_config *config, void *data)
 {
     struct flb_az_li *ctx;
     struct flb_az_li_batch *batch;
+    int work_failed;
+    int plan_result;
+    int upload_result;
+    int uploads;
+    int index;
 
     ctx = data;
     batch = ctx->batch;
@@ -2187,7 +3127,8 @@ static void batch_timer_callback(struct flb_config *config, void *data)
 
     pthread_mutex_lock(&batch->lifecycle_mutex);
     if (config->is_running == FLB_FALSE || config->hot_reloading == FLB_TRUE ||
-        batch->shutting_down || batch->upload_in_progress || batch->fatal_error) {
+        batch->shutting_down || batch->upload_in_progress ||
+        (batch->fatal_error && now_seconds() < batch->next_recovery)) {
         pthread_mutex_unlock(&batch->lifecycle_mutex);
         batch_timer_return(config);
         return;
@@ -2195,100 +3136,127 @@ static void batch_timer_callback(struct flb_config *config, void *data)
     batch->upload_in_progress = FLB_TRUE;
     pthread_mutex_unlock(&batch->lifecycle_mutex);
 
+    work_failed = FLB_FALSE;
     pthread_mutex_lock(&batch->manager->mutex);
-    if (plan_request(ctx) == -1) {
-        flb_plg_error(ctx->ins, "could not plan durable buffered request");
+    if (batch_run_maintenance(ctx, batch->fatal_error) == -1) {
+        work_failed = FLB_TRUE;
     }
     pthread_mutex_unlock(&batch->manager->mutex);
-    if (upload_one(ctx) == -1) {
-        pthread_mutex_lock(&batch->lifecycle_mutex);
-        batch->fatal_error = FLB_TRUE;
-        pthread_mutex_unlock(&batch->lifecycle_mutex);
+
+    uploads = 0;
+    for (index = 0; !work_failed && index < AZLI_MAX_UPLOADS_PER_TICK; index++) {
+        plan_result = plan_request(ctx);
+        if (plan_result < 0) {
+            work_failed = FLB_TRUE;
+            break;
+        }
+        upload_result = upload_one(ctx);
+        if (upload_result < 0) {
+            work_failed = FLB_TRUE;
+            break;
+        }
+        if (upload_result == 0) {
+            break;
+        }
+        uploads++;
+    }
+    if (uploads > 0) {
+        flb_plg_debug(ctx->ins, "batch timer uploads=%d limit=%d",
+                      uploads, AZLI_MAX_UPLOADS_PER_TICK);
+    }
+    if (work_failed) {
         flb_plg_error(ctx->ins,
-                      "durable uploader stopped after a state persistence failure");
+                      "durable spool work failed; entering recoverable backoff");
     }
 
     pthread_mutex_lock(&batch->lifecycle_mutex);
+    if (work_failed) {
+        batch->fatal_error = FLB_TRUE;
+        batch->persistence_degraded = FLB_TRUE;
+        batch->consecutive_failures++;
+        batch->next_recovery = now_seconds() +
+                               retry_delay(ctx, batch->consecutive_failures);
+        metric_counter_add(ctx, ctx->cmt_persistence_failures, 1.0);
+    }
+    else if (batch->fatal_error) {
+        flb_plg_info(ctx->ins, "durable spool recovered without restart");
+        batch->fatal_error = FLB_FALSE;
+        batch->consecutive_failures = 0;
+        batch->next_recovery = 0;
+        if (batch->persistence_degraded) {
+            metric_counter_add(ctx, ctx->cmt_degraded_recoveries, 1.0);
+        }
+        batch->persistence_degraded = FLB_FALSE;
+    }
     batch->upload_in_progress = FLB_FALSE;
     pthread_mutex_unlock(&batch->lifecycle_mutex);
+    pthread_mutex_lock(&batch->manager->mutex);
+    metrics_refresh_locked(ctx);
+    pthread_mutex_unlock(&batch->manager->mutex);
     batch_timer_return(config);
 }
 
 int az_li_batch_init(struct flb_az_li *ctx)
 {
-    flb_sds_t root;
     struct flb_az_li_batch *batch;
     int ret;
 
+#ifndef _WIN32
+    if (mkdir(ctx->buffer_dir, 0700) == -1 && errno != EEXIST) {
+        flb_plg_error(ctx->ins, "could not create dedicated buffer_dir path=%s",
+                      ctx->buffer_dir);
+        return -1;
+    }
+#endif
     batch = flb_calloc(1, sizeof(*batch));
     if (batch == NULL) {
         return -1;
     }
-    batch->lock_fd = -1;
     pthread_mutex_init(&batch->lifecycle_mutex, NULL);
     batch->lifecycle_initialized = FLB_TRUE;
-    root = flb_sds_create_size(strlen(ctx->buffer_dir) + strlen(ctx->buffer_key) + 2);
-    if (root == NULL) {
-        goto error;
-    }
-    root = flb_sds_printf(&root, "%s/%s", ctx->buffer_dir, ctx->buffer_key);
-    if (root == NULL) {
-        goto error;
-    }
-    batch->root_path = root;
-    batch->fs = flb_fstore_create(root, FLB_FSTORE_FS);
-    if (batch->fs == NULL) {
-        goto error;
-    }
-    if (lock_spool_root(batch) == -1) {
-        flb_plg_error(ctx->ins, "buffer_key is already owned by another process");
-        goto error;
-    }
-    batch->sources = flb_fstore_stream_create(batch->fs, AZLI_SOURCE_STREAM);
-    batch->requests = flb_fstore_stream_create(batch->fs, AZLI_REQUEST_STREAM);
-    if (batch->sources == NULL || batch->requests == NULL) {
-        goto error;
-    }
     ctx->batch = batch;
     batch->manager = manager_acquire(ctx);
     if (batch->manager == NULL) {
         goto error;
     }
     pthread_mutex_lock(&batch->manager->mutex);
-    ret = instance_attach(ctx);
+    ret = manager_claim_instance(ctx);
     if (ret == 0) {
-        ret = recover_sources(ctx);
+        ret = instance_attach(ctx);
     }
     if (ret == 0) {
         ret = recover_requests(ctx);
     }
     if (ret == 0) {
-        ret = cleanup_expired_receipts(ctx);
+        ret = validate_source_rows(ctx);
     }
     if (ret == 0) {
-        ret = manager_recount(batch->manager);
+        ret = cleanup_expired_receipts(ctx->batch->manager);
+    }
+    if (ret == 0) {
+        ret = manager_maintain(batch->manager, FLB_TRUE);
+    }
+    if (ret == 0) {
+        metrics_refresh_locked(ctx);
     }
     pthread_mutex_unlock(&batch->manager->mutex);
-    if (ret == -1) {
+    if (ret < 0) {
         goto error;
     }
 
     flb_plg_info(ctx->ins,
-                 "chunk spool enabled path=%s target=%zu aggregate_limit=%zu used=%zu",
-                 root, ctx->batch_target_size, batch->manager->limit,
-                 batch->manager->used);
+                 "SQLite whole-chunk spool enabled path=%s target=%zu "
+                 "aggregate_limit=%zu logical=%zu physical=%zu",
+                 ctx->buffer_dir, ctx->batch_target_size, batch->manager->limit,
+                 batch->manager->logical_used, batch->manager->physical_used);
     return 0;
 
 error:
     if (batch->manager != NULL) {
+        pthread_mutex_lock(&batch->manager->mutex);
+        manager_release_instance(batch);
+        pthread_mutex_unlock(&batch->manager->mutex);
         manager_release(batch->manager);
-    }
-    unlock_spool_root(batch);
-    if (batch->fs != NULL) {
-        flb_fstore_destroy(batch->fs);
-    }
-    if (batch->root_path != NULL) {
-        flb_sds_destroy(batch->root_path);
     }
     if (batch->lifecycle_initialized) {
         pthread_mutex_destroy(&batch->lifecycle_mutex);
@@ -2298,9 +3266,60 @@ error:
     return -1;
 }
 
+static void uploader_start_retry_callback(struct flb_config *config, void *data)
+{
+    int shutting_down;
+    struct flb_az_li *ctx;
+    struct flb_az_li_batch *batch;
+
+    (void) config;
+    ctx = data;
+    batch = ctx->batch;
+    if (batch == NULL) {
+        return;
+    }
+
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    batch->uploader_retry_timer = NULL;
+    shutting_down = batch->shutting_down;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+    if (shutting_down == FLB_FALSE) {
+        az_li_batch_start_uploader(ctx);
+    }
+}
+
+static void uploader_start_failed(struct flb_az_li *ctx,
+                                  struct flb_sched *scheduler)
+{
+    int schedule_retry;
+    struct flb_az_li_batch *batch;
+
+    batch = ctx->batch;
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    batch->fatal_error = FLB_TRUE;
+    if (batch->consecutive_failures < INT_MAX) {
+        batch->consecutive_failures++;
+    }
+    schedule_retry = batch->uploader_retry_timer == NULL &&
+                     batch->shutting_down == FLB_FALSE;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+
+    metric_gauge_set(ctx, ctx->cmt_uploader_up, 0.0);
+    metric_gauge_set(ctx, ctx->cmt_uploader_consecutive_failures,
+                     (double) batch->consecutive_failures);
+    if (schedule_retry && scheduler != NULL &&
+        flb_sched_timer_cb_create(scheduler, FLB_SCHED_TIMER_CB_ONESHOT,
+                                  AZLI_TIMER_MS, uploader_start_retry_callback,
+                                  ctx, &batch->uploader_retry_timer) == -1) {
+        batch->uploader_retry_timer = NULL;
+        flb_plg_error(ctx->ins, "could not schedule batching uploader startup retry");
+    }
+}
+
 int az_li_batch_start_uploader(struct flb_az_li *ctx)
 {
     int ret;
+    int recovered;
     struct flb_sched *scheduler;
     struct flb_az_li_batch *batch;
 
@@ -2310,6 +3329,10 @@ int az_li_batch_start_uploader(struct flb_az_li *ctx)
     }
 
     pthread_mutex_lock(&batch->lifecycle_mutex);
+    if (batch->shutting_down == FLB_TRUE) {
+        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        return -1;
+    }
     if (batch->uploader_started == FLB_TRUE) {
         pthread_mutex_unlock(&batch->lifecycle_mutex);
         return 0;
@@ -2318,28 +3341,33 @@ int az_li_batch_start_uploader(struct flb_az_li *ctx)
 
     scheduler = flb_sched_ctx_get();
     if (scheduler == NULL) {
-        pthread_mutex_lock(&batch->lifecycle_mutex);
-        batch->fatal_error = FLB_TRUE;
-        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        uploader_start_failed(ctx, NULL);
         return -1;
     }
 
     ret = flb_sched_timer_coro_cb_create(scheduler, FLB_SCHED_TIMER_CB_PERM,
                                          AZLI_TIMER_MS, batch_timer_callback,
                                          ctx, NULL);
-    pthread_mutex_lock(&batch->lifecycle_mutex);
     if (ret == -1) {
-        batch->fatal_error = FLB_TRUE;
-        pthread_mutex_unlock(&batch->lifecycle_mutex);
+        uploader_start_failed(ctx, scheduler);
         return -1;
     }
+
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    recovered = batch->fatal_error;
     batch->uploader_started = FLB_TRUE;
     batch->fatal_error = FLB_FALSE;
+    batch->consecutive_failures = 0;
     pthread_mutex_unlock(&batch->lifecycle_mutex);
+    metric_gauge_set(ctx, ctx->cmt_uploader_up, 1.0);
+    metric_gauge_set(ctx, ctx->cmt_uploader_consecutive_failures, 0.0);
+    if (recovered) {
+        flb_plg_info(ctx->ins, "batching uploader started after retry");
+    }
     return 0;
 }
 
-void az_li_batch_destroy(struct flb_az_li *ctx)
+void az_li_batch_stop_uploader(struct flb_az_li *ctx)
 {
     struct flb_az_li_batch *batch;
 
@@ -2347,20 +3375,34 @@ void az_li_batch_destroy(struct flb_az_li *ctx)
     if (batch == NULL) {
         return;
     }
-
-    /* Buffered mode uses exactly one Fluent Bit output worker. The worker
-     * event loop drains an active upstream request before cb_worker_exit runs,
-     * and the worker pool is joined before this output exit callback. It is
-     * therefore safe to release the spool synchronously for the replacement
-     * hot-reload generation. */
     pthread_mutex_lock(&batch->lifecycle_mutex);
     batch->shutting_down = FLB_TRUE;
     pthread_mutex_unlock(&batch->lifecycle_mutex);
+}
 
+void az_li_batch_destroy(struct flb_az_li *ctx)
+{
+    int upload_in_progress;
+    struct flb_az_li_batch *batch;
+
+    batch = ctx->batch;
+    if (batch == NULL) {
+        return;
+    }
+    pthread_mutex_lock(&batch->lifecycle_mutex);
+    batch->shutting_down = FLB_TRUE;
+    upload_in_progress = batch->upload_in_progress;
+    pthread_mutex_unlock(&batch->lifecycle_mutex);
+    if (upload_in_progress == FLB_TRUE) {
+        flb_plg_error(ctx->ins,
+                      "refusing to destroy batching state during an active upload");
+        return;
+    }
+
+    pthread_mutex_lock(&batch->manager->mutex);
+    manager_release_instance(batch);
+    pthread_mutex_unlock(&batch->manager->mutex);
     manager_release(batch->manager);
-    unlock_spool_root(batch);
-    flb_fstore_destroy(batch->fs);
-    flb_sds_destroy(batch->root_path);
     pthread_mutex_destroy(&batch->lifecycle_mutex);
     flb_free(batch);
     ctx->batch = NULL;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
@@ -1,0 +1,38 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2015-2026 The Fluent Bit Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_OUT_AZURE_LOGS_INGESTION_BATCH_H
+#define FLB_OUT_AZURE_LOGS_INGESTION_BATCH_H
+
+#include <stddef.h>
+#include <fluent-bit/flb_sds.h>
+
+struct flb_az_li;
+struct flb_event_chunk;
+struct flb_output_flush;
+
+int az_li_batch_init(struct flb_az_li *ctx);
+int az_li_batch_start_uploader(struct flb_az_li *ctx);
+void az_li_batch_destroy(struct flb_az_li *ctx);
+int az_li_batch_admit_chunk(struct flb_az_li *ctx,
+                            struct flb_output_flush *out_flush,
+                            struct flb_event_chunk *event_chunk,
+                            flb_sds_t *records, size_t record_count);
+
+#endif

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_batch.h
@@ -24,15 +24,17 @@
 #include <fluent-bit/flb_sds.h>
 
 struct flb_az_li;
-struct flb_event_chunk;
 struct flb_output_flush;
 
+#ifdef FLB_HAVE_SQLDB
 int az_li_batch_init(struct flb_az_li *ctx);
 int az_li_batch_start_uploader(struct flb_az_li *ctx);
+void az_li_batch_stop_uploader(struct flb_az_li *ctx);
 void az_li_batch_destroy(struct flb_az_li *ctx);
 int az_li_batch_admit_chunk(struct flb_az_li *ctx,
                             struct flb_output_flush *out_flush,
-                            struct flb_event_chunk *event_chunk,
-                            flb_sds_t *records, size_t record_count);
+                            const void *json, size_t json_size,
+                            size_t record_count);
+#endif
 
 #endif

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -17,6 +17,8 @@
  *  limitations under the License.
  */
 
+#include <ctype.h>
+
 #include <fluent-bit/flb_output_plugin.h>
 #include <fluent-bit/flb_base64.h>
 #include <fluent-bit/flb_utils.h>
@@ -25,6 +27,108 @@
 
 #include "azure_logs_ingestion.h"
 #include "azure_logs_ingestion_conf.h"
+#include "azure_logs_ingestion_batch.h"
+
+#ifdef FLB_HAVE_METRICS
+/* Keep the 200 KiB boundary explicit for the small-request percentage. */
+static const double payload_size_buckets[] = {
+    16384.0,
+    32768.0,
+    65536.0,
+    131072.0,
+    204800.0,
+    262144.0,
+    524288.0,
+    786432.0,
+    900000.0,
+    1048576.0,
+    2097152.0,
+    4194304.0,
+    8388608.0,
+    16777216.0
+};
+
+static int initialize_payload_size_metrics(struct flb_az_li *ctx)
+{
+    size_t bucket_count;
+    struct cmt_histogram_buckets *buckets;
+
+    bucket_count = sizeof(payload_size_buckets) / sizeof(payload_size_buckets[0]);
+    buckets = cmt_histogram_buckets_create_size(
+                    (double *) payload_size_buckets, bucket_count);
+    if (buckets == NULL) {
+        flb_plg_error(ctx->ins, "could not create uncompressed payload size buckets");
+        return -1;
+    }
+
+    ctx->cmt_uncompressed_payload_size = cmt_histogram_create(
+                    ctx->ins->cmt,
+                    "fluentbit",
+                    "azure_logs_ingestion",
+                    "uncompressed_payload_size_bytes",
+                    "Uncompressed request payload size in bytes.",
+                    buckets,
+                    2, (char *[]) {"name", "dcr_id"});
+    if (ctx->cmt_uncompressed_payload_size == NULL) {
+        flb_plg_error(ctx->ins, "could not create uncompressed payload size histogram");
+        return -1;
+    }
+
+    buckets = cmt_histogram_buckets_create_size(
+                    (double *) payload_size_buckets, bucket_count);
+    if (buckets == NULL) {
+        flb_plg_error(ctx->ins, "could not create HTTP payload size buckets");
+        return -1;
+    }
+
+    ctx->cmt_http_payload_size = cmt_histogram_create(
+                    ctx->ins->cmt,
+                    "fluentbit",
+                    "azure_logs_ingestion",
+                    "http_payload_size_bytes",
+                    "HTTP request payload size in bytes.",
+                    buckets,
+                    2, (char *[]) {"name", "dcr_id"});
+    if (ctx->cmt_http_payload_size == NULL) {
+        flb_plg_error(ctx->ins, "could not create HTTP payload size histogram");
+        return -1;
+    }
+
+    ctx->cmt_http_payload_size_min = cmt_gauge_create(
+                    ctx->ins->cmt,
+                    "fluentbit",
+                    "azure_logs_ingestion",
+                    "http_payload_size_min_bytes",
+                    "Minimum HTTP request payload size observed since process start.",
+                    2, (char *[]) {"name", "dcr_id"});
+    if (ctx->cmt_http_payload_size_min == NULL) {
+        flb_plg_error(ctx->ins, "could not create HTTP payload minimum gauge");
+        return -1;
+    }
+
+    ctx->http_payload_size_min = SIZE_MAX;
+    return 0;
+}
+#endif
+
+static int validate_buffer_key(const char *key)
+{
+    const unsigned char *cursor;
+
+    if (key == NULL || key[0] == '\0' ||
+        strcmp(key, ".") == 0 || strcmp(key, "..") == 0) {
+        return -1;
+    }
+
+    cursor = (const unsigned char *) key;
+    while (*cursor != '\0') {
+        if (!isalnum(*cursor) && *cursor != '-' && *cursor != '_' && *cursor != '.') {
+            return -1;
+        }
+        cursor++;
+    }
+    return 0;
+}
 
 static int validate_auth_url_override(struct flb_output_instance *ins,
                                       flb_sds_t auth_url_override)
@@ -145,6 +249,71 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         return NULL;
     }
 
+    if (ctx->buffering_enabled == FLB_TRUE) {
+#ifdef _WIN32
+        flb_plg_error(ins, "buffering_enabled is not supported on Windows because "
+                           "cross-process spool locking is unavailable");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+#endif
+        if (ctx->compress_enabled != FLB_TRUE) {
+            flb_plg_error(ins, "buffering_enabled requires compress=true");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->batch_target_size == 0 ||
+            ctx->batch_target_size > FLB_AZ_LI_MAX_REQUEST_SIZE) {
+            flb_plg_error(ins,
+                          "batch_target_size must be between 1 and %d bytes",
+                          FLB_AZ_LI_MAX_REQUEST_SIZE);
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->batch_timeout <= 0 || ctx->batch_max_uncompressed_size == 0) {
+            flb_plg_error(ins, "batch timeout and uncompressed size must be positive");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->buffer_dir_limit_size == 0) {
+            flb_plg_error(ins,
+                          "buffer_dir_limit_size is required when buffering is enabled");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->buffer_dir_limit_size < FLB_AZ_LI_MIN_BUFFER_SIZE) {
+            flb_plg_error(ins,
+                          "buffer_dir_limit_size must be at least %d bytes to leave "
+                          "request construction headroom",
+                          FLB_AZ_LI_MIN_BUFFER_SIZE);
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->upload_retry_limit < 0 || ctx->upload_retry_base <= 0 ||
+            ctx->buffer_receipt_ttl < 0 || ctx->http_timeout <= 0) {
+            flb_plg_error(ins, "retry, receipt TTL and HTTP timeout values are invalid");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ctx->buffer_key == NULL) {
+            ctx->buffer_key = flb_sds_create_size(flb_sds_len(ctx->dcr_id) +
+                                                  flb_sds_len(ctx->table_name) + 2);
+            if (ctx->buffer_key == NULL) {
+                flb_az_li_ctx_destroy(ctx);
+                return NULL;
+            }
+            flb_sds_snprintf(&ctx->buffer_key, flb_sds_alloc(ctx->buffer_key),
+                             "%s-%s", ctx->dcr_id, ctx->table_name);
+            ctx->buffer_key_owned = FLB_TRUE;
+        }
+        if (validate_buffer_key(ctx->buffer_key) == -1) {
+            flb_plg_error(ins,
+                          "buffer_key must be a non-special path component containing "
+                          "only letters, digits, '.', '_' and '-'");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+    }
+
     if (ctx->auth_url_override) {
         ret = validate_auth_url_override(ins, ctx->auth_url_override);
         if (ret == -1) {
@@ -186,8 +355,29 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
                     FLB_AZ_LI_DCE_URL_TMPLT, ctx->dce_url, 
                     ctx->dcr_id, ctx->table_name);
 
+#ifdef FLB_HAVE_METRICS
+    ret = pthread_mutex_init(&ctx->payload_metrics_mutex, NULL);
+    if (ret != 0) {
+        flb_plg_error(ins, "could not initialize payload metrics mutex");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+    ctx->payload_metrics_mutex_initialized = FLB_TRUE;
+    ret = initialize_payload_size_metrics(ctx);
+    if (ret == -1) {
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+#endif
+
     /* Initialize the auth mutex */
-    pthread_mutex_init(&ctx->token_mutex, NULL);
+    ret = pthread_mutex_init(&ctx->token_mutex, NULL);
+    if (ret != 0) {
+        flb_plg_error(ins, "could not initialize token mutex");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+    }
+    ctx->token_mutex_initialized = FLB_TRUE;
 
     /* Create oauth2 context */
     ctx->u_auth = flb_oauth2_create(config, ctx->auth_url,
@@ -221,6 +411,10 @@ int flb_az_li_ctx_destroy(struct flb_az_li *ctx)
         return -1;
     }
 
+    if (ctx->batch) {
+        az_li_batch_destroy(ctx);
+    }
+
     if (ctx->auth_url) {
         flb_sds_destroy(ctx->auth_url);
     }
@@ -236,6 +430,17 @@ int flb_az_li_ctx_destroy(struct flb_az_li *ctx)
     if (ctx->u_dce) {
         flb_upstream_destroy(ctx->u_dce);
     }
+    if (ctx->token_mutex_initialized == FLB_TRUE) {
+        pthread_mutex_destroy(&ctx->token_mutex);
+    }
+    if (ctx->buffer_key && ctx->buffer_key_owned == FLB_TRUE) {
+        flb_sds_destroy(ctx->buffer_key);
+    }
+#ifdef FLB_HAVE_METRICS
+    if (ctx->payload_metrics_mutex_initialized == FLB_TRUE) {
+        pthread_mutex_destroy(&ctx->payload_metrics_mutex);
+    }
+#endif
     flb_free(ctx);
 
     return 0;

--- a/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
+++ b/plugins/out_azure_logs_ingestion/azure_logs_ingestion_conf.c
@@ -32,8 +32,6 @@
 #ifdef FLB_HAVE_METRICS
 /* Keep the 200 KiB boundary explicit for the small-request percentage. */
 static const double payload_size_buckets[] = {
-    16384.0,
-    32768.0,
     65536.0,
     131072.0,
     204800.0,
@@ -48,7 +46,23 @@ static const double payload_size_buckets[] = {
     16777216.0
 };
 
-static int initialize_payload_size_metrics(struct flb_az_li *ctx)
+static struct cmt_counter *create_counter(struct flb_az_li *ctx,
+                                          const char *name, const char *help)
+{
+    return cmt_counter_create(ctx->ins->cmt, "fluentbit", "azure_logs_ingestion",
+                              (char *) name, (char *) help,
+                              2, (char *[]) {"name", "dcr_id"});
+}
+
+static struct cmt_gauge *create_gauge(struct flb_az_li *ctx,
+                                      const char *name, const char *help)
+{
+    return cmt_gauge_create(ctx->ins->cmt, "fluentbit", "azure_logs_ingestion",
+                            (char *) name, (char *) help,
+                            2, (char *[]) {"name", "dcr_id"});
+}
+
+static void initialize_payload_size_metrics(struct flb_az_li *ctx)
 {
     size_t bucket_count;
     struct cmt_histogram_buckets *buckets;
@@ -56,58 +70,74 @@ static int initialize_payload_size_metrics(struct flb_az_li *ctx)
     bucket_count = sizeof(payload_size_buckets) / sizeof(payload_size_buckets[0]);
     buckets = cmt_histogram_buckets_create_size(
                     (double *) payload_size_buckets, bucket_count);
-    if (buckets == NULL) {
-        flb_plg_error(ctx->ins, "could not create uncompressed payload size buckets");
-        return -1;
-    }
-
-    ctx->cmt_uncompressed_payload_size = cmt_histogram_create(
-                    ctx->ins->cmt,
-                    "fluentbit",
-                    "azure_logs_ingestion",
+    if (buckets != NULL) {
+        ctx->cmt_uncompressed_payload_size = cmt_histogram_create(
+                    ctx->ins->cmt, "fluentbit", "azure_logs_ingestion",
                     "uncompressed_payload_size_bytes",
-                    "Uncompressed request payload size in bytes.",
-                    buckets,
+                    "Uncompressed request payload size in bytes.", buckets,
                     2, (char *[]) {"name", "dcr_id"});
-    if (ctx->cmt_uncompressed_payload_size == NULL) {
-        flb_plg_error(ctx->ins, "could not create uncompressed payload size histogram");
-        return -1;
+        if (ctx->cmt_uncompressed_payload_size == NULL) {
+            cmt_histogram_buckets_destroy(buckets);
+        }
     }
-
     buckets = cmt_histogram_buckets_create_size(
                     (double *) payload_size_buckets, bucket_count);
-    if (buckets == NULL) {
-        flb_plg_error(ctx->ins, "could not create HTTP payload size buckets");
-        return -1;
+    if (buckets != NULL) {
+        ctx->cmt_http_payload_size = cmt_histogram_create(
+                    ctx->ins->cmt, "fluentbit", "azure_logs_ingestion",
+                    "http_payload_size_bytes", "HTTP request payload size in bytes.",
+                    buckets, 2, (char *[]) {"name", "dcr_id"});
+        if (ctx->cmt_http_payload_size == NULL) {
+            cmt_histogram_buckets_destroy(buckets);
+        }
     }
 
-    ctx->cmt_http_payload_size = cmt_histogram_create(
-                    ctx->ins->cmt,
-                    "fluentbit",
-                    "azure_logs_ingestion",
-                    "http_payload_size_bytes",
-                    "HTTP request payload size in bytes.",
-                    buckets,
-                    2, (char *[]) {"name", "dcr_id"});
-    if (ctx->cmt_http_payload_size == NULL) {
-        flb_plg_error(ctx->ins, "could not create HTTP payload size histogram");
-        return -1;
-    }
+    ctx->cmt_admitted_chunks = create_counter(ctx, "admitted_chunks_total",
+                                               "Chunks durably admitted locally.");
+    ctx->cmt_admitted_records = create_counter(ctx, "admitted_records_total",
+                                                "Records durably admitted locally.");
+    ctx->cmt_admitted_bytes = create_counter(ctx, "admitted_bytes_total",
+                                              "JSON bytes durably admitted locally.");
+    ctx->cmt_delivered_chunks = create_counter(ctx, "delivered_chunks_total",
+                                                "Chunks accepted by Azure.");
+    ctx->cmt_delivered_records = create_counter(ctx, "delivered_records_total",
+                                                 "Records accepted by Azure.");
+    ctx->cmt_delivered_bytes = create_counter(ctx, "delivered_bytes_total",
+                                               "JSON bytes accepted by Azure.");
+    ctx->cmt_quarantined_chunks = create_counter(ctx, "quarantined_chunks_total",
+                                                  "Chunks newly quarantined.");
+    ctx->cmt_quarantined_records = create_counter(ctx, "quarantined_records_total",
+                                                   "Records newly quarantined.");
+    ctx->cmt_quota_rejections = create_counter(ctx, "quota_rejections_total",
+                                                "Chunk admissions rejected by quota.");
+    ctx->cmt_persistence_failures = create_counter(ctx, "persistence_failures_total",
+                                                    "Local persistence failures.");
+    ctx->cmt_degraded_recoveries = create_counter(ctx, "degraded_recoveries_total",
+                                                   "Recoveries from degraded state.");
+    ctx->cmt_queued_chunks = create_gauge(ctx, "queued_chunks", "Queued chunks.");
+    ctx->cmt_queued_records = create_gauge(ctx, "queued_records", "Queued records.");
+    ctx->cmt_queued_bytes = create_gauge(ctx, "queued_bytes", "Queued JSON bytes.");
+    ctx->cmt_quarantined_chunks_current = create_gauge(
+                    ctx, "quarantined_chunks", "Currently quarantined chunks.");
+    ctx->cmt_quarantined_bytes = create_gauge(
+                    ctx, "quarantined_bytes", "Currently quarantined JSON bytes.");
+    ctx->cmt_quota_used_bytes = create_gauge(
+                    ctx, "quota_used_bytes", "Logical spool quota used in bytes.");
+    ctx->cmt_quota_limit_bytes = create_gauge(
+                    ctx, "quota_limit_bytes", "Configured spool quota in bytes.");
+    ctx->cmt_oldest_queued_age = create_gauge(
+                    ctx, "oldest_queued_age_seconds", "Age of oldest queued chunk.");
+    ctx->cmt_uploader_up = create_gauge(ctx, "uploader_up", "Uploader health state.");
+    ctx->cmt_uploader_consecutive_failures = create_gauge(
+                    ctx, "uploader_consecutive_failures", "Consecutive local failures.");
+    ctx->cmt_uploader_last_success = create_gauge(
+                    ctx, "uploader_last_success_timestamp_seconds",
+                    "Unix timestamp of last durable Azure success.");
 
-    ctx->cmt_http_payload_size_min = cmt_gauge_create(
-                    ctx->ins->cmt,
-                    "fluentbit",
-                    "azure_logs_ingestion",
-                    "http_payload_size_min_bytes",
-                    "Minimum HTTP request payload size observed since process start.",
-                    2, (char *[]) {"name", "dcr_id"});
-    if (ctx->cmt_http_payload_size_min == NULL) {
-        flb_plg_error(ctx->ins, "could not create HTTP payload minimum gauge");
-        return -1;
+    if (ctx->cmt_uncompressed_payload_size == NULL ||
+        ctx->cmt_http_payload_size == NULL) {
+        flb_plg_warn(ctx->ins, "payload size metrics are unavailable");
     }
-
-    ctx->http_payload_size_min = SIZE_MAX;
-    return 0;
 }
 #endif
 
@@ -189,6 +219,7 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
 {
     int ret;
     struct flb_az_li *ctx;
+    struct flb_oauth2_config oauth2_config;
     (void) ins;
     (void) config;
 
@@ -250,6 +281,12 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     }
 
     if (ctx->buffering_enabled == FLB_TRUE) {
+#ifndef FLB_HAVE_SQLDB
+        flb_plg_error(ins,
+                      "buffering_enabled requires a build with FLB_SQLDB=On");
+        flb_az_li_ctx_destroy(ctx);
+        return NULL;
+#endif
 #ifdef _WIN32
         flb_plg_error(ins, "buffering_enabled is not supported on Windows because "
                            "cross-process spool locking is unavailable");
@@ -258,6 +295,13 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
 #endif
         if (ctx->compress_enabled != FLB_TRUE) {
             flb_plg_error(ins, "buffering_enabled requires compress=true");
+            flb_az_li_ctx_destroy(ctx);
+            return NULL;
+        }
+        if (ins->retry_limit != FLB_OUT_RETRY_UNLIMITED) {
+            flb_plg_error(ins,
+                          "buffering_enabled requires retry_limit=no_limits so "
+                          "pre-ownership retries cannot be dropped");
             flb_az_li_ctx_destroy(ctx);
             return NULL;
         }
@@ -289,7 +333,7 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
             return NULL;
         }
         if (ctx->upload_retry_limit < 0 || ctx->upload_retry_base <= 0 ||
-            ctx->buffer_receipt_ttl < 0 || ctx->http_timeout <= 0) {
+            ctx->buffer_receipt_ttl <= 0 || ctx->http_timeout <= 0) {
             flb_plg_error(ins, "retry, receipt TTL and HTTP timeout values are invalid");
             flb_az_li_ctx_destroy(ctx);
             return NULL;
@@ -357,16 +401,12 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
 
 #ifdef FLB_HAVE_METRICS
     ret = pthread_mutex_init(&ctx->payload_metrics_mutex, NULL);
-    if (ret != 0) {
-        flb_plg_error(ins, "could not initialize payload metrics mutex");
-        flb_az_li_ctx_destroy(ctx);
-        return NULL;
+    if (ret == 0) {
+        ctx->payload_metrics_mutex_initialized = FLB_TRUE;
+        initialize_payload_size_metrics(ctx);
     }
-    ctx->payload_metrics_mutex_initialized = FLB_TRUE;
-    ret = initialize_payload_size_metrics(ctx);
-    if (ret == -1) {
-        flb_az_li_ctx_destroy(ctx);
-        return NULL;
+    else {
+        flb_plg_warn(ins, "payload and lifecycle metrics are unavailable");
     }
 #endif
 
@@ -380,8 +420,19 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
     ctx->token_mutex_initialized = FLB_TRUE;
 
     /* Create oauth2 context */
-    ctx->u_auth = flb_oauth2_create(config, ctx->auth_url,
-                                    FLB_AZ_LI_TOKEN_TIMEOUT);
+    if (ctx->buffering_enabled == FLB_TRUE) {
+        memset(&oauth2_config, 0, sizeof(oauth2_config));
+        oauth2_config.enabled = FLB_TRUE;
+        oauth2_config.auth_method = FLB_OAUTH2_AUTH_METHOD_BASIC;
+        oauth2_config.token_url = ctx->auth_url;
+        oauth2_config.timeout = ctx->http_timeout;
+        oauth2_config.connect_timeout = ctx->http_timeout;
+        ctx->u_auth = flb_oauth2_create_from_config(config, &oauth2_config);
+    }
+    else {
+        ctx->u_auth = flb_oauth2_create(config, ctx->auth_url,
+                                        FLB_AZ_LI_TOKEN_TIMEOUT);
+    }
     if (!ctx->u_auth) {
         flb_plg_error(ins, "cannot create oauth2 context");
         flb_az_li_ctx_destroy(ctx);
@@ -397,6 +448,9 @@ struct flb_az_li* flb_az_li_ctx_create(struct flb_output_instance *ins,
         return NULL;
     }
     flb_output_upstream_set(ctx->u_dce, ins);
+    if (ctx->buffering_enabled == FLB_TRUE) {
+        ctx->u_dce->base.net.connect_timeout = ctx->http_timeout;
+    }
 
     flb_plg_info(ins, "dce_url='%s', dcr='%s', table='%s', stream='Custom-%s'",
                 ctx->dce_url, ctx->dcr_id, ctx->table_name, ctx->table_name);
@@ -411,9 +465,11 @@ int flb_az_li_ctx_destroy(struct flb_az_li *ctx)
         return -1;
     }
 
+#ifdef FLB_HAVE_SQLDB
     if (ctx->batch) {
         az_li_batch_destroy(ctx);
     }
+#endif
 
     if (ctx->auth_url) {
         flb_sds_destroy(ctx->auth_url);

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -454,6 +454,13 @@ Covers:
 
 - Azure Logs Ingestion delivery with OAuth2
 - token and data-plane request validation
+- uncompressed and HTTP request payload-size histograms
+- opt-in immutable chunk spooling and batching across engine flushes
+- exact persisted gzip artifacts, record-span rollover, and timeout flushing
+- byte-identical retry across SIGKILL, durable terminal quarantine, and recovery
+- aggregate disk quota enforcement and cross-process spool ownership exclusion
+- queued, repeated, suspended-upload, and high-volume hot-reload handoff
+- 100,000-record high-volume delivery and bounded suspended-upload shutdown
 
 ### `out_kafka`
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -455,11 +455,16 @@ Covers:
 - Azure Logs Ingestion delivery with OAuth2
 - token and data-plane request validation
 - uncompressed and HTTP request payload-size histograms
-- opt-in immutable chunk spooling and batching across engine flushes
-- exact persisted gzip artifacts, record-span rollover, and timeout flushing
+- opt-in SQLite-only whole-chunk spooling and batching across engine flushes
+- required unlimited engine retry ownership before SQLite admission
+- exact persisted gzip BLOBs, bounded whole-chunk probes, rollover, and timeout flushing
 - byte-identical retry across SIGKILL, durable terminal quarantine, and recovery
-- aggregate disk quota enforcement and cross-process spool ownership exclusion
+- aggregate quota enforcement, reservation safety, and spool ownership exclusion
+- admission, delivery, quarantine, queue, quota, and uploader lifecycle metrics
+  (counters are process-lifetime; durable-state gauges reconstruct after restart)
+- fail-closed rejection of the incompatible record-range prototype spool schema
 - queued, repeated, suspended-upload, and high-volume hot-reload handoff
+- bounded buffered OAuth and data-plane shutdown during suspended responses
 - 100,000-record high-volume delivery and bounded suspended-upload shutdown
 
 ### `out_kafka`

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering.yaml
@@ -1,0 +1,39 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: http
+      tag: azure_logs_ingestion
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure_logs_ingestion
+      log_level: debug
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      buffering_enabled: on
+      buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
+      buffer_key: ${AZURE_LOGS_INGESTION_BUFFER_KEY}
+      batch_target_size: 3000
+      batch_timeout: 5s
+      batch_max_uncompressed_size: 64K
+      buffer_dir_limit_size: ${AZURE_LOGS_INGESTION_BUFFER_LIMIT}
+      upload_retry_limit: 5
+      upload_retry_base: 1
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering.yaml
@@ -33,6 +33,7 @@ pipeline:
       buffer_dir_limit_size: ${AZURE_LOGS_INGESTION_BUFFER_LIMIT}
       upload_retry_limit: 5
       upload_retry_base: 1
+      retry_limit: no_limits
       tls.verify: on
       tls.verify_hostname: on
       tls.vhost: localhost

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_default_sizes.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_default_sizes.yaml
@@ -1,0 +1,38 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: http
+      tag: azure_logs_ingestion
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure_logs_ingestion
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      buffering_enabled: on
+      buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
+      buffer_key: suite-default-sizes
+      batch_target_size: 900000
+      batch_timeout: 15s
+      batch_max_uncompressed_size: 16M
+      buffer_dir_limit_size: 64M
+      upload_retry_limit: 5
+      upload_retry_base: 1
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_default_sizes.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_default_sizes.yaml
@@ -11,10 +11,12 @@ pipeline:
       port: ${FLUENT_BIT_TEST_LISTENER_PORT}
       http2: off
       tls: off
+      buffer_max_size: 4M
 
   outputs:
     - name: azure_logs_ingestion
       match: azure_logs_ingestion
+      log_level: debug
       tenant_id: suite-tenant
       client_id: suite-client
       client_secret: suite-secret
@@ -32,6 +34,7 @@ pipeline:
       buffer_dir_limit_size: 64M
       upload_retry_limit: 5
       upload_retry_base: 1
+      retry_limit: no_limits
       tls.verify: on
       tls.verify_hostname: on
       tls.vhost: localhost

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_high_volume.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_high_volume.yaml
@@ -1,0 +1,45 @@
+service:
+  flush: 1
+  grace: 10
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: azure_logs_ingestion
+      dummy: '{"message":"high-volume batching regression"}'
+      rate: 100000
+      samples: 100000
+
+  filters:
+    - name: record_modifier
+      match: azure_logs_ingestion
+      uuid_key: id
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure_logs_ingestion
+      log_level: debug
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      buffering_enabled: on
+      buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
+      buffer_key: suite-high-volume
+      batch_target_size: 900000
+      batch_timeout: 5s
+      batch_max_uncompressed_size: 16M
+      buffer_dir_limit_size: 128M
+      upload_retry_limit: 5
+      upload_retry_base: 1
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_high_volume.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_high_volume.yaml
@@ -39,6 +39,7 @@ pipeline:
       buffer_dir_limit_size: 128M
       upload_retry_limit: 5
       upload_retry_base: 1
+      retry_limit: no_limits
       tls.verify: on
       tls.verify_hostname: on
       tls.vhost: localhost

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_shared_quota.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_shared_quota.yaml
@@ -1,0 +1,69 @@
+service:
+  flush: 1
+  grace: 10
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: azure_logs_ingestion
+      dummy: '{"message":"shared aggregate quota"}'
+      rate: 1000
+      samples: 1000
+
+  filters:
+    - name: record_modifier
+      match: azure_logs_ingestion
+      uuid_key: id
+
+  outputs:
+    - name: azure_logs_ingestion
+      alias: quota-a
+      match: azure_logs_ingestion
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      buffering_enabled: on
+      buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
+      buffer_key: quota-a
+      batch_target_size: 50000
+      batch_timeout: 2s
+      batch_max_uncompressed_size: 2M
+      buffer_dir_limit_size: 1450000
+      upload_retry_limit: 5
+      upload_retry_base: 1
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}
+    - name: azure_logs_ingestion
+      alias: quota-b
+      match: azure_logs_ingestion
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      buffering_enabled: on
+      buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
+      buffer_key: quota-b
+      batch_target_size: 50000
+      batch_timeout: 2s
+      batch_max_uncompressed_size: 2M
+      buffer_dir_limit_size: 1450000
+      upload_retry_limit: 5
+      upload_retry_base: 1
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_shared_quota.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_shared_quota.yaml
@@ -36,9 +36,10 @@ pipeline:
       batch_target_size: 50000
       batch_timeout: 2s
       batch_max_uncompressed_size: 2M
-      buffer_dir_limit_size: 1450000
+      buffer_dir_limit_size: 1250000
       upload_retry_limit: 5
       upload_retry_base: 1
+      retry_limit: no_limits
       tls.verify: on
       tls.verify_hostname: on
       tls.vhost: localhost
@@ -56,13 +57,14 @@ pipeline:
       compress: on
       buffering_enabled: on
       buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
-      buffer_key: quota-b
+      buffer_key: ${AZURE_LOGS_INGESTION_SECOND_BUFFER_KEY}
       batch_target_size: 50000
       batch_timeout: 2s
       batch_max_uncompressed_size: 2M
-      buffer_dir_limit_size: 1450000
+      buffer_dir_limit_size: 1250000
       upload_retry_limit: 5
       upload_retry_base: 1
+      retry_limit: no_limits
       tls.verify: on
       tls.verify_hostname: on
       tls.vhost: localhost

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_short_timeout.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_short_timeout.yaml
@@ -1,0 +1,40 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: http
+      tag: azure_logs_ingestion
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure_logs_ingestion
+      log_level: debug
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      buffering_enabled: on
+      buffer_dir: ${AZURE_LOGS_INGESTION_BUFFER_DIR}
+      buffer_key: ${AZURE_LOGS_INGESTION_BUFFER_KEY}
+      batch_target_size: 3000
+      batch_timeout: 5s
+      batch_max_uncompressed_size: 64K
+      buffer_dir_limit_size: ${AZURE_LOGS_INGESTION_BUFFER_LIMIT}
+      upload_retry_limit: 5
+      upload_retry_base: 1
+      http_timeout: 3s
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_short_timeout.yaml
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_buffering_short_timeout.yaml
@@ -33,6 +33,7 @@ pipeline:
       buffer_dir_limit_size: ${AZURE_LOGS_INGESTION_BUFFER_LIMIT}
       upload_retry_limit: 5
       upload_retry_base: 1
+      retry_limit: no_limits
       http_timeout: 3s
       tls.verify: on
       tls.verify_hostname: on

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1,6 +1,14 @@
+import base64
 import logging
 import os
+import random
+import re
+import signal
+import sqlite3
+import tempfile
+import time
 
+import pytest
 import requests
 
 from server.http_server import (
@@ -9,18 +17,68 @@ from server.http_server import (
     data_storage,
     http_server_run,
 )
+from utils.fluent_bit_manager import FluentBitStartupError
 from utils.test_service import FluentBitTestService
 
 logger = logging.getLogger(__name__)
 
+METRIC_RE = re.compile(
+    r'^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)\{(?P<labels>[^}]*)\}\s+'
+    r'(?P<value>[-+0-9.eE]+)$'
+)
+UNCOMPRESSED_PAYLOAD_SIZE_METRIC = (
+    "fluentbit_azure_logs_ingestion_uncompressed_payload_size_bytes"
+)
+HTTP_PAYLOAD_SIZE_METRIC = "fluentbit_azure_logs_ingestion_http_payload_size_bytes"
+HTTP_PAYLOAD_SIZE_MIN_METRIC = "fluentbit_azure_logs_ingestion_http_payload_size_min_bytes"
+SMALL_REQUEST_BUCKET = "204800.0"
+
+
+def _labels_to_dict(labels):
+    result = {}
+    for item in labels.split(","):
+        key, value = item.split("=", 1)
+        result[key] = value.strip('"')
+    return result
+
+
+def _metric_value(metrics, metric_name, **labels):
+    for line in metrics.splitlines():
+        match = METRIC_RE.match(line)
+        if not match or match.group("name") != metric_name:
+            continue
+        if _labels_to_dict(match.group("labels")) == labels:
+            return float(match.group("value"))
+    return None
+
 
 class Service:
-    def __init__(self, config_file):
-        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+    def __init__(
+        self,
+        config_file,
+        buffer_dir=None,
+        buffer_limit="4M",
+        buffer_key="suite-buffer",
+        initial_http_status=None,
+        receiver_port=None,
+    ):
+        if os.path.isabs(config_file):
+            self.config_file = config_file
+        else:
+            self.config_file = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "../config", config_file)
+            )
         cert_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate"))
         self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
         self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
         self.oauth_server_port = None
+        self.buffer_dir_owner = None
+        self.initial_http_status = initial_http_status
+        self.receiver_port = receiver_port
+        if buffer_dir is None:
+            self.buffer_dir_owner = tempfile.TemporaryDirectory(prefix="azure-li-batch-")
+            buffer_dir = self.buffer_dir_owner.name
+        self.buffer_dir = buffer_dir
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
@@ -28,12 +86,19 @@ class Service:
             extra_env={
                 "CERTIFICATE_TEST": self.tls_crt_file,
                 "PRIVATE_KEY_TEST": self.tls_key_file,
+                "AZURE_LOGS_INGESTION_BUFFER_DIR": self.buffer_dir,
+                "AZURE_LOGS_INGESTION_BUFFER_LIMIT": buffer_limit,
+                "AZURE_LOGS_INGESTION_BUFFER_KEY": buffer_key,
             },
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
         )
 
     def _start_receiver(self, service):
+        if self.receiver_port is not None:
+            service.test_suite_http_port = self.receiver_port
+            service._allocated_ports.add(self.receiver_port)
+            service._set_env("TEST_SUITE_HTTP_PORT", str(self.receiver_port))
         self.oauth_server_port = service.allocate_port_env("TEST_SUITE_OAUTH_PORT")
         http_server_run(self.oauth_server_port)
         http_server_run(
@@ -43,6 +108,8 @@ class Service:
             tls_key_file=self.tls_key_file,
             reset_state=False,
         )
+        if self.initial_http_status is not None:
+            configure_http_response(status_code=self.initial_http_status)
 
         def _http_ready():
             try:
@@ -106,6 +173,8 @@ class Service:
 
     def stop(self):
         self.service.stop()
+        if self.buffer_dir_owner is not None:
+            self.buffer_dir_owner.cleanup()
 
     def wait_for_requests(self, minimum_count, timeout=10):
         return self.service.wait_for_condition(
@@ -113,6 +182,41 @@ class Service:
             timeout=timeout,
             interval=0.5,
             description=f"{minimum_count} azure logs ingestion requests",
+        )
+
+    def metrics(self, expected, timeout=10):
+        url = (
+            f"http://127.0.0.1:{self.flb.http_monitoring_port}"
+            "/api/v2/metrics/prometheus"
+        )
+
+        def _expected_metric():
+            response = requests.get(url, timeout=2)
+            if response.status_code == 200 and expected in response.text:
+                return response.text
+            return None
+
+        return self.service.wait_for_condition(
+            _expected_metric,
+            timeout=timeout,
+            interval=0.5,
+            description=f"Prometheus metric {expected}",
+        )
+
+    def wait_for_log(self, text, timeout=10):
+        def _contains_text():
+            log_file = self.service.flb.log_file
+            if not log_file or not os.path.exists(log_file):
+                return None
+            with open(log_file, "r", encoding="utf-8", errors="replace") as handle:
+                contents = handle.read()
+            return contents if text in contents else None
+
+        return self.service.wait_for_condition(
+            _contains_text,
+            timeout=timeout,
+            interval=0.5,
+            description=f"Fluent Bit log containing {text!r}",
         )
 
 
@@ -154,3 +258,1202 @@ def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
     assert payload[0]["source"] == "dummy"
     assert payload[0]["level"] == "info"
     assert isinstance(payload[0]["@timestamp"], (int, float))
+
+
+def test_out_azure_logs_ingestion_reports_payload_size_histograms():
+    service = Service(
+        "out_azure_logs_ingestion_oauth2.yaml",
+        initial_http_status=500,
+    )
+    service.start()
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        service.wait_for_requests(2, timeout=15)
+        configure_http_response(status_code=200, body={"status": "received"})
+        requests_seen = service.wait_for_requests(3, timeout=15)
+        metrics = service.metrics(
+            f'{HTTP_PAYLOAD_SIZE_METRIC}_count{{name="azure_logs_ingestion.0",'
+            f'dcr_id="dcr-suite"}} 2'
+        )
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    output_name = "azure_logs_ingestion.0"
+    metric_labels = {"name": output_name, "dcr_id": "dcr-suite"}
+    expected_uncompressed_size = sum(
+        len(request["decoded_data"].encode("utf-8")) for request in data_requests
+    )
+    expected_http_size = sum(
+        int(request["headers"]["Content-Length"]) for request in data_requests
+    )
+
+    assert len(data_requests) == 2
+    for metric_name, expected_size in (
+        (UNCOMPRESSED_PAYLOAD_SIZE_METRIC, expected_uncompressed_size),
+        (HTTP_PAYLOAD_SIZE_METRIC, expected_http_size),
+    ):
+        assert f"# TYPE {metric_name} histogram" in metrics
+        assert _metric_value(metrics, f"{metric_name}_count", **metric_labels) == 2
+        assert _metric_value(metrics, f"{metric_name}_sum", **metric_labels) == expected_size
+        assert _metric_value(
+            metrics,
+            f"{metric_name}_bucket",
+            le=SMALL_REQUEST_BUCKET,
+            **metric_labels,
+        ) == 2
+
+    assert _metric_value(
+        metrics, HTTP_PAYLOAD_SIZE_MIN_METRIC, **metric_labels
+    ) == min(int(request["headers"]["Content-Length"]) for request in data_requests)
+
+
+@pytest.mark.parametrize("buffer_key", [".", ".."])
+def test_out_azure_logs_ingestion_rejects_special_buffer_keys(buffer_key):
+    service = Service(
+        "out_azure_logs_ingestion_buffering.yaml",
+        buffer_key=buffer_key,
+    )
+    try:
+        with pytest.raises(FluentBitStartupError):
+            service.start()
+    finally:
+        service.stop()
+
+
+def test_out_azure_logs_ingestion_rejects_multiple_buffer_workers():
+    config_path = _hot_reload_config()
+    with open(config_path, encoding="utf-8") as handle:
+        config = handle.read()
+    config = config.replace(
+        "      buffering_enabled: on\n",
+        "      buffering_enabled: on\n      workers: 2\n",
+        1,
+    )
+    with open(config_path, "w", encoding="utf-8") as handle:
+        handle.write(config)
+
+    service = Service(config_path)
+    try:
+        with pytest.raises(FluentBitStartupError):
+            service.start()
+    finally:
+        service.stop()
+        os.unlink(config_path)
+
+
+def test_out_azure_logs_ingestion_rejects_second_process_for_shared_root():
+    first = Service("out_azure_logs_ingestion_buffering.yaml")
+    first.start()
+    second = Service(
+        "out_azure_logs_ingestion_buffering.yaml",
+        buffer_dir=first.buffer_dir,
+        buffer_key="second-process",
+    )
+    try:
+        with pytest.raises(FluentBitStartupError):
+            second.start()
+    finally:
+        second.stop()
+        first.stop()
+
+
+def test_out_azure_logs_ingestion_batches_multiple_engine_flushes():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    rng = random.Random(13254)
+    records = []
+    try:
+        for index in range(2):
+            record = {
+                "id": str(index),
+                "message": base64.b64encode(rng.randbytes(1800)).decode("ascii"),
+            }
+            records.append(record)
+            response = requests.post(
+                f"http://127.0.0.1:{service.flb_listener_port}/",
+                json=record,
+                timeout=5,
+            )
+            assert response.status_code == 201
+            if index == 0:
+                time.sleep(1.5)
+                data_requests = [
+                    item for item in data_storage["requests"]
+                    if item["path"].startswith("/dataCollectionRules/")
+                ]
+                assert data_requests == []
+
+        requests_seen = service.wait_for_requests(2, timeout=15)
+    finally:
+        service.stop()
+
+    data_requests = [
+        item for item in requests_seen
+        if item["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
+    ]
+    assert len(data_requests) == 1
+    request = data_requests[0]
+    assert request["headers"].get("Content-Encoding") == "gzip"
+    assert int(request["headers"]["Content-Length"]) <= 5000
+    assert [item["id"] for item in request["json"]] == [item["id"] for item in records]
+    assert len(request["json"]) == 2
+
+
+def test_out_azure_logs_ingestion_uses_ratio_to_reduce_exact_probes():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    rng = random.Random(13260)
+    records = []
+    try:
+        for index in range(4):
+            record = {
+                "id": str(index),
+                "message": base64.b64encode(rng.randbytes(1800)).decode("ascii"),
+            }
+            records.append(record)
+            response = requests.post(
+                f"http://127.0.0.1:{service.flb_listener_port}/",
+                json=record,
+                timeout=5,
+            )
+            assert response.status_code == 201
+            time.sleep(1.5)
+
+        def _all_records_delivered():
+            requests_seen = list(data_storage["requests"])
+            delivered = sum(len(request["json"]) for request in _data_requests(requests_seen))
+            return requests_seen if delivered == 4 else None
+
+        requests_seen = service.service.wait_for_condition(
+            _all_records_delivered,
+            timeout=20,
+            interval=0.5,
+            description="ratio-estimated buffered records",
+        )
+        log_path = service.service.flb.log_file
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    delivered_ids = [record["id"] for request in data_requests for record in request["json"]]
+    assert delivered_ids == [record["id"] for record in records]
+    with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+        log_contents = handle.read()
+    callback_records = [
+        int(records)
+        for records in re.findall(r"buffered callback records=(\d+)", log_contents)
+    ]
+    probe_events = [
+        (int(records), int(probes), float(ratio))
+        for records, probes, ratio in re.findall(
+            r"planned durable request records=(\d+) probes=(\d+) "
+            r"ratio=([0-9.]+)",
+            log_contents,
+        )
+    ]
+
+    assert sum(callback_records) == 4
+    assert sum(records for records, _, _ in probe_events) == 4
+    assert len(probe_events) < len(callback_records)
+    assert 0 < sum(probes for _, probes, _ in probe_events) <= 8
+    assert any(ratio < 1.0 for _, _, ratio in probe_events)
+    assert "deferred exact probe using compression ratio" in log_contents
+
+
+def test_out_azure_logs_ingestion_reaches_default_compressed_target():
+    service = Service("out_azure_logs_ingestion_buffering_default_sizes.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    rng = random.Random(1325400)
+    records = []
+    try:
+        for index in range(100):
+            record = {
+                "id": str(index),
+                "message": base64.b64encode(rng.randbytes(10000)).decode("ascii"),
+            }
+            records.append(record)
+            response = requests.post(
+                f"http://127.0.0.1:{service.flb_listener_port}/",
+                json=record,
+                timeout=5,
+            )
+            assert response.status_code == 201
+        requests_seen = service.wait_for_requests(2, timeout=45)
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 1
+    compressed_size = int(data_requests[0]["headers"]["Content-Length"])
+    assert 900000 <= compressed_size <= 1048576
+    delivered_ids = [record["id"] for record in data_requests[0]["json"]]
+    assert delivered_ids == [record["id"] for record in records[: len(delivered_ids)]]
+
+
+def _send_buffering_records(service, count, seed, byte_count=1800):
+    rng = random.Random(seed)
+    records = []
+    for index in range(count):
+        record = {
+            "id": str(index),
+            "message": base64.b64encode(rng.randbytes(byte_count)).decode("ascii"),
+        }
+        records.append(record)
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json=record,
+            timeout=5,
+        )
+        assert response.status_code == 201
+    return records
+
+
+def _data_requests(requests_seen):
+    return [
+        item for item in requests_seen
+        if item["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
+    ]
+
+
+def _quarantine_count(buffer_dir, buffer_key="suite-buffer"):
+    database = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+    with sqlite3.connect(database) as connection:
+        return connection.execute(
+            "SELECT COUNT(*) FROM azli_requests "
+            "WHERE instance_key=? AND state=5",
+            (buffer_key,),
+        ).fetchone()[0]
+
+
+def test_out_azure_logs_ingestion_rolls_over_at_record_boundaries():
+    service = Service(
+        "out_azure_logs_ingestion_buffering_default_sizes.yaml",
+        buffer_limit="16M",
+    )
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        records = _send_buffering_records(service, 3, 13257, byte_count=700000)
+        requests_seen = service.wait_for_requests(4, timeout=30)
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 3
+    assert all(int(item["headers"]["Content-Length"]) <= 1048576 for item in data_requests)
+    delivered_ids = [record["id"] for request in data_requests for record in request["json"]]
+    assert delivered_ids == [record["id"] for record in records]
+
+
+def test_out_azure_logs_ingestion_timeout_flushes_underfilled_file():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "timeout", "message": "underfilled\nwith embedded newline"},
+            timeout=5,
+        )
+        assert response.status_code == 201
+        requests_seen = service.wait_for_requests(2, timeout=15)
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 1
+    assert int(data_requests[0]["headers"]["Content-Length"]) < 3000
+    assert [record["id"] for record in data_requests[0]["json"]] == ["timeout"]
+    assert data_requests[0]["json"][0]["message"] == "underfilled\nwith embedded newline"
+
+
+def test_out_azure_logs_ingestion_retries_buffered_file_after_500():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=500, body={"error": "temporary"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        _send_buffering_records(service, 2, 13255)
+        first_attempt = list(service.wait_for_requests(2, timeout=15))
+        configure_http_response(status_code=204, body="")
+        requests_seen = service.wait_for_requests(3, timeout=15)
+        metrics = service.metrics(
+            f'{HTTP_PAYLOAD_SIZE_METRIC}_count{{name="azure_logs_ingestion.0",'
+            f'dcr_id="dcr-suite"}} 2'
+        )
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 2
+    assert data_requests[0]["decoded_data"] == data_requests[1]["decoded_data"]
+    assert data_requests[0]["headers"]["Content-Length"] == data_requests[1]["headers"]["Content-Length"]
+    assert len(_data_requests(first_attempt)) == 1
+
+    output_name = "azure_logs_ingestion.0"
+    metric_labels = {"name": output_name, "dcr_id": "dcr-suite"}
+    expected_uncompressed_size = sum(
+        len(request["decoded_data"].encode("utf-8")) for request in data_requests
+    )
+    expected_http_size = sum(
+        int(request["headers"]["Content-Length"]) for request in data_requests
+    )
+    assert _metric_value(
+        metrics, f"{UNCOMPRESSED_PAYLOAD_SIZE_METRIC}_count", **metric_labels
+    ) == 2
+    assert _metric_value(
+        metrics, f"{UNCOMPRESSED_PAYLOAD_SIZE_METRIC}_sum", **metric_labels
+    ) == expected_uncompressed_size
+    assert _metric_value(
+        metrics, f"{HTTP_PAYLOAD_SIZE_METRIC}_count", **metric_labels
+    ) == 2
+    assert _metric_value(
+        metrics, f"{HTTP_PAYLOAD_SIZE_METRIC}_sum", **metric_labels
+    ) == expected_http_size
+    assert _metric_value(
+        metrics,
+        f"{HTTP_PAYLOAD_SIZE_METRIC}_bucket",
+        le=SMALL_REQUEST_BUCKET,
+        **metric_labels,
+    ) == 2
+    assert _metric_value(
+        metrics, HTTP_PAYLOAD_SIZE_MIN_METRIC, **metric_labels
+    ) == min(int(request["headers"]["Content-Length"]) for request in data_requests)
+
+
+def test_out_azure_logs_ingestion_retries_byte_identical_artifact_after_sigkill():
+    with tempfile.TemporaryDirectory(prefix="azure-li-retry-recovery-") as buffer_dir:
+        first = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            initial_http_status=500,
+        )
+        first.start()
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            _send_buffering_records(first, 2, 93255)
+            requests_seen = first.wait_for_requests(2, timeout=15)
+            first_hash = _data_requests(requests_seen)[0]["raw_sha256"]
+            first.flb.send_signal(signal.SIGKILL)
+            first.flb.process.wait(timeout=5)
+        finally:
+            first.stop()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            initial_http_status=204,
+            receiver_port=first.test_suite_http_port,
+        )
+        second.start()
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            requests_seen = second.service.wait_for_condition(
+                lambda: list(data_storage["requests"])
+                if len(_data_requests(data_storage["requests"])) >= 1 else None,
+                timeout=20,
+                interval=0.5,
+                description="byte-identical recovered request",
+            )
+        finally:
+            second.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 1
+    assert data_requests[0]["raw_sha256"] == first_hash
+
+
+def test_out_azure_logs_ingestion_quarantines_corrupt_request_artifact_on_recovery():
+    with tempfile.TemporaryDirectory(prefix="azure-li-corrupt-request-") as buffer_dir:
+        first = Service("out_azure_logs_ingestion_buffering.yaml", buffer_dir=buffer_dir)
+        first.start()
+        configure_http_response(status_code=500, body={"error": "retry"})
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            _send_buffering_records(first, 2, 73256)
+            first.wait_for_requests(2, timeout=15)
+        finally:
+            first.stop()
+
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            connection.execute(
+                "UPDATE azli_requests SET body_digest=zeroblob(32),state=1,next_retry=0 "
+                "WHERE instance_key='suite-buffer'"
+            )
+            connection.commit()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=first.test_suite_http_port,
+        )
+        second.start()
+        try:
+            second.wait_for_log("quarantining spans", timeout=10)
+            with sqlite3.connect(database_path) as connection:
+                state = connection.execute(
+                    "SELECT state,reason FROM azli_requests "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchone()
+            assert state == (5, "artifact_corrupt")
+            assert _data_requests(data_storage["requests"]) == []
+        finally:
+            second.stop()
+
+
+def test_out_azure_logs_ingestion_quarantines_413_without_replay():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=413, body={"error": "too large"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        _send_buffering_records(service, 2, 13256)
+        requests_seen = service.wait_for_requests(2, timeout=15)
+        time.sleep(2.5)
+        assert len(_data_requests(data_storage["requests"])) == 1
+        assert _quarantine_count(service.buffer_dir) == 1
+    finally:
+        service.stop()
+
+    assert len(_data_requests(requests_seen)) == 1
+
+
+def test_out_azure_logs_ingestion_quarantine_remains_terminal_after_restart():
+    with tempfile.TemporaryDirectory(prefix="azure-li-quarantine-recovery-") as buffer_dir:
+        first = Service("out_azure_logs_ingestion_buffering.yaml", buffer_dir=buffer_dir)
+        first.start()
+        configure_http_response(status_code=413, body={"error": "too large"})
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            _send_buffering_records(first, 2, 93256)
+            first.wait_for_requests(2, timeout=15)
+            first.service.wait_for_condition(
+                lambda: _quarantine_count(buffer_dir) == 1,
+                timeout=10,
+                description="durable quarantine state",
+            )
+        finally:
+            first.stop()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=first.test_suite_http_port,
+        )
+        second.start()
+        configure_http_response(status_code=204, body="")
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            time.sleep(3)
+            assert _data_requests(data_storage["requests"]) == []
+            assert _quarantine_count(buffer_dir) == 1
+        finally:
+            second.stop()
+
+
+def test_out_azure_logs_ingestion_recovers_underfilled_active_file():
+    with tempfile.TemporaryDirectory(prefix="azure-li-recovery-") as buffer_dir:
+        first = Service("out_azure_logs_ingestion_buffering.yaml", buffer_dir=buffer_dir)
+        first.start()
+        configure_http_response(status_code=204, body="")
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        record = {"id": "recovered", "message": "small and underfilled"}
+        try:
+            response = requests.post(
+                f"http://127.0.0.1:{first.flb_listener_port}/",
+                json=record,
+                timeout=5,
+            )
+            assert response.status_code == 201
+            first.wait_for_log("buffered callback records=1", timeout=10)
+            assert _data_requests(data_storage["requests"]) == []
+            first.flb.send_signal(signal.SIGKILL)
+            first.flb.process.wait(timeout=5)
+        finally:
+            first.stop()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=first.test_suite_http_port,
+        )
+        second.start()
+        configure_http_response(status_code=204, body="")
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            requests_seen = second.wait_for_requests(2, timeout=15)
+        finally:
+            second.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 1
+    assert [item["id"] for item in data_requests[0]["json"]] == ["recovered"]
+
+
+def test_out_azure_logs_ingestion_serializes_slow_uploads():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="", delay_seconds=3)
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    rng = random.Random(13258)
+    try:
+        for index in range(3):
+            response = requests.post(
+                f"http://127.0.0.1:{service.flb_listener_port}/",
+                json={
+                    "id": f"slow-{index}",
+                    "message": base64.b64encode(rng.randbytes(4000)).decode("ascii"),
+                },
+                timeout=5,
+            )
+            assert response.status_code == 201
+            if index == 0:
+                service.wait_for_requests(2, timeout=15)
+            else:
+                time.sleep(1.5)
+            assert len(_data_requests(data_storage["requests"])) <= index + 1
+
+        def _all_slow_records_delivered():
+            requests_seen = list(data_storage["requests"])
+            data_requests = _data_requests(requests_seen)
+            delivered = [
+                record["id"]
+                for request in data_requests
+                for record in request["json"]
+            ]
+            return requests_seen if delivered == ["slow-0", "slow-1", "slow-2"] else None
+
+        requests_seen = service.service.wait_for_condition(
+            _all_slow_records_delivered,
+            timeout=20,
+            interval=0.5,
+            description="serialized slow-upload records",
+        )
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert 2 <= len(data_requests) <= 3
+    assert [record["id"] for request in data_requests for record in request["json"]] == [
+        "slow-0",
+        "slow-1",
+        "slow-2",
+    ]
+
+
+def _hot_reload_config(base_name="out_azure_logs_ingestion_buffering.yaml"):
+    source = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../config", base_name)
+    )
+    handle = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False)
+    with open(source, encoding="utf-8") as source_handle:
+        text = source_handle.read()
+    with handle:
+        text = text.replace(
+            "  flush: 1\n",
+            "  flush: 1\n  hot_reload: on\n  hot_reload.timeout: 15\n",
+            1,
+        )
+        handle.write(text)
+    return handle.name
+
+
+@pytest.mark.parametrize("reload_method", ["http", "sighup"])
+def test_out_azure_logs_ingestion_hot_reload_recovers_queued_chunks(reload_method):
+    config_path = _hot_reload_config()
+    service = Service(config_path)
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        before = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "before-reload", "message": "queued before reload"},
+            timeout=5,
+        )
+        assert before.status_code == 201
+        service.wait_for_log("buffered callback records=1", timeout=10)
+
+        if reload_method == "http":
+            service.flb.trigger_http_reload()
+        else:
+            service.flb.send_sighup()
+        service.flb.wait_for_hot_reload_count(1, timeout=20)
+
+        after = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "after-reload", "message": "queued after reload"},
+            timeout=5,
+        )
+        assert after.status_code == 201
+        requests_seen = service.wait_for_requests(2, timeout=20)
+    finally:
+        service.stop()
+        os.unlink(config_path)
+
+    delivered = [
+        record["id"]
+        for request in _data_requests(requests_seen)
+        for record in request["json"]
+    ]
+    assert delivered == ["before-reload", "after-reload"]
+
+
+def test_out_azure_logs_ingestion_repeated_hot_reload_applies_credentials():
+    config_path = _hot_reload_config()
+    service = Service(config_path)
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+    expected_ids = []
+
+    try:
+        for generation in range(1, 6):
+            with open(config_path, encoding="utf-8") as handle:
+                config = handle.read()
+            config = re.sub(
+                r"client_secret: suite-secret(?:-\d+)?",
+                f"client_secret: suite-secret-{generation}",
+                config,
+            )
+            pending_path = f"{config_path}.tmp"
+            with open(pending_path, "w", encoding="utf-8") as handle:
+                handle.write(config)
+            os.replace(pending_path, config_path)
+
+            service.flb.trigger_http_reload()
+            service.flb.wait_for_hot_reload_count(generation, timeout=20)
+            record_id = f"generation-{generation}"
+            expected_ids.append(record_id)
+            response = requests.post(
+                f"http://127.0.0.1:{service.flb_listener_port}/",
+                json={"id": record_id, "message": "credential reload"},
+                timeout=5,
+            )
+            assert response.status_code == 201
+
+            def _generation_delivered():
+                data_requests = _data_requests(data_storage["requests"])
+                delivered = [
+                    record["id"]
+                    for request in data_requests
+                    for record in request["json"]
+                ]
+                return delivered if record_id in delivered else None
+
+            service.service.wait_for_condition(
+                _generation_delivered,
+                timeout=15,
+                interval=0.25,
+                description=f"delivery from generation {generation}",
+            )
+    finally:
+        service.stop()
+        os.unlink(config_path)
+
+    delivered = [
+        record["id"]
+        for request in _data_requests(data_storage["requests"])
+        for record in request["json"]
+    ]
+    oauth_bodies = [
+        request["raw_data"]
+        for request in data_storage["requests"]
+        if request["path"] == "/oauth/token"
+    ]
+    assert delivered == expected_ids
+    assert len(set(delivered)) == len(expected_ids)
+    for generation in range(1, 6):
+        assert any(
+            f"client_secret=suite-secret-{generation}" in body
+            for body in oauth_bodies
+        )
+
+
+def test_out_azure_logs_ingestion_hot_reload_during_suspended_upload():
+    config_path = _hot_reload_config(
+        "out_azure_logs_ingestion_buffering_short_timeout.yaml"
+    )
+    service = Service(config_path)
+    service.start()
+    configure_http_response(status_code=204, body="", hang_before_response=True)
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "inflight-reload", "message": "x" * 4000},
+            timeout=5,
+        )
+        assert response.status_code == 201
+        first_requests = service.wait_for_requests(2, timeout=15)
+        assert len(_data_requests(first_requests)) == 1
+
+        service.flb.trigger_http_reload()
+        service.flb.wait_for_hot_reload_count(1, timeout=20)
+        configure_http_response(status_code=204, body="", hang_before_response=False)
+
+        def _retry_acked():
+            data_requests = _data_requests(data_storage["requests"])
+            if len(data_requests) < 2:
+                return None
+            database = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+            with sqlite3.connect(database) as connection:
+                pending = connection.execute(
+                    "SELECT COUNT(*) FROM azli_requests "
+                    "WHERE instance_key='suite-buffer' AND state<>5"
+                ).fetchone()[0]
+                sources = connection.execute(
+                    "SELECT COUNT(*) FROM azli_sources "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchone()[0]
+            return data_requests if pending == 0 and sources == 0 else None
+
+        data_requests = service.service.wait_for_condition(
+            _retry_acked,
+            timeout=20,
+            interval=0.25,
+            description="acknowledged retry after hot reload",
+        )
+    finally:
+        service.stop()
+        os.unlink(config_path)
+
+    assert data_requests[0]["raw_sha256"] == data_requests[1]["raw_sha256"]
+    assert [record["id"] for record in data_requests[1]["json"]] == ["inflight-reload"]
+
+
+def test_out_azure_logs_ingestion_stops_while_upload_is_suspended():
+    service = Service("out_azure_logs_ingestion_buffering_short_timeout.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="", hang_before_response=True)
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    stopped = False
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "suspended-stop", "message": "x" * 4000},
+            timeout=5,
+        )
+        assert response.status_code == 201
+        service.wait_for_requests(2, timeout=15)
+        started = time.monotonic()
+        service.stop()
+        stopped = True
+        assert time.monotonic() - started < 10
+    finally:
+        if not stopped:
+            service.stop()
+
+
+def test_out_azure_logs_ingestion_quarantines_uncompressed_singleton():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "large-compressible", "message": "A" * 70000},
+            timeout=5,
+        )
+        assert response.status_code == 201
+        service.wait_for_log("quarantined record", timeout=10)
+        time.sleep(1.5)
+        assert _data_requests(data_storage["requests"]) == []
+        with sqlite3.connect(
+            os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+        ) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_sources "
+                "WHERE instance_key='suite-buffer' AND has_quarantine=1"
+            ).fetchone()[0] == 1
+    finally:
+        service.stop()
+
+
+def test_out_azure_logs_ingestion_high_volume_survives_hot_reload():
+    config_path = _hot_reload_config(
+        "out_azure_logs_ingestion_buffering_high_volume.yaml"
+    )
+    with open(config_path, encoding="utf-8") as handle:
+        config = handle.read()
+    config = config.replace("      rate: 100000", "      rate: 10000")
+    with open(config_path, "w", encoding="utf-8") as handle:
+        handle.write(config)
+
+    service = Service(
+        config_path,
+        buffer_key="suite-high-volume",
+        initial_http_status=500,
+    )
+    service.start()
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    try:
+        failed_requests = service.wait_for_requests(2, timeout=30)
+        failed_before_ids = {
+            record["id"]
+            for request in _data_requests(failed_requests)
+            for record in request["json"]
+        }
+        assert failed_before_ids
+        with open(config_path, encoding="utf-8") as handle:
+            config = handle.read()
+        config = config.replace(
+            "      dummy: '{\"message\":\"high-volume batching regression\"}'",
+            "      dummy: '{\"message\":\"high-volume batching after reload\"}'",
+        )
+        pending_path = f"{config_path}.tmp"
+        with open(pending_path, "w", encoding="utf-8") as handle:
+            handle.write(config)
+        os.replace(pending_path, config_path)
+
+        service.flb.trigger_http_reload()
+        service.flb.wait_for_hot_reload_count(1, timeout=30)
+        data_storage["payloads"] = []
+        data_storage["requests"] = []
+        configure_http_response(status_code=204, body="")
+        database_path = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+
+        def _spool_drained_after_reload():
+            with sqlite3.connect(database_path) as connection:
+                sources = connection.execute(
+                    "SELECT COUNT(*) FROM azli_sources WHERE instance_key='suite-high-volume'"
+                ).fetchone()[0]
+                requests_count = connection.execute(
+                    "SELECT COUNT(*) FROM azli_requests "
+                    "WHERE instance_key='suite-high-volume'"
+                ).fetchone()[0]
+            data_requests = _data_requests(data_storage["requests"])
+            delivered = [
+                record for request in data_requests for record in request["json"]
+            ]
+            before_ids = {
+                record["id"] for record in delivered
+                if record["message"] == "high-volume batching regression"
+            }
+            before_count = len(before_ids)
+            after_count = sum(
+                record["message"] == "high-volume batching after reload"
+                for record in delivered
+            )
+            if (failed_before_ids.issubset(before_ids) and
+                after_count >= 100000 and sources == 0 and requests_count == 0):
+                return (delivered, data_requests, before_count, after_count)
+            return None
+
+        delivered, data_requests, before_count, after_count = service.service.wait_for_condition(
+            _spool_drained_after_reload,
+            timeout=120,
+            interval=0.5,
+            description="pre- and post-reload high-volume spool drain",
+        )
+    finally:
+        service.stop()
+        os.unlink(config_path)
+
+    delivered_ids = [record["id"] for record in delivered]
+    assert before_count >= len(failed_before_ids)
+    assert after_count >= 100000
+    assert len(set(delivered_ids)) == len(delivered_ids)
+    assert all(
+        int(request["headers"]["Content-Length"]) <= 1048576
+        for request in data_requests
+    )
+
+def test_out_azure_logs_ingestion_high_volume_batches_and_stops_cleanly():
+    service = Service("out_azure_logs_ingestion_buffering_high_volume.yaml")
+    started = time.monotonic()
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    def _all_records_received():
+        data_requests = _data_requests(data_storage["requests"])
+        delivered = sum(len(request["json"]) for request in data_requests)
+        return data_requests if delivered >= 100000 else None
+
+    try:
+        data_requests = service.service.wait_for_condition(
+            _all_records_received,
+            timeout=120,
+            interval=0.25,
+            description="100000 high-volume Azure records",
+        )
+        database_path = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+
+        def _spool_drained():
+            with sqlite3.connect(database_path) as connection:
+                sources = connection.execute(
+                    "SELECT COUNT(*) FROM azli_sources WHERE instance_key='suite-high-volume'"
+                ).fetchone()[0]
+                requests_count = connection.execute(
+                    "SELECT COUNT(*) FROM azli_requests "
+                    "WHERE instance_key='suite-high-volume'"
+                ).fetchone()[0]
+                receipts = connection.execute(
+                    "SELECT COUNT(*) FROM azli_receipts "
+                    "WHERE instance_key='suite-high-volume'"
+                ).fetchone()[0]
+            return receipts if sources == 0 and requests_count == 0 and receipts > 0 else None
+
+        receipt_count = service.service.wait_for_condition(
+            _spool_drained,
+            timeout=20,
+            interval=0.25,
+            description="drained high-volume durable spool",
+        )
+        with sqlite3.connect(database_path) as connection:
+            integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+        instance_root = os.path.join(service.buffer_dir, "suite-high-volume")
+        source_files = os.listdir(os.path.join(instance_root, "sources"))
+        request_files = os.listdir(os.path.join(instance_root, "requests"))
+        allocated_bytes = 0
+        for root, _, files in os.walk(service.buffer_dir):
+            for name in files:
+                info = os.stat(os.path.join(root, name))
+                allocated_bytes += getattr(info, "st_blocks", 0) * 512 or info.st_size
+        log_path = service.service.flb.log_file
+    finally:
+        stop_started = time.monotonic()
+        service.stop()
+        stop_elapsed = time.monotonic() - stop_started
+
+    elapsed = time.monotonic() - started
+    payloads = [record for request in data_requests for record in request["json"]]
+    compressed_sizes = [int(request["headers"]["Content-Length"]) for request in data_requests]
+    ids = [record["id"] for record in payloads]
+    with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+        log_contents = handle.read()
+    callback_events = [
+        int(records)
+        for records in re.findall(r"buffered callback records=(\d+)", log_contents)
+    ]
+    plan_events = [
+        (int(records), int(probes))
+        for records, probes in re.findall(
+            r"planned durable request records=(\d+) probes=(\d+)",
+            log_contents,
+        )
+    ]
+
+    assert len(payloads) == 100000
+    assert len(set(ids)) == 100000
+    assert receipt_count > 0
+    assert integrity == "ok"
+    assert source_files == []
+    assert request_files == []
+    assert allocated_bytes < 128 * 1024 * 1024
+    assert all(size <= 1048576 for size in compressed_sizes)
+    assert any(size >= 900000 for size in compressed_sizes)
+    assert sum(callback_events) == 100000
+    assert sum(records for records, _ in plan_events) == 100000
+    assert 0 < sum(probes for _, probes in plan_events) < 100
+    assert elapsed < 120
+    assert stop_elapsed < 10
+
+
+def test_out_azure_logs_ingestion_enforces_shared_aggregate_quota():
+    service = Service(
+        "out_azure_logs_ingestion_buffering_shared_quota.yaml",
+        initial_http_status=500,
+    )
+    service.start()
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+    try:
+        service.wait_for_log("batch buffer full", timeout=20)
+        with sqlite3.connect(
+            os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+        ) as connection:
+            used = connection.execute(
+                "SELECT COALESCE((SELECT SUM(bytes) FROM azli_sources),0) + "
+                "COALESCE((SELECT SUM(bytes) FROM azli_requests),0)"
+            ).fetchone()[0]
+            instances = connection.execute(
+                "SELECT COUNT(*) FROM azli_instances WHERE instance_key IN ('quota-a','quota-b')"
+            ).fetchone()[0]
+        allocated_bytes = 0
+        for root, _, files in os.walk(service.buffer_dir):
+            for name in files:
+                info = os.stat(os.path.join(root, name))
+                allocated_bytes += getattr(info, "st_blocks", 0) * 512 or info.st_size
+        assert instances == 2
+        assert 0 < used <= 1450000
+        assert allocated_bytes <= 1450000
+    finally:
+        service.stop()
+
+
+def test_out_azure_logs_ingestion_buffer_exhaustion_retries_after_space_frees():
+    service = Service(
+        "out_azure_logs_ingestion_buffering.yaml",
+        # Immutable source, exact gzip artifact, SQLite WAL and headroom are charged.
+        buffer_limit="1700000",
+    )
+    service.start()
+    configure_http_response(status_code=500, body={"error": "blocked"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    rng = random.Random(13259)
+    records = [
+        {
+            "id": str(index),
+            "message": base64.b64encode(
+                rng.randbytes(40000 if index == 0 else 150000)
+            ).decode("ascii"),
+        }
+        for index in range(2)
+    ]
+
+    try:
+        first = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json=records[0],
+            timeout=5,
+        )
+        assert first.status_code == 201
+        service.wait_for_requests(2, timeout=15)
+        second = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json=records[1],
+            timeout=5,
+        )
+        assert second.status_code == 201
+
+        service.wait_for_log("batch buffer full", timeout=10)
+        configure_http_response(status_code=204, body="")
+        service.service.wait_for_condition(
+            lambda: len(_data_requests(data_storage["requests"])) >= 2,
+            timeout=20,
+            interval=0.5,
+            description="blocked durable request to drain",
+        )
+        after_free = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "after-free", "message": "space is available"},
+            timeout=5,
+        )
+        assert after_free.status_code == 201
+
+        def _after_free_record_delivered():
+            requests_seen = list(data_storage["requests"])
+            delivered = [
+                item["id"]
+                for request in _data_requests(requests_seen)
+                for item in request["json"]
+            ]
+            return requests_seen if "after-free" in delivered else None
+
+        requests_seen = service.service.wait_for_condition(
+            _after_free_record_delivered,
+            timeout=20,
+            interval=0.5,
+            description="new buffered record delivered after space is freed",
+        )
+    finally:
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    delivered_batches = [[item["id"] for item in request["json"]] for request in data_requests]
+    flattened = [item for batch in delivered_batches for item in batch]
+    assert len(delivered_batches) >= 3
+    assert all(batch == ["0"] for batch in delivered_batches[:2])
+    assert "after-free" in flattened

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1017,7 +1017,7 @@ def test_out_azure_logs_ingestion_repeated_hot_reload_applies_credentials():
 
             service.service.wait_for_condition(
                 _generation_delivered,
-                timeout=15,
+                timeout=30,
                 interval=0.25,
                 description=f"delivery from generation {generation}",
             )

--- a/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/tests/integration/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import logging
 import os
 import random
@@ -30,7 +31,7 @@ UNCOMPRESSED_PAYLOAD_SIZE_METRIC = (
     "fluentbit_azure_logs_ingestion_uncompressed_payload_size_bytes"
 )
 HTTP_PAYLOAD_SIZE_METRIC = "fluentbit_azure_logs_ingestion_http_payload_size_bytes"
-HTTP_PAYLOAD_SIZE_MIN_METRIC = "fluentbit_azure_logs_ingestion_http_payload_size_min_bytes"
+LIFECYCLE_METRIC_PREFIX = "fluentbit_azure_logs_ingestion_"
 SMALL_REQUEST_BUCKET = "204800.0"
 
 
@@ -61,6 +62,7 @@ class Service:
         buffer_key="suite-buffer",
         initial_http_status=None,
         receiver_port=None,
+        second_buffer_key="quota-b",
     ):
         if os.path.isabs(config_file):
             self.config_file = config_file
@@ -89,6 +91,7 @@ class Service:
                 "AZURE_LOGS_INGESTION_BUFFER_DIR": self.buffer_dir,
                 "AZURE_LOGS_INGESTION_BUFFER_LIMIT": buffer_limit,
                 "AZURE_LOGS_INGESTION_BUFFER_KEY": buffer_key,
+                "AZURE_LOGS_INGESTION_SECOND_BUFFER_KEY": second_buffer_key,
             },
             pre_start=self._start_receiver,
             post_stop=self._stop_receiver,
@@ -203,20 +206,20 @@ class Service:
             description=f"Prometheus metric {expected}",
         )
 
-    def wait_for_log(self, text, timeout=10):
+    def wait_for_log(self, text, timeout=10, count=1):
         def _contains_text():
             log_file = self.service.flb.log_file
             if not log_file or not os.path.exists(log_file):
                 return None
             with open(log_file, "r", encoding="utf-8", errors="replace") as handle:
                 contents = handle.read()
-            return contents if text in contents else None
+            return contents if contents.count(text) >= count else None
 
         return self.service.wait_for_condition(
             _contains_text,
             timeout=timeout,
             interval=0.5,
-            description=f"Fluent Bit log containing {text!r}",
+            description=f"Fluent Bit log containing {count} occurrence(s) of {text!r}",
         )
 
 
@@ -307,10 +310,6 @@ def test_out_azure_logs_ingestion_reports_payload_size_histograms():
             **metric_labels,
         ) == 2
 
-    assert _metric_value(
-        metrics, HTTP_PAYLOAD_SIZE_MIN_METRIC, **metric_labels
-    ) == min(int(request["headers"]["Content-Length"]) for request in data_requests)
-
 
 @pytest.mark.parametrize("buffer_key", [".", ".."])
 def test_out_azure_logs_ingestion_rejects_special_buffer_keys(buffer_key):
@@ -346,6 +345,114 @@ def test_out_azure_logs_ingestion_rejects_multiple_buffer_workers():
         os.unlink(config_path)
 
 
+@pytest.mark.parametrize("retry_setting", ["", "      retry_limit: 2\n"])
+def test_out_azure_logs_ingestion_requires_unlimited_engine_retries(retry_setting):
+    config_path = _config_replacing("      retry_limit: no_limits\n", retry_setting)
+    service = Service(config_path)
+    try:
+        with pytest.raises(FluentBitStartupError):
+            service.start()
+    finally:
+        service.stop()
+        os.unlink(config_path)
+
+
+def test_out_azure_logs_ingestion_rejects_legacy_record_range_schema():
+    with tempfile.TemporaryDirectory(prefix="azure-li-legacy-schema-") as buffer_dir:
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            connection.execute(
+                "CREATE TABLE azli_sources("
+                "source_pk INTEGER PRIMARY KEY,next_record INTEGER NOT NULL)"
+            )
+            connection.execute(
+                "INSERT INTO azli_sources(source_pk,next_record) VALUES(1,4)"
+            )
+            connection.commit()
+
+        service = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+        )
+        try:
+            with pytest.raises(FluentBitStartupError):
+                service.start()
+        finally:
+            service.stop()
+
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 0
+            assert connection.execute(
+                "SELECT source_pk,next_record FROM azli_sources"
+            ).fetchall() == [(1, 4)]
+
+
+def test_out_azure_logs_ingestion_rejects_fstore_spool_schema():
+    with tempfile.TemporaryDirectory(prefix="azure-li-fstore-schema-") as buffer_dir:
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("PRAGMA user_version=2")
+
+        service = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+        )
+        try:
+            with pytest.raises(FluentBitStartupError):
+                service.start()
+        finally:
+            service.stop()
+
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    (("state", 6), ("record_count", 0)),
+)
+def test_out_azure_logs_ingestion_rejects_invalid_spool_state(column, value):
+    with tempfile.TemporaryDirectory(prefix="azure-li-invalid-state-") as buffer_dir:
+        slow_config = _config_replacing(
+            "      batch_timeout: 5s", "      batch_timeout: 60s"
+        )
+        first = Service(slow_config, buffer_dir=buffer_dir)
+        first.start()
+        try:
+            _post_chunk(first, [{"id": "invalid", "message": "durable source"}])
+            first.wait_for_log("buffered whole chunk records=1", timeout=10)
+        finally:
+            first.stop()
+            os.unlink(slow_config)
+
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("PRAGMA ignore_check_constraints=ON")
+            connection.execute(
+                f"UPDATE azli_sources SET {column}=? "
+                "WHERE instance_key='suite-buffer'",
+                (value,),
+            )
+            connection.commit()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=first.test_suite_http_port,
+        )
+        try:
+            with pytest.raises(FluentBitStartupError):
+                second.start()
+        finally:
+            second.stop()
+
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute(
+                f"SELECT {column} FROM azli_sources "
+                "WHERE instance_key='suite-buffer'"
+            ).fetchone()[0] == value
+
+
 def test_out_azure_logs_ingestion_rejects_second_process_for_shared_root():
     first = Service("out_azure_logs_ingestion_buffering.yaml")
     first.start()
@@ -362,6 +469,94 @@ def test_out_azure_logs_ingestion_rejects_second_process_for_shared_root():
         first.stop()
 
 
+def test_out_azure_logs_ingestion_rejects_duplicate_live_buffer_key():
+    service = Service(
+        "out_azure_logs_ingestion_buffering_shared_quota.yaml",
+        second_buffer_key="quota-a",
+    )
+    try:
+        with pytest.raises(FluentBitStartupError):
+            service.start()
+    finally:
+        service.stop()
+
+
+def test_out_azure_logs_ingestion_rejects_buffer_key_reuse_for_another_dcr():
+    with tempfile.TemporaryDirectory(prefix="azure-li-destination-guard-") as buffer_dir:
+        first = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+        )
+        first.start()
+        receiver_port = first.test_suite_http_port
+        first.stop()
+
+        config_path = _hot_reload_config()
+        with open(config_path, encoding="utf-8") as handle:
+            config = handle.read()
+        config = config.replace("dcr_id: dcr-suite", "dcr_id: dcr-other", 1)
+        with open(config_path, "w", encoding="utf-8") as handle:
+            handle.write(config)
+
+        second = Service(
+            config_path,
+            buffer_dir=buffer_dir,
+            receiver_port=receiver_port,
+        )
+        try:
+            with pytest.raises(FluentBitStartupError):
+                second.start()
+        finally:
+            second.stop()
+            os.unlink(config_path)
+
+
+def _config_replacing(old, new):
+    config_path = _hot_reload_config()
+    with open(config_path, encoding="utf-8") as handle:
+        config = handle.read()
+    assert old in config
+    with open(config_path, "w", encoding="utf-8") as handle:
+        handle.write(config.replace(old, new))
+    return config_path
+
+
+def _config_replacing_in_file(config_path, old, new):
+    with open(config_path, encoding="utf-8") as handle:
+        config = handle.read()
+    assert old in config
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as handle:
+        handle.write(config.replace(old, new))
+        return handle.name
+
+
+def _post_chunk(service, records):
+    response = requests.post(
+        f"http://127.0.0.1:{service.flb_listener_port}/",
+        json=records,
+        timeout=10,
+    )
+    assert response.status_code == 201
+
+
+def _spool_is_empty(buffer_dir, buffer_key):
+    database = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+    with sqlite3.connect(database) as connection:
+        sources = connection.execute(
+            "SELECT COUNT(*) FROM azli_sources WHERE instance_key=?",
+            (buffer_key,),
+        ).fetchone()[0]
+        requests_count = connection.execute(
+            "SELECT COUNT(*) FROM azli_requests WHERE instance_key=?",
+            (buffer_key,),
+        ).fetchone()[0]
+    return sources == 0 and requests_count == 0
+
+
+def _assert_empty_artifact_directories(buffer_dir, buffer_key):
+    assert not os.path.exists(os.path.join(buffer_dir, buffer_key))
+
+
 def test_out_azure_logs_ingestion_batches_multiple_engine_flushes():
     service = Service("out_azure_logs_ingestion_buffering.yaml")
     service.start()
@@ -372,29 +567,30 @@ def test_out_azure_logs_ingestion_batches_multiple_engine_flushes():
     )
 
     rng = random.Random(13254)
-    records = []
-    try:
-        for index in range(2):
-            record = {
-                "id": str(index),
-                "message": base64.b64encode(rng.randbytes(1800)).decode("ascii"),
+    chunks = [
+        [
+            {
+                "id": f"{chunk_index}-{record_index}",
+                "message": base64.b64encode(rng.randbytes(1000)).decode("ascii"),
             }
-            records.append(record)
-            response = requests.post(
-                f"http://127.0.0.1:{service.flb_listener_port}/",
-                json=record,
-                timeout=5,
-            )
-            assert response.status_code == 201
-            if index == 0:
-                time.sleep(1.5)
-                data_requests = [
-                    item for item in data_storage["requests"]
-                    if item["path"].startswith("/dataCollectionRules/")
-                ]
-                assert data_requests == []
+            for record_index in range(2)
+        ]
+        for chunk_index in range(2)
+    ]
+    try:
+        _post_chunk(service, chunks[0])
+        first_log = service.wait_for_log("buffered whole chunk records=2", timeout=10)
+        first_gzip_size = int(
+            re.findall(r"buffered whole chunk records=2 .*gzip_bytes=(\d+)", first_log)[-1]
+        )
+        assert first_gzip_size < 3000
+        assert _data_requests(data_storage["requests"]) == []
 
-        requests_seen = service.wait_for_requests(2, timeout=15)
+        second_started = time.monotonic()
+        _post_chunk(service, chunks[1])
+        requests_seen = service.wait_for_requests(2, timeout=10)
+        assert time.monotonic() - second_started < 5
+        service.wait_for_log("planned durable request chunks=2 records=4", timeout=10)
     finally:
         service.stop()
 
@@ -405,76 +601,11 @@ def test_out_azure_logs_ingestion_batches_multiple_engine_flushes():
     assert len(data_requests) == 1
     request = data_requests[0]
     assert request["headers"].get("Content-Encoding") == "gzip"
-    assert int(request["headers"]["Content-Length"]) <= 5000
-    assert [item["id"] for item in request["json"]] == [item["id"] for item in records]
-    assert len(request["json"]) == 2
-
-
-def test_out_azure_logs_ingestion_uses_ratio_to_reduce_exact_probes():
-    service = Service("out_azure_logs_ingestion_buffering.yaml")
-    service.start()
-    configure_http_response(status_code=204, body="")
-    configure_oauth_token_response(
-        status_code=200,
-        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
-    )
-
-    rng = random.Random(13260)
-    records = []
-    try:
-        for index in range(4):
-            record = {
-                "id": str(index),
-                "message": base64.b64encode(rng.randbytes(1800)).decode("ascii"),
-            }
-            records.append(record)
-            response = requests.post(
-                f"http://127.0.0.1:{service.flb_listener_port}/",
-                json=record,
-                timeout=5,
-            )
-            assert response.status_code == 201
-            time.sleep(1.5)
-
-        def _all_records_delivered():
-            requests_seen = list(data_storage["requests"])
-            delivered = sum(len(request["json"]) for request in _data_requests(requests_seen))
-            return requests_seen if delivered == 4 else None
-
-        requests_seen = service.service.wait_for_condition(
-            _all_records_delivered,
-            timeout=20,
-            interval=0.5,
-            description="ratio-estimated buffered records",
-        )
-        log_path = service.service.flb.log_file
-    finally:
-        service.stop()
-
-    data_requests = _data_requests(requests_seen)
-    delivered_ids = [record["id"] for request in data_requests for record in request["json"]]
-    assert delivered_ids == [record["id"] for record in records]
-    with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
-        log_contents = handle.read()
-    callback_records = [
-        int(records)
-        for records in re.findall(r"buffered callback records=(\d+)", log_contents)
+    assert 3000 <= int(request["headers"]["Content-Length"]) <= 5000
+    assert [item["id"] for item in request["json"]] == [
+        item["id"] for chunk in chunks for item in chunk
     ]
-    probe_events = [
-        (int(records), int(probes), float(ratio))
-        for records, probes, ratio in re.findall(
-            r"planned durable request records=(\d+) probes=(\d+) "
-            r"ratio=([0-9.]+)",
-            log_contents,
-        )
-    ]
-
-    assert sum(callback_records) == 4
-    assert sum(records for records, _, _ in probe_events) == 4
-    assert len(probe_events) < len(callback_records)
-    assert 0 < sum(probes for _, probes, _ in probe_events) <= 8
-    assert any(ratio < 1.0 for _, _, ratio in probe_events)
-    assert "deferred exact probe using compression ratio" in log_contents
+    assert len(request["json"]) == 4
 
 
 def test_out_azure_logs_ingestion_reaches_default_compressed_target():
@@ -548,7 +679,7 @@ def _quarantine_count(buffer_dir, buffer_key="suite-buffer"):
         ).fetchone()[0]
 
 
-def test_out_azure_logs_ingestion_rolls_over_at_record_boundaries():
+def test_out_azure_logs_ingestion_rolls_over_at_whole_chunk_boundaries():
     service = Service(
         "out_azure_logs_ingestion_buffering_default_sizes.yaml",
         buffer_limit="16M",
@@ -560,17 +691,36 @@ def test_out_azure_logs_ingestion_rolls_over_at_record_boundaries():
         body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
     )
 
+    rng = random.Random(13257)
+    chunks = [
+        [
+            {
+                "id": f"{chunk_index}-{record_index}",
+                "message": base64.b64encode(rng.randbytes(350000)).decode("ascii"),
+            }
+            for record_index in range(2)
+        ]
+        for chunk_index in range(3)
+    ]
     try:
-        records = _send_buffering_records(service, 3, 13257, byte_count=700000)
-        requests_seen = service.wait_for_requests(4, timeout=30)
+        for chunk_index, chunk in enumerate(chunks):
+            _post_chunk(service, chunk)
+            service.wait_for_log(
+                "buffered whole chunk records=2",
+                timeout=10,
+                count=chunk_index + 1,
+            )
+        requests_seen = service.wait_for_requests(4, timeout=35)
     finally:
         service.stop()
 
     data_requests = _data_requests(requests_seen)
     assert len(data_requests) == 3
     assert all(int(item["headers"]["Content-Length"]) <= 1048576 for item in data_requests)
-    delivered_ids = [record["id"] for request in data_requests for record in request["json"]]
-    assert delivered_ids == [record["id"] for record in records]
+    expected_ids = [[record["id"] for record in chunk] for chunk in chunks]
+    delivered_ids = [[record["id"] for record in request["json"]]
+                     for request in data_requests]
+    assert delivered_ids == expected_ids
 
 
 def test_out_azure_logs_ingestion_timeout_flushes_underfilled_file():
@@ -582,22 +732,30 @@ def test_out_azure_logs_ingestion_timeout_flushes_underfilled_file():
         body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
     )
 
+    chunks = [
+        [{"id": "timeout-0", "message": "first underfilled chunk"}],
+        [{"id": "timeout-1", "message": "second underfilled chunk"}],
+    ]
     try:
-        response = requests.post(
-            f"http://127.0.0.1:{service.flb_listener_port}/",
-            json={"id": "timeout", "message": "underfilled\nwith embedded newline"},
-            timeout=5,
-        )
-        assert response.status_code == 201
-        requests_seen = service.wait_for_requests(2, timeout=15)
+        _post_chunk(service, chunks[0])
+        service.wait_for_log("buffered whole chunk records=1", timeout=10)
+        assert _data_requests(data_storage["requests"]) == []
+        time.sleep(2.5)
+
+        second_started = time.monotonic()
+        _post_chunk(service, chunks[1])
+        service.wait_for_log("buffered whole chunk records=1", timeout=10, count=2)
+        requests_seen = service.wait_for_requests(2, timeout=10)
+        assert time.monotonic() - second_started < 4.5
     finally:
         service.stop()
 
     data_requests = _data_requests(requests_seen)
     assert len(data_requests) == 1
     assert int(data_requests[0]["headers"]["Content-Length"]) < 3000
-    assert [record["id"] for record in data_requests[0]["json"]] == ["timeout"]
-    assert data_requests[0]["json"][0]["message"] == "underfilled\nwith embedded newline"
+    assert [record["id"] for record in data_requests[0]["json"]] == [
+        record["id"] for chunk in chunks for record in chunk
+    ]
 
 
 def test_out_azure_logs_ingestion_retries_buffered_file_after_500():
@@ -615,8 +773,8 @@ def test_out_azure_logs_ingestion_retries_buffered_file_after_500():
         configure_http_response(status_code=204, body="")
         requests_seen = service.wait_for_requests(3, timeout=15)
         metrics = service.metrics(
-            f'{HTTP_PAYLOAD_SIZE_METRIC}_count{{name="azure_logs_ingestion.0",'
-            f'dcr_id="dcr-suite"}} 2'
+            f'{LIFECYCLE_METRIC_PREFIX}delivered_records_total'
+            f'{{name="azure_logs_ingestion.0",dcr_id="dcr-suite"}} 2'
         )
     finally:
         service.stop()
@@ -624,6 +782,7 @@ def test_out_azure_logs_ingestion_retries_buffered_file_after_500():
     data_requests = _data_requests(requests_seen)
     assert len(data_requests) == 2
     assert data_requests[0]["decoded_data"] == data_requests[1]["decoded_data"]
+    assert data_requests[0]["raw_sha256"] == data_requests[1]["raw_sha256"]
     assert data_requests[0]["headers"]["Content-Length"] == data_requests[1]["headers"]["Content-Length"]
     assert len(_data_requests(first_attempt)) == 1
 
@@ -653,9 +812,101 @@ def test_out_azure_logs_ingestion_retries_buffered_file_after_500():
         le=SMALL_REQUEST_BUCKET,
         **metric_labels,
     ) == 2
+    admitted_chunks = _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}admitted_chunks_total", **metric_labels
+    )
+    delivered_chunks = _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}delivered_chunks_total", **metric_labels
+    )
+    admitted_bytes = _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}admitted_bytes_total", **metric_labels
+    )
+    assert admitted_chunks > 0
+    assert delivered_chunks == admitted_chunks
     assert _metric_value(
-        metrics, HTTP_PAYLOAD_SIZE_MIN_METRIC, **metric_labels
-    ) == min(int(request["headers"]["Content-Length"]) for request in data_requests)
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}admitted_records_total", **metric_labels
+    ) == 2
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}delivered_records_total", **metric_labels
+    ) == 2
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}delivered_bytes_total", **metric_labels
+    ) == admitted_bytes
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}queued_chunks", **metric_labels
+    ) == 0
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}quota_limit_bytes", **metric_labels
+    ) > 0
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}uploader_up", **metric_labels
+    ) == 1
+    assert _metric_value(
+        metrics,
+        f"{LIFECYCLE_METRIC_PREFIX}uploader_last_success_timestamp_seconds",
+        **metric_labels,
+    ) > 0
+
+
+def test_out_azure_logs_ingestion_reports_admission_persistence_failure():
+    service = Service("out_azure_logs_ingestion_buffering.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    database = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+    locker = sqlite3.connect(database, timeout=0, isolation_level=None)
+    persistence_metric = f"{LIFECYCLE_METRIC_PREFIX}persistence_failures_total"
+    recovery_metric = f"{LIFECYCLE_METRIC_PREFIX}degraded_recoveries_total"
+    metric_labels = {"name": "azure_logs_ingestion.0", "dcr_id": "dcr-suite"}
+    metrics_url = (
+        f"http://127.0.0.1:{service.flb.http_monitoring_port}"
+        "/api/v2/metrics/prometheus"
+    )
+
+    try:
+        locker.execute("BEGIN IMMEDIATE")
+        _post_chunk(service, [{"id": "locked", "message": "retry after sqlite lock"}])
+
+        def _persistence_failure_observed():
+            response = requests.get(metrics_url, timeout=2)
+            value = _metric_value(response.text, persistence_metric, **metric_labels)
+            return response.text if value is not None and value >= 1 else None
+
+        metrics = service.service.wait_for_condition(
+            _persistence_failure_observed,
+            timeout=10,
+            interval=0.05,
+            description="admission persistence failure metric",
+        )
+        assert _metric_value(metrics, persistence_metric, **metric_labels) == 1
+        assert _data_requests(data_storage["requests"]) == []
+        assert locker.execute(
+            "SELECT COUNT(*) FROM azli_sources WHERE instance_key='suite-buffer'"
+        ).fetchone()[0] == 0
+
+        locker.execute("ROLLBACK")
+        locker.close()
+        locker = None
+        requests_seen = service.wait_for_requests(2, timeout=30)
+        metrics = service.metrics(persistence_metric, timeout=10)
+    finally:
+        if locker is not None:
+            try:
+                locker.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            locker.close()
+        service.stop()
+
+    data_requests = _data_requests(requests_seen)
+    assert len(data_requests) == 1
+    assert [record["id"] for record in data_requests[0]["json"]] == ["locked"]
+    assert _metric_value(metrics, persistence_metric, **metric_labels) == 1
+    assert _metric_value(metrics, recovery_metric, **metric_labels) in (None, 0)
 
 
 def test_out_azure_logs_ingestion_retries_byte_identical_artifact_after_sigkill():
@@ -706,6 +957,22 @@ def test_out_azure_logs_ingestion_retries_byte_identical_artifact_after_sigkill(
     assert data_requests[0]["raw_sha256"] == first_hash
 
 
+def _create_retry_spool(buffer_dir, seed):
+    service = Service("out_azure_logs_ingestion_buffering.yaml", buffer_dir=buffer_dir)
+    service.start()
+    configure_http_response(status_code=500, body={"error": "retry"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+    try:
+        _send_buffering_records(service, 2, seed)
+        service.wait_for_requests(2, timeout=15)
+        return service.test_suite_http_port
+    finally:
+        service.stop()
+
+
 def test_out_azure_logs_ingestion_quarantines_corrupt_request_artifact_on_recovery():
     with tempfile.TemporaryDirectory(prefix="azure-li-corrupt-request-") as buffer_dir:
         first = Service("out_azure_logs_ingestion_buffering.yaml", buffer_dir=buffer_dir)
@@ -736,7 +1003,7 @@ def test_out_azure_logs_ingestion_quarantines_corrupt_request_artifact_on_recove
         )
         second.start()
         try:
-            second.wait_for_log("quarantining spans", timeout=10)
+            second.wait_for_log("quarantining corrupt request", timeout=10)
             with sqlite3.connect(database_path) as connection:
                 state = connection.execute(
                     "SELECT state,reason FROM azli_requests "
@@ -748,10 +1015,339 @@ def test_out_azure_logs_ingestion_quarantines_corrupt_request_artifact_on_recove
             second.stop()
 
 
-def test_out_azure_logs_ingestion_quarantines_413_without_replay():
+def test_out_azure_logs_ingestion_quarantines_corrupt_attached_source_before_replay():
+    with tempfile.TemporaryDirectory(prefix="azure-li-corrupt-member-") as buffer_dir:
+        receiver_port = _create_retry_spool(buffer_dir, 93256)
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        replacement = b'[{"id":"valid-but-not-requested"}]'
+        replacement_digest = hashlib.sha256(replacement).digest()
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_sources WHERE request_pk IS NOT NULL"
+            ).fetchone()[0] > 0
+            connection.execute(
+                "UPDATE azli_sources SET content=?,digest=?,json_bytes=? "
+                "WHERE instance_key='suite-buffer' AND request_pk IS NOT NULL",
+                (replacement, replacement_digest, len(replacement)),
+            )
+            connection.commit()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=receiver_port,
+        )
+        second.start()
+        try:
+            second.wait_for_log("mismatched source membership", timeout=10)
+            with sqlite3.connect(database_path) as connection:
+                request_state = connection.execute(
+                    "SELECT state,reason FROM azli_requests "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchone()
+                source_states = connection.execute(
+                    "SELECT DISTINCT state FROM azli_sources "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchall()
+            assert request_state == (5, "source_membership_mismatch")
+            assert source_states == [(3,)]
+            assert _data_requests(data_storage["requests"]) == []
+        finally:
+            second.stop()
+
+
+def test_out_azure_logs_ingestion_rejects_conflicting_active_receipt():
+    with tempfile.TemporaryDirectory(prefix="azure-li-receipt-conflict-") as buffer_dir:
+        receiver_port = _create_retry_spool(buffer_dir, 103256)
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            connection.execute(
+                "INSERT INTO azli_receipts(instance_key,source_id,digest,completed,"
+                "expires,bytes) SELECT instance_key,source_id,zeroblob(32),"
+                "strftime('%s','now'),strftime('%s','now')+86400,256 "
+                "FROM azli_sources WHERE instance_key='suite-buffer' LIMIT 1"
+            )
+            connection.commit()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=receiver_port,
+        )
+        try:
+            with pytest.raises(FluentBitStartupError):
+                second.start()
+        finally:
+            second.stop()
+
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_receipts "
+                "WHERE instance_key='suite-buffer' AND digest=zeroblob(32)"
+            ).fetchone()[0] == 1
+
+
+def test_out_azure_logs_ingestion_repairs_missing_acked_receipt_before_cleanup():
+    with tempfile.TemporaryDirectory(prefix="azure-li-acked-receipt-") as buffer_dir:
+        receiver_port = _create_retry_spool(buffer_dir, 113256)
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            connection.execute(
+                "UPDATE azli_sources SET state=2 WHERE instance_key='suite-buffer'"
+            )
+            connection.execute(
+                "UPDATE azli_requests SET state=4 WHERE instance_key='suite-buffer'"
+            )
+            connection.execute(
+                "DELETE FROM azli_receipts WHERE instance_key='suite-buffer'"
+            )
+            connection.commit()
+
+        second = Service(
+            "out_azure_logs_ingestion_buffering.yaml",
+            buffer_dir=buffer_dir,
+            receiver_port=receiver_port,
+        )
+        second.start()
+        try:
+            second.service.wait_for_condition(
+                lambda: _spool_is_empty(buffer_dir, "suite-buffer"),
+                timeout=10,
+                interval=0.25,
+                description="ACKED cleanup after receipt repair",
+            )
+        finally:
+            second.stop()
+
+        with sqlite3.connect(database_path) as connection:
+            receipt = connection.execute(
+                "SELECT length(digest),expires>completed,bytes "
+                "FROM azli_receipts WHERE instance_key='suite-buffer'"
+            ).fetchone()
+        assert receipt == (32, 1, 256)
+        assert _data_requests(data_storage["requests"]) == []
+
+
+def test_out_azure_logs_ingestion_quarantines_corrupt_source_and_continues():
+    with tempfile.TemporaryDirectory(prefix="azure-li-corrupt-source-") as buffer_dir:
+        slow_config = _config_replacing("      batch_timeout: 5s", "      batch_timeout: 60s")
+        first = Service(slow_config, buffer_dir=buffer_dir)
+        first.start()
+        configure_http_response(status_code=204, body="")
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            _post_chunk(first, [{"id": "corrupt", "message": "preserve forensic payload"}])
+            first.wait_for_log("buffered whole chunk records=1", timeout=10)
+        finally:
+            first.stop()
+            os.unlink(slow_config)
+
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_requests WHERE instance_key='suite-buffer'"
+            ).fetchone()[0] == 0
+            connection.execute(
+                "UPDATE azli_sources SET content=zeroblob(length(content)) "
+                "WHERE instance_key='suite-buffer'"
+            )
+            connection.commit()
+
+        fast_config = _config_replacing(
+            "      batch_target_size: 3000", "      batch_target_size: 100"
+        )
+        second = Service(
+            fast_config,
+            buffer_dir=buffer_dir,
+            receiver_port=first.test_suite_http_port,
+        )
+        second.start()
+        configure_http_response(status_code=204, body="")
+        configure_oauth_token_response(
+            status_code=200,
+            body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+        )
+        try:
+            second.wait_for_log("quarantining corrupt source", timeout=10)
+            _post_chunk(second, [{"id": "healthy", "message": "continues"}])
+            requests_seen = second.wait_for_requests(2, timeout=15)
+            with sqlite3.connect(database_path) as connection:
+                quarantined = connection.execute(
+                    "SELECT state,quarantine_reason FROM azli_sources "
+                    "WHERE instance_key='suite-buffer' AND quarantine_reason IS NOT NULL"
+                ).fetchall()
+                assert quarantined == [(3, "content_corrupt")]
+                assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        finally:
+            second.stop()
+            os.unlink(fast_config)
+
+    assert [record["id"] for request in _data_requests(requests_seen)
+            for record in request["json"]] == ["healthy"]
+
+
+def test_out_azure_logs_ingestion_expires_receipts_and_reclaims_wal():
+    config_path = _config_replacing(
+        "      batch_timeout: 5s",
+        "      batch_timeout: 5s\n      buffer_receipt_ttl: 3s",
+    )
+    metric_name = f"{LIFECYCLE_METRIC_PREFIX}uploader_last_success_timestamp_seconds"
+    metric_labels = {"name": "azure_logs_ingestion.0", "dcr_id": "dcr-suite"}
+
+    with tempfile.TemporaryDirectory(prefix="azure-li-receipt-expiry-") as buffer_dir:
+        service = Service(config_path, buffer_dir=buffer_dir)
+        service.start()
+        configure_http_response(status_code=204, body="")
+        configure_oauth_token_response(
+            status_code=200,
+            body={
+                "access_token": "oauth-access-token",
+                "token_type": "Bearer",
+                "expires_in": 300,
+            },
+        )
+        database_path = os.path.join(buffer_dir, ".azure_logs_ingestion.db")
+        receiver_port = service.test_suite_http_port
+        try:
+            _post_chunk(service, [{"id": "receipt", "message": "expire me"}])
+            service.wait_for_requests(2, timeout=15)
+
+            def receipt_count(expected):
+                with sqlite3.connect(database_path) as connection:
+                    count = connection.execute(
+                        "SELECT COUNT(*) FROM azli_receipts "
+                        "WHERE instance_key='suite-buffer'"
+                    ).fetchone()[0]
+                return count == expected
+
+            service.service.wait_for_condition(
+                lambda: receipt_count(1), timeout=5, interval=0.2,
+                description="durable completion receipt",
+            )
+            service.service.wait_for_condition(
+                lambda: receipt_count(0), timeout=10, interval=0.5,
+                description="runtime receipt expiry",
+            )
+            with sqlite3.connect(database_path) as connection:
+                assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+                last_success = connection.execute(
+                    "SELECT last_success FROM azli_instances "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchone()[0]
+            assert last_success > 0
+            metrics = service.metrics(metric_name)
+            assert _metric_value(metrics, metric_name, **metric_labels) == last_success
+
+            wal_path = f"{database_path}-wal"
+            wal_size = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
+            assert wal_size < 4 * 1024 * 1024
+            _post_chunk(service, [{"id": "after-maintenance", "message": "still live"}])
+            requests_seen = service.service.wait_for_condition(
+                lambda: list(data_storage["requests"])
+                if any(record.get("id") == "after-maintenance"
+                       for request in _data_requests(data_storage["requests"])
+                       for record in request["json"]) else None,
+                timeout=15, interval=0.5,
+                description="delivery after receipt and WAL maintenance",
+            )
+            with sqlite3.connect(database_path) as connection:
+                latest_success = connection.execute(
+                    "SELECT last_success FROM azli_instances "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchone()[0]
+            assert latest_success >= last_success
+            last_success = latest_success
+        finally:
+            service.stop()
+
+        assert any(record["id"] == "after-maintenance"
+                   for request in _data_requests(requests_seen)
+                   for record in request["json"])
+
+        restarted = Service(
+            config_path,
+            buffer_dir=buffer_dir,
+            receiver_port=receiver_port,
+        )
+        try:
+            restarted.start()
+            metrics = restarted.metrics(metric_name)
+            assert _metric_value(metrics, metric_name, **metric_labels) == last_success
+        finally:
+            restarted.stop()
+
+    os.unlink(config_path)
+
+
+def test_out_azure_logs_ingestion_expires_receipts_for_all_shared_instances():
+    config_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../config/out_azure_logs_ingestion_buffering_shared_quota.yaml",
+        )
+    )
+    with open(config_path, encoding="utf-8") as handle:
+        config = handle.read()
+    config = config.replace(
+        "      upload_retry_base: 1\n",
+        "      upload_retry_base: 1\n      buffer_receipt_ttl: 30s\n",
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as handle:
+        handle.write(config)
+        temporary_config = handle.name
+
+    service = Service(temporary_config, buffer_limit="4M")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+    database_path = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+    try:
+        service.wait_for_requests(3, timeout=20)
+
+        def receipt_counts():
+            with sqlite3.connect(database_path) as connection:
+                return dict(
+                    connection.execute(
+                        "SELECT instance_key,COUNT(*) FROM azli_receipts "
+                        "GROUP BY instance_key"
+                    ).fetchall()
+                )
+
+        service.service.wait_for_condition(
+            lambda: receipt_counts()
+            if receipt_counts().get("quota-a", 0) > 0 and
+               receipt_counts().get("quota-b", 0) > 0 else None,
+            timeout=10,
+            interval=0.25,
+            description="receipts for both shared instances",
+        )
+        service.service.wait_for_condition(
+            lambda: True if receipt_counts() == {} else None,
+            timeout=45,
+            interval=0.5,
+            description="root-wide receipt expiry",
+        )
+    finally:
+        service.stop()
+        os.unlink(temporary_config)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "reason"),
+    [(400, "permanent"), (413, "http_413")],
+)
+def test_out_azure_logs_ingestion_quarantines_permanent_response_without_replay(
+    status_code, reason
+):
     service = Service("out_azure_logs_ingestion_buffering.yaml")
     service.start()
-    configure_http_response(status_code=413, body={"error": "too large"})
+    configure_http_response(status_code=status_code, body={"error": "permanent"})
     configure_oauth_token_response(
         status_code=200,
         body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
@@ -763,10 +1359,35 @@ def test_out_azure_logs_ingestion_quarantines_413_without_replay():
         time.sleep(2.5)
         assert len(_data_requests(data_storage["requests"])) == 1
         assert _quarantine_count(service.buffer_dir) == 1
+        with sqlite3.connect(
+            os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+        ) as connection:
+            state = connection.execute(
+                "SELECT state,reason FROM azli_requests "
+                "WHERE instance_key='suite-buffer'"
+            ).fetchone()
+        assert state == (5, reason)
+        metrics = service.metrics(
+            f'{LIFECYCLE_METRIC_PREFIX}quarantined_records_total'
+            f'{{name="azure_logs_ingestion.0",dcr_id="dcr-suite"}} 2'
+        )
     finally:
         service.stop()
 
+    metric_labels = {"name": "azure_logs_ingestion.0", "dcr_id": "dcr-suite"}
     assert len(_data_requests(requests_seen)) == 1
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}quarantined_chunks_total", **metric_labels
+    ) > 0
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}quarantined_records_total", **metric_labels
+    ) == 2
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}quarantined_chunks", **metric_labels
+    ) > 0
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}quarantined_bytes", **metric_labels
+    ) > 0
 
 
 def test_out_azure_logs_ingestion_quarantine_remains_terminal_after_restart():
@@ -825,7 +1446,7 @@ def test_out_azure_logs_ingestion_recovers_underfilled_active_file():
                 timeout=5,
             )
             assert response.status_code == 201
-            first.wait_for_log("buffered callback records=1", timeout=10)
+            first.wait_for_log("buffered whole chunk records=1", timeout=10)
             assert _data_requests(data_storage["requests"]) == []
             first.flb.send_signal(signal.SIGKILL)
             first.flb.process.wait(timeout=5)
@@ -943,7 +1564,7 @@ def test_out_azure_logs_ingestion_hot_reload_recovers_queued_chunks(reload_metho
             timeout=5,
         )
         assert before.status_code == 201
-        service.wait_for_log("buffered callback records=1", timeout=10)
+        service.wait_for_log("buffered whole chunk records=1", timeout=10)
 
         if reload_method == "http":
             service.flb.trigger_http_reload()
@@ -1044,6 +1665,51 @@ def test_out_azure_logs_ingestion_repeated_hot_reload_applies_credentials():
         )
 
 
+def test_out_azure_logs_ingestion_buffered_oauth_timeout_bounds_shutdown():
+    service = Service("out_azure_logs_ingestion_buffering_short_timeout.yaml")
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(hang_before_response=True)
+
+    stopped = False
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={"id": "oauth-timeout", "message": "durably queued"},
+            timeout=5,
+        )
+        assert response.status_code == 201
+        service.wait_for_requests(1, timeout=15)
+        service.wait_for_log("response timeout reached", timeout=15)
+
+        database = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+
+        def _request_is_retryable():
+            with sqlite3.connect(database) as connection:
+                state = connection.execute(
+                    "SELECT state FROM azli_requests "
+                    "WHERE instance_key='suite-buffer'"
+                ).fetchone()
+            return state == (3,)
+
+        service.service.wait_for_condition(
+            _request_is_retryable,
+            timeout=5,
+            interval=0.25,
+            description="durable request to remain retryable after OAuth timeout",
+        )
+        assert _data_requests(data_storage["requests"]) == []
+
+        started = time.monotonic()
+        service.stop()
+        stopped = True
+        assert time.monotonic() - started < 8
+    finally:
+        configure_oauth_token_response(hang_before_response=False)
+        if not stopped:
+            service.stop()
+
+
 def test_out_azure_logs_ingestion_hot_reload_during_suspended_upload():
     config_path = _hot_reload_config(
         "out_azure_logs_ingestion_buffering_short_timeout.yaml"
@@ -1127,7 +1793,7 @@ def test_out_azure_logs_ingestion_stops_while_upload_is_suspended():
             service.stop()
 
 
-def test_out_azure_logs_ingestion_quarantines_uncompressed_singleton():
+def test_out_azure_logs_ingestion_retries_uncompressed_oversized_chunk():
     service = Service("out_azure_logs_ingestion_buffering.yaml")
     service.start()
     configure_http_response(status_code=204, body="")
@@ -1143,16 +1809,73 @@ def test_out_azure_logs_ingestion_quarantines_uncompressed_singleton():
             timeout=5,
         )
         assert response.status_code == 201
-        service.wait_for_log("quarantined record", timeout=10)
-        time.sleep(1.5)
+        log_contents = service.wait_for_log(
+            "exceeds uncompressed request limit", timeout=20, count=2
+        )
+        source_ids = re.findall(
+            r"uncompressed request limit id=([^ ]+)", log_contents
+        )
+        assert len(source_ids) >= 2
+        assert len(set(source_ids)) == 1
         assert _data_requests(data_storage["requests"]) == []
         with sqlite3.connect(
             os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
         ) as connection:
             assert connection.execute(
-                "SELECT COUNT(*) FROM azli_sources "
-                "WHERE instance_key='suite-buffer' AND has_quarantine=1"
-            ).fetchone()[0] == 1
+                "SELECT COUNT(*) FROM azli_sources WHERE instance_key='suite-buffer'"
+            ).fetchone()[0] == 0
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_requests WHERE instance_key='suite-buffer'"
+            ).fetchone()[0] == 0
+        assert _quarantine_count(service.buffer_dir) == 0
+        _assert_empty_artifact_directories(service.buffer_dir, "suite-buffer")
+    finally:
+        service.stop()
+
+
+def test_out_azure_logs_ingestion_retries_compressed_oversized_chunk():
+    service = Service(
+        "out_azure_logs_ingestion_buffering_default_sizes.yaml",
+        buffer_key="suite-default-sizes",
+    )
+    service.start()
+    configure_http_response(status_code=204, body="")
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    rng = random.Random(13261)
+    try:
+        response = requests.post(
+            f"http://127.0.0.1:{service.flb_listener_port}/",
+            json={
+                "id": "large-incompressible",
+                "message": base64.b64encode(rng.randbytes(1100000)).decode("ascii"),
+            },
+            timeout=10,
+        )
+        assert response.status_code == 201
+        log_contents = service.wait_for_log(
+            "exceeds compressed request limit", timeout=25, count=2
+        )
+        source_ids = re.findall(r"compressed request limit id=([^ ]+)", log_contents)
+        assert len(source_ids) >= 2
+        assert len(set(source_ids)) == 1
+        assert _data_requests(data_storage["requests"]) == []
+        with sqlite3.connect(
+            os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+        ) as connection:
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_sources WHERE instance_key='suite-default-sizes'"
+            ).fetchone()[0] == 0
+            assert connection.execute(
+                "SELECT COUNT(*) FROM azli_requests WHERE instance_key='suite-default-sizes'"
+            ).fetchone()[0] == 0
+        assert _quarantine_count(service.buffer_dir, "suite-default-sizes") == 0
+        _assert_empty_artifact_directories(
+            service.buffer_dir, "suite-default-sizes"
+        )
     finally:
         service.stop()
 
@@ -1260,7 +1983,19 @@ def test_out_azure_logs_ingestion_high_volume_batches_and_stops_cleanly():
         body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
     )
 
+    peak_sizes = {"database": 0, "wal": 0}
+
     def _all_records_received():
+        database_path = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+        wal_path = f"{database_path}-wal"
+        peak_sizes["database"] = max(
+            peak_sizes["database"],
+            os.path.getsize(database_path) if os.path.exists(database_path) else 0,
+        )
+        peak_sizes["wal"] = max(
+            peak_sizes["wal"],
+            os.path.getsize(wal_path) if os.path.exists(wal_path) else 0,
+        )
         data_requests = _data_requests(data_storage["requests"])
         delivered = sum(len(request["json"]) for request in data_requests)
         return data_requests if delivered >= 100000 else None
@@ -1297,9 +2032,11 @@ def test_out_azure_logs_ingestion_high_volume_batches_and_stops_cleanly():
         )
         with sqlite3.connect(database_path) as connection:
             integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+        final_database_size = os.path.getsize(database_path)
+        wal_path = f"{database_path}-wal"
+        final_wal_size = os.path.getsize(wal_path) if os.path.exists(wal_path) else 0
         instance_root = os.path.join(service.buffer_dir, "suite-high-volume")
-        source_files = os.listdir(os.path.join(instance_root, "sources"))
-        request_files = os.listdir(os.path.join(instance_root, "requests"))
+        instance_artifacts_exist = os.path.exists(instance_root)
         allocated_bytes = 0
         for root, _, files in os.walk(service.buffer_dir):
             for name in files:
@@ -1319,13 +2056,32 @@ def test_out_azure_logs_ingestion_high_volume_batches_and_stops_cleanly():
         log_contents = handle.read()
     callback_events = [
         int(records)
-        for records in re.findall(r"buffered callback records=(\d+)", log_contents)
+        for records in re.findall(r"buffered whole chunk records=(\d+)", log_contents)
     ]
     plan_events = [
-        (int(records), int(probes))
-        for records, probes in re.findall(
-            r"planned durable request records=(\d+) probes=(\d+)",
+        (int(chunks), int(records))
+        for chunks, records in re.findall(
+            r"planned durable request chunks=(\d+) records=(\d+)",
             log_contents,
+        )
+    ]
+    probe_events = [
+        (int(probes), int(limit))
+        for probes, limit in re.findall(
+            r"whole-chunk planner probes=(\d+) limit=(\d+)", log_contents
+        )
+    ]
+    snapshot_events = [
+        (int(size), int(limit), int(sources))
+        for size, limit, sources in re.findall(
+            r"whole-chunk planner snapshot_bytes=(\d+) limit=(\d+) sources=(\d+)",
+            log_contents,
+        )
+    ]
+    upload_events = [
+        (int(uploads), int(limit))
+        for uploads, limit in re.findall(
+            r"batch timer uploads=(\d+) limit=(\d+)", log_contents
         )
     ]
 
@@ -1333,16 +2089,93 @@ def test_out_azure_logs_ingestion_high_volume_batches_and_stops_cleanly():
     assert len(set(ids)) == 100000
     assert receipt_count > 0
     assert integrity == "ok"
-    assert source_files == []
-    assert request_files == []
+    assert not instance_artifacts_exist
     assert allocated_bytes < 128 * 1024 * 1024
     assert all(size <= 1048576 for size in compressed_sizes)
-    assert any(size >= 900000 for size in compressed_sizes)
     assert sum(callback_events) == 100000
-    assert sum(records for records, _ in plan_events) == 100000
-    assert 0 < sum(probes for _, probes in plan_events) < 100
+    assert sum(records for _, records in plan_events) == 100000
+    assert all(0 < chunks <= 8 for chunks, _ in plan_events)
+    assert len(probe_events) == len(plan_events)
+    assert all(0 < probes <= limit == 8 for probes, limit in probe_events)
+    assert snapshot_events
+    assert all(2 <= size <= limit == 16_000_000
+               for size, limit, _ in snapshot_events)
+    assert all(0 < sources <= 8 for _, _, sources in snapshot_events)
+    assert upload_events
+    assert all(0 < uploads <= limit == 4 for uploads, limit in upload_events)
+    assert any(uploads > 1 for uploads, _ in upload_events)
+    logger.info(
+        "SQLite batching benchmark records=%d elapsed=%.3fs records_per_second=%.1f "
+        "peak_db=%d peak_wal=%d final_db=%d final_wal=%d",
+        len(payloads), elapsed, len(payloads) / elapsed,
+        peak_sizes["database"], peak_sizes["wal"],
+        final_database_size, final_wal_size,
+    )
     assert elapsed < 120
     assert stop_elapsed < 10
+
+
+def test_out_azure_logs_ingestion_accounts_database_reservations():
+    config_path = _config_replacing(
+        "      batch_target_size: 3000",
+        "      batch_target_size: 1048576",
+    )
+    config_path_with_timeout = _config_replacing_in_file(
+        config_path,
+        "      batch_timeout: 5s",
+        "      batch_timeout: 60s",
+    )
+    service = Service(
+        config_path_with_timeout,
+        buffer_limit="1300000",
+        initial_http_status=500,
+    )
+    service.start()
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+    rng = random.Random(213259)
+    try:
+        admitted = 0
+        for index in range(15):
+            _post_chunk(
+                service,
+                [{
+                    "id": f"account-{index}",
+                    "message": base64.b64encode(rng.randbytes(16000)).decode("ascii"),
+                }],
+            )
+            try:
+                service.wait_for_log(
+                    "buffered whole chunk records=1",
+                    timeout=3,
+                    count=admitted + 1,
+                )
+                admitted += 1
+            except TimeoutError:
+                break
+        log_contents = service.wait_for_log("batch buffer full", timeout=10)
+        logical_values = re.findall(r"batch buffer full logical=(\d+)", log_contents)
+        assert logical_values
+        database_path = os.path.join(service.buffer_dir, ".azure_logs_ingestion.db")
+        with sqlite3.connect(database_path) as connection:
+            sql_logical = connection.execute(
+                "SELECT COALESCE((SELECT SUM(bytes) FROM azli_sources),0) + "
+                "COALESCE((SELECT SUM(bytes) FROM azli_requests),0) + "
+                "COALESCE((SELECT SUM(bytes) FROM azli_receipts),0)"
+            ).fetchone()[0]
+            source_count = connection.execute(
+                "SELECT COUNT(*) FROM azli_sources"
+            ).fetchone()[0]
+        assert admitted >= 5
+        assert source_count == admitted
+        assert int(logical_values[-1]) == sql_logical
+        assert sql_logical > source_count * (4096 + 256)
+    finally:
+        service.stop()
+        os.unlink(config_path)
+        os.unlink(config_path_with_timeout)
 
 
 def test_out_azure_logs_ingestion_enforces_shared_aggregate_quota():
@@ -1362,19 +2195,25 @@ def test_out_azure_logs_ingestion_enforces_shared_aggregate_quota():
         ) as connection:
             used = connection.execute(
                 "SELECT COALESCE((SELECT SUM(bytes) FROM azli_sources),0) + "
-                "COALESCE((SELECT SUM(bytes) FROM azli_requests),0)"
+                "COALESCE((SELECT SUM(bytes) FROM azli_requests),0) + "
+                "COALESCE((SELECT SUM(bytes) FROM azli_receipts),0)"
             ).fetchone()[0]
             instances = connection.execute(
                 "SELECT COUNT(*) FROM azli_instances WHERE instance_key IN ('quota-a','quota-b')"
             ).fetchone()[0]
+            page_size = connection.execute("PRAGMA page_size").fetchone()[0]
+            page_count = connection.execute("PRAGMA page_count").fetchone()[0]
         allocated_bytes = 0
         for root, _, files in os.walk(service.buffer_dir):
             for name in files:
                 info = os.stat(os.path.join(root, name))
                 allocated_bytes += getattr(info, "st_blocks", 0) * 512 or info.st_size
         assert instances == 2
-        assert 0 < used <= 1450000
-        assert allocated_bytes <= 1450000
+        assert 0 < used <= 1250000
+        wal_headroom = max(1250000 // 4, page_size * 16)
+        main_limit = 1250000 - wal_headroom - page_size * 16
+        assert page_count * page_size <= main_limit
+        assert allocated_bytes <= 1250000
     finally:
         service.stop()
 
@@ -1382,8 +2221,8 @@ def test_out_azure_logs_ingestion_enforces_shared_aggregate_quota():
 def test_out_azure_logs_ingestion_buffer_exhaustion_retries_after_space_frees():
     service = Service(
         "out_azure_logs_ingestion_buffering.yaml",
-        # Immutable source, exact gzip artifact, SQLite WAL and headroom are charged.
-        buffer_limit="1700000",
+        # Source/request BLOBs plus SQLite WAL and transition headroom are charged.
+        buffer_limit="1200000",
     )
     service.start()
     configure_http_response(status_code=500, body={"error": "blocked"})
@@ -1397,7 +2236,7 @@ def test_out_azure_logs_ingestion_buffer_exhaustion_retries_after_space_frees():
         {
             "id": str(index),
             "message": base64.b64encode(
-                rng.randbytes(40000 if index == 0 else 150000)
+                rng.randbytes(40000)
             ).decode("ascii"),
         }
         for index in range(2)
@@ -1420,18 +2259,30 @@ def test_out_azure_logs_ingestion_buffer_exhaustion_retries_after_space_frees():
 
         service.wait_for_log("batch buffer full", timeout=10)
         configure_http_response(status_code=204, body="")
+
+        def _rejected_source_delivered_and_spool_clear():
+            requests_seen = list(data_storage["requests"])
+            delivered = [
+                item["id"]
+                for request in _data_requests(requests_seen)
+                for item in request["json"]
+            ]
+            if delivered.count("1") == 1 and _spool_is_empty(
+                service.buffer_dir, "suite-buffer"
+            ):
+                return requests_seen
+            return None
+
         service.service.wait_for_condition(
-            lambda: len(_data_requests(data_storage["requests"])) >= 2,
-            timeout=20,
+            _rejected_source_delivered_and_spool_clear,
+            timeout=30,
             interval=0.5,
-            description="blocked durable request to drain",
+            description="engine-retried source delivered after durable quota is freed",
         )
-        after_free = requests.post(
-            f"http://127.0.0.1:{service.flb_listener_port}/",
-            json={"id": "after-free", "message": "space is available"},
-            timeout=5,
+        _post_chunk(
+            service,
+            [{"id": "after-free", "message": "space is available"}],
         )
-        assert after_free.status_code == 201
 
         def _after_free_record_delivered():
             requests_seen = list(data_storage["requests"])
@@ -1448,12 +2299,20 @@ def test_out_azure_logs_ingestion_buffer_exhaustion_retries_after_space_frees():
             interval=0.5,
             description="new buffered record delivered after space is freed",
         )
+        metrics = service.metrics(
+            f"{LIFECYCLE_METRIC_PREFIX}quota_rejections_total{{"
+        )
     finally:
         service.stop()
 
+    metric_labels = {"name": "azure_logs_ingestion.0", "dcr_id": "dcr-suite"}
+    assert _metric_value(
+        metrics, f"{LIFECYCLE_METRIC_PREFIX}quota_rejections_total", **metric_labels
+    ) >= 1
     data_requests = _data_requests(requests_seen)
     delivered_batches = [[item["id"] for item in request["json"]] for request in data_requests]
     flattened = [item for batch in delivered_batches for item in batch]
     assert len(delivered_batches) >= 3
     assert all(batch == ["0"] for batch in delivered_batches[:2])
-    assert "after-free" in flattened
+    assert flattened.count("1") == 1
+    assert flattened.count("after-free") == 1

--- a/tests/integration/src/server/http_server.py
+++ b/tests/integration/src/server/http_server.py
@@ -14,9 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import gzip
+import hashlib
 import json
 import logging
-import gzip
 import threading
 import time
 
@@ -230,6 +231,7 @@ def _record_request():
             "method": request.method,
             "headers": dict(request.headers),
             "raw_data": raw_data,
+            "raw_sha256": hashlib.sha256(raw_payload).hexdigest(),
             "decoded_data": decoded_data,
             "json": data,
         }

--- a/tests/integration/src/server/http_server.py
+++ b/tests/integration/src/server/http_server.py
@@ -232,6 +232,7 @@ def _record_request():
             "headers": dict(request.headers),
             "raw_data": raw_data,
             "raw_sha256": hashlib.sha256(raw_payload).hexdigest(),
+            "received_monotonic": time.monotonic(),
             "decoded_data": decoded_data,
             "json": data,
         }


### PR DESCRIPTION
## Summary

Add opt-in, durable whole-engine-chunk batching to `out_azure_logs_ingestion`.

The existing synchronous path remains the default. With buffering enabled, the output transactionally admits complete formatted engine chunks into a SQLite spool, combines whole chunks in FIFO order into exact gzip requests, and retries the persisted request bytes until Azure accepts them or the configured terminal policy quarantines them.

This implementation is designed to apply on top of the request payload metrics in #12392. The clean stacked branch is `nourdouf/azure-logs-ingestion-batching-on-request-metrics` at `179830c43`.

## Delivery and durability contract

- A source is one complete engine chunk; requests never split a source or mix output/DCR instances.
- The 900,000-byte target is soft. A target-crossing whole chunk is included when the exact result remains at or below 1,048,576 compressed bytes.
- A source that alone exceeds the compressed or configured uncompressed limit is rejected before local ownership with `FLB_RETRY`; it is not split or quarantined.
- Buffered mode requires `retry_limit no_limits`, so pre-ownership backpressure remains engine-owned rather than being dropped after the default retry budget.
- Source JSON bytes and ownership metadata commit atomically in SQLite with WAL and `synchronous=FULL` before `FLB_OK`.
- Exact gzip request bytes and complete-source membership commit atomically and are replayed byte-for-byte after retry, restart, or hot reload.
- Delivery remains at-least-once: Azure acceptance followed by a crash before the local ACK commit can duplicate a request.
- Permanent HTTP failures, retry exhaustion, and proven request corruption retain complete source/request BLOBs in quarantine.

## Storage and lifecycle

- SQLite-only schema v3; there is no FStore/ChunkIO payload authority.
- Legacy record-range and unshipped FStore prototype schemas fail closed without mutation.
- Receipt expiry, WAL checkpoint/truncation, freelist reuse, quota-pressure reclamation, and corrupt source/request isolation run during normal operation.
- Buffered OAuth and DCE connect/response/read-idle operations are bounded by `http_timeout`.
- SQLDB-disabled builds retain legacy output behavior and explicitly reject enabled buffering.
- One live owner is allowed per spool root and per `buffer_key`.
- Planner work is bounded to eight whole chunks/eight exact probes; compression occurs outside the shared manager mutex.
- A timer invocation drains at most four requests serially.

## Metrics

The two #12392 payload histograms remain HTTP-attempt metrics:

- `fluentbit_azure_logs_ingestion_uncompressed_payload_size_bytes`
- `fluentbit_azure_logs_ingestion_http_payload_size_bytes`

Buffered mode also exposes fixed-cardinality admission, delivery, quarantine, quota, persistence, queue, and uploader lifecycle metrics using only `name` and `dcr_id` labels. Metric initialization and updates are best-effort and cannot prevent delivery.

Generic output processed/latency metrics end at durable local admission in buffered mode; the plugin delivery metrics represent later Azure acceptance.

## Required configuration

Buffered mode requires:

- `compress true`
- `workers 1` (selected automatically when omitted)
- `retry_limit no_limits`
- a stable, destination-specific `buffer_key`
- a positive `buffer_dir_limit_size`
- a dedicated externally quota-bounded filesystem/volume

`buffer_dir_limit_size` is a logical owned-data limit with SQLite transition headroom. The deployment filesystem or Kubernetes ephemeral-storage limit is the physical hard boundary.

## Validation

Current implementation validation:

- Fluent Bit build passed.
- Azure integration scenario: **46 passed**.
- Strict macOS Leaks Azure scenario: **46 passed**.
- Shared HTTP/Splunk server regression passed.
- Metrics-disabled Azure plugin build passed.
- SQLite integrity, receipt/WAL reclamation, quota recovery, corrupt BLOB isolation, timeout, SIGKILL, restart, and hot-reload cases pass.
- Synthetic 100,000-record runs sustained roughly 13k–29k records/s depending on instrumentation, with exact uniqueness checks.
- Independent review found no blocker or high-severity correctness/liveness issue for a narrow supervised canary.

Stack validation:

- The batching-only patch applies with zero fuzz to #12392 commit `07de56883`.
- The stacked source builds successfully as Fluent Bit v5.1.3 development.
- Focused stacked tests for payload metrics, whole-chunk batching, HTTP retry, admission persistence failure, and receipt/WAL reclamation passed: **5 passed**.
- A buffered `--dry-run` configuration test passes; empty dry-run worker callbacks are guarded explicitly.

## Remaining rollout work

The source is ready for a narrow supervised canary, not broad fleet rollout. Before broad rollout:

- package the batching-only patch after the #12392 patch;
- deploy the lifecycle OpenMetrics mappings and alerts;
- enforce an external disk/ephemeral-storage limit;
- measure peak RSS and source-chunk rate on the production OS/filesystem;
- run staff outage, quota-pressure, SIGTERM, SIGKILL, restart, and hot-reload drills;
- document quarantine inspection/removal and schema rollback procedures;
- add deterministic SQLite COMMIT/rollback fault injection when a safe test seam is available.

> This pull request was prepared with AI assistance.
