### PR TITLE
in_forward: ingest all metrics contexts in payload

### DIFF
--- a/include/fluent-bit/flb_input_metric.h
+++ b/include/fluent-bit/flb_input_metric.h
@@ -28,6 +28,10 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
                              const char *tag, size_t tag_len,
                              struct cmt *cmt);
 
+int flb_input_metrics_append_list(struct flb_input_instance *ins,
+                                  const char *tag, size_t tag_len,
+                                  struct cfl_list *contexts);
+
 int flb_input_metrics_append_skip_processor_stages(
         struct flb_input_instance *ins,
         size_t processor_starting_stage,

--- a/plugins/in_forward/fw_prot.c
+++ b/plugins/in_forward/fw_prot.c
@@ -1248,13 +1248,85 @@ static int receiver_to_unpacker(struct fw_conn *conn, size_t request_size,
     return 0;
 }
 
+static void destroy_metrics_contexts(struct cfl_list *contexts)
+{
+    struct cmt *cmt;
+    struct cfl_list *head;
+    struct cfl_list *tmp;
+
+    cfl_list_foreach_safe(head, tmp, contexts) {
+        cmt = cfl_list_entry(head, struct cmt, _head);
+        cfl_list_del(&cmt->_head);
+        cmt_decode_msgpack_destroy(cmt);
+    }
+}
+
+static int append_metrics(struct flb_input_instance *ins, struct fw_conn *conn,
+                          flb_sds_t out_tag, const void *data, size_t len)
+{
+    int ret;
+    size_t off;
+    size_t previous_off;
+    struct cmt *cmt;
+    struct cfl_list contexts;
+
+    off = 0;
+    cfl_list_init(&contexts);
+
+    while (off < len) {
+        previous_off = off;
+        ret = cmt_decode_msgpack_create(&cmt, (char *) data, len, &off);
+        if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
+            flb_plg_error(ins, "cmt_decode_msgpack_create failed. ret=%d", ret);
+            destroy_metrics_contexts(&contexts);
+            return -1;
+        }
+
+        if (off <= previous_off) {
+            flb_plg_error(ins, "cmt_decode_msgpack_create consumed no data");
+            cmt_decode_msgpack_destroy(cmt);
+            destroy_metrics_contexts(&contexts);
+            return -1;
+        }
+
+        cfl_list_add(&cmt->_head, &contexts);
+    }
+
+    if (cfl_list_is_empty(&contexts)) {
+        flb_plg_error(ins, "empty metrics payload");
+        return -1;
+    }
+
+    if (conn->ctx->use_ingress_queue == FLB_TRUE) {
+        ret = flb_input_ingress_queue_metrics_list(conn->ctx->ins,
+                                                   out_tag, flb_sds_len(out_tag),
+                                                   &contexts, len);
+        if (ret != 0) {
+            flb_plg_error(ins, "could not append metrics. ret=%d", ret);
+            return -1;
+        }
+
+        return 0;
+    }
+
+    ret = flb_input_metrics_append_list(conn->ctx->ins,
+                                        out_tag, flb_sds_len(out_tag),
+                                        &contexts);
+    destroy_metrics_contexts(&contexts);
+    if (ret != 0) {
+        flb_plg_error(ins, "could not append metrics. ret=%d", ret);
+        return -1;
+    }
+
+    return 0;
+}
+
 static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
                       int event_type,
                       flb_sds_t out_tag, const void *data, size_t len)
 {
     int ret;
     size_t off = 0;
-    struct cmt *cmt;
     struct ctrace *ctr;
 
     if (event_type == FLB_EVENT_TYPE_LOGS) {
@@ -1269,26 +1341,7 @@ static int append_log(struct flb_input_instance *ins, struct fw_conn *conn,
         return 0;
     }
     else if (event_type == FLB_EVENT_TYPE_METRICS) {
-        ret = cmt_decode_msgpack_create(&cmt, (char *) data, len, &off);
-        if (ret != CMT_DECODE_MSGPACK_SUCCESS) {
-            flb_plg_error(ins, "cmt_decode_msgpack_create failed. ret=%d", ret);
-            return -1;
-        }
-
-        ret = fw_ingest_metrics(conn->ctx,
-                                out_tag, flb_sds_len(out_tag),
-                                cmt, len);
-        if (ret != 0) {
-            flb_plg_error(ins, "could not append metrics. ret=%d", ret);
-            if (conn->ctx->use_ingress_queue == FLB_FALSE) {
-                cmt_decode_msgpack_destroy(cmt);
-            }
-            return -1;
-        }
-
-        if (conn->ctx->use_ingress_queue == FLB_FALSE) {
-            cmt_decode_msgpack_destroy(cmt);
-        }
+        return append_metrics(ins, conn, out_tag, data, len);
     }
     else if (event_type == FLB_EVENT_TYPE_TRACES) {
         off = 0;

--- a/src/flb_input_ingest.c
+++ b/src/flb_input_ingest.c
@@ -331,16 +331,12 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
                                        struct flb_config *config,
                                        void *context)
 {
-    int append_result;
     int result;
     size_t pending_events;
     size_t pending_bytes;
     struct mk_list *head;
     struct mk_list *tmp;
     struct mk_list queue;
-    struct cfl_list *iterator;
-    struct cfl_list *list_tmp;
-    struct cmt *metrics_context;
     struct flb_input_ingress_event *event;
 
     (void) config;
@@ -401,20 +397,11 @@ static int flb_input_ingress_collector(struct flb_input_instance *ins,
                 }
             }
             else if (event->type == FLB_INPUT_INGRESS_METRICS) {
-                result = 0;
-                cfl_list_foreach_safe(iterator, list_tmp, &event->metrics) {
-                    metrics_context = cfl_list_entry(iterator, struct cmt, _head);
-                    cfl_list_del(&metrics_context->_head);
-                    append_result = flb_input_metrics_append(
-                                        ins,
-                                        event->tag,
-                                        event->tag != NULL ? flb_sds_len(event->tag) : 0,
-                                        metrics_context);
-                    cmt_destroy(metrics_context);
-                    if (append_result != 0) {
-                        result = append_result;
-                    }
-                }
+                result = flb_input_metrics_append_list(
+                             ins,
+                             event->tag,
+                             event->tag != NULL ? flb_sds_len(event->tag) : 0,
+                             &event->metrics);
             }
             else if (event->type == FLB_INPUT_INGRESS_TRACES) {
                 result = flb_input_trace_append(ins,

--- a/src/flb_input_metric.c
+++ b/src/flb_input_metric.c
@@ -23,30 +23,44 @@
 #include <fluent-bit/flb_input_metric.h>
 #include <fluent-bit/flb_input_plugin.h>
 #include <fluent-bit/flb_hash_table.h>
+#include <fluent-bit/flb_mem.h>
 #include <cfl/cfl.h>
 
-static int input_metrics_append(struct flb_input_instance *ins,
+struct input_metrics_encoded_context {
+    char *buffer;
+    size_t size;
+};
+
+static void input_metrics_resolve_tag(struct flb_input_instance *ins,
+                                      const char **tag, size_t *tag_len)
+{
+    if (*tag != NULL) {
+        return;
+    }
+
+    if (ins->tag && ins->tag_len > 0) {
+        *tag = ins->tag;
+        *tag_len = ins->tag_len;
+    }
+    else {
+        *tag = ins->name;
+        *tag_len = strlen(ins->name);
+    }
+}
+
+static int input_metrics_encode(struct flb_input_instance *ins,
                                 size_t processor_starting_stage,
                                 const char *tag, size_t tag_len,
-                                struct cmt *cmt)
+                                struct cmt *cmt, char **out_buf,
+                                size_t *out_size)
 {
     int ret;
-    char *mt_buf;
-    size_t mt_size;
     int processor_is_active;
     struct cmt *out_context = NULL;
     struct cmt *encode_context;
 
-    if (tag == NULL) {
-        if (ins->tag && ins->tag_len > 0) {
-            tag = ins->tag;
-            tag_len = ins->tag_len;
-        }
-        else {
-            tag = ins->name;
-            tag_len = strlen(ins->name);
-        }
-    }
+    *out_buf = NULL;
+    *out_size = 0;
 
     processor_is_active = flb_processor_is_active(ins->processor);
     if (processor_is_active) {
@@ -79,7 +93,7 @@ static int input_metrics_append(struct flb_input_instance *ins,
     }
 
     /* Convert metrics to msgpack */
-    ret = cmt_encode_msgpack_create(encode_context, &mt_buf, &mt_size);
+    ret = cmt_encode_msgpack_create(encode_context, out_buf, out_size);
 
     if (out_context && out_context != cmt) {
         cmt_destroy(out_context);
@@ -90,14 +104,23 @@ static int input_metrics_append(struct flb_input_instance *ins,
         return -1;
     }
 
+    return 0;
+}
+
+static int input_metrics_append_encoded(struct flb_input_instance *ins,
+                                        const char *tag, size_t tag_len,
+                                        const char *buf, size_t size,
+                                        size_t records)
+{
+    int ret;
+
     /*
      * Metrics chunks still need a positive logical event count when they
-     * enter the chunk/task pipeline. Passing 0 propagates as total_records=0,
-     * and later stages can treat the chunk as empty even though it carries a
-     * valid encoded metrics payload. Use 1 as a non-zero sentinel count.
+     * enter the chunk/task pipeline. The record count is the number of encoded
+     * contexts in the payload.
      */
-    ret = flb_input_chunk_append_raw(ins, FLB_INPUT_METRICS, 1,
-                                     tag, tag_len, mt_buf, mt_size);
+    ret = flb_input_chunk_append_raw(ins, FLB_INPUT_METRICS, records,
+                                     tag, tag_len, buf, size);
 
     if (ret == 0 && tag != NULL) {
         void *chunk_ref;
@@ -116,6 +139,27 @@ static int input_metrics_append(struct flb_input_instance *ins,
         pthread_mutex_unlock(&ins->metrics_chunk_lock);
     }
 
+    return ret;
+}
+
+static int input_metrics_append(struct flb_input_instance *ins,
+                                size_t processor_starting_stage,
+                                const char *tag, size_t tag_len,
+                                struct cmt *cmt)
+{
+    int ret;
+    char *mt_buf;
+    size_t mt_size;
+
+    input_metrics_resolve_tag(ins, &tag, &tag_len);
+
+    ret = input_metrics_encode(ins, processor_starting_stage,
+                               tag, tag_len, cmt, &mt_buf, &mt_size);
+    if (ret != 0 || mt_buf == NULL) {
+        return ret;
+    }
+
+    ret = input_metrics_append_encoded(ins, tag, tag_len, mt_buf, mt_size, 1);
     cmt_encode_msgpack_destroy(mt_buf);
 
     return ret;
@@ -130,6 +174,93 @@ int flb_input_metrics_append(struct flb_input_instance *ins,
                                 0,
                                 tag, tag_len,
                                 cmt);
+}
+
+int flb_input_metrics_append_list(struct flb_input_instance *ins,
+                                  const char *tag, size_t tag_len,
+                                  struct cfl_list *contexts)
+{
+    int ret;
+    size_t index;
+    size_t count;
+    size_t encoded_count;
+    size_t total_size;
+    char *payload;
+    char *write_offset;
+    struct cmt *context;
+    struct cfl_list *head;
+    struct input_metrics_encoded_context *encoded;
+
+    if (contexts == NULL || cfl_list_is_empty(contexts)) {
+        return -1;
+    }
+
+    input_metrics_resolve_tag(ins, &tag, &tag_len);
+
+    count = cfl_list_size(contexts);
+    encoded = flb_calloc(count, sizeof(struct input_metrics_encoded_context));
+    if (encoded == NULL) {
+        flb_errno();
+        return -1;
+    }
+
+    index = 0;
+    encoded_count = 0;
+    total_size = 0;
+    cfl_list_foreach(head, contexts) {
+        context = cfl_list_entry(head, struct cmt, _head);
+        ret = input_metrics_encode(ins, 0, tag, tag_len, context,
+                                   &encoded[index].buffer,
+                                   &encoded[index].size);
+        if (ret != 0) {
+            goto cleanup;
+        }
+
+        if (encoded[index].buffer != NULL) {
+            if (encoded[index].size > SIZE_MAX - total_size) {
+                ret = -1;
+                goto cleanup;
+            }
+
+            total_size += encoded[index].size;
+            encoded_count++;
+        }
+        index++;
+    }
+
+    if (total_size == 0) {
+        ret = 0;
+        goto cleanup;
+    }
+
+    payload = flb_malloc(total_size);
+    if (payload == NULL) {
+        flb_errno();
+        ret = -1;
+        goto cleanup;
+    }
+
+    write_offset = payload;
+    for (index = 0; index < count; index++) {
+        if (encoded[index].buffer != NULL) {
+            memcpy(write_offset, encoded[index].buffer, encoded[index].size);
+            write_offset += encoded[index].size;
+        }
+    }
+
+    ret = input_metrics_append_encoded(ins, tag, tag_len, payload,
+                                       total_size, encoded_count);
+    flb_free(payload);
+
+cleanup:
+    for (index = 0; index < count; index++) {
+        if (encoded[index].buffer != NULL) {
+            cmt_encode_msgpack_destroy(encoded[index].buffer);
+        }
+    }
+    flb_free(encoded);
+
+    return ret;
 }
 
 /* Take a metric context and enqueue it as a Metric's Chunk */

--- a/tests/integration/scenarios/in_forward/config/in_forward_atomic_metrics_stdout.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_atomic_metrics_stdout.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      workers: 1
+      processors:
+        metrics:
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: upsert
+            key: retry_safe
+            value: "true"
+
+  outputs:
+    - name: stdout
+      match: test

--- a/tests/integration/scenarios/in_forward/config/in_forward_multi_metrics_stdout.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_forward_multi_metrics_stdout.yaml
@@ -1,0 +1,17 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      workers: ${FORWARD_INPUT_WORKERS}
+
+  outputs:
+    - name: stdout
+      match: test

--- a/tests/integration/scenarios/in_forward/config/in_opentelemetry_to_forward_receiver_single_worker.yaml
+++ b/tests/integration/scenarios/in_forward/config/in_opentelemetry_to_forward_receiver_single_worker.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+
+  outputs:
+    - name: forward
+      match: '*'
+      host: 127.0.0.1
+      port: ${FORWARD_RECEIVER_PORT}
+      workers: 1
+      send_options: true
+      require_ack_response: true

--- a/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/tests/integration/scenarios/in_forward/tests/test_in_forward_001.py
@@ -342,6 +342,68 @@ def _assert_forward_signal_message(message, *, expected_tag, expected_signal):
     assert len(message["records"]) >= 1
 
 
+def _forward_metric_names(messages):
+    names = set()
+
+    for message in messages:
+        if message["options"].get("fluent_signal") != 1:
+            continue
+
+        for record in message["records"]:
+            payload = record.get("raw")
+            if not isinstance(payload, dict):
+                continue
+
+            for metric in payload.get("metrics", []):
+                names.add(metric["meta"]["opts"]["name"])
+
+    return names
+
+
+def _otel_metrics_request(metric_name):
+    base_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../../in_opentelemetry/tests/data_files",
+        )
+    )
+    request = ExportMetricsServiceRequest()
+    json_payload = read_json_file(os.path.join(base_path, "test_metrics_001.in.json"))
+
+    json_format.Parse(json.dumps(json_payload), request)
+    request.resource_metrics[0].scope_metrics[0].metrics[0].name = metric_name
+
+    return request
+
+
+def _forward_metric_contexts(metric_names):
+    timeout = 30 if memory_check_enabled() else 10
+    source = ForwardReceiverService(
+        "in_opentelemetry_to_forward_receiver_single_worker.yaml"
+    )
+
+    source.start()
+    try:
+        for metric_name in metric_names:
+            source.send_request("/v1/metrics", _otel_metrics_request(metric_name))
+            source.service.wait_for_condition(
+                lambda: forward_data_storage["messages"]
+                if metric_name in _forward_metric_names(forward_data_storage["messages"])
+                else None,
+                timeout=timeout,
+                interval=0.2,
+                description=f"source cmetrics context {metric_name}",
+            )
+
+        return [
+            message["raw"][1]
+            for message in forward_data_storage["messages"]
+            if message["options"].get("fluent_signal") == 1
+        ]
+    finally:
+        source.stop()
+
+
 def _pack_uint(value):
     if value < 0x80:
         return bytes([value])
@@ -1962,6 +2024,130 @@ def test_out_forward_metrics_signal_e2e_with_forward_receiver():
     assert record_payload["metrics"][0]["meta"]["opts"]["name"] == "requests_total"
     assert record_payload["metrics"][0]["values"][0]["labels"] == ["checkout"]
     assert record_payload["metrics"][0]["values"][0]["value_int64"] == 42
+
+
+def test_in_forward_ingests_all_metrics_contexts_from_single_payload():
+    expected_names = {"forward_metric_a", "forward_metric_b"}
+    timeout = 30 if memory_check_enabled() else 10
+    metrics_payload = b"".join(_forward_metric_contexts(expected_names))
+
+    receiver_config = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../config/in_forward_multi_metrics_stdout.yaml",
+        )
+    )
+    payload = _pack_obj(["test", metrics_payload, {"fluent_signal": 1}])
+
+    for input_workers in (1, 2):
+        receiver = FluentBitTestService(
+            receiver_config,
+            extra_env={"FORWARD_INPUT_WORKERS": input_workers},
+        )
+        receiver.start()
+        try:
+            with socket.create_connection(
+                ("127.0.0.1", receiver.flb_listener_port), timeout=5
+            ) as sock:
+                sock.sendall(payload)
+
+            output = receiver.wait_for_condition(
+                lambda: read_file(receiver.flb.log_file)
+                if all(
+                    metric_name in read_file(receiver.flb.log_file)
+                    for metric_name in expected_names
+                )
+                else None,
+                timeout=timeout,
+                interval=0.2,
+                description=(
+                    f"both forwarded cmetrics contexts with {input_workers} workers"
+                ),
+            )
+        finally:
+            receiver.stop()
+
+        assert all(metric_name in output for metric_name in expected_names)
+
+
+def test_in_forward_metrics_payload_append_is_atomic():
+    metric_names = ("forward_atomic_a", "forward_atomic_b")
+    contexts = _forward_metric_contexts(metric_names)
+    chunk_id = "atomic-metrics-payload"
+    timeout = 30 if memory_check_enabled() else 10
+
+    assert len(contexts) == 2
+    invalid_context = contexts[1].replace(
+        b"opentelemetry", b"invalid-value", 1
+    )
+    assert invalid_context != contexts[1]
+
+    invalid_payload = _pack_obj([
+        "test",
+        contexts[0] + invalid_context,
+        {"fluent_signal": 1, "chunk": chunk_id},
+    ])
+    valid_payload = _pack_obj([
+        "test",
+        b"".join(contexts),
+        {"fluent_signal": 1, "chunk": chunk_id},
+    ])
+    receiver_config = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "../config/in_forward_atomic_metrics_stdout.yaml",
+        )
+    )
+    receiver = FluentBitTestService(receiver_config)
+
+    receiver.start()
+    try:
+        with socket.create_connection(
+            ("127.0.0.1", receiver.flb_listener_port), timeout=5
+        ) as sock:
+            sock.settimeout(2)
+            sock.sendall(invalid_payload)
+            try:
+                response = sock.recv(4096)
+            except socket.timeout:
+                response = b""
+
+        assert response == b""
+        receiver.wait_for_condition(
+            lambda: read_file(receiver.flb.log_file)
+            if "could not append metrics" in read_file(receiver.flb.log_file)
+            else None,
+            timeout=timeout,
+            interval=0.2,
+            description="rejected atomic metrics payload",
+        )
+        time.sleep(2)
+        assert not any(
+            metric_name in read_file(receiver.flb.log_file)
+            for metric_name in metric_names
+        )
+
+        with socket.create_connection(
+            ("127.0.0.1", receiver.flb_listener_port), timeout=5
+        ) as sock:
+            sock.sendall(valid_payload)
+            assert _recv_msgpack_value(sock) == {"ack": chunk_id}
+
+        output = receiver.wait_for_condition(
+            lambda: read_file(receiver.flb.log_file)
+            if all(
+                metric_name in read_file(receiver.flb.log_file)
+                for metric_name in metric_names
+            )
+            else None,
+            timeout=timeout,
+            interval=0.2,
+            description="retried atomic metrics payload",
+        )
+    finally:
+        receiver.stop()
+
+    assert all(metric_name in output for metric_name in metric_names)
 
 
 def test_out_forward_traces_signal_e2e_with_forward_receiver():


### PR DESCRIPTION
## Problem

`in_forward` decoded only the first cmetrics context from a metrics BIN
payload. Forward metrics chunks may contain several concatenated cmetrics
contexts, so the remaining contexts were silently discarded.

Fixes #12373.

## Changes

- Decode and validate every cmetrics context in the Forward payload before
  ingestion.
- Reject malformed trailing data and guard against a decoder that makes no
  progress.
- Enqueue decoded contexts as one list for multi-worker ingress, preserving
  ownership and payload accounting.
- Add a Python integration regression test covering both the direct
  single-worker and queued multi-worker input paths.

This restores delivery of all contexts without changing the Forward wire
format or configuration surface.

## Validation

- Confirmed the regression test fails against the pre-fix v5.1.1 binary: only
  the first context is emitted.
- `cmake --build build -j8`
- `tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_ingests_all_metrics_contexts_from_single_payload -q`
- `VALGRIND=1 VALGRIND_STRICT=1 tests/integration/.venv/bin/python -m pytest tests/integration/scenarios/in_forward/tests/test_in_forward_001.py::test_in_forward_ingests_all_metrics_contexts_from_single_payload -q`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master tests/integration/.venv/bin/python .github/scripts/commit_prefix_check.py`

The focused integration test passes normally and under strict Valgrind; all
three Fluent Bit processes report zero errors. The existing
`flb-rt-in_forward` runtime test could not complete in this environment because
port 24224 is occupied by the host `fluentd.service`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Forward input now correctly processes multiple metric contexts contained in a single payload.
  - Invalid or incomplete metric payloads are rejected atomically without producing partial output.
  - Improved cleanup and batching reduce ingestion errors and resource issues.

- **Tests**
  - Added integration coverage for multi-metric forwarding with different worker configurations.
  - Added scenarios validating OpenTelemetry-to-Forward metric transmission.
  - Added validation for atomic handling of corrupted metric payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->