### PR TITLE
packaging: stabilize Debian release images

### DIFF
--- a/.github/workflows/build-master-packages.yaml
+++ b/.github/workflows/build-master-packages.yaml
@@ -31,7 +31,10 @@ jobs:
       - id: set-matrix
         run: |
           matrix=$((
-            echo '{ "distro" : [ "debian/bullseye", "ubuntu/20.04", "ubuntu/22.04", "centos/7" ]}'
+            echo '{ "distro" : ['
+            echo '"debian/bullseye", "debian/trixie",'
+            echo '"ubuntu/20.04", "ubuntu/22.04", "centos/7"'
+            echo ']}'
           ) | jq -c .)
           if [ -n "${{ github.event.inputs.target || '' }}" ]; then
             echo "Overriding matrix to build: ${{ github.event.inputs.target }}"

--- a/packaging/distros/debian/Dockerfile
+++ b/packaging/distros/debian/Dockerfile
@@ -76,6 +76,14 @@ ENV DEBIAN_FRONTEND="noninteractive" \
 
 ARG CMAKE_VERSION="3.31.6"
 ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+ARG BULLSEYE_SECURITY_SNAPSHOT="20260904T000000Z"
+
+# Bullseye LTS ended on 2026-08-31. Pin its security repository to an
+# immutable snapshot so package indexes cannot race package removal.
+RUN sed -i \
+    "s#deb.debian.org/debian-security#snapshot.debian.org/archive/debian-security/${BULLSEYE_SECURITY_SNAPSHOT}#g" \
+    /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
 
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \
@@ -102,6 +110,14 @@ COPY --from=multiarch-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
 
 ARG CMAKE_VERSION="3.31.6"
 ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download"
+ARG BULLSEYE_SECURITY_SNAPSHOT="20260904T000000Z"
+
+# Bullseye LTS ended on 2026-08-31. Pin its security repository to an
+# immutable snapshot so package indexes cannot race package removal.
+RUN sed -i \
+    "s#deb.debian.org/debian-security#snapshot.debian.org/archive/debian-security/${BULLSEYE_SECURITY_SNAPSHOT}#g" \
+    /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
 
 # hadolint ignore=DL3008,DL3015
 RUN apt-get -qq update && \


### PR DESCRIPTION
## Problem

Bullseye package builds can fail when the mutable Debian security mirror advertises packages that are removed before the build downloads them. This produced HTTP 404 failures for packages such as `libunbound8` and `mariadb-common`.

The fast master-package workflow also exercised Bullseye but did not continuously validate the current Debian stable release, Trixie.

## Changes

- Pin the Bullseye security repository to the immutable `20260904T000000Z` snapshot for amd64 and arm64 package-builder stages.
- Disable `Valid-Until` checks for the pinned snapshot.
- Add `debian/trixie` to the fast master-package build matrix.

Trixie was already present in the complete release configuration, repository publication scripts, package index generation, and smoke tests. This change adds it to continuous master-package validation.

## Verification

- `podman build --target debian-bullseye-base --build-arg BASE_BUILDER=debian-bullseye-base -t flb-debian-bullseye-base-fix -f packaging/distros/debian/Dockerfile .`
- `podman build --authfile /tmp/flb-empty-auth.json --target debian-trixie-base --build-arg BASE_BUILDER=debian-trixie-base -t flb-debian-trixie-base -f packaging/distros/debian/Dockerfile .`
- Workflow parsed successfully with PyYAML.
- Generated matrix JSON includes `debian/bullseye` and `debian/trixie`.
- `git diff --check` passed.
- Full PR commit-prefix validation passed.

The ARM64 image stages were not executed locally. Memory-checker testing is not applicable to these packaging and workflow-only changes.

## Compatibility

Bullseye remains available and becomes reproducible against the pinned security snapshot. Trixie package behavior is unchanged; it receives additional CI coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Debian 13 (Trixie) as a supported target for staging package builds.

- **Bug Fixes**
  - Improved reproducibility and reliability of Debian Bullseye package builds by using a fixed security repository snapshot, avoiding issues caused by the distribution’s end-of-life repository changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->